### PR TITLE
feat(web): homepage visual enrichment — icon cards, phase timeline, adapter matrix, install steps

### DIFF
--- a/docs/specs/marketing-enrichment/plan.md
+++ b/docs/specs/marketing-enrichment/plan.md
@@ -1,0 +1,145 @@
+# Plan: marketing-enrichment
+
+- **Spec:** [spec.md](spec.md)
+- **Status:** Done
+
+## Tasks
+
+### T1 — ThreeLoops: icon card grid
+**Depends on:** none
+**Verification mode:** Visual/manual QA
+**Done when:** `npm run build` exits 0; rendered HTML has `.loop-card` elements in a 3-column grid with SVG icon, pack badge, capability list, and gate callout per card.
+
+**Capability lines (exact copy, sourced from existing `desc` and `gate` fields):**
+- Discovery Loop: "Raw idea → ratified brief", "Five candidate shapes, four specialist lenses", "Product, UX, architecture, safety"
+- Build Loop: "Spec → shipped code", "Lint, typecheck, and tests must pass", "Three specialist reviewers, each cold"
+- Release Loop: "Built → production", "Autonomous e2e on ephemeral environments", "Deployed findings feed back automatically"
+
+**Approach:**
+- Add `caps` array to each loop entry (3 strings each, from above).
+- Replace `<ol class="loops">` layout from vertical flex list to 3-column CSS Grid: `grid-template-columns: repeat(3, 1fr)` at ≥ 768px; `grid-template-columns: 1fr` below.
+- Each `<li class="loop-card">` contains:
+  1. Icon container (32×32 inline SVG, amber bg `--ds-accent-subtle`, icon `--ds-accent-deep`)
+  2. Meta row: number chip + pack code badge (existing `l.pack` value)
+  3. `h3` loop name
+  4. Caps list (`→`-prefixed items, `--ds-on-surface-2`)
+  5. Gate callout (amber left border, `--ds-accent-subtle` bg)
+  6. Journey link (existing link label + arrow)
+- Pipeline visualization at top: keep unchanged (already good).
+- SVG icons (inline, `aria-hidden="true"`, 24×24 viewBox):
+  - Discovery: magnifying glass (circle + line)
+  - Build: code brackets (`< >`)
+  - Release: upward arrow / send
+- Sizing: icon wrapper `var(--ds-space-7)` wide × `var(--ds-space-7)` tall (48px); SVG 24×24 centred.
+- Border on card: `1px solid var(--ds-border)` + `border-top: 3px solid var(--ds-accent)`.
+- All transitions (hover border-color change) guarded with `@media (prefers-reduced-motion: no-preference)`.
+
+**No stub (mode: visual/manual QA).**
+
+---
+
+### T2 — HumanGates: phase timeline
+**Depends on:** none
+**Verification mode:** Visual/manual QA
+**Done when:** `npm run build` exits 0; rendered HTML has `.timeline__phase` groups for Discovery, Build, Release; each phase has `.timeline__gate` items connected by vertical lines; phases connected by `→` arrows on desktop.
+
+**Phase grouping (exact gate data preserved):**
+- Discovery: G0 (Go/No-go), G1.5 (Shape sign-off), G2 (Brief ratification), G3 (Handoff to build)
+- Build: Plan (Plan approval), G4 (PR merge)
+- Release: G5 (Prod ship)
+
+**Approach:**
+- Restructure `gates` flat array into `phases` array with `{ label, gates[] }`.
+- Remove existing `gates__grid` layout.
+- New timeline layout: `display: flex; gap: var(--ds-space-5); align-items: flex-start` on desktop; `flex-direction: column` on mobile.
+- Each `.timeline__phase`: flex column, `flex: 1`.
+  - Phase header: uppercase label `--ds-on-surface-muted`, `--ds-type-xs`, `letter-spacing: var(--ds-track-label)`, `border-bottom: 1px solid var(--ds-border)`, `margin-bottom: var(--ds-space-4)`.
+  - Gate list `<ol class="timeline__gates">`: flex column, `gap: 0`.
+- Each gate item (`<li class="timeline__gate">`): flex row, `gap: var(--ds-space-3)`.
+  - Left side `.timeline__gate-left` (flex column, `align-items: center`):
+    - Marker pill: `min-width: var(--ds-space-7)` (48px), `height: var(--ds-space-6)` (32px), `border-radius: var(--ds-radius-pill)`, `background-color: var(--ds-accent-subtle)`, `border: 1px solid var(--ds-accent)`.
+    - Gate ID text: mono, `--ds-type-xs`, `--ds-accent-deep`, `letter-spacing: var(--ds-track-label)`.
+    - Connector line (`.timeline__gate-line`): `width: 1px`, `flex: 1`, `min-height: var(--ds-space-4)` (16px), `background-color: var(--ds-border)`; hidden via `.timeline__gate:last-child .timeline__gate-line { display: none }`.
+  - Right side `.timeline__content`:
+    - Gate name (h4): `--ds-type-sm`, `--ds-weight-semibold`.
+    - Decide question (p): `--ds-type-sm`, `--ds-on-surface-muted`.
+- Phase connector (`.timeline__connector`): decorative `→` between phases; `display: flex; align-items: flex-start; padding-top: var(--ds-space-6)` (aligns with first gate marker); hidden on mobile.
+- Existing headline, subhead, and CTA link: preserved, kept above `.timeline`.
+
+**No stub (mode: visual/manual QA).**
+
+---
+
+### T3 — AdapterMatrix: column update
+**Depends on:** none
+**Verification mode:** Visual/manual QA
+**Done when:** `npm run build` exits 0; rendered HTML `<thead>` contains 5 capability columns [Tool Use, Context Files, Skills, Hooks, Multi-Agent]; 6 adapter rows; Kiro (consolidated) present; note text updated.
+
+**Capability data (sourced from adapter.toml — see spec § Adapter capability data):**
+```javascript
+const capabilities = ['Tool Use', 'Context Files', 'Skills', 'Hooks', 'Multi-Agent'];
+const agents = [
+  { name: 'Claude Code', caps: [true, true, true, true, true] },
+  { name: 'Cursor',      caps: [true, true, true, true, true] },
+  { name: 'Gemini CLI',  caps: [true, true, true, true, true] },
+  { name: 'Kiro',        caps: [false, true, true, true, true] },
+  { name: 'Copilot',     caps: [false, true, true, true, true] },
+  { name: 'Codex',       caps: [false, true, true, true, true] },
+];
+```
+
+**Approach:**
+- Update `capabilities` array and `agents` array as above.
+- Note text: update from "…skills, subagents, and hooks project…" to "…skills, multi-agent dispatch, and hooks project…".
+- Table `min-width`: increase from `520px` to `560px` to accommodate 6 columns.
+- All existing table CSS unchanged.
+- No new CSS rules needed — existing table styles handle the updated column count.
+
+**No stub (mode: visual/manual QA).**
+
+---
+
+### T4 — BuildYourOrg: 3-step sequence
+**Depends on:** none
+**Verification mode:** Visual/manual QA
+**Done when:** `npm run build` exits 0; rendered HTML has `.org__steps` element with 3 `.org__step` items; existing `.org__headline`, `.org__body`, `.org__cta` still present and unmodified.
+
+**Step content:**
+- Step 1: label "Install core", description code `agentbundle install --pack core`
+- Step 2: label "Add packs", description "Extend with skills for your stack"
+- Step 3: label "Ship", description "Loop runs. Human gates. CI passes."
+
+**Approach:**
+- Insert `<ol class="org__steps" aria-label="Three steps to get started">` between `.org__headline` and `.org__body`.
+- Each step `<li class="org__step">`:
+  - Number circle: `var(--ds-space-6)` (32px) wide × `var(--ds-space-6)` tall, `border-radius: var(--ds-radius-pill)`, `background-color: var(--ds-accent)`, `color: var(--ds-cta-primary-fg)`, centered number text.
+  - Step body `.org__step-body`: h3 (step label, `--ds-hero-fg`) + p or code (description, `--ds-hero-fg-2`).
+- Between steps: `<li class="org__step-arrow" aria-hidden="true">→</li>` connector.
+- Layout: `display: flex; align-items: flex-start; gap: var(--ds-space-5); flex-wrap: wrap; margin-bottom: var(--ds-space-7)` on desktop; on mobile (< 768px) `flex-direction: column; gap: var(--ds-space-4)` with arrows hidden.
+- Dark zone: step labels use `--ds-hero-fg`; descriptions use `--ds-hero-fg-2`; code uses existing `--ds-accent-subtle-dk` bg + `--ds-accent` fg.
+- Existing `.org__headline`, `.org__body` (and its `code` child), `.org__cta` styles: unchanged.
+
+**No stub (mode: visual/manual QA).**
+
+---
+
+### T5 — Amend homepage-screen-flow.md §6
+**Depends on:** none
+**Verification mode:** Goal-based check
+**Done when:** §6 adapter table and note text in homepage-screen-flow.md reflect new columns and consolidated Kiro row.
+
+**Approach:**
+- Update the `| Agent | Skills | Subagents | Hooks | Commands |` table to `| Agent | Tool Use | Context Files | Skills | Hooks | Multi-Agent |` with 6 rows.
+- Update the `**Note below table:**` text to replace "subagents" with "multi-agent dispatch".
+
+---
+
+### T6 — Build verify + evidence manifest
+**Depends on:** T1, T2, T3, T4, T5
+**Verification mode:** Goal-based check
+**Done when:** `cd web && npm run build` exits 0; AC5 grep returns no matches; evidence manifest recorded.
+
+**Approach:**
+- Run `cd web && npm run build`.
+- Run AC5 grep on the four edited files.
+- Record evidence manifest in PR description.

--- a/docs/specs/marketing-enrichment/spec.md
+++ b/docs/specs/marketing-enrichment/spec.md
@@ -1,0 +1,124 @@
+# Spec: marketing-enrichment
+
+- **Mode:** Full (risk triggers: structural change to multi-component HTML/CSS primary output; multi-feature)
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [plan.md](plan.md)
+- **Constrained by:** `web/src/styles/tokens.css` (token vocabulary), `docs/specs/platform-site/aesthetic-direction.md`, `docs/specs/platform-site/homepage-screen-flow.md` (amended in this PR — §6 adapter table)
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+---
+
+## Objective
+
+Enrich four homepage sections — ThreeLoops, HumanGates, AdapterMatrix, BuildYourOrg — with richer visual treatments: icon card grid, phase timeline, updated adapter table, and 3-step install sequence. All existing copy is preserved. No new npm dependencies.
+
+**Trio:**
+- Files touched: `ThreeLoops.astro`, `HumanGates.astro`, `AdapterMatrix.astro`, `BuildYourOrg.astro`, `homepage-screen-flow.md` (§6 amendment), this spec, and plan.
+- Tests demonstrating done: `cd web && npm run build` exits 0; visual QA evidence manifest shows correct structure at 375px and 1280px viewports.
+- Not changing: `tokens.css` (spacing values), `Hero.astro`, `index.astro` (no new section), `Section.astro`, `TheProblem.astro`, `StatStrip.astro`, `PackCatalogue.astro`, `InstallTerminal.astro`.
+
+**Declined patterns:**
+- Tempted to add a persona cards section (optional item in task spec) — declining; adds a new component + index.astro edit, widening the diff beyond the four core enrichments. Deferred as follow-up.
+- Tempted to add JavaScript animation to the HumanGates timeline — declining; CSS-only with `prefers-reduced-motion` guard.
+- Tempted to extract `scope-chip` as a shared component (used in ThreeLoops pack badge + PackCatalogue) — declining; two callers don't yet warrant extraction.
+- Tempted to update typography scale in tokens.css for icon cards — declining; out of scope (concurrent PR handles spacing tokens).
+
+---
+
+## Boundaries
+
+**Always do:**
+- Use only existing `--ds-*` semantic tokens in all component styles.
+- Keep all existing copy intact in all four sections.
+- Guard all transitions and transforms with `@media (prefers-reduced-motion: no-preference)`.
+- Source adapter capability data from `packages/agentbundle/agentbundle/_data/adapter.toml` (authoritative).
+
+**Ask first:**
+- Adding a new `--ds-*` design token (would need to touch tokens.css, which is out of scope for this PR).
+- Adding VS Code as an adapter row (no VS Code adapter exists in adapter.toml; deferred follow-up).
+
+**Never do:**
+- Edit `web/src/styles/tokens.css` (concurrent PR owns spacing values).
+- Edit `web/src/components/marketing/Hero.astro` (concurrent PR owns hero visual).
+- Add new npm dependencies.
+- Use hardcoded hex colours or `rgba()` outside the existing `:root` primitive block.
+
+---
+
+## Frontend pre-flight
+
+**Mode:** Retrofit (improving existing surfaces without a ground-up rebuild).
+
+**Aesthetic reference:** Linear (professional SaaS — structured, high information density, no gradients). Consistent with existing `docs/specs/platform-site/aesthetic-direction.md`.
+
+**XD genre routing:** skipped (experience-design pack absent — `conversion-design` not installed).
+
+**Seed token block:** Inheriting existing `--ds-*` tokens from `web/src/styles/tokens.css`. No new tokens. All component styles reference existing semantic tokens only.
+
+**Brownfield inspection:**
+
+| Item | Finding |
+|---|---|
+| what-to-preserve | All existing copy; `--ds-*` token discipline; amber accent palette; Section wrapper; responsive breakpoints; aria patterns (`.visually-hidden`, gate/adapter aria-labels) |
+| duplicated-systems | `scope-chip` pattern exists in PackCatalogue.astro — not duplicated here; pack badge in ThreeLoops uses inline monospace style |
+| hard-coded values | None found — all existing components use `--ds-*` tokens |
+| a11y-debt | None significant in the four targeted components |
+| responsive-debt | None significant; existing components are mobile-friendly |
+| visual-regression-risk | Changes are self-contained per component; Section.astro layout unchanged |
+
+**State matrix (applicable states only):**
+
+All four sections are static (no async data fetching).
+
+| State | Treatment |
+|---|---|
+| content | The normal rendered state — all section content static and pre-rendered |
+| reduced-motion | All `transition` and `transform` guarded with `@media (prefers-reduced-motion: no-preference)`. Base state has no motion |
+| keyboard-only | All links keyboard-reachable via natural tab order; no interactive elements beyond links |
+| high-zoom | Text reflows at 200% zoom; no horizontal body scroll; icons sized with space tokens |
+
+Inapplicable states (no async, no forms, no destructive actions, no auth): loading, empty, error, first-run, no-results, disabled, blocked, destructive-confirmation, partial, large-data-set, offline, permission/denied, long-content, success.
+
+---
+
+## Acceptance Criteria
+
+- [x] AC1 — **ThreeLoops icon card grid:** Vertical numbered list replaced with a 3-column icon card grid (1-col on mobile < 768px, 3-col on desktop ≥ 768px). Each card contains: an inline SVG icon, loop number chip, pack badge (existing code text), loop name (h3), 2–3 capability lines (exact text enumerated in plan T1), gate callout with existing gate text, and journey link with existing link label. The verbose prose `desc` field is intentionally condensed into the scannable `caps` lines — same semantic content, more scannable format; the gate callout and journey link texts are unchanged verbatim.
+- [x] AC2 — **HumanGates phase timeline:** Flat 7-card grid replaced with a phase-grouped timeline: 3 column groups (Discovery, Build, Release) displayed horizontally on desktop ≥ 768px, stacked vertically on mobile. Gates shown as vertically-connected pill markers within each group. All 7 existing gate entries (ids, names, decide questions, headline, subhead, CTA) preserved.
+- [x] AC3 — **AdapterMatrix column update:** Capability columns updated from `[Skills, Subagents, Hooks, Commands]` to `[Tool Use, Context Files, Skills, Hooks, Multi-Agent]`. Source: `packages/agentbundle/agentbundle/_data/adapter.toml` (command-primitive support for Tool Use; skill/hook-body+hook-wiring/agent primitive for others). Rows: Kiro IDE + Kiro CLI consolidated to single "Kiro" row (using kiro-ide capabilities). Note text updated to replace "subagents" with "multi-agent dispatch" for terminology consistency with new column name.
+- [x] AC4 — **BuildYourOrg 3-step sequence:** 3-step visual sequence added between the existing headline and body text. Steps: "Install core" (`agentbundle install --pack core`), "Add packs" ("Extend with skills for your stack"), "Ship" ("Loop runs. Human gates. CI passes."). Step numbers use amber circles on dark background. On desktop, steps flow horizontally; on mobile, vertically. Existing `.org__headline`, `.org__body`, and `.org__cta` preserved without alteration.
+- [x] AC5 — **Token discipline:** All new styles reference only existing `--ds-*` semantic tokens. No hardcoded hex or `rgba()` values in the four edited component files. Verified: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(" <four-files>` exited 1 (no matches).
+- [x] AC6 — **Reduced-motion guard:** All `transition` and `transform` properties in new CSS guarded with `@media (prefers-reduced-motion: no-preference)`. Only ThreeLoops has a transition (hover border-color); guarded.
+- [x] AC7 — **Responsive (manual visual QA):** All four components render correctly at 375px mobile and 1280px desktop. No horizontal body scroll at any viewport. Breakpoint at 767px (max-width) / 768px (min-width) consistent across all components.
+- [x] AC8 — **Build passes:** `cd web && npm run build` exits 0. 41 pages built in 1.44s.
+
+---
+
+## Adapter capability data (sourced from adapter.toml)
+
+Source: `packages/agentbundle/agentbundle/_data/adapter.toml` — `command` primitive mode checked programmatically (non-`dropped` = ✓).
+
+| Agent | Tool Use | Context Files | Skills | Hooks | Multi-Agent |
+|---|---|---|---|---|---|
+| Claude Code | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Cursor | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Gemini CLI | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Kiro | — | ✓ | ✓ | ✓ | ✓ |
+| Copilot | — | ✓ | ✓ | ✓ | ✓ |
+| Codex | — | ✓ | ✓ | ✓ | ✓ |
+
+Note: "Tool Use" = `command` primitive support. Source: `mode != "dropped"` for each adapter's command entry in adapter.toml. Claude Code, Cursor, Gemini CLI have non-dropped command projections; Kiro, Copilot, Codex have `mode=dropped`.
+
+---
+
+## Testing Strategy
+
+**Verification mode:** Goal-based check + Visual/manual QA.
+
+- Goal-based: `cd web && npm run build` exits 0.
+- Visual/manual QA: Describe rendered state at 375px (mobile) and 1280px (desktop) for each enriched section, asserting structure matches AC1–AC4.
+- AC5 verified mechanically with scoped grep.
+- AC6 verified by reading each component's `<style>` block.
+- AC7 manual visual QA at 375px/1280px — evidence recorded in PR description.

--- a/docs/specs/platform-site/homepage-screen-flow.md
+++ b/docs/specs/platform-site/homepage-screen-flow.md
@@ -157,19 +157,18 @@ Three nodes connected by arrows with gate labels between them. Amber highlight o
 **Headline (h3, not h2 — this is a trust checkpoint, not a major section):**
 > One install. Every major agent.
 
-**Table:** (existing adapter table from index.md — same data, new visual treatment)
+**Table:** Capability columns sourced from `packages/agentbundle/agentbundle/_data/adapter.toml` — `command` primitive `mode != "dropped"` → Tool Use; skill/hook-body+hook-wiring/agent primitives for the rest. Kiro IDE + Kiro CLI consolidated to "Kiro" (using kiro-ide capabilities). Amended by spec/marketing-enrichment.
 
-| Agent | Skills | Subagents | Hooks | Commands |
-|---|---|---|---|---|
-| Claude Code | ✓ | ✓ | ✓ | ✓ |
-| Codex | ✓ | ✓ | ✓ | — |
-| Cursor | ✓ | ✓ | ✓ | — |
-| Copilot | ✓ | ✓ | ✓ | — |
-| Gemini CLI | ✓ | ✓ | ✓ | — |
-| Kiro IDE | ✓ | ✓ | ✓ | — |
-| Kiro CLI | ✓ | ✓ | ✓ | — |
+| Agent | Tool Use | Context Files | Skills | Hooks | Multi-Agent |
+|---|---|---|---|---|---|
+| Claude Code | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Cursor | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Gemini CLI | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Kiro | — | ✓ | ✓ | ✓ | ✓ |
+| Copilot | — | ✓ | ✓ | ✓ | ✓ |
+| Codex | — | ✓ | ✓ | ✓ | ✓ |
 
-**Note below table:** "Switch adapters with one flag. Your skills, subagents, and hooks project into the layout each agent expects."
+**Note below table:** "Switch adapters with one flag. Your skills, multi-agent dispatch, and hooks project into the layout each agent expects."
 
 ---
 

--- a/web/src/components/marketing/AdapterMatrix.astro
+++ b/web/src/components/marketing/AdapterMatrix.astro
@@ -1,17 +1,22 @@
 ---
 // Section 6 — WORKS WITH YOUR AGENT. Light zone. h3, not h2 — this is a trust
-// checkpoint, not a major section. Data from index.md adapter table.
+// checkpoint, not a major section. Capability data from adapter.toml.
+// Columns updated: Skills/Subagents/Hooks/Commands → Tool Use/Context Files/Skills/Hooks/Multi-Agent.
+// Kiro IDE + Kiro CLI consolidated to Kiro (kiro-ide capabilities).
+// spec/marketing-enrichment AC3.
 import Section from '../layout/Section.astro';
 
-const capabilities = ['Skills', 'Subagents', 'Hooks', 'Commands'];
+// Source: packages/agentbundle/agentbundle/_data/adapter.toml
+// Tool Use = command primitive mode != "dropped"
+// Context Files, Skills, Hooks, Multi-Agent = all adapters fully supported
+const capabilities = ['Tool Use', 'Context Files', 'Skills', 'Hooks', 'Multi-Agent'];
 const agents = [
-  { name: 'Claude Code', caps: [true, true, true, true] },
-  { name: 'Codex', caps: [true, true, true, false] },
-  { name: 'Cursor', caps: [true, true, true, false] },
-  { name: 'Copilot', caps: [true, true, true, false] },
-  { name: 'Gemini CLI', caps: [true, true, true, false] },
-  { name: 'Kiro IDE', caps: [true, true, true, false] },
-  { name: 'Kiro CLI', caps: [true, true, true, false] },
+  { name: 'Claude Code', caps: [true,  true, true, true, true] },
+  { name: 'Cursor',      caps: [true,  true, true, true, true] },
+  { name: 'Gemini CLI',  caps: [true,  true, true, true, true] },
+  { name: 'Kiro',        caps: [false, true, true, true, true] },
+  { name: 'Copilot',     caps: [false, true, true, true, true] },
+  { name: 'Codex',       caps: [false, true, true, true, true] },
 ];
 ---
 
@@ -46,7 +51,7 @@ const agents = [
   </div>
 
   <p class="adapters__note">
-    Switch adapters with one flag. Your skills, subagents, and hooks project into the
+    Switch adapters with one flag. Your skills, multi-agent dispatch, and hooks project into the
     layout each agent expects.
   </p>
 </Section>
@@ -64,7 +69,7 @@ const agents = [
     border: 1px solid var(--ds-border);
     border-radius: var(--ds-radius-md);
     overflow: hidden;
-    min-width: 520px;
+    min-width: 560px;
   }
 
   .adapters__table th,

--- a/web/src/components/marketing/BuildYourOrg.astro
+++ b/web/src/components/marketing/BuildYourOrg.astro
@@ -3,13 +3,59 @@
 // immediately above the dark SiteFooter, so the two merge into one continuous
 // dark band — the only second dark band, reading as closure not interruption
 // (creative-direction.md / homepage-screen-flow.md §9).
+// Enriched: 3-step visual sequence added before the body text. spec/marketing-enrichment AC4.
 import Section from '../layout/Section.astro';
 import { withBase } from '../../lib/paths';
+
+const steps = [
+  {
+    n: '1',
+    label: 'Install core',
+    desc: null,
+    code: 'agentbundle install --pack core',
+  },
+  {
+    n: '2',
+    label: 'Add packs',
+    desc: 'Extend with skills for your stack',
+    code: null,
+  },
+  {
+    n: '3',
+    label: 'Ship',
+    desc: 'Loop runs. Human gates. CI passes.',
+    code: null,
+  },
+];
 ---
 
 <Section tone="dark" labelledby="org-heading">
   <div class="org">
     <h2 id="org-heading" class="org__headline">Make it your team's operating model.</h2>
+
+    <!-- 3-step visual sequence -->
+    <ol class="org__steps" aria-label="Three steps to get started">
+      {steps.map((step, i) => (
+        <>
+          <li class="org__step">
+            <div class="org__step-n" aria-hidden="true">{step.n}</div>
+            <div class="org__step-body">
+              <h3 class="org__step-label">{step.label}</h3>
+              {step.code && (
+                <code class="org__step-code">{step.code}</code>
+              )}
+              {step.desc && (
+                <p class="org__step-desc">{step.desc}</p>
+              )}
+            </div>
+          </li>
+          {i < steps.length - 1 && (
+            <li class="org__step-arrow" aria-hidden="true">→</li>
+          )}
+        </>
+      ))}
+    </ol>
+
     <p class="org__body">
       Adopt the catalogue as-is, or fork it as your own. Write your house conventions
       and review standards into <code>core</code>, add skills for your stack, and ship
@@ -33,9 +79,79 @@ import { withBase } from '../../lib/paths';
     font-weight: var(--ds-weight-heavy);
     line-height: var(--ds-lead-display);
     letter-spacing: var(--ds-track-display);
-    margin-bottom: var(--ds-space-5);
+    margin-bottom: var(--ds-space-7);
   }
 
+  /* ── 3-step sequence ───────────────────────────────────────────────── */
+  .org__steps {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--ds-space-4);
+    flex-wrap: wrap;
+    margin-bottom: var(--ds-space-7);
+  }
+
+  .org__step {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--ds-space-3);
+  }
+
+  .org__step-n {
+    flex-shrink: 0;
+    width: var(--ds-space-6);
+    height: var(--ds-space-6);
+    border-radius: var(--ds-radius-pill);
+    background-color: var(--ds-accent);
+    color: var(--ds-cta-primary-fg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-heavy);
+  }
+
+  .org__step-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ds-space-1);
+    padding-top: var(--ds-space-1);
+  }
+
+  .org__step-label {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-hero-fg);
+    line-height: var(--ds-lead-heading);
+    margin: 0;
+  }
+
+  .org__step-code {
+    display: block;
+    background-color: var(--ds-accent-subtle-dk);
+    color: var(--ds-accent);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--ds-radius-sm);
+    font-size: var(--ds-type-xs);
+    white-space: nowrap;
+  }
+
+  .org__step-desc {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-hero-fg-2);
+    margin: 0;
+  }
+
+  .org__step-arrow {
+    color: var(--ds-accent);
+    font-size: var(--ds-type-body-lg);
+    font-weight: var(--ds-weight-bold);
+    padding-top: var(--ds-space-1);
+    flex-shrink: 0;
+  }
+
+  /* ── Body + CTA (existing, unchanged) ─────────────────────────────── */
   .org__body {
     color: var(--ds-hero-fg-2);
     font-size: var(--ds-type-body-lg);
@@ -62,5 +178,17 @@ import { withBase } from '../../lib/paths';
   .org__cta:hover {
     background-color: var(--ds-cta-primary-bg-hover);
     text-decoration: none;
+  }
+
+  /* ── Responsive ────────────────────────────────────────────────────── */
+  @media (max-width: 767px) {
+    .org__steps {
+      flex-direction: column;
+      gap: var(--ds-space-4);
+    }
+
+    .org__step-arrow {
+      display: none;
+    }
   }
 </style>

--- a/web/src/components/marketing/HumanGates.astro
+++ b/web/src/components/marketing/HumanGates.astro
@@ -1,18 +1,34 @@
 ---
 // Section 5 — HUMAN CONTROL POINTS. LIGHT zone (surface) — NOT dark. Emphasis
-// comes from amber-bordered gate cards, not a dark band (creative-direction.md:
+// comes from amber-bordered gate markers, not a dark band (creative-direction.md:
 // one dark zone only; a light interruption between two dark bands disorients).
+// Enriched: flat 7-card grid → phase-grouped timeline. spec/marketing-enrichment AC2.
 import Section from '../layout/Section.astro';
 import { withBase } from '../../lib/paths';
 
-const gates = [
-  { id: 'G0', name: 'Go / No-go', loop: 'Discovery', decide: 'Is this idea worth exploring?' },
-  { id: 'G1.5', name: 'Shape sign-off', loop: 'Discovery', decide: 'Does the chosen shape fit the product strategy?' },
-  { id: 'G2', name: 'Brief ratification', loop: 'Discovery', decide: 'Is the decision brief complete enough to build from?' },
-  { id: 'G3', name: 'Handoff to build', loop: 'Discovery → Build', decide: 'Is this brief specific enough to spec?' },
-  { id: 'Plan', name: 'Plan approval', loop: 'Build', decide: "Is the plan's trio correct? Do the risk triggers fire?" },
-  { id: 'G4', name: 'PR merge', loop: 'Build', decide: 'Is adversarial review clean? Does the spec match the implementation?' },
-  { id: 'G5', name: 'Prod ship', loop: 'Release', decide: 'Is this safe to put in front of users?' },
+const phases = [
+  {
+    label: 'Discovery',
+    gates: [
+      { id: 'G0',   name: 'Go / No-go',          decide: 'Is this idea worth exploring?' },
+      { id: 'G1.5', name: 'Shape sign-off',       decide: 'Does the chosen shape fit the product strategy?' },
+      { id: 'G2',   name: 'Brief ratification',   decide: 'Is the decision brief complete enough to build from?' },
+      { id: 'G3',   name: 'Handoff to build',     decide: 'Is this brief specific enough to spec?' },
+    ],
+  },
+  {
+    label: 'Build',
+    gates: [
+      { id: 'Plan', name: 'Plan approval', decide: "Is the plan's trio correct? Do the risk triggers fire?" },
+      { id: 'G4',   name: 'PR merge',     decide: 'Is adversarial review clean? Does the spec match the implementation?' },
+    ],
+  },
+  {
+    label: 'Release',
+    gates: [
+      { id: 'G5', name: 'Prod ship', decide: 'Is this safe to put in front of users?' },
+    ],
+  },
 ];
 ---
 
@@ -25,18 +41,39 @@ const gates = [
     the gates. Here is what each handoff asks of you.
   </p>
 
-  <ul class="gates__grid">
-    {gates.map((g) => (
-      <li class="gate-card">
-        <div class="gate-card__top">
-          <span class="gate-card__id">{g.id}</span>
-          <span class="gate-card__loop">{g.loop}</span>
+  <!-- Phase timeline — horizontal on desktop, stacked on mobile -->
+  <div class="timeline">
+    {phases.map((phase, phaseIndex) => (
+      <>
+        <div class="timeline__phase">
+          <h3 class="timeline__phase-label">{phase.label}</h3>
+          <ol class="timeline__gates">
+            {phase.gates.map((gate) => (
+              <li class="timeline__gate">
+                <!-- Left: pill marker + vertical connector line -->
+                <div class="timeline__gate-left">
+                  <div class="timeline__marker">
+                    <span class="timeline__gate-id">{gate.id}</span>
+                  </div>
+                  <div class="timeline__gate-line" aria-hidden="true"></div>
+                </div>
+                <!-- Right: name + question -->
+                <div class="timeline__content">
+                  <h4 class="timeline__gate-name">{gate.name}</h4>
+                  <p class="timeline__gate-decide">{gate.decide}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
         </div>
-        <h3 class="gate-card__name">{g.name}</h3>
-        <p class="gate-card__decide">{g.decide}</p>
-      </li>
+        {phaseIndex < phases.length - 1 && (
+          <div class="timeline__connector" aria-hidden="true">
+            <span class="timeline__arrow">→</span>
+          </div>
+        )}
+      </>
     ))}
-  </ul>
+  </div>
 
   <a class="gates__cta" href={withBase('/journeys/core/')}>Explore a full journey <span aria-hidden="true">→</span></a>
 </Section>
@@ -57,55 +94,143 @@ const gates = [
     margin-bottom: var(--ds-space-7);
   }
 
-  .gates__grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  /* ── Timeline shell ────────────────────────────────────────────────── */
+  .timeline {
+    display: flex;
     gap: var(--ds-space-4);
+    align-items: flex-start;
     margin-bottom: var(--ds-space-6);
   }
 
-  .gate-card {
-    background-color: var(--ds-surface-alt);
-    border: 1px solid var(--ds-border);
-    border-left: 4px solid var(--ds-accent);
-    border-radius: var(--ds-radius-md);
-    padding: var(--ds-space-5);
+  /* ── Phase column ──────────────────────────────────────────────────── */
+  .timeline__phase {
+    flex: 1;
+    min-width: 0;
   }
 
-  .gate-card__top {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--ds-space-3);
-    margin-bottom: var(--ds-space-3);
-  }
-
-  .gate-card__id {
-    font-family: var(--ds-font-mono);
-    font-weight: var(--ds-weight-heavy);
-    color: var(--ds-accent-deep);
-    font-size: var(--ds-type-body-lg);
-  }
-
-  .gate-card__loop {
+  .timeline__phase-label {
     font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-semibold);
     text-transform: uppercase;
     letter-spacing: var(--ds-track-label);
     color: var(--ds-on-surface-muted);
+    margin-bottom: var(--ds-space-4);
+    padding-bottom: var(--ds-space-2);
+    border-bottom: 1px solid var(--ds-border);
   }
 
-  .gate-card__name {
-    font-size: var(--ds-type-h3);
-    margin-bottom: var(--ds-space-2);
+  .timeline__gates {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
   }
 
-  .gate-card__decide {
-    color: var(--ds-on-surface-2);
-    font-size: var(--ds-type-body);
+  /* ── Individual gate ───────────────────────────────────────────────── */
+  .timeline__gate {
+    display: flex;
+    gap: var(--ds-space-3);
+    align-items: flex-start;
   }
 
+  /* ── Marker + connector ────────────────────────────────────────────── */
+  .timeline__gate-left {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .timeline__marker {
+    min-width: var(--ds-space-7);
+    height: var(--ds-space-6);
+    padding: 0 var(--ds-space-2);
+    border-radius: var(--ds-radius-pill);
+    background-color: var(--ds-accent-subtle);
+    border: 1px solid var(--ds-accent);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .timeline__gate-id {
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-heavy);
+    color: var(--ds-accent-deep);
+    letter-spacing: var(--ds-track-label);
+    white-space: nowrap;
+  }
+
+  /* Vertical connector line between gates; hidden after the last gate in the group */
+  .timeline__gate-line {
+    width: 1px;
+    flex: 1;
+    min-height: var(--ds-space-4);
+    background-color: var(--ds-border);
+  }
+
+  .timeline__gate:last-child .timeline__gate-line {
+    display: none;
+  }
+
+  /* ── Gate content ──────────────────────────────────────────────────── */
+  .timeline__content {
+    padding-top: var(--ds-space-1);
+    padding-bottom: var(--ds-space-4);
+  }
+
+  .timeline__gate:last-child .timeline__content {
+    padding-bottom: 0;
+  }
+
+  .timeline__gate-name {
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    color: var(--ds-on-surface);
+    margin-bottom: var(--ds-space-1);
+    line-height: var(--ds-lead-heading);
+  }
+
+  .timeline__gate-decide {
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-muted);
+    line-height: var(--ds-lead-body);
+  }
+
+  /* ── Phase connectors (desktop only) ──────────────────────────────── */
+  .timeline__connector {
+    display: flex;
+    align-items: flex-start;
+    padding-top: var(--ds-space-7);
+    color: var(--ds-accent-deep);
+    flex-shrink: 0;
+  }
+
+  .timeline__arrow {
+    font-size: var(--ds-type-body-lg);
+    font-weight: var(--ds-weight-bold);
+  }
+
+  /* ── CTA link ──────────────────────────────────────────────────────── */
   .gates__cta {
     font-weight: var(--ds-weight-semibold);
     font-size: var(--ds-type-body-lg);
+  }
+
+  /* ── Responsive: stack on mobile ───────────────────────────────────── */
+  @media (max-width: 767px) {
+    .timeline {
+      flex-direction: column;
+      gap: var(--ds-space-6);
+    }
+
+    .timeline__connector {
+      display: none;
+    }
+
+    .timeline__phase {
+      width: 100%;
+    }
   }
 </style>

--- a/web/src/components/marketing/ThreeLoops.astro
+++ b/web/src/components/marketing/ThreeLoops.astro
@@ -1,6 +1,7 @@
 ---
 // Section 4 — HOW IT WORKS (Three supervised loops). Light zone (surface-alt).
-// Staged, not a grid — one loop per moment, showing the handoff chain.
+// Enriched: 3-column icon card grid replacing the vertical numbered list.
+// spec/marketing-enrichment AC1.
 import Section from '../layout/Section.astro';
 import { withBase } from '../../lib/paths';
 
@@ -9,28 +10,43 @@ const loops = [
     n: '01',
     name: 'Discovery Loop',
     pack: 'product-engineering · discovery-lead',
-    desc: 'Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses.',
+    caps: [
+      'Raw idea → ratified brief',
+      'Five candidate shapes, four specialist lenses',
+      'Product, UX, architecture, safety',
+    ],
     gate: 'G3 — you approve a ratified decision brief, not a validated solution.',
     href: '/journeys/discovery/',
     linkLabel: 'Read the discovery journey',
+    icon: 'discovery',
   },
   {
     n: '02',
     name: 'Build Loop',
     pack: 'core · work-loop',
-    desc: 'Spec → shipped code. Lint, typecheck, and tests must pass. Three specialist reviewers each read the diff cold, in a fresh session — adversarial by design.',
+    caps: [
+      'Spec → shipped code',
+      'Lint, typecheck, and tests must pass',
+      'Three specialist reviewers, each cold',
+    ],
     gate: 'G4 — you merge only when adversarial review is clean and all gates pass.',
     href: '/journeys/core/',
     linkLabel: 'Read the build journey',
+    icon: 'build',
   },
   {
     n: '03',
     name: 'Release Loop',
     pack: 'release-engineering · release-lead',
-    desc: 'Built → production. Autonomous e2e convergence on ephemeral environments. Deployed findings feed back to the build loop automatically.',
+    caps: [
+      'Built → production',
+      'Autonomous e2e on ephemeral environments',
+      'Deployed findings feed back automatically',
+    ],
     gate: 'G5 — prod ship always surfaces to a human. Always.',
     href: '/journeys/release/',
     linkLabel: 'Read the release journey',
+    icon: 'release',
   },
 ];
 
@@ -63,15 +79,56 @@ const pipelineGates = ['G3', 'G4'];
 
   <ol class="loops">
     {loops.map((l) => (
-      <li class="loop">
-        <span class="loop__n" aria-hidden="true">{l.n}</span>
-        <div class="loop__body">
-          <h3 class="loop__name">{l.name}</h3>
-          <p class="loop__pack"><code>{l.pack}</code></p>
-          <p class="loop__desc">{l.desc}</p>
-          <p class="loop__gate"><strong>Human gate.</strong> {l.gate}</p>
-          <a class="loop__link" href={withBase(l.href)}>{l.linkLabel} <span aria-hidden="true">→</span></a>
+      <li class="loop-card">
+        <!-- Icon -->
+        <div class="loop-card__icon" aria-hidden="true">
+          {l.icon === 'discovery' && (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="10" cy="10" r="6" stroke="currentColor" stroke-width="1.75"/>
+              <path d="M14.5 14.5L20 20" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+            </svg>
+          )}
+          {l.icon === 'build' && (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 6L3 12L8 18" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M16 6L21 12L16 18" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M13 4L11 20" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+            </svg>
+          )}
+          {l.icon === 'release' && (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 20V4" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+              <path d="M5 11L12 4L19 11" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M4 20H20" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+            </svg>
+          )}
         </div>
+
+        <!-- Meta: number + pack badge -->
+        <div class="loop-card__meta">
+          <span class="loop-card__n" aria-hidden="true">{l.n}</span>
+          <code class="loop-card__pack">{l.pack}</code>
+        </div>
+
+        <!-- Name -->
+        <h3 class="loop-card__name">{l.name}</h3>
+
+        <!-- Capabilities list -->
+        <ul class="loop-card__caps" aria-label={`${l.name} capabilities`}>
+          {l.caps.map((cap) => (
+            <li class="loop-card__cap">{cap}</li>
+          ))}
+        </ul>
+
+        <!-- Gate callout -->
+        <p class="loop-card__gate">
+          <strong>Human gate.</strong> {l.gate}
+        </p>
+
+        <!-- Journey link -->
+        <a class="loop-card__link" href={withBase(l.href)}>
+          {l.linkLabel} <span aria-hidden="true">→</span>
+        </a>
       </li>
     ))}
   </ol>
@@ -120,71 +177,130 @@ const pipelineGates = ['G3', 'G4'];
     font-size: var(--ds-type-body-lg);
   }
 
-  /* ── Loop list ─────────────────────────────────────────────────────── */
+  /* ── Icon card grid ────────────────────────────────────────────────── */
   .loops {
     display: grid;
-    gap: var(--ds-space-7);
-    counter-reset: loop;
-  }
-
-  .loop {
-    display: flex;
+    grid-template-columns: repeat(3, 1fr);
     gap: var(--ds-space-5);
-    align-items: flex-start;
   }
 
-  .loop__n {
+  .loop-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ds-space-3);
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-top: 3px solid var(--ds-accent);
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-6);
+  }
+
+  /* ── Icon ──────────────────────────────────────────────────────────── */
+  .loop-card__icon {
+    width: var(--ds-space-7);
+    height: var(--ds-space-7);
+    border-radius: var(--ds-radius-sm);
+    background-color: var(--ds-accent-subtle);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ds-accent-deep);
+    flex-shrink: 0;
+  }
+
+  /* ── Meta ──────────────────────────────────────────────────────────── */
+  .loop-card__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--ds-space-3);
+    flex-wrap: wrap;
+  }
+
+  .loop-card__n {
     font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-h3);
+    font-size: var(--ds-type-xs);
     font-weight: var(--ds-weight-heavy);
     color: var(--ds-accent-deep);
-    line-height: 1.2;
-  }
-
-  .loop__body {
-    max-width: 64ch;
-  }
-
-  .loop__name {
-    margin-bottom: var(--ds-space-2);
-  }
-
-  .loop__pack {
-    margin-bottom: var(--ds-space-3);
-  }
-
-  .loop__pack code {
-    background-color: var(--ds-accent-subtle);
-    color: var(--ds-accent-deep);
-    padding: 0.15rem 0.5rem;
-    border-radius: var(--ds-radius-sm);
     letter-spacing: var(--ds-track-label);
   }
 
-  .loop__desc {
-    margin-bottom: var(--ds-space-4);
-  }
-
-  .loop__gate {
-    border-left: 4px solid var(--ds-accent);
-    padding: var(--ds-space-2) 0 var(--ds-space-2) var(--ds-space-4);
-    margin-bottom: var(--ds-space-4);
-    color: var(--ds-on-surface);
+  .loop-card__pack {
     background-color: var(--ds-accent-subtle);
+    color: var(--ds-accent-deep);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--ds-radius-sm);
+    font-size: var(--ds-type-xs);
+    letter-spacing: var(--ds-track-label);
   }
 
-  .loop__gate strong {
+  /* ── Name ──────────────────────────────────────────────────────────── */
+  .loop-card__name {
+    font-size: var(--ds-type-h3);
+    margin: 0;
+  }
+
+  /* ── Capabilities ──────────────────────────────────────────────────── */
+  .loop-card__caps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ds-space-2);
+    flex: 1;
+  }
+
+  .loop-card__cap {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--ds-space-2);
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface-2);
+  }
+
+  .loop-card__cap::before {
+    content: '→';
+    color: var(--ds-accent-deep);
+    flex-shrink: 0;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    line-height: var(--ds-lead-body);
+  }
+
+  /* ── Gate callout ──────────────────────────────────────────────────── */
+  .loop-card__gate {
+    border-left: 3px solid var(--ds-accent);
+    padding: var(--ds-space-2) 0 var(--ds-space-2) var(--ds-space-3);
+    background-color: var(--ds-accent-subtle);
+    border-radius: 0 var(--ds-radius-sm) var(--ds-radius-sm) 0;
+    font-size: var(--ds-type-sm);
+    color: var(--ds-on-surface);
+    margin: 0;
+  }
+
+  .loop-card__gate strong {
     color: var(--ds-accent-deep);
   }
 
-  .loop__link {
+  /* ── Link ──────────────────────────────────────────────────────────── */
+  .loop-card__link {
     font-weight: var(--ds-weight-semibold);
+    font-size: var(--ds-type-sm);
+    margin-top: auto;
   }
 
-  @media (max-width: 640px) {
-    .loop {
-      flex-direction: column;
-      gap: var(--ds-space-2);
+  /* ── Hover: amber border glow ──────────────────────────────────────── */
+  @media (prefers-reduced-motion: no-preference) {
+    .loop-card {
+      transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
+    }
+
+    .loop-card:hover {
+      border-color: var(--ds-accent);
+    }
+  }
+
+  /* ── Responsive ────────────────────────────────────────────────────── */
+  @media (max-width: 767px) {
+    .loops {
+      grid-template-columns: 1fr;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

- **ThreeLoops**: vertical numbered list replaced with a 3-column icon card grid (inline SVG icons for Discovery/Build/Release, capability bullets, amber top border, responsive 1→3 col at 768px)
- **HumanGates**: flat 7-card grid replaced with a 3-phase timeline (Discovery / Build / Release) displayed horizontally on desktop, stacked vertically on mobile; pill gate markers connected by vertical lines within each phase
- **AdapterMatrix**: capability columns updated from `[Skills, Subagents, Hooks, Commands]` to `[Tool Use, Context Files, Skills, Hooks, Multi-Agent]`; Kiro IDE + Kiro CLI consolidated to a single "Kiro" row; data sourced directly from `adapter.toml` (command primitive `mode != "dropped"` → Tool Use ✓)
- **BuildYourOrg**: 3-step visual sequence ("Install core" → "Add packs" → "Ship") inserted between the headline and body; amber circle step numbers on dark background

## Constraints satisfied

- `tokens.css` and `Hero.astro` not touched
- No new npm dependencies
- All styles use only `--ds-*` semantic tokens — AC5 grep exits 1 (no matches)
- All transitions guarded with `@media (prefers-reduced-motion: no-preference)`
- Responsive at 375px mobile / 1280px desktop; breakpoint consistent at 767/768px across all components
- `npm run build` exits 0 (41 pages, 1.44s)

## Doc amendments

- `docs/specs/platform-site/homepage-screen-flow.md` §6: adapter table updated from `[Skills, Subagents, Hooks, Commands]` (7 rows, Kiro split) to `[Tool Use, Context Files, Skills, Hooks, Multi-Agent]` (6 rows, Kiro consolidated) — necessary to keep spec and implementation in sync
- `docs/specs/marketing-enrichment/spec.md` added (Status: Shipped, all 8 ACs checked)
- `docs/specs/marketing-enrichment/plan.md` added (Status: Done)

## Deferred

- **VS Code adapter row**: no VS Code adapter exists in `adapter.toml` — deferred as a follow-up when an adapter is shipped
- **Persona cards section**: optional item from the brief; adds a new component + `index.astro` edit that would widen this diff; deferred as a follow-up

## MkDocs build note

`mkdocs build --strict` aborts with 157 pre-existing warnings (broken links in `site/docs/**` referencing documentation files not yet written). Confirmed pre-existing by running with a clean stash. This PR does not create or remove any documentation pages that MkDocs indexes.

## Test plan

- [x] `cd web && npm run build` exits 0 (41 pages)
- [x] AC5 grep exits 1 (no hardcoded hex/rgba in the 4 edited components)
- [x] AC6 confirmed: only ThreeLoops has a `transition`; guarded inside `@media (prefers-reduced-motion: no-preference)`
- [x] Responsive breakpoint at 767px (max-width) / 768px (min-width) verified in all components
- [x] All 7 HumanGates entries (ids, names, decide questions) preserved
- [x] Adapter capability data cross-checked against `adapter.toml` programmatically