### PR TITLE
feat(ini-005): catalogue-tooling Wave 5b — docs + guides + release-coupling

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -165,3 +165,26 @@ Applies to all new code. Production code (`packages/agentbundle/agentbundle/`) i
   `os.environ["HOME"]`, no hardcoded `/tmp`.
 - **Subprocess:** list form only, never `shell=True`. Do not invoke `which`, `grep`, `find`, `sed`,
   `awk`, `make`, `sh`, or `bash` via subprocess in portable code.
+
+## Release Coupling
+
+Changes to `packages/agentbundle/` that alter a public CLI verb, add or remove a `catalogue` sub-command,
+or change an output format visible to callers require a version bump and a PyPI release before downstream
+repos can consume them. Changes that stay inside internal helpers, test utilities, or schema-validation
+details do not — bump only when a caller would break or need to change.
+
+**What always requires an AgentBundle release:**
+- Adding, removing, or renaming a `agentbundle catalogue <sub>` command.
+- Changing required CLI flags or their semantics for any published command.
+- Changing the output layout of `dist/` or archive/sidecar file names.
+- Changing `catalogue.toml` or `pack.toml` schema in a way that invalidates existing valid files.
+
+**What does not require a release:**
+- Internal refactors to `agentbundle/catalogue/` that preserve observable CLI behaviour.
+- Adding optional flags with backward-compatible defaults.
+- Updating `docs/guides/` or `tools/` without touching the package.
+- Adding tests or improving error messages in ways that don't change exit codes.
+
+**Portable mechanics belong in `packages/agentbundle/`; repo-internal policy belongs in `tools/`.**
+The boundary is the public `agentbundle catalogue *` interface. Anything that lives exclusively in
+`tools/` or `Makefile` is not a release boundary — it is repo governance and can be changed freely.

--- a/docs/guides/explanation/release-coupling.md
+++ b/docs/guides/explanation/release-coupling.md
@@ -1,0 +1,48 @@
+# Release coupling — what requires an AgentBundle release
+
+Not every change to the catalogue needs an AgentBundle release. This page explains the boundary.
+
+## The boundary
+
+AgentBundle ships as a Python package on PyPI. Its public surface — what adopters call — is the
+`agentbundle catalogue *` command group and the `catalogue.toml` / `pack.toml` schema. Anything
+that changes that surface is a release-boundary change. Anything that stays inside repo-local tooling
+or does not alter observable CLI behaviour is not.
+
+## Changes that require an AgentBundle release
+
+| Change | Why |
+|--------|-----|
+| Adding a new `agentbundle catalogue <sub>` command | Adopters need to call it; it can't exist until released |
+| Removing or renaming a `catalogue` sub-command | Callers break |
+| Changing required CLI flags or flag semantics | Callers break |
+| Changing the output layout of `dist/` or archive file names | Downstream tools expect a fixed layout |
+| Changing `catalogue.toml` or `pack.toml` schema in a way that invalidates previously-valid files | Adopter catalogues fail validation |
+| Adding a required field to either schema | Existing catalogues fail until updated |
+
+## Changes that do not require a release
+
+| Change | Why |
+|--------|-----|
+| Refactoring internal helpers that preserve observable CLI behaviour | Callers see no difference |
+| Adding optional CLI flags with backward-compatible defaults | Callers not using the flag are unaffected |
+| Updating `docs/guides/` or `tools/` without touching the package | No installed code changes |
+| Improving error messages (without changing exit codes) | Observable behaviour is exit code + stdout schema |
+| Adding or changing tests | Never reaches the installed surface |
+| Updating Makefile targets that delegate to existing commands | Repo governance, not a public interface |
+
+## The data-driven config preference
+
+When possible, drive variation through `catalogue.toml` configuration rather than new CLI flags or
+sub-commands. Data-driven config changes are cheaper: they don't require a release if the field is
+optional and backward-compatible, and adopters can adjust without updating their tooling.
+
+## Portable mechanics vs internal policy
+
+The split between `packages/agentbundle/` and `tools/` is a design boundary:
+
+- `packages/agentbundle/agentbundle/` — portable mechanics; installed in every adopter's environment; release-gated.
+- `tools/` — repo-internal policy; runs only in this checkout; no release required.
+
+When a new capability is purely repo-governance (a new lint check, a new gate), put it in `tools/`.
+When it is something every catalogue author needs in their own CI pipeline, put it in `packages/agentbundle/` — and plan a release.

--- a/docs/guides/how-to/create-external-catalogue.md
+++ b/docs/guides/how-to/create-external-catalogue.md
@@ -1,0 +1,98 @@
+# How to create an external catalogue
+
+An external catalogue is any directory that follows the catalogue layout and contains a
+`catalogue.toml`. It does not need to be this repository, does not require the `Makefile`, and
+does not require any files from `tools/`.
+
+## Prerequisites
+
+- Python 3.11+
+- AgentBundle ≥ 0.14.0: `pip install agentbundle`
+
+## Step 1 — Create the layout
+
+```
+my-catalogue/
+  catalogue.toml
+  packs/
+    my-first-pack/
+      pack.toml
+      .claude-plugin/plugin.json
+      .apm/skills/my-skill/SKILL.md
+```
+
+## Step 2 — Write `catalogue.toml`
+
+```toml
+[catalogue]
+name        = "my-catalogue"
+version     = "0.1.0"
+description = "Example external catalogue."
+```
+
+See the [catalogue.toml reference](../reference/catalogue-toml.md) for all fields.
+
+## Step 3 — Write `pack.toml`
+
+```toml
+[pack]
+name             = "my-first-pack"
+version          = "0.1.0"
+description      = "My first pack."
+adapter-contract = "0.14"
+```
+
+## Step 4 — Write a skill
+
+Create `.apm/skills/my-skill/SKILL.md`:
+
+```markdown
+---
+name: my-skill
+description: Does a thing when the user needs a thing done.
+---
+
+# Body
+
+Step 1: identify the thing.
+Step 2: do the thing.
+```
+
+## Step 5 — Lint
+
+```bash
+agentbundle catalogue lint --root my-catalogue/
+```
+
+Fix any errors before continuing. Add `--format json` to get machine-readable output.
+
+## Step 6 — Verify
+
+```bash
+agentbundle catalogue verify --root my-catalogue/
+```
+
+This runs the full 18-step pipeline including a build into a temp directory. It must exit 0 before
+you publish or distribute the catalogue.
+
+## Step 7 — Project to self-host adapters (optional)
+
+If this catalogue is also used in the repository that hosts it:
+
+```bash
+agentbundle catalogue self-host --root my-catalogue/ --write
+```
+
+## Step 8 — Build the dist tree
+
+```bash
+agentbundle catalogue build --root my-catalogue/ --output my-catalogue/dist
+```
+
+`dist/` is ready for use as a source in agentbundle or for uploading to a registry.
+
+## What you don't need
+
+- The `Makefile` from this repository — it is home-repository governance.
+- Any file from `tools/` — all portable logic is in `agentbundle catalogue *`.
+- A specific CI system — you can run the same commands in any CI environment.

--- a/docs/guides/how-to/enterprise-app-store.md
+++ b/docs/guides/how-to/enterprise-app-store.md
@@ -1,0 +1,100 @@
+# How to package a catalogue for enterprise app-store distribution
+
+This guide covers the Artifactory-based packaging workflow for distributing a catalogue to
+disconnected hosts within an enterprise network.
+
+## Overview
+
+The workflow has two sides:
+
+- **Connected host** — has access to the catalogue source repo and Artifactory; builds and publishes.
+- **Disconnected host** — can reach the internal Artifactory registry; downloads and installs.
+
+## Prerequisites
+
+- Catalogue passes `agentbundle catalogue verify --root .` on the connected host.
+- Artifactory repository accessible from the connected host.
+- Bundle identifier, release version, and channel name agreed with your platform team.
+
+## Step 1 — Build the dist tree
+
+```bash
+agentbundle catalogue build --root . --output dist
+```
+
+## Step 2 — Verify (confirm pre-package state)
+
+```bash
+agentbundle catalogue verify --root .
+```
+
+The verify step must exit 0 before packaging.
+
+## Step 3 — Package
+
+```bash
+agentbundle catalogue package \
+  --root . \
+  --bundle engineering \
+  --release 1.2.0 \
+  --channel stable \
+  --output dist/artifactory \
+  --source-revision "$(git rev-parse HEAD)"
+```
+
+Output layout:
+
+```
+dist/artifactory/catalogues/engineering/releases/1.2.0/stable/
+  engineering-1.2.0.tar.gz
+  engineering-1.2.0.tar.gz.sha256
+  channel.json
+```
+
+## Step 4 — Upload to Artifactory
+
+Upload the archive and sidecar (not the channel descriptor — it is audit metadata only and is not
+used by the disconnected host to resolve a local catalogue):
+
+```bash
+jf rt upload \
+  "dist/artifactory/catalogues/engineering/releases/1.2.0/stable/engineering-1.2.0.tar.gz*" \
+  "agentbundle-catalogues/engineering/releases/1.2.0/stable/"
+```
+
+## Step 5 — Download on the disconnected host
+
+```bash
+jf rt download \
+  "agentbundle-catalogues/engineering/releases/1.2.0/stable/engineering-1.2.0.tar.gz" \
+  /tmp/downloads/
+
+jf rt download \
+  "agentbundle-catalogues/engineering/releases/1.2.0/stable/engineering-1.2.0.tar.gz.sha256" \
+  /tmp/downloads/
+```
+
+## Step 6 — Verify and extract
+
+See [Flow E — fully disconnected host](flow-e-disconnected.md) for the complete receive-side
+workflow.
+
+## CI integration
+
+For automated packaging in CI:
+
+```yaml
+- name: Package catalogue
+  run: |
+    agentbundle catalogue verify --root .
+    agentbundle catalogue package \
+      --root . \
+      --bundle ${{ env.BUNDLE }} \
+      --release ${{ env.RELEASE }} \
+      --channel ${{ env.CHANNEL }} \
+      --output dist/artifactory \
+      --source-revision ${{ github.sha }}
+```
+
+Never embed production Artifactory URLs, credentials, or bearer tokens in workflow YAML. Use
+secrets or a credentials broker.

--- a/docs/guides/how-to/flow-e-disconnected.md
+++ b/docs/guides/how-to/flow-e-disconnected.md
@@ -1,0 +1,98 @@
+# Flow E — fully disconnected host
+
+This flow covers installing a catalogue on a host that cannot reach the public internet or a
+catalogue registry. It requires a pre-packaged archive produced on a connected host.
+
+**Not supported:** resolving a channel descriptor (`channel.json`) from a local directory to
+install packs. Local channel-descriptor resolution is NOT supported. The disconnected path is
+archive-only: transfer archive + sidecar, verify, extract, configure the source path.
+
+## What you need
+
+- `<bundle>-<release>.tar.gz` — the packaged archive
+- `<bundle>-<release>.tar.gz.sha256` — the SHA-256 sidecar
+- AgentBundle ≥ 0.14.0 installed on the disconnected host
+
+The channel descriptor (`channel.json`) is NOT required on the disconnected host. It is audit
+metadata for the connected-side registry only.
+
+## Step 1 — Transfer
+
+Copy the archive and sidecar to the disconnected host. Use whatever secure transfer mechanism your
+environment provides (scp, a mounted network share, an internal Artifactory mirror).
+
+```
+/tmp/downloads/
+  engineering-1.2.0.tar.gz
+  engineering-1.2.0.tar.gz.sha256
+```
+
+Do NOT transfer `channel.json` — it is not used on the disconnected side.
+
+## Step 2 — Verify the archive
+
+```bash
+agentbundle catalogue verify \
+  --archive /tmp/downloads/engineering-1.2.0.tar.gz \
+  --sha256-file /tmp/downloads/engineering-1.2.0.tar.gz.sha256
+```
+
+Verify must exit 0. Do not extract an archive that fails verification.
+
+## Step 3 — Extract to a stable path
+
+```bash
+mkdir -p /opt/company/agentbundle/catalogues/engineering
+tar -xzf /tmp/downloads/engineering-1.2.0.tar.gz \
+    -C /opt/company/agentbundle/catalogues/engineering
+```
+
+The extracted layout contains:
+
+```
+/opt/company/agentbundle/catalogues/engineering/
+  packs/
+    core/
+    governance-extras/
+    ...
+  .claude-plugin/marketplace.json
+```
+
+## Step 4 — Confirm the layout
+
+```bash
+ls /opt/company/agentbundle/catalogues/engineering/packs/
+ls /opt/company/agentbundle/catalogues/engineering/.claude-plugin/marketplace.json
+```
+
+Both must exist before proceeding.
+
+## Step 5 — Configure the local catalogue path
+
+```bash
+agentbundle config set source /opt/company/agentbundle/catalogues/engineering
+```
+
+This tells agentbundle to use the extracted directory as the catalogue source instead of a remote URL.
+
+## Step 6 — Confirm pack availability
+
+```bash
+agentbundle list-packs
+```
+
+The packs from the extracted catalogue appear in the output.
+
+## Upgrading
+
+To upgrade to a new release, repeat Steps 1–5 with the new archive. The `config set source` in
+Step 5 points to the versioned extraction root; update the path to the new version's extraction
+directory.
+
+## Limitations
+
+- Local channel-descriptor resolution (`channel.json` in a local directory) is **not supported**.
+  The channel descriptor is a registry artifact, not a local install mechanism.
+- Moving from an Artifactory-hosted source to a local-path source (or vice versa) is a source
+  change. Use `agentbundle config set source <new-source>` and follow any reinstall process
+  required for installed packs to reflect the new source.

--- a/docs/guides/reference/catalogue-archive.md
+++ b/docs/guides/reference/catalogue-archive.md
@@ -1,0 +1,87 @@
+# Catalogue archive format
+
+A packaged catalogue is a set of three files produced by `agentbundle catalogue package`. Together
+they form the distributable unit for fully-disconnected hosts.
+
+## Output files
+
+```
+<output>/catalogues/<bundle>/releases/<release>/<channel>/
+  <bundle>-<release>.tar.gz        # archive
+  <bundle>-<release>.tar.gz.sha256 # SHA-256 sidecar
+  channel.json                     # channel descriptor
+```
+
+### Archive (`<bundle>-<release>.tar.gz`)
+
+A gzip-compressed tar archive. The extracted layout mirrors the catalogue source tree:
+
+```
+packs/
+  <pack-name>/
+    pack.toml
+    .claude-plugin/plugin.json
+    .apm/
+      skills/<name>/SKILL.md
+      agents/<name>.md
+      hooks/<name>.py
+      ...
+    seeds/
+    evals/
+```
+
+### SHA-256 sidecar (`.sha256`)
+
+A single line containing the hex SHA-256 digest of the archive, followed by two spaces and the
+archive filename:
+
+```
+3a7b9c... <bundle>-<release>.tar.gz
+```
+
+This matches `sha256sum` output format. The sidecar is what the receiving host uses to verify
+integrity before extraction.
+
+### Channel descriptor (`channel.json`)
+
+JSON metadata about this release, including the channel name, release version, bundle identifier,
+published-at timestamp, and minimum agentbundle version. It is audit context for the connected-side
+registry and is NOT used by the disconnected host to resolve a local catalogue.
+
+## Verification
+
+Before extracting on the receiving host, verify the archive against its sidecar:
+
+```bash
+agentbundle catalogue verify \
+  --archive <bundle>-<release>.tar.gz \
+  --sha256-file <bundle>-<release>.tar.gz.sha256
+```
+
+Exits 0 on success. Do not extract an archive that fails verification.
+
+## Transfer
+
+Transfer only the archive and sidecar to the disconnected host:
+
+- `<bundle>-<release>.tar.gz`
+- `<bundle>-<release>.tar.gz.sha256`
+
+The channel descriptor (`channel.json`) is not needed on the disconnected host — it is registry
+audit metadata for the connected side only.
+
+## Extraction
+
+After successful verification:
+
+```bash
+mkdir -p /opt/company/agentbundle/catalogues/<bundle>
+tar -xzf <bundle>-<release>.tar.gz -C /opt/company/agentbundle/catalogues/<bundle>
+```
+
+The extracted root contains `packs/` and `.claude-plugin/marketplace.json`. Configure agentbundle
+to use it as the local catalogue source:
+
+```bash
+agentbundle config set source /opt/company/agentbundle/catalogues/<bundle>
+```

--- a/docs/guides/reference/catalogue-commands.md
+++ b/docs/guides/reference/catalogue-commands.md
@@ -1,0 +1,126 @@
+# Catalogue commands reference
+
+All commands operate on a catalogue rooted at `--root` (defaults to the current directory).
+
+## `agentbundle catalogue lint`
+
+Validates pack sources against contracts without building.
+
+```
+agentbundle catalogue lint [--root ROOT] [--pack PACK] [--format {table,json}]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root` | `.` | Catalogue root directory |
+| `--pack` | _(all)_ | Limit to a single pack name |
+| `--format` | `table` | Output format: `table` or `json` |
+
+Exits 0 when all checks pass; non-zero on any failure. Runs as step 2 of `catalogue verify`.
+
+## `agentbundle catalogue verify`
+
+Runs the full 18-step source pipeline: lint, schema validation, contract checks, build (into a temp
+directory), self-host drift check, and more.
+
+```
+agentbundle catalogue verify [--root ROOT] [--pack PACK] [--archive ARCHIVE]
+                             [--sha256-file SHA256_FILE] [--format {table,json}]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root` | `.` | Catalogue root directory (source mode) |
+| `--pack` | _(all)_ | Limit to a single pack |
+| `--archive` | _(none)_ | Path to a `.tar.gz` archive (archive mode) |
+| `--sha256-file` | _(none)_ | SHA-256 sidecar for archive verification |
+| `--format` | `table` | Output format |
+
+When `--archive` is given, verify switches to archive mode: it checks the archive's SHA-256 against
+the sidecar and validates the extracted layout without touching source files.
+
+## `agentbundle catalogue build`
+
+Builds the catalogue dist tree (populates `dist/` or `--output`).
+
+```
+agentbundle catalogue build [--root ROOT] [--output OUTPUT]
+                            [--pack PACK] [--recipe RECIPE]
+                            [--format {table,json}]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root` | `.` | Catalogue root directory |
+| `--output` | From `catalogue.toml` | Output directory |
+| `--pack` | _(all)_ | Limit to a single pack |
+| `--recipe` | _(default)_ | Recipe name or `.toml` path |
+| `--format` | `table` | Output format |
+
+## `agentbundle catalogue self-host`
+
+Manages the self-host projection — writes or checks adapter-projected files (skills, agents, hooks,
+commands) from `.apm/` sources into the adapter-expected layout.
+
+```
+agentbundle catalogue self-host [--root ROOT] [--check | --write] [--force]
+                                [--format {table,json}]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root` | `.` | Catalogue root directory |
+| `--check` | — | Dry-run; exits non-zero if projection is out of date |
+| `--write` | — | Write projected files |
+| `--force` | `false` | Write even on a dirty working tree |
+| `--format` | `table` | Output format |
+
+One of `--check` or `--write` is required.
+
+## `agentbundle catalogue package`
+
+Packages the built catalogue into a distributable archive with a SHA-256 sidecar and a channel
+descriptor, following the Artifactory output layout.
+
+```
+agentbundle catalogue package --bundle BUNDLE --release RELEASE
+                               --channel CHANNEL --output OUTPUT
+                               [--root ROOT] [--source-revision REV]
+                               [--minimum-agentbundle-version VER]
+                               [--published-at TIMESTAMP]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--bundle` | yes | Bundle/product identifier (e.g. `engineering`) |
+| `--release` | yes | Release version string (e.g. `1.0.0`) |
+| `--channel` | yes | Channel name (e.g. `stable`) |
+| `--output` | yes | Output root directory |
+| `--root` | no | Catalogue root (default: `.`) |
+| `--source-revision` | no | VCS revision for audit metadata |
+| `--minimum-agentbundle-version` | no | Minimum consumer version required |
+| `--published-at` | no | Timestamp override (ISO-8601) |
+
+Output layout:
+
+```
+<output>/catalogues/<bundle>/releases/<release>/<channel>/
+  <bundle>-<release>.tar.gz        # archive
+  <bundle>-<release>.tar.gz.sha256 # SHA-256 sidecar
+  channel.json                     # channel descriptor (do not publish before verifying)
+```
+
+## `agentbundle catalogue sync-defaults`
+
+Syncs `[catalogue.install-defaults]` from `catalogue.toml` into the self-hosted adapters' install
+manifests.
+
+```
+agentbundle catalogue sync-defaults [--root ROOT] [--check | --write]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--root` | `.` | Catalogue root directory |
+| `--check` | — | Dry-run; exits non-zero on drift |
+| `--write` | — | Write updated manifests |

--- a/docs/guides/reference/catalogue-migration.md
+++ b/docs/guides/reference/catalogue-migration.md
@@ -1,0 +1,38 @@
+# Catalogue command migration guide
+
+Command surface changed in AgentBundle 0.14.0 (Wave 2) through 0.16.0 (Wave 4). This table maps
+every old invocation to its canonical replacement.
+
+## Command mapping
+
+| Old command | New command | Notes |
+|-------------|-------------|-------|
+| `python -m agentbundle.build lint-packs --packs-dir packs` | `agentbundle catalogue lint --root .` | `--root` replaces `--packs-dir` |
+| `python -m agentbundle.build build --packs-dir packs --output-dir dist` | `agentbundle catalogue build --root . --output dist` | Same semantics; output dir is now `--output` |
+| `python -m agentbundle.build check --packs-dir packs` | `agentbundle catalogue self-host --root . --check` | Renamed to self-host; mode flag explicit |
+| `python -m agentbundle.build self --packs-dir packs` | `agentbundle catalogue self-host --root . --write` | Renamed to self-host; mode flag explicit |
+| `python -m agentbundle.build self --packs-dir packs --force` | `agentbundle catalogue self-host --root . --write --force` | `--force` preserved |
+| `python -m agentbundle.build verify --packs-dir packs` | `agentbundle catalogue verify --root .` | Verb unchanged; `--root` replaces `--packs-dir` |
+| `make lint-packs` | `agentbundle catalogue lint --root .` | Makefile target still works; now delegates |
+| `make build-self` | `agentbundle catalogue self-host --root . --write` | Makefile target still works |
+| `make build-self-dry-run` | `agentbundle catalogue self-host --root . --check` | Makefile target still works |
+| `python tools/build_gate_chain.py build-self` | `python tools/repo/build_gate_chain.py build-self` | Shim at old path; prefer new path |
+| `python tools/build_gate_chain.py build-check` | `python tools/repo/build_gate_chain.py build-check` | Shim at old path; prefer new path |
+| `python tools/pre-pr-catalogue.py` | `python tools/catalogue/pre_pr_catalogue.py` | Shim at old path; prefer new path |
+
+## Makefile variables
+
+The following Makefile variables changed meaning or were added:
+
+| Variable | Old behavior | New behavior |
+|----------|-------------|--------------|
+| `PACKS_DIR` | Passed to build scripts as pack directory | Ignored (use `--root .` instead) |
+| `OUTPUT_DIR` | Passed to build scripts | Still used for `catalogue build --output` |
+| `PACK` | _(not supported)_ | Limits build to a single pack (`--pack`) |
+| `BUNDLE` | _(not supported)_ | Required for `make package` |
+| `RELEASE` | _(not supported)_ | Required for `make package` |
+| `CHANNEL` | _(not supported)_ | Required for `make package` |
+
+## Minimum version
+
+The `agentbundle catalogue` sub-command group requires AgentBundle ≥ 0.14.0.

--- a/docs/guides/reference/catalogue-toml.md
+++ b/docs/guides/reference/catalogue-toml.md
@@ -1,0 +1,93 @@
+# catalogue.toml reference
+
+`catalogue.toml` sits at the root of any pack catalogue (the same directory that contains `packs/`).
+It is the single file that makes a directory a recognised catalogue.
+
+## Required fields
+
+```toml
+[catalogue]
+name = "my-catalogue"          # slug — kebab-case, globally unique within your org
+version = "0.1.0"              # SemVer; bump on every published change
+description = "One sentence."  # shown in agentbundle show output
+```
+
+## Optional fields
+
+```toml
+[catalogue]
+display-name = "My Catalogue"        # human-readable name for UIs
+homepage     = "https://example.com" # project home page URL
+maintainers  = [{ name = "Alice", email = "alice@example.com" }]
+keywords     = ["security", "platform"]
+```
+
+### `[catalogue.channels]`
+
+Declares the publish channels this catalogue supports.
+
+```toml
+[catalogue.channels]
+stable  = "https://registry.example.com/catalogues/my-catalogue/stable.json"
+preview = "https://registry.example.com/catalogues/my-catalogue/preview.json"
+```
+
+Channel names are arbitrary strings. `stable` is conventional for the production channel.
+
+### `[catalogue.install-defaults]`
+
+Controls which packs are installed by default when an adopter runs `agentbundle install`.
+
+```toml
+[catalogue.install-defaults]
+packs    = ["core", "governance-extras"]
+adapters = ["claude-code"]
+```
+
+Run `agentbundle catalogue sync-defaults --root .` to sync these values into the self-hosted adapters'
+install manifests.
+
+### `[catalogue.packaging]`
+
+Controls archive output paths for `agentbundle catalogue package`.
+
+```toml
+[catalogue.packaging]
+output-root = "dist/artifactory"
+bundle      = "engineering"
+release     = "1.0.0"
+channel     = "stable"
+```
+
+## Valid values
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `name` | string | kebab-case, 1–64 chars |
+| `version` | string | SemVer (`MAJOR.MINOR.PATCH`) |
+| `description` | string | ≤ 280 chars recommended |
+| `display-name` | string | free text |
+| `homepage` | string | valid URL |
+| `maintainers[].name` | string | required when maintainer present |
+| `maintainers[].email` | string | optional |
+| `keywords` | array of strings | free text |
+
+## Example
+
+```toml
+[catalogue]
+name         = "acme-platform"
+version      = "2.3.1"
+description  = "ACME platform packs — security, compliance, and delivery tooling."
+display-name = "ACME Platform Catalogue"
+homepage     = "https://intranet.acme.example/dev/agentbundle"
+maintainers  = [{ name = "Platform Engineering", email = "pe@acme.example" }]
+keywords     = ["security", "compliance", "ci"]
+
+[catalogue.channels]
+stable  = "https://registry.acme.example/agentbundle/stable.json"
+
+[catalogue.install-defaults]
+packs    = ["core", "security-baseline"]
+adapters = ["claude-code", "cursor"]
+```

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+
 ## [repo][wave-5b-docs] — 2026-07-25
 
 ### Changed

--- a/docs/specs/catalogue-tooling-docs/spec.md
+++ b/docs/specs/catalogue-tooling-docs/spec.md
@@ -1,6 +1,6 @@
 # Spec: Catalogue Tooling — Documentation
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Initiative:** ini-005 AgentBundle Portable Catalogue Tooling
 - **Plan:** [`plan.md`](plan.md)
@@ -95,32 +95,32 @@ corrected Flow E for fully-disconnected hosts.
 
 ## Acceptance Criteria
 
-- [ ] AC1: `packs/AGENTS.md` is ≤ 150 lines.
-- [ ] AC2: `packs/AGENTS.md` lists all primitive directories from the adapter
+- [x] AC1: `packs/AGENTS.md` is ≤ 150 lines.
+- [x] AC2: `packs/AGENTS.md` lists all primitive directories from the adapter
   contract (`docs/contracts/adapter.toml`) — no hardcoded list that can drift.
-- [ ] AC3: `packs/AGENTS.md` contains a pack.toml schema map covering all major
+- [x] AC3: `packs/AGENTS.md` contains a pack.toml schema map covering all major
   tables: `[pack]`, `[pack.adapter-contract]`, recipes, dependencies, conflicts,
   seeds, per-scope layout, first-value metadata, adaptation inference,
   substitutions, augmentation points.
-- [ ] AC4: `packs/AGENTS.md` primary workflow references `agentbundle catalogue
+- [x] AC4: `packs/AGENTS.md` primary workflow references `agentbundle catalogue
   lint`, `agentbundle catalogue verify`, `agentbundle catalogue self-host --write`.
-- [ ] AC5: `packs/AGENTS.md` contains the pack design model (intent → journey
+- [x] AC5: `packs/AGENTS.md` contains the pack design model (intent → journey
   → stage → capability → output).
-- [ ] AC6: `AGENTS.local.md` contains a section titled "Release Coupling"
+- [x] AC6: `AGENTS.local.md` contains a section titled "Release Coupling"
   (or equivalent) explaining what does/doesn't require an AgentBundle release.
-- [ ] AC7: `packs/core/seeds/AGENTS.md` and `AGENTS.md` do NOT contain the
+- [x] AC7: `packs/core/seeds/AGENTS.md` and `AGENTS.md` do NOT contain the
   release-coupling section (test: grep both files for the section heading).
-- [ ] AC8: A `docs/guides/` migration page exists documenting the old → new
+- [x] AC8: A `docs/guides/` migration page exists documenting the old → new
   command mapping in a table.
-- [ ] AC9: A Flow E guide exists and correctly states: (a) channel-descriptor
+- [x] AC9: A Flow E guide exists and correctly states: (a) channel-descriptor
   resolution from a local directory is NOT supported; (b) transfer archive +
   sidecar only; (c) verify before extraction; (d) configure local catalogue path.
-- [ ] AC10: CLI examples in guide docs use `agentbundle catalogue lint/verify/build/
+- [x] AC10: CLI examples in guide docs use `agentbundle catalogue lint/verify/build/
   self-host/package` (not old `python -m agentbundle.build` forms, except in the
   migration table).
-- [ ] AC11: The Bucket 14 contract tests pass (a new test file asserts all
+- [x] AC11: The Bucket 14 contract tests pass (a new test file asserts all
   structural invariants programmatically).
-- [ ] AC12: All existing tests pass.
+- [x] AC12: All existing tests pass.
 
 ## Assumptions
 

--- a/tools/test_catalogue_tooling_docs.py
+++ b/tools/test_catalogue_tooling_docs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Bucket 14 contract tests for catalogue-tooling-docs (Wave 5b)."""
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_PACKS_AGENTS = REPO_ROOT / "packs" / "AGENTS.md"
+_AGENTS_LOCAL = REPO_ROOT / "AGENTS.local.md"
+_AGENTS_ROOT = REPO_ROOT / "AGENTS.md"
+_SEEDS_AGENTS = REPO_ROOT / "packs" / "core" / "seeds" / "AGENTS.md"
+_ADAPTER_TOML = REPO_ROOT / "docs" / "contracts" / "adapter.toml"
+
+_EXPECTED_GUIDES = [
+    "docs/guides/reference/catalogue-toml.md",
+    "docs/guides/reference/catalogue-commands.md",
+    "docs/guides/reference/catalogue-migration.md",
+    "docs/guides/reference/catalogue-archive.md",
+    "docs/guides/how-to/create-external-catalogue.md",
+    "docs/guides/how-to/enterprise-app-store.md",
+    "docs/guides/how-to/flow-e-disconnected.md",
+    "docs/guides/explanation/release-coupling.md",
+]
+
+
+class AgentsMdTest(unittest.TestCase):
+    def setUp(self):
+        self._text = _PACKS_AGENTS.read_text(encoding="utf-8")
+        self._lines = self._text.splitlines()
+
+    def test_line_count(self):
+        self.assertLessEqual(len(self._lines), 150, f"packs/AGENTS.md is {len(self._lines)} lines; must be ≤ 150")
+
+    def test_primitive_dirs(self):
+        adapter_text = _ADAPTER_TOML.read_text(encoding="utf-8")
+        source_paths = re.findall(r'source-path\s*=\s*"([^"]+)"', adapter_text)
+        self.assertTrue(source_paths, "No source-path entries found in adapter.toml")
+        for path in source_paths:
+            self.assertIn(path, self._text, f"Primitive source path {path!r} missing from packs/AGENTS.md")
+
+    def test_schema_tables(self):
+        major_tables = (
+            "adapter-contract",
+            "recipes",
+            "dependencies",
+            "seeds",
+            "layout",
+            "first-value",
+            "adaptation",
+        )
+        for table in major_tables:
+            self.assertIn(table, self._text, f"Schema table {table!r} missing from packs/AGENTS.md")
+
+    def test_canonical_commands(self):
+        self.assertIn("agentbundle catalogue lint", self._text)
+        self.assertIn("agentbundle catalogue verify", self._text)
+        self.assertIn("agentbundle catalogue self-host", self._text)
+
+    def test_pack_design_model(self):
+        for word in ("intent", "journey", "capability"):
+            self.assertIn(word, self._text, f"Design model word {word!r} missing from packs/AGENTS.md")
+
+
+class AgentsLocalMdTest(unittest.TestCase):
+    def setUp(self):
+        self._text = _AGENTS_LOCAL.read_text(encoding="utf-8")
+
+    def test_has_release_coupling(self):
+        self.assertIn(
+            "release coupling",
+            self._text.lower(),
+            "AGENTS.local.md must contain a Release Coupling section",
+        )
+
+    def test_projected_agents_no_release_coupling(self):
+        for path in (_AGENTS_ROOT, _SEEDS_AGENTS):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn(
+                "Release Coupling",
+                text,
+                f"{path.relative_to(REPO_ROOT)} must NOT contain 'Release Coupling'",
+            )
+
+
+class GuideDocsTest(unittest.TestCase):
+    def test_guide_files_exist(self):
+        for rel in _EXPECTED_GUIDES:
+            p = REPO_ROOT / rel
+            self.assertTrue(p.exists(), f"Missing guide: {rel}")
+
+    def test_flow_e_no_local_descriptor_claim(self):
+        p = REPO_ROOT / "docs/guides/how-to/flow-e-disconnected.md"
+        self.assertTrue(p.exists(), "flow-e-disconnected.md guide must exist")
+        text = p.read_text(encoding="utf-8").lower()
+        self.assertIn(
+            "not supported",
+            text,
+            "Flow E guide must explicitly state that local channel-descriptor resolution is NOT supported",
+        )
+
+    def test_guide_uses_canonical_commands(self):
+        old_patterns = (
+            "agentbundle.build lint-packs",
+            "agentbundle.build build",
+            "agentbundle.build check",
+        )
+        for rel in _EXPECTED_GUIDES:
+            p = REPO_ROOT / rel
+            if not p.exists():
+                continue
+            if "migration" in rel:
+                continue  # migration table is allowed to reference old commands
+            text = p.read_text(encoding="utf-8")
+            for old in old_patterns:
+                self.assertNotIn(old, text, f"{rel} references old command {old!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workspace.toml
+++ b/workspace.toml
@@ -369,10 +369,9 @@ shipped = [
   "spec/catalogue-tooling-verify",
   "spec/catalogue-tooling-package-enhanced",
   "spec/catalogue-tooling-rewire",
+  "spec/catalogue-tooling-docs",
 ]
 queue   = [
-  # docs needs verify (Flow E, command names), package-enhanced (allowlist + output paths), and rewire (make build-check wording)
-  {path = "spec/catalogue-tooling-docs", needs = "work:spec/catalogue-tooling-verify,work:spec/catalogue-tooling-package-enhanced,work:spec/catalogue-tooling-rewire"},
   # ci-gates needs all Wave 4+5 specs; Gate F specifically needs rewire
   {path = "spec/catalogue-tooling-ci-gates", needs = "work:spec/catalogue-tooling-package-enhanced,work:spec/catalogue-tooling-rewire"},
 ]


### PR DESCRIPTION
## Summary

- Rewrites `packs/AGENTS.md` (114 lines, ≤ 150 limit): primitive layout table derived from `docs/contracts/adapter.toml`, `pack.toml` schema map, pack design model, canonical `agentbundle catalogue *` primary workflow
- Adds "Release Coupling" section to `AGENTS.local.md` explaining what does/doesn't require an AgentBundle release
- Adds 8 guide docs in new Diátaxis-organized top-level directories: `docs/guides/reference/` (catalogue-toml, catalogue-commands, catalogue-migration, catalogue-archive), `docs/guides/how-to/` (create-external-catalogue, enterprise-app-store, flow-e-disconnected), `docs/guides/explanation/` (release-coupling)
- Flow E guide explicitly states local channel-descriptor resolution is NOT supported

**Spec:** `docs/specs/catalogue-tooling-docs/spec.md` (Status: Shipped, all 12 ACs checked)

## Test plan

- [x] 10 Bucket 14 contract tests pass (`tools/test_catalogue_tooling_docs.py`)
- [x] All 43 Wave 5 tests pass (includes Wave 5a rewire tests)
- [x] `packs/AGENTS.md` is 114 lines (≤ 150)
- [x] All primitive source paths from adapter.toml appear in `packs/AGENTS.md`
- [x] All major `pack.toml` tables appear in the schema map
- [x] `AGENTS.local.md` has Release Coupling section; `AGENTS.md` and `packs/core/seeds/AGENTS.md` do not
- [x] Flow E guide contains "not supported" for local channel-descriptor resolution
- [x] No guide (except migration table) references old `agentbundle.build` commands
- [x] `workspace.toml` updated: `catalogue-tooling-docs` moved to shipped

**Deferred:** Wave 5c (CI gates) is the next PR in the ini-005 wave sequence.