### PR TITLE
fix(agentbundle): upgrade --all blocked for legacy 'agent-ready-repo' sentinel sources

### DIFF
--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -217,8 +217,9 @@ def _run_source_version_preflight(
     for row in rows:
         raw_source = row.pack_state.source  # type: ignore[attr-defined]
         cs = canonicalize_source(raw_source)
-        if cs is None and raw_source is None:
-            # Old install: source was never recorded. Fall back to the 5-layer
+        if cs is None and (raw_source is None or raw_source == "agent-ready-repo"):
+            # Old install: source was never recorded (None) or was stored as the
+            # legacy "agent-ready-repo" sentinel. Fall back to the 5-layer
             # default chain — same resolution used by fresh installs — so pre-
             # source-recording packs can still be upgraded.
             config_source = getattr(user_config, "source", None) if user_config else None

--- a/packages/agentbundle/tests/unit/test_upgrade_bulk_all.py
+++ b/packages/agentbundle/tests/unit/test_upgrade_bulk_all.py
@@ -38,6 +38,7 @@ from agentbundle.commands.upgrade import (
     _run_source_version_preflight,
     _was_dist_tree_install,
 )
+from agentbundle.catalogue import CatalogueError
 from agentbundle.config import ConfigError, PackState, State
 
 
@@ -285,9 +286,14 @@ def test_classify_row_cross_consistency_with_list_installed_semantics():
 
 
 def test_preflight_source_unknown(tmp_path):
-    """Row with source='agent-ready-repo' gets status=unknown, source-unknown."""
+    """Row with source='agent-ready-repo' gets status=unknown, source-unknown
+    when the default-chain fallback also fails."""
     state = _make_state([("core", "claude-code", "agent-ready-repo", "0.13.6")])
-    rows, _ = _run_source_version_preflight(state, scope="repo", root=tmp_path)
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        rows, _ = _run_source_version_preflight(state, scope="repo", root=tmp_path)
     assert rows[0].status == "unknown"
     assert rows[0].status_reason == "source-unknown"
     assert rows[0]._projection is None
@@ -545,14 +551,24 @@ def test_blocked_preflight_all_outcomes_blocked(tmp_path):
     _setup_state(tmp_path, [
         ("core", "claude-code", "agent-ready-repo", "0.13.6"),  # unknown (source-unknown)
     ])
-    result = _run_all_capture(_make_args(scope="repo", yes=True), tmp_path)
+    # "agent-ready-repo" triggers the default-chain fallback; mock it to fail so
+    # the row is still source-unknown (no default configured in test env).
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        result = _run_all_capture(_make_args(scope="repo", yes=True), tmp_path)
     assert result.exit_code != 0
     assert all(r.outcome == "blocked" for r in result.rows)
 
 
 def test_dry_run_blocked_returns_nonzero(tmp_path):
     _setup_state(tmp_path, [("core", "claude-code", "agent-ready-repo", "0.13.6")])
-    result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
     assert result.exit_code != 0
 
 
@@ -956,7 +972,11 @@ def test_redact_credentials_git_plus_https():
 def test_table_output_headers_present(tmp_path):
     """Table output must include PACK, ADAPTER, STATUS, OUTCOME columns (AC29)."""
     _setup_state(tmp_path, [("core", "claude-code", "agent-ready-repo", "0.13.6")])
-    result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
     output = result.stdout + result.stderr
     assert "PACK" in output or "core" in output
 
@@ -972,19 +992,29 @@ def test_table_unicode_identifier(tmp_path):
     # Create an empty state file so _run_all doesn't fail with FileNotFoundError
     state_path = tmp_path / ".agentbundle-state.toml"
     state_path.write_text('schema-version = "0.4"\n', encoding="utf-8")
-    with patch("agentbundle.commands.upgrade.load_state", return_value=state):
+    with (
+        patch("agentbundle.commands.upgrade.load_state", return_value=state),
+        patch(
+            "agentbundle.source_defaults.resolve_default_source",
+            side_effect=CatalogueError("no default configured"),
+        ),
+    ):
         result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
     assert "núcleo" in result.stdout or "núcleo" in result.stderr
 
 
 def test_table_long_source_truncated(tmp_path):
     """AC35: Long source URIs are truncated gracefully."""
-    long_source = "agent-ready-repo"  # canonicalize_source -> None, but test the table display
+    long_source = "agent-ready-repo"  # canonicalize_source -> None; triggers default-chain fallback
     state = _make_state([("core", "claude-code", long_source, "0.13.6")])
     _write_state_toml(tmp_path, state)
-    result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        result = _run_all_capture(_make_args(scope="repo", dry_run=True), tmp_path)
     # Should not raise; output produced
-    assert result.exit_code != 0  # blocked (source-unknown)
+    assert result.exit_code != 0  # blocked (source-unknown — default chain failed)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_upgrade_source_inference.py
+++ b/packages/agentbundle/tests/unit/test_upgrade_source_inference.py
@@ -112,3 +112,54 @@ def test_source_present_unchanged():
     # canonical_source must be derived from the pack's recorded source
     assert row.canonical_source is not None
     assert "example.com" in row.canonical_source
+
+
+# ---------------------------------------------------------------------------
+# Test 4: source="agent-ready-repo" (legacy sentinel) + default chain succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_sentinel_source_infers_from_default_chain():
+    """The legacy 'agent-ready-repo' sentinel is treated the same as None —
+    inference via the 5-layer default chain, not an immediate source-unknown block.
+    """
+    state = _make_state(source="agent-ready-repo")
+
+    mock_resolve_cat = MagicMock(side_effect=CatalogueError("catalogue not found"))
+
+    with (
+        patch(
+            "agentbundle.source_defaults.resolve_default_source",
+            return_value="https://example.com/catalogue.toml",
+        ),
+        patch("agentbundle.commands.upgrade.resolve_catalogue", mock_resolve_cat),
+    ):
+        rows, _ = _run_source_version_preflight(state, scope="user", root=None)
+
+    row = rows[0]
+    assert row.canonical_source is not None, "canonical_source must be set when inference succeeds"
+    assert row.status_reason != "source-unknown", (
+        f"expected inference to succeed; got status_reason={row.status_reason!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: source="agent-ready-repo" (legacy sentinel) + default chain raises
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_sentinel_source_default_chain_fails_marks_unknown():
+    """When source is the legacy sentinel and resolve_default_source raises,
+    the row is marked status='unknown', status_reason='source-unknown'."""
+    state = _make_state(source="agent-ready-repo")
+
+    with patch(
+        "agentbundle.source_defaults.resolve_default_source",
+        side_effect=CatalogueError("no default configured"),
+    ):
+        rows, _ = _run_source_version_preflight(state, scope="user", root=None)
+
+    row = rows[0]
+    assert row.status == "unknown"
+    assert row.status_reason == "source-unknown"
+    assert row.canonical_source is None


### PR DESCRIPTION
## Summary

- **Root cause**: `upgrade --all` was blocked for adopters whose packs predate source-provenance recording. The fallback introduced in Wave 2 only fired for `pack_state.source is None`, but old packs stored `source = "agent-ready-repo"` (the pre-provenance sentinel). `canonicalize_source` correctly returns `None` for the sentinel, yet the guard `raw_source is None` was `False` — so the 5-layer default chain was never consulted and every row got `status=unknown` → all blocked.
- **Fix**: Extend the fallback condition to `raw_source is None or raw_source == "agent-ready-repo"`.
- **Tests**: Six existing tests updated (add `resolve_default_source` mock so "blocked" assertions stay valid through the correct path). Two new tests cover sentinel + inference succeeds and sentinel + inference fails.

## Test plan

- [x] `test_upgrade_source_inference.py` — 5 tests pass (includes 2 new sentinel cases)
- [x] `test_upgrade_bulk_all.py` — 72 tests pass
- [x] Full unit suite — 1765 passed, 2 skipped