### PR TITLE
chore(privacy): scrub PII from test fixtures; add Privacy rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,16 @@ the `work-loop` skill's *Anti-patterns* section.
 | "I'll grep the codebase as I go." | Verify APIs *before* you start writing, not while you're writing — same rigor as the *Grep to verify a function exists* bullet above. |
 | "I'll match the surrounding code's pattern." | Check [Source of truth](#source-of-truth) first; local style may already conflict with the canonical convention. |
 
+## Privacy
+
+Never commit real personal information — names, email addresses, phone
+numbers, company names, or account identifiers (AAD object IDs, UUIDs)
+— to the repo. Use `example.com`, generic names (`Example User`,
+`Colleague`), and placeholder UUIDs in all code, docs, specs, test
+fixtures, and commit messages. When authoring governance docs (ADRs,
+RFCs, specs), populate author and decider fields from the project's
+established conventions only — do not infer them from session context.
+
 ## When this file is wrong
 
 Flag drift in your PR — don't silently work around it. AGENTS.md vs. reality

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema.py
@@ -277,9 +277,9 @@ categories = ["research", "documentation"]
 keywords = ["osint", "synthesis", "citations"]
 
 [[pack.maintainers]]
-name = "Eugene Lim"
-email = "eugenelim@users.noreply.github.com"
-url = "https://github.com/eugenelim"
+name = "Example User"
+email = "example@example.com"
+url = "https://github.com/example-user"
 
 [pack.links]
 homepage = "https://example.com"

--- a/packages/agentbundle/agentbundle/build/tests/test_plugin_manifest_schema.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_plugin_manifest_schema.py
@@ -169,7 +169,7 @@ class PluginManifestSchemaProjectableSubsetTests(unittest.TestCase):
     # category is marketplace-only — not a valid field in plugin.json (derived schema).
     # It is kept in the source schema's allow-list for hand-authored files only.
     _SUBSET = {
-        "author": {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"},
+        "author": {"name": "Example User", "email": "example@example.com"},
         "license": "Apache-2.0",
         "homepage": "https://example.com",
         "repository": "https://github.com/example/repo",

--- a/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
@@ -34,8 +34,8 @@ categories = ["research", "documentation"]
 keywords = ["osint", "synthesis", "citations"]
 
 [[pack.maintainers]]
-name = "Eugene Lim"
-email = "eugenelim@users.noreply.github.com"
+name = "Example User"
+email = "example@example.com"
 
 [pack.links]
 homepage = "https://example.com"
@@ -59,7 +59,7 @@ class DeriveProjectableSubsetTests(unittest.TestCase):
         self.assertEqual(
             subset,
             {
-                "author": {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"},
+                "author": {"name": "Example User", "email": "example@example.com"},
                 "license": "Apache-2.0",
                 "homepage": "https://example.com",
                 "repository": "https://github.com/example/repo",

--- a/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
+++ b/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
@@ -31,10 +31,10 @@ _PACK_WITH_METADATA = {
         "version": "0.2.0",
         "description": "Research skills.",
         "maintainers": [
-            {"name": "Eugene Lim", "email": "eugenelim@users.noreply.github.com"}
+            {"name": "Example User", "email": "example@example.com"}
         ],
         "links": {
-            "repository": "https://github.com/eugenelim/agent-ready-repo",
+            "repository": "https://github.com/example-org/example-repo",
         },
     }
 }
@@ -45,9 +45,9 @@ _PACK_NAME_ONLY = {
         "name": "research",
         "version": "0.2.0",
         "description": "Research skills.",
-        "maintainers": [{"name": "Eugene Lim"}],
+        "maintainers": [{"name": "Example User"}],
         "links": {
-            "repository": "https://github.com/eugenelim/agent-ready-repo",
+            "repository": "https://github.com/example-org/example-repo",
         },
     }
 }
@@ -83,19 +83,19 @@ class TestDeriveProjectableSubsetAuthor:
         from agentbundle.build.main import derive_projectable_subset
 
         result = derive_projectable_subset(_PACK_WITH_METADATA)
-        assert result["author"]["name"] == "Eugene Lim"
+        assert result["author"]["name"] == "Example User"
 
     def test_author_contains_email_key_when_present(self):
         from agentbundle.build.main import derive_projectable_subset
 
         result = derive_projectable_subset(_PACK_WITH_METADATA)
-        assert result["author"]["email"] == "eugenelim@users.noreply.github.com"
+        assert result["author"]["email"] == "example@example.com"
 
     def test_author_omits_email_key_when_absent(self):
         from agentbundle.build.main import derive_projectable_subset
 
         result = derive_projectable_subset(_PACK_NAME_ONLY)
-        assert result["author"] == {"name": "Eugene Lim"}
+        assert result["author"] == {"name": "Example User"}
         assert "email" not in result["author"]
 
     def test_author_absent_when_no_maintainers(self):
@@ -127,7 +127,7 @@ class TestDeriveProjectableSubsetSource:
         from agentbundle.build.main import derive_projectable_subset
 
         result = derive_projectable_subset(_PACK_WITH_METADATA)
-        assert result["source"]["repo"] == "eugenelim/agent-ready-repo"
+        assert result["source"]["repo"] == "example-org/example-repo"
 
     def test_source_branch_is_dist_branch(self):
         from agentbundle.build.main import derive_projectable_subset

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -209,6 +209,16 @@ the `work-loop` skill's *Anti-patterns* section.
 | "I'll grep the codebase as I go." | Verify APIs *before* you start writing, not while you're writing — same rigor as the *Grep to verify a function exists* bullet above. |
 | "I'll match the surrounding code's pattern." | Check [Source of truth](#source-of-truth) first; local style may already conflict with the canonical convention. |
 
+## Privacy
+
+Never commit real personal information — names, email addresses, phone
+numbers, company names, or account identifiers (AAD object IDs, UUIDs)
+— to the repo. Use `example.com`, generic names (`Example User`,
+`Colleague`), and placeholder UUIDs in all code, docs, specs, test
+fixtures, and commit messages. When authoring governance docs (ADRs,
+RFCs, specs), populate author and decider fields from the project's
+established conventions only — do not infer them from session context.
+
 ## When this file is wrong
 
 Flag drift in your PR — don't silently work around it. AGENTS.md vs. reality


### PR DESCRIPTION
## Summary

- Replaced real committer name and noreply email in 4 test fixture files with generic placeholders (`Example User`, `example@example.com`, `example-org/example-repo`)
- Added `## Privacy` section to root `AGENTS.md` and `packs/core/seeds/AGENTS.md`, instructing agents not to infer personal identifiers from session context and to use only project-established conventions

## Why

Real committer name and noreply email were baked into schema/regression test fixtures — a problem for a public template repo others fork. The `packs/AGENTS.md` already had a Privacy rule but it didn't cover the root or the seed projected to adopters, and it didn't address the session-context inference path.

## Test plan

- [x] All 72 tests in the 4 affected test files pass (`python -m pytest ... -x -q`)
- [x] No personal info remains in any of the 4 test files (verified via grep)

## Deferred

- `new-adr` SKILL.md still says "a name, a GitHub handle, or an email are all valid" for author/decider fields — this actively permits session-context inference. Worth tightening in a follow-up, but the AGENTS.md Privacy rule now provides a higher-priority constraint Claude should see first.