### PR TITLE
feat(frontend-engineering): promote to first-class pack

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -290,7 +290,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
 
   ¹ Structural: new module boundary, new dependency, new abstraction layer, new top-level directory. Re-fires on mid-EXECUTE re-plan.
   ² Security: auth, secrets, user input, deserialization, file/network I/O. Infra-flavored work: mandatory. Dispatch in **spec-stage secure-design mode**; inline boundary-matching modules (net-new wiring only) per the [`security-checklists` Module index](../security-checklists/SKILL.md#module-index).
-  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`.
+  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. When the `frontend-engineering` pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
 - **Initialize the loop's state file.** Run this skill's bundled
@@ -363,7 +363,7 @@ contract the agent already holds. (Detail in
 surface trigger fires, the `frontend-engineering` skill has already been
 loaded inline during PLAN. Its craft rules govern all HTML element selection,
 CSS token discipline, accessibility patterns, and state completeness during
-EXECUTE; its GATES section defines the verification commands to run at step 3.
+EXECUTE; its GATES section defines the verification commands to run at step 3. When the `frontend-engineering` pack is installed, atomic craft skills from the pack are available as supplementary inline loads during EXECUTE for specific concerns — load `token-architecture` when the primary task is token system design, `a11y-engineering` for accessibility-focused work, `fe-performance` for CWV remediation.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -658,6 +658,7 @@ note in the summary, not a blocker.
   key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
+- Match `frontend-reviewer` — for diffs whose primary output is HTML/CSS/JS, **in full-mode work**. Pass the diff and the surface's evidence manifest state (known exceptions, last gate run). It applies the diff-level lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance and Target Size (the two manual-verification items automated tooling misses), and CWV regression signals. Does not duplicate adversarial-reviewer (spec drift), quality-engineer (testability), or experience-reviewer (aesthetic taste). Fallback if `frontend-reviewer` is absent (frontend-engineering pack not installed): proceed and record a named skip — absence of the pack is not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -737,7 +738,7 @@ mode below, then evaluate the terminal-state bullet last.
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
     final loop of a multi-loop spec; `experience-reviewer` on
-    user-facing surface diffs in full-mode work): either the subagent
+    user-facing surface diffs in full-mode work; `frontend-reviewer` on HTML/CSS/JS primary-output diffs in full-mode work): either the subagent
     returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.15.1"
+      "version": "0.15.2"
     },
     {
       "author": {

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -290,7 +290,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
 
   ¹ Structural: new module boundary, new dependency, new abstraction layer, new top-level directory. Re-fires on mid-EXECUTE re-plan.
   ² Security: auth, secrets, user input, deserialization, file/network I/O. Infra-flavored work: mandatory. Dispatch in **spec-stage secure-design mode**; inline boundary-matching modules (net-new wiring only) per the [`security-checklists` Module index](../security-checklists/SKILL.md#module-index).
-  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`.
+  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. When the `frontend-engineering` pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
 - **Initialize the loop's state file.** Run this skill's bundled
@@ -363,7 +363,7 @@ contract the agent already holds. (Detail in
 surface trigger fires, the `frontend-engineering` skill has already been
 loaded inline during PLAN. Its craft rules govern all HTML element selection,
 CSS token discipline, accessibility patterns, and state completeness during
-EXECUTE; its GATES section defines the verification commands to run at step 3.
+EXECUTE; its GATES section defines the verification commands to run at step 3. When the `frontend-engineering` pack is installed, atomic craft skills from the pack are available as supplementary inline loads during EXECUTE for specific concerns — load `token-architecture` when the primary task is token system design, `a11y-engineering` for accessibility-focused work, `fe-performance` for CWV remediation.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -658,6 +658,7 @@ note in the summary, not a blocker.
   key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
+- Match `frontend-reviewer` — for diffs whose primary output is HTML/CSS/JS, **in full-mode work**. Pass the diff and the surface's evidence manifest state (known exceptions, last gate run). It applies the diff-level lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance and Target Size (the two manual-verification items automated tooling misses), and CWV regression signals. Does not duplicate adversarial-reviewer (spec drift), quality-engineer (testability), or experience-reviewer (aesthetic taste). Fallback if `frontend-reviewer` is absent (frontend-engineering pack not installed): proceed and record a named skip — absence of the pack is not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -737,7 +738,7 @@ mode below, then evaluate the terminal-state bullet last.
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
     final loop of a multi-loop spec; `experience-reviewer` on
-    user-facing surface diffs in full-mode work): either the subagent
+    user-facing surface diffs in full-mode work; `frontend-reviewer` on HTML/CSS/JS primary-output diffs in full-mode work): either the subagent
     returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent

--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -339,6 +339,30 @@ export default defineConfig({
               ],
             },
             {
+              label: 'Frontend Engineering',
+              items: [
+                { label: 'Overview', slug: 'guides/frontend-engineering' },
+                {
+                  label: 'Tutorials',
+                  items: [
+                    { label: 'Scaffold a Component', slug: 'guides/frontend-engineering/tutorials/scaffold-a-component' },
+                  ],
+                },
+                {
+                  label: 'How-to',
+                  items: [
+                    { label: 'Run an Audit', slug: 'guides/frontend-engineering/how-to/run-an-audit' },
+                  ],
+                },
+                {
+                  label: 'Reference',
+                  items: [
+                    { label: 'Frontend Engineering Pack', slug: 'guides/frontend-engineering/reference/frontend-engineering' },
+                  ],
+                },
+              ],
+            },
+            {
               label: 'Contracts',
               items: [
                 { label: 'Overview', slug: 'guides/contracts' },

--- a/docs/adr/0056-frontend-engineering-pack-promotion.md
+++ b/docs/adr/0056-frontend-engineering-pack-promotion.md
@@ -1,0 +1,57 @@
+# ADR-0056: Promote `frontend-engineering` to first-class pack
+
+- **Status:** Accepted
+- **Date:** 2026-07-25
+- **Decision-makers:** eugenelim
+- **Related:** [`docs/guides/frontend-engineering/`](../guides/frontend-engineering/), [`.claude/skills/frontend-engineering/SKILL.md`](../../.claude/skills/frontend-engineering/SKILL.md)
+
+## Decision summary
+
+- **Decision:** The `frontend-engineering` resident skill (`.claude/skills/frontend-engineering/`) is promoted to a first-class pack (`packs/frontend-engineering/`) with 9 skills, a `frontend-reviewer` agent, a guide tree, and a catalogue page. The resident skill file remains in place — it is not deleted. The pack includes the resident skill verbatim as one of its 9 shipped skills.
+- **Because:** The skill has accumulated enough depth and distinct concerns — token system architecture, accessibility engineering, performance diagnostics, rendering strategy, component API design, responsive layout, CSS architecture — that a flat single-skill surface no longer serves the full range of tasks. A pack partitions those concerns into named atomic skills a practitioner loads by task, without forcing them to internalize the entire 661-line skill every session.
+- **Applies to:** `packs/frontend-engineering/` and the four work-loop insertion points that reference the pack's atomic skills and the `frontend-reviewer`.
+- **Tradeoff accepted:** Nine skills and an agent to maintain rather than one. The tradeoff is accepted because the pack's skills are distinct and non-overlapping; the maintenance cost grows sub-linearly with the concern count.
+- **Revisit if:** The pack grows beyond 12 skills, at which point a split by concern cluster (accessibility / performance / architecture) should be evaluated.
+
+## Context
+
+The resident `frontend-engineering` SKILL.md covers the full create/retrofit/audit/verify workflow, CSS token discipline, accessibility patterns, GATES commands, an evidence manifest, and performance targets. That breadth is intentional for a surface-level skill loaded at PLAN time — the practitioner needs the whole context to set up the pre-flight correctly.
+
+The limitation appears when a task is narrowly scoped: a performance remediation, a token system design, a dedicated accessibility audit. Loading the full skill to address one of those concerns brings 600+ lines of incidental context. The pack partitions the skill into atomic disciplines a practitioner loads by task.
+
+## Why ADR, not RFC
+
+RFC-first is the right gate for a **new top-level directory** or a **cross-cutting change that affects multiple packs**. The `packs/` directory exists; `frontend-engineering` is an established, shipped skill. The promotion pattern — resident skill to pack — is the same pattern `experience-design` and `architect` followed, and it does not require a new structural decision. This is an execution decision, not a governance decision: ADR records it, pack ships it.
+
+RFC would be appropriate if: the promotion required a new adapter-contract version, restructured `packs/` layout conventions, or proposed a new top-level directory. None of those apply here.
+
+## Risk triggers (full-mode justification)
+
+The following risk triggers fired, routing this work to full-mode work-loop:
+
+- **Multi-feature or dependent tasks** — 9 skills, 1 agent, 4 work-loop insertion points, a guide tree, a sidebar addition, and a catalogue page are interdependent.
+- **Structural or public-interface change** — the pack introduces a `frontend-reviewer` agent as a public interface; the work-loop REVIEW phase references it by name.
+- **New dependency** — the pack's `frontend-engineering` skill formalizes a co-install dependency on the `experience-design` pack for genre routing (T2 gate already present in the resident skill; the pack makes it explicit).
+
+## What changes
+
+| Before | After |
+|---|---|
+| One 661-line skill in `.claude/skills/frontend-engineering/` | Same file in place; also shipped verbatim as `packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md` |
+| No atomic craft skills | 8 additional atomic skills partitioning the main skill's concerns |
+| No diff-level reviewer | `frontend-reviewer` agent in `.apm/agents/` |
+| No catalogue page | `web/src/content/packs/frontend-engineering.md` |
+| No guide tree | `docs/guides/frontend-engineering/` with tutorials, how-to, and reference |
+| No work-loop integration | 4 insertion points in `work-loop` SKILL.md (footnote, EXECUTE FE, REVIEW, DECIDE) |
+
+## What does not change
+
+- The resident `.claude/skills/frontend-engineering/SKILL.md` is **not modified or deleted**. It remains the primary surface for users without the pack installed.
+- The main skill's frontmatter `description` is not changed — it continues to correctly describe when to load the skill.
+- The `experience-design` co-install requirement in the main skill (step 1b, genre routing) is unchanged — the pack does not alter the existing T2 gate.
+
+## Options considered
+
+**Option A — RFC first, then ship:** Open an RFC, gather feedback, accept, then implement. Appropriate for new top-level directories and cross-cutting structural decisions. Rejected: `packs/` exists; the promotion pattern is established; the ADR captures the relevant decision context without requiring an additional RFC cycle.
+
+**Option B — ADR + ship (selected):** Record the decision and its rationale in an ADR; implement immediately. The `packs/` precedent (`experience-design`, `architect`, `desk-research`) is the reference; no new structural decision is being made.

--- a/docs/guides/frontend-engineering/README.md
+++ b/docs/guides/frontend-engineering/README.md
@@ -1,0 +1,49 @@
+---
+title: Frontend Engineering
+description: Guides for the frontend-engineering pack — building web surfaces from design handoff to shipped component.
+---
+
+# Frontend Engineering guides
+
+This guide tree covers the `frontend-engineering` pack: how to build web
+surfaces that meet the frontend engineering quality floor, how to use the
+pack's atomic craft skills, and a reference for all skills and the reviewer.
+
+## Who these guides are for
+
+Engineers who build product web surfaces in HTML, CSS, and JS — from design
+handoff to shipped, gate-passing component. The guides assume you are using
+the `frontend-engineering` pack with an agent (Claude Code, Codex, Copilot,
+Cursor, Kiro, or Gemini).
+
+## What's here
+
+| Section | Contents |
+|---|---|
+| [Tutorials](tutorials/scaffold-a-component.md) | Step-by-step: scaffold a component from a screen brief to a gate-passing evidence manifest |
+| [How-to](how-to/run-an-audit.md) | Run the full frontend-engineering audit on an existing surface |
+| [Reference](reference/frontend-engineering.md) | All 9 skills and the reviewer agent — one-line descriptions and when to use each |
+
+## The quality floor
+
+Every surface built with this pack is held to one shared quality floor:
+
+1. **Handle all states** — every applicable state from the 18-state matrix
+   must be implemented (loading, empty, error, content, and the rest that
+   apply). A surface that only handles the happy path ships broken.
+2. **WCAG 2.2 AA** — accessibility is not a feature. The GATES phase runs
+   pa11y/axe-core to `wcag21aa` and adds two manual checks for the WCAG 2.2
+   criteria automated tools miss (2.4.11 Focus Appearance, 2.5.8 Target Size).
+3. **Token discipline** — no hardcoded hex, rgb, or magic pixel values outside
+   the `:root` primitive definition block. All colour and spacing through
+   `var(--ds-*)`.
+4. **Evidence manifest** — completion is not claimed without a manifest. The
+   manifest is the record of what was tested and what was found.
+
+## Co-install
+
+For full genre routing in the pre-flight, co-install with `experience-design`:
+```
+agentbundle install --pack frontend-engineering --scope user
+agentbundle install --pack experience-design --scope user
+```

--- a/docs/guides/frontend-engineering/how-to/run-an-audit.md
+++ b/docs/guides/frontend-engineering/how-to/run-an-audit.md
@@ -1,0 +1,204 @@
+---
+title: Run an Audit
+description: How to run the full frontend-engineering audit on an existing surface — what to run, in what order, what each gate catches, how to read the output, and what to record in the evidence manifest.
+---
+
+# How-to: Run a frontend-engineering audit
+
+Use this guide when you need to audit an **existing surface** — a component,
+a page, or a set of pages you did not build. The output is an audit report and,
+after any necessary fixes, a baseline evidence manifest.
+
+**When to audit:** before starting significant new work on an existing surface,
+before a release on a surface with no prior gate history, or when a surface has
+reported a11y or performance complaints.
+
+**Skill to load:** `frontend-engineering` in `audit` mode. (If the surface
+has no gate history, also load `fe-status` first to understand what's known.)
+
+---
+
+## Before you start
+
+1. **Orient with `fe-status`** — if the surface has an evidence manifest,
+   read it first. `fe-status` returns a summary of covered states, last gate
+   results, known exceptions, and the highest-priority next action. If no
+   manifest exists, `fe-status` will tell you so.
+
+2. **Identify the surface scope** — which routes, files, or components are
+   in scope for this audit? Name them. An audit of "the whole product" is not
+   a single audit; scope it to one route or feature area.
+
+3. **Collect the files** — locate the HTML, CSS, and JS source files for the
+   surface. For a server-rendered page, build it to static HTML first.
+
+---
+
+## Step 1. State matrix audit
+
+Compare the surface against all 18 states in the state matrix. For each
+applicable state, mark: **Covered** / **Absent** / **Broken**.
+
+The 18 states: loading, empty, error, partial, disabled, content, success,
+first-run, no-results, permission/denied, offline, blocked,
+destructive-confirmation, long-content, large-data-set, high-zoom,
+reduced-motion, keyboard-only.
+
+To check state coverage, read the HTML. A state is covered if its HTML exists.
+A state is absent if there is no HTML for it. A state is broken if the HTML
+exists but is incorrect (e.g., a loading state with no `aria-busy`, an error
+state with no retry affordance).
+
+**What this catches:** surfaces that only handle the happy path, missing
+first-run states (often confused with empty), and missing keyboard-only or
+reduced-motion states.
+
+**Time required:** 15–30 minutes for a single-page surface.
+
+---
+
+## Step 2. Accessibility audit
+
+Run both automated tools and the two manual checks.
+
+**Automated (run either or both):**
+
+```bash
+# pa11y — lighter, good for single files
+npx pa11y "file:///$(pwd)/page.html" --standard WCAG2AA --reporter cli
+
+# axe-core — more rules, better for complex pages
+npx axe "file:///$(pwd)/page.html" \
+  --tags wcag21aa \
+  --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
+```
+
+**How to read the output:**
+- Each finding shows the WCAG success criterion (e.g., `WCAG2AA.Principle1.Guideline1_4.1_4_3`), the failing element, and a description. Fix blockers (contrast violations, missing labels) before anything else.
+- Findings tagged `wcag21aa` are WCAG 2.1 AA violations. Note that WCAG 2.2 AA is the declared baseline — all 2.1 findings are also 2.2 findings.
+- After automated tools pass, two WCAG 2.2 criteria still require manual checks.
+
+**Manual check 1 — WCAG 2.4.11 Focus Appearance:**
+For every interactive element, tab to it and inspect:
+- Is a focus indicator visible?
+- Is the focus ring at least 2px in width?
+- Does the focus ring have at least 3:1 contrast against the adjacent background?
+
+Record: pass / fail for each interactive element type.
+
+**Manual check 2 — WCAG 2.5.8 Target Size Minimum:**
+For every interactive element, measure in DevTools:
+- Is the target at least 24×24 CSS pixels? Or if smaller, does it have
+  24px of spacing from the nearest adjacent interactive element?
+
+Record: pass / fail for each interactive element type.
+
+**What this catches:** missing labels, contrast failures, missing focus
+styles, unlabeled form controls, live-region problems, and the two WCAG 2.2
+items automated tools miss.
+
+---
+
+## Step 3. CWV measurement
+
+Measure LCP, INP, and CLS at p75 (mobile and desktop separately where
+field data exists).
+
+**Lighthouse (lab data, good for a baseline):**
+```bash
+npx lighthouse <url> --output json --output-path ./lighthouse-report.json
+# Open the HTML report: npx lighthouse <url>
+```
+
+Targets: LCP ≤2.5s, INP ≤200ms, CLS ≤0.1.
+
+**How to read the output:**
+- Lighthouse shows a score per metric. A score below 90 on LCP or CLS is
+  worth investigating. INP is not scored by Lighthouse (field metric only);
+  check the "Total Blocking Time" as a proxy.
+- Each failing metric has linked audits that explain contributing factors
+  (e.g., "Eliminate render-blocking resources" for LCP).
+
+If CWV are already within targets, note the result and move on. If any metric
+is out-of-budget, load `fe-performance` for a structured diagnosis.
+
+---
+
+## Step 4. CSS token compliance check
+
+```bash
+grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>
+```
+
+Output should return only the `:root` / primitive token-definition block.
+Any hardcoded colour or spacing value outside that block is a violation.
+
+Triage priority: colour values first (affect theming and contrast), then
+magic spacing pixels.
+
+---
+
+## Step 5. Brownfield inspection
+
+Walk the six-item brownfield checklist from `frontend-engineering` retrofit
+mode:
+
+| Item | What to check |
+|---|---|
+| what-to-preserve | What works and must not regress |
+| duplicated-systems | Parallel implementations that could be consolidated |
+| hard-coded values | CSS values that should be tokens |
+| a11y-debt | Pre-existing a11y failures — note which this audit can address |
+| responsive-debt | Viewport breakpoints that fail |
+| visual-regression-risk | Downstream components that share styling |
+
+---
+
+## Step 6. Write the audit report
+
+Return findings as a prioritised list with severity:
+
+- **Blocker** — must be fixed before the surface ships in its current form
+  (new WCAG violation, missing critical state)
+- **Major** — materially weakens the surface; should be fixed soon
+- **Minor** — improvement; reviewer will not block on
+- **Note** — informational
+
+Each finding maps to the step that caught it (state matrix, a11y, CWV, tokens,
+brownfield), with one concrete recommendation.
+
+---
+
+## Step 7. Record the baseline evidence manifest
+
+After the audit, record what was tested — even if findings exist. The manifest
+is a factual record, not a certificate of completion.
+
+```
+routes: [list of routes/files audited]
+viewports: [viewport widths tested]
+browsers: [browsers tested]
+states: [which of the 18 states were present and which were absent/broken]
+screenshots: [filenames or notes on captured states]
+a11y result:
+  pa11y/axe-core wcag21aa: [pass/fail + finding count]
+  manual 2.4.11 Focus Appearance: [pass/fail + notes]
+  manual 2.5.8 Target Size Minimum: [pass/fail + notes]
+perf result: [LCP / INP / CLS values from Lighthouse; mobile and desktop]
+console/network result: [console error count; unexpected third-party calls]
+analytics events: [which measurement events were verified]
+known exceptions: [documented, accepted gaps with rationale and owner]
+unverified items: [items not verifiable in this session + reason]
+```
+
+Record Blockers and Majors in `known exceptions` with a rationale and planned
+resolution if they are accepted for now. Do not silently omit them.
+
+---
+
+## What you have at the end
+
+An audit report with severity-tagged findings plus a baseline evidence
+manifest. The manifest is the ground truth for this surface's gate history
+— future work on the surface starts from `fe-status` reading this manifest,
+not from re-running the full audit from scratch.

--- a/docs/guides/frontend-engineering/reference/frontend-engineering.md
+++ b/docs/guides/frontend-engineering/reference/frontend-engineering.md
@@ -1,0 +1,154 @@
+---
+title: Frontend Engineering Pack
+description: Reference — all 9 skills and the frontend-reviewer agent in the frontend-engineering pack.
+---
+
+# `frontend-engineering` — the skills and the reviewer
+
+The `frontend-engineering` pack installs 9 skills and one reviewer agent.
+This page gives one-line descriptions and the correct trigger for each.
+
+---
+
+## Primary surface skill
+
+### `frontend-engineering`
+
+The entry point for all frontend work. Four modes — create (new surface),
+retrofit (improving existing), audit (review only), verify (run gates).
+Provides the design pre-flight (named aesthetic reference, genre routing,
+seed token block, state matrix), craft rules, GATES verification commands,
+and evidence manifest format. Load this skill whenever a task's primary output
+is HTML, CSS, or JS.
+
+**Load when:** the task's primary output is HTML, CSS, or JavaScript.
+
+---
+
+## Atomic craft skills
+
+Load the skill that matches the specific concern of the task. Do not load
+multiple atomic craft skills for a single task — load the one that addresses
+the task's primary concern.
+
+### `token-architecture`
+
+Design and govern a three-tier CSS custom property token system
+(primitive → semantic → component), including semantic alias layers,
+light/dark theming, and DTCG-compatible source generation.
+
+**Load when:** the primary task is designing or auditing a token system —
+not seeding a token block for a single surface (the seed block in
+`frontend-engineering` step 2 covers that).
+
+### `a11y-engineering`
+
+Deep accessibility engineering beyond automated tooling — focus management
+architecture, ARIA role correctness under dynamic mutation, live-region
+discipline, keyboard contract specification, and manual WCAG 2.2 AA
+verification for the two criteria automated tools miss (2.4.11 Focus
+Appearance, 2.5.8 Target Size).
+
+**Load when:** accessibility is the primary task — a dedicated audit,
+retrofitting broken patterns, or designing a complex interaction
+(combobox, data grid, drag-and-drop) where the a11y contract is the
+central deliverable.
+
+**Near-miss:** for routine component work, use the accessibility section in
+`frontend-engineering` — it covers baseline ARIA patterns and the WCAG
+contrast floor. `a11y-engineering` is for the dedicated a11y task.
+
+### `fe-performance`
+
+Measure, diagnose, and remediate Core Web Vitals and asset budget violations
+using structured profiling, causality analysis, and repeatable remediation
+patterns.
+
+**Load when:** the primary output is a CWV diagnosis or performance remediation
+— not when Lighthouse runs as a gate at the end of a normal build (use the
+GATES section of `frontend-engineering` for that).
+
+### `rendering-strategy`
+
+Select and implement the correct rendering model (CSR/SSR/SSG/ISR/RSC) for
+each route based on data-access patterns, performance targets, and
+personalization requirements.
+
+**Load when:** selecting or auditing the rendering architecture of a route or
+surface — not for routine component authoring where the rendering model is
+already decided.
+
+### `component-contract`
+
+Design a UI component's public interface — props/slots/events, controlled
+vs. uncontrolled ownership, composition patterns, lifecycle contract, and
+usage documentation — before writing any implementation.
+
+**Load when:** designing a new shared component (one that will be used by
+multiple callers) before writing any implementation code.
+
+### `responsive-layout`
+
+Design and implement adaptive layouts using CSS Grid, Flexbox, container
+queries, and fluid typography/spacing — the craft layer for layouts that work
+correctly across all viewport sizes without JavaScript.
+
+**Load when:** the primary task is designing or debugging a layout that must
+work across breakpoints. Not for routine margin adjustments on an already-responsive surface.
+
+### `css-architecture`
+
+Organize CSS at scale using cascade layers, scoping strategies, and
+specificity budgets — preventing specificity wars, enabling safe deletion,
+and making CSS that other engineers can reason about.
+
+**Load when:** setting up CSS architecture for a new codebase, or auditing
+and refactoring CSS in an existing one with specificity conflicts or
+hard-to-predict cascade behavior.
+
+### `fe-status`
+
+Orient skill — read the current surface's evidence manifest, known exceptions,
+and gate history to return a surface-state summary against the frontend
+engineering quality floor.
+
+**Load when:** starting work on an existing surface to orient without reading
+all the code. Returns a structured summary of covered states, gate results,
+known exceptions, and the recommended next action.
+
+---
+
+## The reviewer agent
+
+### `frontend-reviewer`
+
+A **forked-context, read-only reviewer** for diffs whose primary output is
+HTML/CSS/JS. Applies the fe-diff-review lens across five areas:
+
+| Lens | What it checks |
+|---|---|
+| CSS token drift | Hardcoded hex/rgba/px/rem values where `--ds-*` tokens should be used |
+| ARIA mutation completeness | `aria-expanded`, `aria-selected`, `aria-sort`, `aria-checked` set in HTML but never updated in JS |
+| State coverage regression | States from the 18-state matrix present before the diff but absent after |
+| WCAG 2.2 manual items | 2.4.11 Focus Appearance (ring size and contrast), 2.5.8 Target Size (touch target ≥24×24 CSS px) |
+| CWV regression signals | Synchronous scripts, unsized images, lazy LCP candidates, route chunk size increase >10KB |
+
+**Not in scope:** spec/plan drift (adversarial-reviewer), testability
+(quality-engineer), aesthetic taste (experience-reviewer), security
+boundaries (security-reviewer).
+
+**When pack is absent:** the orchestrator records a named skip —
+`frontend-reviewer: pack not installed; review skipped`. Absence is not
+a silent pass.
+
+---
+
+## The quality floor
+
+All surfaces built with this pack are held to one shared quality floor:
+
+1. Handle all applicable states from the 18-state matrix.
+2. WCAG 2.2 AA — automated `wcag21aa` gate plus two manual checks
+   (2.4.11 and 2.5.8).
+3. Token discipline — no hardcoded values outside the `:root` primitive block.
+4. Evidence manifest — completion requires a manifest.

--- a/docs/guides/frontend-engineering/tutorials/scaffold-a-component.md
+++ b/docs/guides/frontend-engineering/tutorials/scaffold-a-component.md
@@ -1,0 +1,350 @@
+---
+title: Scaffold a Component
+description: A worked tutorial — receive a screen brief, run the pre-flight, write the HTML/CSS, implement all states, run the gates, and produce an evidence manifest.
+---
+
+# Tutorial: Scaffold a component from a screen brief
+
+This tutorial walks the full `frontend-engineering` create-mode workflow on a
+concrete example: a **notification card** component with loading, empty,
+content, and error states. By the end you will have a gate-passing component
+and a completed evidence manifest.
+
+**Time:** ~45 minutes for the first attempt; ~20 minutes once the workflow
+is familiar.
+
+**What you need:** the `frontend-engineering` pack installed, a project with
+HTML/CSS output.
+
+---
+
+## The screen brief
+
+You received this brief from your design collaborator:
+
+> **Notification card** — shows the user's most recent notification. States:
+> loading (skeleton while fetching), empty (no notifications yet, first-run),
+> content (notification with title, body, and timestamp), error (fetch failed,
+> retry affordance). The card sits in a 360px-wide sidebar column. Aesthetic
+> reference: Linear (professional dark-surface SaaS).
+
+---
+
+## Step 1. Load the skill and select the mode
+
+Tell your agent:
+
+```
+Load frontend-engineering in create mode.
+```
+
+The skill loads. You are now in the PLAN phase.
+
+---
+
+## Step 2. Name the aesthetic reference
+
+From the brief: **Linear** — professional SaaS, dark surface, high contrast,
+no gradients.
+
+Record this in the spec:
+
+```
+Aesthetic reference: Linear (professional SaaS — dark surface, high contrast,
+no gradients, sharp edges, monochrome icon treatment)
+```
+
+---
+
+## Step 3. Genre routing (step 1b — requires experience-design)
+
+This is a product UI component, not a marketing, documentation, or analytical
+surface. None of the XD genre skills apply. Record:
+
+```
+XD genre routing: not applicable — product UI component (no genre-specific
+surface type)
+```
+
+If `experience-design` is not installed, record:
+```
+XD genre routing: skipped (experience-design pack absent)
+```
+
+---
+
+## Step 4. Seed the token block
+
+Provide the CSS custom properties block before writing HTML. Based on the
+Linear aesthetic reference, seed a dark-surface token block:
+
+```css
+:root {
+  /* Color — dark surface, Linear aesthetic */
+  --ds-color-surface:      #0d0d0d;
+  --ds-color-surface-alt:  #141414;
+  --ds-color-on-surface:   #e2e8f0;
+  --ds-color-on-surface-2: rgba(255, 255, 255, 0.50);
+  --ds-color-primary:      #8b93e8;
+  --ds-color-on-primary:   #0d0d0d;
+  --ds-color-error:        #f87171;
+  --ds-color-on-error:     #0d0d0d;
+  --ds-color-outline:      rgba(255, 255, 255, 0.10);
+  --ds-color-success:      #4ade80;
+
+  /* Spacing — 4px base, 8-step scale */
+  --ds-space-1:  4px;
+  --ds-space-2:  8px;
+  --ds-space-3:  12px;
+  --ds-space-4:  16px;
+  --ds-space-5:  24px;
+  --ds-space-6:  32px;
+
+  /* Type scale */
+  --ds-text-sm:   0.75rem;
+  --ds-text-base: 0.875rem;
+  --ds-text-lg:   1rem;
+  --ds-font-regular: 400;
+  --ds-font-medium:  500;
+  --ds-leading-tight:  1.25;
+  --ds-leading-normal: 1.5;
+
+  /* Radius — sharp edges match Linear aesthetic */
+  --ds-radius-sm: 3px;
+  --ds-radius-md: 6px;
+
+  /* Motion */
+  --ds-duration-moderate: 200ms;
+  --ds-ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+}
+```
+
+Record the token block in the spec.
+
+---
+
+## Step 5. Enumerate the state matrix
+
+From the brief, the notification card requires these states:
+
+| State | Treatment |
+|---|---|
+| loading | Skeleton matching the card shape — title line, body line, timestamp line; `aria-busy="true"` on the container |
+| empty (first-run) | "No notifications yet" message + optional CTA to explore |
+| content | Notification with title, body, and timestamp |
+| error | "Could not load notifications" + retry button |
+
+States not applicable to this component: partial, disabled, success, no-results,
+permission/denied, offline, blocked, destructive-confirmation, long-content,
+large-data-set. Note in spec: "states omitted — not applicable to a single
+notification card fetch."
+
+States that are applicable and must be tested:
+- high-zoom: verify layout at 200% zoom
+- reduced-motion: animation on state transitions must be guarded
+- keyboard-only: verify focus states are visible; no interactions require pointer
+
+---
+
+## Step 6. Fill the page/screen contract
+
+```
+target user: Authenticated product user checking for updates
+primary job: See the most recent notification and act on it
+primary action: Click through to the referenced item (if in content state)
+expected result: User navigates to the notification's context
+next action: Clear the notification or take the referenced action
+first-screen content: Notification title + body snippet + timestamp
+product proof: n/a — this is a utility component
+read/write consequence: Read-only fetch; error shows retry affordance
+critical states: loading, first-run, content, error
+responsive behavior: Fixed at 360px column width; no breakpoint changes
+a11y requirements: WCAG 2.2 AA; aria-busy on loading; live region for
+  async state changes; focus managed on retry click
+measurement event: notification_card_viewed, notification_card_clicked
+```
+
+---
+
+## Step 7. Write the HTML
+
+With the pre-flight complete, write the HTML for all four states. The
+states can be toggled via a data attribute (`data-state="loading"` etc.)
+or rendered as separate elements — choose the pattern that matches your
+templating system.
+
+**Skeleton loading state:**
+```html
+<article
+  class="notif-card notif-card--loading"
+  aria-busy="true"
+  aria-label="Loading notifications"
+>
+  <div class="notif-card__skeleton">
+    <div class="notif-card__skeleton-title"></div>
+    <div class="notif-card__skeleton-body"></div>
+    <div class="notif-card__skeleton-meta"></div>
+  </div>
+</article>
+```
+
+**First-run (empty) state:**
+```html
+<article class="notif-card notif-card--empty">
+  <p class="notif-card__empty-msg">No notifications yet.</p>
+  <a href="/explore" class="notif-card__cta">Explore what's new</a>
+</article>
+```
+
+**Content state:**
+```html
+<article class="notif-card notif-card--content">
+  <h3 class="notif-card__title">Your export is ready</h3>
+  <p class="notif-card__body">The CSV export you requested finished. 1,204 records.</p>
+  <time class="notif-card__time" datetime="2026-07-25T08:34:00Z">
+    8:34 AM
+  </time>
+  <a href="/exports/123" class="notif-card__link">View export</a>
+</article>
+```
+
+**Error state:**
+```html
+<article class="notif-card notif-card--error" role="alert">
+  <p class="notif-card__error-msg">Could not load notifications.</p>
+  <button type="button" class="notif-card__retry">Retry</button>
+</article>
+```
+
+---
+
+## Step 8. Write the CSS
+
+Key rules from the token block and craft rules:
+
+```css
+.notif-card {
+  --notif-bg:           var(--ds-color-surface-alt);
+  --notif-border:       var(--ds-color-outline);
+  --notif-text:         var(--ds-color-on-surface);
+  --notif-text-muted:   var(--ds-color-on-surface-2);
+  --notif-radius:       var(--ds-radius-md);
+  --notif-padding:      var(--ds-space-4);
+
+  background-color:  var(--notif-bg);
+  border:            1px solid var(--notif-border);
+  border-radius:     var(--notif-radius);
+  padding:           var(--notif-padding);
+}
+
+/* Skeleton animation — guarded for reduced motion */
+.notif-card__skeleton-title,
+.notif-card__skeleton-body,
+.notif-card__skeleton-meta {
+  background-color: var(--ds-color-outline);
+  border-radius: var(--ds-radius-sm);
+}
+
+/* Default: no animation */
+.notif-card__skeleton-title,
+.notif-card__skeleton-body,
+.notif-card__skeleton-meta {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes shimmer {
+    0%   { opacity: 0.5; }
+    50%  { opacity: 1; }
+    100% { opacity: 0.5; }
+  }
+  .notif-card__skeleton-title,
+  .notif-card__skeleton-body,
+  .notif-card__skeleton-meta {
+    animation: shimmer var(--ds-duration-moderate) var(--ds-ease-standard) infinite;
+  }
+}
+
+/* Focus styles — WCAG 2.2 AA */
+.notif-card__retry:focus-visible,
+.notif-card__link:focus-visible,
+.notif-card__cta:focus-visible {
+  outline: 2px solid var(--ds-color-primary);
+  outline-offset: 2px;
+}
+```
+
+---
+
+## Step 9. Run the GATES
+
+After the HTML and CSS are written, run the four GATES in order:
+
+**Gate 1 — HTML validation:**
+```bash
+npx html-validate --preset standard,a11y --max-warnings 0 notification-card.html
+```
+
+**Gate 2 — Accessibility audit:**
+```bash
+npx pa11y "file:///$(pwd)/notification-card.html" --standard WCAG2AA --reporter cli
+```
+
+Then manually verify:
+- WCAG 2.4.11: the `.notif-card__retry` and `.notif-card__link` focus rings are
+  at least 2px, with 3:1 contrast against the adjacent surface.
+- WCAG 2.5.8: `.notif-card__retry` button is at least 24×24 CSS px
+  (add `min-height: 32px; min-width: 32px` if needed).
+
+**Gate 3 — CSS token enforcement:**
+```bash
+grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" notification-card.css
+```
+
+Output should return only the `:root` token definition block.
+
+**Gate 4 — Visual QA checklist:**
+- [ ] All 4 states are present in the HTML (loading, first-run, content, error)
+- [ ] No hardcoded values outside the `:root` block
+- [ ] Skeleton shape matches the content layout (no layout shift on load)
+- [ ] Screenshot taken for each state
+
+---
+
+## Step 10. Produce the evidence manifest
+
+After gates pass, fill the evidence manifest:
+
+```
+routes: notification-card.html
+viewports: 375px (mobile), 1280px (desktop)
+browsers: Chrome (Baseline Widely Available policy)
+states: loading, first-run, content, error, high-zoom (200%), reduced-motion,
+  keyboard-only
+screenshots: loading-state.png, empty-state.png, content-state.png, error-state.png
+a11y result:
+  pa11y wcag21aa: 0 errors, 0 warnings
+  manual 2.4.11 Focus Appearance: pass — 2px outline at 4.8:1 contrast
+  manual 2.5.8 Target Size Minimum: pass — retry button 32×40px, link 32×24px
+perf result: component-level; no CWV measurement for isolated component
+console/network result: no console errors; fetch mock active during review
+analytics events: notification_card_viewed fires on content state render
+known exceptions: none
+unverified items: none
+```
+
+---
+
+## What you have built
+
+A notification card component that:
+- Implements all 4 applicable states
+- Passes HTML validation, pa11y WCAG2AA, and the two WCAG 2.2 manual checks
+- Has no hardcoded values — all colour and spacing through tokens
+- Has a skeleton that matches the content layout
+- Has guarded animations (respects `prefers-reduced-motion`)
+- Has visible focus styles meeting WCAG 2.4.11
+- Has a completed evidence manifest
+
+This is the workflow for every component and surface built with the
+`frontend-engineering` pack.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -290,7 +290,7 @@ For anything beyond trivial, *think before you write code*. Concretely:
 
   ¹ Structural: new module boundary, new dependency, new abstraction layer, new top-level directory. Re-fires on mid-EXECUTE re-plan.
   ² Security: auth, secrets, user input, deserialization, file/network I/O. Infra-flavored work: mandatory. Dispatch in **spec-stage secure-design mode**; inline boundary-matching modules (net-new wiring only) per the [`security-checklists` Module index](../security-checklists/SKILL.md#module-index).
-  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`.
+  ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. When the `frontend-engineering` pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
 - **Initialize the loop's state file.** Run this skill's bundled
@@ -363,7 +363,7 @@ contract the agent already holds. (Detail in
 surface trigger fires, the `frontend-engineering` skill has already been
 loaded inline during PLAN. Its craft rules govern all HTML element selection,
 CSS token discipline, accessibility patterns, and state completeness during
-EXECUTE; its GATES section defines the verification commands to run at step 3.
+EXECUTE; its GATES section defines the verification commands to run at step 3. When the `frontend-engineering` pack is installed, atomic craft skills from the pack are available as supplementary inline loads during EXECUTE for specific concerns — load `token-architecture` when the primary task is token system design, `a11y-engineering` for accessibility-focused work, `fe-performance` for CWV remediation.
 
 For each task, implement the smallest coherent unit of work toward the
 goal. Resist the urge to fix unrelated things you notice along the way;
@@ -658,6 +658,7 @@ note in the summary, not a blocker.
   key pages from the output, not the code diff. Fallback if
   no `experience-reviewer` is installed (experience-design pack absent): proceed and
   note it — absence of the experience-design pack is a named skip, not a silent pass.
+- Match `frontend-reviewer` — for diffs whose primary output is HTML/CSS/JS, **in full-mode work**. Pass the diff and the surface's evidence manifest state (known exceptions, last gate run). It applies the diff-level lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance and Target Size (the two manual-verification items automated tooling misses), and CWV regression signals. Does not duplicate adversarial-reviewer (spec drift), quality-engineer (testability), or experience-reviewer (aesthetic taste). Fallback if `frontend-reviewer` is absent (frontend-engineering pack not installed): proceed and record a named skip — absence of the pack is not a silent pass.
 
 **Dispatch reviewers in parallel when you invoke more than one** per
 the [Parallel dispatch discipline](#parallel-dispatch-discipline)
@@ -737,7 +738,7 @@ mode below, then evaluate the terminal-state bullet last.
     always; `security-reviewer` on security-boundary diffs;
     `quality-engineer` on every loop, plus a whole-spec pass on the
     final loop of a multi-loop spec; `experience-reviewer` on
-    user-facing surface diffs in full-mode work): either the subagent
+    user-facing surface diffs in full-mode work; `frontend-reviewer` on HTML/CSS/JS primary-output diffs in full-mode work): either the subagent
     returned `Clean — ready to commit.`, **or** no matching subagent was
     installed and the final summary names the missing review by its
     role label — e.g. `adversarial-reviewer: no matching subagent

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.1"
+version = "0.15.2"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/frontend-engineering/.apm/agents/frontend-reviewer.md
+++ b/packs/frontend-engineering/.apm/agents/frontend-reviewer.md
@@ -1,0 +1,194 @@
+---
+name: frontend-reviewer
+description: "Diff-level reviewer for HTML/CSS/JS diffs — forked context, read-only. Applies the fe-diff-review lens: CSS token drift, ARIA mutation completeness, state coverage regression against the 18-state matrix, WCAG 2.2 Focus Appearance and Target Size (the two manual-verification items automated tooling misses), and CWV regression signals. Does not duplicate adversarial-reviewer (spec drift), quality-engineer (testability/observability), experience-reviewer (aesthetic taste), or security-reviewer (auth/secrets/input). Use in full-mode work-loop when the diff's primary output is HTML, CSS, or JS."
+tools: Read, Grep, Glob
+model: opus
+---
+
+# Frontend reviewer
+
+You are a senior frontend engineer reviewing a code diff whose primary output
+is HTML, CSS, or JavaScript. You read adversarially. You are looking for
+specific, concrete problems across five lenses. You do not give encouraging
+feedback or summarize what the diff does — the author knows what it does.
+
+You exist as a **forked context** so the review is independent. You have not
+seen the authoring session. That is the point. You are the independent check
+between the author and the gate.
+
+## Reviewer independence — what you are seeded with
+
+The orchestrator seeds you with **the diff** plus the surface's evidence
+manifest state if available — specifically: the known exceptions list and the
+most recent gate run results. You are never given the authoring chain-of-thought.
+If you were not given an evidence manifest, review against the diff alone.
+
+## Confirm before reviewing
+
+1. There is a **diff in scope** — a specific set of file changes to review,
+   not a general question about frontend engineering.
+2. The diff's primary output is **HTML, CSS, or JavaScript** — component markup,
+   stylesheets, templates, or client-side scripts. If the diff is primarily
+   Python, Go, SQL, or configuration, return WRONG ARTIFACT and name the right
+   reviewer.
+3. The ask is for **severity-tagged findings**, not a discussion.
+
+If any check fails, say so and stop.
+
+## What you review — the five lenses
+
+Walk every lens. Do not silently drop one. Each finding must be confirmed
+against the actual diff before it is reported — a finding about a pattern
+you cannot see in the diff is not a finding.
+
+### Lens 1 — CSS token drift
+
+Scan CSS changes for hardcoded colour, spacing, or radius values where
+`--ds-*` tokens should be used.
+
+**Look for:**
+- Hex values (`#5e6ad2`, `#fff`)
+- `rgb()` / `rgba()` / `hsl()` colour functions
+- Magic pixel values for spacing, padding, margin, gap, font-size, border-radius
+  (`margin: 13px`, `padding: 20px`, `font-size: 14px`, `border-radius: 8px`)
+
+**Exemptions (do not flag these):**
+- Values inside `:root {}` token definition blocks — these ARE the tokens
+- `transparent`, `currentColor`, `inherit` — relational values, not literals
+- `1px` for borders and outlines — single-pixel is an acceptable primitive
+- Values inside `@media print` blocks — print overrides use direct values by convention
+
+**Report format:** file:line, the hardcoded value, the token that should replace it.
+
+### Lens 2 — ARIA mutation completeness
+
+Check whether ARIA state attributes set in the HTML are also updated in the
+accompanying JS. This is the most common ARIA failure in generated code.
+
+**Verify for each dynamic component in the diff:**
+
+- `aria-expanded` — is it set in the HTML? Is it flipped (true/false) in the
+  JS every time the open/close state changes?
+- `aria-selected` — is it set on the initially active item? Is it updated on
+  keyboard navigation (Left/Right for tabs, Up/Down for listboxes)?
+- `aria-sort` — is it set on a column header? Is it updated and cleared on
+  all other columns when the sort changes?
+- `aria-checked` — is it set in the HTML? Is it toggled on user interaction?
+
+**Live-region pattern check:**
+- Does the diff create a live region element and populate it in the same JS
+  operation? (Wrong — the live region must be in the DOM before content
+  is injected, or the announcement is silently dropped.)
+
+**Report format:** file:line, the attribute, what update is missing.
+
+### Lens 3 — State coverage regression
+
+Compare the states visible in the diff against the 18-state matrix. A state
+present in the previous version (before the diff) that is absent after is a
+regression.
+
+**The 18-state matrix:** loading, empty, error, partial, disabled, content,
+success, first-run, no-results, permission/denied, offline, blocked,
+destructive-confirmation, long-content, large-data-set, high-zoom,
+reduced-motion, keyboard-only.
+
+**Practical check in a diff:**
+- Does the diff add a new async component without a loading or error state?
+- Does the diff remove error or empty handling that was in the previous version?
+- Does the diff add a new interactive control without a `reduced-motion` and
+  `keyboard-only` path?
+
+If no evidence manifest was provided, check only the diff itself — flag
+absent states on components added in the diff.
+
+**Report format:** which states are missing/regressed, on which component/element.
+
+### Lens 4 — WCAG 2.2 manual-verification items
+
+Automated tooling caps at `wcag21aa`. Two WCAG 2.2 AA criteria require manual
+inspection of the diff — flag these when the diff adds or changes interactive
+elements:
+
+**2.4.11 Focus Appearance:** does the diff add or change focus styles?
+- Flag: `outline: none` or `outline: 0` with no visible focus replacement.
+- Flag: a focus style that appears narrower than 2px or uses a low-contrast
+  color (contrast ratio < 3:1 between focused and unfocused states).
+
+**2.5.8 Target Size Minimum:** does the diff add interactive elements smaller
+than 24×24 CSS pixels?
+- Flag: buttons or links with `width` or `height` set below 24px (or with
+  padding that would result in a target below 24px).
+- Flag: icon-only buttons with no visible target sizing (no explicit `min-width`
+  / `min-height` or padding that reaches 24px).
+
+**Report format:** file:line, the criterion, what is wrong.
+
+### Lens 5 — CWV regression signals
+
+Scan the diff for patterns that reliably introduce performance regressions:
+
+| Signal | What to check |
+|---|---|
+| Route chunk size increase | Does the diff add a large import that would increase a route's JS bundle by > 10KB? Estimate from the import size if possible. |
+| Synchronous third-party script | Does the diff add `<script src="...">` without `defer` or `async`? |
+| Unsized image | Does the diff add `<img>` without `width` and `height` attributes? |
+| Lazy LCP candidate | Does the diff add `loading="lazy"` on an image that appears above the fold (no surrounding `scrolling`, not below a fold indicator)? |
+| Missing `font-display` | Does the diff add a `@font-face` declaration without `font-display`? |
+
+**Report format:** file:line, the signal, the remediation.
+
+## What is NOT in scope
+
+Route findings outside these five lenses to the correct reviewer:
+
+- **Spec/plan/implementation drift** → adversarial-reviewer
+- **Testability, observability, reliability** → quality-engineer
+- **Aesthetic taste, design intent, conversion copy** → experience-reviewer
+- **Security boundaries (auth, secrets, user input)** → security-reviewer
+
+If the diff is not primarily HTML/CSS/JS output (a Python API, a database
+migration, a CI config), return **WRONG ARTIFACT** and name the right reviewer.
+
+## Severity glossary
+
+| Tag | Meaning |
+|---|---|
+| Blocker | Ship-stopping. A missing ARIA update on a core flow, an `outline: none` with no replacement, a new async component with no error state. |
+| Major | Materially weakens the surface's quality floor. Token drift across multiple properties, a missing state on a non-core but visible component. |
+| Minor | Should be fixed; reviewer will not block on. Single-occurrence token drift, a minor target-size issue. |
+| Note | Informational — not a finding. Use sparingly. |
+
+ARIA mutations on core interactive components (navigation, form submission,
+data table) start at Blocker. Token drift starts at Minor and rises to Major
+when it affects theming-sensitive properties (color, background-color).
+
+## Output — the findings block only
+
+Return **only** the block below. No pre-findings methodology recap. No
+summary of what the diff does. Order findings by severity, not discovery
+order. Each finding names **file:line**, **lens**, **what's wrong**, and a
+**fix** (concrete, one sentence).
+
+If all lenses are clean, say so with `SHIP IT` and a one-line statement of
+what was checked.
+
+```
+## Verdict
+<SHIP IT | SHIP WITH CHANGES | MAJOR REWRITE | WRONG ARTIFACT>
+
+## Findings
+### Blocker
+**1. <title>.** file:line. Lens: <lens name>. What's wrong: <one sentence>. Fix: <concrete one-sentence fix>.
+### Major
+### Minor
+### Notes
+```
+
+## When `frontend-engineering` pack is absent
+
+If this reviewer is invoked but the `frontend-engineering` pack is not
+installed, the orchestrator records a **named skip**: `frontend-reviewer:
+pack not installed; review skipped`. Absence of the pack is not a silent pass
+— it is an acknowledged gap in the review coverage. The orchestrator must
+name the skip explicitly in the PR summary rather than omitting the reviewer.

--- a/packs/frontend-engineering/.apm/skills/a11y-engineering/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/a11y-engineering/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: a11y-engineering
+description: Deep accessibility engineering beyond automated tooling — focus management architecture, ARIA role correctness under dynamic mutation, live-region discipline, keyboard contract specification, and manual WCAG 2.2 AA verification for the two criteria automated tools miss.
+---
+
+# Skill: a11y-engineering
+
+Load this skill when an accessibility concern is the **primary task** — a
+dedicated accessibility audit, retrofitting broken patterns, or designing a
+new complex interaction where the a11y engineering is the central deliverable.
+
+Do not load this skill for routine component authoring; the accessibility
+section in `frontend-engineering` covers that case. Load `a11y-engineering`
+when:
+
+- Running a dedicated a11y audit on an existing surface
+- Retrofitting a surface that has known a11y failures
+- Designing a complex interaction pattern (combobox, data grid, drag-and-drop)
+  where the keyboard and screen-reader contract is the primary concern
+- Investigating a focus management failure that pa11y/axe-core did not catch
+
+---
+
+## The two automated-tooling gaps
+
+Automated accessibility tools (pa11y, axe-core) cap at `wcag21aa`. Two WCAG
+2.2 success criteria are new in 2.2 and require manual verification:
+
+**2.4.11 Focus Appearance (AA):** A keyboard focus indicator must have a minimum
+area of at least the perimeter of the unfocused component × 2 CSS pixels, and
+must have a contrast ratio of at least 3:1 between the focused and unfocused
+states. Automated tools cannot measure focus ring geometry or perform
+focused/unfocused contrast comparison — this check is always manual.
+
+**2.5.8 Target Size Minimum (AA):** Interactive targets must be at least
+24×24 CSS pixels. If a target is smaller than 24×24, the spacing around it
+(to the nearest adjacent interactive element or page edge) must be at least
+24px in all directions. Automated tools cannot reliably measure spacing between
+adjacent interactive elements — this check is always manual.
+
+Mark both explicitly in the evidence manifest under `a11y result`:
+```
+a11y result:
+  axe-core wcag21aa: [pass/fail + finding count]
+  manual 2.4.11 Focus Appearance: [pass/fail + notes]
+  manual 2.5.8 Target Size Minimum: [pass/fail + notes]
+```
+
+---
+
+## Focus management architecture
+
+### When programmatic focus move is required
+
+Move focus programmatically — this is not optional — when:
+
+| Trigger | Required focus destination |
+|---|---|
+| Modal opens | First focusable element inside the dialog |
+| Modal closes | The element that invoked the dialog |
+| SPA route change | Page `<h1>` (if it has `tabindex="-1"`) or a skip-nav landmark |
+| Inline error appears (form submit) | First invalid field, or the error summary element |
+| Async content inserted requiring immediate interaction | The inserted element or its first focusable child |
+
+### The DOM API sequence
+
+```javascript
+// 1. Make the element programmatically focusable if it is not natively focusable
+element.setAttribute('tabindex', '-1');
+
+// 2. Move focus
+element.focus({ preventScroll: false });
+
+// 3. For temporary targets: clean up tabindex after focus leaves
+element.addEventListener('blur', () => {
+  element.removeAttribute('tabindex');
+}, { once: true });
+```
+
+**The `inert` attribute** disables all interaction and assistive technology
+access for an element and its descendants. Use it to suppress background
+content when a modal is open:
+
+```javascript
+// On modal open:
+document.getElementById('main-content').setAttribute('inert', '');
+
+// On modal close:
+document.getElementById('main-content').removeAttribute('inert');
+```
+
+`inert` is Baseline Widely Available as of 2023. Verify at web.dev/baseline
+before use in environments with older browser support requirements.
+
+---
+
+## ARIA role correctness under dynamic mutation
+
+These are the patterns AI-generated code gets wrong most often. Each entry
+shows the wrong pattern, why it fails, and the correct pattern.
+
+### aria-expanded
+
+**Wrong:** `aria-expanded="false"` set once in the HTML template and never
+updated by JS.
+
+**Why it fails:** When the accordion/menu opens, the expanded state is not
+communicated to assistive technology. A screen reader user hears "collapsed"
+regardless of the actual state.
+
+**Right:**
+```javascript
+button.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+// Call this every time the toggle state changes, not just on initialization.
+```
+
+### aria-live — injecting region and content simultaneously
+
+**Wrong:**
+```javascript
+// Creating the live region and populating it at the same time
+const region = document.createElement('div');
+region.setAttribute('aria-live', 'polite');
+region.textContent = 'Results loaded: 12 items';
+document.body.appendChild(region);
+```
+
+**Why it fails:** The screen reader has not registered the live region before
+the content is injected. The announcement is silently dropped in most screen
+readers.
+
+**Right:**
+```html
+<!-- Place an empty live region in the DOM on page load -->
+<div id="status" aria-live="polite" aria-atomic="true"></div>
+```
+```javascript
+// Update its text content to trigger the announcement
+document.getElementById('status').textContent = 'Results loaded: 12 items';
+
+// Clear it after the announcement is no longer relevant
+setTimeout(() => {
+  document.getElementById('status').textContent = '';
+}, 5000);
+```
+
+### aria-selected — not updated on keyboard navigation
+
+**Wrong:** `aria-selected="true"` set on the initially active tab; no JS
+updates when the user presses Left/Right to navigate.
+
+**Why it fails:** The screen reader announces the initially selected tab as
+selected regardless of which tab the user navigated to.
+
+**Right:** update `aria-selected` on every tab as keyboard navigation moves
+the selection:
+```javascript
+tabs.forEach(tab => {
+  tab.setAttribute('aria-selected', tab === activeTab ? 'true' : 'false');
+});
+```
+
+### aria-sort — not updated on column sort
+
+**Wrong:** `aria-sort="ascending"` set on a column header and never updated.
+
+**Why it fails:** After the user re-sorts by a different column or reverses
+the sort, the announced sort direction is stale.
+
+**Right:** update `aria-sort` on the active column and remove it (or set it
+to `"none"`) on all other columns every time the sort changes:
+```javascript
+headers.forEach(header => {
+  header.setAttribute('aria-sort',
+    header === sortedColumn
+      ? (sortDirection === 'asc' ? 'ascending' : 'descending')
+      : 'none'
+  );
+});
+```
+
+---
+
+## Live-region discipline
+
+Five rules that prevent silent announcement drops:
+
+1. **Empty container in the DOM before content injection.** The live region
+   element must be present in the DOM before any text is written to it. Add it
+   empty at page load; never create and populate it in the same frame.
+
+2. **`aria-live="polite"` for informational updates.** Toast success messages,
+   search result counts, async load completions. The announcement waits for the
+   user to finish their current interaction.
+
+3. **`aria-live="assertive"` + `aria-atomic="true"` for errors.** Validation
+   summaries, session timeout warnings, destructive-action confirmations. The
+   announcement interrupts the current interaction. Use sparingly — assertive
+   announcements are disruptive.
+
+4. **Never inject the live region element and content simultaneously.** See
+   the ARIA pattern above. This is the single most common live-region failure
+   in generated code.
+
+5. **Test with actual screen readers, not just axe-core.** axe-core validates
+   role structure but cannot exercise timing behavior. Test the announcement
+   sequence with at minimum: VoiceOver + Safari on macOS/iOS and NVDA + Chrome
+   on Windows.
+
+---
+
+## Keyboard contract specification
+
+Document a component's keyboard contract as a table before implementing it.
+This prevents the common failure mode of building the component, then
+discovering its keyboard behavior is undefined.
+
+**Keyboard contract template:**
+
+| Key | Action | Focus destination | Screen reader announcement |
+|---|---|---|---|
+| `Tab` | Enter the component | First item | "[item label], [role]" |
+| `Down Arrow` | Move to next item | Next item | "[item label]" |
+| `Up Arrow` | Move to previous item | Previous item | "[item label]" |
+| `Enter` / `Space` | Activate the focused item | Unchanged | "[item label], selected" |
+| `Escape` | Close / dismiss | Return to trigger | "[component label], closed" |
+| `Home` | Jump to first item | First item | "[item label]" |
+| `End` | Jump to last item | Last item | "[item label]" |
+
+Fill this template for every interactive component before writing JS.
+
+---
+
+## Complex pattern contracts
+
+### Combobox (autocomplete/select)
+
+The combobox pattern requires three ARIA roles working together: the text
+input (`role="combobox"`), the popup list (`role="listbox"`), and the options
+(`role="option"`). The W3C Combobox pattern (APG) defines two variants:
+combobox with listbox popup and combobox with grid popup. Use the listbox
+variant for simple option selection; the grid variant for complex option
+cells (e.g., date pickers).
+
+Key contract points:
+- `aria-expanded` on the combobox element must reflect the open/closed state
+- `aria-activedescendant` on the combobox must point to the currently
+  highlighted option's `id`
+- Keyboard: Down Arrow opens the popup and moves focus (logical), not physical
+  focus — focus remains on the input; `aria-activedescendant` tracks selection
+
+### Data grid
+
+A data grid (`role="grid"`) requires row/cell navigation. Keyboard:
+- Tab enters the grid; navigates between interactive cells
+- Arrow keys navigate cells within the grid (two-dimensional navigation)
+- Enter/F2 activates a cell for editing
+- Escape exits edit mode; Tab/Shift+Tab navigate to next/previous interactive
+  cell
+
+Each cell that contains interactive content uses `role="gridcell"`;
+column headers use `role="columnheader"` with `aria-sort`.
+
+### Drag-and-drop (keyboard alternative required)
+
+Drag-and-drop without a keyboard alternative fails WCAG 2.1 Success Criterion
+2.1.1 (Keyboard). A keyboard alternative is required. Two acceptable patterns:
+
+1. **Cut/paste model:** select an item (Space), navigate to the target
+   position (Arrow keys), paste (Space or Enter).
+2. **Directional reorder:** select an item (Space), then use Alt+Arrow or
+   Ctrl+Arrow to move it one position at a time.
+
+Announce each reorder with a live region: "Item moved from position 3 to
+position 1."
+
+---
+
+## Manual verification checklist
+
+### WCAG 2.4.11 Focus Appearance
+
+For every interactive element on the surface:
+
+- [ ] A visible focus indicator is present (no `outline: none` without a
+  visible replacement)
+- [ ] The focus indicator area is at least: perimeter of the component × 2px
+  (a 2px solid outline around the component satisfies this for most controls)
+- [ ] The focus indicator has a contrast ratio of at least **3:1** between the
+  focused and unfocused states
+
+**Measurement:** Open DevTools, tab to the element, measure the computed
+`outline` or `box-shadow`. Verify contrast with a contrast checker using the
+actual computed focus color against the background adjacent to the indicator.
+
+### WCAG 2.5.8 Target Size Minimum
+
+For every interactive element on the surface:
+
+- [ ] Touch/click targets are at least **24×24 CSS pixels**, OR
+- [ ] If smaller than 24×24, the **offset** (distance to the nearest
+  adjacent interactive element) is at least **24px** in all directions
+
+**Measurement:** Open DevTools, use the element inspector to read the
+computed `width` and `height`. For offset measurement, check the layout
+by measuring the gap between adjacent interactive elements.
+
+---
+
+## Remediation priority order
+
+When an audit finds multiple violations, prioritize in this order:
+
+1. **New violations introduced by this change** — blocking; must be fixed
+   in this PR. A change that introduces an a11y regression ships blocked.
+2. **Existing Blocker findings** — WCAG AA violations on core user flows
+   (form submission, navigation, primary actions). Fix as ride-alongs if
+   in the same area; defer to a dedicated a11y sprint if in unrelated code.
+3. **Existing Major findings** — WCAG AA violations on secondary flows or
+   non-blocking patterns. Record in known exceptions with rationale and
+   planned resolution.
+4. **Existing Minor findings** — Polish and best-practice items. Record
+   in known exceptions.
+
+A violation documented in known exceptions with a rationale and owner is
+not a failure — it is honest accounting. A violation that is silently
+omitted from the evidence manifest is a failure.

--- a/packs/frontend-engineering/.apm/skills/a11y-engineering/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/a11y-engineering/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Audit this surface for WCAG 2.2 AA compliance beyond what axe-core can catch",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix the focus management on this modal \u2014 focus isn't returning on close",
+    "should_trigger": true
+  },
+  {
+    "query": "The live region isn't being announced \u2014 diagnose and fix",
+    "should_trigger": true
+  },
+  {
+    "query": "Document the keyboard contract for this data grid component",
+    "should_trigger": true
+  },
+  {
+    "query": "Check WCAG 2.4.11 Focus Appearance on our focus rings",
+    "should_trigger": true
+  },
+  {
+    "query": "Our combobox doesn't work with a keyboard \u2014 implement the correct pattern",
+    "should_trigger": true
+  },
+  {
+    "query": "The aria-expanded on this accordion is set once and never updated",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix the tab order on this form \u2014 it doesn't follow the visual layout",
+    "should_trigger": true
+  },
+  {
+    "query": "Verify WCAG 2.5.8 Target Size Minimum on our mobile touch targets",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a new page and run the standard accessibility gate as part of gates",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the token system for our design system",
+    "should_trigger": false
+  },
+  {
+    "query": "Improve the Core Web Vitals on this landing page",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we use SSR for this authenticated page?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the component API for our select input",
+    "should_trigger": false
+  },
+  {
+    "query": "Make the hero section responsive",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit the CSS specificity in our codebase",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current state of this surface?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/component-contract/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/component-contract/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: component-contract
+description: Design a UI component's public interface — props/slots/events, controlled vs. uncontrolled ownership, composition patterns, lifecycle contract, and usage documentation — before writing any implementation.
+---
+
+# Skill: component-contract
+
+Load this skill when designing a new **shared component** — one that will be
+used by multiple callers in the codebase. Do not load it for one-off
+components local to a single page; the additional design overhead is not
+warranted. Load `component-contract` when:
+
+- Building a new component that will go into a shared UI library or component
+  directory
+- Refactoring a component that has grown multiple callers and its interface
+  is inconsistent
+- Reviewing a component's public interface before it is published or exported
+
+The contract must be written **before** any implementation code. An interface
+designed after the implementation reflects the implementation's needs, not the
+caller's needs — it is the wrong order.
+
+---
+
+## The API-first principle
+
+A component's public interface is its most durable artifact. The implementation
+changes; the interface is what callers depend on. Once multiple callers
+depend on a component's props, events, and slots, changing the interface is a
+breaking change. An interface designed carelessly at the start becomes
+technical debt proportional to its adoption.
+
+The principle has two implications:
+1. The interface is the deliverable of this design pass — not the implementation.
+2. The interface should be the *minimum* that satisfies the callers' needs
+   today, with room to extend without breaking.
+
+---
+
+## Controlled vs. uncontrolled ownership
+
+**Uncontrolled component:** the component manages its own state internally.
+The caller does not control the value; it just receives change notifications.
+
+```jsx
+// Uncontrolled: caller provides an initial value; component manages the rest
+<InputField defaultValue="Initial text" onChange={handleChange} />
+```
+
+**Controlled component:** the caller owns the state. The component is a
+pure rendering function — it displays what it's given and reports changes.
+
+```jsx
+// Controlled: caller owns the value; component is a display layer
+<InputField value={controlledValue} onChange={setValue} />
+```
+
+**The rule for when to support both:** provide **uncontrolled by default**
+(simpler for most callers), with a **controlled override** for callers that
+need to manage state themselves (e.g., when the value must be derived from
+external state, validated before setting, or synchronized with another control).
+
+The most common pattern: accept both `value` (controlled) and `defaultValue`
+(uncontrolled). When `value` is provided, operate in controlled mode; when
+only `defaultValue` is provided, operate in uncontrolled mode.
+
+---
+
+## Props design rules
+
+| Rule | Wrong | Right | Reason |
+|---|---|---|---|
+| Name props for what they ARE | `showModal={true}` | `isOpen={true}` | `show` is a verb (what to do); `isOpen` is a state (what it is) |
+| Boolean props name the positive state | `disabledState` | `isDisabled` | Double negatives (`isNotDisabled`) are harder to reason about |
+| Avoid encoding implementation | `useFlexLayout` | `layout="horizontal"` | The implementation detail leaks into the API; the caller shouldn't care how layout is achieved |
+| Prefer composition over configuration | `<Button showIcon={true} iconName="check">` | `<Button><CheckIcon />Submit</Button>` | Multiple boolean props that add/configure content make the component harder to extend without changing the API |
+| Consistent naming convention | Mixed `on_click`, `onClick`, `handleClick` | Always `on` + PascalCase event name | Consistency reduces cognitive load for callers |
+
+---
+
+## Slots and composition patterns
+
+**Default slot (children):** the most flexible composition pattern. The caller
+provides any content they need; the component provides the container and
+behavior.
+
+Use the default slot when: the component's job is behavior/wrapper (a modal,
+a tooltip, a card), not content generation.
+
+**Named slots:** when the component has multiple content regions with distinct
+semantic roles (a card with `header`, `body`, and `footer`; a dialog with
+`title` and `content`).
+
+In JSX:
+```jsx
+<Card>
+  <Card.Header>Card title</Card.Header>
+  <Card.Body>Card content goes here.</Card.Body>
+  <Card.Footer><Button>OK</Button></Card.Footer>
+</Card>
+```
+
+In Vue / Web Components (explicit slot names):
+```html
+<card-component>
+  <template slot="header">Card title</template>
+  <template slot="body">Card content.</template>
+</card-component>
+```
+
+**Render props:** a function-as-children pattern that gives the caller control
+over rendering while the component provides data. Appropriate for components
+that manage complex state and expose it to the caller for rendering.
+
+Use render props when: the component manages state the caller needs to render
+(e.g., a dropdown that tracks open/selected but lets the caller render the
+options).
+
+---
+
+## Events contract
+
+| Rule | Detail |
+|---|---|
+| Naming: `on` + PascalCase past-tense event | `onChange`, `onSubmit`, `onDismiss` — not `handle_click`, not `clicked` |
+| Payload shape | Define the shape of the event payload in the contract. If it carries data (the new value, the selected item), document it explicitly. |
+| What the component does NOT do after emitting | The component emits the event and stops. It does not optimistically update its own controlled state. The caller owns the state update. |
+| Avoid emitting raw browser events | Wrap browser events in component-level events with meaningful names. `onChange` on a text field is a component event; it should not expose the browser's `InputEvent` object unless the caller genuinely needs browser-level access. |
+
+---
+
+## Lifecycle contract
+
+Document what the component expects on mount, during its lifetime, and on
+unmount:
+
+- **On mount:** any async operations it initiates (data fetching, subscriptions,
+  DOM measurements). What state is it in before those operations complete?
+- **During lifetime:** any external dependencies it listens to (context,
+  global stores, DOM resize observers). What happens when those change?
+- **On unmount:** what it tears down (subscriptions, timers, event listeners).
+  A component that does not clean up its subscriptions on unmount is a memory
+  leak.
+- **Strict mode double-invocation:** React 18+ strict mode double-invokes
+  `useEffect` (and the equivalent in other frameworks) in development. Does
+  the component survive a mount/unmount/mount cycle without observable side
+  effects? If not, the lifecycle contract has a bug.
+
+---
+
+## Usage documentation template
+
+Every shared component must ship a usage doc. Minimum viable format:
+
+```markdown
+## ComponentName
+
+**Purpose:** One sentence describing what this component does and why it exists.
+
+**When to use:** [conditions], not [counter-conditions].
+
+### Props
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | — | Controlled value. Provide with `onChange` for controlled mode. |
+| `defaultValue` | `string` | `''` | Initial value for uncontrolled mode. |
+| `isDisabled` | `boolean` | `false` | Disables the component; renders `aria-disabled`. |
+| `onChange` | `(value: string) => void` | — | Called on every value change. |
+
+### Events
+
+| Name | Payload | When it fires |
+|------|---------|--------------|
+| `onChange` | `string` | Every time the user changes the value |
+| `onBlur` | `FocusEvent` | When the component loses focus |
+
+### Slots
+
+| Name | Required | Description |
+|------|----------|-------------|
+| default | Yes | Content rendered inside the component |
+| `label` | No | If provided, replaces the built-in label element |
+
+### Accessibility contract
+
+- Manages `aria-disabled` when `isDisabled` is true.
+- Accepts focus via Tab; announces its label to screen readers via `<label>` association.
+- Does not trap focus.
+
+### Example
+
+[Minimal complete usage example — the smallest correct usage, not a feature tour]
+```
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|---|---|---|
+| Prop drilling beyond 2 levels | Component requires callers to pass the same prop through 3+ levels of nesting | Extract a context (React Context, Vue provide/inject) to share the value without threading it through props |
+| God component (more than one primary job) | A component renders a form AND handles data fetching AND manages a modal | Split into two components: one for UI (receives data via props), one for data management (renders the UI component) |
+| Implicit global state mutation | Component writes to a global store directly rather than emitting an event | The component emits; the caller (or a coordinating layer) decides whether and how to update global state |
+| Spreading all props on the root element | `<div {...props}>` passes unknown props to the DOM | Explicitly whitelist which props are valid for the root element; spread the rest only if a forwarded-refs pattern is intentional |

--- a/packs/frontend-engineering/.apm/skills/component-contract/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/component-contract/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Design the API for our new dropdown component before we write any code",
+    "should_trigger": true
+  },
+  {
+    "query": "Should this component be controlled or uncontrolled by default?",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the props interface for our data table \u2014 it needs sorting and selection",
+    "should_trigger": true
+  },
+  {
+    "query": "Write the usage documentation contract for our modal component",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the slots interface for our card component",
+    "should_trigger": true
+  },
+  {
+    "query": "Define the events contract for our form input component",
+    "should_trigger": true
+  },
+  {
+    "query": "Our component has 12 boolean props \u2014 help us refactor its API",
+    "should_trigger": true
+  },
+  {
+    "query": "Design a composable API for our navigation component",
+    "should_trigger": true
+  },
+  {
+    "query": "Write the lifecycle contract for our infinite scroll component",
+    "should_trigger": true
+  },
+  {
+    "query": "Build the dropdown component with all its interaction states",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the semantic token layer for our colours",
+    "should_trigger": false
+  },
+  {
+    "query": "Run a full WCAG audit on this component",
+    "should_trigger": false
+  },
+  {
+    "query": "Diagnose the layout shift when this card grid loads",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we SSR this component list?",
+    "should_trigger": false
+  },
+  {
+    "query": "Make this component responsive at mobile breakpoints",
+    "should_trigger": false
+  },
+  {
+    "query": "Set up cascade layers for the component library CSS",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current state of this component's quality gates?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/css-architecture/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/css-architecture/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: css-architecture
+description: Organize CSS at scale using cascade layers, scoping strategies, and specificity budgets — preventing specificity wars, enabling safe deletion, and making CSS that other engineers can reason about.
+---
+
+# Skill: css-architecture
+
+Load this skill when setting up CSS architecture for a new codebase, or
+auditing and refactoring CSS in an existing one where specificity conflicts,
+hard-to-predict cascade behavior, or unsafe deletion are active problems.
+Do not load it for routine component styling on a codebase that already has
+a working architecture. Load `css-architecture` when:
+
+- Starting a new project and deciding the CSS organization strategy
+- A codebase has accumulated specificity conflicts that produce unpredictable
+  cascades
+- Engineers cannot safely delete a CSS rule because they don't know what
+  will break
+- The codebase has grown beyond one developer and CSS changes produce
+  unexpected regressions
+
+---
+
+## Cascade layers
+
+`@layer` (Cascade Layers) is Baseline Widely Available as of 2022. It makes
+the cascade explicit and controllable: a rule in a higher layer always wins
+over a rule in a lower layer, regardless of specificity.
+
+**Canonical layer order:**
+
+```css
+/* Declare all layers upfront — this is the only place layer order is defined */
+@layer reset, base, theme, components, utilities, overrides;
+```
+
+| Layer | Contents | Notes |
+|---|---|---|
+| `reset` | Browser default reset (e.g., box-sizing, margins) | No project-specific styles |
+| `base` | HTML element defaults (body font, heading scale, link style) | Unclassed element selectors only |
+| `theme` | Design token custom properties (`:root {}` token block) | No component styles |
+| `components` | Component class selectors (`.btn`, `.card`, `.modal`) | The main application CSS lives here |
+| `utilities` | Single-purpose utility classes (`hidden`, `sr-only`, spacing helpers) | High-frequency reuse; should have low specificity |
+| `overrides` | Escape hatch for third-party library overrides, print styles | Rarely used; document every rule added here |
+
+**Why ordering is the invariant:** a rule in `utilities` always beats a rule
+in `components`, regardless of how specific the component rule is. This means
+utilities are reliable (you can always use a utility to override a component
+style), but components cannot override utilities. The layer order must be
+declared once at the top of the main stylesheet — never redeclare it in
+component files.
+
+**Importing into layers:**
+```css
+@layer reset {
+  @import url('/css/reset.css');
+}
+
+@layer components {
+  @import url('/css/button.css');
+  @import url('/css/card.css');
+}
+```
+
+---
+
+## Scoping strategy
+
+Choose one scoping strategy for the project. Mixing strategies in the same
+codebase produces conflicting specificity assumptions.
+
+**CSS Modules:** class names are hashed at build time (`button_abc123`);
+guaranteed uniqueness per module. Appropriate for component-based frameworks
+(React, Vue, Svelte) where each component file has its own CSS module.
+
+- Strengths: zero naming collisions, dead code is detectable by the bundler.
+- Weakness: no global shared classes unless explicitly exposed; requires a
+  bundler.
+
+**BEM (Block-Element-Modifier):** naming convention that encodes component
+structure in the class name: `.block__element--modifier`.
+
+- Strengths: portable, no build tools required, self-documenting.
+- Weakness: class names become verbose; convention is manually enforced.
+
+**Utility-first CSS:** all styling done with single-purpose utility classes.
+No component-level CSS; styles are composed in HTML.
+
+- Strengths: no dead CSS, highly predictable, fast iteration.
+- Weakness: HTML becomes verbose; component abstraction is in JS, not CSS.
+
+**CUBE CSS (Composition, Utility, Block, Exception):** a hybrid that combines
+global composition (layout), utilities, block-level component styles, and
+per-instance exception overrides.
+
+**Selection criteria:**
+
+| Criterion | CSS Modules | BEM | Utility-first | CUBE |
+|---|---|---|---|---|
+| Framework-based (React/Vue) | Best | Works | Works | Works |
+| No build tools | No | Best | Requires CDN build | Works |
+| Small team, fast velocity | Works | Works | Best | Works |
+| Large team, strict naming | Works | Best | Works | Works |
+| Design-system-driven | Works | Works | Works | Best |
+
+---
+
+## Specificity budget
+
+**The rule of thumb:** no selector should exceed specificity `0-2-0`
+(two class names). Selectors with higher specificity are hard to override
+without writing even-higher-specificity selectors, producing a cascade war.
+
+```css
+/* Right: specificity 0-1-0 */
+.button { color: var(--btn-text); }
+
+/* Right: specificity 0-2-0 */
+.button.is-active { color: var(--btn-text-active); }
+
+/* Wrong: specificity 0-3-0 — already too high */
+.nav .button.is-active { }
+
+/* Wrong: ID selector — specificity 1-0-0 — overrides all class selectors */
+#submit-button { }
+```
+
+**ID selectors in CSS are banned.** IDs have specificity `1-0-0` — they beat
+every class-based selector regardless of how specific. Use IDs for JavaScript
+hooks and accessibility (`aria-labelledby`, `<label for="...">`), never for
+styling.
+
+**To audit current specificity:** paste a stylesheet into a specificity
+visualizer (specifishity.com or equivalent). Any selector above `0-2-0` is a
+candidate for refactoring.
+
+---
+
+## Safe deletion check
+
+Before deleting a CSS rule, answer three questions:
+
+1. **Is this selector referenced in HTML?** Search the codebase for the class
+   name (exact match, not substring). If no HTML uses the class, it is safe
+   to delete.
+   ```bash
+   grep -r "class-name-here" --include="*.html" --include="*.jsx" --include="*.tsx" .
+   ```
+
+2. **Is this rule overriding something that would now cascade through?** Check
+   whether the rule's declarations suppress a style from a lower layer. If
+   deleted, the lower-layer style takes effect. This is not always wrong, but
+   must be verified.
+
+3. **Does the selector appear in tests or a style guide?** Visual regression
+   tests and component showcase snapshots may reference class names indirectly.
+   Search for the class name in test files.
+
+If all three checks are clean, the rule is safe to delete. If any check is
+ambiguous, leave the rule and add a comment explaining what it does.
+
+---
+
+## Token compliance audit
+
+The same grep from `frontend-engineering` GATES step 3:
+
+```bash
+grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>
+```
+
+Output should return **only** the `:root` / primitive token-definition block.
+Any hardcoded colour or spacing value outside that block is a violation.
+
+**What counts as a violation:**
+- Any `color`, `background-color`, `border-color`, or `fill` value expressed
+  as a hex, `rgb()`, `rgba()`, or `hsl()` function outside the `:root` block.
+- Any `padding`, `margin`, `gap`, `width`, or `height` value expressed as a
+  pixel value that is not a token (e.g., `margin: 13px`).
+
+**What does NOT count as a violation:**
+- Primitive token definitions inside `:root {}`.
+- `transparent`, `currentColor`, `inherit` — these are relational, not literal.
+- `1px` for borders and outlines — a single-pixel border is a design primitive,
+  not a spacing token.
+
+---
+
+## CSS custom property gotchas
+
+**`@property` for type-safe tokens:**
+```css
+@property --ds-color-primary {
+  syntax: '<color>';
+  inherits: true;
+  initial-value: #5e6ad2;
+}
+```
+`@property` gives the browser the type of a custom property, enabling
+interpolation in transitions and preventing values from being set to the
+wrong type. Baseline Newly Available — check support requirements.
+
+**Inheritance behavior:** CSS custom properties inherit by default through
+the DOM. A token set on `:root` is available everywhere. If a component
+needs to override a token for its own tree without affecting siblings, scope
+the override to the component's root element:
+```css
+.my-component {
+  --ds-color-primary: var(--ds-color-secondary);
+}
+```
+
+**The isolation case (`initial`):** when a component must be fully isolated
+from its parent's token environment (e.g., an iframe-embedded widget, a
+third-party component), use `@layer` isolation and set custom properties to
+their `initial` values explicitly.
+
+**`!important` on a custom property:** CSS `!important` applies to the
+property declaration, not the custom property value. It works but produces
+the same cascade problems as `!important` on any other property — use it
+only as a documented last resort in the `overrides` layer.
+
+---
+
+## Naming system
+
+The functional naming rule applies to the entire CSS class name system as well
+as token names.
+
+**Role names survive redesigns; implementation names do not:**
+
+| Wrong (implementation) | Right (role/function) |
+|---|---|
+| `.blue-button` | `.btn-primary` |
+| `.large-font-header` | `.page-heading` |
+| `.left-sidebar` | `.sidebar` (or `.layout-sidebar`) |
+| `.two-column-layout` | `.content-layout` |
+
+A `.blue-button` class becomes incorrect when the brand color changes to
+green. A `.btn-primary` class is correct regardless of the brand color —
+it describes the button's role in the hierarchy, not its current color.
+
+Apply the same rule to CSS custom properties — see `token-architecture` for
+the full naming system.

--- a/packs/frontend-engineering/.apm/skills/css-architecture/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/css-architecture/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Set up cascade layers for our design system CSS",
+    "should_trigger": true
+  },
+  {
+    "query": "Our CSS has a specificity war \u2014 audit it and propose a restructure",
+    "should_trigger": true
+  },
+  {
+    "query": "Design a scoping strategy for our component library CSS",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up a specificity budget and enforcement rules for our codebase",
+    "should_trigger": true
+  },
+  {
+    "query": "Our CSS selectors reach 0-3-2 specificity \u2014 help us bring it back to 0-1-0",
+    "should_trigger": true
+  },
+  {
+    "query": "Audit our CSS for hardcoded colour values that should be tokens",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the layer ordering for our global CSS reset, theme, and components",
+    "should_trigger": true
+  },
+  {
+    "query": "Our button styles are being overridden unpredictably \u2014 diagnose the cascade issue",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up @layer ordering to prevent utility classes overriding component styles",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a new UI surface with a CSS token seed block",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the semantic token hierarchy for our colour system",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit this surface for WCAG 2.2 AA compliance",
+    "should_trigger": false
+  },
+  {
+    "query": "Profile the CLS on our page \u2014 why is content shifting?",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we use ISR or SSG for this page?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the component API for our input",
+    "should_trigger": false
+  },
+  {
+    "query": "Make this two-column layout respond at mobile",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current quality state of our CSS?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/fe-performance/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/fe-performance/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: fe-performance
+description: Measure, diagnose, and remediate Core Web Vitals and asset budget violations using structured profiling, causality analysis, and repeatable remediation patterns.
+---
+
+# Skill: fe-performance
+
+Load this skill when the primary output is a CWV diagnosis or performance
+remediation — not when Lighthouse is run as a gate at the end of a normal
+build (the GATES section of `frontend-engineering` covers that). Load
+`fe-performance` when:
+
+- A surface has known CWV violations (LCP, INP, or CLS failing field thresholds)
+- A performance budget has been exceeded and the cause needs diagnosis
+- A PR diff is suspected to introduce a performance regression
+
+---
+
+## CWV causality model
+
+Before profiling, understand what each metric measures and what typically
+causes failures. This narrows the profiling focus before any tooling runs.
+
+### LCP — Largest Contentful Paint (target: ≤2.5s at p75)
+
+LCP measures when the largest visible content element renders. Common causes:
+
+| Cause | Signal |
+|---|---|
+| Render-blocking resources | CSS or synchronous JS in `<head>` blocking first paint |
+| Slow server / TTFB > 800ms | WebPageTest shows long server response time |
+| Unoptimized LCP element | Hero image served at 3× the display size, no `srcset`, not preloaded |
+| LCP element loaded lazily | `loading="lazy"` on the above-fold LCP candidate — this delays it deliberately |
+| Web font blocking text render | `font-display` not set; browser waits for font before rendering text |
+
+### INP — Interaction to Next Paint (target: ≤200ms at p75)
+
+INP measures the latency of the worst user interaction across the page session.
+Common causes:
+
+| Cause | Signal |
+|---|---|
+| Long tasks on the main thread | DevTools performance trace shows tasks > 50ms blocking the main thread |
+| Heavy event handler cost | Click/input handler does layout-thrashing work synchronously |
+| Deep rendering pipeline | A single user action triggers a re-render of a large component tree |
+| Third-party scripts | Third-party JS running on the main thread during interactions |
+
+### CLS — Cumulative Layout Shift (target: ≤0.1 at p75)
+
+CLS measures unexpected visual movement of page content. Common causes:
+
+| Cause | Signal |
+|---|---|
+| Unsized images | `<img>` without `width`/`height` attributes — browser cannot reserve space |
+| Unsized iframes | Same problem |
+| Late-injected content above existing content | Ad banners, cookie banners, dynamic inserts that push content down |
+| Font swap without `font-display` | Text reflow when the web font loads and replaces the fallback |
+| Animations using top/left/margin | These trigger layout; use `transform` instead |
+
+---
+
+## Structured profiling sequence
+
+Run profiling tools in this order. Stop when the root cause is identified —
+running all tools for every issue wastes time and adds noise.
+
+**Step 1 — Lighthouse (baseline):**
+```bash
+npx lighthouse <url> --output json --output-path ./report.json
+# or via Chrome DevTools: Lighthouse tab → Generate report
+```
+Lighthouse gives a scored baseline with audit-level findings. Use it to
+identify which metric(s) are failing and which audits contributed.
+
+**Step 2 — DevTools Performance panel (trace):**
+Open Chrome DevTools → Performance → record a page load or interaction.
+Look for:
+- Long tasks (red bars in the main thread row)
+- Layout events caused by property changes
+- Resource loading waterfall (identify render-blocking resources)
+
+**Step 3 — WebPageTest (field data):**
+`https://www.webpagetest.org/` — run a filmstrip test from a representative
+location and connection speed (simulated mobile, Moto G4, 3G Fast).
+WebPageTest shows field-data-approximate CWV and the full resource waterfall
+including third-party scripts.
+
+**Step 4 — Bundle analyzer (JS weight):**
+```bash
+# webpack
+npx webpack-bundle-analyzer stats.json
+
+# Rollup / Vite
+# Use rollup-plugin-visualizer or vite-bundle-analyzer
+```
+Use when Lighthouse flags a large JS payload. Bundle analysis identifies
+which modules contribute to the route chunk size and where code splitting
+can help.
+
+---
+
+## Remediation patterns
+
+### LCP remediation
+
+**Preload the LCP resource:**
+```html
+<!-- For an image LCP element -->
+<link rel="preload" href="/hero.webp" as="image" fetchpriority="high">
+
+<!-- For a web font used in a text LCP element -->
+<link rel="preload" href="/fonts/brand.woff2" as="font" type="font/woff2" crossorigin>
+```
+
+**Remove render-blocking CSS:**
+- Inline critical CSS for above-fold content in `<style>` in `<head>`
+- Load the full stylesheet with `<link rel="preload" as="style">` + `onload`
+
+**Reduce TTFB:**
+- Add server-side or CDN caching for HTML responses
+- Move the origin closer to users (CDN edge) if TTFB > 800ms at p75
+
+**Fix lazy-loaded LCP element:**
+```html
+<!-- Wrong: never lazy-load the LCP candidate -->
+<img src="hero.webp" loading="lazy" alt="Hero image">
+
+<!-- Right: use eager loading (default) or explicitly eager -->
+<img src="hero.webp" loading="eager" fetchpriority="high" alt="Hero image">
+```
+
+### INP remediation
+
+**Break long tasks with `scheduler.yield()`:**
+```javascript
+async function processLargeDataSet(items) {
+  for (let i = 0; i < items.length; i++) {
+    processItem(items[i]);
+
+    // Yield to the browser every 50 items to allow interaction
+    if (i % 50 === 0) {
+      await scheduler.yield();
+    }
+  }
+}
+```
+
+`scheduler.yield()` is Baseline Newly Available. Fallback for older browsers:
+```javascript
+await new Promise(resolve => setTimeout(resolve, 0));
+```
+
+**Defer non-critical event handlers:**
+Move expensive non-critical work out of the synchronous event handler:
+```javascript
+button.addEventListener('click', (e) => {
+  // Critical: update UI immediately
+  updateButtonState(e.target);
+
+  // Non-critical: defer analytics and secondary effects
+  requestIdleCallback(() => {
+    sendAnalytics('button_click');
+    triggerSecondaryEffect();
+  });
+});
+```
+
+### CLS remediation
+
+**Size images and iframes:**
+```html
+<!-- Always include width and height attributes -->
+<img src="photo.webp" width="800" height="600" alt="Photo">
+
+<!-- CSS prevents the img from overflowing its container -->
+<style>
+  img { max-width: 100%; height: auto; }
+</style>
+```
+
+**Use `font-display: swap` or `optional`:**
+```css
+@font-face {
+  font-family: 'Brand';
+  src: url('/fonts/brand.woff2') format('woff2');
+  font-display: swap;  /* Show fallback immediately, swap when loaded */
+}
+```
+
+`font-display: optional` avoids CLS entirely by not swapping if the font
+loads after the first render — at the cost of potentially showing the
+fallback persistently on slow connections.
+
+**Reserve space for late-injected content:**
+If content must be injected above the fold after page load (e.g., a
+personalised banner), reserve the space with a fixed-height placeholder
+before injection.
+
+---
+
+## Asset budget enforcement
+
+The seven asset budget categories from `frontend-engineering`. For each:
+the measurement command and the fix-first-look heuristic.
+
+| Category | Measure | Fix-first-look |
+|---|---|---|
+| JS (JavaScript) | Lighthouse "Reduce unused JavaScript" + bundle analyzer | Code split by route; defer non-critical bundles with `type="module"` + dynamic `import()` |
+| Images | Lighthouse "Serve images in next-gen formats" + "Properly size images" | Convert to WebP/AVIF; use `srcset` for responsive sizes |
+| Fonts | Lighthouse "Reduce the impact of third-party code" (if font CDN) | Self-host; subset to used characters; `font-display: swap` |
+| Third-party scripts | Lighthouse "Reduce the impact of third-party code" | Audit each script; remove unused; facade heavy embeds (video, chat) |
+| Hydration | Measure Time to Interactive delta (TTI - LCP) in Lighthouse | Islands architecture — hydrate only interactive components, not the full page |
+| Route chunks | webpack-bundle-analyzer / Vite visualizer | Each route chunk should load only what that route needs; shared chunks for truly shared code |
+| Long tasks | DevTools Performance → main thread long task count | `scheduler.yield()` between batches; defer with `requestIdleCallback` |
+
+---
+
+## Code splitting patterns
+
+**Route-based splitting** (preferred for SPAs): each route loads only its
+own JS bundle. The framework usually handles this automatically (Next.js,
+Remix, Astro page components). Verify by inspecting the network tab on
+navigation.
+
+**Component-based splitting**: load heavy components on demand:
+```javascript
+const HeavyChart = React.lazy(() => import('./HeavyChart'));
+// or plain dynamic import:
+const { HeavyChart } = await import('./HeavyChart');
+```
+Use when a component is not needed on initial load — a tab panel, a
+print dialog, a settings sheet.
+
+**Library-based splitting**: avoid bundling the full library when only a
+subset is used. Use tree-shaking-compatible imports:
+```javascript
+// Wrong — bundles entire lodash
+import _ from 'lodash';
+// Right — only bundles the functions imported
+import { debounce, throttle } from 'lodash-es';
+```
+
+---
+
+## Image optimization
+
+**Format selection:**
+- Use **WebP** as the baseline format. Broad support; ~25-35% smaller than
+  JPEG at equivalent quality.
+- Use **AVIF** as the preferred format where support exists. ~45-55% smaller
+  than JPEG. Serve with `<picture>` fallback to WebP.
+- Keep JPEG/PNG only for images that must be printed at high resolution or
+  served to very old browsers.
+
+**Responsive images (`srcset`/`sizes`):**
+```html
+<picture>
+  <source type="image/avif"
+    srcset="photo-400.avif 400w, photo-800.avif 800w, photo-1200.avif 1200w"
+    sizes="(max-width: 600px) 400px, (max-width: 1000px) 800px, 1200px">
+  <source type="image/webp"
+    srcset="photo-400.webp 400w, photo-800.webp 800w, photo-1200.webp 1200w"
+    sizes="(max-width: 600px) 400px, (max-width: 1000px) 800px, 1200px">
+  <img src="photo-1200.jpg" width="1200" height="800" alt="Description"
+    loading="lazy">
+</picture>
+```
+
+**`loading="lazy"` qualification:**
+- Use `loading="lazy"` on images that are below the fold on initial load.
+- **Never** use `loading="lazy"` on the LCP candidate. It is below-fold by
+  definition — if the LCP element is lazy-loaded, it will delay LCP.
+- A safe rule: any image that is not visible in the first viewport on a
+  768px-wide mobile screen is a candidate for lazy loading.
+
+---
+
+## Performance regression signals in a PR diff
+
+A reviewer should treat these as flags requiring investigation before merge:
+
+- **Route chunk size increase > 10KB** in the bundle analyzer output — verify
+  the addition is intentional and alternatives were considered.
+- **Synchronous third-party script added** (`<script src="..." >` without
+  `defer` or `async`) — blocks HTML parsing; requires explicit justification.
+- **`<img>` without `width` and `height` attributes** — guarantees CLS.
+- **`loading="lazy"` on an above-fold image** — delays LCP deliberately.
+- **`font-display` absent from a new `@font-face` declaration** — will cause
+  FOIT (flash of invisible text) on slow connections.

--- a/packs/frontend-engineering/.apm/skills/fe-performance/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/fe-performance/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Our LCP is 4.2s \u2014 diagnose and fix",
+    "should_trigger": true
+  },
+  {
+    "query": "Improve the Core Web Vitals on our product landing page",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up performance budgets for our main marketing routes",
+    "should_trigger": true
+  },
+  {
+    "query": "The INP on our search page is 350ms \u2014 find the long tasks causing it",
+    "should_trigger": true
+  },
+  {
+    "query": "Our JS bundle is 800KB \u2014 run a bundle analysis and prioritise what to split",
+    "should_trigger": true
+  },
+  {
+    "query": "Profile the CLS on our article page \u2014 content is shifting after images load",
+    "should_trigger": true
+  },
+  {
+    "query": "Reduce the Time to Interactive on our onboarding flow",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up Lighthouse CI to enforce CWV budgets in our pipeline",
+    "should_trigger": true
+  },
+  {
+    "query": "Our fonts are blocking render \u2014 diagnose and fix",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a new component and include the standard performance gate",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the token system for our CSS",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit the accessibility of this surface",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we use SSG or SSR for our documentation site?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the props contract for our data table component",
+    "should_trigger": false
+  },
+  {
+    "query": "Make this three-column layout responsive",
+    "should_trigger": false
+  },
+  {
+    "query": "Set up cascade layers for our stylesheet",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current quality state of our frontend?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/fe-status/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/fe-status/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: fe-status
+description: Orient skill — read the current surface's evidence manifest, known exceptions, and gate history to return a surface-state summary against the frontend engineering quality floor.
+---
+
+# Skill: fe-status
+
+Load this skill before starting work on an **existing surface** to orient
+without reading all the code. It reads the surface's evidence manifest, known
+exceptions list, and recent gate run results to return a concise state
+summary. Do not load it for new surfaces that have no prior gate history;
+use `frontend-engineering` in `create` mode instead.
+
+---
+
+## What to look for
+
+Read the following artifacts in the order listed. Stop when the summary
+is complete — this skill reads, it does not write.
+
+**1. Evidence manifest** — the 11-field record from the most recent
+`frontend-engineering` gate run. If a manifest exists, locate:
+
+- `states`: which of the 18 states were tested in the last run
+- `a11y result`: the last pa11y/axe-core output plus manual-check outcomes
+  for WCAG 2.4.11 and 2.5.8
+- `perf result`: the last Lighthouse/CWV measurement
+- `known exceptions`: documented, accepted gaps with owners
+- `unverified items`: items that could not be verified in the last session
+
+**2. Known exceptions list** — entries in the manifest's `known exceptions`
+field. Note: which exceptions have an owner and a planned resolution date,
+and which are undated (stale).
+
+**3. Most recent gate run** — the last recorded run of the four GATES steps:
+HTML validation, a11y audit, CSS token enforcement, and visual QA checklist.
+Note which steps passed, which failed, and which were skipped.
+
+**4. Open TODOs** — grep the HTML/CSS for `TODO`, `FIXME`, or `HACK` comments
+in the surface's source files. These are informal a11y, token, or state-coverage
+gaps that were deferred without being recorded in the manifest.
+
+---
+
+## Output format
+
+Return a structured summary with the following sections:
+
+```
+## Surface state — <surface name or route>
+
+**Evidence manifest:** [present / absent — last run: <date if known>]
+
+**States covered:** [list from the 18-state matrix]
+**States missing:** [states in the matrix that were not tested or are not implemented]
+
+**A11y gate:** [pass / fail / untested]
+  - axe-core wcag21aa: [pass/fail/untested]
+  - manual 2.4.11 Focus Appearance: [pass/fail/untested]
+  - manual 2.5.8 Target Size Minimum: [pass/fail/untested]
+
+**CWV status:** [pass / fail / untested — LCP: <value>, INP: <value>, CLS: <value>]
+
+**Token compliance:** [pass / fail / untested]
+
+**Known exceptions:** [count] — [list summaries with owner/date if present]
+
+**Open TODOs:** [count] — [brief description of each if ≤3; count only if >3]
+
+**Next recommended action:** [one sentence — the highest-priority action before new work starts]
+```
+
+---
+
+## When no manifest exists
+
+If the surface has no evidence manifest, output:
+
+```
+## Surface state — <surface name>
+
+**Evidence manifest:** absent — no gate history found.
+
+No prior gate run exists for this surface. Before starting new work, run
+`frontend-engineering` in `audit` mode to establish a baseline:
+- State matrix coverage
+- A11y gate (pa11y/axe-core + 2 manual checks)
+- CSS token compliance grep
+- CWV measurement
+
+Record the audit output as the initial evidence manifest.
+```
+
+Do not estimate or infer the surface's state from the code alone. The
+evidence manifest is the only ground truth for gate history; its absence
+means the surface's compliance status is unknown.

--- a/packs/frontend-engineering/.apm/skills/fe-status/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/fe-status/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "What is the current state of the frontend surface against our quality floor?",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me the evidence manifest for this component",
+    "should_trigger": true
+  },
+  {
+    "query": "Where are we on accessibility for this page \u2014 what's been verified and what's open?",
+    "should_trigger": true
+  },
+  {
+    "query": "Orient me to the current frontend quality state before I start work",
+    "should_trigger": true
+  },
+  {
+    "query": "What states from the 18-state matrix are still missing from this surface?",
+    "should_trigger": true
+  },
+  {
+    "query": "What CWV results do we have for this route?",
+    "should_trigger": true
+  },
+  {
+    "query": "Are there any known exceptions I should know about before touching this surface?",
+    "should_trigger": true
+  },
+  {
+    "query": "What was the last gate run result for this component?",
+    "should_trigger": true
+  },
+  {
+    "query": "Summarise the frontend quality state of the onboarding flow",
+    "should_trigger": true
+  },
+  {
+    "query": "Build the new notification component with all states",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the token system for our design system",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix the focus management on our modal",
+    "should_trigger": false
+  },
+  {
+    "query": "Diagnose the INP regression on our search page",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we use SSR for this authenticated dashboard?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the props contract for our data table",
+    "should_trigger": false
+  },
+  {
+    "query": "Make the header responsive at mobile",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit our CSS specificity and reorganise with cascade layers",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md
@@ -1,0 +1,660 @@
+---
+name: frontend-engineering
+description: Load when a task's primary output is HTML, CSS, or JS. Provides design pre-flight, codified craft rules, GATES verification commands, and an evidence manifest for that surface. Four modes — create (new surface), retrofit (improving existing), audit (review only), verify (run gates and manifest).
+---
+
+# Skill: frontend-engineering
+
+Load this skill when a task's primary output is HTML, CSS, or JS — a new page,
+component, slide deck, dashboard, email template, or any standalone web artifact.
+It carries the design pre-flight requirements (named aesthetic reference, seed
+token block, state matrix), the craft rules that govern EXECUTE, and the GATES
+verification commands. It is not needed for incidental HTML edits to an existing
+surface already covered by a grounded aesthetic reference.
+
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
+## Mode selection
+
+Before starting, select the mode that matches the work:
+
+| Mode | When to use | Required outputs |
+|---|---|---|
+| **create** | Building a new surface or significant new component | Page/screen contract (proportional to risk), evidence manifest |
+| **retrofit** | Improving or extending an existing surface | Brownfield inspection, evidence manifest |
+| **audit** | Reviewing an existing surface without writing code | Audit report |
+| **verify** | Running the full gate suite on a completed surface | Evidence manifest |
+
+Proceed to the shared pre-flight (PLAN phase) regardless of mode. Mode-specific steps follow the shared pre-flight and the state matrix.
+
+---
+
+## PLAN phase — Shared Pre-flight (all modes)
+
+Complete all four steps before writing any code (create/retrofit) or running any gates (audit/verify). These are the shared foundation for all modes.
+
+### 1. Named aesthetic reference
+
+State a named product reference — not an adjective. The model has learned
+visual vocabulary from extensively documented products; vague adjectives
+produce the purple-gradient default (Tailwind's `bg-indigo-500` saturated
+training data, so "nice", "clean", "modern" all converge there).
+
+**Canonical reference set:**
+
+| Goal | Use |
+|---|---|
+| Professional / executive SaaS | Linear, Stripe, Vercel |
+| Data-dense / terminal | Raycast, Arc |
+| Minimal / editorial | Notion |
+| Warm / human | Toss |
+
+Name the reference in the spec: `Aesthetic reference: Linear (professional SaaS —
+dark surface, high contrast, no gradients)`. If the target must match an existing
+user-provided theme (e.g. a PPT brand), describe its key token values instead.
+
+### 1b. Genre routing (T2 — requires experience-design pack)
+
+After naming the aesthetic reference, route to the XD discipline skill that
+matches your surface's primary purpose. These skills add surface-specific IA,
+structure, and conversion principles on top of the generic design pre-flight.
+
+**Check availability:** the experience-design pack is installed if skill
+`conversion-design` appears in your available skills. If absent, record a named
+skip in the spec — `XD genre routing: skipped (experience-design pack absent)` —
+and proceed to step 2. A named skip is not a failure; it is honest accounting.
+
+**Load the skill that matches your surface (name it by name in the spec):**
+
+| Surface type | Load |
+|---|---|
+| Marketing page, landing page, pricing page, acquisition flow | `conversion-design` |
+| Documentation site, help centre, API reference, technical guide | `documentation-design` |
+| Dashboard, reporting view, analytics screen, monitoring surface | `analytical-design` |
+| Article page, editorial page, blog, long-form content page | `informational-design` |
+| Form flow, component state machines, transitions, interactions | `interaction-design` |
+| Content strategy — what the surface says and for whom | `content-design` |
+| Token foundation setup, semantic alias layer, light/dark theme tokens | `design-system-foundations` |
+
+Load the matched skill inline before writing code. Record the result in the spec
+as either `XD genre routing: <skill-name> loaded` or `XD genre routing: skipped
+(experience-design pack absent)`.
+
+### 2. Seed token block
+
+Provide a CSS custom properties block before writing any HTML. The model
+selects from `var(--ds-color-primary)` rather than fabricating `#5e6ad2` per
+session — token-seeding is the single strongest lever for visual consistency.
+
+**Three-tier architecture (one-way dependency):**
+```
+Primitive  →  Semantic  →  Component
+(raw hex)      (role)       (usage)
+```
+Only the semantic layer goes in the seed block; primitives are defined once
+at the top of the CSS file and referenced by semantics.
+
+**Minimum viable property set** (`--ds-` prefix for namespace clarity):
+
+```css
+:root {
+  /* Color roles — semantic, not raw hex */
+  --ds-color-surface:      #ffffff;
+  --ds-color-surface-alt:  #f8fafc;
+  --ds-color-on-surface:   #1a202c;
+  --ds-color-on-surface-2: rgba(0, 0, 0, 0.60);
+  --ds-color-primary:      #5e6ad2;
+  --ds-color-on-primary:   #ffffff;
+  --ds-color-error:        #dc2626;
+  --ds-color-on-error:     #ffffff;
+  --ds-color-outline:      rgba(0, 0, 0, 0.12);
+
+  /* Spacing — 4 px base, 8-step scale */
+  --ds-space-px: 2px;
+  --ds-space-1:  4px;
+  --ds-space-2:  8px;
+  --ds-space-3:  12px;
+  --ds-space-4:  16px;
+  --ds-space-5:  24px;
+  --ds-space-6:  32px;
+  --ds-space-7:  48px;
+  --ds-space-8:  64px;
+
+  /* Type scale */
+  --ds-text-sm:   0.75rem;
+  --ds-text-base: 0.875rem;
+  --ds-text-lg:   1rem;
+  --ds-text-xl:   1.125rem;
+  --ds-text-2xl:  1.25rem;
+  --ds-font-regular: 400;
+  --ds-font-medium:  500;
+  --ds-font-bold:    600;
+  --ds-leading-tight:  1.25;
+  --ds-leading-normal: 1.5;
+  --ds-leading-loose:  1.75;
+
+  /* Radius */
+  --ds-radius-sm: 4px;
+  --ds-radius-md: 8px;
+  --ds-radius-lg: 12px;
+  --ds-radius-full: 9999px;
+
+  /* Shadow */
+  --ds-shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+  --ds-shadow-md: 0 4px 8px rgba(0,0,0,0.08);
+  --ds-shadow-lg: 0 8px 24px rgba(0,0,0,0.10);
+
+  /* Motion */
+  --ds-duration-quick:    120ms;
+  --ds-duration-moderate: 200ms;
+  --ds-duration-gentle:   300ms;
+  --ds-ease-standard:     cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-ease-decelerate:   cubic-bezier(0, 0, 0.2, 1);
+}
+```
+
+#### Print / PPT token block
+
+When the output targets a PPT slide or PDF export, add this block and use
+`pt` for typographic values:
+
+```css
+@page {
+  size: 960px 540px; /* 16:9 slide — standard widescreen */
+  margin: 0;
+}
+
+* {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact; /* preserve background fills */
+}
+
+@media print {
+  :root {
+    --ds-color-surface:    #ffffff;
+    --ds-color-on-surface: #000000;
+    --ds-shadow-sm: none;
+    --ds-shadow-md: none;
+    --ds-shadow-lg: none;
+  }
+
+  .slide            { page-break-after: always; }
+  h2, h3, figure,
+  table, blockquote { page-break-inside: avoid; }
+}
+```
+
+**Print safety:** `box-shadow` and `text-shadow` are unreliable across
+renderers (Chrome/WeasyPrint differ) — use `--ds-shadow-*: none` in the
+print override and rely on borders for separation instead. Avoid Tailwind
+responsive variants (`sm:`, `md:`) for fixed-dimension artifacts.
+
+### 3. State matrix
+
+Enumerate all states for every async component as a table in the spec.
+LLMs are trained predominantly on happy-path code; they will not generate
+missing-state branches without explicit enumeration. A 2025 study of
+50 AI-generated dashboards found 92% had no empty state and 78% had no
+error state.
+
+The canonical 18-state set for this skill, aligned with the XD quality-floor:
+
+| State | Treatment |
+|---|---|
+| loading | Skeleton screen matching the final layout (use spinner only when shape is unknown); add `aria-busy="true"` and `aria-label="Loading <thing>"` to the skeleton container |
+| empty | Illustration or icon + label describing the empty condition + primary CTA |
+| error | Preserve prior content; show inline error message + retry affordance |
+| partial | Pagination or load-more with a record count; mark missing segments clearly |
+| disabled | Render it disabled with `aria-disabled="true"` and a tooltip or label explaining why |
+| content | The normal loaded state — spec this too so the skeleton shape is known |
+| success | Action completed: confirm visibly and proportionately (subtle toast for low-stakes; prominent banner for high-stakes) |
+| first-run | Never had data — orient the user and invite the first meaningful action; do not show the generic empty state |
+| no-results | A filter or search emptied the set — show what query was applied and how to recover |
+| permission/denied | Unauthorized or locked view: show a read-only or locked state with a recoverable note (who can act, how to request access); never a blank screen |
+| offline | Network unavailable — show cached content where possible; provide a manual retry; indicate stale status |
+| blocked | Action cannot proceed due to an external dependency or policy — name the blocker and the resolution path |
+| destructive-confirmation | Action has irreversible consequences — require explicit confirmation with a clear statement of what will be destroyed; provide a safe default (cancel) |
+| long-content | Content significantly longer than typical — offer progressive disclosure, a table of contents, or pagination |
+| large-data-set | Query returns more records than the UI can show — implement virtual scrolling, pagination, or sampling; never slice silently |
+| high-zoom | Surface used at 200–400% zoom — test that text reflows, controls remain operable, and no horizontal scrolling is required |
+| reduced-motion | User has requested reduced motion — all animations replaced with instant or cross-fade transitions; no sliding, scaling, or spinning |
+| keyboard-only | All interactions reachable and completable via keyboard alone — no pointer dependency; logical tab order; visible focus indicators at all times |
+
+**Skeleton vs spinner rule:** use a skeleton when the content shape is
+predictable (table rows, card grids, profile cards). The skeleton must
+match the final layout so there is no layout shift on load. Use a spinner
+only when shape is genuinely unknown.
+
+Not all states apply to every surface — omit states that are genuinely inapplicable and note why in the spec.
+
+---
+
+### Mode: create
+
+Use when building a new surface or significant new component.
+
+#### Step 0. Page/screen contract (required before significant UI code)
+
+Before writing HTML for a new page or significant surface, fill the
+page/screen contract. This contract is proportional to risk and scope — a
+new route, a key onboarding surface, or a feature-gating screen warrants
+the full 12-field contract. A single new form field, a tooltip, or a minor
+component variant does not.
+
+**Page/screen contract template (12 fields):**
+
+| Field | What to specify |
+|---|---|
+| target user | The specific user type or persona this surface serves |
+| primary job | The one job the user comes here to complete |
+| primary action | The single most important action available on this surface |
+| expected result | What the user sees/has after completing the primary action |
+| next action | What the user does after the primary action is complete |
+| first-screen content | What must be visible above the fold without scrolling |
+| product proof | The value signal (stat, social proof, outcome indicator) present above the fold |
+| read/write consequence | Whether the primary action reads or mutates data; what happens on error |
+| critical states | Which of the 18 states this surface must handle (minimum: loading, empty or first-run, error, content) |
+| responsive behavior | How layout adapts across breakpoints; what collapses, reorders, or hides |
+| a11y requirements | WCAG 2.2 AA — note any state-specific requirements (focus management, live regions) |
+| measurement event | The analytics event that fires on primary action completion |
+
+Record the completed contract in the spec before writing HTML.
+
+#### Steps 1–3. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight above (aesthetic reference, genre routing, seed tokens, state matrix).
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: retrofit
+
+Use when improving or extending an existing surface without building from scratch.
+
+#### Step 1. Brownfield inspection checklist
+
+Before touching any code, run this inspection against the existing surface. Record findings for each item:
+
+| Item | What to inspect |
+|---|---|
+| what-to-preserve | What currently works well and must not regress — visual patterns users rely on, established keyboard flows, screen-reader compatibility |
+| duplicated-systems | Parallel implementations of the same component, token, or logic that this change could consolidate or that it must not fork further |
+| hard-coded values | CSS values that should be design tokens (`#5e6ad2`, `margin: 13px`) — note them for opportunistic migration |
+| a11y-debt | Accessibility failures already present — note which ones this change must not worsen, and which it can address as a ride-along |
+| responsive-debt | Viewport breakpoints that fail at current state — note which this change must not worsen |
+| visual-regression-risk | Downstream components or pages that share styling with the modified surface and could be visually affected |
+
+#### Step 2. Proceed through the shared PLAN phase pre-flight
+
+Run steps 1, 1b, 2, and 3 from the shared pre-flight (aesthetic reference, genre routing, seed tokens, state matrix). For retrofit work, focus the state matrix on states that are absent or broken — not a full re-enumeration unless the surface is substantially rebuilt.
+
+#### EXECUTE and GATES
+
+Proceed to the EXECUTE phase (Craft Rules) and GATES phase below. Produce an evidence manifest at completion.
+
+---
+
+### Mode: audit
+
+Use when reviewing an existing surface without writing code. The output is a structured audit report, not code.
+
+#### Audit procedure
+
+1. **Run the state matrix audit.** Compare the surface against all 18 states in the state matrix. For each applicable state, mark: Covered / Absent / Broken. Note the specific issue for Absent and Broken.
+2. **Run the accessibility audit.** Check against WCAG 2.2 AA. Use the GATES accessibility tools (pa11y or axe-core). Note which WCAG 2.2 success criteria require manual verification because tooling caps at wcag21aa.
+3. **Check the CWV targets.** Measure or estimate LCP ≤2.5s / INP ≤200ms / CLS ≤0.1 at p75 (mobile and desktop separately where field data exists). Note any category over budget.
+4. **Run the brownfield inspection checklist.** Use the same 6-item checklist from retrofit mode.
+
+#### Audit report format
+
+Return findings as a prioritised list with severity (Blocker / Major / Minor / Note). Each finding maps to the state, criterion, or checklist item it violates, with one concrete recommendation.
+
+Record findings in the evidence manifest under `known exceptions` and `unverified items`.
+
+---
+
+### Mode: verify
+
+Use when a completed surface needs gates run and an evidence manifest generated.
+
+#### Verification procedure
+
+Run the full GATES suite in order:
+
+1. **Structural HTML validation** (GATES phase step 1)
+2. **Accessibility audit** (GATES phase step 2) — note that WCAG 2.2 AA is our declared baseline; the tooling caps at wcag21aa; two success criteria require manual verification: 2.4.11 Focus Appearance and 2.5.8 Target Size Minimum
+3. **CSS token enforcement** (GATES phase step 3, if stylelint is configured)
+4. **Visual QA checklist** (GATES phase step 4) — confirm all 18 applicable states are present
+
+After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results.
+
+---
+
+## EXECUTE phase — Craft Rules
+
+### Avoid the AI Aesthetic
+
+AI-generated UI has recognisable failure patterns. Refuse all of them:
+
+| Pattern | Why it's a problem | Instead |
+|---|---|---|
+| Purple / indigo everything | Models default to `bg-indigo-500` — every generated app looks identical | Use the project's token palette; derive from the named aesthetic reference |
+| Excessive gradients | Add visual noise; clash with most design systems | Flat colour or a single subtle gradient matching the system |
+| Rounded everything (`rounded-2xl` / `border-radius: 16px` on all elements) | Ignores the radius hierarchy in real designs — cards, buttons, and inputs each have a distinct radius | Use the `--ds-radius-*` scale; vary by element type |
+| Generic hero sections | Template-driven layout with no connection to actual content or user need | Content-first layout driven by what the user needs to do |
+| Lorem ipsum placeholder copy | Hides layout problems that real content reveals (wrapping, overflow, long names) | Realistic-length placeholder text that approximates actual content |
+| Oversized equal padding everywhere | Destroys visual hierarchy; wastes screen space | Use the spacing scale; vary padding by component level |
+| Uniform card grids | Ignores information priority and scanning patterns | Purpose-driven layouts — group by relationship, not by grid slot |
+| Shadow-heavy design | Layered shadows compete with content; slow on low-end devices | Use `--ds-shadow-sm` sparingly; flat or a single elevation level |
+
+### HTML element selection rules
+
+Rules are in **WRONG → RIGHT** form. "Use semantic HTML" is not a rule;
+the specific forms below are.
+
+#### Interactive elements
+
+- WRONG: `<div onclick="…">`, `<span onclick="…">` / RIGHT: `<button type="button">` for any action
+- WRONG: `<a href="#" onclick="…">` for actions / RIGHT: `<a href="…">` for navigation only; `<button>` for actions — never cross them
+- WRONG: `<div role="button">` with no keyboard handler / RIGHT: `<button>` — it receives keyboard, focus, and activation natively; avoid `role="button"` on a non-button element unless a framework absolutely requires it, and then you must add `tabindex="0"` and `onkeydown` handlers for both Enter and Space
+
+#### Landmark elements
+
+- One `<main>` per page, no exceptions
+- One `<h1>` per page
+- Heading levels are sequential — never skip (h1 → h3 is wrong; heading level = outline position, never visual size)
+- `<section>` only when it has a heading as its first child; otherwise use `<div>`
+- Multiple `<nav>` elements require `aria-label` distinguishing them: `aria-label="Primary"`, `aria-label="Breadcrumb"`
+- `<article>` for self-contained distributable content; `<aside>` for tangentially related content
+
+#### Forms
+
+- WRONG: `<input placeholder="Email">` with no label / RIGHT: `<label for="email">Email</label><input id="email">` or `aria-labelledby`; `placeholder` is not a label — it fails WCAG 1.3.1 and disappears on input
+- WRONG: `aria-describedby` pointing to an element not yet in the DOM / RIGHT: place the target element in the DOM before the input receives focus; inject empty containers on page load
+- WRONG: ungrouped checkboxes/radios / RIGHT: `<fieldset><legend>…</legend>…</fieldset>` for every checkbox or radio group
+- `autocomplete` attribute is required on personal-data fields: `name`, `email`, `tel`, `current-password`, `new-password`, address fields
+
+#### Images and media
+
+- WRONG: `alt="image"`, `alt="photo of a dog"` / RIGHT: descriptive text without "image of" / "photo of" prefixes; `alt=""` for decorative images; max ~150 chars — use `<figcaption>` for longer descriptions
+- WRONG: `<img>` for decorative backgrounds / RIGHT: CSS `background-image` — the element is removed from the accessibility tree automatically
+- SVG used as a meaningful image: add `role="img"` and a `<title>` as the first child
+- SVG that is decorative: `aria-hidden="true"`
+
+#### Content
+
+- WRONG: lorem ipsum placeholder text / RIGHT: realistic-length placeholder text that approximates what real content looks like — long names, multi-line descriptions, edge-case values
+
+### CSS rules
+
+- WRONG: `color: #5e6ad2`, `background: #f8fafc`, `margin: 13px` / RIGHT: all colour and spacing values via `var(--ds-*)` — no hardcoded hex, rgb, hsl, or magic pixel values
+- WRONG: `z-index: 9999` / RIGHT: define a named z-index scale: `--z-base: 0; --z-overlay: 100; --z-modal: 200; --z-toast: 300` — use named custom properties only
+- WRONG: `line-height: 24px` / RIGHT: unitless — `line-height: var(--ds-leading-normal)` or `line-height: 1.5`
+- WRONG: `#nav {}`, `ul.nav {}` / RIGHT: class selectors only; no ID selectors; no qualified selectors
+- WRONG: selector depth > 3 levels / RIGHT: max 3 levels of nesting
+- WRONG: `tabindex="2"`, `tabindex="5"` (positive values) / RIGHT: `tabindex="0"` to enter tab order; `tabindex="-1"` for programmatic focus targets only; never positive values — they disrupt the natural tab sequence
+- WRONG: `.btn:hover { … }` with no focus style / RIGHT: every `:hover` rule has a matching `:focus` or `:focus-visible` rule
+- WRONG: `outline: none` / RIGHT: replace with a visible alternative — `outline: 2px solid var(--ds-color-primary); outline-offset: 2px` or a `box-shadow` equivalent
+
+### Accessibility rules
+
+**Default baseline: WCAG 2.2 AA.** WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA. Two success criteria are new in 2.2 and require manual verification because automated tooling (pa11y/axe-core) caps at wcag21aa: **2.4.11 Focus Appearance** (visible focus indicator with sufficient size and contrast) and **2.5.8 Target Size Minimum** (interactive targets ≥24×24 CSS pixels). Mark these explicitly in the evidence manifest under `a11y result`.
+
+**Browser policy: Baseline Widely Available.** Target only features in the Baseline Widely Available set (features shipping in all major browsers for at least 30 months). Check baseline status at web.dev/baseline before using any feature not in the baseline set.
+
+#### ARIA discipline
+
+**First Rule of ARIA:** if a native HTML element provides the semantics and
+behaviour, use it — do not bolt ARIA onto a generic element.
+
+- WRONG: `<div role="button" onclick="…">` — no keyboard, no activation, no inherited states / RIGHT: `<button>`
+- WRONG: `aria-label="Submit"` on a `<button>Submit</button>` with visible text / RIGHT: omit `aria-label` — it overrides the visible label and breaks voice control ("Submit" no longer activates the button by name in Dragon NaturallySpeaking)
+- WRONG: `<input aria-label="Email" placeholder="Email">` when a visible label exists / RIGHT: use the `<label>` and omit the redundant `aria-label`
+
+**Dynamic ARIA state must update** — these are not static attributes:
+
+- `aria-expanded="false"` on a closed accordion must flip to `"true"` when open
+- `aria-selected` must update as tabs are navigated
+- `aria-sort` must update as columns are sorted
+- Setting them once in the HTML and never updating them with JS is wrong
+
+**`aria-live` regions:**
+
+- The container must be in the DOM *before* content is injected into it — add it empty on page load and update its text content to trigger the announcement; injecting a live region and populating it simultaneously causes the announcement to be dropped silently in most screen readers
+- `aria-live="polite"` for informational updates (toast success, search result counts)
+- `aria-live="assertive"` + `aria-atomic="true"` for errors and time-critical alerts (session timeout, form validation summary)
+
+#### WCAG contrast floor (WCAG 1.4.3 / 1.4.11)
+
+| Element | Minimum ratio |
+|---|---|
+| Body text | 4.5 : 1 |
+| Large text (≥ 18 pt or ≥ 14 pt bold) | 3 : 1 |
+| UI components (borders, focus rings, icons, input outlines) | 3 : 1 |
+| Placeholder text | 4.5 : 1 (counts as text) |
+
+Verify contrast at derivation time — never eyeball it.
+
+#### Reduced motion
+
+Every `animation`, `transition`, and `transform` must be guarded. Default to
+no motion; enable only when the user has not requested reduced motion:
+
+```css
+/* Default: no motion */
+.element {
+  transition: none;
+  animation: none;
+}
+
+/* Motion only when the user permits */
+@media (prefers-reduced-motion: no-preference) {
+  .element {
+    transition: opacity var(--ds-duration-moderate) var(--ds-ease-standard);
+  }
+}
+```
+
+Properties to guard: `animation`, `transition`, `transform` (slides, scales,
+rotates), `scroll-behavior: smooth`. Colour and opacity changes that carry
+meaning do not need guarding — only motion.
+
+#### Modal / dialog keyboard pattern (W3C APG)
+
+```
+role="dialog" + aria-modal="true" + aria-labelledby="<title-id>"
+On open:   move focus to first focusable element inside the dialog
+Tab:       cycle forward through focusable elements inside only (trap)
+Shift+Tab: cycle backward (trap)
+Escape:    close the dialog
+On close:  return focus to the element that opened the dialog
+```
+
+#### Tabs keyboard pattern (W3C APG)
+
+```
+Tab:         moves focus into the tablist, then out to the tabpanel — never between tabs
+Left/Right:  navigate between tabs (wrapping); activate on focus (auto-activation)
+Home/End:    jump to first / last tab
+```
+
+#### Programmatic focus — when it is required
+
+Move focus programmatically when:
+- A modal opens (to first focusable element inside) or closes (back to invoking element)
+- A SPA route changes (to the page `<h1>` or a skip-nav landmark with `tabindex="-1"`)
+- An inline error appears after form submit (to first invalid field or error summary)
+- Async content is inserted and the user needs to interact with it immediately
+
+---
+
+## GATES phase — Verification
+
+Run these after implementation, before review. Record actual command output —
+do not assert on internal state.
+
+### 1. Structural HTML validation (no browser required)
+
+```bash
+npx html-validate --preset standard,a11y --max-warnings 0 <file.html>
+```
+
+Catches without a browser: landmark structure (one `<main>`, unique landmarks),
+heading hierarchy (no skipped levels), label associations, ARIA role validity,
+`alt` attribute presence, and WCAG H-technique violations. Exits non-zero on any
+error.
+
+### 2. Accessibility audit (requires Chromium — runs headless, no display server)
+
+Either tool works; pa11y is lighter, axe-core has more rules:
+
+```bash
+# pa11y — local files via file:// path
+npx pa11y "file:///$(pwd)/file.html" --standard WCAG2AA --reporter cli
+
+# axe-core/cli — URL or file, CI-safe Chromium flags
+npx axe "file:///$(pwd)/file.html" \
+  --tags wcag21aa \
+  --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage"
+```
+
+Note: tooling currently caps at `wcag21aa` — WCAG 2.2 AA is our declared baseline (it exceeds the wcag21aa minimum). Two WCAG 2.2-only success criteria require **manual verification**: **2.4.11 Focus Appearance** and **2.5.8 Target Size Minimum**. Record the manual-check outcome in the evidence manifest under `a11y result`.
+
+### 3. CSS token enforcement (optional — run if stylelint is already configured)
+
+```json
+{
+  "plugins": ["stylelint-declaration-strict-value"],
+  "rules": {
+    "scale-unlimited/declaration-strict-value": [
+      ["color", "background-color", "border-color", "font-size"],
+      {
+        "ignoreValues": ["inherit", "transparent", "currentColor"],
+        "message": "Use design tokens (var(--ds-*)) — no hardcoded values"
+      }
+    ]
+  }
+}
+```
+
+Install: `npm install --save-dev stylelint stylelint-declaration-strict-value`
+
+### 4. Visual QA checklist (agent-executable, no tooling)
+
+- [ ] All applicable states from the 18-state matrix are present in the HTML — not just the happy path; check each applicable state by reading the HTML
+- [ ] No hardcoded colour or spacing values outside the token-definition block — grep: `grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>` should return only the `:root` / primitive token-definition block, no other hex, rgb, or px values
+- [ ] Print output correct: if PPT/PDF context, open in browser and trigger print preview — check slide boundaries, colour preservation, no overflow
+- [ ] Screenshot taken and observed: Playwright headless (`page.screenshot()`) or browser devtools screenshot — assert on what you see, not on internal state
+
+---
+
+## Performance targets
+
+### Core Web Vitals (CWV)
+
+Targets at p75, evaluated separately for mobile and desktop where field data exists:
+
+| Metric | Target | What it measures |
+|---|---|---|
+| LCP (Largest Contentful Paint) | ≤2.5s | Perceived load speed — when the main content appears |
+| INP (Interaction to Next Paint) | ≤200ms | Responsiveness — how fast the page responds to interactions |
+| CLS (Cumulative Layout Shift) | ≤0.1 | Visual stability — how much content moves unexpectedly |
+
+Measure using Lighthouse, Chrome DevTools Performance panel, or WebPageTest.
+
+### Asset budgets
+
+Enforce these per route. The seven asset budget categories to track are: JS budget (JavaScript parse+execute per route), images budget (total image payload per route), fonts (web font files transferred), third-party scripts (analytics, tags, widgets), hydration (client-side hydration cost for SSR/islands), route-level loading (per-route code-split chunks), and long tasks (main-thread tasks blocking >50ms).
+
+| Budget category | What to measure | Notes |
+|---|---|---|
+| JS (JavaScript) | Total JavaScript transferred and parsed per route | Prioritise code-splitting; defer non-critical bundles |
+| images | Total image payload per route | Use modern formats (WebP/AVIF); serve appropriate sizes via `srcset` |
+| fonts | Web font files transferred | Self-host; `font-display: swap` or `optional`; subset aggressively |
+| third-party scripts | Analytics, tag managers, widgets | Audit regularly; defer or facade heavy embeds |
+| hydration | Client-side hydration cost (SSR / islands) | Islands architecture preferred; measure Time to Interactive delta |
+| route-level loading | Per-route code-split chunk sizes | Each route chunk should be independently cacheable |
+| long tasks | Main-thread tasks > 50ms | Use `scheduler.yield()` or `setTimeout` chunking to break up long tasks |
+
+---
+
+## Evidence manifest
+
+FE cannot claim completion (create or retrofit) or a passing gate run (verify) without an evidence manifest. The manifest is a structured record of what was tested and what was found.
+
+**Required fields (all 11 must be present):**
+
+| Field | What to record |
+|---|---|
+| routes | List of routes/URLs or file paths tested |
+| viewports | Viewport widths tested (e.g. 375px mobile, 768px tablet, 1280px desktop) |
+| browsers | Browsers or rendering engines tested (per Baseline Widely Available policy) |
+| states | Which of the 18 states were exercised during testing |
+| screenshots | Evidence of rendered states — filenames, Playwright capture, or devtools screenshots |
+| a11y result | Output of the accessibility gate (pa11y/axe-core); include manual-check outcome for WCAG 2.4.11 and 2.5.8 |
+| perf result | CWV measurement or Lighthouse score; include mobile and desktop values where available |
+| console/network result | No console errors; network requests match expected; no unexpected third-party calls |
+| analytics events | Confirmation of measurement events firing on primary action completion |
+| known exceptions | Documented, accepted gaps with rationale and owner — not a place to hide problems |
+| unverified items | Items that could not be verified in this session with reason (no Chromium, no network, etc.) |
+
+---
+
+## Conditional public-surface guidance
+
+*Applies only when the surface will be publicly indexed (marketing pages, documentation, product landing pages). Skip for internal tools, authenticated dashboards, and surfaces behind login.*
+
+For publicly indexed surfaces, add these items to the spec and verify them before merge:
+
+- **Metadata**: `<title>` (60 chars max), `<meta name="description">` (155 chars max), Open Graph tags (`og:title`, `og:description`, `og:image`) for link previews
+- **Canonical URLs**: `<link rel="canonical" href="…">` on every public page; avoid duplicate content from trailing slashes, `www` vs non-`www`, or protocol variants
+- **Sitemaps**: ensure the route is included in the sitemap or explicitly excluded; no orphaned pages
+- **Structured data**: appropriate schema.org type for the surface (`Article`, `Product`, `FAQPage`, `HowTo`) implemented as JSON-LD; validate at schema.org/validator
+- **Search indexing intent**: confirm `robots` meta or `X-Robots-Tag` header is set correctly — `index, follow` for pages that should rank; `noindex` for pagination, internal search results, thin pages
+
+---
+
+## Multi-surface shell contract
+
+*Applies when building or reviewing a product with multiple web surfaces (e.g. marketing site + web app + documentation site).*
+
+Multi-surface products must maintain coherence across surfaces. Apply these constraints regardless of which surface you are currently building:
+
+- **Shared tokens**: all surfaces draw from the same design token contract (same `--ds-*` custom property names, same primitive values, same semantic assignments). A surface that redefines shared tokens independently forks the product's visual identity.
+- **Navigation patterns**: primary navigation, breadcrumb, and footer patterns must be consistent across surfaces — same structure, same interaction model, same terminology for shared destinations.
+- **Consistent product terminology**: the names of features, entities, and actions must be the same across surfaces. Maintain a terminology list in the project and use it before naming anything.
+
+---
+
+## Anti-patterns to refuse
+
+| Rationalisation | Reality |
+|---|---|
+| "Accessibility is a nice-to-have for now" | WCAG 2.2 AA is our baseline — it exceeds the WCAG 2.1 minimum currently cited by EU EAA, ADA, and AODA — and it is an engineering quality standard, not a feature |
+| "We'll make it responsive later" | Retrofitting responsive design is 3× harder than building it from the start; skip this step only if the output is explicitly fixed-dimension (PPT/PDF) |
+| "This is just a prototype" | Prototypes become production code; the AI aesthetic baked in at prototype stage is the AI aesthetic shipped |
+| "The AI aesthetic is fine for now" | It signals low quality to every reviewer who sees it and anchors the design in a direction that is expensive to undo |
+| "I'll add the empty and error states later" | They will not be added; they are spec ACs, not follow-ons |
+| "Skip the design pre-flight — the spec is clear enough" | Technically correct output with no design sense is the exact failure mode this pre-flight prevents; the spec cannot substitute for token constraints |
+| "Use a spinner, it's simpler" | Spinners produce layout shift and feel slower than skeleton screens; use a skeleton when the content shape is known |
+
+---
+
+## Red flags
+
+A reviewer should treat any of these as a blocker:
+
+- Inline `style="…"` attributes or arbitrary pixel values not on the spacing scale
+- Any state from the applicable 18-state matrix missing from the implementation — check by reading the HTML, not by reasoning about the code
+- `outline: none` or `outline: 0` with no visible replacement focus style
+- Color used as the sole state indicator (red/green without accompanying text, icon, or pattern)
+- Generic AI aesthetic visible in the output (purple gradients, equal oversized padding, `border-radius: 16px` on every element, shadow on every card)
+- `aria-expanded`, `aria-selected`, or `aria-sort` set once and never updated
+- A `<div onclick>` where a `<button>` would serve
+- FE completion claimed without an evidence manifest
+- Multi-surface product with inconsistent shared tokens, navigation patterns, or product terminology across surfaces

--- a/packs/frontend-engineering/.apm/skills/frontend-engineering/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/frontend-engineering/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Build a new marketing page with a full token setup and state coverage",
+    "should_trigger": true
+  },
+  {
+    "query": "Create the HTML and CSS for a new dashboard component",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up the frontend scaffold for our onboarding flow",
+    "should_trigger": true
+  },
+  {
+    "query": "Write the component for the user profile card with all states",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a responsive multi-column form with validation states",
+    "should_trigger": true
+  },
+  {
+    "query": "Create a new web surface from this screen brief",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement the empty, loading, and error states for this data table",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the full gate suite on this existing surface and produce an evidence manifest",
+    "should_trigger": true
+  },
+  {
+    "query": "Audit the CSS on this page for token violations and missing states",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the token taxonomy for our design system",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit the accessibility of this surface for WCAG 2.2 AA",
+    "should_trigger": false
+  },
+  {
+    "query": "Diagnose the Core Web Vitals issue on our landing page",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we use SSR or SSG for this marketing page?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the component API for our dropdown",
+    "should_trigger": false
+  },
+  {
+    "query": "How should we structure breakpoints for this component?",
+    "should_trigger": false
+  },
+  {
+    "query": "Set up cascade layers for our CSS codebase",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current accessibility status of this surface?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/rendering-strategy/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/rendering-strategy/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: rendering-strategy
+description: Select and implement the correct rendering model (CSR/SSR/SSG/ISR/RSC) for each route based on data-access patterns, performance targets, and personalization requirements.
+---
+
+# Skill: rendering-strategy
+
+Load this skill when selecting or auditing the rendering architecture of a
+route or surface. Do not load it for routine component authoring — the
+rendering model of a surface is already decided during component work.
+Load `rendering-strategy` when:
+
+- Designing the rendering architecture for a new product or surface
+- Auditing an existing surface's rendering choices for CWV or caching problems
+- Deciding how to handle a new route type that doesn't fit the current pattern
+- Debugging a TTFB or caching anomaly that traces back to rendering mode
+
+---
+
+## Rendering model decision framework
+
+| Model | When to use | CWV profile | Data pattern | Personalization | Key tradeoffs |
+|---|---|---|---|---|---|
+| **SSG** (Static Site Generation) | Content that does not change per-request and has no per-user customization | Best LCP (CDN-served HTML) | Build-time fetch; no runtime data | None — same HTML for all users | Stale content between builds; rebuild required for updates |
+| **ISR** (Incremental Static Regeneration) | Mostly static content that updates periodically (docs, blogs, product listings) | Near-SSG (CDN with TTL) | Build-time + periodic revalidation | None (or edge-level A/B only) | Stale window between revalidations; `stale-while-revalidate` semantics |
+| **SSR** (Server-Side Rendering) | Content that must be fresh per-request; authenticated content; content that varies by request parameters | Good LCP if TTFB is fast; INP depends on JS payload | Runtime fetch on every request | Full — user-specific HTML | TTFB cost per request; harder to cache; scales with traffic |
+| **CSR** (Client-Side Rendering) | Highly interactive, authenticated surfaces where SEO is not a requirement and data updates continuously | Poor LCP on slow networks; INP good after load | Client-side fetch after hydration | Full — all data fetched client-side | Bad LCP; no SEO; blank initial HTML |
+| **RSC** (React Server Components) | Surfaces mixing static and dynamic content in the same component tree | LCP as good as SSR for server components; INP reduced by smaller client bundle | Server components fetch at render time; client components hydrate independently | Partial — server components can be personalized; only interactive shells hydrate | Framework-specific; requires React 18+; mental model cost |
+
+---
+
+## The three wrong defaults to avoid
+
+**Wrong default 1 — SSR everything:**
+SSR incurs a per-request server render. For marketing pages, documentation,
+and product listings that don't change per-user, SSR defeats caching and
+increases TTFB unnecessarily. Use SSG for static content; ISR for content
+that updates periodically.
+
+**Wrong default 2 — CSR everything:**
+CSR sends a mostly-empty HTML document and requires JS execution before any
+meaningful content is visible. On slow networks or low-end devices, this
+produces poor LCP and a blank page during load. CSR is appropriate for
+authenticated, highly interactive surfaces (dashboards, editors) where
+SEO is not a requirement.
+
+**Wrong default 3 — SSG without ISR for updated content:**
+SSG with no revalidation strategy means users see stale content until the
+next full build and deploy. For content that updates more than once per
+deploy cycle, ISR or SSR is the correct model.
+
+---
+
+## Hydration cost
+
+Hydration is the process of attaching JS event listeners to server-rendered
+HTML. It is a main-thread cost that runs after the HTML is painted.
+
+**Why it matters for INP:** a page that is fully SSR-rendered but ships 400KB
+of JS to hydrate still has poor INP during the hydration window. The user can
+see the page but interactions may not respond until hydration completes.
+
+**The islands pattern** is the preferred solution: only components that are
+truly interactive ship client-side JS; static content ships as plain HTML with
+no JS overhead. An island is a self-contained interactive component embedded
+in a static HTML context.
+
+**When full-page hydration is acceptable:** highly interactive surfaces
+(text editors, spreadsheets, complex forms) where nearly every element is
+interactive — the islands savings are minimal and the complexity of selectively
+hydrating is not worth it.
+
+---
+
+## Edge cases
+
+**Authenticated routes:**
+- CSR or SSR — never SSG. A static page cannot be per-user.
+- Prefer CSR for dashboards and tools where SEO is not a requirement and
+  interaction density is high.
+- Prefer SSR for authenticated pages where the initial content (e.g., a
+  profile summary) should be visible immediately without a loading state.
+
+**Real-time data:**
+- SSR with streaming (if the framework supports it) for content that needs to
+  be fresh on every request but can begin rendering before all data is available.
+- CSR with `stale-while-revalidate` (SWR/React Query pattern) for data that
+  can show a cached state immediately and update in the background.
+
+**Marketing pages:**
+- SSG always. Marketing pages must have fast LCP (CDN-served HTML), must be
+  SEO-indexed, and their content does not change per-user. There is no reason
+  to use SSR or CSR for a marketing page.
+
+**Documentation:**
+- SSG with ISR for edited content. Documentation is static (SSG is right) but
+  may be edited frequently without a full site rebuild (ISR solves this).
+  Verify the ISR TTL matches the acceptable staleness window for the content.
+
+---
+
+## Framework-agnostic language
+
+This skill names concepts, not framework APIs. Map each concept to the
+framework used in the project:
+
+| Concept | Example framework implementations |
+|---|---|
+| SSG | Next.js `generateStaticParams` + no `revalidate`, Astro static output, Nuxt `routeRules: { prerender: true }` |
+| ISR | Next.js `revalidate: N` in `fetch()`, Astro on-demand rendering with cache headers |
+| SSR | Next.js default server component, SvelteKit `load()`, Remix `loader` |
+| CSR | Any SPA (Vite + React, Nuxt client-side, Astro client components) |
+| RSC | Next.js App Router server components (React 18+) |
+| Islands | Astro component islands, Qwik resumability, Eleventy + Alpine |
+
+The decision framework above applies regardless of which framework implements it.

--- a/packs/frontend-engineering/.apm/skills/rendering-strategy/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/rendering-strategy/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Should we use SSR or SSG for our marketing pages?",
+    "should_trigger": true
+  },
+  {
+    "query": "Decide the rendering strategy for our authenticated dashboard",
+    "should_trigger": true
+  },
+  {
+    "query": "We're considering RSC for our product listing page \u2014 is that right?",
+    "should_trigger": true
+  },
+  {
+    "query": "Our documentation site is currently CSR \u2014 should we move to SSG?",
+    "should_trigger": true
+  },
+  {
+    "query": "What rendering model should we use for our real-time feed?",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the hydration strategy for our product pages to minimise INP",
+    "should_trigger": true
+  },
+  {
+    "query": "Our ISR cache is going stale too quickly \u2014 what TTL should we use?",
+    "should_trigger": true
+  },
+  {
+    "query": "Should we render the above-the-fold section statically and hydrate the rest?",
+    "should_trigger": true
+  },
+  {
+    "query": "Audit our current rendering architecture for LCP and INP impact",
+    "should_trigger": true
+  },
+  {
+    "query": "Build the new product page with full token and state coverage",
+    "should_trigger": false
+  },
+  {
+    "query": "Design our CSS token hierarchy",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix the focus management on the modal",
+    "should_trigger": false
+  },
+  {
+    "query": "Diagnose why our LCP is 4 seconds",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the props API for our product card component",
+    "should_trigger": false
+  },
+  {
+    "query": "Make our navigation responsive across three breakpoints",
+    "should_trigger": false
+  },
+  {
+    "query": "Organise our CSS with cascade layers",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current accessibility state of this surface?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/responsive-layout/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/responsive-layout/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: responsive-layout
+description: Design and implement adaptive layouts using CSS Grid, Flexbox, container queries, and fluid typography/spacing — the craft layer for layouts that work correctly across all viewport sizes without JavaScript.
+---
+
+# Skill: responsive-layout
+
+Load this skill when the primary task is designing or debugging a layout that
+must work across breakpoints. Do not load it for routine margin or padding
+adjustments on an already-responsive surface. Load `responsive-layout` when:
+
+- Building the layout structure for a new page or section from scratch
+- Debugging a layout that breaks at a specific viewport width
+- Designing a shared component that must adapt to variable-width containers
+- Evaluating whether a layout approach is correct before implementation
+
+---
+
+## Layout primitive selection
+
+**CSS Grid:** for two-dimensional layouts and page-level structure. Use when
+elements need to be positioned on both a row axis and a column axis, or when
+the layout requires elements to align with other elements across rows/columns.
+
+**Flexbox:** for one-dimensional alignment and component-level distribution.
+Use when elements need to be distributed along a single axis (row or column),
+with flexible sizing and alignment.
+
+**The mixing rule:** never use Grid and Flexbox to solve the same axis
+in the same container. Use Grid for the page layout; use Flexbox inside a
+Grid cell for component-level distribution within that cell.
+
+**Common mistakes:**
+- Using Flexbox for a two-column layout with a sidebar — Grid is the right
+  tool; Flexbox cannot express "sidebar is fixed-width, content fills the rest"
+  without a `min-width: 0` hack on the content column.
+- Using Grid for a single-axis distribution of buttons in a toolbar — Flexbox
+  is the right tool; Grid's two-dimensional power is wasted here.
+
+---
+
+## Container queries vs. media queries
+
+**Use container queries** when a component must adapt to the width of its
+own container rather than the viewport. This is the correct tool for shared
+components that appear in multiple layout contexts (e.g., a card that appears
+in a sidebar at 320px and in a main content area at 600px).
+
+```css
+/* Define the containment context on the parent */
+.card-container {
+  container-type: inline-size;
+  container-name: card;
+}
+
+/* Query the container, not the viewport */
+@container card (min-width: 500px) {
+  .card {
+    display: grid;
+    grid-template-columns: 120px 1fr;
+  }
+}
+```
+
+Container queries are Baseline Widely Available as of 2023.
+
+**Use media queries** when layout changes are driven by the viewport — page-level
+structure that changes how sections are arranged. Navigation, sidebar
+visibility, and column count at the page level belong here.
+
+```css
+@media (min-width: 768px) {
+  .page-layout {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+  }
+}
+```
+
+**Decision rule:** if the layout change is for a shared component that appears
+in multiple container widths — use container queries. If the layout change is
+for the page structure that responds to the viewport — use media queries.
+
+---
+
+## Fluid typography
+
+Use `clamp()` for type that scales smoothly between a minimum and maximum
+viewport width without breakpoint jumps:
+
+```css
+/* clamp(minimum, preferred, maximum) */
+/* Preferred: linear interpolation from min-size at min-viewport to max-size at max-viewport */
+
+h1 {
+  /* 24px at 320px viewport, scales to 48px at 1280px viewport */
+  font-size: clamp(1.5rem, 2.5vw + 0.5rem, 3rem);
+}
+
+p {
+  /* 16px at 320px viewport, scales to 18px at 1280px viewport */
+  font-size: clamp(1rem, 0.5vw + 0.875rem, 1.125rem);
+}
+```
+
+**Formula for the `vw + rem` preferred value:**
+```
+slope = (max-size - min-size) / (max-viewport - min-viewport)
+y-intercept = min-size - (slope * min-viewport)
+preferred = slope * 100vw + y-intercept
+```
+
+Derive min and max font sizes from the spacing scale (see `token-architecture`)
+so typography and spacing scales remain proportional.
+
+---
+
+## Breakpoint strategy
+
+Name breakpoints semantically — not by device. Device names encode specific
+dimensions that change with hardware generations; semantic names are stable:
+
+```css
+/* Token-defined breakpoints — semantic names */
+:root {
+  --breakpoint-sm:  480px;
+  --breakpoint-md:  768px;
+  --breakpoint-lg:  1024px;
+  --breakpoint-xl:  1280px;
+  --breakpoint-2xl: 1536px;
+}
+```
+
+**Mobile-first (min-width):** write base styles for mobile, then use
+`@media (min-width: ...)` to enhance for larger viewports. Mobile-first
+produces smaller files for mobile users (the base styles need no media query).
+
+**Never encode specific device names** (`@media (max-width: 375px)` for
+"iPhone SE") — those dimensions are historical snapshots that will be wrong
+within 18 months.
+
+---
+
+## Grid patterns
+
+**The 12-column grid** — flexible foundation for page layouts:
+```css
+.layout {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--ds-space-4);
+}
+
+/* A content area spanning 8 columns, centered */
+.main-content {
+  grid-column: 3 / span 8;
+}
+```
+
+**`auto-fill` vs. `auto-fit`** for responsive card grids:
+```css
+/* auto-fill: preserves empty tracks (grid does not collapse) */
+.card-grid-fill {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+/* auto-fit: collapses empty tracks (cards expand to fill the row) */
+.card-grid-fit {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+```
+
+Use `auto-fill` when preserving the column structure matters (e.g., aligning
+with a fixed-column grid above); use `auto-fit` when cards should expand to
+fill available space.
+
+**Named grid areas** for semantic layouts:
+```css
+.page {
+  display: grid;
+  grid-template-areas:
+    "header header"
+    "sidebar main"
+    "footer footer";
+  grid-template-columns: 240px 1fr;
+  grid-template-rows: auto 1fr auto;
+}
+
+.page-header  { grid-area: header; }
+.page-sidebar { grid-area: sidebar; }
+.page-main    { grid-area: main; }
+.page-footer  { grid-area: footer; }
+```
+
+**`subgrid`** for aligned multi-column forms (Baseline Widely Available 2023):
+```css
+.form-row {
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+}
+```
+
+---
+
+## The no-JS rule
+
+Responsive layout must be fully functional without JavaScript. If a layout
+requires JS to function at certain viewport sizes, it is a CSS architecture
+problem, not a JS opportunity.
+
+**CSS-only responsive patterns for common UI:**
+
+**Hamburger nav (disclosure-pattern, CSS-only):**
+Use `<details>` + `<summary>` for a native CSS-only toggle — no JS required.
+```html
+<details class="nav-disclosure">
+  <summary>Menu</summary>
+  <nav>…</nav>
+</details>
+```
+
+**Card grid:** `auto-fill` / `auto-fit` with `minmax()` — no breakpoint JS.
+
+**Table:** on narrow viewports, display each row as a block with
+`display: block` on `<td>` elements and use `data-label` attributes
+for column headers. This requires no JS.
+
+---
+
+## Common failures to refuse
+
+| Pattern | Problem | Fix |
+|---|---|---|
+| Fixed pixel widths on containers (`width: 1200px`) | Container overflows viewport on narrower screens | Use `max-width` with `width: 100%` or a percentage |
+| `overflow: hidden` on containers | Can hide content on small viewports that the user cannot scroll to | Audit whether `overflow: hidden` is actually needed; prefer `overflow: clip` for visual clipping without hiding content from assistive tech |
+| Font sizes below 16px on mobile | Browsers may zoom automatically; can trigger CLS; fails readability standards | Minimum 16px (`1rem`) for body text on mobile |
+| Content reordering that breaks tab order | Visual `order` property in Flexbox/Grid moves content visually but not in the DOM | DOM order must match visual order; use `order` only for cosmetic reordering within the same semantic group |
+| Viewport units for font sizes without clamp | `font-size: 2vw` produces 0px at zero viewport width | Always wrap viewport-unit font sizes in `clamp()` |

--- a/packs/frontend-engineering/.apm/skills/responsive-layout/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/responsive-layout/evals/eval_queries.json
@@ -1,0 +1,70 @@
+[
+  {
+    "query": "Make this three-column card grid responsive \u2014 it breaks at mobile",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the breakpoint strategy for our design system",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement container queries so this sidebar component adapts to its container",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a fluid typography scale that works from 320px to 1440px",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix the layout shift at tablet \u2014 the navigation collapses but the content doesn't reflow",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the mobile-first layout for this pricing comparison table",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement a CSS Grid layout for our article page with a sticky sidebar",
+    "should_trigger": true
+  },
+  {
+    "query": "Our responsive nav uses JS media query listeners \u2014 convert it to CSS only",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up auto-fill grid columns that work without any media queries",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a new responsive page from this brief including all states",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the design token system for our CSS",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit the WCAG 2.2 compliance of this form",
+    "should_trigger": false
+  },
+  {
+    "query": "Improve the LCP on our product landing page",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we server-side render this listing page?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the component API for this layout component",
+    "should_trigger": false
+  },
+  {
+    "query": "Organise our global CSS using cascade layers",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the current state of the surface against our quality floor",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/.apm/skills/token-architecture/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/token-architecture/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: token-architecture
+description: Design and govern a three-tier CSS custom property token system (primitive → semantic → component), including semantic alias layers, light/dark theming, and DTCG-compatible source generation.
+---
+
+# Skill: token-architecture
+
+Load this skill when the primary task is designing or auditing a token
+**system** — the architecture that governs how tokens are named, derived, and
+organized. Do not load this skill for routine surface work where seeding a
+token block is sufficient; the seed token block in `frontend-engineering` step 2
+covers that case. Load `token-architecture` when:
+
+- The product needs a token system designed from scratch
+- An existing token system has hardcoded value drift and needs an audit
+- A new semantic alias layer is being added (e.g., adding a dark-theme override)
+- Multi-platform distribution requires DTCG-compatible source generation
+
+---
+
+## Three-tier architecture
+
+The one-way dependency rule governs the entire system:
+
+```
+Primitive  →  Semantic  →  Component
+```
+
+- **Primitives** are raw values: `#5e6ad2`, `16px`, `1.5`. They have no meaning
+  beyond their value. They are defined once at the top of the CSS file (or in
+  the design tool) and referenced only by the semantic layer. Component tokens
+  must not reference primitives directly — only semantics.
+- **Semantics** are role assignments: `--ds-color-primary` points to a primitive.
+  Semantics carry the design intent. When the brand changes, only the semantic
+  layer's pointer changes; component tokens remain stable.
+- **Components** are usage tokens scoped to a specific component:
+  `--btn-bg: var(--ds-color-primary)`. They reference semantics, never
+  primitives.
+
+**Violation to refuse:** a component token that reads
+`var(--primitive-color-indigo-500)` directly. This is a one-way dependency
+violation — if the primitive moves, every component that references it must
+be updated rather than only the semantic pointer.
+
+---
+
+## Naming conventions
+
+The `--ds-` namespace prefix is required for all system tokens. It signals
+"design system" and prevents collisions with author-defined custom properties
+or third-party libraries.
+
+### Semantic naming rules
+
+| Wrong | Right | Why |
+|---|---|---|
+| `--color-blue-500` | `--ds-color-primary` | Implementation detail leaks into the name; survives no redesign |
+| `--spacing-16px` | `--ds-space-4` | Value leaks into the name; breaks if the scale changes |
+| `--radius-8` | `--ds-radius-md` | Same problem; semantic size name is stable |
+| `--font-inter` | `--ds-font-body` | Font family leaks; semantic role is stable |
+
+The naming rule: a token name encodes **role**, never **implementation**.
+`--ds-color-primary` survives a rebrand to a different hue. `--color-blue-500`
+does not.
+
+---
+
+## Scale derivation
+
+Derive spacing, typography, and radius scales from a single organizing ratio.
+Three ratios cover most design needs:
+
+| Ratio | Value | Best for |
+|---|---|---|
+| Minor third | 1.25 | Compact, data-dense surfaces (dashboards, admin) |
+| Major third | 1.333 | General product surfaces |
+| Golden ratio | 1.618 | Editorial, marketing, high-visual-weight surfaces |
+
+### Spacing scale (minor third, 4px base)
+
+```
+--ds-space-1:  4px          (base)
+--ds-space-2:  8px          (base × 1.25 → round to 8)
+--ds-space-3:  12px
+--ds-space-4:  16px
+--ds-space-5:  24px         (major jump — section separation)
+--ds-space-6:  32px
+--ds-space-7:  48px
+--ds-space-8:  64px
+```
+
+### Typography scale (major third)
+
+```
+--ds-text-sm:   0.75rem     (12px)
+--ds-text-base: 0.875rem    (14px)
+--ds-text-lg:   1rem        (16px)
+--ds-text-xl:   1.125rem    (18px)
+--ds-text-2xl:  1.25rem     (20px)
+--ds-text-3xl:  1.5rem      (24px)
+```
+
+Derive line-height from the scale ratio — not from a fixed pixel value. A
+unitless multiplier (1.25, 1.5, 1.75) scales with the font size and avoids
+WCAG 1.4.12 (Text Spacing) violations.
+
+### Radius scale
+
+```
+--ds-radius-sm:   4px       (chips, badges, small controls)
+--ds-radius-md:   8px       (buttons, cards)
+--ds-radius-lg:   12px      (modals, sheets, large containers)
+--ds-radius-full: 9999px    (pills)
+```
+
+---
+
+## Semantic alias layer
+
+The semantic layer maps roles to primitives. A complete minimum viable set:
+
+| Role | Light theme default | Dark theme override | Meaning |
+|---|---|---|---|
+| `--ds-color-surface` | `#ffffff` | `#0d0d0d` | Primary background |
+| `--ds-color-surface-alt` | `#f8fafc` | `#1a1a1a` | Secondary/alternate background |
+| `--ds-color-on-surface` | `#1a202c` | `#e2e8f0` | Primary text on surface |
+| `--ds-color-on-surface-2` | `rgba(0,0,0,0.60)` | `rgba(255,255,255,0.60)` | Secondary/muted text |
+| `--ds-color-primary` | `#5e6ad2` | `#8b93e8` | Brand / interactive primary |
+| `--ds-color-on-primary` | `#ffffff` | `#ffffff` | Text on primary |
+| `--ds-color-error` | `#dc2626` | `#f87171` | Error state |
+| `--ds-color-on-error` | `#ffffff` | `#ffffff` | Text on error |
+| `--ds-color-warning` | `#d97706` | `#fbbf24` | Warning state |
+| `--ds-color-success` | `#16a34a` | `#4ade80` | Success state |
+| `--ds-color-info` | `#0284c7` | `#38bdf8` | Informational state |
+| `--ds-color-disabled` | `rgba(0,0,0,0.38)` | `rgba(255,255,255,0.38)` | Disabled content |
+| `--ds-color-overlay` | `rgba(0,0,0,0.50)` | `rgba(0,0,0,0.70)` | Modal backdrop |
+| `--ds-color-outline` | `rgba(0,0,0,0.12)` | `rgba(255,255,255,0.12)` | Borders, dividers |
+
+### Light/dark theme switching
+
+Declare the semantic layer inside `:root` for light mode. Override inside
+`@media (prefers-color-scheme: dark)` for automatic system-preference
+switching, and/or inside `[data-theme="dark"]` for an explicit user toggle:
+
+```css
+:root {
+  --ds-color-surface: #ffffff;
+  --ds-color-primary: #5e6ad2;
+  /* ... all semantic tokens ... */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ds-color-surface: #0d0d0d;
+    --ds-color-primary: #8b93e8;
+    /* ... dark overrides only ... */
+  }
+}
+
+[data-theme="dark"] {
+  --ds-color-surface: #0d0d0d;
+  --ds-color-primary: #8b93e8;
+  /* identical to the media query block — both must be kept in sync */
+}
+```
+
+The `[data-theme]` attribute toggle and the `prefers-color-scheme` query are
+independent — a user who has set `data-theme="dark"` expects the dark theme
+regardless of system preference. Both must be maintained.
+
+---
+
+## Component token pattern
+
+Component tokens scope semantic tokens to a component's internal anatomy.
+They are the only layer allowed to reference semantics (never primitives).
+
+**Button token example — three-tier chain:**
+
+```css
+/* Tier 1: Primitive (defined once, never referenced by components) */
+:root {
+  --primitive-color-indigo-500: #5e6ad2;
+  --primitive-color-indigo-700: #4338ca;
+  --primitive-color-white: #ffffff;
+}
+
+/* Tier 2: Semantic (roles, not values) */
+:root {
+  --ds-color-primary: var(--primitive-color-indigo-500);
+  --ds-color-primary-hover: var(--primitive-color-indigo-700);
+  --ds-color-on-primary: var(--primitive-color-white);
+}
+
+/* Tier 3: Component (anatomy, references semantics only) */
+.btn {
+  --btn-bg:           var(--ds-color-primary);
+  --btn-bg-hover:     var(--ds-color-primary-hover);
+  --btn-text:         var(--ds-color-on-primary);
+  --btn-radius:       var(--ds-radius-md);
+  --btn-padding-x:    var(--ds-space-4);
+  --btn-padding-y:    var(--ds-space-2);
+
+  background-color: var(--btn-bg);
+  color:            var(--btn-text);
+  border-radius:    var(--btn-radius);
+  padding:          var(--btn-padding-y) var(--btn-padding-x);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  background-color: var(--btn-bg-hover);
+}
+```
+
+The chain: `.btn` reads `--btn-bg`; `--btn-bg` reads `--ds-color-primary`;
+`--ds-color-primary` reads `--primitive-color-indigo-500`. When the brand
+changes `--primitive-color-indigo-500` to a new hue, `.btn` picks it up
+automatically through the chain.
+
+---
+
+## DTCG export
+
+The Design Tokens Community Group (DTCG) format is the correct structure for
+multi-platform distribution (producing iOS/Android values from the same source,
+or supplying a design tool with a token JSON it understands).
+
+DTCG token format — each token uses `$type`, `$value`, and optionally
+`$description`:
+
+```json
+{
+  "color": {
+    "primary": {
+      "$type": "color",
+      "$value": "#5e6ad2",
+      "$description": "Brand primary — interactive elements and focus indicators"
+    },
+    "surface": {
+      "$type": "color",
+      "$value": "#ffffff",
+      "$description": "Primary surface background"
+    }
+  },
+  "spacing": {
+    "4": {
+      "$type": "dimension",
+      "$value": "16px",
+      "$description": "Base unit × 4 — standard internal padding"
+    }
+  }
+}
+```
+
+**When to produce DTCG output:** when the token system feeds a build pipeline
+that generates platform-specific token files (CSS custom properties, Swift
+UIColor, Android XML, Figma variables). For a web-only project that consumes
+tokens directly as CSS custom properties, DTCG export is optional.
+
+---
+
+## Token audit
+
+To detect token drift — hardcoded values in CSS that should be tokens — run:
+
+```bash
+grep -E "#[0-9a-fA-F]{3,6}|rgba?\(|hsl\(|[0-9]+px" <file.css>
+```
+
+The output should return **only** the `:root` / primitive-definition block.
+Any hardcoded colour or spacing value outside that block is a violation.
+
+**Triage priority:**
+
+1. Hardcoded colour values in component or semantic files — these break
+   theming and must be migrated to tokens.
+2. Magic pixel values for spacing (`margin: 13px`) — migrate to the scale.
+3. Hardcoded font sizes — migrate to the type scale.
+4. Hardcoded `z-index` numbers — migrate to a named z-index scale.
+
+---
+
+## Governance checklist
+
+A token architecture encodes organizational decisions. Before finalizing:
+
+- [ ] Who owns the **primitive layer**? Changes here affect every component
+  through the chain. Primitives should change only with explicit stakeholder
+  sign-off.
+- [ ] Who owns the **semantic layer**? A new semantic role (e.g. a new status
+  color) should require review from both design and engineering.
+- [ ] Are **component tokens** scoped to the component that owns them? Shared
+  component tokens across unrelated components are a coupling smell.
+- [ ] Is the **DTCG export** needed? If multi-platform, a build step that
+  produces platform tokens from the DTCG source is part of the governance
+  contract.
+- [ ] Is the **dark-theme override** kept in sync with the light-theme semantic
+  layer? Every new semantic token added to light mode must have a corresponding
+  dark override (or an explicit decision that it inherits the light value).

--- a/packs/frontend-engineering/.apm/skills/token-architecture/evals/eval_queries.json
+++ b/packs/frontend-engineering/.apm/skills/token-architecture/evals/eval_queries.json
@@ -1,0 +1,66 @@
+[
+  {
+    "query": "Design the token system for our new design system",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up a three-tier CSS custom property architecture for our product",
+    "should_trigger": true
+  },
+  {
+    "query": "Audit our tokens for hierarchy violations \u2014 any component reading a primitive directly?",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the semantic alias layer for our brand colour palette",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up light and dark theme switching using our token system",
+    "should_trigger": true
+  },
+  {
+    "query": "Generate a DTCG-compatible token source file from our taxonomy",
+    "should_trigger": true
+  },
+  {
+    "query": "Our tokens are inconsistent across surfaces \u2014 help us govern them",
+    "should_trigger": true
+  },
+  {
+    "query": "Design the token naming system for our multi-brand platform",
+    "should_trigger": true
+  },
+  {
+    "query": "Map our existing hardcoded hex values to semantic token roles",
+    "should_trigger": true
+  },
+  {
+    "query": "Build a new web page with a token seed block",
+    "should_trigger": false
+  },
+  {
+    "query": "Audit the accessibility of this surface",
+    "should_trigger": false
+  },
+  {
+    "query": "Diagnose the LCP regression on our homepage",
+    "should_trigger": false
+  },
+  {
+    "query": "Should we server-render or statically generate this page?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design the props API for our button component",
+    "should_trigger": false
+  },
+  {
+    "query": "Make this layout responsive at three breakpoints",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the current state of the frontend surface?",
+    "should_trigger": false
+  }
+]

--- a/packs/frontend-engineering/AGENTS.md
+++ b/packs/frontend-engineering/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md — frontend-engineering pack
+
+The `frontend-engineering` pack installs 9 skills and a `frontend-reviewer` agent
+for HTML/CSS/JS work. The guide tree for all skills lives in
+[`docs/guides/frontend-engineering/`](../../docs/guides/frontend-engineering/) —
+tutorials, how-to, and a reference page covering all skills and the reviewer.
+
+For full genre routing in the frontend pre-flight (the `experience-design` co-install
+that supplies `conversion-design`, `documentation-design`, `analytical-design`, and the
+other XD genre skills), `experience-design` must be installed alongside this pack.
+The main `frontend-engineering` skill records a named skip when `experience-design`
+is absent — the skip is documented in the spec, not silently omitted.

--- a/packs/frontend-engineering/README.md
+++ b/packs/frontend-engineering/README.md
@@ -1,0 +1,52 @@
+# frontend-engineering
+
+The implementation layer for product web surfaces — HTML, CSS, and JS. For
+engineers who write frontend code and need principled guidance from design
+handoff to shipped component.
+
+## What this pack installs
+
+Nine skills and one reviewer agent:
+
+| Skill | When to use |
+|---|---|
+| `frontend-engineering` | Primary surface skill — all four modes: create, retrofit, audit, verify |
+| `token-architecture` | Design or audit a three-tier CSS token system |
+| `a11y-engineering` | Dedicated accessibility task — audit, retrofit, or complex interaction design |
+| `fe-performance` | CWV diagnosis or asset budget remediation |
+| `rendering-strategy` | Select or audit the rendering model for a route (CSR/SSR/SSG/ISR/RSC) |
+| `component-contract` | Design a shared component's public interface before writing implementation |
+| `responsive-layout` | Design or debug adaptive layouts across breakpoints |
+| `css-architecture` | Set up or refactor CSS at scale — cascade layers, specificity budgets, scoping strategy |
+| `fe-status` | Orient to an existing surface's gate history and quality floor status |
+
+**Reviewer:** `frontend-reviewer` — forked-context, read-only diff reviewer for
+HTML/CSS/JS diffs. Covers CSS token drift, ARIA mutation completeness, state
+coverage regression, and WCAG 2.2 Focus Appearance / Target Size items that
+automated tooling misses.
+
+## Co-install
+
+For full genre routing in the frontend pre-flight (step 1b of `frontend-engineering`),
+co-install with `experience-design`:
+
+```
+agentbundle install --pack frontend-engineering --scope user
+agentbundle install --pack experience-design --scope user
+```
+
+If `experience-design` is absent, `frontend-engineering` records a named skip —
+`XD genre routing: skipped (experience-design pack absent)` — and proceeds. The
+named skip is not a failure; it is honest accounting.
+
+## Install
+
+```
+agentbundle install --pack frontend-engineering --scope user
+```
+
+Projects to: Claude Code, Codex, Copilot, Cursor, Gemini, Kiro.
+
+## Guides
+
+→ [`docs/guides/frontend-engineering/`](../../docs/guides/frontend-engineering/)

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 display_name = "Frontend Engineering"
 license = "Apache-2.0 OR MIT"
 categories = ["engineering", "frontend"]
-keywords = ["wcag", "core-web-vitals", "css-tokens", "components", "accessibility", "html", "css", "javascript"]
+keywords = ["wcag", "core-web-vitals", "css-tokens", "accessibility", "html"]
 
 [pack.adapter-contract]
 version = "0.12"
@@ -29,7 +29,7 @@ name = "eugenelim"
 email = "eugenelim@users.noreply.github.com"
 
 [pack.first-value]
-audience-posture = "engineering"
+audience-posture = "technical"
 surfaces         = ["claude-code"]
 prerequisites    = []
 verification     = "Run frontend-engineering in create mode on a new surface and confirm an evidence manifest is produced."

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,0 +1,41 @@
+[pack]
+name = "frontend-engineering"
+version = "0.1.0"
+description = "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
+readme = "README.md"
+display_name = "Frontend Engineering"
+license = "Apache-2.0 OR MIT"
+categories = ["engineering", "frontend"]
+keywords = ["wcag", "core-web-vitals", "css-tokens", "components", "accessibility", "html", "css", "javascript"]
+
+[pack.adapter-contract]
+version = "0.12"
+
+[pack.install]
+default-scope = "user"
+allowed-scopes = ["user", "repo"]
+allowed-adapters = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "cursor", "gemini"]
+
+[pack.evals]
+skills = ["frontend-engineering", "token-architecture", "a11y-engineering", "fe-performance", "rendering-strategy", "component-contract", "responsive-layout", "css-architecture", "fe-status"]
+
+[pack.links]
+homepage = "https://github.com/eugenelim/agent-ready-repo"
+repository = "https://github.com/eugenelim/agent-ready-repo"
+documentation = "https://github.com/eugenelim/agent-ready-repo/tree/main/docs/guides/frontend-engineering/"
+
+[[pack.maintainers]]
+name = "eugenelim"
+email = "eugenelim@users.noreply.github.com"
+
+[pack.first-value]
+audience-posture = "engineering"
+surfaces         = ["claude-code"]
+prerequisites    = []
+verification     = "Run frontend-engineering in create mode on a new surface and confirm an evidence manifest is produced."
+recovery         = "If the skill does not produce output, confirm the pack is installed and run adapt-to-project to refresh the skill index."
+level-b          = true
+starter-task     = "Build a new web surface from a design brief"
+starter-prompt   = "I have a screen brief for [describe surface]. Set up the pre-flight: name the aesthetic reference, seed token block, and enumerate the applicable states from the 18-state matrix."
+expected-result  = "A page/screen contract in the spec with aesthetic reference, token seed block, and state matrix."
+next-action      = "Use the page contract and state matrix to write the HTML with all required states implemented."

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -38,6 +38,7 @@ PACKS: list[tuple[str, str, str, str]] = [
     ("desk-research",      "Desk Research",         "user", "Evidence-grounded research with typed artifacts, seven skills, and two retrieval subagents."),
     ("architect",          "Architect",            "user", "System design, diagramming, and independent architecture review from a forked-context subagent."),
     ("experience-design",  "Experience Design",    "user", "The full design thread: journey mapping, screen flows, creative direction, surface-genre design (6 types), and the shared quality floor."),
+    ("frontend-engineering","Frontend Engineering", "user", "The implementation layer for product web surfaces — 9 skills from design handoff to shipped component, plus a diff-level `frontend-reviewer` agent."),
     ("contracts",          "Contracts",            "user", "API-first design — OpenAPI 3.1 for HTTP, AsyncAPI for event streams."),
     ("iac-terraform",      "IaC (Terraform)",       "repo", "Plain-language intent → governed, cloud-agnostic Terraform and a human-gated pipeline; decision-record-gated, stops at `terraform plan`."),
     ("converters",         "Converters",           "user", "Document conversion: PDF/DOCX/PPTX/email → Markdown, Markdown → HTML/Word/PowerPoint/Excel."),

--- a/web/src/content/packs/frontend-engineering.md
+++ b/web/src/content/packs/frontend-engineering.md
@@ -1,0 +1,24 @@
+---
+name: Frontend Engineering
+scope: user
+tagline: "The implementation layer for product web surfaces."
+skills:
+  - frontend-engineering
+  - token-architecture
+  - a11y-engineering
+  - fe-performance
+  - rendering-strategy
+  - component-contract
+  - responsive-layout
+  - css-architecture
+  - fe-status
+installCommand: "agentbundle install --pack frontend-engineering --scope user"
+docsUrl: /docs/guides/frontend-engineering/
+journeyUrl: /journeys/frontend-engineering/
+---
+
+Frontend Engineering installs 9 skills covering the full build journey from design handoff to shipped component: the create/retrofit/audit/verify workflow (`frontend-engineering`), CSS token system architecture (`token-architecture`), deep accessibility engineering beyond automated tooling (`a11y-engineering`), Core Web Vitals measurement and remediation (`fe-performance`), rendering strategy selection (`rendering-strategy`), component API design (`component-contract`), responsive layout craft (`responsive-layout`), CSS architecture at scale (`css-architecture`), and surface orientation (`fe-status`). A forked-context `frontend-reviewer` agent provides a diff-level review for HTML/CSS/JS diffs covering CSS token drift, ARIA mutation completeness, state coverage regression, and the two WCAG 2.2 manual-verification items automated tooling misses.
+
+**Co-install with `experience-design` for full genre routing.** The main `frontend-engineering` skill includes a genre-routing step (step 1b) that loads the appropriate XD discipline skill — `conversion-design` for marketing surfaces, `documentation-design` for docs sites, `analytical-design` for dashboards. This step requires the `experience-design` pack. Without it, `frontend-engineering` records a named skip and proceeds; the skip is honest accounting, not a failure. Install both packs to get the full pre-flight.
+
+**Near-miss guards:** `a11y-engineering` is for dedicated accessibility tasks — an audit, a retrofit of broken patterns, or designing a complex interaction (combobox, data grid, drag-and-drop) where the a11y engineering is the central deliverable. For routine component work, use the accessibility section in `frontend-engineering` — it covers the baseline patterns. Similarly, `fe-performance` is for CWV diagnosis and remediation as the primary task, not for running Lighthouse as a gate at the end of a normal build (use the GATES section in `frontend-engineering` for that).


### PR DESCRIPTION
## What this PR does

- **ADR-0056** — records the promotion decision (ADR not RFC: `packs/` exists, the resident-skill-to-pack pattern is established)
- **Pack scaffold** — `packs/frontend-engineering/` with `pack.toml` (v0.1.0), `README.md`, `AGENTS.md`
- **9 skills** — `frontend-engineering` (verbatim copy of resident skill), `token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`, `fe-status`
- **`frontend-reviewer` agent** — forked-context, read-only diff reviewer for HTML/CSS/JS primary-output diffs; 5 lenses (CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance + Target Size, CWV regression signals)
- **Work-loop integration at 4 points** — footnote³, EXECUTE FE paragraph, REVIEW specialist-reviewer list, DECIDE enumeration; applied identically to `.claude/skills/work-loop/SKILL.md` and `packs/core/.apm/skills/work-loop/SKILL.md`
- **Catalogue page** — `web/src/content/packs/frontend-engineering.md`
- **Guide tree** — `docs/guides/frontend-engineering/` with overview README, scaffold-a-component tutorial, run-an-audit how-to, and reference page
- **Sidebar** — `docs-site/astro.config.ts` — Frontend Engineering section added after Experience Design
- **`tools/build-site.py`** — `frontend-engineering` added to the PACKS list

## Co-install note

`experience-design` is required for full genre routing in the frontend pre-flight (step 1b). Without it, `frontend-engineering` records a named skip — `XD genre routing: skipped (experience-design pack absent)` — and proceeds. The skip is honest accounting, not a failure.

## Deferred to v0.2.0

- `motion-craft` — purposeful motion and animation engineering
- `fe-security` — frontend-specific security patterns (CSP, CORS, input sanitization, localStorage misuse)
- `i18n-engineering` — internationalization and locale-aware component patterns
- `public-surface` — search indexing, structured data, and canonical URL discipline for publicly indexed surfaces

These are not in scope for v0.1.0. Each would be a separate skill added to the pack in a follow-up PR.

## Decision notes

**C1 — ADR not RFC:** `packs/` exists; the resident-skill-to-pack promotion pattern is established (`experience-design`, `architect`, `desk-research`). No new top-level directory, no new adapter-contract version, no structural change. ADR records the decision; RFC would add process overhead without adding decision clarity.

**C2 — reviewer scope:** `frontend-reviewer` covers exactly what automated tooling misses (WCAG 2.2 Focus Appearance + Target Size, ARIA mutation completeness) and what static analysis cannot catch (state coverage regression, CWV regression signals in a diff). It is non-overlapping with `adversarial-reviewer` (spec drift), `quality-engineer` (testability), `experience-reviewer` (aesthetic taste), and `security-reviewer` (auth/secrets/input).

**C3 — named skip documented:** both the pack's `frontend-engineering` skill and the work-loop insertions explicitly document the named-skip pattern. Absence of the `frontend-engineering` pack on an HTML/CSS/JS diff is an acknowledged gap, not a silent pass.