### PR TITLE
chore(privacy): expand Privacy rule to cover all git artifacts and PII categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,13 +199,22 @@ the `work-loop` skill's *Anti-patterns* section.
 
 ## Privacy
 
-Never commit real personal information — names, email addresses, phone
-numbers, company names, or account identifiers (AAD object IDs, UUIDs)
-— to the repo. Use `example.com`, generic names (`Example User`,
-`Colleague`), and placeholder UUIDs in all code, docs, specs, test
-fixtures, and commit messages. When authoring governance docs (ADRs,
-RFCs, specs), populate author and decider fields from the project's
-established conventions only — do not infer them from session context.
+**Never commit personal information to any file in this repo.** This includes:
+- Real names, email addresses, usernames, or account identifiers
+- Org-specific domains, subdomains, or employer hostnames
+- AAD/UUID identifiers tied to real people
+- Device names, profile paths, or user-specific filesystem paths
+- Names of personal service providers or platforms that identify account relationships
+
+Use generic placeholders everywhere: `user@example.com`, `colleague@example.com`,
+`Example User`, `https://mail.yourorg.com/`, `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+`example-service`, `[service type]`.
+
+**This rule covers all git artifacts** — code, comments, docs, specs, commit messages,
+PR titles, PR bodies, and PR comments are permanent record. Never use real service or
+vendor names as examples; use `example-service` or `[service type]` instead. When
+authoring governance docs (ADRs, RFCs, specs), populate author and decider fields from
+the project's established conventions only — do not infer them from session context.
 
 ## When this file is wrong
 

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -211,13 +211,22 @@ the `work-loop` skill's *Anti-patterns* section.
 
 ## Privacy
 
-Never commit real personal information — names, email addresses, phone
-numbers, company names, or account identifiers (AAD object IDs, UUIDs)
-— to the repo. Use `example.com`, generic names (`Example User`,
-`Colleague`), and placeholder UUIDs in all code, docs, specs, test
-fixtures, and commit messages. When authoring governance docs (ADRs,
-RFCs, specs), populate author and decider fields from the project's
-established conventions only — do not infer them from session context.
+**Never commit personal information to any file in this repo.** This includes:
+- Real names, email addresses, usernames, or account identifiers
+- Org-specific domains, subdomains, or employer hostnames
+- AAD/UUID identifiers tied to real people
+- Device names, profile paths, or user-specific filesystem paths
+- Names of personal service providers or platforms that identify account relationships
+
+Use generic placeholders everywhere: `user@example.com`, `colleague@example.com`,
+`Example User`, `https://mail.yourorg.com/`, `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+`example-service`, `[service type]`.
+
+**This rule covers all git artifacts** — code, comments, docs, specs, commit messages,
+PR titles, PR bodies, and PR comments are permanent record. Never use real service or
+vendor names as examples; use `example-service` or `[service type]` instead. When
+authoring governance docs (ADRs, RFCs, specs), populate author and decider fields from
+the project's established conventions only — do not infer them from session context.
 
 ## When this file is wrong
 


### PR DESCRIPTION
## Summary

- Rewrites the `## Privacy` section in root `AGENTS.md` and `packs/core/seeds/AGENTS.md` to match a stronger guardrail shape: explicit bullet list of forbidden categories, concrete placeholder examples, and an explicit call-out that the rule covers all git artifacts (commit messages, PR titles/bodies, PR comments) — not just code and docs.
- Scrubs committer name and noreply email from PR #727 body, which named them as examples of what was removed.

## Why

The previous one-paragraph rule listed some categories but missed org-specific domains, device/path identifiers, and personal service/vendor names. It also didn't call out PRs and commits as in-scope — a gap the #727 body illustrated directly.

## Test plan

- [ ] `AGENTS.md` and `packs/core/seeds/AGENTS.md` Privacy sections are identical in shape
- [ ] No personal info in either file (verify via grep)