### PR TITLE
style(web): tighten section spacing tokens

### DIFF
--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -140,8 +140,8 @@
   --ds-space-10: 128px;
 
   /* Section rhythm — responsive */
-  --ds-section-gap:    clamp(5rem, 10vw, 8rem);   /* between major sections */
-  --ds-section-pad-y:  clamp(4rem, 8vw, 6rem);    /* internal section padding */
+  --ds-section-gap:    clamp(3.5rem, 7vw, 5.5rem); /* between major sections */
+  --ds-section-pad-y:  clamp(3rem, 6vw, 4.5rem);  /* internal section padding */
   --ds-content-max:    1140px;                     /* max content width */
   --ds-content-pad-x:  clamp(1.25rem, 5vw, 2.5rem); /* horizontal margin */
 


### PR DESCRIPTION
## What changed

Reduced the two section-spacing CSS custom properties in `web/src/styles/tokens.css` to eliminate excess whitespace between and within page sections:

| Token | Before | After |
|---|---|---|
| `--ds-section-gap` | `clamp(5rem, 10vw, 8rem)` | `clamp(3.5rem, 7vw, 5.5rem)` |
| `--ds-section-pad-y` | `clamp(4rem, 8vw, 6rem)` | `clamp(3rem, 6vw, 4.5rem)` |

## Why

The current values produce noticeably large vertical gaps — roughly 80–128px between sections at desktop widths. The new values bring this down to 56–88px, which reads as tight and purposeful rather than sparse.

## Scope

Single file, two lines. No structural change, no new dependency, no framework change. `npm run build` exits 0 (41 pages).