### PR TITLE
fix(ci): install credbroker + lint extra in Gate H pre-release test suite

### DIFF
--- a/.github/workflows/release-agentbundle.yml
+++ b/.github/workflows/release-agentbundle.yml
@@ -114,8 +114,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install agentbundle (editable) + pytest
-        run: pip install -e packages/agentbundle pytest
+      - name: Install agentbundle (editable) + optional extras + pytest
+        run: pip install -e 'packages/agentbundle[lint]' -e packages/credbroker pytest
 
       - name: Full agentbundle test suite (Gate H pre-publish)
         working-directory: packages/agentbundle


### PR DESCRIPTION
## Summary

- Gate H ran `pip install -e packages/agentbundle pytest` (no optional extras)
- Tests needing PyYAML (`test_lint_agent_artifacts_metadata_auth.py`) and credbroker (`test_credential_setup_skill.py`, `test_credential_user_scope_invocation.py`) were failing at collection time
- Fix: install `agentbundle[lint]` (brings PyYAML) and `credbroker` (local editable install)

## Test plan
- [ ] Gate H passes on the next tag push