### PR TITLE
docs(experience-design): fill three guide gaps — workspace-design, token-chain tutorial, analytical/interaction boundary

### DIFF
--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -320,6 +320,14 @@ export default defineConfig({
                     { label: 'Author Design Intent', slug: 'guides/experience-design/how-to/author-design-intent' },
                     { label: 'Three-Way Copy Boundary', slug: 'guides/experience-design/how-to/copy-layer-boundary' },
                     { label: 'Content Design vs UX Writing', slug: 'guides/experience-design/how-to/content-design-vs-ux-writing' },
+                    { label: 'Workspace Design', slug: 'guides/experience-design/how-to/workspace-design' },
+                    { label: 'Analytical vs Interaction Design', slug: 'guides/experience-design/how-to/analytical-vs-interaction-design' },
+                  ],
+                },
+                {
+                  label: 'Tutorials',
+                  items: [
+                    { label: 'Design Token Chain', slug: 'guides/experience-design/tutorials/design-token-chain-worked-example' },
                   ],
                 },
                 {

--- a/docs/guides/experience-design/how-to/analytical-vs-interaction-design.md
+++ b/docs/guides/experience-design/how-to/analytical-vs-interaction-design.md
@@ -1,0 +1,48 @@
+# analytical-design vs. interaction-design: pick the right skill
+
+**Use this when:** a task touches data layout, chart selection, or visualization — and you need to decide whether `analytical-design` or `interaction-design` is the right skill.
+**Prerequisites:** `experience-design` pack installed.
+**Result:** a clear routing decision, so data-encoding and visualization work lands in the right skill and no step is done twice.
+
+> **How-to** — task-oriented. Pick the right skill using the triggers below. For *why* the thread is shaped this way, read [The experience thread](../explanation/the-experience-thread.md).
+
+## The boundary
+
+**`analytical-design`** owns the structural specification for analytical surfaces: the widget hierarchy, the spatial layout grammar, and the role-based view architecture that lets a user move from a status signal to a diagnostic to a corrective action without losing their place. It is dashboard IA. It does not design individual chart encodings or component interactions.
+
+**`interaction-design`** owns the behavioral layer for a screen or component: how it responds to actions, validates input, transitions between states, and guides users through gesture and cognitive fit. When a chart or widget has interactive behavior — drill-through, hover tooltips, filter state changes, animated data updates — that behavior belongs to `interaction-design`.
+
+The two skills are complementary. Run `analytical-design` to set the structural frame (widget hierarchy, zone layout, role-based views, per-widget state set). Then run `interaction-design` for the interactive components that inhabit that frame.
+
+## Decision triggers
+
+| Stimulus | Skill |
+|---|---|
+| "What chart type should go here?" | `analytical-design` |
+| "How should the KPI row be organized?" | `analytical-design` |
+| "What goes above vs. below the fold on this dashboard?" | `analytical-design` |
+| "What views do we need for the executive vs. the on-call engineer?" | `analytical-design` |
+| "What should a widget show when it has no data?" | `analytical-design` (per-widget state spec) |
+| "How does a drill-through click behave step by step?" | `interaction-design` |
+| "What happens when the user hovers over a data point?" | `interaction-design` |
+| "Design the filter panel — how does it open, apply, and reset?" | `interaction-design` |
+| "How does form validation work on a report-configuration form?" | `interaction-design` |
+| "What is the feedback timing when a chart is refreshing?" | `interaction-design` |
+| "Design the animated transition when data updates." | `interaction-design` |
+
+## The split-ownership case
+
+A chart widget on a dashboard spans both skills:
+
+- **`analytical-design`** owns where the widget sits in the hierarchy, which business question it answers, and its required state set (loading / empty / error / populated / stale).
+- **`interaction-design`** owns what happens *inside* the widget once it is placed: the state machine for hover, click, drill-through, and tooltip; the feedback timing for data refresh; the animated transition between data states (if any).
+
+Run `analytical-design` first. Placement and state-set decisions are structural constraints; the behavioral decisions build on top of them.
+
+## Common mistakes
+
+**Using `interaction-design` to choose chart types.** Chart type selection follows from the domain model and the business question the widget answers — it is an `analytical-design` decision, not a component behavioral one. Routing chart-type work to `interaction-design` produces a behavioral spec with no structural grounding.
+
+**Using `analytical-design` for form validation on a filter panel.** If the task is about how a filter input validates, what happens on a submit error, or the tab order through a configuration form, that is `interaction-design` territory. `analytical-design` defines the filter panel's placement and its business-question role; `interaction-design` defines how interacting with the panel feels.
+
+**Conflating "widget states" with "widget behavior."** `analytical-design` names which states a widget must handle (the quality floor: loading, empty, error, populated, stale). `interaction-design` designs the transitions and feedback that animate those states. One names the set; the other models the machine.

--- a/docs/guides/experience-design/how-to/workspace-design.md
+++ b/docs/guides/experience-design/how-to/workspace-design.md
@@ -1,0 +1,85 @@
+# Design a workspace surface
+
+**Use this when:** you are designing a productivity tool, collaborative environment, agentic UI, or any surface whose primary purpose is to support sustained professional work across sessions.
+**Prerequisites:** `experience-design` pack installed; a session arc and collaboration model named.
+**Result:** a structural specification for the workspace surface — context-persistence architecture, attention zone layout, collaboration state IA, interrupt design, and the agentic patterns that make the surface feel controllable.
+
+> **How-to** — task-oriented. Pick `workspace-design` when the surface supports sustained professional work; pick `interaction-design` when the surface is a conventional screen state machine. For *why* the thread is shaped this way, read [The experience thread](../explanation/the-experience-thread.md).
+
+## workspace-design vs. interaction-design — the key decision
+
+Both skills design *how* a surface behaves, but they operate at different scopes and for different surface genres:
+
+| Signal | Skill |
+|---|---|
+| Surface supports repeated, cross-session professional work | `workspace-design` |
+| Surface includes autonomous agents running tasks on the user's behalf | `workspace-design` |
+| Surface coordinates multiple agents with a visible dependency structure | `workspace-design` |
+| Dashboard or monitoring view for data comprehension and action | `analytical-design` |
+| Component needs a finite-state behavioral model (form, button, wizard step) | `interaction-design` |
+| Screen needs feedback timing, validation flow, and micro-interactions | `interaction-design` |
+| Cross-screen navigation routes are being decided | `user-flow` |
+
+`workspace-design` is IA and structure — it specifies *how the workspace is organized* so that context, collaboration state, and agent activity are legible. `interaction-design` is behavioral — it specifies how a specific component or screen *responds* to user actions within that structure. They are complementary: run `workspace-design` first to set the structural frame, then run `interaction-design` for the individual components that inhabit it.
+
+Do **not** use `workspace-design` for dashboards and monitoring views — those belong to `analytical-design`. Do **not** use it for marketplace surfaces — those belong to `marketplace-design`.
+
+## The agentic-UI surface constraint
+
+A workspace surface becomes an agentic UI when autonomous agents run tasks on the user's behalf. What makes this distinct from a standard product screen:
+
+- **Agent activity must be legible without demanding constant attention.** The user needs to know what the agent is doing, in what order, and where they need to intervene — without a live notification stream demanding focus.
+- **Every consequential agentic output needs a review surface before it is applied.** An agent that writes files, sends messages, or modifies data without a review step between output and application has no undo.
+- **HITL confirmations must name the consequence before the action.** A human-in-the-loop confirmation dialog names the action clearly, makes the consequence visible (how many files? which ones?), and offers a "show me what this affects" affordance before the user approves.
+- **Multi-agent coordination must be visible.** When multiple agents run in parallel or in a chain, the dependency graph — which agents are running, which is waiting for which, where the current bottleneck is — must be visible from the workspace surface. A coordination graph hidden from the user produces a surface that feels unpredictable.
+
+These are structural constraints, not component-level decisions. They determine the workspace's zone layout — where the task queue lives, where the output review surface sits, how the HITL confirmation is positioned — before any individual component is designed.
+
+## How to author a workspace brief
+
+Before running `workspace-design`, name three things:
+
+**1. The session arc** — what does a complete work session look like? Walk all five stages:
+
+| Stage | What the user needs |
+|---|---|
+| Arrive | Context re-establishment — where was I? |
+| Orient | What requires attention — what's new? |
+| Work | Uninterrupted focus on the primary task |
+| Persist | My work is safe when I leave |
+| Collaborate | Share, hand off, or review with another person |
+
+Decisions made for the Work stage often break the Arrive and Persist stages. Walk the arc explicitly before designing any zone.
+
+**2. The collaboration model** — single-user, asynchronously collaborative, or real-time collaborative. The answer drives presence indicators, live-editing state IA (whose cursor is where, whether two users can edit the same object simultaneously), and the sharing model.
+
+**3. The agentic patterns in scope** — task queue visibility, agent status indicators (running / waiting for input / error / complete), HITL confirmation surfaces, output review surfaces, multi-agent coordination visibility — or none, if the surface is non-agentic.
+
+Then invoke `workspace-design`:
+
+> "Design the workspace for [surface name]. The session arc is [arrive/orient/work/persist/collaborate description]. The collaboration model is [single-user / async / real-time]. The agentic patterns in scope are [task queue / HITL / output review / multi-agent coordination / none]."
+
+`workspace-design` produces: the context-persistence architecture (last-location persistence, returning-session re-orientation, breadcrumb/recents/activity), the attention zone layout, the collaboration state IA, the interrupt escalation ladder, and the agentic pattern specifications.
+
+## The multi-agent coordination pattern
+
+When multiple agents run in parallel or in a chain, the workspace surface must make the dependency structure visible at a glance:
+
+- **Which agents are running** — named, not anonymous
+- **Which agent is waiting for which other agent** — dependency direction made visible
+- **Where the current bottleneck is** — blocked items surface without requiring the user to poll
+- **Where the user can intervene** — a recoverable action is reachable at every blocked or errored agent
+
+The coordination IA is designed at the structural level first — the zone that shows the graph, the ambient vs. focal signals, the intervention affordance — before any individual agent status indicator is designed. `interaction-design` handles the per-component state machines (the indicator's own running / waiting / error / complete transitions); `workspace-design` sets the structural frame those components inhabit.
+
+## Common mistakes
+
+**Using `interaction-design` for workspace IA.** If you reach for `interaction-design` to design the zone layout, context-persistence model, or agent activity visibility, the output will be a component behavioral model, not a structural specification. Run `workspace-design` for the structure; run `interaction-design` for the components that live in it.
+
+**Designing the Work stage only.** A workspace surface that looks good in the focused-work state but has no designed Arrive or Persist stage will lose users' context on every return. Walk the session arc explicitly.
+
+**Omitting the task queue.** An agentic workspace with no visible task queue leaves the user guessing what the agent is doing. The task queue is the agent's working memory made visible: pending, active, completed, blocked.
+
+**Making agentic output non-reviewable before application.** An output applied before the user can review it is an output without an undo. Design the output review surface before designing the output itself.
+
+**Using focal interrupts for ambient information.** Notification modality inflation — sound, motion, or modal overlays for non-urgent information — trains users to dismiss focal interrupts without reading them. The default posture for all notification types in a workspace is ambient; escalate to focal only when the information is time-sensitive and action-required.

--- a/docs/guides/experience-design/tutorials/design-token-chain-worked-example.md
+++ b/docs/guides/experience-design/tutorials/design-token-chain-worked-example.md
@@ -1,0 +1,207 @@
+# Tutorial: Design token chain — from aesthetic direction to working foundation
+
+This tutorial walks the two-skill design token chain using a concrete example: a professional SaaS analytics dashboard. You will run `design-token-taxonomy` to derive the token taxonomy from a named aesthetic direction, then run `design-system-foundations` to apply it as a working foundation — arriving at a real component token set with CSS custom property names.
+
+By the end, you will have:
+
+- A token taxonomy derived from a named aesthetic direction
+- A semantic token structure for the full lightweight foundation
+- A concrete before/after button component token set showing what working tokens look like
+- A clear handoff to the next step (component state machines, screen layout)
+
+**Pre-requisites:** `experience-design` pack installed; a committed aesthetic direction (from `creative-direction`).
+
+---
+
+## The chain
+
+```
+creative-direction  →  design-token-taxonomy  →  design-system-foundations
+(named direction)      (token/scale taxonomy)     (working foundation)
+```
+
+`design-token-taxonomy` names what tokens are *for* and derives the organizing scales from the aesthetic direction. `design-system-foundations` applies the taxonomy as a working foundation — semantic token sets, alias layers, and component tokens the team builds on. Neither step produces concrete numeric values for you; the team maps the taxonomy method to values in their design tool or code.
+
+---
+
+## Step 1. Name the aesthetic direction
+
+Before deriving a taxonomy, an aesthetic direction must exist. For this example, `creative-direction` has produced the following for a professional SaaS analytics dashboard:
+
+**Product context:** an analytics dashboard for operations teams at mid-market SaaS companies. Users are data-literate professionals who return to this surface daily; they need to trust the data and act quickly.
+
+**Named aesthetic direction:**
+- **Composed authority** — visual weight communicates hierarchy without shouting; primary signals are unambiguous; secondary information recedes
+- **Earned trust** — accuracy and predictability over novelty; no decorative motion; every visual element earns its place
+- **Legible density** — high-density layout that remains readable; generous line-height; type scale that distinguishes heading from body without excessive contrast
+
+These three named goals are the constraints every token decision must trace back to.
+
+---
+
+## Step 2. Run design-token-taxonomy
+
+With the aesthetic direction named, invoke `design-token-taxonomy`:
+
+> "Derive the token taxonomy for the analytics dashboard — composed authority, earned trust, legible density. Use a minor-third ratio as the organizing concept."
+
+### Token naming — semantic role first
+
+Every token is named for the job it does, not for how it looks today:
+
+| Token role | Named for | Not named for |
+|---|---|---|
+| `color.primary` | The surface's primary action color | `color.blue` |
+| `color.surface` | The background of a card or panel | `color.white` |
+| `color.on-surface` | Text or icon placed on top of a surface color | `color.charcoal` |
+| `color.status-error` | Error states and validation failures | `color.red` |
+| `space.step-base` | The base unit of the spacing scale | `space.16px` |
+
+Names tied to appearance create rename-hell when the direction shifts. Names tied to role survive redesigns.
+
+### Scale derivation — one ratio as the organizing concept
+
+For "legible density," a minor-third ratio (1.2×) produces tight, readable steps without large jumps. Steps are expressed symbolically; the team maps each to a concrete value using the ratio and their chosen base unit:
+
+```
+Type scale (minor-third, 1.2×):
+  text.xs    = step −2  (captions, legal copy)
+  text.sm    = step −1  (secondary labels, metadata)
+  text.base  = base     (paragraph body)
+  text.lg    = step +1  (emphasized body, card labels)
+  text.xl    = step +2  (section heading)
+  text.2xl   = step +3  (page heading)
+
+Spacing scale (same ratio):
+  space.1    = step −2
+  space.2    = step −1
+  space.3    = base
+  space.4    = step +1
+  space.5    = step +2
+  space.6    = step +3
+```
+
+The taxonomy records the method; the team supplies the numbers.
+
+### Accessibility as a floor
+
+Every token pair that forms a foreground/background relationship is designed to clear the recognized accessibility standard (WCAG AA: 4.5:1 for text, 3:1 for UI components) at taxonomy derivation time — not as a cleanup pass afterward. The contrast budget is allocated across the tier hierarchy: primary signals at maximum contrast; secondary diagnostics slightly receded; tertiary details de-emphasized within the floor.
+
+---
+
+## Step 3. Run design-system-foundations (lightweight mode)
+
+With the taxonomy derived, invoke `design-system-foundations` in lightweight mode:
+
+> "Apply the token taxonomy for the analytics dashboard as a working foundation. Use lightweight mode — we need to unblock component work; a single theme is enough for now."
+
+The skill produces the working foundation token set. Below is the button component — a before/after showing what working tokens actually look like.
+
+### Before: no token foundation
+
+Without a foundation, component values are hardcoded and disconnected from one another:
+
+```css
+/* BEFORE — hardcoded values, no semantic layer */
+.btn-primary {
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  outline: 2px solid transparent;
+}
+.btn-primary:hover {
+  background: #1d4ed8;
+}
+.btn-primary:disabled {
+  background: #93c5fd;
+  color: #dbeafe;
+  cursor: not-allowed;
+}
+```
+
+Problems with this: the hover blue has no derivable relationship to the base blue; the disabled colors have no named semantic role; changing the primary color requires a grep-and-replace across every component; accessibility is assumed, not declared.
+
+### After: semantic token foundation applied
+
+With the foundation in place, the button component reads from semantic tokens. The skill names the token structure; the team maps values using the taxonomy method:
+
+```css
+/* AFTER — semantic token layer (values supplied by the team from the taxonomy method) */
+:root {
+  /* Semantic color roles */
+  --ds-color-primary:        /* derived from composed-authority palette */;
+  --ds-color-primary-hover:  /* one step darker in the primary scale */;
+  --ds-color-primary-active: /* two steps darker; distinct from hover */;
+  --ds-color-on-primary:     /* highest-contrast foreground on primary; WCAG AA confirmed */;
+  --ds-color-disabled-bg:    /* muted primary; meets WCAG AA against surface */;
+  --ds-color-disabled-fg:    /* readable on disabled-bg; below active hierarchy */;
+  --ds-color-focus-ring:     /* focus indicator color; meets WCAG 2.4.11 AA */;
+
+  /* Spacing tokens */
+  --ds-space-2:              /* step −1 of minor-third scale */;
+  --ds-space-4:              /* step +1 of minor-third scale */;
+
+  /* Typography */
+  --ds-text-sm:              /* step −1 of minor-third type scale */;
+  --ds-font-weight-medium:   /* 500 equivalent */;
+
+  /* Radius */
+  --ds-radius-md:            /* calibrated to composed-authority direction */;
+
+  /* Button component tokens — mapped from semantic layer */
+  --ds-btn-bg:               var(--ds-color-primary);
+  --ds-btn-bg-hover:         var(--ds-color-primary-hover);
+  --ds-btn-bg-active:        var(--ds-color-primary-active);
+  --ds-btn-bg-disabled:      var(--ds-color-disabled-bg);
+  --ds-btn-fg:               var(--ds-color-on-primary);
+  --ds-btn-fg-disabled:      var(--ds-color-disabled-fg);
+  --ds-btn-focus-ring:       var(--ds-color-focus-ring);
+  --ds-btn-radius:           var(--ds-radius-md);
+  --ds-btn-py:               var(--ds-space-2);
+  --ds-btn-px:               var(--ds-space-4);
+  --ds-btn-font-size:        var(--ds-text-sm);
+  --ds-btn-font-weight:      var(--ds-font-weight-medium);
+}
+
+/* Button component — reads only from component tokens */
+.btn-primary {
+  background:      var(--ds-btn-bg);
+  color:           var(--ds-btn-fg);
+  border-radius:   var(--ds-btn-radius);
+  padding:         var(--ds-btn-py) var(--ds-btn-px);
+  font-size:       var(--ds-btn-font-size);
+  font-weight:     var(--ds-btn-font-weight);
+}
+.btn-primary:hover        { background: var(--ds-btn-bg-hover); }
+.btn-primary:active       { background: var(--ds-btn-bg-active); }
+.btn-primary:focus-visible { outline: 2px solid var(--ds-btn-focus-ring); outline-offset: 2px; }
+.btn-primary:disabled {
+  background: var(--ds-btn-bg-disabled);
+  color:      var(--ds-btn-fg-disabled);
+  cursor:     not-allowed;
+}
+```
+
+Now changing the primary color requires updating one semantic token value, not hunting down hex codes across files. The hover, active, and disabled states each have a named role. The focus ring declaration traces directly to the accessibility floor.
+
+The semantic alias chain — primitive → semantic → component — means no component reads a raw primitive directly. When the team later adds a dark theme, they override the semantic layer; every component that reads from it picks up the change without modification.
+
+---
+
+## Step 4. Where to go next
+
+After the foundation is set up:
+
+1. **Component state machines** — route to `interaction-design` for the button state machine: the finite-state model that drives default → hover → active → loading → disabled → error transitions, feedback timing, and keyboard behavior.
+2. **Screen layout** — route to `information-architecture` to apply the token foundation to the spatial hierarchy of the dashboard.
+3. **Full mode** — when the team needs a DTCG-compatible token source, light/dark theme switching, or the full component anatomy (navigation, form controls, data display, feedback), re-run `design-system-foundations` in full mode.
+
+---
+
+## See also
+
+- [Derive a token taxonomy and apply the design token foundation](../how-to/design-system-chain.md) — the how-to guide covering lightweight vs. full mode and the full two-step sequencing.
+- [Thread a feature from journey to screens](../how-to/author-design-intent.md) — the full XD chain in which this token chain sits.


### PR DESCRIPTION
## Summary

- Adds `docs/guides/experience-design/how-to/workspace-design.md` — decision guide for when to use `workspace-design` vs `interaction-design`, covering the agentic-UI surface constraint, how to author a workspace brief, and the multi-agent coordination pattern.
- Adds `docs/guides/experience-design/tutorials/design-token-chain-worked-example.md` — worked example walking through `design-token-taxonomy` → `design-system-foundations` using a professional SaaS dashboard context, including a concrete before/after button component token set with CSS custom property names.
- Adds `docs/guides/experience-design/how-to/analytical-vs-interaction-design.md` — short decision guide with a decision-trigger table and the boundary between `analytical-design` (widget hierarchy, chart type selection, IA) and `interaction-design` (component state machines, form flows, drill-through behavior).
- Updates `docs-site/astro.config.ts` sidebar: two new How-to entries under Experience Design, plus a new Tutorials section with the token-chain tutorial.

## Test plan

- [ ] `tools/build-site.py` runs cleanly and mirrors all three new files into `docs-site/src/content/docs/`
- [ ] `cd docs-site && npm run build` completes with no errors (verified: 212 pages built)
- [ ] New sidebar entries resolve to the correct slugs