### PR TITLE
fix(contracts): complete pack schema, add skill/profile schemas, wire taplo, drop lint-skill-spec refs

### DIFF
--- a/.agents/skills/assimilate-primitive/SKILL.md
+++ b/.agents/skills/assimilate-primitive/SKILL.md
@@ -36,7 +36,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    — executable code, not prose — flag it as a higher-scrutiny class and require
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
-   internal lints that apply to the artifact kind (`lint-skill-spec`,
+   internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
    `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses

--- a/.agents/skills/assimilate-primitive/references/ingest-safety.md
+++ b/.agents/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `lint-skill-spec`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/.agents/skills/propose-catalogue-pack/references/pack-shell.md
+++ b/.agents/skills/propose-catalogue-pack/references/pack-shell.md
@@ -27,6 +27,6 @@ it's a first for the catalogue.
 - The per-pack guide home and a changelog entry are follow-on artifacts.
 
 ## Register check
-`lint-packs` + the pack schema validate the shell; `lint-skill-spec` /
+`lint-packs` + the pack schema validate the shell; `agentbundle catalogue lint --deep` /
 `lint-agent-artifacts` validate its primitives. A green run means the shell
 registers.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -68,7 +68,7 @@ Each `SKILL.md` should:
 Every skill in this repo — and every skill an adopter scaffolds from
 this template — is held to the [agentskills.io
 specification](https://agentskills.io/specification). The contract is
-mechanical, enforced by `tools/lint-skill-spec.py`; the linter runs in
+mechanical, enforced by `agentbundle catalogue lint --root . --deep`; the linter runs in
 CI, in the pre-PR hook, and on demand.
 
 ### Blessed layout
@@ -145,9 +145,9 @@ is delegated.
 
 ### Enforcement floor
 
-`tools/lint-skill-spec.py` walks both the projection
+`agentbundle catalogue lint --root . --deep` walks both the projection
 (`.claude/skills/*/SKILL.md`) and the seeds
 (`packs/*/.apm/skills/*/SKILL.md`) so drift between source-of-truth
 and rendered output can't sneak past `make build-check`. Run it
-manually with `python3 tools/lint-skill-spec.py`. The companion
-self-test is `python3 tools/test-lint-skill-spec.py`.
+manually with `agentbundle catalogue lint --root . --deep`. The companion
+self-test is `python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py -v`.

--- a/.claude/skills/assimilate-primitive/SKILL.md
+++ b/.claude/skills/assimilate-primitive/SKILL.md
@@ -36,7 +36,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    — executable code, not prose — flag it as a higher-scrutiny class and require
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
-   internal lints that apply to the artifact kind (`lint-skill-spec`,
+   internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
    `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses

--- a/.claude/skills/assimilate-primitive/references/ingest-safety.md
+++ b/.claude/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `lint-skill-spec`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/.claude/skills/propose-catalogue-pack/references/pack-shell.md
+++ b/.claude/skills/propose-catalogue-pack/references/pack-shell.md
@@ -27,6 +27,6 @@ it's a first for the catalogue.
 - The per-pack guide home and a changelog entry are follow-on artifacts.
 
 ## Register check
-`lint-packs` + the pack schema validate the shell; `lint-skill-spec` /
+`lint-packs` + the pack schema validate the shell; `agentbundle catalogue lint --deep` /
 `lint-agent-artifacts` validate its primitives. A green run means the shell
 registers.

--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -129,6 +129,10 @@ jobs:
 
           [pack.adapter-contract]
           version = "0.14"
+
+          [pack.install]
+          default-scope = "repo"
+          allowed-scopes = ["repo"]
           TOML
 
           cat > /tmp/ext-cat/packs/sample-pack/.claude-plugin/plugin.json <<'JSON'

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,11 @@
+[[rule]]
+include = ["catalogue.toml"]
+schema = { path = "docs/contracts/catalogue.schema.json" }
+
+[[rule]]
+include = ["packs/*/pack.toml"]
+schema = { path = "docs/contracts/pack.schema.json" }
+
+[[rule]]
+include = ["profiles/*.toml"]
+schema = { path = "docs/contracts/profile.schema.json" }

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -113,18 +113,9 @@
           }
         },
         "recipes": {
-          "type": "object",
-          "description": "Named recipe map — each key is a recipe identifier, value is the recipe config.",
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["description"],
-            "properties": {
-              "description": {"type": "string"},
-              "steps": {"type": "array", "items": {"type": "string"}},
-              "adapter": {"type": "string"}
-            }
-          }
+          "type": "array",
+          "description": "Named catalogue recipes this pack participates in.",
+          "items": {"type": "string"}
         },
         "dependencies": {
           "type": "object",

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -86,17 +86,17 @@
             }
           },
           "if": {
-            "properties": {"default-scope": {"const": "user"}},
+            "properties": {"default-scope": {"enum": ["user"]}},
             "required": ["default-scope"]
           },
           "then": {
             "properties": {
-              "allowed-scopes": {"contains": {"const": "user"}}
+              "allowed-scopes": {"contains": {"enum": ["user"]}}
             }
           },
           "else": {
             "properties": {
-              "allowed-scopes": {"contains": {"const": "repo"}}
+              "allowed-scopes": {"contains": {"enum": ["repo"]}}
             }
           }
         },
@@ -253,7 +253,18 @@
         }
       },
       "if": {
-        "required": ["adapter-contract"]
+        "required": ["adapter-contract"],
+        "properties": {
+          "adapter-contract": {
+            "type": "object",
+            "required": ["version"],
+            "properties": {
+              "version": {
+                "pattern": "^0\\.([2-9]|[1-9][0-9])|^[1-9]"
+              }
+            }
+          }
+        }
       },
       "then": {
         "required": ["install"]

--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -1,9 +1,15 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "pack.schema.json",
+  "title": "PackConfig",
+  "description": "JSON Schema for pack.toml — pack metadata and adapter-contract configuration.",
   "type": "object",
+  "additionalProperties": false,
   "required": ["pack"],
   "properties": {
     "pack": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["name", "version"],
       "properties": {
         "name": {"type": "string"},
@@ -13,6 +19,7 @@
         "display_name": {"type": "string"},
         "license": {"type": "string"},
         "catalogue": {"type": "string"},
+        "lint-seeds": {"type": "boolean"},
         "categories": {
           "type": "array",
           "items": {"type": "string"},
@@ -27,6 +34,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "required": ["name"],
             "properties": {
               "name": {"type": "string"},
@@ -37,6 +45,7 @@
         },
         "links": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "homepage": {"type": "string"},
             "repository": {"type": "string"},
@@ -46,24 +55,86 @@
             "icon": {"type": "string"}
           }
         },
-        "metadata": {"type": "object"},
+        "metadata": {
+          "type": "object",
+          "description": "Open extension table — additionalProperties intentionally unrestricted."
+        },
         "adapter-contract": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "version": {"type": "string"}
           }
         },
+        "install": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["default-scope"],
+          "properties": {
+            "default-scope": {"enum": ["repo", "user"]},
+            "allowed-scopes": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"enum": ["repo", "user"]}
+            },
+            "user-scope-hooks": {"type": "boolean"},
+            "allowed-adapters": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"type": "string"}
+            }
+          },
+          "if": {
+            "properties": {"default-scope": {"const": "user"}},
+            "required": ["default-scope"]
+          },
+          "then": {
+            "properties": {
+              "allowed-scopes": {"contains": {"const": "user"}}
+            }
+          },
+          "else": {
+            "properties": {
+              "allowed-scopes": {"contains": {"const": "repo"}}
+            }
+          }
+        },
+        "evals": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Tier-A activation eval coverage — lists every user-triggered skill that ships evals/eval_queries.json.",
+          "properties": {
+            "skills": {
+              "type": "array",
+              "items": {"type": "string"},
+              "uniqueItems": true
+            }
+          }
+        },
         "recipes": {
-          "type": "array",
-          "items": {"type": "string"}
+          "type": "object",
+          "description": "Named recipe map — each key is a recipe identifier, value is the recipe config.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["description"],
+            "properties": {
+              "description": {"type": "string"},
+              "steps": {"type": "array", "items": {"type": "string"}},
+              "adapter": {"type": "string"}
+            }
+          }
         },
         "dependencies": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "required": {
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -76,6 +147,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -88,6 +160,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -100,12 +173,14 @@
         },
         "adaptation": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "infer-from": {"type": "string"},
             "substitutions": {
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "marker": {"type": "string"},
                   "infer-from": {"type": "string"}
@@ -116,6 +191,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "target": {"type": "string"},
                   "section-marker": {"type": "string"},
@@ -134,26 +210,31 @@
         },
         "layout": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "repo": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "parent": {"type": "string"},
-                "template": {"type": "string"}
+                "template": {"type": "string"},
+                "output_dir": {"type": "string"}
               }
             },
             "user": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "parent": {"type": "string"},
-                "template": {"type": "string"}
+                "template": {"type": "string"},
+                "output_dir": {"type": "string"}
               }
             }
           }
         },
         "first-value": {
           "type": "object",
-          "description": "Pack first-value contract (RFC-0064 Amendment #4). Level A required for all packs; Level B required when level-b = true.",
+          "additionalProperties": false,
           "properties": {
             "audience-posture": {"type": "string", "enum": ["non-technical", "mixed", "technical"]},
             "surfaces": {"type": "array", "items": {"type": "string"}},
@@ -168,61 +249,14 @@
             "tutorial": {"type": "string"},
             "writes-to-repo": {"type": "boolean"},
             "safety-gate": {"type": "string"}
-          },
-          "additionalProperties": false
+          }
         }
       },
       "if": {
-        "properties": {
-          "adapter-contract": {
-            "type": "object",
-            "properties": {"version": {"enum": ["0.2", "0.3", "0.6"]}},
-            "required": ["version"]
-          }
-        },
         "required": ["adapter-contract"]
       },
       "then": {
-        "required": ["install"],
-        "properties": {
-          "install": {
-            "type": "object",
-            "required": ["default-scope"],
-            "properties": {
-              "default-scope": {"enum": ["repo", "user"]},
-              "allowed-scopes": {
-                "type": "array",
-                "minItems": 1,
-                "items": {"enum": ["repo", "user"]}
-              },
-              "user-scope-hooks": {"type": "boolean"},
-              "allowed-adapters": {
-                "type": "array",
-                "minItems": 1,
-                "uniqueItems": true,
-                "items": {"type": "string"}
-              }
-            },
-            "if": {
-              "properties": {"default-scope": {"enum": ["user"]}},
-              "required": ["default-scope"]
-            },
-            "then": {
-              "properties": {
-                "allowed-scopes": {
-                  "contains": {"enum": ["user"]}
-                }
-              }
-            },
-            "else": {
-              "properties": {
-                "allowed-scopes": {
-                  "contains": {"enum": ["repo"]}
-                }
-              }
-            }
-          }
-        }
+        "required": ["install"]
       }
     }
   }

--- a/docs/contracts/profile.schema.json
+++ b/docs/contracts/profile.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "profile.schema.json",
+  "title": "ProfileConfig",
+  "description": "JSON Schema for profiles/*.toml — pack-profile install bundles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["scope", "description", "packs"],
+  "properties": {
+    "scope": {
+      "type": "string",
+      "enum": ["user", "repo"],
+      "description": "Install scope — all packs in the profile must allow this scope (lint-profiles.py scope-homogeneous invariant)."
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line description of the profile's intended use case."
+    },
+    "packs": {
+      "type": "array",
+      "description": "Ordered list of packs to install — deps-first ordered (dependencies before dependents).",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pack"],
+        "properties": {
+          "pack": {
+            "type": "string",
+            "description": "Pack name as it appears in the catalogue."
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/skill.schema.json
+++ b/docs/contracts/skill.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "skill.schema.json",
+  "title": "SkillFrontmatter",
+  "description": "JSON Schema for SKILL.md frontmatter — the closed key set enforced by agentbundle catalogue lint --deep.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Kebab-case skill identifier (1–64 chars).",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "description": {
+      "type": "string",
+      "description": "Trigger surface shown to IDEs — hard cap 1024 chars (Kiro truncates at byte boundary).",
+      "maxLength": 1024
+    },
+    "license": {
+      "type": "string"
+    },
+    "compatibility": {
+      "type": "object",
+      "description": "Open object — adapter-compatibility constraints declared by the skill."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Open extension table — any additional frontmatter keys must be nested here."
+    },
+    "allowed-tools": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Explicit tool allowlist for this skill."
+    }
+  }
+}

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/).
 
 
+## [agentbundle][Unreleased]
+
+### Changed
+
+- **Bundled `pack.schema.json` tightened** — added `additionalProperties: false` throughout, `$schema`/`$id` headers, and missing tables (`evals`, `lint-seeds`, `display_name`, `output_dir`, `allowed-adapters`). Packs with `adapter-contract.version >= 0.2` now require `[pack.install]` to pass schema validation.
+
+---
+
 ## [agentbundle][0.17.0] — 2026-07-25
 
 ### Added

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -113,18 +113,9 @@
           }
         },
         "recipes": {
-          "type": "object",
-          "description": "Named recipe map — each key is a recipe identifier, value is the recipe config.",
-          "additionalProperties": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["description"],
-            "properties": {
-              "description": {"type": "string"},
-              "steps": {"type": "array", "items": {"type": "string"}},
-              "adapter": {"type": "string"}
-            }
-          }
+          "type": "array",
+          "description": "Named catalogue recipes this pack participates in.",
+          "items": {"type": "string"}
         },
         "dependencies": {
           "type": "object",

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -1,9 +1,15 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "pack.schema.json",
+  "title": "PackConfig",
+  "description": "JSON Schema for pack.toml — pack metadata and adapter-contract configuration.",
   "type": "object",
+  "additionalProperties": false,
   "required": ["pack"],
   "properties": {
     "pack": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["name", "version"],
       "properties": {
         "name": {"type": "string"},
@@ -13,6 +19,7 @@
         "display_name": {"type": "string"},
         "license": {"type": "string"},
         "catalogue": {"type": "string"},
+        "lint-seeds": {"type": "boolean"},
         "categories": {
           "type": "array",
           "items": {"type": "string"},
@@ -27,6 +34,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "required": ["name"],
             "properties": {
               "name": {"type": "string"},
@@ -37,6 +45,7 @@
         },
         "links": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "homepage": {"type": "string"},
             "repository": {"type": "string"},
@@ -46,24 +55,86 @@
             "icon": {"type": "string"}
           }
         },
-        "metadata": {"type": "object"},
+        "metadata": {
+          "type": "object",
+          "description": "Open extension table — additionalProperties intentionally unrestricted."
+        },
         "adapter-contract": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "version": {"type": "string"}
           }
         },
+        "install": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["default-scope"],
+          "properties": {
+            "default-scope": {"enum": ["repo", "user"]},
+            "allowed-scopes": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"enum": ["repo", "user"]}
+            },
+            "user-scope-hooks": {"type": "boolean"},
+            "allowed-adapters": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"type": "string"}
+            }
+          },
+          "if": {
+            "properties": {"default-scope": {"enum": ["user"]}},
+            "required": ["default-scope"]
+          },
+          "then": {
+            "properties": {
+              "allowed-scopes": {"contains": {"enum": ["user"]}}
+            }
+          },
+          "else": {
+            "properties": {
+              "allowed-scopes": {"contains": {"enum": ["repo"]}}
+            }
+          }
+        },
+        "evals": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Tier-A activation eval coverage — lists every user-triggered skill that ships evals/eval_queries.json.",
+          "properties": {
+            "skills": {
+              "type": "array",
+              "items": {"type": "string"},
+              "uniqueItems": true
+            }
+          }
+        },
         "recipes": {
-          "type": "array",
-          "items": {"type": "string"}
+          "type": "object",
+          "description": "Named recipe map — each key is a recipe identifier, value is the recipe config.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["description"],
+            "properties": {
+              "description": {"type": "string"},
+              "steps": {"type": "array", "items": {"type": "string"}},
+              "adapter": {"type": "string"}
+            }
+          }
         },
         "dependencies": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "required": {
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -76,6 +147,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -88,6 +160,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["catalogue", "pack", "version"],
                 "properties": {
                   "catalogue": {"type": "string"},
@@ -100,12 +173,14 @@
         },
         "adaptation": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "infer-from": {"type": "string"},
             "substitutions": {
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "marker": {"type": "string"},
                   "infer-from": {"type": "string"}
@@ -116,6 +191,7 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "target": {"type": "string"},
                   "section-marker": {"type": "string"},
@@ -134,26 +210,31 @@
         },
         "layout": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "repo": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "parent": {"type": "string"},
-                "template": {"type": "string"}
+                "template": {"type": "string"},
+                "output_dir": {"type": "string"}
               }
             },
             "user": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "parent": {"type": "string"},
-                "template": {"type": "string"}
+                "template": {"type": "string"},
+                "output_dir": {"type": "string"}
               }
             }
           }
         },
         "first-value": {
           "type": "object",
-          "description": "Pack first-value contract (RFC-0064 Amendment #4). Level A required for all packs; Level B required when level-b = true.",
+          "additionalProperties": false,
           "properties": {
             "audience-posture": {"type": "string", "enum": ["non-technical", "mixed", "technical"]},
             "surfaces": {"type": "array", "items": {"type": "string"}},
@@ -168,61 +249,25 @@
             "tutorial": {"type": "string"},
             "writes-to-repo": {"type": "boolean"},
             "safety-gate": {"type": "string"}
-          },
-          "additionalProperties": false
+          }
         }
       },
       "if": {
+        "required": ["adapter-contract"],
         "properties": {
           "adapter-contract": {
             "type": "object",
-            "properties": {"version": {"enum": ["0.2", "0.3", "0.6"]}},
-            "required": ["version"]
-          }
-        },
-        "required": ["adapter-contract"]
-      },
-      "then": {
-        "required": ["install"],
-        "properties": {
-          "install": {
-            "type": "object",
-            "required": ["default-scope"],
+            "required": ["version"],
             "properties": {
-              "default-scope": {"enum": ["repo", "user"]},
-              "allowed-scopes": {
-                "type": "array",
-                "minItems": 1,
-                "items": {"enum": ["repo", "user"]}
-              },
-              "user-scope-hooks": {"type": "boolean"},
-              "allowed-adapters": {
-                "type": "array",
-                "minItems": 1,
-                "uniqueItems": true,
-                "items": {"type": "string"}
-              }
-            },
-            "if": {
-              "properties": {"default-scope": {"enum": ["user"]}},
-              "required": ["default-scope"]
-            },
-            "then": {
-              "properties": {
-                "allowed-scopes": {
-                  "contains": {"enum": ["user"]}
-                }
-              }
-            },
-            "else": {
-              "properties": {
-                "allowed-scopes": {
-                  "contains": {"enum": ["repo"]}
-                }
+              "version": {
+                "pattern": "^0\\.([2-9]|[1-9][0-9])|^[1-9]"
               }
             }
           }
         }
+      },
+      "then": {
+        "required": ["install"]
       }
     }
   }

--- a/packs/catalogue-curation/.apm/skills/assimilate-primitive/SKILL.md
+++ b/packs/catalogue-curation/.apm/skills/assimilate-primitive/SKILL.md
@@ -36,7 +36,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    — executable code, not prose — flag it as a higher-scrutiny class and require
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
-   internal lints that apply to the artifact kind (`lint-skill-spec`,
+   internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
    `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses

--- a/packs/catalogue-curation/.apm/skills/assimilate-primitive/references/ingest-safety.md
+++ b/packs/catalogue-curation/.apm/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `lint-skill-spec`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/packs/catalogue-curation/.apm/skills/propose-catalogue-pack/references/pack-shell.md
+++ b/packs/catalogue-curation/.apm/skills/propose-catalogue-pack/references/pack-shell.md
@@ -27,6 +27,6 @@ it's a first for the catalogue.
 - The per-pack guide home and a changelog entry are follow-on artifacts.
 
 ## Register check
-`lint-packs` + the pack schema validate the shell; `lint-skill-spec` /
+`lint-packs` + the pack schema validate the shell; `agentbundle catalogue lint --deep` /
 `lint-agent-artifacts` validate its primitives. A green run means the shell
 registers.

--- a/tools/hooks/README.md
+++ b/tools/hooks/README.md
@@ -73,7 +73,7 @@ Exits non-zero on the first failure; a missing tool is skipped, not fatal.
 
 **This catalogue's own full gate** is the repo-native, never-projected
 `tools/pre-pr-catalogue.py`: it runs the 8 catalogue checks
-(`lint-agents-md`, `lint-agent-artifacts`, `lint-skill-spec`, `lint-knowledge`,
+(`lint-agents-md`, `lint-agent-artifacts`, `agentbundle catalogue lint --deep`, `lint-knowledge`,
 `lint-build`, `lint-catalogue-seeds`, `lint_credentialed_skills`, and the
 `test-lint-credentialed-skills` self-test), then delegates to the shipped
 `pre-pr.py`. `make pre-pr` and `make build-check` run it. See


### PR DESCRIPTION
## Summary

- **pack.schema.json repaired**: added `$schema`/`$id` headers; `additionalProperties: false` throughout; moved `install` from broken `then`-only block to main `properties` (making it work with `additionalProperties: false`); fixed `if/then` condition which only matched versions 0.2/0.3/0.6 but all 20 real packs use 0.8–0.12; added `lint-seeds` boolean, `evals.skills` array, `layout.repo/user.output_dir`, corrected `recipes` type from array-of-strings to named-key object (matching AGENTS.md schema map). Validated against all 20 pack.toml files — all pass.
- **skill.schema.json added**: covers the closed SKILL.md frontmatter key set (`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`) with kebab-case pattern and 1024-char description cap. Validated against 15 real SKILL.md files.
- **profile.schema.json added**: derived from all 4 profiles/*.toml files — `scope` enum, `description`, `packs` array. All 4 profiles pass.
- **.taplo.toml added**: wires the three schemas for `taplo check` in CI.
- **Dead references to `tools/lint-skill-spec.py` removed**: the standalone script was ported into agentbundle in #721. Updated `.claude/skills/README.md` (canonical), pack source skill files in `packs/catalogue-curation/.apm/skills/`, and `tools/hooks/README.md`. Ran `build-self --force` to propagate source changes to `.claude/` and `.agents/` projections. Note: references in frozen ADRs/RFCs/specs left as historical record.

## Not changed

- Frozen docs (ADRs, RFCs, specs, guides) — historical mentions of `lint-skill-spec` left as-is
- `.github/workflows/docs.yml` job named `lint-skill-spec` — the job runs `agentbundle catalogue lint --root . --deep` already (correct); only the job label references the old name
- `tools/test-all.py` label `lint-skill-spec` — correctly invokes `pytest packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py`, not the old script