### PR TITLE
chore(release): agentbundle 0.17.1 — upgrade --all sentinel fix

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.17.1] — 2026-07-25
+
+### Fixed
+
+- **`upgrade --all` no longer blocked for adopters on legacy `"agent-ready-repo"` sentinel sources.**
+  Packs installed before source-provenance tracking was added stored
+  `source = "agent-ready-repo"` in the state file. The 5-layer default-chain
+  fallback introduced in 0.14.0 only fired when `source` was `None`; packs
+  carrying the old sentinel bypassed the fallback and were immediately marked
+  `source-unknown` → all rows blocked. The condition now covers both absent
+  cases (`None` and `"agent-ready-repo"`), so pre-provenance installs resolve
+  through the configured default source and upgrade normally.
+
 ## [0.13.0] — 2026-07-24
 
 ### Added

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.17.0"
+CLI_VERSION = "0.17.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.17.0"
+version = "0.17.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## Summary

- Bumps `agentbundle` to **0.17.1** (patch)
- Single fix: `upgrade --all` blocked for adopters with legacy `"agent-ready-repo"` sentinel sources (landed in #724)
- CHANGELOG entry added

## Test plan

- [x] CI passed on #724 (the fix itself)
- [x] Version bump is the only change here — no new logic