### PR TITLE
fix(tools): Windows cp1252 UTF-8 guard for all Python scripts

### DIFF
--- a/.agents/skills/assimilate-primitive/scripts/ssrf_check.py
+++ b/.agents/skills/assimilate-primitive/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/.agents/skills/assimilate-repo/scripts/ssrf_check.py
+++ b/.agents/skills/assimilate-repo/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -88,12 +88,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
-    import tomllib
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
+    import tomllib
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -90,6 +90,10 @@ from pathlib import Path
 
 try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
     import tomllib
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -50,6 +50,10 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATE_PATH = SCRIPT_DIR.parent / "assets" / "state.json"
 

--- a/.claude/skills/assimilate-primitive/scripts/ssrf_check.py
+++ b/.claude/skills/assimilate-primitive/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/.claude/skills/assimilate-repo/scripts/ssrf_check.py
+++ b/.claude/skills/assimilate-repo/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -88,12 +88,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
-    import tomllib
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
+    import tomllib
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -90,6 +90,10 @@ from pathlib import Path
 
 try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
     import tomllib
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -50,6 +50,10 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATE_PATH = SCRIPT_DIR.parent / "assets" / "state.json"
 

--- a/packages/agentbundle/tests/hooks/test_pre_pr_py.py
+++ b/packages/agentbundle/tests/hooks/test_pre_pr_py.py
@@ -93,7 +93,7 @@ def sandbox(tmp_path: Path) -> Path:
 def _run(cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(cwd / "packs/core/.apm/hooks/pre-pr.py")],
-        cwd=cwd, capture_output=True, text=True,
+        cwd=cwd, capture_output=True, text=True, encoding="utf-8",
     )
 
 
@@ -130,7 +130,7 @@ def test_pre_pr_adopter_tree_no_tooling_is_graceful(tmp_path: Path) -> None:
     repo = tmp_path / "adopter"
     repo.mkdir()
     result = subprocess.run(
-        [sys.executable, str(HOOK)], cwd=repo, capture_output=True, text=True,
+        [sys.executable, str(HOOK)], cwd=repo, capture_output=True, text=True, encoding="utf-8",
     )
     assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
     assert "pre-pr: all checks passed" in result.stdout

--- a/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
@@ -33,10 +33,17 @@ from agentbundle.config import PackState, State, dump_state
 
 
 def _set_home(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
-    """Set HOME (POSIX) and USERPROFILE (Windows) so Path.expanduser works cross-platform."""
+    """Pin the user-scope root to *path* for this test.
+
+    Sets HOME + USERPROFILE so Path.expanduser resolves correctly, and also
+    patches agentbundle.scope.resolve_user_root directly — on some Windows CI
+    runners monkeypatching env-vars alone does not propagate into expanduser.
+    """
     monkeypatch.setenv("HOME", str(path))
     if sys.platform == "win32":
         monkeypatch.setenv("USERPROFILE", str(path))
+    import agentbundle.scope as _scope_mod
+    monkeypatch.setattr(_scope_mod, "resolve_user_root", lambda: path)
 
 
 def _write_state(path: Path, files: dict[str, str], scope: str = "repo") -> None:

--- a/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
@@ -23,12 +23,20 @@ from __future__ import annotations
 import argparse
 import contextlib
 import io
+import sys
 from pathlib import Path
 
 import pytest
 
 from agentbundle.commands import adapt
 from agentbundle.config import PackState, State, dump_state
+
+
+def _set_home(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    """Set HOME (POSIX) and USERPROFILE (Windows) so Path.expanduser works cross-platform."""
+    monkeypatch.setenv("HOME", str(path))
+    if sys.platform == "win32":
+        monkeypatch.setenv("USERPROFILE", str(path))
 
 
 def _write_state(path: Path, files: dict[str, str], scope: str = "repo") -> None:
@@ -63,7 +71,7 @@ def test_adapt_writes_per_scope_pending_reports(tmp_path, monkeypatch):
     fake_home = tmp_path / "home"
     user_dir = fake_home / ".agentbundle"
     user_dir.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(fake_home))
+    _set_home(monkeypatch, fake_home)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -109,7 +117,7 @@ def test_adapt_ci_or_across_scopes(tmp_path, monkeypatch, case):
     fake_home = tmp_path / "home"
     user_dir = fake_home / ".agentbundle"
     user_dir.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(fake_home))
+    _set_home(monkeypatch, fake_home)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -134,7 +142,7 @@ def test_adapt_ci_or_across_scopes(tmp_path, monkeypatch, case):
 def test_adapt_ci_passes_when_neither_scope_has_companions(tmp_path, monkeypatch):
     fake_home = tmp_path / "home"
     (fake_home / ".agentbundle").mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(fake_home))
+    _set_home(monkeypatch, fake_home)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -160,7 +168,7 @@ def test_adapt_handles_missing_user_state(tmp_path, monkeypatch):
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
+    _set_home(monkeypatch, fake_home)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -190,7 +198,7 @@ def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch
     fake_home = tmp_path / "home"
     user_dir = fake_home / ".agentbundle"
     user_dir.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(fake_home))
+    _set_home(monkeypatch, fake_home)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()

--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -40,6 +40,8 @@ intent → user journey → stage → capability → output
 
 ## Primary workflow (any catalogue)
 
+Run after any pack change. If `agentbundle` is not installed: `pip install agentbundle`.
+
 ```bash
 agentbundle catalogue lint --root .
 agentbundle catalogue verify --root .
@@ -128,3 +130,5 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 ```
 
 Windows CI (Python 3.11, cp1252 default) crashes on any Unicode character — including ✓, ✗, →, — — without this guard. `errors="strict"` on stdout surfaces encoding bugs immediately; `errors="backslashreplace"` on stderr prevents diagnostic messages from being lost.
+
+Any `subprocess.run` call with `text=True` must also pass `encoding="utf-8"` — child scripts reconfigured to UTF-8 produce bytes undefined in cp1252, which corrupts the parent's decoded output.

--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -98,7 +98,7 @@ Edit `.apm/skills/<name>/SKILL.md`. Run `make build-self` to project. Run `pytho
 - **Path rules in body:** self-references use skill-relative paths (`scripts/foo.py`); cross-skill references use the skill name only — never `.claude/skills/<...>/` or `packs/.../skills/<...>/` prefixes.
 
 **Craft rules (not linted — hold in head):**
-- **`description` is the trigger surface** — body must not restate when to invoke.
+- **`description` is the trigger surface** — body must not restate when to invoke. **Hard cap: 1024 chars** (Kiro's frontmatter parser silently truncates at the byte boundary; `lint-skill-spec.py` enforces this).
 - **Body answers what to do once invoked** — preconditions, judgment, procedure. Keep it terse.
 - **Declare output rendering directives** — `## Output rendering` before the first procedural `##` for skills that surface structured output. Catalog: `docs/guides/core/reference/output-rendering.md`.
 - **No internal-governance citations** — no RFC/ADR numbers or internal spec paths in any `.apm/**` content.

--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -116,3 +116,15 @@ A non-cosmetic pack update must also update the pack's eval harness:
 - **Tier-B-lite** — additionally an `expect` block + `evals/files/` fixture for deterministic skills.
 
 Verify locally with `python tools/run-pack-evals.py --pack <pack> --mode judge --judge-adapter claude-code --artifacts <file>`.
+
+## Windows-safe Python scripts
+
+Any script under `.apm/` that prints to stdout or stderr must include the UTF-8 reconfigure guard immediately after `import sys`, before any `print()` call:
+
+```python
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+```
+
+Windows CI (Python 3.11, cp1252 default) crashes on any Unicode character — including ✓, ✗, →, — — without this guard. `errors="strict"` on stdout surfaces encoding bugs immediately; `errors="backslashreplace"` on stderr prevents diagnostic messages from being lost.

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/crawl_space.py
@@ -16,7 +16,6 @@ PAT is never accepted on the command line.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import logging
 import re
 import sys
@@ -388,6 +387,7 @@ async def _run_check(client: ConfluenceClient, flavor: str) -> int:
 
 
 async def main_async(args: argparse.Namespace) -> int:
+    import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
     # Auth selector: sso-config.toml with auth_default = "sso-cookie"
     # routes to the cookie path; absent or "creds" → today's token path unchanged.
     try:
@@ -500,6 +500,7 @@ def main() -> int:
     # Exception` deliberately does NOT catch KeyboardInterrupt (130 below) or
     # SystemExit (BaseException) — those pass through.
     try:
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         return asyncio.run(main_async(args))
     except KeyboardInterrupt:
         log.warning("interrupted")

--- a/packs/atlassian/.apm/skills/jira-align/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/_client.py
@@ -13,7 +13,6 @@ callers can branch on it if product behavior ever diverges.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import secrets
 from dataclasses import dataclass
@@ -95,6 +94,7 @@ class JiraAlignClient:
         # Concurrency is gated by the semaphore alone. Throttling for
         # rate-limited endpoints comes from the API's own 429 + Retry-After
         # response, which the request loop honors.
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         self._sem = asyncio.Semaphore(concurrency)
 
     async def __aenter__(self) -> "JiraAlignClient":
@@ -128,6 +128,7 @@ class JiraAlignClient:
                     )
                 except httpx.TransportError as exc:
                     last_exc = exc
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(self._backoff(attempt))
                     continue
 
@@ -152,6 +153,7 @@ class JiraAlignClient:
                         "HTTP %s on %s — retrying in %.1fs",
                         resp.status_code, path, delay,
                     )
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(delay)
                     continue
                 if resp.status_code >= 400:

--- a/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
+++ b/packs/atlassian/.apm/skills/jira-align/scripts/jira_align.py
@@ -19,7 +19,6 @@ Tier 2 OS keyring → Tier 3 dotfile); run ``credential-setup`` skill to populat
 from __future__ import annotations
 
 import argparse
-import asyncio
 import csv
 import json
 import logging
@@ -607,6 +606,7 @@ def main(argv: list[str] | None = None) -> int:
     # Top-level catch-all: no exception escapes as a traceback. `except
     # Exception` deliberately does NOT catch SystemExit / KeyboardInterrupt.
     try:
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         return asyncio.run(_run(args))
     except Exception as exc:  # noqa: BLE001 — intentional functional catch-all
         name = type(exc).__name__

--- a/packs/atlassian/.apm/skills/jira/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_client.py
@@ -22,7 +22,6 @@ JQL search differs:
 """
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import logging
@@ -164,6 +163,7 @@ class JiraClient:
         # Concurrency is gated by the semaphore alone. Throttling for
         # rate-limited endpoints comes from the API's own 429 + Retry-After
         # response, which the request loop honors.
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         self._sem = asyncio.Semaphore(concurrency)
 
     @classmethod
@@ -245,6 +245,7 @@ class JiraClient:
             trust_env=True,  # corporate proxy + SSL_CERT_FILE/SSL_CERT_DIR
             follow_redirects=False,  # never re-attach the cookie cross-host
         )
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         self._sem = asyncio.Semaphore(concurrency)
         return self
 
@@ -309,6 +310,7 @@ class JiraClient:
                     )
                 except httpx.TransportError as exc:
                     last_exc = exc
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(self._backoff(attempt))
                     continue
 
@@ -358,6 +360,7 @@ class JiraClient:
                         "HTTP %s on %s — retrying in %.1fs",
                         resp.status_code, path, delay,
                     )
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(delay)
                     continue
                 if resp.status_code >= 400:

--- a/packs/atlassian/.apm/skills/jira/scripts/jira.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/jira.py
@@ -36,7 +36,6 @@ Tier 3 dotfile); run ``credential-setup`` skill to populate the namespace.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import csv
 import json
 import logging
@@ -787,6 +786,7 @@ def main(argv: list[str] | None = None) -> int:
     # Exception` deliberately does NOT catch SystemExit / KeyboardInterrupt
     # (BaseException) — argparse usage exits and Ctrl-C (130) pass through.
     try:
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         return asyncio.run(_run(args))
     except Exception as exc:  # noqa: BLE001 — intentional functional catch-all
         name = type(exc).__name__

--- a/packs/catalogue-curation/.apm/skills/assimilate-primitive/scripts/ssrf_check.py
+++ b/packs/catalogue-curation/.apm/skills/assimilate-primitive/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/packs/catalogue-curation/.apm/skills/assimilate-repo/scripts/ssrf_check.py
+++ b/packs/catalogue-curation/.apm/skills/assimilate-repo/scripts/ssrf_check.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 import ipaddress
 import socket
 from urllib.parse import urlsplit
+import sys
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 ALLOWED_URL_SCHEMES = frozenset({"https", "git", "ssh"})
 # Schemes that turn "fetch a URL" into a local-file read or an SSRF pivot.

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
@@ -47,12 +47,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:
-    from PIL import Image
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:
+    from PIL import Image
 except ImportError:
     print(
         "ERROR: Pillow is required. Install with:\n"

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/split_image.py
@@ -49,6 +49,10 @@ from typing import Any
 
 try:
     from PIL import Image
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ImportError:
     print(
         "ERROR: Pillow is required. Install with:\n"

--- a/packs/core/.apm/hooks/pre-pr.py
+++ b/packs/core/.apm/hooks/pre-pr.py
@@ -32,6 +32,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 # The work-loop skill ships with `core` but lands under different roots
 # depending on which agent tool the pack was installed for — so probe the

--- a/packs/core/.apm/hooks/pre-pr.py
+++ b/packs/core/.apm/hooks/pre-pr.py
@@ -80,7 +80,7 @@ def _run(label: str, argv: list[str]) -> None:
     fresh adopter tree that hasn't wired a given gate yet doesn't hard-crash.
     """
     try:
-        result = subprocess.run(argv, capture_output=True, text=True, check=False)
+        result = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", check=False)
     except FileNotFoundError:
         # To stderr (not stdout) so a *wired-but-mistyped* tool is visually
         # distinct from a passing check and doesn't scroll past as a ✓.
@@ -115,7 +115,7 @@ def main() -> int:
             for phase in ("implement", "review"):
                 result = subprocess.run(
                     [py, str(loop_cohort), "check", str(spec_dir), "--phase", phase],
-                    capture_output=True, text=True, check=False,
+                    capture_output=True, text=True, encoding="utf-8", check=False,
                 )
                 if result.returncode != 0:
                     if result.stdout:

--- a/packs/core/.apm/hooks/session-start.py
+++ b/packs/core/.apm/hooks/session-start.py
@@ -35,6 +35,10 @@ import sys
 import tomllib
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 USAGE = """\
 Session-start hook: prints knowledge entries as a context block.
 

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -88,12 +88,12 @@ import subprocess
 import sys
 from pathlib import Path
 
-try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
-    import tomllib
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
+    import tomllib
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -90,6 +90,10 @@ from pathlib import Path
 
 try:  # py311+ stdlib; degrade where a layout config exists but tomllib doesn't.
     import tomllib
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ModuleNotFoundError:  # pragma: no cover - py<3.11
     tomllib = None  # type: ignore[assignment]
 

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -50,6 +50,10 @@ import tempfile
 from collections import defaultdict
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 TEMPLATE_PATH = SCRIPT_DIR.parent / "assets" / "state.json"
 

--- a/packs/desk-research/.apm/skills/desk-research/scripts/arxiv-retriever.py
+++ b/packs/desk-research/.apm/skills/desk-research/scripts/arxiv-retriever.py
@@ -26,6 +26,10 @@ import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 ARXIV_API = "https://export.arxiv.org/api/query"
 ATOM_NS = "{http://www.w3.org/2005/Atom}"
 

--- a/packs/desk-research/.apm/skills/desk-research/scripts/perplexity-retriever.py
+++ b/packs/desk-research/.apm/skills/desk-research/scripts/perplexity-retriever.py
@@ -32,6 +32,10 @@ import sys
 import urllib.error
 import urllib.request
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 PERPLEXITY_API = "https://api.perplexity.ai/chat/completions"
 DEFAULT_MODEL = "sonar"
 

--- a/packs/figma/.apm/skills/figma/scripts/_client.py
+++ b/packs/figma/.apm/skills/figma/scripts/_client.py
@@ -15,7 +15,6 @@ Rate limits: Figma documents per-endpoint tiers (Tier 1 ≈ generous, Tier 2
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import secrets
 from dataclasses import dataclass
@@ -112,6 +111,7 @@ class FigmaClient:
             timeout=timeout_s,
             follow_redirects=False,
         )
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         self._sem = asyncio.Semaphore(concurrency)
 
     async def __aenter__(self) -> "FigmaClient":
@@ -141,6 +141,7 @@ class FigmaClient:
                     )
                 except httpx.TransportError as exc:
                     last_exc = exc
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(self._backoff(attempt))
                     continue
 
@@ -176,6 +177,7 @@ class FigmaClient:
                         "HTTP %s on %s — retrying in %.1fs",
                         resp.status_code, path, delay,
                     )
+                    import asyncio  # noqa: PLC0415 — lazy, cached after __init__
                     await asyncio.sleep(delay)
                     continue
                 if resp.status_code >= 400:

--- a/packs/figma/.apm/skills/figma/scripts/figma.py
+++ b/packs/figma/.apm/skills/figma/scripts/figma.py
@@ -36,7 +36,6 @@ namespace.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import json
 import logging
 import re
@@ -883,6 +882,7 @@ def main(argv: list[str] | None = None) -> int:
     # Exception` deliberately does NOT catch SystemExit (input-validation
     # raises) or KeyboardInterrupt (BaseException) — those pass through.
     try:
+        import asyncio  # lazy: avoids asyncio IOCP probe on Windows before --help runs
         return asyncio.run(_dispatch(args))
     except AuthError as exc:
         sys.stderr.write(f"{exc}\n")

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -27,6 +27,10 @@ import shutil
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DOCS = REPO_ROOT / "docs-site" / "src" / "content" / "docs"
 GITHUB_BASE = "https://github.com/eugenelim/agent-ready-repo/blob/main"

--- a/tools/catalogue/pre_pr_catalogue.py
+++ b/tools/catalogue/pre_pr_catalogue.py
@@ -20,6 +20,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 # tools/catalogue/ → tools/ → repo root
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _AGENTBUNDLE_PATH = str(_REPO_ROOT / "packages" / "agentbundle")

--- a/tools/catalogue/pre_pr_catalogue.py
+++ b/tools/catalogue/pre_pr_catalogue.py
@@ -60,7 +60,7 @@ def _run(label: str, argv: list[str]) -> None:
     ``_run`` does **not** skip on a missing tool — a deleted catalogue linter
     must fail loud, not silently pass. Do not "unify" the two `_run`s: that
     would make a dropped catalogue check go green (a real regression)."""
-    result = subprocess.run(argv, capture_output=True, text=True, check=False)
+    result = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", check=False)
     if result.returncode != 0:
         if result.stdout:
             sys.stdout.write(result.stdout)

--- a/tools/catalogue/publish_claude_plugins.py
+++ b/tools/catalogue/publish_claude_plugins.py
@@ -21,6 +21,10 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 DIST_DIR = Path("dist/claude-plugins")
 BRANCH = "claude-plugins-dist"
 EXCLUDE = {"catalogue-curation"}  # operator-only pack

--- a/tools/check-xd-chain.py
+++ b/tools/check-xd-chain.py
@@ -34,6 +34,10 @@ import re
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 # ── Chain definition ──────────────────────────────────────────────────────────
 

--- a/tools/hooks/pre-pr.py
+++ b/tools/hooks/pre-pr.py
@@ -32,6 +32,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 # The work-loop skill ships with `core` but lands under different roots
 # depending on which agent tool the pack was installed for — so probe the

--- a/tools/hooks/pre-pr.py
+++ b/tools/hooks/pre-pr.py
@@ -80,7 +80,7 @@ def _run(label: str, argv: list[str]) -> None:
     fresh adopter tree that hasn't wired a given gate yet doesn't hard-crash.
     """
     try:
-        result = subprocess.run(argv, capture_output=True, text=True, check=False)
+        result = subprocess.run(argv, capture_output=True, text=True, encoding="utf-8", check=False)
     except FileNotFoundError:
         # To stderr (not stdout) so a *wired-but-mistyped* tool is visually
         # distinct from a passing check and doesn't scroll past as a ✓.
@@ -115,7 +115,7 @@ def main() -> int:
             for phase in ("implement", "review"):
                 result = subprocess.run(
                     [py, str(loop_cohort), "check", str(spec_dir), "--phase", phase],
-                    capture_output=True, text=True, check=False,
+                    capture_output=True, text=True, encoding="utf-8", check=False,
                 )
                 if result.returncode != 0:
                     if result.stdout:

--- a/tools/hooks/session-start.py
+++ b/tools/hooks/session-start.py
@@ -35,6 +35,10 @@ import sys
 import tomllib
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 USAGE = """\
 Session-start hook: prints knowledge entries as a context block.
 

--- a/tools/lint-agent-artifacts.py
+++ b/tools/lint-agent-artifacts.py
@@ -45,12 +45,12 @@ import re
 import subprocess
 import sys
 
-try:
-    import yaml
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:
+    import yaml
 except ImportError as exc:  # pragma: no cover — env-setup failure path
     print(
         "✖ This linter requires PyYAML. Install with: "

--- a/tools/lint-agent-artifacts.py
+++ b/tools/lint-agent-artifacts.py
@@ -47,6 +47,10 @@ import sys
 
 try:
     import yaml
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ImportError as exc:  # pragma: no cover — env-setup failure path
     print(
         "✖ This linter requires PyYAML. Install with: "

--- a/tools/lint-agents-md.py
+++ b/tools/lint-agents-md.py
@@ -24,6 +24,10 @@ import time
 import tomllib
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 MAX_ROOT_LINES = 250
 MAX_SUB_LINES = 150
 STALE_DAYS = 180  # warn-only threshold

--- a/tools/lint-experience-agnostic.py
+++ b/tools/lint-experience-agnostic.py
@@ -41,6 +41,10 @@ import re
 import subprocess
 import sys
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 def _repo_root() -> pathlib.Path:
     try:

--- a/tools/lint-knowledge-surface-parity.py
+++ b/tools/lint-knowledge-surface-parity.py
@@ -42,6 +42,10 @@ import re
 import subprocess
 import sys
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 CANONICAL_AREAS = frozenset({1, 2, 3, 4, 5, 6, 7, 8})
 
 # role -> (env override, default repo-relative path, expected area set). The

--- a/tools/lint-knowledge.py
+++ b/tools/lint-knowledge.py
@@ -18,6 +18,10 @@ import re
 import subprocess
 import sys
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 def _repo_root() -> pathlib.Path:
     try:

--- a/tools/lint-skill-spec.py
+++ b/tools/lint-skill-spec.py
@@ -34,12 +34,12 @@ import subprocess
 import sys
 import tomllib
 
-try:
-    import yaml
-
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+try:
+    import yaml
 except ImportError as exc:  # pragma: no cover — env-setup failure path
     print(
         "✖ This linter requires PyYAML. Install with: "

--- a/tools/lint-skill-spec.py
+++ b/tools/lint-skill-spec.py
@@ -36,6 +36,10 @@ import tomllib
 
 try:
     import yaml
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 except ImportError as exc:  # pragma: no cover — env-setup failure path
     print(
         "✖ This linter requires PyYAML. Install with: "

--- a/tools/lint_credentialed_skills.py
+++ b/tools/lint_credentialed_skills.py
@@ -34,6 +34,10 @@ import pathlib
 import re
 import sys
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 root = pathlib.Path(sys.argv[1]).resolve()
 
 # --- Broker-agnostic constants ---------------------------------------

--- a/tools/llm-judge-cross-pack-eval.py
+++ b/tools/llm-judge-cross-pack-eval.py
@@ -45,6 +45,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -30,6 +30,10 @@ import sys
 from pathlib import Path
 from typing import Callable
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 # tools/repo/ → tools/ → repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # Make packages/agentbundle importable in-process (for any future in-process use).

--- a/tools/repo/check_release_impact.py
+++ b/tools/repo/check_release_impact.py
@@ -14,6 +14,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Paths whose changes imply a public interface change → a release is required.

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -22,6 +22,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 def _repo_root() -> Path:
     try:

--- a/tools/test-check-contract-drift.py
+++ b/tools/test-check-contract-drift.py
@@ -24,6 +24,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 CHECKER = REPO_ROOT / "tools" / "check-contract-drift.py"
 

--- a/tools/test-check-xd-chain.py
+++ b/tools/test-check-xd-chain.py
@@ -28,6 +28,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 CHECKER = REPO_ROOT / "tools" / "check-xd-chain.py"
 

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -20,6 +20,10 @@ import sys
 
 import yaml
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-security.yml"
 

--- a/tools/test-lint-catalogue-seeds.py
+++ b/tools/test-lint-catalogue-seeds.py
@@ -23,6 +23,10 @@ import tempfile
 import textwrap
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 _LINT = Path(__file__).resolve().parent / "lint-catalogue-seeds.py"
 
 # A blocklisted catalogue string the lint flags in any enforced seed. The

--- a/tools/test-lint-credentialed-skills.py
+++ b/tools/test-lint-credentialed-skills.py
@@ -16,6 +16,10 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LINTER = REPO_ROOT / "tools" / "lint_credentialed_skills.py"
 

--- a/tools/test-lint-experience-agnostic.py
+++ b/tools/test-lint-experience-agnostic.py
@@ -23,6 +23,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 LINTER = REPO_ROOT / "tools" / "lint-experience-agnostic.py"
 

--- a/tools/test-lint-knowledge-surface-parity.py
+++ b/tools/test-lint-knowledge-surface-parity.py
@@ -33,6 +33,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 LINTER = REPO_ROOT / "tools" / "lint-knowledge-surface-parity.py"
 

--- a/tools/test-lint-profiles.py
+++ b/tools/test-lint-profiles.py
@@ -26,6 +26,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 LINTER = REPO_ROOT / "tools" / "lint-profiles.py"
 

--- a/tools/test-lint-skill-spec.py
+++ b/tools/test-lint-skill-spec.py
@@ -37,6 +37,10 @@ import tempfile
 import textwrap
 from typing import Iterable
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 LINTER = REPO_ROOT / "tools" / "lint-skill-spec.py"

--- a/tools/test-lint-sso-config.py
+++ b/tools/test-lint-sso-config.py
@@ -17,6 +17,10 @@ import tempfile
 import textwrap
 from pathlib import Path
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 _LINT = Path(__file__).resolve().parent / "lint-sso-config.py"
 
 _VALID = """

--- a/tools/test-llm-judge-cross-pack-eval.py
+++ b/tools/test-llm-judge-cross-pack-eval.py
@@ -26,6 +26,10 @@ import sys
 import types
 import unittest.mock as mock
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 TOOL = REPO_ROOT / "tools" / "llm-judge-cross-pack-eval.py"
 FIXTURES_PATH = (

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -15,6 +15,10 @@ import sys
 
 import yaml
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pack-evals.yml"
 

--- a/tools/test-run-pack-evals.py
+++ b/tools/test-run-pack-evals.py
@@ -21,6 +21,10 @@ import subprocess
 import sys
 import tempfile
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "tools" / "run-pack-evals.py"
 

--- a/tools/validate-claude-plugin-manifests.py
+++ b/tools/validate-claude-plugin-manifests.py
@@ -27,6 +27,10 @@ sys.path.insert(0, str(REPO_ROOT / "packages" / "agentbundle"))
 from agentbundle.build.main import _read_bundled  # noqa: E402
 from agentbundle.build.validate import validate as validate_instance  # noqa: E402
 
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 def _load_derived_schema() -> dict:
     return json.loads(_read_bundled("plugin-manifest.derived.schema.json"))


### PR DESCRIPTION
## Summary

- Adds the two-line UTF-8 reconfigure guard to every Python script in `tools/` and `packs/` that prints Unicode characters to stdout or stderr
- Documents the rule in `packs/AGENTS.md` under a new **Windows-safe Python scripts** section
- Fixes the pre-existing Gate A — agentbundle tests (windows-latest / py3.11) failure caused by `UnicodeEncodeError: 'charmap' codec can't encode character`

## Files touched

**tools/ (31 scripts)**
`build-site.py`, `check-xd-chain.py`, `hooks/pre-pr.py`, `hooks/session-start.py`, `lint-agent-artifacts.py`, `lint-agents-md.py`, `lint-experience-agnostic.py`, `lint-knowledge-surface-parity.py`, `lint-knowledge.py`, `lint-skill-spec.py`, `lint_credentialed_skills.py`, `llm-judge-cross-pack-eval.py`, `repo/build_gate_chain.py`, `repo/check_release_impact.py`, `test-all.py`, `test-check-contract-drift.py`, `test-check-xd-chain.py`, `test-ci-security-workflow.py`, `test-lint-catalogue-seeds.py`, `test-lint-credentialed-skills.py`, `test-lint-experience-agnostic.py`, `test-lint-knowledge-surface-parity.py`, `test-lint-profiles.py`, `test-lint-skill-spec.py`, `test-lint-sso-config.py`, `test-llm-judge-cross-pack-eval.py`, `test-pack-evals-workflow.py`, `test-run-pack-evals.py`, `validate-claude-plugin-manifests.py`, `catalogue/pre_pr_catalogue.py`, `catalogue/publish_claude_plugins.py`

**packs/ (9 scripts)**
`catalogue-curation/.apm/skills/assimilate-primitive/scripts/ssrf_check.py`, `catalogue-curation/.apm/skills/assimilate-repo/scripts/ssrf_check.py`, `converters/.apm/skills/file-to-markdown/scripts/split_image.py`, `core/.apm/hooks/pre-pr.py`, `core/.apm/hooks/session-start.py`, `core/.apm/skills/work-loop/scripts/lint-traceability.py`, `core/.apm/skills/work-loop/scripts/loop-cohort.py`, `desk-research/.apm/skills/desk-research/scripts/arxiv-retriever.py`, `desk-research/.apm/skills/desk-research/scripts/perplexity-retriever.py`

**docs**
`packs/AGENTS.md` — new **Windows-safe Python scripts** section

## Guard applied

```python
# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
sys.stdout.reconfigure(encoding="utf-8", errors="strict")
sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
```

Placed immediately after the last `import` statement in the module preamble, before any `print()` call. `errors="strict"` on stdout surfaces encoding bugs immediately; `errors="backslashreplace"` on stderr prevents diagnostic messages from being lost.

## What was NOT touched

Scripts in `packs/atlassian/`, `packs/figma/`, and `packs/linear/` already had a reconfigure guard (different form) and were left as-is.