### PR TITLE
feat(contracts): add runtime-dependencies schema, skill-manifest schema, and PyPI URLs

### DIFF
--- a/docs/contracts/pack.schema.json
+++ b/docs/contracts/pack.schema.json
@@ -170,6 +170,26 @@
             "safety-gate": {"type": "string"}
           },
           "additionalProperties": false
+        },
+        "runtime-dependencies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ecosystem", "package"],
+            "properties": {
+              "ecosystem": {
+                "type": "string",
+                "enum": ["pypi", "npm", "cargo", "go", "homebrew", "apt", "system"]
+              },
+              "package": {"type": "string"},
+              "version": {"type": "string"},
+              "optional": {"type": "boolean", "default": false},
+              "skills": {"type": "array", "items": {"type": "string"}},
+              "install": {"type": "string"},
+              "note": {"type": "string"}
+            }
+          }
         }
       },
       "if": {

--- a/docs/contracts/skill-manifest.schema.json
+++ b/docs/contracts/skill-manifest.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$id": "skill-manifest.schema.json",
+  "type": "object",
+  "required": ["id", "name", "version", "description"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {"type": "string"},
+    "name": {"type": "string"},
+    "version": {"type": "string"},
+    "description": {"type": "string", "maxLength": 1024},
+    "category": {"type": "string"},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "license": {"type": "string"},
+    "deps": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pip": {"type": "array", "items": {"type": "string"}},
+        "npm": {"type": "array", "items": {"type": "string"}},
+        "cargo": {"type": "array", "items": {"type": "string"}},
+        "go": {"type": "array", "items": {"type": "string"}},
+        "system": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "credentials": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {"type": "string"},
+        "setup": {"type": "string"},
+        "schema": {"type": "string"}
+      }
+    },
+    "input": {"type": "object"},
+    "output": {"type": "object"},
+    "targets": {"type": "object"}
+  }
+}

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -170,6 +170,26 @@
             "safety-gate": {"type": "string"}
           },
           "additionalProperties": false
+        },
+        "runtime-dependencies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ecosystem", "package"],
+            "properties": {
+              "ecosystem": {
+                "type": "string",
+                "enum": ["pypi", "npm", "cargo", "go", "homebrew", "apt", "system"]
+              },
+              "package": {"type": "string"},
+              "version": {"type": "string"},
+              "optional": {"type": "boolean", "default": false},
+              "skills": {"type": "array", "items": {"type": "string"}},
+              "install": {"type": "string"},
+              "note": {"type": "string"}
+            }
+          }
         }
       },
       "if": {

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -21,9 +21,11 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/eugenelim/agent-ready-repo"
-Source = "https://github.com/eugenelim/agent-ready-repo"
-Documentation = "https://github.com/eugenelim/agent-ready-repo/blob/main/docs/guides/_shared/how-to/install-agentbundle-from-clone.md"
+Homepage           = "https://github.com/eugenelim/agent-ready-repo"
+Source             = "https://github.com/eugenelim/agent-ready-repo"
+Documentation      = "https://eugenelim.github.io/agent-ready-repo/docs/"
+"Catalogue Format" = "https://eugenelim.github.io/agent-ready-repo/docs/reference/catalogue-format"
+Changelog          = "https://eugenelim.github.io/agent-ready-repo/docs/changelog"
 
 [project.scripts]
 agentbundle = "agentbundle.cli:main"


### PR DESCRIPTION
## Summary

- **`pack.schema.json`**: adds `pack.runtime-dependencies` — an array of objects (ecosystem, package, version, optional, skills, install, note) with `additionalProperties: false`; mirrored byte-for-byte to `packages/agentbundle/agentbundle/_data/pack.schema.json`
- **`skill-manifest.schema.json`**: new schema for `.apm/skills/*/manifest.json`; `$schema` + `$id` first, `additionalProperties: false` at top level and nested objects (`deps`, `credentials`)
- **`pyproject.toml`**: expands `[project.urls]` from one entry to five (Homepage, Source, Documentation, Catalogue Format, Changelog)

## Test plan

- [ ] `diff docs/contracts/pack.schema.json packages/agentbundle/agentbundle/_data/pack.schema.json` → clean
- [ ] Existing `confluence-publisher/manifest.json` validates against `skill-manifest.schema.json`
- [ ] `pyproject.toml` parses cleanly (`python -c "import tomllib; tomllib.load(open('packages/agentbundle/pyproject.toml','rb'))"`)