### PR TITLE
docs(packs): add pack-local concept anchors

### DIFF
--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -1,0 +1,16 @@
+# packs/
+
+This directory holds every first-party pack in the catalogue. Each pack is a self-contained directory that agentbundle reads, validates, and installs into an adopter's repo.
+
+## Pack layout
+
+| Path | Purpose |
+|---|---|
+| `pack.toml` | Pack manifest — name, version, description, scope, dependencies, adapter contract, evals allowlist, maintainer metadata. The source of truth for what the pack declares. |
+| `README.md` | Install manifest for adopters — what ships, the skills table with adapter support, install command, compatibility, and first-value guidance. |
+| `.apm/skills/<name>/SKILL.md` | Skill definition. Projected into the adapter's tool directory at install time (e.g. `.claude/skills/<name>/`). |
+| `.apm/agents/<name>.md` | Subagent definition. Projected into the adapter's agent directory at install time (e.g. `.claude/agents/<name>.md`). |
+| `seeds/` | Files delivered into the adopter's repo on first install (repo-scope packs only). Seeds are scaffold — they carry placeholder content, not instance content. |
+| `evals/` | Activation eval queries (`evals/eval_queries.json`) and LLM-judge rubrics (`evals/evals.json`) for skill-level activation testing. Catalogue-internal; never installed. |
+| `docs/` | Concept anchor and pack-local guides — never projected or installed; travels in Artifactory packages. `docs/index.md` explains what the pack IS, why it exists, and how it relates to other packs (distinct from README.md, which is the install manifest). |
+| `AGENTS.md` | Pack-local agent context for agents working on the pack itself — migration notes, naming conventions, pack-specific build rules. |

--- a/packs/architect/docs/index.md
+++ b/packs/architect/docs/index.md
@@ -1,0 +1,27 @@
+# Architect
+
+> A user-scope pack of three architecture skills plus a forked-context design-reviewer subagent — workspace-agnostic, no configuration required.
+
+## Why this pack exists
+
+Architecture decisions made without a structured format tend to live in PR descriptions or Slack threads where they are hard to find, hard to critique independently, and impossible to compare against alternatives. With this pack, an agent can produce a Google-style design document that surfaces context, proposal, alternatives, and risks in a consistent shape — and then hand it to an independent subagent for a critique that doesn't share the authoring assumptions.
+
+## What it is
+
+**Skills (3):** `architect-design` (frame a problem and produce a design document — TL;DR, context, proposal, alternatives considered, and risks), `architect-diagram` (produce Mermaid diagrams across eight view types: system context, container, component, sequence, state machine, entity-relationship, C4, and roadmap), `architect-review` (critique an architecture artifact with severity-tagged findings and a SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT verdict).
+
+**Subagents (1):** `design-reviewer` — forked-context, read-only architecture critique subagent. It receives only the artifact and the agreed constraints, never the authoring chain of thought, so it gives an independent second opinion.
+
+No hooks. No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a UML modeling tool — it produces Mermaid diagrams as design intent artifacts, not as formal model-driven engineering inputs.
+- Not a diagramming GUI — it generates diagram source that renders in any Mermaid-compatible viewer.
+- Not a code architecture linter — it evaluates design documents and diagrams, not source code structure.
+
+## How it relates to other packs
+
+No required pack dependencies. `core`'s `adversarial-reviewer` subagent complements `architect-review` when an architectural change is part of a larger implementation: architect-review evaluates the design document; adversarial-reviewer evaluates the implementation diff against the spec.

--- a/packs/atlassian/docs/index.md
+++ b/packs/atlassian/docs/index.md
@@ -1,0 +1,25 @@
+# Atlassian
+
+> A user-scope pack of 11 skills that connect agents directly to Jira, Jira Align, and Confluence — authenticated, composable, and flow-metrics-aware.
+
+## Why this pack exists
+
+Every Jira interaction without this pack is a context-switch to a browser: copy an epic title into a prompt, paste the result back into a ticket, repeat. With it, an agent can triage a sprint backlog, turn a Jira epic into a structured product brief, compute DORA metrics over a project scope, or crawl a Confluence space and produce clean Markdown — all in a single prompt, authenticated against your organization's SSO.
+
+## What it is
+
+**Skills (11):** `jira` (read and mutate Jira items via REST API — JQL search, create, update, transition), `jira-align` (read and mutate Jira Align features and programs), `flow-metrics` (compute cycle time, throughput, and WIP from a Jira scope), `confluence-crawler` (crawl a Confluence space and convert pages to Markdown), `confluence-publisher` (publish Markdown or XHTML to a Confluence page), `jira-brief-intake` (turn a Jira epic into a product brief and hand off to receive-brief), `jira-align-brief-intake` (turn a Jira Align feature into a product brief), `jira-team-status` (read-only sprint and backlog summary for stand-up views), `jira-story-triage` (review items against a five-question readiness bar, writes back only after user approval), `jira-defect-flow` (handle a defect end-to-end: fix, open PR, comment, transition), `ai-adoption-report` (compare flow-metric snapshots to produce a pre-vs-post-AI adoption report).
+
+No subagents. No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a Jira admin tool — it cannot create projects, manage schemes, or configure permissions.
+- Not a project management dashboard — it produces reports and surfaces data; it does not replace your team's planning ceremonies.
+- Not a sync engine — it reads and writes on demand; it does not maintain a live mirror of your Jira state.
+
+## How it relates to other packs
+
+No required pack dependencies. Works best alongside `credential-brokers`, which supplies the SSO-cookie mechanism these skills rely on for authentication against Atlassian cloud instances.

--- a/packs/catalogue-curation/docs/index.md
+++ b/packs/catalogue-curation/docs/index.md
@@ -1,0 +1,25 @@
+# Catalogue Curation
+
+> A repo-scope toolkit of four skills for catalogue operators — ingest primitives from external sources, survey repositories, propose pack areas, and export redistributable derivatives.
+
+## Why this pack exists
+
+A catalogue that cannot grow in a governed way becomes a closed system. Without structured intake tooling, adding an external skill means copying files manually with no audit trail, no review gate, and no way to trace where the primitive came from. With this pack, every ingestion produces a structured diff and a linked proposal that records the source, the rationale, and the decision — making the catalogue auditable and forkable.
+
+## What it is
+
+**Skills (4):** `assimilate-primitive` (bring a single external skill, subagent, or hook into the catalogue from a local path or URL, producing a reviewable RFC), `assimilate-repo` (survey a whole external repository for ingestion candidates and produce a prioritized RFC with a proposal for each), `propose-catalogue-pack` (justify and scaffold a new pack area, testing the proposal against the catalogue's charter principles and emitting an RFC), `export-catalogue` (produce a redistributable derivative of the catalogue in white-label mode — zero upstream trace — or attributed mode, with a fail-closed identity-leak check).
+
+No subagents. No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a package registry — it does not host packages, resolve versions, or manage transitive dependencies for production workloads.
+- Not a CI/CD deployment tool — it manages the catalogue's own content, not application deployments.
+- Not an open intake gate — every assimilation produces an RFC that a human must review and accept before the primitive is considered part of the catalogue.
+
+## How it relates to other packs
+
+Requires `core` (the build loop that governs implementation of any work the intake process surfaces) and `governance-extras` (the RFC workflow that every assimilation and proposal runs through). No other packs depend on catalogue-curation.

--- a/packs/core/docs/index.md
+++ b/packs/core/docs/index.md
@@ -1,0 +1,31 @@
+# Core
+
+> The build loop — a repo-scope pack of 13 skills, 4 specialist subagents, 3 hooks, and a full repo scaffold that gives any project a structured, verifiable implementation workflow.
+
+## Why this pack exists
+
+Without a shared implementation structure, every task starts from scratch: no plan contract, no verification gates, no way to tell when "done" is actually done. Core replaces that void with a mechanical loop (plan → execute → gate → review) where termination is determined by objective gates passing, not by the agent deciding it feels finished.
+
+Install this first. All other packs assume it is present at repo scope.
+
+## What it is
+
+**Skills (13):** `work-loop` (the plan-execute-gate-review loop with an iteration cap), `new-spec` (write a spec and drive implementation from it), `bug-fix` (diagnose and fix a behavioral deviation), `adapt-to-project` (post-install configuration walkthrough), `init-project` (scaffold a new repo from an idea), `receive-brief` (decompose a multi-feature product brief into specs), `author-brief` (turn unstructured input into a brief), `capture-work` (record follow-ons into workspace.toml), `workspace-status` (orient at session start), `frontend-engineering` (HTML/CSS/JS surface craft rules and gates), `contract-acquisition` (acquire a platform's real contract before building against it), `operational-safety` (blast-radius and idempotency checklists for the reviewer), `security-checklists` (OWASP-anchored depth modules for the security reviewer).
+
+**Subagents (4):** `adversarial-reviewer` (spec/plan/implementation drift finder), `quality-engineer` (testability, observability, maintainability lens), `security-reviewer` (OWASP multi-framework threat model), `implementer` (single-task executor for supervisor mode).
+
+**Hooks (3):** `pre-pr` (pre-commit gate runner), `session-start` (orient on wakeup), `work-loop-check` (iteration-cap enforcement).
+
+**Seeds:** `AGENTS.md`, `CLAUDE.md`, `CHARTER.md`, `CONVENTIONS.md`, `docs/architecture/`, `docs/knowledge/`, `docs/product/`, `docs/specs/`, `workspace.toml` — the full repo scaffold installed on first install.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a project management tool — it doesn't track epics, assign tickets, or report velocity.
+- Not a runtime framework — it installs no production code into your application.
+- Not a code generator — it structures the process of writing code, not the code itself.
+
+## How it relates to other packs
+
+Core is the foundation every other pack builds on. `governance-extras` and `catalogue-curation` list core as a required dependency. `atlassian`, `architect`, `desk-research`, and `experience-design` are complementary user-scope packs that work alongside core without depending on it.

--- a/packs/credential-brokers/docs/index.md
+++ b/packs/credential-brokers/docs/index.md
@@ -1,0 +1,27 @@
+# Credential Brokers
+
+> A user-scope pack that gives credentialed skills secure in-process credential resolution through the OS keychain — cleartext never reaches the model context.
+
+## Why this pack exists
+
+Skills that need API tokens have to get them from somewhere. Without a credential broker, the options are bad: prompt the user each time (insecure and fragile), hard-code them (dangerous), or require environment variables that disappear across terminal sessions. With this pack, credentials are stored once in the OS native keychain and resolved silently at runtime through a four-layer chain — environment variable, keyring, dotfile, interactive prompt — without ever surfacing the raw secret in the conversation.
+
+## What it is
+
+**Skills (1):** `credential-setup` — an interactive walkthrough that helps users store API keys and tokens into the OS native keychain for later silent resolution.
+
+**Libraries (2):** The `credbroker` pip-installable library provides in-process resolution for skills that declare `auth: creds` — it is what skills call at runtime to retrieve a credential without asking the user. The `sso-broker` subprocess binary provides SSO-cookie resolution for skills that declare `auth: sso-cookie` (primarily Atlassian SSO flows).
+
+No subagents. No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a secrets manager or vault — it delegates storage to the OS keychain; it does not provide its own encrypted store.
+- Not a multi-user or team credential store — credentials are stored per-user on the local machine.
+- Not a replacement for proper secrets management in CI/CD environments — it is designed for interactive development contexts, not headless pipelines.
+
+## How it relates to other packs
+
+No required pack dependencies. The `atlassian` pack's SSO-authenticated skills (`jira`, `confluence-crawler`, etc.) rely on the `sso-broker` binary this pack installs. Other credentialed packs that declare `auth: creds` in their skill manifests consume the `credbroker` library at runtime.

--- a/packs/desk-research/docs/index.md
+++ b/packs/desk-research/docs/index.md
@@ -1,0 +1,31 @@
+# Desk Research
+
+> A user-scope pack of 12 skills and two retrieval subagents for evidence-grounded research — from quick lookups to sustained multi-week investigations — grounded in seven convergent methodologies.
+
+## Why this pack exists
+
+Without structured research tooling, agents retrieve the nearest plausible answer from a single source without assessing quality, triangulating evidence, or flagging what they don't know. A prompt like "research the market for X" produces a confident summary with no provenance and no adversarial check. With this pack, every research output is multi-source, source-ranked, adversarially reviewed for counter-evidence, and available in typed artifact formats that downstream governance and strategy workflows can consume directly.
+
+## What it is
+
+**Skills (12) in two families:**
+
+*Single-shot skills:* `desk-research` (evidence-grounded research with four depth modes: quick, standard, applied, deep), `build-outline` (decompose a research question into sub-questions using STORM and PRISMA framing), `source-map` (curate authoritative sources by surveying adjacent material), `identify-perspectives` (enumerate named camps on a contested topic before research begins), `compare-hypotheses` (compare competing hypotheses via an ACH evidence matrix with parallel per-hypothesis retrieval), `devils-advocate` (adversarial review of a research artifact for counter-evidence and irreducible tensions), `decision-archaeology` (reconstruct the rationale for a past decision from time-ordered artifacts).
+
+*Project-mode lifecycle (four skills):* `desk-research-project-start` (scaffold a stateful multi-week research project), `desk-research-project-status` (read-only orient to the current project phase, hypothesis, and stop-signal), `desk-research-project-check` (qualitatively assess whether the corpus has reached saturation), `desk-research-project-digest` (build a synthesis matrix and analytic memos), `desk-research-project-synthesize` (produce a typed verdict and governance brief from the completed corpus).
+
+**Subagents (2):** `evidence-retriever` (parallel retrieval across web and local sources), `source-extractor` (per-URL extraction and synthesis).
+
+No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a web scraper or crawler — it retrieves and synthesizes; it does not crawl sites at scale or maintain a local index.
+- Not a citation manager — it produces citations in-context for each research output, not a persistent bibliography database.
+- Not a replacement for primary research — it synthesizes secondary sources (published literature, public data, expert writing); it does not conduct surveys, interviews, or experiments.
+
+## How it relates to other packs
+
+No required pack dependencies. Research outputs frequently feed `governance-extras` (to inform an RFC) or `architect` (to ground a design document). The `product-strategy` pack uses research methodology as the foundation for market analysis and competitive intelligence workflows.

--- a/packs/experience-design/docs/index.md
+++ b/packs/experience-design/docs/index.md
@@ -1,0 +1,31 @@
+# Experience Design
+
+> A user-scope pack of 19 skills and a forked-context experience-reviewer subagent for the full design thread — from journey mapping to per-screen craft — grounded in published standards, never pixel comps.
+
+## Why this pack exists
+
+Product teams designing screens without structured UX tooling default to the happy path: the interface works when everything goes right, but falls apart on errors, edge states, and the emotional arc of a real user session. Without a shared design methodology, handoffs between PMs, designers, and engineers carry implicit assumptions that only surface when users complain. With this pack, every design decision has an explicit method, an artifact format that engineers can build from, and an independent review from a subagent that never sees the authoring assumptions.
+
+## What it is
+
+**Skills (19) in two families:**
+
+*Connective skills* walk the thread from outcome to surface: `journey-mapping` (map customer journey stages, actions, emotions, pains, and opportunities), `content-design` (decide what a surface says, for whom, before wireframes), `tone-of-voice` (turn a vague copy register into named copy goals and arbitration rules), `user-flow` (sequence screens and transitions with error flows and per-screen briefs), `service-blueprint` (map backing services across frontstage, backstage, and support rows), `process-mapping` (map internal operations as swimlane flows — as-is/to-be, SIPOC, pain register), `design-principles` (derive 3–5 named principles from journey insights to resolve design disputes).
+
+*Craft skills* design and critique each screen: `creative-direction` (turn a vague mood into ranked emotional and brand goals), `design-system` (derive a token taxonomy from an aesthetic direction), `information-architecture` (organize a screen — hierarchy, reading flow, wayfinding), `interaction-design` (design the behavioral layer — states, validation, transitions, micro-interactions), `design-review` (severity-rated heuristic, accessibility, and aesthetic critique of an existing screen). Six surface-genre skills apply the full craft method to a specific screen type: `analytical-design`, `conversion-design`, `documentation-design`, `informational-design`, `marketplace-design`, `workspace-design`. Plus `experience-status` for read-only orientation to the current design thread.
+
+**Subagents (1):** `experience-reviewer` — forked-context, design-time critique subagent. It receives only the artifact (journey map, screen flow, aesthetic direction, or generated screen), never the authoring chain of thought.
+
+No seeds.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a prototyping tool — it produces design intent artifacts (flows, token taxonomies, screen briefs), not interactive mockups.
+- Not a production design system — the token taxonomies it derives are design intent inputs; production implementation is the engineer's responsibility.
+- Not a visual design tool — it outputs structured text artifacts that reference published standards (WCAG, Material 3, Apple HIG); it does not produce images or SVGs.
+
+## How it relates to other packs
+
+No required pack dependencies. Works alongside `core` when implementing a designed surface — core's `adversarial-reviewer` evaluates the implementation diff, while `experience-reviewer` evaluates the design artifact. The `architect` pack covers the systems layer above UX (service architecture, data flow, API contracts).

--- a/packs/governance-extras/docs/index.md
+++ b/packs/governance-extras/docs/index.md
@@ -1,0 +1,25 @@
+# Governance Extras
+
+> A repo-scope pack of four skills that give teams a structured, traceable workflow for proposing changes and recording architectural decisions.
+
+## Why this pack exists
+
+Without a formal decision record, teams capture choices in Slack threads, PR descriptions, or nowhere at all — making it impossible later to understand why a constraint exists or what alternatives were considered. With this pack, every significant decision gets either an RFC (open proposal under review) or an ADR (closed, immutable record) with a consistent structure that survives team turnover.
+
+## What it is
+
+**Skills (4):** `new-rfc` (draft and shepherd a proposal through the RFC lifecycle, including generating follow-on specs for an Accepted RFC), `new-adr` (capture a decision, its context, and the alternatives considered), `update-conventions` (propose changes to CONVENTIONS.md or CHARTER.md through an RFC review gate rather than a direct PR), `rfc-status` (read-only overview of the RFC landscape — what is open, accepted, or rejected).
+
+No subagents. Installs RFC and ADR file templates plus seed READMEs for `docs/rfc/` and `docs/adr/`.
+
+See the README for the complete manifest table.
+
+## What it is not
+
+- Not a full governance platform — it does not manage voting, quorum, or role-based access to decisions.
+- Not a meeting management tool — it produces records, not agendas or minutes.
+- Not a replacement for code review — it governs *what* to build and *why*, not *how* it is implemented.
+
+## How it relates to other packs
+
+Requires `core` (the build loop these RFC-based decisions ultimately feed). `catalogue-curation` requires both `core` and `governance-extras` — it uses the RFC skill to create a traceable intake record every time a new primitive is assimilated into the catalogue.


### PR DESCRIPTION
## Summary

- Creates `packs/<name>/docs/index.md` for 8 packs: `core`, `governance-extras`, `atlassian`, `credential-brokers`, `catalogue-curation`, `architect`, `desk-research`, `experience-design`.
- Each `index.md` follows the specified concept-anchor structure: tagline, why it exists, what it is (skills/agents/hooks/seeds), what it is not (non-goals), how it relates to other packs.
- Creates `packs/AGENTS.md` with the pack directory layout table, documenting `docs/` as: concept anchor and guides — never projected or installed; travels in Artifactory packages.
- No code changes. No version bump. No changelog.

These `docs/` directories are distinct from `README.md` (the install manifest) and from `guides/<pack>/` (user-facing Diátaxis guides). They explain what the pack IS for catalogue operators and contributors.

## Test plan

- [x] `python tools/pre-pr-catalogue.py` — all 20 checks passed
- [x] `python -m pytest packages/agentbundle/` — all tests passed (exit 0)
- [ ] CI green