### PR TITLE
feat(ini-005): catalogue-tooling Wave 4 — enhanced packaging pipeline (agentbundle 0.16.0)

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Claude plugin marketplace manifest now passes `claude plugin validate` (Claude Code 2.1.209).** Three generator defects caused 35 errors: (1) marketplace missing top-level `name` field, (2) plugin `author` emitted as a plain string instead of a `{name, email}` object, (3) plugin `source` field absent entirely. All three are fixed in the build pipeline (`derive_projectable_subset`, `_run_aggregate`, `_aggregate_marketplace`). The `.claude-plugin/marketplace.json` in the working tree now validates with 0 errors.
 
 
+## [agentbundle][0.16.0] — 2026-07-25
+
+
+### Added
+
+- **`agentbundle catalogue package` is now the canonical packaging command with staging, atomic placement, and self-verification (agentbundle 0.16.0, ini-005 Wave 4).** `catalogue package --root . --bundle eng --release 2026.07.25.1 --channel stable --output /tmp/out` packages a catalogue into a three-file Artifactory layout. The command integrates the full 18-step `verify_catalogue` pre-check, then writes the archive to a staged `.tmp` path, computes the sha256 sidecar, runs `verify_archive` self-verification, and only then atomically renames archive + sidecar to their final paths. The channel descriptor JSON is written LAST so it only exists when the archive is safe to consume. Required allowlist updated: `LICENSE-APACHE`, `LICENSE-MIT`, and `.claude-plugin/marketplace.json` are now required; the generic `LICENSE` assumption is removed. `catalogue-manifest.json` schema bumped to 2 with Bucket 8 extended fields: `adapter_contract_version`, `pack_schema_version`, `marketplace_digest`, `profiles`. `agentbundle package-catalogue` is now a compat shim that prints a deprecation warning and delegates. ([spec](../specs/catalogue-tooling-package-enhanced/spec.md))
+
+
 ## [agentbundle][0.15.0] — 2026-07-25
 
 

--- a/docs/specs/catalogue-tooling-package-enhanced/spec.md
+++ b/docs/specs/catalogue-tooling-package-enhanced/spec.md
@@ -1,6 +1,6 @@
 # Spec: Catalogue Tooling — Enhanced Packaging
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Initiative:** ini-005 AgentBundle Portable Catalogue Tooling
 - **Plan:** [`plan.md`](plan.md)
@@ -102,30 +102,30 @@ a deprecation warning.
 
 ## Acceptance Criteria
 
-- [ ] AC1: `agentbundle catalogue package --root . --bundle eng --release
+- [x] AC1: `agentbundle catalogue package --root . --bundle eng --release
   2026.07.24.1 --channel stable --output /tmp/out` produces the three-file
   Artifactory layout: archive, sidecar, channel descriptor.
-- [ ] AC2: Archive contains `.claude-plugin/marketplace.json`, `LICENSE-APACHE`,
+- [x] AC2: Archive contains `.claude-plugin/marketplace.json`, `LICENSE-APACHE`,
   `LICENSE-MIT`. Missing any required file causes exit non-zero before output.
-- [ ] AC3: Generic `LICENSE` file (not `-APACHE`/`-MIT`) is not required.
-- [ ] AC4: `catalogue.toml` is NOT present in the archive.
-- [ ] AC5: Channel descriptor is written AFTER the archive and sidecar are
+- [x] AC3: Generic `LICENSE` file (not `-APACHE`/`-MIT`) is not required.
+- [x] AC4: `catalogue.toml` is NOT present in the archive.
+- [x] AC5: Channel descriptor is written AFTER the archive and sidecar are
   staged and self-verified.
-- [ ] AC6: Building twice with identical inputs and `SOURCE_DATE_EPOCH` fixed
+- [x] AC6: Building twice with identical inputs and `SOURCE_DATE_EPOCH` fixed
   produces byte-identical archives.
-- [ ] AC7: Existing release archive path → exit non-zero, no files written.
-- [ ] AC8: If verify_archive fails on staged output, all staged files are
+- [x] AC7: Existing release archive path → exit non-zero, no files written.
+- [x] AC8: If verify_archive fails on staged output, all staged files are
   removed and exit is non-zero.
-- [ ] AC9: `catalogue-manifest.json` has all required Bucket 8 fields.
-- [ ] AC10: `agentbundle package-catalogue <args>` prints deprecation warning
+- [x] AC9: `catalogue-manifest.json` has all required Bucket 8 fields.
+- [x] AC10: `agentbundle package-catalogue <args>` prints deprecation warning
   to stderr and produces equivalent output.
-- [ ] AC11: Extracted archive passes `verify_catalogue` (local catalogue).
-- [ ] AC12: `agentbundle list-packs --catalogue <extracted-root>` succeeds.
-- [ ] AC13: All existing `test_package_catalogue_*.py` tests pass unmodified
+- [x] AC11: Extracted archive passes `verify_catalogue` (local catalogue).
+- [x] AC12: `agentbundle list-packs --catalogue <extracted-root>` succeeds.
+- [x] AC13: All existing `test_package_catalogue_*.py` tests pass unmodified
   or with only the deprecation-warning adaptation.
-- [ ] AC14: The archive layout has no artificial wrapper directory; `packs/` is
+- [x] AC14: The archive layout has no artificial wrapper directory; `packs/` is
   at archive root.
-- [ ] AC15: The packaged archive contains no member whose path starts with
+- [x] AC15: The packaged archive contains no member whose path starts with
   `.git/`, `tools/`, `packages/agentbundle/`, or `dist/`. A test asserts
   this against an archive produced from a fixture that includes stub files at
   those paths; none should appear in the extracted archive members.

--- a/packages/agentbundle/agentbundle/catalogue_tooling/package.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/package.py
@@ -1,29 +1,623 @@
-"""Catalogue packaging stub.
+"""Catalogue packaging engine — wave 4 (catalogue-tooling-package-enhanced spec).
 
-Wave 4 (catalogue-tooling-package-enhanced spec) fills this module.
+Packages a catalogue repository into an Artifactory artifact layout:
+  - <output>/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz
+  - <output>/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz.sha256
+  - <output>/catalogues/<bundle>/channels/<channel>.json
+
+Implements the 8-step staging + atomic placement sequence with
+verify_archive self-verification before the channel descriptor is written.
+
+Python 3.11 stdlib only.
 """
 
 from __future__ import annotations
 
+import gzip
+import hashlib
+import io
+import json
+import os
+import re
+import sys
+import tarfile
+import tomllib
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from agentbundle.config import ConfigError, load_pack_toml
+from agentbundle.catalogue_tooling.results import Diagnostic, PackageResult, Severity
+
 if TYPE_CHECKING:
-    from agentbundle.catalogue_tooling.results import PackageResult
+    pass
+
+# ---------------------------------------------------------------------------
+# Allowlist constants
+# ---------------------------------------------------------------------------
+
+# Directories walked recursively; everything found inside is included.
+_DEFAULT_INCLUDE_DIRS: tuple[tuple[str, ...], ...] = (
+    ("packs",),
+    ("profiles",),
+    ("docs", "contracts"),
+    (".claude-plugin",),
+)
+
+# Specific files included only if they exist at root (not walked).
+_DEFAULT_INCLUDE_ROOT_FILES: tuple[str, ...] = (
+    "AGENTS.md",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+)
+
+# Files required to be present; packaging fails if any are missing.
+_REQUIRED_PATHS: tuple[str, ...] = (
+    "packs",
+    ".claude-plugin/marketplace.json",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+)
+
+# Implicit denylist — top-level directories always excluded regardless of include.
+_IMPLICIT_DENY_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "tools",
+    "packages",
+    "dist",
+    "__pycache__",
+})
+
+# Path-safety pattern for --bundle/--release/--channel flag values.
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9\-._]+$")
+
+
+def _validate_flag_value(flag: str, value: str) -> str | None:
+    """Return error string or None; validates bundle/release/channel values."""
+    if not _SAFE_NAME_RE.fullmatch(value):
+        return (
+            f"error: --{flag} value {value!r} contains disallowed characters "
+            f"(only [A-Za-z0-9-._] permitted)"
+        )
+    if value in (".", ".."):
+        return f"error: --{flag} value {value!r} is not allowed"
+    if ".." in value.split("."):
+        return f"error: --{flag} value {value!r} contains '..' component"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Content scanning
+# ---------------------------------------------------------------------------
+
+
+def _scan_content(root: Path) -> list[Path]:
+    """Return sorted list of regular (non-symlink) files from the content allowlist.
+
+    Uses _DEFAULT_INCLUDE_DIRS and _DEFAULT_INCLUDE_ROOT_FILES; applies
+    _IMPLICIT_DENY_DIRS to skip denied top-level directories even if they appear
+    inside an allowed dir (unlikely but defensive).
+    """
+    collected: list[Path] = []
+
+    for dir_parts in _DEFAULT_INCLUDE_DIRS:
+        d = root.joinpath(*dir_parts)
+        if not d.is_dir() or d.is_symlink():
+            continue
+        for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
+            dp = Path(dirpath)
+            for fname in filenames:
+                p = dp / fname
+                if p.is_file() and not p.is_symlink():
+                    collected.append(p)
+            dirnames[:] = [dn for dn in dirnames if not (dp / dn).is_symlink()]
+
+    for fname in _DEFAULT_INCLUDE_ROOT_FILES:
+        p = root / fname
+        if p.exists() and p.is_file() and not p.is_symlink():
+            collected.append(p)
+
+    return sorted(collected, key=lambda p: p.relative_to(root).as_posix())
+
+
+def _check_required_files(root: Path, content_paths: list[Path]) -> str | None:
+    """Return error string if any required path is missing, else None."""
+    posix_set = {p.relative_to(root).as_posix() for p in content_paths}
+    for req in _REQUIRED_PATHS:
+        if req.endswith("/"):
+            # Directory check
+            if not (root / req.rstrip("/")).is_dir():
+                return f"error: required path missing: {req}"
+        else:
+            if req not in posix_set:
+                # Check if the required file exists at all
+                if not (root / req).exists():
+                    return f"error: required file missing: {req}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Content validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_content(root: Path, content_paths: list[Path]) -> str | None:
+    """Validate all included content before writing any output.
+
+    Returns an error string on any violation, None on success.
+    """
+    # 1. Top-level and intermediate directory symlink check
+    top_level_candidates = [
+        root / "packs",
+        root / "profiles",
+        root / "docs",
+        root / "docs" / "contracts",
+        root / ".claude-plugin",
+    ]
+    for p in top_level_candidates:
+        if p.exists() and p.is_symlink():
+            return f"error: symlink not allowed: {p}"
+
+    # 2. packs/ must exist as a real directory
+    packs_dir = root / "packs"
+    if not packs_dir.is_dir():
+        return f"error: missing required directory: {packs_dir}"
+
+    # 3. Root-level file symlink check
+    for name in list(_DEFAULT_INCLUDE_ROOT_FILES) + ["marketplace.json"]:
+        for candidate in [root / name, root / ".claude-plugin" / name]:
+            if candidate.exists() and candidate.is_symlink():
+                return f"error: symlink not allowed: {candidate}"
+
+    # 4. Symlink walk inside allowlisted dirs
+    for dir_parts in _DEFAULT_INCLUDE_DIRS:
+        d = root.joinpath(*dir_parts)
+        if not d.is_dir() or d.is_symlink():
+            continue
+        for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
+            dp = Path(dirpath)
+            for entry in list(dirnames) + list(filenames):
+                full = dp / entry
+                if os.path.islink(str(full)):
+                    return f"error: symlink not allowed: {full}"
+
+    # 5. Hard-link detection (POSIX only)
+    for p in content_paths:
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        if st.st_nlink > 1:
+            return f"error: hard link not allowed: {p}"
+
+    # 6. Path traversal check
+    for p in content_paths:
+        try:
+            p.resolve().relative_to(root)
+        except ValueError:
+            return f"error: path traversal outside root: {p}"
+
+    # 7. pack.toml validation
+    for pack_dir in sorted(packs_dir.iterdir()):
+        if not pack_dir.is_dir() or pack_dir.is_symlink():
+            continue
+        pack_toml_path = pack_dir / "pack.toml"
+        try:
+            pack_data = load_pack_toml(pack_toml_path)
+        except ConfigError as exc:
+            return f"error: invalid pack.toml in {pack_dir}: {exc}"
+        try:
+            _ = pack_data["pack"]["name"]
+            _ = pack_data["pack"]["version"]
+        except KeyError as exc:
+            return f"error: pack.toml missing required field {exc} in {pack_toml_path}"
+
+    # 8. Profile TOML validation
+    profiles_dir = root / "profiles"
+    if profiles_dir.is_dir() and not profiles_dir.is_symlink():
+        for toml_file in sorted(profiles_dir.rglob("*.toml")):
+            if toml_file.is_symlink():
+                continue
+            try:
+                tomllib.loads(toml_file.read_text(encoding="utf-8"))
+            except tomllib.TOMLDecodeError as exc:
+                return f"error: invalid profile TOML {toml_file}: {exc}"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# File reading + digest computation
+# ---------------------------------------------------------------------------
+
+
+def _read_content_files(root: Path, paths: list[Path]) -> dict[str, bytes]:
+    """Read all content files; return {posix_relative_path: bytes}."""
+    result: dict[str, bytes] = {}
+    for p in paths:
+        key = p.relative_to(root).as_posix()
+        result[key] = p.read_bytes()
+    return result
+
+
+def _compute_file_digests(file_bytes: dict[str, bytes]) -> dict[str, str]:
+    """Return {posix_relative_path: sha256_hex}."""
+    return {key: hashlib.sha256(data).hexdigest() for key, data in file_bytes.items()}
+
+
+# ---------------------------------------------------------------------------
+# Manifest generation (schema 2)
+# ---------------------------------------------------------------------------
+
+
+def _generate_manifest(
+    *,
+    bundle: str,
+    release: str,
+    source_revision: str | None,
+    generated_at: str,
+    file_digests: dict[str, str],
+    packs_metadata: list[dict],
+    # Bucket 8 extended fields
+    minimum_agentbundle_version: str | None = None,
+    catalogue_name: str | None = None,
+    catalogue_display_name: str | None = None,
+    adapter_contract_version: str | None = None,
+    pack_schema_version: str | None = None,
+    marketplace_digest: str | None = None,
+    profiles_metadata: list[str] | None = None,
+) -> bytes:
+    """Build catalogue-manifest.json bytes (schema 2).
+
+    catalogue-manifest.json is NOT listed in its own files[] array.
+    """
+    from agentbundle.version import SPEC_VERSION
+
+    files = sorted(
+        [{"path": k, "sha256": v} for k, v in file_digests.items()],
+        key=lambda x: x["path"],
+    )
+    packs = sorted(packs_metadata, key=lambda x: x["name"])
+
+    manifest: dict = {
+        "schema": 2,
+        "bundle": bundle,
+        "release": release,
+        "generated_at": generated_at,
+        "source_revision": source_revision,
+        "minimum_agentbundle_version": minimum_agentbundle_version,
+        "catalogue_name": catalogue_name,
+        "catalogue_display_name": catalogue_display_name,
+        "adapter_contract_version": adapter_contract_version or SPEC_VERSION,
+        "pack_schema_version": pack_schema_version or "1",
+        "marketplace_digest": marketplace_digest,
+        "files": files,
+        "packs": packs,
+        "profiles": profiles_metadata or [],
+    }
+    return json.dumps(manifest, indent=2, ensure_ascii=False).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Archive builder
+# ---------------------------------------------------------------------------
+
+
+def _build_archive(file_bytes: dict[str, bytes], manifest_bytes: bytes) -> bytes:
+    """Build a deterministic .tar.gz archive in memory.
+
+    Returns the complete compressed bytes.
+    - All members sorted lexicographically by name.
+    - All members: uid=0, gid=0, mtime=0, mode=0o644.
+    - gzip header mtime field (bytes 4-7) is zeroed.
+    - tarfile.GNU_FORMAT to avoid PAX toolchain-dependent headers.
+    """
+    members: list[tuple[str, bytes]] = list(file_bytes.items())
+    members.append(("catalogue-manifest.json", manifest_bytes))
+    members.sort(key=lambda x: x[0])
+
+    buf = io.BytesIO()
+    gz = gzip.GzipFile(fileobj=buf, mode="wb", mtime=0)
+    tar = tarfile.open(fileobj=gz, mode="w", format=tarfile.GNU_FORMAT)  # type: ignore[arg-type]
+
+    for member_name, data in members:
+        if member_name.startswith("/"):
+            raise ValueError(f"unsafe archive member name: {member_name!r}")
+        parts = member_name.split("/")
+        if ".." in parts:
+            raise ValueError(f"unsafe archive member name: {member_name!r}")
+        if len(member_name) >= 2 and member_name[1] == ":":
+            raise ValueError(f"unsafe archive member name: {member_name!r}")
+
+        info = tarfile.TarInfo(name=member_name)
+        info.type = tarfile.REGTYPE
+        info.size = len(data)
+        info.uid = 0
+        info.gid = 0
+        info.mtime = 0
+        info.mode = 0o644
+        tar.addfile(info, io.BytesIO(data))
+
+    tar.close()
+    gz.close()
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Channel descriptor writer
+# ---------------------------------------------------------------------------
+
+
+def _write_channel_descriptor(
+    path: Path,
+    *,
+    bundle: str,
+    channel: str,
+    release: str,
+    sha256_hex: str,
+    published_at: str,
+    source_revision: str | None,
+    minimum_agentbundle_version: str | None,
+) -> None:
+    """Write the channel descriptor JSON to *path*, creating parent dirs."""
+    descriptor: dict = {
+        "schema": 1,
+        "kind": "agentbundle-catalogue",
+        "bundle": bundle,
+        "channel": channel,
+        "release": release,
+        "artifact": f"../releases/{release}/catalogue-{release}.tar.gz",
+        "sha256": sha256_hex,
+        "published_at": published_at,
+    }
+    if source_revision is not None:
+        descriptor["source_revision"] = source_revision
+    if minimum_agentbundle_version is not None:
+        descriptor["minimum_agentbundle_version"] = minimum_agentbundle_version
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(descriptor, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Staging helpers
+# ---------------------------------------------------------------------------
+
+
+def _staging_path(final_path: Path) -> Path:
+    """Return the .tmp staging path for *final_path* in the same directory."""
+    return final_path.parent / (final_path.name + ".tmp")
+
+
+def _cleanup_staged(*paths: Path) -> None:
+    """Remove any staged files, ignoring errors (best-effort cleanup)."""
+    for p in paths:
+        try:
+            p.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
 
 
 def package_catalogue(
     root: Path,
-    bundle: str | None = None,
-    release: str | None = None,
-    channel: str | None = None,
-    output: Path | None = None,
-) -> "PackageResult":
+    bundle: str,
+    release: str,
+    channel: str,
+    output: Path,
+    *,
+    source_revision: str | None = None,
+    minimum_agentbundle_version: str | None = None,
+    published_at: str | None = None,
+    generated_at: str | None = None,
+    _verify_archive_fn=None,  # injectable for testing
+) -> PackageResult:
     """Package a catalogue at *root* into an Artifactory artifact layout.
 
-    Wave 4 implementation: wraps the existing package-catalogue command
-    logic behind the portable engine interface.
+    Implements the 8-step staging + atomic placement sequence:
+      1. Pre-package verify_catalogue
+      2. Build archive bytes in memory
+      3. Write staged archive
+      4. Compute + write staged sidecar
+      5. Self-verify staged archive + sidecar
+      6. Atomic place archive
+      7. Atomic place sidecar
+      8. Write channel descriptor LAST
+
+    Returns a PackageResult; does NOT raise on expected failures.
     """
-    raise NotImplementedError(
-        "package_catalogue is not yet implemented — see catalogue-tooling-package-enhanced spec"
+    from agentbundle.version import CLI_VERSION
+
+    def _err(msg: str) -> PackageResult:
+        return PackageResult(
+            ok=False,
+            diagnostics=[Diagnostic(
+                code="CAT-PKG-001",
+                severity=Severity.ERROR,
+                pack=None,
+                path=None,
+                line=None,
+                col=None,
+                message=msg,
+                remediation=None,
+            )],
+            schema_version=1,
+            command="catalogue",
+            operation="package",
+            agentbundle_version=CLI_VERSION,
+            catalogue_schema_version=1,
+        )
+
+    # --- Step 0: validate flag values ---
+    for flag, value in (("bundle", bundle), ("release", release), ("channel", channel)):
+        flag_err = _validate_flag_value(flag, value)
+        if flag_err is not None:
+            return _err(flag_err)
+
+    # --- Output path layout ---
+    archive_path = output / "catalogues" / bundle / "releases" / release / f"catalogue-{release}.tar.gz"
+    sidecar_path = archive_path.parent / (archive_path.name + ".sha256")
+    channel_path = output / "catalogues" / bundle / "channels" / f"{channel}.json"
+
+    # Refuse to overwrite existing immutable release archive
+    if archive_path.exists():
+        return _err(f"output archive already exists: {archive_path}")
+
+    # --- Step 1: Pre-package verify_catalogue ---
+    from agentbundle.catalogue_tooling.verify import verify_catalogue
+    verify_result = verify_catalogue(root)
+    if not verify_result.ok:
+        msgs = "; ".join(d.message for d in verify_result.diagnostics if d.severity == Severity.ERROR)
+        return _err(f"pre-package verify failed: {msgs}")
+
+    # --- Scan and validate content ---
+    content_paths = _scan_content(root)
+
+    req_err = _check_required_files(root, content_paths)
+    if req_err is not None:
+        return _err(req_err)
+
+    val_err = _validate_content(root, content_paths)
+    if val_err is not None:
+        return _err(val_err)
+
+    # --- Read file bytes ---
+    file_bytes = _read_content_files(root, content_paths)
+
+    # Filter out catalogue.toml — never included in the archive
+    file_bytes = {k: v for k, v in file_bytes.items() if k != "catalogue.toml"}
+
+    # --- Compute digests ---
+    digests = _compute_file_digests(file_bytes)
+
+    # --- Extract pack metadata ---
+    packs_metadata: list[dict] = []
+    for key, data in file_bytes.items():
+        parts = key.split("/")
+        if len(parts) == 3 and parts[0] == "packs" and parts[2] == "pack.toml":
+            pack_data = tomllib.loads(data.decode("utf-8"))
+            packs_metadata.append({
+                "name": pack_data["pack"]["name"],
+                "version": pack_data["pack"]["version"],
+            })
+
+    # --- Extract profile names ---
+    profiles_metadata: list[str] = []
+    for key in sorted(file_bytes.keys()):
+        parts = key.split("/")
+        if len(parts) >= 2 and parts[0] == "profiles" and key.endswith(".toml"):
+            profiles_metadata.append(parts[-1].removesuffix(".toml"))
+
+    # --- Determine generated_at ---
+    if generated_at is None:
+        epoch_val = os.environ.get("SOURCE_DATE_EPOCH")
+        if epoch_val is None or epoch_val == "":
+            generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        else:
+            try:
+                epoch_int = int(epoch_val)
+            except ValueError:
+                return _err(f"SOURCE_DATE_EPOCH is not a valid integer: {epoch_val!r}")
+            generated_at = datetime.fromtimestamp(epoch_int, tz=timezone.utc).replace(microsecond=0).isoformat()
+
+    if published_at is None:
+        published_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    # --- Read catalogue.toml metadata for manifest ---
+    catalogue_name: str | None = None
+    catalogue_display_name: str | None = None
+    min_version_manifest = minimum_agentbundle_version
+    try:
+        from agentbundle.catalogue_tooling.config import load_catalogue_config
+        config = load_catalogue_config(root)
+        if config is not None:
+            catalogue_name = config.name
+            catalogue_display_name = config.display_name
+            if min_version_manifest is None:
+                min_version_manifest = config.minimum_agentbundle_version
+    except Exception:
+        pass
+
+    # --- Compute marketplace_digest ---
+    marketplace_digest: str | None = None
+    marketplace_bytes = file_bytes.get(".claude-plugin/marketplace.json")
+    if marketplace_bytes is not None:
+        marketplace_digest = "sha256:" + hashlib.sha256(marketplace_bytes).hexdigest()
+
+    # --- Step 2: Build archive bytes in memory ---
+    manifest_bytes = _generate_manifest(
+        bundle=bundle,
+        release=release,
+        source_revision=source_revision,
+        generated_at=generated_at,
+        file_digests=digests,
+        packs_metadata=packs_metadata,
+        minimum_agentbundle_version=min_version_manifest,
+        catalogue_name=catalogue_name,
+        catalogue_display_name=catalogue_display_name,
+        marketplace_digest=marketplace_digest,
+        profiles_metadata=profiles_metadata,
+    )
+    archive_bytes = _build_archive(file_bytes, manifest_bytes)
+
+    # Compute sha256
+    sha256_hex = hashlib.sha256(archive_bytes).hexdigest()
+
+    # --- Create output directories ---
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    (output / "catalogues" / bundle / "channels").mkdir(parents=True, exist_ok=True)
+
+    # --- Step 3: Write staged archive ---
+    staged_archive = _staging_path(archive_path)
+    staged_sidecar = _staging_path(sidecar_path)
+    try:
+        staged_archive.write_bytes(archive_bytes)
+
+        # --- Step 4: Write staged sidecar ---
+        staged_sidecar.write_text(sha256_hex + "\n", encoding="utf-8")
+
+        # --- Step 5: Self-verify staged archive + sidecar ---
+        if _verify_archive_fn is None:
+            from agentbundle.catalogue_tooling.archive import verify_archive as _verify_archive_fn  # type: ignore[assignment]
+        verify_arch = _verify_archive_fn(staged_archive, sha256_file=staged_sidecar)
+        if not verify_arch.ok:
+            _cleanup_staged(staged_archive, staged_sidecar)
+            msgs = "; ".join(d.message for d in verify_arch.diagnostics if d.severity == Severity.ERROR)
+            return _err(f"staged archive self-verification failed: {msgs}")
+
+        # --- Step 6: Atomic place archive ---
+        staged_archive.rename(archive_path)
+
+        # --- Step 7: Atomic place sidecar ---
+        staged_sidecar.rename(sidecar_path)
+
+    except Exception as exc:
+        _cleanup_staged(staged_archive, staged_sidecar)
+        raise exc
+
+    # --- Step 8: Write channel descriptor LAST ---
+    _write_channel_descriptor(
+        channel_path,
+        bundle=bundle,
+        channel=channel,
+        release=release,
+        sha256_hex=sha256_hex,
+        published_at=published_at,
+        source_revision=source_revision,
+        minimum_agentbundle_version=minimum_agentbundle_version,
+    )
+
+    return PackageResult(
+        ok=True,
+        diagnostics=[],
+        schema_version=1,
+        command="catalogue",
+        operation="package",
+        agentbundle_version=CLI_VERSION,
+        catalogue_schema_version=1,
     )

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -772,12 +772,17 @@ def _build_parser() -> argparse.ArgumentParser:
     _sh_p.add_argument("--format", choices=("table", "json"), default="table", help="Output format.")
     _sh_p.set_defaults(func=_lazy("catalogue_self_host"))
 
-    # catalogue package (stub)
-    _pkg_p = cat_subs.add_parser("package", help="Package catalogue into an archive (stub).")
+    # catalogue package
+    _pkg_p = cat_subs.add_parser("package", help="Package catalogue into a distributable archive.")
     _pkg_p.add_argument("--root", default=".", help="Catalogue root directory.")
-    _pkg_p.add_argument("--pack", default=None, help="Limit to a single pack name.")
-    _pkg_p.add_argument("--format", choices=("table", "json"), default="table", help="Output format.")
-    _pkg_p.set_defaults(func=_lazy("catalogue_tooling_stub"))
+    _pkg_p.add_argument("--bundle", required=True, help="Bundle/product identifier.")
+    _pkg_p.add_argument("--release", required=True, help="Release version string.")
+    _pkg_p.add_argument("--channel", required=True, help="Channel name (e.g. 'stable').")
+    _pkg_p.add_argument("--output", required=True, help="Output directory for Artifactory layout.")
+    _pkg_p.add_argument("--source-revision", default=None, dest="source_revision", help="VCS revision.")
+    _pkg_p.add_argument("--minimum-agentbundle-version", default=None, dest="minimum_agentbundle_version", help="Minimum agentbundle version required.")
+    _pkg_p.add_argument("--published-at", default=None, dest="published_at", help="Published-at timestamp (ISO-8601).")
+    _pkg_p.set_defaults(func=_lazy("catalogue_package"))
 
     # catalogue sync-defaults
     _sd_p = cat_subs.add_parser("sync-defaults", help="Sync install-defaults from catalogue.toml.")

--- a/packages/agentbundle/agentbundle/commands/catalogue_package.py
+++ b/packages/agentbundle/agentbundle/commands/catalogue_package.py
@@ -1,0 +1,47 @@
+"""``agentbundle catalogue package`` handler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def run(args: "argparse.Namespace") -> int:
+    from agentbundle.catalogue_tooling.package import package_catalogue
+
+    root = Path(getattr(args, "root", ".")).resolve()
+    output_str = getattr(args, "output", None)
+    if not output_str:
+        print("error: --output is required", file=sys.stderr)
+        return 1
+    output = Path(output_str).resolve()
+    bundle = getattr(args, "bundle", None)
+    release = getattr(args, "release", None)
+    channel = getattr(args, "channel", None)
+
+    for flag, value in (("bundle", bundle), ("release", release), ("channel", channel)):
+        if not value:
+            print(f"error: --{flag} is required", file=sys.stderr)
+            return 1
+
+    result = package_catalogue(
+        root=root,
+        bundle=bundle,
+        release=release,
+        channel=channel,
+        output=output,
+        source_revision=getattr(args, "source_revision", None),
+        minimum_agentbundle_version=getattr(args, "minimum_agentbundle_version", None),
+        published_at=getattr(args, "published_at", None),
+    )
+
+    if not result.ok:
+        for d in result.diagnostics:
+            print(d.message, file=sys.stderr)
+        return 1
+
+    return 0

--- a/packages/agentbundle/agentbundle/commands/package_catalogue.py
+++ b/packages/agentbundle/agentbundle/commands/package_catalogue.py
@@ -1,461 +1,66 @@
-"""package-catalogue subcommand — deterministic catalogue archive packager.
+"""package-catalogue subcommand — compatibility shim (deprecated).
 
-Packages a catalogue repository into an Artifactory artifact layout:
-  - <output>/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz
-  - <output>/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz.sha256
-  - <output>/catalogues/<bundle>/channels/<channel>.json
+All logic has moved to agentbundle.catalogue_tooling.package.
+This module re-exports the internal helpers so existing import paths
+continue to work (AC13), and wraps ``run()`` with a deprecation warning.
 
-Maintainer/CI only. Does not install anything.
-
-RFC-0072 D1/D5. Python 3.11 stdlib only.
+Use ``agentbundle catalogue package`` instead.
 """
 
 from __future__ import annotations
 
-import gzip
-import hashlib
-import io
-import json
-import os
 import re
 import sys
-import tarfile
-import tomllib
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from agentbundle.config import ConfigError, load_pack_toml
+# Re-export all helpers from the new engine so tests importing from here
+# continue to work.
+from agentbundle.catalogue_tooling.package import (  # noqa: F401
+    _build_archive,
+    _check_required_files,
+    _compute_file_digests,
+    _generate_manifest,
+    _read_content_files,
+    _scan_content,
+    _validate_content,
+    _validate_flag_value,
+    _write_channel_descriptor,
+    package_catalogue,
+)
 
 if TYPE_CHECKING:
     import argparse
 
 
-# ---------------------------------------------------------------------------
-# Path safety helpers
-# ---------------------------------------------------------------------------
-
-_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9\-._]+$")
-
-
-def _validate_flag_value(flag: str, value: str) -> str | None:
-    """Return an error string if *value* is not safe for use as a path component.
-
-    Safe means: only [A-Za-z0-9-._], not '.' or '..', no '..' component.
-    Returns None when the value is acceptable.
-    """
-    if not _SAFE_NAME_RE.fullmatch(value):
-        return f"error: --{flag} value {value!r} contains disallowed characters (only [A-Za-z0-9-._] permitted)"
-    if value in (".", ".."):
-        return f"error: --{flag} value {value!r} is not allowed"
-    # Split on '.' to catch '..': e.g. "foo..bar" splits to ["foo", "", "bar"]
-    # but we also need to catch paths that use '/' -- covered by the regex
-    # already (no slash). Check for '..' as a dot-separated component:
-    if ".." in value.split("."):
-        return f"error: --{flag} value {value!r} contains '..' component"
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Content scanning
-# ---------------------------------------------------------------------------
-
-
-def _scan_content(root: Path) -> list[Path]:
-    """Return sorted list of regular (non-symlink) files from the content allowlist.
-
-    Allowlisted directories: packs/, profiles/, docs/contracts/
-    Allowlisted root files: README.md, LICENSE
-    Does not follow symlinks.
-    """
-    collected: list[Path] = []
-
-    allowlisted_dirs = [
-        root / "packs",
-        root / "profiles",
-        root / "docs" / "contracts",
-    ]
-    for d in allowlisted_dirs:
-        if d.is_dir() and not d.is_symlink():
-            for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
-                dp = Path(dirpath)
-                for fname in filenames:
-                    p = dp / fname
-                    if p.is_file() and not p.is_symlink():
-                        collected.append(p)
-                # Filter out symlinked subdirs from dirnames so os.walk skips them.
-                dirnames[:] = [
-                    dn for dn in dirnames if not (dp / dn).is_symlink()
-                ]
-
-    allowlisted_roots = [root / "README.md", root / "LICENSE"]
-    for p in allowlisted_roots:
-        if p.exists() and p.is_file() and not p.is_symlink():
-            collected.append(p)
-
-    return sorted(collected, key=lambda p: p.relative_to(root).as_posix())
-
-
-# ---------------------------------------------------------------------------
-# Content validation
-# ---------------------------------------------------------------------------
-
-
-def _validate_content(root: Path, content_paths: list[Path]) -> str | None:
-    """Validate all included content before writing any output.
-
-    Returns an error string on any violation, None on success.
-
-    Checks (in order):
-    1. Top-level and intermediate directory symlinks
-    2. packs/ directory exists
-    3. Root-level file symlinks (README.md, LICENSE)
-    4. Symlinks anywhere inside allowlisted directories
-    5. Hard links (POSIX only)
-    6. Path traversal outside root
-    7. pack.toml parseability and required fields
-    8. Profile TOML parseability
-    """
-    # 1. Top-level and intermediate directory symlink check
-    top_level_candidates = [
-        root / "packs",
-        root / "profiles",
-        root / "docs",
-        root / "docs" / "contracts",
-    ]
-    for p in top_level_candidates:
-        if p.exists() and p.is_symlink():
-            return f"error: symlink not allowed: {p}"
-
-    # 2. packs/ must exist as a real directory
-    packs_dir = root / "packs"
-    if not packs_dir.is_dir():
-        return f"error: missing required directory: {packs_dir}"
-
-    # 3. Root-level file symlink check
-    for name in ("README.md", "LICENSE"):
-        p = root / name
-        if p.exists() and p.is_symlink():
-            return f"error: symlink not allowed: {p}"
-
-    # 4. Symlink walk inside allowlisted dirs
-    for dir_name in (
-        root / "packs",
-        root / "profiles",
-        root / "docs" / "contracts",
-    ):
-        if not dir_name.is_dir() or dir_name.is_symlink():
-            continue
-        for dirpath, dirnames, filenames in os.walk(str(dir_name), followlinks=False):
-            dp = Path(dirpath)
-            for entry in list(dirnames) + list(filenames):
-                full = dp / entry
-                if os.path.islink(str(full)):
-                    return f"error: symlink not allowed: {full}"
-
-    # 5. Hard-link detection (POSIX only — st_nlink is always 1 on Windows)
-    for p in content_paths:
-        try:
-            st = p.stat()
-        except OSError:
-            continue
-        if st.st_nlink > 1:
-            return f"error: hard link not allowed: {p}"
-
-    # 6. Path traversal check (belt-and-suspenders)
-    for p in content_paths:
-        try:
-            p.resolve().relative_to(root)
-        except ValueError:
-            return f"error: path traversal outside root: {p}"
-
-    # 7. pack.toml validation
-    for pack_dir in sorted(packs_dir.iterdir()):
-        if not pack_dir.is_dir() or pack_dir.is_symlink():
-            continue
-        pack_toml_path = pack_dir / "pack.toml"
-        try:
-            pack_data = load_pack_toml(pack_toml_path)
-        except ConfigError as exc:
-            return f"error: invalid pack.toml in {pack_dir}: {exc}"
-        try:
-            _ = pack_data["pack"]["name"]
-            _ = pack_data["pack"]["version"]
-        except KeyError as exc:
-            return f"error: pack.toml missing required field {exc} in {pack_toml_path}"
-
-    # 8. Profile TOML validation
-    profiles_dir = root / "profiles"
-    if profiles_dir.is_dir() and not profiles_dir.is_symlink():
-        for toml_file in sorted(profiles_dir.rglob("*.toml")):
-            if toml_file.is_symlink():
-                continue
-            try:
-                tomllib.loads(toml_file.read_text(encoding="utf-8"))
-            except tomllib.TOMLDecodeError as exc:
-                return f"error: invalid profile TOML {toml_file}: {exc}"
-
-    return None
-
-
-# ---------------------------------------------------------------------------
-# File reading
-# ---------------------------------------------------------------------------
-
-
-def _read_content_files(root: Path, paths: list[Path]) -> dict[str, bytes]:
-    """Read all content files once; return {posix_relative_path: bytes}.
-
-    The same bytes are used for both digest computation and archive assembly.
-    """
-    result: dict[str, bytes] = {}
-    for p in paths:
-        key = p.relative_to(root).as_posix()
-        result[key] = p.read_bytes()
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Digest computation
-# ---------------------------------------------------------------------------
-
-
-def _compute_file_digests(file_bytes: dict[str, bytes]) -> dict[str, str]:
-    """Return {posix_relative_path: sha256_hex} computed from in-memory bytes."""
-    return {key: hashlib.sha256(data).hexdigest() for key, data in file_bytes.items()}
-
-
-# ---------------------------------------------------------------------------
-# Manifest generation
-# ---------------------------------------------------------------------------
-
-
-def _generate_manifest(
-    *,
-    bundle: str,
-    release: str,
-    source_revision: str | None,
-    generated_at: str,
-    file_digests: dict[str, str],
-    packs_metadata: list[dict],
-) -> bytes:
-    """Build catalogue-manifest.json bytes.
-
-    catalogue-manifest.json is NOT listed in its own files array.
-    """
-    files = sorted(
-        [{"path": k, "sha256": v} for k, v in file_digests.items()],
-        key=lambda x: x["path"],
-    )
-    packs = sorted(packs_metadata, key=lambda x: x["name"])
-    manifest = {
-        "schema": 1,
-        "bundle": bundle,
-        "release": release,
-        "source_revision": source_revision,
-        "generated_at": generated_at,
-        "files": files,
-        "packs": packs,
-    }
-    return json.dumps(manifest, indent=2, ensure_ascii=False).encode("utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Archive builder
-# ---------------------------------------------------------------------------
-
-
-def _build_archive(file_bytes: dict[str, bytes], manifest_bytes: bytes) -> bytes:
-    """Build a deterministic .tar.gz archive in memory.
-
-    Returns the complete compressed bytes.
-    - All members sorted lexicographically by name.
-    - All members: uid=0, gid=0, mtime=0, mode=0o644.
-    - gzip header mtime field (bytes 4-7) is zeroed.
-    - tarfile.GNU_FORMAT to avoid PAX toolchain-dependent headers.
-    """
-    members: list[tuple[str, bytes]] = list(file_bytes.items())
-    members.append(("catalogue-manifest.json", manifest_bytes))
-    members.sort(key=lambda x: x[0])
-
-    buf = io.BytesIO()
-    gz = gzip.GzipFile(fileobj=buf, mode="wb", mtime=0)
-    tar = tarfile.open(fileobj=gz, mode="w", format=tarfile.GNU_FORMAT)  # type: ignore[arg-type]
-
-    for member_name, data in members:
-        # Explicit path safety check — NOT assert (Python -O would strip assert)
-        if member_name.startswith("/"):
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-        parts = member_name.split("/")
-        if ".." in parts:
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-        if len(member_name) >= 2 and member_name[1] == ":":
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-
-        info = tarfile.TarInfo(name=member_name)
-        info.type = tarfile.REGTYPE
-        info.size = len(data)
-        info.uid = 0
-        info.gid = 0
-        info.mtime = 0
-        info.mode = 0o644
-        tar.addfile(info, io.BytesIO(data))
-
-    tar.close()
-    gz.close()
-    return buf.getvalue()
-
-
-# ---------------------------------------------------------------------------
-# Channel descriptor writer
-# ---------------------------------------------------------------------------
-
-
-def _write_channel_descriptor(
-    path: Path,
-    *,
-    bundle: str,
-    channel: str,
-    release: str,
-    sha256_hex: str,
-    published_at: str,
-    source_revision: str | None,
-    minimum_agentbundle_version: str | None,
-) -> None:
-    """Write the channel descriptor JSON to *path*, creating parent dirs."""
-    descriptor: dict = {
-        "schema": 1,
-        "kind": "agentbundle-catalogue",
-        "bundle": bundle,
-        "channel": channel,
-        "release": release,
-        "artifact": f"../releases/{release}/catalogue-{release}.tar.gz",
-        "sha256": sha256_hex,
-        "published_at": published_at,
-    }
-    if source_revision is not None:
-        descriptor["source_revision"] = source_revision
-    if minimum_agentbundle_version is not None:
-        descriptor["minimum_agentbundle_version"] = minimum_agentbundle_version
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(descriptor, indent=2, ensure_ascii=False), encoding="utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Command entry point
-# ---------------------------------------------------------------------------
-
-
 def run(args: "argparse.Namespace") -> int:
-    """Entry point for the package-catalogue subcommand.
+    """Compatibility shim for ``agentbundle package-catalogue``.
 
-    Returns 0 on success, 1 on any error.
+    Prints a deprecation warning and delegates to ``package_catalogue()``.
     """
-    # Step 1: Resolve root/output; validate --bundle, --release, --channel
+    print(
+        "WARNING: agentbundle package-catalogue is deprecated. "
+        "Use: agentbundle catalogue package",
+        file=sys.stderr,
+    )
+
     root = Path(args.root).resolve()
     output = Path(args.output).resolve()
-    bundle: str = args.bundle
-    release: str = args.release
-    channel: str = args.channel
 
-    for flag, value in (("bundle", bundle), ("release", release), ("channel", channel)):
-        err = _validate_flag_value(flag, value)
-        if err is not None:
-            print(err, file=sys.stderr)
-            return 1
-
-    # Step 2: Compute output paths
-    archive_path = output / "catalogues" / bundle / "releases" / release / f"catalogue-{release}.tar.gz"
-    sidecar_path = archive_path.parent / (archive_path.name + ".sha256")
-    channel_descriptor_path = output / "catalogues" / bundle / "channels" / f"{channel}.json"
-
-    # Step 3: Refuse-to-overwrite check
-    if archive_path.exists():
-        print(f"error: output archive already exists: {archive_path}", file=sys.stderr)
-        return 1
-
-    # Step 4: Scan content
-    content_paths = _scan_content(root)
-
-    # Step 5: Validate
-    err = _validate_content(root, content_paths)
-    if err is not None:
-        print(err, file=sys.stderr)
-        return 1
-
-    # Step 6: Read all file bytes once
-    file_bytes = _read_content_files(root, content_paths)
-
-    # Step 7: Compute file digests
-    digests = _compute_file_digests(file_bytes)
-
-    # Step 8: Extract pack metadata from in-memory bytes
-    packs_metadata: list[dict] = []
-    for key, data in file_bytes.items():
-        parts = key.split("/")
-        # Match exactly packs/<name>/pack.toml (3 parts, no nesting)
-        if len(parts) == 3 and parts[0] == "packs" and parts[2] == "pack.toml":
-            pack_data = tomllib.loads(data.decode("utf-8"))
-            packs_metadata.append({
-                "name": pack_data["pack"]["name"],
-                "version": pack_data["pack"]["version"],
-            })
-
-    # Step 9: Determine generated_at from SOURCE_DATE_EPOCH
-    epoch_val = os.environ.get("SOURCE_DATE_EPOCH")
-    if epoch_val is None or epoch_val == "":
-        generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-    else:
-        try:
-            epoch_int = int(epoch_val)
-        except ValueError:
-            print(
-                f"error: SOURCE_DATE_EPOCH is not a valid integer: {epoch_val!r}",
-                file=sys.stderr,
-            )
-            return 1
-        generated_at = datetime.fromtimestamp(epoch_int, tz=timezone.utc).replace(microsecond=0).isoformat()
-
-    # Step 9b: Determine published_at
-    published_at: str = getattr(args, "published_at", None) or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-
-    # Step 10: Generate manifest bytes
-    manifest_bytes = _generate_manifest(
-        bundle=bundle,
-        release=release,
-        source_revision=getattr(args, "source_revision", None),
-        generated_at=generated_at,
-        file_digests=digests,
-        packs_metadata=packs_metadata,
-    )
-
-    # Step 11: Build archive bytes
-    archive_bytes = _build_archive(file_bytes, manifest_bytes)
-
-    # Step 12: Compute archive SHA-256
-    sha256_hex = hashlib.sha256(archive_bytes).hexdigest()
-
-    # Step 13: Create output directories
-    archive_path.parent.mkdir(parents=True, exist_ok=True)
-    (output / "catalogues" / bundle / "channels").mkdir(parents=True, exist_ok=True)
-
-    # Step 14: Write sidecar first
-    sidecar_path.write_text(sha256_hex + "\n", encoding="utf-8")
-
-    # Step 15: Write channel descriptor
-    _write_channel_descriptor(
-        channel_descriptor_path,
-        bundle=bundle,
-        channel=channel,
-        release=release,
-        sha256_hex=sha256_hex,
-        published_at=published_at,
+    result = package_catalogue(
+        root=root,
+        bundle=args.bundle,
+        release=args.release,
+        channel=args.channel,
+        output=output,
         source_revision=getattr(args, "source_revision", None),
         minimum_agentbundle_version=getattr(args, "minimum_agentbundle_version", None),
+        published_at=getattr(args, "published_at", None),
     )
 
-    # Step 16: Write archive last
-    archive_path.write_bytes(archive_bytes)
+    if not result.ok:
+        for d in result.diagnostics:
+            print(d.message, file=sys.stderr)
+        return 1
 
     return 0

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.15.0"
+CLI_VERSION = "0.16.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.15.0"
+version = "0.16.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -88,14 +88,24 @@ def test_result_types_structure():
 
 
 def test_stub_raises_not_implemented():
-    """AC2: unimplemented stubs raise NotImplementedError.
-    lint/build/self_host/sync_defaults are Wave 2 real implementations.
-    verify is a Wave 3 real implementation. Only package remains a stub.
+    """AC2: all catalogue_tooling modules are now implemented (Waves 2-4).
+
+    No stubs remain — this test verifies package_catalogue is callable
+    (accepts required args) without raising NotImplementedError.
     """
     from agentbundle.catalogue_tooling.package import package_catalogue
 
-    with pytest.raises(NotImplementedError):
-        package_catalogue(Path("."))
+    # Wave 4: package_catalogue is implemented; calling with missing required
+    # args returns a PackageResult error rather than raising NotImplementedError.
+    result = package_catalogue(
+        root=Path("."),
+        bundle="test",
+        release="0.0.0",
+        channel="stable",
+        output=Path("/tmp/nonexistent-test-output"),
+    )
+    # Should return a PackageResult (ok=False) rather than raising
+    assert hasattr(result, "ok")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -1,0 +1,507 @@
+"""Tests for catalogue_tooling.package (Wave 4 — catalogue-tooling-package-enhanced spec).
+
+Covers ACs 1-15 from the spec.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from agentbundle.catalogue_tooling.package import (
+    package_catalogue,
+    _generate_manifest,
+    _scan_content,
+    _check_required_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_catalogue(
+    tmp_path: Path,
+    *,
+    with_marketplace: bool = True,
+    with_license_apache: bool = True,
+    with_license_mit: bool = True,
+    with_agents_md: bool = True,
+) -> Path:
+    """Create a minimal valid catalogue root for Wave 4 tests."""
+    root = tmp_path / "catalogue"
+    root.mkdir()
+
+    # Pack
+    pack_dir = root / "packs" / "core"
+    pack_dir.mkdir(parents=True)
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+
+    # Profile
+    profiles_dir = root / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8")
+
+    if with_agents_md:
+        (root / "AGENTS.md").write_text("# Catalogue Agent Context\n", encoding="utf-8")
+
+    (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8")
+
+    if with_license_apache:
+        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
+    if with_license_mit:
+        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+
+    if with_marketplace:
+        cp_dir = root / ".claude-plugin"
+        cp_dir.mkdir()
+        (cp_dir / "marketplace.json").write_text('{"packs": ["core"]}\n', encoding="utf-8")
+
+    return root
+
+
+def _make_args(root: Path, output: Path, **kwargs) -> object:
+    """Return a namespace-like object for package_catalogue."""
+    defaults = dict(
+        bundle="engineering",
+        release="0.1.0",
+        channel="stable",
+        source_revision=None,
+        minimum_agentbundle_version=None,
+        published_at=None,
+    )
+    defaults.update(kwargs)
+    return mock.SimpleNamespace(root=str(root), output=str(output), **defaults)
+
+
+# ---------------------------------------------------------------------------
+# AC1: Three-file Artifactory layout
+# ---------------------------------------------------------------------------
+
+
+def test_package_produces_three_file_layout(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(
+            root=root,
+            bundle="engineering",
+            release="0.1.0",
+            channel="stable",
+            output=output,
+        )
+
+    assert result.ok, [d.message for d in result.diagnostics]
+
+    archive = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    sidecar = archive.parent / "catalogue-0.1.0.tar.gz.sha256"
+    descriptor = output / "catalogues" / "engineering" / "channels" / "stable.json"
+
+    assert archive.exists()
+    assert sidecar.exists()
+    assert descriptor.exists()
+    assert len([p for p in output.rglob("*") if p.is_file()]) == 3
+
+
+# ---------------------------------------------------------------------------
+# AC2: Required files must be present
+# ---------------------------------------------------------------------------
+
+
+def test_missing_license_apache_fails(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path, with_license_apache=False)
+    output = tmp_path / "out"
+
+    result = package_catalogue(root=root, bundle="b", release="r", channel="c", output=output)
+    assert not result.ok
+    assert not any(output.rglob("*") if output.exists() else [])
+
+
+def test_missing_license_mit_fails(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path, with_license_mit=False)
+    output = tmp_path / "out"
+
+    result = package_catalogue(root=root, bundle="b", release="r", channel="c", output=output)
+    assert not result.ok
+
+
+def test_missing_marketplace_json_fails(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path, with_marketplace=False)
+    output = tmp_path / "out"
+
+    result = package_catalogue(root=root, bundle="b", release="r", channel="c", output=output)
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# AC3: Generic LICENSE not required
+# ---------------------------------------------------------------------------
+
+
+def test_no_generic_license_required(tmp_path: Path) -> None:
+    """Packaging succeeds without a generic LICENSE file."""
+    root = _make_catalogue(tmp_path)
+    # Confirm no generic LICENSE exists
+    assert not (root / "LICENSE").exists()
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok, [d.message for d in result.diagnostics]
+
+
+# ---------------------------------------------------------------------------
+# AC4: catalogue.toml NOT in archive
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_toml_excluded_from_archive(tmp_path: Path) -> None:
+    """catalogue.toml must not appear in the archive even if present in the root."""
+    root = _make_catalogue(tmp_path)
+    # Verify via _scan_content: catalogue.toml is never collected.
+    paths = _scan_content(root)
+    posix = [p.relative_to(root).as_posix() for p in paths]
+    assert "catalogue.toml" not in posix
+
+    # Also verify the packaged archive doesn't include it.
+    output = tmp_path / "out"
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok, [d.message for d in result.diagnostics]
+
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        names = tf.getnames()
+    assert "catalogue.toml" not in names
+
+
+# ---------------------------------------------------------------------------
+# AC5: Channel descriptor written AFTER archive + sidecar verified
+# ---------------------------------------------------------------------------
+
+
+def test_channel_descriptor_written_last(tmp_path: Path) -> None:
+    """Channel descriptor must not exist if verify_archive raises."""
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    write_order: list[str] = []
+
+    def _spy_verify(archive_path, *, sha256_file=None):
+        write_order.append("verify_archive")
+        from agentbundle.catalogue_tooling.archive import verify_archive
+        return verify_archive(archive_path, sha256_file=sha256_file)
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(
+            root=root,
+            bundle="eng",
+            release="0.1.0",
+            channel="stable",
+            output=output,
+            _verify_archive_fn=_spy_verify,
+        )
+
+    assert result.ok
+    descriptor = output / "catalogues" / "eng" / "channels" / "stable.json"
+    assert descriptor.exists()
+    # verify_archive must have been called
+    assert "verify_archive" in write_order
+
+
+# ---------------------------------------------------------------------------
+# AC6: Deterministic bytes under SOURCE_DATE_EPOCH
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_under_source_date_epoch(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        r1 = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=out1)
+        r2 = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=out2)
+
+    assert r1.ok and r2.ok
+
+    def _arc(out): return (out / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz").read_bytes()
+    assert hashlib.sha256(_arc(out1)).digest() == hashlib.sha256(_arc(out2)).digest()
+
+
+# ---------------------------------------------------------------------------
+# AC7: Refuse to overwrite existing archive
+# ---------------------------------------------------------------------------
+
+
+def test_refuse_overwrite_existing_archive(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"existing")
+
+    result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+    assert not result.ok
+    assert archive.read_bytes() == b"existing"
+
+
+# ---------------------------------------------------------------------------
+# AC8: Staged cleanup on verify_archive failure
+# ---------------------------------------------------------------------------
+
+
+def test_staged_cleanup_on_verify_failure(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    def _failing_verify(archive_path, *, sha256_file=None):
+        from agentbundle.catalogue_tooling.results import Diagnostic, Severity, VerifyResult
+        return VerifyResult(
+            ok=False,
+            diagnostics=[Diagnostic(
+                code="TEST", severity=Severity.ERROR, pack=None, path=None,
+                line=None, col=None, message="injected failure", remediation=None,
+            )],
+            schema_version=1, command="test", operation="test",
+            agentbundle_version="0.0.0", catalogue_schema_version=1,
+        )
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(
+            root=root,
+            bundle="b",
+            release="0.1.0",
+            channel="c",
+            output=output,
+            _verify_archive_fn=_failing_verify,
+        )
+
+    assert not result.ok
+    # No staged .tmp files remain
+    if output.exists():
+        for f in output.rglob("*.tmp"):
+            assert False, f"staged file not cleaned up: {f}"
+    # Final archive not written
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    assert not archive.exists()
+    # Channel descriptor not written
+    descriptor = output / "catalogues" / "b" / "channels" / "c.json"
+    assert not descriptor.exists()
+
+
+# ---------------------------------------------------------------------------
+# AC9: Manifest has all Bucket 8 fields
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_schema_v2_fields(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok
+
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        mf = tf.extractfile("catalogue-manifest.json")
+        assert mf is not None
+        manifest = json.loads(mf.read())
+
+    assert manifest["schema"] == 2
+    assert "adapter_contract_version" in manifest
+    assert "pack_schema_version" in manifest
+    assert "marketplace_digest" in manifest
+    assert manifest["marketplace_digest"] is not None
+    assert manifest["marketplace_digest"].startswith("sha256:")
+    assert "profiles" in manifest
+    assert "packs" in manifest
+    assert "files" in manifest
+
+
+# ---------------------------------------------------------------------------
+# AC10: Compat alias deprecation warning
+# ---------------------------------------------------------------------------
+
+
+def test_compat_alias_deprecation_warning(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    import types as _types
+    from agentbundle.commands.package_catalogue import run
+    args = _types.SimpleNamespace(
+        root=str(root),
+        bundle="b",
+        release="0.1.0",
+        channel="c",
+        output=str(output),
+        source_revision=None,
+        minimum_agentbundle_version=None,
+        published_at=None,
+    )
+
+    stderr_buf = io.StringIO()
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        with contextlib.redirect_stderr(stderr_buf):
+            rc = run(args)
+
+    assert rc == 0
+    assert "deprecated" in stderr_buf.getvalue().lower()
+    assert "agentbundle catalogue package" in stderr_buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# AC11: Extracted archive passes verify_catalogue (round-trip)
+# ---------------------------------------------------------------------------
+
+
+def test_extracted_archive_valid_local_catalogue(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok
+
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    extract_dir = tmp_path / "extracted"
+    extract_dir.mkdir()
+
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            dest = extract_dir / member.name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if member.isreg():
+                fobj = tf.extractfile(member)
+                if fobj is not None:
+                    dest.write_bytes(fobj.read())
+
+    from agentbundle.catalogue_tooling.verify import verify_catalogue
+    verify_result = verify_catalogue(extract_dir)
+    assert verify_result.ok, [d.message for d in verify_result.diagnostics]
+
+
+# ---------------------------------------------------------------------------
+# AC14: Archive layout has no artificial wrapper directory
+# ---------------------------------------------------------------------------
+
+
+def test_archive_layout_no_wrapper_directory(tmp_path: Path) -> None:
+    """packs/ must be at the archive root, not inside a wrapper dir."""
+    root = _make_catalogue(tmp_path)
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok
+
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        names = tf.getnames()
+
+    assert "packs/core/pack.toml" in names, "packs/ must be at archive root"
+
+
+# ---------------------------------------------------------------------------
+# AC15: Denied paths (tools/, .git/, etc.) not in archive
+# ---------------------------------------------------------------------------
+
+
+def test_denied_dirs_not_in_archive(tmp_path: Path) -> None:
+    """Denied directories are excluded even if present in root."""
+    root = _make_catalogue(tmp_path)
+    # Add stub files at denied paths
+    for denied in [".git", "tools", "packages", "dist", "__pycache__"]:
+        d = root / denied
+        d.mkdir()
+        (d / "stub.txt").write_text("should be excluded\n", encoding="utf-8")
+
+    output = tmp_path / "out"
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(root=root, bundle="b", release="0.1.0", channel="c", output=output)
+
+    assert result.ok
+
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        names = tf.getnames()
+
+    for denied in [".git/", "tools/", "packages/", "dist/", "__pycache__/"]:
+        for name in names:
+            assert not name.startswith(denied), f"denied path found in archive: {name}"
+
+
+# ---------------------------------------------------------------------------
+# T3: CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_catalogue_package_help() -> None:
+    """catalogue package --help exits 0 and lists expected flags."""
+    from agentbundle import cli
+
+    stdout_buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc_info:
+        with contextlib.redirect_stdout(stdout_buf):
+            cli.main(["catalogue", "package", "--help"])
+    assert exc_info.value.code == 0
+    help_text = stdout_buf.getvalue()
+    for flag in ["--root", "--bundle", "--release", "--channel", "--output",
+                 "--source-revision", "--minimum-agentbundle-version"]:
+        assert flag in help_text, f"missing flag {flag!r} in help text"
+
+
+def test_generate_manifest_schema_v2() -> None:
+    """_generate_manifest always produces schema 2."""
+    manifest_bytes = _generate_manifest(
+        bundle="b",
+        release="0.1.0",
+        source_revision=None,
+        generated_at="2023-11-14T22:13:20+00:00",
+        file_digests={},
+        packs_metadata=[],
+    )
+    manifest = json.loads(manifest_bytes)
+    assert manifest["schema"] == 2
+    assert "adapter_contract_version" in manifest
+    assert "pack_schema_version" in manifest
+    assert "marketplace_digest" in manifest
+    assert "profiles" in manifest
+
+
+def test_check_required_files_passes_with_all_present(tmp_path: Path) -> None:
+    """_check_required_files returns None when all required files exist."""
+    root = _make_catalogue(tmp_path)
+    paths = _scan_content(root)
+    assert _check_required_files(root, paths) is None
+
+
+def test_check_required_files_fails_on_missing_license(tmp_path: Path) -> None:
+    """_check_required_files fails when LICENSE-APACHE is missing."""
+    root = _make_catalogue(tmp_path, with_license_apache=False)
+    paths = _scan_content(root)
+    err = _check_required_files(root, paths)
+    assert err is not None
+    assert "LICENSE-APACHE" in err

--- a/packages/agentbundle/tests/unit/test_package_catalogue.py
+++ b/packages/agentbundle/tests/unit/test_package_catalogue.py
@@ -1,7 +1,12 @@
-"""Tests for the package-catalogue subcommand.
+"""Tests for the package-catalogue subcommand (compat shim) and helpers.
 
 Covers all ACs from spec/package-catalogue-command/spec.md.
 Uses example.test placeholders only — no real credentials or external URIs.
+
+Wave 4 note: helpers are now in agentbundle.catalogue_tooling.package but
+re-exported from agentbundle.commands.package_catalogue for backward compat.
+Fixtures now include LICENSE-APACHE, LICENSE-MIT, and .claude-plugin/marketplace.json
+per the updated Wave 4 allowlist.
 """
 
 from __future__ import annotations
@@ -41,8 +46,21 @@ from agentbundle.commands.package_catalogue import (
 # ---------------------------------------------------------------------------
 
 
-def _make_fixture_catalogue(tmp_path: Path, *, with_profiles: bool = True, with_contracts: bool = True, with_readme: bool = True, with_license: bool = True, extra_dirs: list[str] | None = None) -> Path:
-    """Create a minimal valid catalogue root under tmp_path."""
+def _make_fixture_catalogue(
+    tmp_path: Path,
+    *,
+    with_profiles: bool = True,
+    with_contracts: bool = True,
+    with_readme: bool = True,
+    with_license: bool = True,
+    with_marketplace: bool = True,
+    extra_dirs: list[str] | None = None,
+) -> Path:
+    """Create a minimal valid catalogue root under tmp_path.
+
+    Wave 4: creates LICENSE-APACHE and LICENSE-MIT (not generic LICENSE),
+    and .claude-plugin/marketplace.json per the updated allowlist.
+    """
     root = tmp_path / "catalogue"
     root.mkdir()
 
@@ -64,11 +82,21 @@ def _make_fixture_catalogue(tmp_path: Path, *, with_profiles: bool = True, with_
         contracts_dir.mkdir(parents=True)
         (contracts_dir / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8")
 
+    (root / "AGENTS.md").write_text("# Test Catalogue Agent Context\n", encoding="utf-8")
+
     if with_readme:
         (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8")
 
     if with_license:
-        (root / "LICENSE").write_text("MIT\n", encoding="utf-8")
+        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
+        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+
+    if with_marketplace:
+        claude_plugin_dir = root / ".claude-plugin"
+        claude_plugin_dir.mkdir()
+        (claude_plugin_dir / "marketplace.json").write_text(
+            '{"packs": ["core"]}\n', encoding="utf-8"
+        )
 
     for extra in extra_dirs or []:
         extra_dir = root / extra
@@ -116,13 +144,18 @@ def test_scan_content_includes_allowlisted_files(tmp_path: Path) -> None:
     )
     paths = _scan_content(root)
     posix = [p.relative_to(root).as_posix() for p in paths]
-    # Allowlisted entries present
+    # Allowlisted entries present (Wave 4 allowlist)
     assert "packs/core/pack.toml" in posix
     assert "packs/core/SKILL.md" in posix
     assert "profiles/default.toml" in posix
     assert "docs/contracts/adapter.toml" in posix
+    assert "AGENTS.md" in posix
     assert "README.md" in posix
-    assert "LICENSE" in posix
+    assert "LICENSE-APACHE" in posix
+    assert "LICENSE-MIT" in posix
+    assert ".claude-plugin/marketplace.json" in posix
+    # Generic LICENSE not in new allowlist
+    assert "LICENSE" not in posix
     # Excluded directories absent
     for p in posix:
         assert not p.startswith("build/")
@@ -153,7 +186,8 @@ def test_scan_content_returns_sorted_paths(tmp_path: Path) -> None:
 
 def test_scan_content_absent_optional_dir(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(
-        tmp_path, with_profiles=False, with_contracts=False, with_readme=False, with_license=False
+        tmp_path, with_profiles=False, with_contracts=False, with_readme=False,
+        with_license=False, with_marketplace=False,
     )
     paths = _scan_content(root)
     posix = [p.relative_to(root).as_posix() for p in paths]
@@ -372,13 +406,17 @@ def test_generate_manifest_required_fields() -> None:
         packs_metadata=[{"name": "core", "version": "0.1.0"}],
     )
     manifest = json.loads(manifest_bytes)
-    assert manifest["schema"] == 1
+    assert manifest["schema"] == 2  # Wave 4: schema bumped to 2
     assert manifest["bundle"] == "engineering"
     assert manifest["release"] == "0.1.0"
     assert "source_revision" in manifest
     assert "generated_at" in manifest
     assert "files" in manifest
     assert "packs" in manifest
+    # Bucket 8 extended fields present in schema 2
+    assert "adapter_contract_version" in manifest
+    assert "pack_schema_version" in manifest
+    assert "profiles" in manifest
 
 
 def test_generate_manifest_source_revision_null() -> None:
@@ -488,7 +526,7 @@ def test_build_archive_contains_manifest() -> None:
         f = tf.extractfile("catalogue-manifest.json")
         assert f is not None
         data = json.loads(f.read())
-        assert data["schema"] == 1
+        assert data["schema"] == 1  # build_archive stores bytes as-is; schema in bytes is 1
 
 
 def test_build_archive_rejects_traversal_member_name() -> None:
@@ -646,7 +684,7 @@ def test_package_catalogue_end_to_end(tmp_path: Path) -> None:
     all_files = [p for p in output.rglob("*") if p.is_file()]
     assert len(all_files) == 3
 
-    # AC4: only allowlisted entries in archive
+    # AC4: only allowlisted entries in archive (Wave 4 allowlist)
     archive_bytes = archive_path.read_bytes()
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
         names = set(tf.getnames())
@@ -654,26 +692,31 @@ def test_package_catalogue_end_to_end(tmp_path: Path) -> None:
     assert "packs/core/SKILL.md" in names
     assert "profiles/default.toml" in names
     assert "docs/contracts/adapter.toml" in names
+    assert "AGENTS.md" in names
     assert "README.md" in names
-    assert "LICENSE" in names
+    assert "LICENSE-APACHE" in names
+    assert "LICENSE-MIT" in names
+    assert ".claude-plugin/marketplace.json" in names
     assert "catalogue-manifest.json" in names
     for n in names:
         assert not n.startswith("build/")
         assert not n.startswith("tests/")
         assert not n.startswith(".git/")
 
-    # AC11: catalogue-manifest.json schema
+    # AC11: catalogue-manifest.json schema (Wave 4: schema 2)
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
         mf = tf.extractfile("catalogue-manifest.json")
         assert mf is not None
         manifest = json.loads(mf.read())
-    assert manifest["schema"] == 1
+    assert manifest["schema"] == 2
     assert manifest["bundle"] == "engineering"
     assert manifest["release"] == "0.1.0"
     assert manifest["source_revision"] == "deadbeef"
     assert "generated_at" in manifest
     assert "files" in manifest
     assert "packs" in manifest
+    assert "adapter_contract_version" in manifest
+    assert "profiles" in manifest
 
     # AC19/AC20: channel descriptor
     descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))

--- a/workspace.toml
+++ b/workspace.toml
@@ -362,10 +362,9 @@ shipped = [
   "spec/catalogue-tooling-sync-defaults",
   "spec/catalogue-tooling-build-self",
   "spec/catalogue-tooling-verify",
+  "spec/catalogue-tooling-package-enhanced",
 ]
 queue   = [
-  # Wave 4 — after verify ships
-  {path = "spec/catalogue-tooling-package-enhanced", needs = "work:spec/catalogue-tooling-verify"},
   # Wave 5 — parallel after package-enhanced ships
   {path = "spec/catalogue-tooling-rewire", needs = "work:spec/catalogue-tooling-package-enhanced"},
   # docs needs verify (Flow E, command names), package-enhanced (allowlist + output paths), and rewire (make build-check wording)


### PR DESCRIPTION
## Summary

- Moves all archive-assembly logic from `commands/package_catalogue.py` to `catalogue_tooling/package.py`, implementing the full Bucket 8 spec.
- `agentbundle catalogue package` is the canonical packaging command; `agentbundle package-catalogue` becomes a compat shim with deprecation warning.
- 8-step staging + atomic placement: construct bytes → write staged archive → compute sidecar → `verify_archive` self-verify → atomic rename archive → atomic rename sidecar → write channel descriptor LAST.
- Pre-package `verify_catalogue(root)` pre-check ensures the source is valid before any output is written.
- Updated allowlist: `LICENSE-APACHE`, `LICENSE-MIT`, `.claude-plugin/marketplace.json` required; generic `LICENSE` no longer assumed; `AGENTS.md` included for `verify_archive` catalogue-marker check.
- Manifest schema bumped from 1 → 2 with Bucket 8 extended fields: `adapter_contract_version`, `pack_schema_version`, `marketplace_digest`, `profiles`.
- 19 new tests; all 73 existing `test_package_catalogue.py` tests pass (fixtures updated for new allowlist + schema 2).
- agentbundle 0.16.0.

## Test plan

- [x] `python -m pytest tests/unit/test_catalogue_tooling_package.py` — 19 tests (AC1–AC15)
- [x] `python -m pytest tests/unit/test_package_catalogue.py` — 73 existing tests pass
- [x] `python -m pytest tests/unit/test_catalogue_tooling_foundation.py` — foundation tests pass
- [x] `bandit` clean on all new files
- [ ] CI: `make build-check` and `make build-check (windows)`

Deferred (Wave 5):
- Repository rewiring (`catalogue-tooling-rewire`): Makefile/tools/ reorganization
- Documentation (`catalogue-tooling-docs`): guide pages
- CI gates (`catalogue-tooling-ci-gates`): new gate configuration