### PR TITLE
feat(ini-005): catalogue-tooling-foundation — Wave 1

### DIFF
--- a/catalogue.toml
+++ b/catalogue.toml
@@ -1,0 +1,37 @@
+# catalogue.toml — ini-005 Bucket 3 configuration layer for this repository.
+# Defines the portable catalogue engine's view of this repo's catalogue.
+# Schema: https://github.com/eugenelim/agent-ready-repo/docs/contracts/catalogue.schema.json
+schema = 1
+
+[catalogue]
+name                         = "agent-ready-repo"
+display-name                 = "Agent-Ready Repo"
+description                  = "Reference catalogue for the agent-ready-repo adapter contract."
+minimum-agentbundle-version  = "0.14.0"
+
+[catalogue.paths]
+packs       = "packs"
+profiles    = "profiles"
+contracts   = "docs/contracts"
+marketplace = ".claude-plugin/marketplace.json"
+build-output = "dist"
+
+[catalogue.build]
+recipes                  = ["default"]
+self-host                = false
+claude-plugin-branch     = "main"
+marketplace-description  = "Reference catalogue providing agent-ready skills, agents, and tooling for the adapter contract."
+
+[catalogue.package]
+# Packs to include in a packaged archive; 'core' is always required.
+include  = ["packs/core"]
+required = ["packs/core"]
+
+[distribution.agentbundle]
+install-defaults-output = "packages/agentbundle/agentbundle/_data/install-defaults.toml"
+preferred-adapter        = "claude-code"
+default-source           = "git+https://github.com/eugenelim/agent-ready-repo"
+
+[distribution.agentbundle.artifactory]
+# Disabled by default — private forks configure this to point to their registry.
+enabled = false

--- a/docs/contracts/catalogue.schema.json
+++ b/docs/contracts/catalogue.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "catalogue.schema.json",
+  "title": "CatalogueConfig",
+  "description": "JSON Schema for catalogue.toml — ini-005 Bucket 3 configuration layer.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "catalogue", "distribution"],
+  "properties": {
+    "schema": {
+      "type": "integer",
+      "description": "Schema version — must be 1.",
+      "enum": [1]
+    },
+    "catalogue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "display-name",
+        "description",
+        "minimum-agentbundle-version",
+        "paths",
+        "build",
+        "package"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Safe identifier — [A-Za-z0-9][A-Za-z0-9_-]*.",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_\\-]*$"
+        },
+        "display-name": {
+          "type": "string",
+          "description": "Human-readable catalogue name."
+        },
+        "description": {
+          "type": "string",
+          "description": "One-line description of the catalogue."
+        },
+        "minimum-agentbundle-version": {
+          "type": "string",
+          "description": "Minimum agentbundle version required to use this catalogue."
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["packs", "profiles", "contracts", "marketplace", "build-output"],
+          "properties": {
+            "packs": {
+              "type": "string",
+              "description": "Relative path to the packs directory."
+            },
+            "profiles": {
+              "type": "string",
+              "description": "Relative path to the profiles directory."
+            },
+            "contracts": {
+              "type": "string",
+              "description": "Relative path to the contracts directory."
+            },
+            "marketplace": {
+              "type": "string",
+              "description": "Relative path to the marketplace.json file."
+            },
+            "build-output": {
+              "type": "string",
+              "description": "Relative path for build output."
+            }
+          }
+        },
+        "build": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["recipes", "self-host", "claude-plugin-branch", "marketplace-description"],
+          "properties": {
+            "recipes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Build recipe IDs or relative .toml paths."
+            },
+            "self-host": {
+              "type": "boolean",
+              "description": "Whether to generate self-host install-defaults.toml."
+            },
+            "claude-plugin-branch": {
+              "type": "string",
+              "description": "Branch name for claude-plugin publishing."
+            },
+            "marketplace-description": {
+              "type": "string",
+              "description": "Description for marketplace.json."
+            }
+          }
+        },
+        "package": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["include", "required"],
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Pack paths to include in a packaged archive."
+            },
+            "required": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Pack paths that must be present (subset of include)."
+            }
+          }
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agentbundle"],
+      "properties": {
+        "agentbundle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "install-defaults-output",
+            "preferred-adapter",
+            "default-source",
+            "artifactory"
+          ],
+          "properties": {
+            "install-defaults-output": {
+              "type": "string",
+              "description": "Relative path for generated install-defaults.toml."
+            },
+            "preferred-adapter": {
+              "type": "string",
+              "description": "Default adapter hint written to install-defaults.toml."
+            },
+            "default-source": {
+              "type": "string",
+              "description": "Default catalogue source URI (git+https:// or local path)."
+            },
+            "artifactory": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled"],
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Whether the Artifactory bootstrap is active."
+                },
+                "base-url": {
+                  "type": "string",
+                  "description": "Artifactory base URL (https:// only, required when enabled)."
+                },
+                "repository": {
+                  "type": "string",
+                  "description": "Artifactory repository name (required when enabled)."
+                },
+                "bundle": {
+                  "type": "string",
+                  "description": "Catalogue bundle name (required when enabled)."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/catalogue-tooling-foundation/plan.md
+++ b/docs/specs/catalogue-tooling-foundation/plan.md
@@ -1,7 +1,7 @@
 # Plan: Catalogue Tooling Foundation
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting
+- **Status:** Shipped
 
 ## Approach
 
@@ -152,7 +152,7 @@ tests file at `tests/unit/test_catalogue_tooling_foundation.py`.
 - `test_config_valid_public` — parse minimal valid public config; assert success
 - `test_config_valid_enterprise` — parse enterprise config with Artifactory;
   assert success
-- One test per validation rule (13 tests): bad schema, unsafe name, absolute
+- One test per validation rule (14 tests): bad schema, unsafe name, absolute
   path, traversal, symlink escape, required⊄include, unknown recipe, unsafe
   recipe path, bad adapter, bad source, bad Artifactory, credential URL, bad
   version, unknown key

--- a/docs/specs/catalogue-tooling-foundation/spec.md
+++ b/docs/specs/catalogue-tooling-foundation/spec.md
@@ -1,6 +1,6 @@
 # Spec: Catalogue Tooling Foundation
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Initiative:** ini-005 AgentBundle Portable Catalogue Tooling
 - **Plan:** [`plan.md`](plan.md)
@@ -92,42 +92,42 @@ errors. All Wave 2 specs depend on these foundations.
 
 ## Acceptance Criteria
 
-- [ ] AC1: `agentbundle/catalogue_tooling/` exists with all 11 modules
+- [x] AC1: `agentbundle/catalogue_tooling/` exists with all 11 modules
   importable with no `ImportError`.
-- [ ] AC2: Every stub function/class in Wave 2-4 modules raises
+- [x] AC2: Every stub function/class in Wave 2-4 modules raises
   `NotImplementedError` (not `pass` — the raise is the signal to Wave 2 implementers).
-- [ ] AC3: `results.py` exports at least: `Severity` (enum: ERROR/WARN/INFO),
+- [x] AC3: `results.py` exports at least: `Severity` (enum: ERROR/WARN/INFO),
   `Diagnostic` (dataclass: code, severity, pack, path, line, col, message,
   remediation), `CommandResult` (dataclass: ok, diagnostics, schema_version,
   command, operation, agentbundle_version, catalogue_schema_version),
   `LintResult(CommandResult)`, `VerifyResult(CommandResult)`,
   `BuildResult(CommandResult)`, `SelfHostResult(CommandResult)`,
   `PackageResult(CommandResult)`, `SyncDefaultsResult(CommandResult)`.
-- [ ] AC4: `docs/contracts/catalogue.schema.json` exists and is valid JSON.
+- [x] AC4: `docs/contracts/catalogue.schema.json` exists and is valid JSON.
   `agentbundle/_data/catalogue.schema.json` exists and is byte-identical.
   A test asserts byte equality.
-- [ ] AC5: `load_catalogue_config(root)` returns `None` when `catalogue.toml`
+- [x] AC5: `load_catalogue_config(root)` returns `None` when `catalogue.toml`
   is absent, preserving all existing default behavior.
-- [ ] AC6: `load_catalogue_config(root)` raises `CatalogueConfigError` for each
-  of the 13 validation failure paths listed in Boundaries: bad schema integer,
+- [x] AC6: `load_catalogue_config(root)` raises `CatalogueConfigError` for each
+  of the 14 validation failure paths listed in Boundaries: bad schema integer,
   unsafe name, absolute path, traversal, symlink escape, required not in include,
   unknown recipe, unsafe recipe path, unknown preferred-adapter, invalid source,
   malformed Artifactory fields, credential URL, non-comparable version string,
   unknown top-level key (without extension table).
-- [ ] AC7: `catalogue.toml` at repo root is present, parses without error, and
+- [x] AC7: `catalogue.toml` at repo root is present, parses without error, and
   passes `load_catalogue_config` validation.
-- [ ] AC8: `catalogue.toml` contains: `schema`, `[catalogue]` (name,
+- [x] AC8: `catalogue.toml` contains: `schema`, `[catalogue]` (name,
   display-name, description, minimum-agentbundle-version),
   `[catalogue.paths]` (packs, profiles, contracts, marketplace, build-output),
   `[catalogue.build]` (recipes list, self-host bool, claude-plugin-branch,
   marketplace-description), `[catalogue.package]` (include, required),
   `[distribution.agentbundle]` (install-defaults-output, preferred-adapter,
   default-source), `[distribution.agentbundle.artifactory]` (enabled = false).
-- [ ] AC9: `agentbundle catalogue --help` exits non-zero (stub) and lists
+- [x] AC9: `agentbundle catalogue --help` exits non-zero (stub) and lists
   `lint`, `verify`, `build`, `self-host`, `package`, `sync-defaults` in output.
-- [ ] AC10: `agentbundle lint packs --help` exits non-zero (stub) and shows
+- [x] AC10: `agentbundle lint packs --help` exits non-zero (stub) and shows
   `--root` in the help text.
-- [ ] AC11: All existing AgentBundle tests pass unmodified.
+- [x] AC11: All existing AgentBundle tests pass unmodified.
 
 ## Assumptions
 

--- a/packages/agentbundle/AGENTS.md
+++ b/packages/agentbundle/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md — packages/agentbundle
+
+This package is the `agentbundle` CLI and engine.
+
+## Engine-change guard
+
+Any PR that modifies files under `packages/agentbundle/` (except
+`agentbundle/build/recipes/**` and `tests/**`) is treated as an
+engine-behaviour change by `tools/lint-catalogue-curation-guard.py`
+(RFC-0059 D6). That check will hard-fail CI unless at least one commit
+message in the branch contains the trailer:
+
+```
+Engine-Change-RFC: <rfc-or-ini-id>
+```
+
+Add a commit with that trailer before pushing. An empty commit is fine:
+
+```bash
+git commit --allow-empty -m "chore: exempt engine-change guard
+
+Engine-Change-RFC: <rfc-or-ini-id>"
+```
+
+The trailer must match the RFC or initiative driving the change.

--- a/packages/agentbundle/agentbundle/_data/catalogue.schema.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue.schema.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "catalogue.schema.json",
+  "title": "CatalogueConfig",
+  "description": "JSON Schema for catalogue.toml — ini-005 Bucket 3 configuration layer.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "catalogue", "distribution"],
+  "properties": {
+    "schema": {
+      "type": "integer",
+      "description": "Schema version — must be 1.",
+      "enum": [1]
+    },
+    "catalogue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "display-name",
+        "description",
+        "minimum-agentbundle-version",
+        "paths",
+        "build",
+        "package"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Safe identifier — [A-Za-z0-9][A-Za-z0-9_-]*.",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_\\-]*$"
+        },
+        "display-name": {
+          "type": "string",
+          "description": "Human-readable catalogue name."
+        },
+        "description": {
+          "type": "string",
+          "description": "One-line description of the catalogue."
+        },
+        "minimum-agentbundle-version": {
+          "type": "string",
+          "description": "Minimum agentbundle version required to use this catalogue."
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["packs", "profiles", "contracts", "marketplace", "build-output"],
+          "properties": {
+            "packs": {
+              "type": "string",
+              "description": "Relative path to the packs directory."
+            },
+            "profiles": {
+              "type": "string",
+              "description": "Relative path to the profiles directory."
+            },
+            "contracts": {
+              "type": "string",
+              "description": "Relative path to the contracts directory."
+            },
+            "marketplace": {
+              "type": "string",
+              "description": "Relative path to the marketplace.json file."
+            },
+            "build-output": {
+              "type": "string",
+              "description": "Relative path for build output."
+            }
+          }
+        },
+        "build": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["recipes", "self-host", "claude-plugin-branch", "marketplace-description"],
+          "properties": {
+            "recipes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Build recipe IDs or relative .toml paths."
+            },
+            "self-host": {
+              "type": "boolean",
+              "description": "Whether to generate self-host install-defaults.toml."
+            },
+            "claude-plugin-branch": {
+              "type": "string",
+              "description": "Branch name for claude-plugin publishing."
+            },
+            "marketplace-description": {
+              "type": "string",
+              "description": "Description for marketplace.json."
+            }
+          }
+        },
+        "package": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["include", "required"],
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Pack paths to include in a packaged archive."
+            },
+            "required": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Pack paths that must be present (subset of include)."
+            }
+          }
+        }
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agentbundle"],
+      "properties": {
+        "agentbundle": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "install-defaults-output",
+            "preferred-adapter",
+            "default-source",
+            "artifactory"
+          ],
+          "properties": {
+            "install-defaults-output": {
+              "type": "string",
+              "description": "Relative path for generated install-defaults.toml."
+            },
+            "preferred-adapter": {
+              "type": "string",
+              "description": "Default adapter hint written to install-defaults.toml."
+            },
+            "default-source": {
+              "type": "string",
+              "description": "Default catalogue source URI (git+https:// or local path)."
+            },
+            "artifactory": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["enabled"],
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Whether the Artifactory bootstrap is active."
+                },
+                "base-url": {
+                  "type": "string",
+                  "description": "Artifactory base URL (https:// only, required when enabled)."
+                },
+                "repository": {
+                  "type": "string",
+                  "description": "Artifactory repository name (required when enabled)."
+                },
+                "bundle": {
+                  "type": "string",
+                  "description": "Catalogue bundle name (required when enabled)."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/agentbundle/agentbundle/catalogue_tooling/__init__.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/__init__.py
@@ -1,0 +1,12 @@
+"""agentbundle.catalogue_tooling — portable catalogue engine.
+
+This package provides the configuration schema, result types, and command
+stubs for the agentbundle catalogue * and agentbundle lint packs CLI surface.
+
+Wave 2-4 specs fill the command logic; this package establishes the stable
+contract layer between all modules.
+"""
+
+from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+__all__ = ["CatalogueConfigError", "load_catalogue_config"]

--- a/packages/agentbundle/agentbundle/catalogue_tooling/archive.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/archive.py
@@ -1,0 +1,18 @@
+"""Catalogue archive verification stub.
+
+Wave 4 (catalogue-tooling-package-enhanced spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def verify_archive(archive: Path, sha256_file: Path | None = None) -> bool:
+    """Verify a packaged catalogue archive and optional SHA-256 checksum file.
+
+    Wave 4 implementation: validates archive integrity and channel descriptor.
+    """
+    raise NotImplementedError(
+        "verify_archive is not yet implemented — see catalogue-tooling-package-enhanced spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/build.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/build.py
@@ -1,0 +1,23 @@
+"""Catalogue build engine stub.
+
+Wave 2 (catalogue-tooling-build-self spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import BuildResult
+
+
+def build_catalogue(root: Path, output: Path, pack: str | None = None) -> "BuildResult":
+    """Build a catalogue at *root* to *output*.
+
+    Wave 2 implementation: renders all packs through the F-build pipeline,
+    writes the dist/ tree and marketplace.json.
+    """
+    raise NotImplementedError(
+        "build_catalogue is not yet implemented — see catalogue-tooling-build-self spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/config.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/config.py
@@ -1,0 +1,459 @@
+"""catalogue.toml configuration loading and validation.
+
+Implements load_catalogue_config — the entry point Wave 2-4 specs call to
+read the repo's catalogue.toml. All validation logic is here; no business
+logic belongs in this module.
+
+Validation order:
+  1. JSON Schema (structural) via agentbundle.build.validate (Assumption 2)
+  2. Business rules — symlink escape, credentials, version comparability, etc.
+
+Python 3.11 stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+# Bundled recipe IDs that are always valid without a path on disk.
+_BUNDLED_RECIPES: frozenset[str] = frozenset({"default"})
+
+# Safe identifier pattern for catalogue names.
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-]*$")
+
+# Safe name pattern for Artifactory repository/bundle fields.
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Simple semver / PEP-440 subset — version must start with a digit.
+_VERSION_RE = re.compile(r"^\d+(\.\d+)*([.\-+][A-Za-z0-9._+\-]*)?$")
+
+# Query-param names that signal embedded credentials.
+_CREDENTIAL_PARAMS = frozenset({"token", "password", "key", "secret", "api_key", "apikey"})
+
+
+class CatalogueConfigError(ValueError):
+    """Raised when catalogue.toml fails validation."""
+
+
+@dataclass
+class CataloguePaths:
+    packs: str
+    profiles: str
+    contracts: str
+    marketplace: str
+    build_output: str
+
+
+@dataclass
+class CatalogueBuild:
+    recipes: list[str]
+    self_host: bool
+    claude_plugin_branch: str
+    marketplace_description: str
+
+
+@dataclass
+class CataloguePackage:
+    include: list[str]
+    required: list[str]
+
+
+@dataclass
+class ArtifactoryConfig:
+    enabled: bool
+    base_url: str | None = None
+    repository: str | None = None
+    bundle: str | None = None
+
+
+@dataclass
+class AgentbundleDistribution:
+    install_defaults_output: str
+    preferred_adapter: str
+    default_source: str
+    artifactory: ArtifactoryConfig
+
+
+@dataclass
+class DistributionConfig:
+    agentbundle: AgentbundleDistribution
+
+
+@dataclass
+class CatalogueConfig:
+    schema: int
+    name: str
+    display_name: str
+    description: str
+    minimum_agentbundle_version: str
+    paths: CataloguePaths
+    build: CatalogueBuild
+    package: CataloguePackage
+    distribution: DistributionConfig
+
+
+def _load_schema() -> dict:
+    """Load catalogue.schema.json from the bundled _data directory.
+
+    Raises CatalogueConfigError when the schema cannot be found or is
+    invalid JSON — the validator cannot run without it.
+    """
+    # Primary: importlib.resources (installed package path)
+    try:
+        from importlib.resources import files
+
+        resource = files("agentbundle").joinpath("_data/catalogue.schema.json")
+        if resource.is_file():
+            return json.loads(resource.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+
+    # Fallback: filesystem path relative to this file (editable install)
+    here = Path(__file__).resolve()
+    data_schema = here.parents[1] / "_data" / "catalogue.schema.json"
+    if data_schema.exists():
+        try:
+            return json.loads(data_schema.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CatalogueConfigError(
+                f"catalogue.toml: cannot load catalogue.schema.json: {exc}"
+            ) from exc
+
+    raise CatalogueConfigError(
+        "catalogue.toml: catalogue.schema.json not found in _data/ — "
+        "cannot validate without the schema"
+    )
+
+
+def _apply_schema_validation(raw: dict) -> None:
+    """Run JSON Schema validation via the existing build/validate.py subset."""
+    from agentbundle.build.validate import validate
+
+    schema = _load_schema()
+    errors = validate(raw, schema)
+    if errors:
+        raise CatalogueConfigError(
+            "catalogue.toml: schema validation failed:\n  " + "\n  ".join(errors)
+        )
+
+
+def _load_adapter_names() -> frozenset[str]:
+    """Return adapter names from the bundled adapter contract.
+
+    Raises CatalogueConfigError if the contract cannot be loaded — the
+    preferred-adapter check cannot pass without the contract (fail-closed).
+    """
+    # Primary: importlib.resources
+    try:
+        from importlib.resources import files
+
+        resource = files("agentbundle").joinpath("_data/adapter.toml")
+        if resource.is_file():
+            data = tomllib.loads(resource.read_text(encoding="utf-8"))
+            adapters = data.get("adapter", {})
+            if isinstance(adapters, dict):
+                return frozenset(adapters.keys())
+    except Exception:
+        pass
+
+    # Fallback: filesystem path relative to repo root
+    here = Path(__file__).resolve()
+    # packages/agentbundle/agentbundle/catalogue_tooling/config.py -> repo root
+    repo_root = here.parents[4]
+    adapter_toml = repo_root / "docs" / "contracts" / "adapter.toml"
+    if adapter_toml.exists():
+        try:
+            data = tomllib.loads(adapter_toml.read_text(encoding="utf-8"))
+            adapters = data.get("adapter", {})
+            if isinstance(adapters, dict):
+                return frozenset(adapters.keys())
+        except Exception as exc:
+            raise CatalogueConfigError(
+                f"catalogue.toml: cannot load adapter contract for preferred-adapter "
+                f"validation: {exc}"
+            ) from exc
+
+    raise CatalogueConfigError(
+        "catalogue.toml: adapter contract (adapter.toml) not found — "
+        "cannot validate preferred-adapter without it"
+    )
+
+
+def _check_no_credentials(value: str, field_name: str) -> None:
+    """Raise CatalogueConfigError if *value* looks like a credential-bearing URL."""
+    if not isinstance(value, str):
+        return
+    parsed = urlsplit(value)
+    if "@" in parsed.netloc:
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} must not contain credentials (userinfo in URL)"
+        )
+    if parsed.query:
+        params = {p.split("=", 1)[0].lower() for p in parsed.query.split("&") if "=" in p}
+        bad = params & _CREDENTIAL_PARAMS
+        if bad:
+            raise CatalogueConfigError(
+                f"catalogue.toml: {field_name!r} must not contain credential query params: "
+                f"{sorted(bad)}"
+            )
+
+
+def _validate_path(root: Path, p: str, field_name: str) -> None:
+    """Validate that *p* is a relative, non-traversal, non-symlink-escape path."""
+    if not isinstance(p, str):
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} must be a string, got {type(p).__name__}"
+        )
+    # Must not be absolute
+    if p.startswith("/") or (len(p) > 1 and p[1] == ":"):
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} path must be relative, not absolute: {p!r}"
+        )
+    # No leading ..
+    parts = Path(p).parts
+    if ".." in parts:
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} path must not traverse outside root: {p!r}"
+        )
+    # Resolve and check inside root (catches symlinks)
+    resolved_root = root.resolve()
+    try:
+        resolved_path = (root / p).resolve()
+    except OSError:
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} path cannot be resolved: {p!r}"
+        )
+    if not resolved_path.is_relative_to(resolved_root):
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} path escapes catalogue root "
+            f"(symlink or traversal): {p!r}"
+        )
+
+
+def _validate_source(value: str, field_name: str) -> None:
+    """Validate a source URL using agentbundle.source_defaults._is_valid_source.
+
+    Raises CatalogueConfigError if the validator cannot be imported (fail-closed).
+    """
+    try:
+        from agentbundle.source_defaults import _is_valid_source  # type: ignore[import]
+    except ImportError as exc:
+        raise CatalogueConfigError(
+            f"catalogue.toml: cannot import source validator for {field_name!r}: {exc}"
+        ) from exc
+
+    if not _is_valid_source(value):
+        raise CatalogueConfigError(
+            f"catalogue.toml: {field_name!r} is not a valid catalogue source: {value!r}"
+        )
+
+
+def load_catalogue_config(root: Path) -> CatalogueConfig | None:
+    """Load and validate catalogue.toml at *root*.
+
+    Returns ``None`` when catalogue.toml is absent (backward compat).
+    Raises ``CatalogueConfigError`` on any validation failure.
+    """
+    toml_path = root / "catalogue.toml"
+    if not toml_path.exists():
+        return None
+
+    try:
+        raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise CatalogueConfigError(f"catalogue.toml: TOML parse error: {exc}") from exc
+
+    # --- Step 1: JSON Schema structural validation (Assumption 2) ---
+    _apply_schema_validation(raw)
+
+    # --- Step 2: Business rules beyond schema ---
+
+    # Rule 1: schema is integer 1 (redundant with schema enum, belt-and-suspenders)
+    schema_val = raw.get("schema")
+    if schema_val != 1:
+        raise CatalogueConfigError(
+            f"catalogue.toml: 'schema' must be integer 1, got {schema_val!r}"
+        )
+
+    cat = raw.get("catalogue", {})
+
+    # Rule 2: safe name
+    name = cat.get("name", "")
+    if not _SAFE_NAME_RE.match(name):
+        raise CatalogueConfigError(
+            f"catalogue.toml: catalogue.name must match ^[A-Za-z0-9][A-Za-z0-9_\\-]*$, "
+            f"got {name!r}"
+        )
+
+    display_name = cat.get("display-name")
+    if not display_name:
+        raise CatalogueConfigError("catalogue.toml: catalogue.display-name is required")
+
+    description = cat.get("description")
+    if not description:
+        raise CatalogueConfigError("catalogue.toml: catalogue.description is required")
+
+    min_version = cat.get("minimum-agentbundle-version", "")
+
+    # Rule 11: minimum-agentbundle-version is safe-comparable
+    if not isinstance(min_version, str) or not _VERSION_RE.match(min_version):
+        raise CatalogueConfigError(
+            f"catalogue.toml: minimum-agentbundle-version must be a valid version string, "
+            f"got {min_version!r}"
+        )
+
+    # --- [catalogue.paths] --- Rules 3 & 4
+    paths_raw = cat.get("paths", {})
+    path_fields = {
+        "packs": paths_raw.get("packs", ""),
+        "profiles": paths_raw.get("profiles", ""),
+        "contracts": paths_raw.get("contracts", ""),
+        "marketplace": paths_raw.get("marketplace", ""),
+        "build-output": paths_raw.get("build-output", ""),
+    }
+    for field_key, path_val in path_fields.items():
+        _validate_path(root, path_val, f"catalogue.paths.{field_key}")
+
+    paths = CataloguePaths(
+        packs=path_fields["packs"],
+        profiles=path_fields["profiles"],
+        contracts=path_fields["contracts"],
+        marketplace=path_fields["marketplace"],
+        build_output=path_fields["build-output"],
+    )
+
+    # --- [catalogue.build] --- Rule 6
+    build_raw = cat.get("build", {})
+    recipes = build_raw.get("recipes", [])
+
+    for recipe in recipes:
+        if not isinstance(recipe, str):
+            raise CatalogueConfigError(
+                f"catalogue.toml: recipe entry must be a string, got {type(recipe).__name__}"
+            )
+        if recipe in _BUNDLED_RECIPES:
+            continue
+        if not recipe.endswith(".toml"):
+            raise CatalogueConfigError(
+                f"catalogue.toml: unknown recipe {recipe!r} — not a bundled recipe "
+                f"({sorted(_BUNDLED_RECIPES)}) and not a .toml path"
+            )
+        # Route through _validate_path: catches absolute paths (including Windows
+        # drive-absolute), traversal, and symlink escape, matching the same
+        # rigor applied to [catalogue.paths] entries.
+        _validate_path(root, recipe, f"catalogue.build.recipes ({recipe!r})")
+
+    build = CatalogueBuild(
+        recipes=recipes,
+        self_host=build_raw.get("self-host", False),
+        claude_plugin_branch=build_raw.get("claude-plugin-branch", "main"),
+        marketplace_description=build_raw.get("marketplace-description", ""),
+    )
+
+    # --- [catalogue.package] --- Rule 5
+    pkg_raw = cat.get("package", {})
+    include = pkg_raw.get("include", [])
+    required = pkg_raw.get("required", [])
+
+    include_set = set(include)
+    required_set = set(required)
+    not_in_include = required_set - include_set
+    if not_in_include:
+        raise CatalogueConfigError(
+            f"catalogue.toml: package.required entries not in package.include: "
+            f"{sorted(not_in_include)}"
+        )
+
+    package = CataloguePackage(include=include, required=required)
+
+    # --- [distribution.agentbundle] ---
+    dist_raw = raw.get("distribution", {})
+    ab_raw = dist_raw.get("agentbundle", {})
+
+    preferred_adapter = ab_raw.get("preferred-adapter", "")
+    default_source = ab_raw.get("default-source", "")
+    install_defaults_output = ab_raw.get("install-defaults-output", "")
+
+    # Rule 7: preferred-adapter ∈ adapter contract (fail-closed)
+    known_adapters = _load_adapter_names()
+    if preferred_adapter not in known_adapters:
+        raise CatalogueConfigError(
+            f"catalogue.toml: distribution.agentbundle.preferred-adapter "
+            f"{preferred_adapter!r} is not in the adapter contract. "
+            f"Known: {sorted(known_adapters)}"
+        )
+
+    # Rules 8 & 10: default-source valid, no credentials
+    _check_no_credentials(default_source, "distribution.agentbundle.default-source")
+    _validate_source(default_source, "distribution.agentbundle.default-source")
+
+    # --- [distribution.agentbundle.artifactory] --- Rule 9
+    art_raw = ab_raw.get("artifactory", {})
+    art_enabled = art_raw.get("enabled", False)
+    art = ArtifactoryConfig(enabled=bool(art_enabled))
+
+    if art_enabled:
+        base_url = art_raw.get("base-url")
+        if not base_url:
+            raise CatalogueConfigError(
+                "catalogue.toml: distribution.agentbundle.artifactory.base-url "
+                "is required when enabled = true"
+            )
+        if not isinstance(base_url, str) or not base_url.startswith("https://"):
+            raise CatalogueConfigError(
+                "catalogue.toml: distribution.agentbundle.artifactory.base-url "
+                "must start with 'https://'"
+            )
+        parsed_art = urlsplit(base_url)
+        if "@" in parsed_art.netloc:
+            raise CatalogueConfigError(
+                "catalogue.toml: distribution.agentbundle.artifactory.base-url "
+                "must not contain userinfo"
+            )
+        if parsed_art.query:
+            raise CatalogueConfigError(
+                "catalogue.toml: distribution.agentbundle.artifactory.base-url "
+                "must not contain a query string"
+            )
+
+        repository = art_raw.get("repository")
+        bundle = art_raw.get("bundle")
+        for seg_name, seg_val in (("repository", repository), ("bundle", bundle)):
+            if not seg_val:
+                raise CatalogueConfigError(
+                    f"catalogue.toml: distribution.agentbundle.artifactory.{seg_name} "
+                    "is required when enabled = true"
+                )
+            if not isinstance(seg_val, str) or not _SAFE_SEGMENT_RE.match(seg_val):
+                raise CatalogueConfigError(
+                    f"catalogue.toml: distribution.agentbundle.artifactory.{seg_name} "
+                    f"must match [A-Za-z0-9._-]+, got {seg_val!r}"
+                )
+        art.base_url = base_url
+        art.repository = repository
+        art.bundle = bundle
+
+    agentbundle_dist = AgentbundleDistribution(
+        install_defaults_output=install_defaults_output,
+        preferred_adapter=preferred_adapter,
+        default_source=default_source,
+        artifactory=art,
+    )
+    distribution = DistributionConfig(agentbundle=agentbundle_dist)
+
+    return CatalogueConfig(
+        schema=schema_val,
+        name=name,
+        display_name=display_name,
+        description=description,
+        minimum_agentbundle_version=min_version,
+        paths=paths,
+        build=build,
+        package=package,
+        distribution=distribution,
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/defaults.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/defaults.py
@@ -1,0 +1,32 @@
+"""Catalogue sync-defaults stub.
+
+Wave 2 (catalogue-tooling-sync-defaults spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import SyncDefaultsResult
+
+
+def check_defaults(root: Path) -> "SyncDefaultsResult":
+    """Check whether install-defaults.toml is in sync with catalogue.toml.
+
+    Wave 2 implementation: reads both files and reports drift.
+    """
+    raise NotImplementedError(
+        "check_defaults is not yet implemented — see catalogue-tooling-sync-defaults spec"
+    )
+
+
+def write_defaults(root: Path) -> "SyncDefaultsResult":
+    """Regenerate install-defaults.toml from catalogue.toml.
+
+    Wave 2 implementation: writes the [defaults] and [organization] blocks.
+    """
+    raise NotImplementedError(
+        "write_defaults is not yet implemented — see catalogue-tooling-sync-defaults spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/diagnostics.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/diagnostics.py
@@ -1,0 +1,14 @@
+"""Stable diagnostic code enum for catalogue_tooling.
+
+Codes will be populated by Wave 2 specs (lint, verify, build).
+"""
+
+from __future__ import annotations
+
+import enum
+
+
+class DiagnosticCode(str, enum.Enum):
+    """Placeholder — Wave 2 specs define the actual codes."""
+
+    UNKNOWN = "UNKNOWN"

--- a/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
@@ -1,0 +1,23 @@
+"""Catalogue lint engine stub.
+
+Wave 2 (catalogue-tooling-lint spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import LintResult
+
+
+def lint_catalogue(root: Path, pack: str | None = None) -> "LintResult":
+    """Lint a catalogue at *root*, optionally scoped to *pack*.
+
+    Wave 2 implementation: validates pack.toml structure, skill/agent
+    frontmatter, hook wiring, and cross-references.
+    """
+    raise NotImplementedError(
+        "lint_catalogue is not yet implemented — see catalogue-tooling-lint spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/package.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/package.py
@@ -1,0 +1,29 @@
+"""Catalogue packaging stub.
+
+Wave 4 (catalogue-tooling-package-enhanced spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import PackageResult
+
+
+def package_catalogue(
+    root: Path,
+    bundle: str | None = None,
+    release: str | None = None,
+    channel: str | None = None,
+    output: Path | None = None,
+) -> "PackageResult":
+    """Package a catalogue at *root* into an Artifactory artifact layout.
+
+    Wave 4 implementation: wraps the existing package-catalogue command
+    logic behind the portable engine interface.
+    """
+    raise NotImplementedError(
+        "package_catalogue is not yet implemented — see catalogue-tooling-package-enhanced spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/results.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/results.py
@@ -1,0 +1,69 @@
+"""Shared result and diagnostic types for catalogue_tooling commands.
+
+These types are the stable contract between all catalogue_tooling modules.
+Wave 2-4 specs populate the logic; this module defines the shape.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class Severity(enum.IntEnum):
+    ERROR = 3
+    WARN = 2
+    INFO = 1
+
+
+@dataclass
+class Diagnostic:
+    code: str
+    severity: Severity
+    pack: str | None
+    path: str | None
+    line: int | None
+    col: int | None
+    message: str
+    remediation: str | None
+
+
+@dataclass
+class CommandResult:
+    ok: bool
+    diagnostics: list[Diagnostic]
+    schema_version: int
+    command: str
+    operation: str
+    agentbundle_version: str
+    catalogue_schema_version: int
+
+
+@dataclass
+class LintResult(CommandResult):
+    pass
+
+
+@dataclass
+class VerifyResult(CommandResult):
+    pass
+
+
+@dataclass
+class BuildResult(CommandResult):
+    pass
+
+
+@dataclass
+class SelfHostResult(CommandResult):
+    pass
+
+
+@dataclass
+class PackageResult(CommandResult):
+    pass
+
+
+@dataclass
+class SyncDefaultsResult(CommandResult):
+    pass

--- a/packages/agentbundle/agentbundle/catalogue_tooling/self_host.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/self_host.py
@@ -1,0 +1,33 @@
+"""Catalogue self-host tooling stub.
+
+Wave 2 (catalogue-tooling-build-self spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import SelfHostResult
+
+
+def check_self_host(root: Path) -> "SelfHostResult":
+    """Check self-host configuration at *root*.
+
+    Wave 2 implementation: validates install-defaults.toml shape and
+    preferred-adapter setting.
+    """
+    raise NotImplementedError(
+        "check_self_host is not yet implemented — see catalogue-tooling-build-self spec"
+    )
+
+
+def write_self_host(root: Path) -> "SelfHostResult":
+    """Write self-host configuration at *root*.
+
+    Wave 2 implementation: generates install-defaults.toml from catalogue.toml.
+    """
+    raise NotImplementedError(
+        "write_self_host is not yet implemented — see catalogue-tooling-build-self spec"
+    )

--- a/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
@@ -1,0 +1,23 @@
+"""Catalogue verification engine stub.
+
+Wave 2 (catalogue-tooling-verify spec) fills this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentbundle.catalogue_tooling.results import VerifyResult
+
+
+def verify_catalogue(root: Path, pack: str | None = None) -> "VerifyResult":
+    """Verify a catalogue at *root* against its contracts.
+
+    Wave 3 implementation: checks adapter contract conformance, schema
+    compliance, and install-marker integrity.
+    """
+    raise NotImplementedError(
+        "verify_catalogue is not yet implemented — see catalogue-tooling-verify spec"
+    )

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -163,6 +163,20 @@ def _shipped_adapters_choices() -> tuple[str, ...]:
     return shipped_adapters_from_contract()
 
 
+class _StubHelpAction(argparse.Action):
+    """A --help action for stub subcommand groups that exits 1 (not 0).
+
+    Used on the `catalogue` and `lint packs` parsers so callers can
+    distinguish "this group is not yet implemented" (exit 1) from a
+    normal help print (exit 0). Wave 2-4 specs replace these stubs with
+    real handlers; this action will be removed at that point.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.print_help()
+        parser.exit(1)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = _VerbAwareParser(
         prog="agentbundle",
@@ -706,6 +720,61 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Publication timestamp for the channel descriptor (ISO-8601).",
     )
     sp.set_defaults(func=_lazy("package_catalogue"))
+
+    # --- catalogue <sub> --- (Wave 2-4 stubs; all exit 1 until implemented)
+    cat_parser = subparsers.add_parser(
+        "catalogue",
+        help="Portable catalogue engine commands (Wave 2-4 — not yet implemented).",
+        add_help=False,
+    )
+    cat_parser.add_argument(
+        "-h",
+        "--help",
+        action=_StubHelpAction,
+        default=argparse.SUPPRESS,
+        nargs=0,
+        help="show this help message and exit",
+    )
+    cat_subs = cat_parser.add_subparsers(dest="catalogue_sub", metavar="<sub>")
+    for _cat_sub, _cat_help in (
+        ("lint", "Lint catalogue packs (stub)."),
+        ("verify", "Verify catalogue against contracts (stub)."),
+        ("build", "Build catalogue dist tree (stub)."),
+        ("self-host", "Write self-host install-defaults (stub)."),
+        ("package", "Package catalogue into an archive (stub)."),
+        ("sync-defaults", "Sync install-defaults from catalogue.toml (stub)."),
+    ):
+        _p = cat_subs.add_parser(_cat_sub, help=_cat_help)
+        _p.add_argument("--root", default=".", help="Catalogue root directory.")
+        if _cat_sub in ("lint", "verify", "build", "package"):
+            _p.add_argument("--pack", default=None, help="Limit to a single pack name.")
+        if _cat_sub in ("lint", "verify", "package"):
+            _p.add_argument(
+                "--format", choices=("table", "json"), default="table", help="Output format."
+            )
+        _p.set_defaults(func=_lazy("catalogue_tooling_stub"))
+
+    # --- lint packs --- (Wave 2 stub; exits 1 until implemented)
+    lint_parser = subparsers.add_parser(
+        "lint",
+        help="Lint commands (Wave 2 — not yet implemented).",
+    )
+    lint_subs = lint_parser.add_subparsers(dest="lint_sub", metavar="<sub>")
+    packs_p = lint_subs.add_parser(
+        "packs",
+        help="Lint catalogue packs (stub — use 'agentbundle catalogue lint' instead).",
+        add_help=False,
+    )
+    packs_p.add_argument(
+        "-h",
+        "--help",
+        action=_StubHelpAction,
+        default=argparse.SUPPRESS,
+        nargs=0,
+        help="show this help message and exit",
+    )
+    packs_p.add_argument("--root", default=".", help="Catalogue root directory.")
+    packs_p.set_defaults(func=_lazy("catalogue_tooling_stub"))
 
     return parser
 

--- a/packages/agentbundle/agentbundle/commands/catalogue_tooling_stub.py
+++ b/packages/agentbundle/agentbundle/commands/catalogue_tooling_stub.py
@@ -1,0 +1,22 @@
+"""Stub handler for agentbundle catalogue <sub> and agentbundle lint packs.
+
+All catalogue_tooling subcommands exit 1 with "not yet implemented" until
+Wave 2-4 specs fill them in.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def run(args: "argparse.Namespace") -> int:
+    sub = getattr(args, "catalogue_sub", None) or getattr(args, "lint_sub", None) or ""
+    print(
+        f"agentbundle catalogue {sub} not yet implemented — see ini-005 Wave 2-4 specs".rstrip(),
+        file=sys.stderr,
+    )
+    return 1

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -1,0 +1,539 @@
+"""Foundation tests for catalogue_tooling package (T1–T4).
+
+Verification modes per plan.md:
+  T1 — TDD: import, result-type structure, stub raises
+  T2 — TDD: config loading and all 13 validation failure paths
+  T3 — Goal-based: schema drift check + repo catalogue.toml valid
+  T4 — Goal-based: CLI subcommand groups registered
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# T1: Package skeleton + result types
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_tooling_imports():
+    """AC1: all 11 modules import without ImportError."""
+    modules = [
+        "agentbundle.catalogue_tooling",
+        "agentbundle.catalogue_tooling.config",
+        "agentbundle.catalogue_tooling.diagnostics",
+        "agentbundle.catalogue_tooling.results",
+        "agentbundle.catalogue_tooling.lint",
+        "agentbundle.catalogue_tooling.verify",
+        "agentbundle.catalogue_tooling.build",
+        "agentbundle.catalogue_tooling.self_host",
+        "agentbundle.catalogue_tooling.package",
+        "agentbundle.catalogue_tooling.archive",
+        "agentbundle.catalogue_tooling.defaults",
+    ]
+    import importlib
+
+    for name in modules:
+        importlib.import_module(name)
+
+
+def test_result_types_structure():
+    """AC3: result types export required fields and subtype relationships."""
+    from agentbundle.catalogue_tooling.results import (
+        BuildResult,
+        CommandResult,
+        Diagnostic,
+        LintResult,
+        PackageResult,
+        SelfHostResult,
+        Severity,
+        SyncDefaultsResult,
+        VerifyResult,
+    )
+
+    # Severity has ERROR, WARN, INFO
+    assert hasattr(Severity, "ERROR")
+    assert hasattr(Severity, "WARN")
+    assert hasattr(Severity, "INFO")
+
+    # Diagnostic has all 9 fields
+    import dataclasses
+
+    diag_fields = {f.name for f in dataclasses.fields(Diagnostic)}
+    # Diagnostic has 8 fields per spec AC3 and results.py
+    for field in ("code", "severity", "pack", "path", "line", "col", "message", "remediation"):
+        assert field in diag_fields, f"Diagnostic missing field: {field}"
+
+    # CommandResult has ok, diagnostics, schema_version, command, operation,
+    # agentbundle_version, catalogue_schema_version
+    cr_fields = {f.name for f in dataclasses.fields(CommandResult)}
+    for field in (
+        "ok",
+        "diagnostics",
+        "schema_version",
+        "command",
+        "operation",
+        "agentbundle_version",
+        "catalogue_schema_version",
+    ):
+        assert field in cr_fields, f"CommandResult missing field: {field}"
+
+    # Subtypes are subclasses of CommandResult
+    for subtype in (LintResult, VerifyResult, BuildResult, SelfHostResult, PackageResult, SyncDefaultsResult):
+        assert issubclass(subtype, CommandResult), f"{subtype.__name__} not subclass of CommandResult"
+
+
+def test_stub_raises_not_implemented():
+    """AC2: stub functions raise NotImplementedError."""
+    from agentbundle.catalogue_tooling.lint import lint_catalogue
+    from agentbundle.catalogue_tooling.verify import verify_catalogue
+    from agentbundle.catalogue_tooling.build import build_catalogue
+    from agentbundle.catalogue_tooling.package import package_catalogue
+
+    with pytest.raises(NotImplementedError):
+        lint_catalogue(Path("."))
+    with pytest.raises(NotImplementedError):
+        verify_catalogue(Path("."))
+    with pytest.raises(NotImplementedError):
+        build_catalogue(Path("."), Path("."))
+    with pytest.raises(NotImplementedError):
+        package_catalogue(Path("."))
+
+
+# ---------------------------------------------------------------------------
+# T2: config.py validation
+# ---------------------------------------------------------------------------
+
+
+def _minimal_valid_toml(overrides: dict | None = None) -> str:
+    """Build a minimal valid catalogue.toml TOML string."""
+    base = {
+        "schema": 1,
+        "catalogue": {
+            "name": "test-catalogue",
+            "display-name": "Test Catalogue",
+            "description": "A test catalogue",
+            "minimum-agentbundle-version": "0.14.0",
+            "paths": {
+                "packs": "packs",
+                "profiles": "profiles",
+                "contracts": "docs/contracts",
+                "marketplace": ".claude-plugin/marketplace.json",
+                "build-output": "dist",
+            },
+            "build": {
+                "recipes": ["default"],
+                "self-host": False,
+                "claude-plugin-branch": "main",
+                "marketplace-description": "Test",
+            },
+            "package": {
+                "include": ["packs/core"],
+                "required": ["packs/core"],
+            },
+        },
+        "distribution": {
+            "agentbundle": {
+                "install-defaults-output": "agentbundle/_data/install-defaults.toml",
+                "preferred-adapter": "claude-code",
+                "default-source": "git+https://github.com/example/catalogue",
+                "artifactory": {
+                    "enabled": False,
+                },
+            }
+        },
+    }
+    if overrides:
+        _deep_merge(base, overrides)
+    import tomllib as _tl  # noqa: F401 — stdlib write is not available; build via string
+    # Build TOML manually for the base case
+    return _dict_to_toml(base)
+
+
+def _deep_merge(base: dict, overrides: dict) -> None:
+    for k, v in overrides.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            _deep_merge(base[k], v)
+        else:
+            base[k] = v
+
+
+def _dict_to_toml(d: dict, prefix: str = "") -> str:
+    """Minimal TOML serializer for test fixture generation (no arrays of tables)."""
+    scalars: list[str] = []
+    subsections: list[str] = []
+
+    for k, v in d.items():
+        key = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            inner = _dict_to_toml(v, prefix=key)
+            subsections.append(f"\n[{key}]\n{inner}")
+        elif isinstance(v, bool):
+            scalars.append(f"{k} = {'true' if v else 'false'}")
+        elif isinstance(v, int):
+            scalars.append(f"{k} = {v}")
+        elif isinstance(v, str):
+            scalars.append(f"{k} = {v!r}")
+        elif isinstance(v, list):
+            items = ", ".join(repr(i) if isinstance(i, str) else str(i) for i in v)
+            scalars.append(f"{k} = [{items}]")
+
+    return "\n".join(scalars) + "".join(subsections)
+
+
+def _write_toml(tmp_path: Path, content: str) -> Path:
+    f = tmp_path / "catalogue.toml"
+    f.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_config_absent_returns_none(tmp_path):
+    """AC5: absent catalogue.toml returns None."""
+    from agentbundle.catalogue_tooling.config import load_catalogue_config
+
+    result = load_catalogue_config(tmp_path)
+    assert result is None
+
+
+def test_config_valid_public(tmp_path):
+    """AC5/AC6: valid minimal public config parses without error."""
+    from agentbundle.catalogue_tooling.config import load_catalogue_config
+
+    content = _minimal_valid_toml()
+    _write_toml(tmp_path, content)
+    result = load_catalogue_config(tmp_path)
+    assert result is not None
+    assert result.name == "test-catalogue"
+
+
+def test_config_valid_enterprise(tmp_path):
+    """AC6: valid enterprise config with Artifactory enabled parses without error."""
+    from agentbundle.catalogue_tooling.config import load_catalogue_config
+
+    # Build enterprise config with Artifactory enabled
+    content = (
+        "schema = 1\n"
+        "\n"
+        "[catalogue]\n"
+        "name = 'my-catalogue'\n"
+        "display-name = 'My Catalogue'\n"
+        "description = 'Enterprise catalogue'\n"
+        "minimum-agentbundle-version = '0.14.0'\n"
+        "\n"
+        "[catalogue.paths]\n"
+        "packs = 'packs'\n"
+        "profiles = 'profiles'\n"
+        "contracts = 'docs/contracts'\n"
+        "marketplace = '.claude-plugin/marketplace.json'\n"
+        "build-output = 'dist'\n"
+        "\n"
+        "[catalogue.build]\n"
+        "recipes = ['default']\n"
+        "self-host = false\n"
+        "claude-plugin-branch = 'main'\n"
+        "marketplace-description = 'Ent'\n"
+        "\n"
+        "[catalogue.package]\n"
+        "include = ['packs/core']\n"
+        "required = ['packs/core']\n"
+        "\n"
+        "[distribution.agentbundle]\n"
+        "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+        "preferred-adapter = 'claude-code'\n"
+        "default-source = 'git+https://github.com/example/repo'\n"
+        "\n"
+        "[distribution.agentbundle.artifactory]\n"
+        "enabled = true\n"
+        "base-url = 'https://art.example.com'\n"
+        "repository = 'my-repo'\n"
+        "bundle = 'engineering'\n"
+    )
+    _write_toml(tmp_path, content)
+    result = load_catalogue_config(tmp_path)
+    assert result is not None
+
+
+def test_config_bad_schema_integer(tmp_path):
+    """AC6: non-integer schema field raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = (
+        "schema = 2\n"  # only 1 is valid
+        "[catalogue]\n"
+        "name = 'x'\n"
+        "display-name = 'X'\n"
+        "description = 'x'\n"
+        "minimum-agentbundle-version = '0.14.0'\n"
+        "[catalogue.paths]\n"
+        "packs = 'packs'\nprofiles = 'profiles'\ncontracts = 'docs/contracts'\n"
+        "marketplace = '.claude-plugin/marketplace.json'\nbuild-output = 'dist'\n"
+        "[catalogue.build]\n"
+        "recipes = ['default']\nself-host = false\nclaude-plugin-branch = 'main'\n"
+        "marketplace-description = 'x'\n"
+        "[catalogue.package]\n"
+        "include = ['packs/core']\nrequired = ['packs/core']\n"
+        "[distribution.agentbundle]\n"
+        "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+        "preferred-adapter = 'claude-code'\n"
+        "default-source = 'git+https://github.com/example/repo'\n"
+        "[distribution.agentbundle.artifactory]\nenabled = false\n"
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="schema"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_unsafe_name(tmp_path):
+    """AC6: catalogue name with unsafe characters raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = (
+        "schema = 1\n"
+        "[catalogue]\n"
+        "name = 'my catalogue!'\n"  # space and ! are invalid
+        "display-name = 'X'\ndescription = 'x'\nminimum-agentbundle-version = '0.14.0'\n"
+        "[catalogue.paths]\n"
+        "packs = 'packs'\nprofiles = 'profiles'\ncontracts = 'docs/contracts'\n"
+        "marketplace = '.claude-plugin/marketplace.json'\nbuild-output = 'dist'\n"
+        "[catalogue.build]\n"
+        "recipes = ['default']\nself-host = false\nclaude-plugin-branch = 'main'\n"
+        "marketplace-description = 'x'\n"
+        "[catalogue.package]\n"
+        "include = ['packs/core']\nrequired = ['packs/core']\n"
+        "[distribution.agentbundle]\n"
+        "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+        "preferred-adapter = 'claude-code'\n"
+        "default-source = 'git+https://github.com/example/repo'\n"
+        "[distribution.agentbundle.artifactory]\nenabled = false\n"
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="name"):
+        load_catalogue_config(tmp_path)
+
+
+_VALID_BASE = (
+    "schema = 1\n"
+    "[catalogue]\n"
+    "name = 'test'\ndisplay-name = 'T'\ndescription = 't'\n"
+    "minimum-agentbundle-version = '0.14.0'\n"
+    "[catalogue.paths]\n"
+    "packs = 'packs'\nprofiles = 'profiles'\ncontracts = 'docs/contracts'\n"
+    "marketplace = '.claude-plugin/marketplace.json'\nbuild-output = 'dist'\n"
+    "[catalogue.build]\n"
+    "recipes = ['default']\nself-host = false\nclaude-plugin-branch = 'main'\n"
+    "marketplace-description = 't'\n"
+    "[catalogue.package]\n"
+    "include = ['packs/core']\nrequired = ['packs/core']\n"
+    "[distribution.agentbundle]\n"
+    "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+    "preferred-adapter = 'claude-code'\n"
+    "default-source = 'git+https://github.com/example/repo'\n"
+    "[distribution.agentbundle.artifactory]\nenabled = false\n"
+)
+
+
+def test_config_absolute_path(tmp_path):
+    """AC6: absolute path in catalogue.paths raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace("packs = 'packs'", "packs = '/absolute/packs'")
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="absolute|path"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_traversal_path(tmp_path):
+    """AC6: traversal path raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace("packs = 'packs'", "packs = '../outside'")
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="traversal|outside|path"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_symlink_escape(tmp_path):
+    """AC6: symlink escaping catalogue root raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    # Create a symlink pointing outside tmp_path
+    target = tmp_path.parent / "outside_dir"
+    target.mkdir(exist_ok=True)
+    link = tmp_path / "escape_link"
+    link.symlink_to(target)
+
+    content = _VALID_BASE.replace("packs = 'packs'", "packs = 'escape_link'")
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="escape|symlink|outside|path"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_required_not_in_include(tmp_path):
+    """AC6: required ⊄ include raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "include = ['packs/core']\nrequired = ['packs/core']",
+        "include = ['packs/core']\nrequired = ['packs/enterprise']",
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="required|include"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_unknown_recipe(tmp_path):
+    """AC6: unknown recipe raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace("recipes = ['default']", "recipes = ['nonexistent-recipe-xyz']")
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="recipe"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_unsafe_recipe_path(tmp_path):
+    """AC6: unsafe recipe relative path raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "recipes = ['default']", "recipes = ['../outside/recipe.toml']"
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="recipe|path|outside"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_unknown_preferred_adapter(tmp_path):
+    """AC6: unknown preferred-adapter raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "preferred-adapter = 'claude-code'", "preferred-adapter = 'nonexistent-adapter'"
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="adapter"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_invalid_source(tmp_path):
+    """AC6: invalid default-source raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "default-source = 'git+https://github.com/example/repo'",
+        "default-source = 'ftp://invalid-scheme.example.com'",
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="source"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_bad_artifactory_fields(tmp_path):
+    """AC6: Artifactory enabled with missing required fields raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "[distribution.agentbundle.artifactory]\nenabled = false\n",
+        "[distribution.agentbundle.artifactory]\nenabled = true\n",
+        # no base-url, repository, bundle
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="artifactory|base-url|required"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_credential_url(tmp_path):
+    """AC6: credential-bearing URL in default-source raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "default-source = 'git+https://github.com/example/repo'",
+        "default-source = 'git+https://user:token@github.com/example/repo'",
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="credential|source"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_bad_version_string(tmp_path):
+    """AC6: non-comparable minimum-agentbundle-version raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE.replace(
+        "minimum-agentbundle-version = '0.14.0'",
+        "minimum-agentbundle-version = 'not-a-version!!'",
+    )
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="version"):
+        load_catalogue_config(tmp_path)
+
+
+def test_config_unknown_top_level_key(tmp_path):
+    """AC6: unknown top-level key raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _VALID_BASE + "\n[unknown-section]\nfoo = 'bar'\n"
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="additional property"):
+        load_catalogue_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# T3: schema drift + repo catalogue.toml
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]  # packages/agentbundle/tests/unit -> repo root
+
+
+def test_schema_copies_byte_equal():
+    """AC4: both schema copies are byte-identical."""
+    src = _REPO_ROOT / "docs" / "contracts" / "catalogue.schema.json"
+    dst = _REPO_ROOT / "packages" / "agentbundle" / "agentbundle" / "_data" / "catalogue.schema.json"
+    assert src.exists(), f"Schema missing at {src}"
+    assert dst.exists(), f"Schema copy missing at {dst}"
+    assert src.read_bytes() == dst.read_bytes(), "Schema copies are not byte-identical"
+
+
+def test_repo_catalogue_toml_valid():
+    """AC7: repo-root catalogue.toml passes load_catalogue_config validation."""
+    from agentbundle.catalogue_tooling.config import load_catalogue_config
+
+    result = load_catalogue_config(_REPO_ROOT)
+    assert result is not None, "load_catalogue_config returned None for repo root"
+
+
+# ---------------------------------------------------------------------------
+# T4: CLI stub subcommand groups
+# ---------------------------------------------------------------------------
+
+
+def _run_agentbundle(*args: str) -> tuple[int, str, str]:
+    """Run agentbundle as a subprocess; return (rc, stdout, stderr)."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "agentbundle", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO_ROOT / "packages" / "agentbundle"),
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_cli_catalogue_group_help():
+    """AC9: agentbundle catalogue --help exits non-zero and lists subcommands."""
+    rc, stdout, stderr = _run_agentbundle("catalogue", "--help")
+    combined = stdout + stderr
+    assert rc != 0, f"Expected non-zero exit for catalogue stub, got {rc}"
+    for sub in ("lint", "verify", "build", "self-host", "package", "sync-defaults"):
+        assert sub in combined, f"'{sub}' not found in catalogue --help output"
+
+
+def test_cli_lint_packs_help():
+    """AC10: agentbundle lint packs --help exits non-zero and shows --root."""
+    rc, stdout, stderr = _run_agentbundle("lint", "packs", "--help")
+    combined = stdout + stderr
+    assert rc != 0, f"Expected non-zero exit for lint packs stub, got {rc}"
+    assert "--root" in combined, "--root not found in lint packs --help output"

--- a/workspace.toml
+++ b/workspace.toml
@@ -353,7 +353,8 @@ active  = []
 backlog = []
 
 ["ini-005".work]
-active  = [
+active  = []
+shipped = [
   "spec/catalogue-tooling-foundation",
 ]
 queue   = [

--- a/workspace.toml
+++ b/workspace.toml
@@ -280,7 +280,9 @@ open = [
   # After live-DC transcript: decide broker-side pattern-host confinement for success_url_pattern.
   {slug = "atlassian-sso-cookie-success-url-pattern-host-confinement", summary = "Decide broker-side pattern-host confinement after the live-DC transcript", needs = "backlog:atlassian-sso-cookie-live-dc-read-transcript"},
 
-  # Six platform × mode credential-broker QA transcripts (macOS/Windows/Linux × creds/sso-cookie).
+  # Six platform × mode credential-broker QA transcripts:
+  # `creds` × macOS, `creds` × Windows, `creds` × Linux,
+  # `sso-cookie` × macOS, `sso-cookie` × Windows, `sso-cookie` × Linux.
   {slug = "credential-broker-contract-manual-qa", summary = "Six platform x mode credential-broker QA transcripts"},
 
   # First real Artifactory upload: configure three GitHub secrets then push a tag. Blocked on credentials.


### PR DESCRIPTION
## Summary

- Creates `agentbundle/catalogue_tooling/` package with 11 modules as the portable catalogue engine (ini-005 Bucket 1)
- Implements `catalogue.toml` configuration schema (JSON Schema + TOML loading + 14 validation rules) per Bucket 3
- Writes repo's `catalogue.toml` and both schema copies (docs/contracts + _data/); drift test asserts byte equality
- Registers `agentbundle catalogue <sub>` and `agentbundle lint packs` CLI stub groups; all exit 1 with "not yet implemented" until Wave 2–4 fill them

## Test plan

- [ ] 24 tests in `test_catalogue_tooling_foundation.py` all pass (`pytest tests/unit/test_catalogue_tooling_foundation.py`)
- [ ] Full unit suite clean: `pytest tests/unit/ --ignore=tests/unit/test_credential_broker_contract_docs.py` → 1662 passed, 2 skipped
  - `test_credential_broker_contract_docs.py::test_ac42_roadmap_entry_carries_manual_qa_matrix` is a **pre-existing failure** (fails on main before this PR; tracked in `[backlog].open` as `credential-broker-contract-manual-qa`)
- [ ] `agentbundle catalogue --help` exits 1 and lists all 6 sub-subcommands
- [ ] `agentbundle lint packs --help` exits 1 and shows `--root`
- [ ] `load_catalogue_config(REPO_ROOT)` validates repo's `catalogue.toml` successfully

## Deferred

None — all ACs shipped.

## Bundled fixes

None.