### PR TITLE
fix(ci): add pytest.importorskip guard for httpx in test_linear_primitive

### DIFF
--- a/packages/agentbundle/tests/test_linear_primitive.py
+++ b/packages/agentbundle/tests/test_linear_primitive.py
@@ -15,8 +15,9 @@ import sys
 import types
 from pathlib import Path
 
-import httpx
 import pytest
+
+httpx = pytest.importorskip("httpx")
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LINEAR_SCRIPT = (


### PR DESCRIPTION
## Summary

- Gate H pre-release test suite runs `pytest tests/ agentbundle/build/tests/ -q` without optional extras installed
- `tests/test_linear_primitive.py` has a bare top-level `import httpx` that crashes test collection before any test runs
- Replace with `pytest.importorskip("httpx")` so the module is skipped cleanly when httpx is absent

## Test plan
- [ ] Gate H will now skip `test_linear_primitive.py` cleanly when httpx is not installed
- [ ] No change to test behavior when httpx is installed (all tests still run)