### PR TITLE
feat(agentbundle): docs verb, runtime-deps schema, pack layout docs row (0.20.0)

### DIFF
--- a/contracts/pack.schema.json
+++ b/contracts/pack.schema.json
@@ -199,6 +199,30 @@
             "pattern": "^[^/].*"
           }
         },
+        "runtime-dependencies": {
+          "type": "array",
+          "description": "External runtime dependencies required by this pack's skills.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ecosystem", "package"],
+            "properties": {
+              "ecosystem": {
+                "type": "string",
+                "enum": ["pypi", "npm", "cargo", "go", "homebrew", "apt", "system"]
+              },
+              "package": {"type": "string"},
+              "version": {"type": "string"},
+              "optional": {"type": "boolean", "default": false},
+              "skills": {
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              "install": {"type": "string"},
+              "note": {"type": "string"}
+            }
+          }
+        },
         "layout": {
           "type": "object",
           "additionalProperties": false,

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [agentbundle][0.20.0] — 2026-07-27
+
+### Added
+
+- **`agentbundle docs <pack>`** — read pack documentation from the catalogue
+  source. `--list` enumerates available files; `<file>` displays a specific file
+  by stem. Works across all source types.
+
+- **`[pack.runtime-dependencies]` in pack schema** — declare external runtime
+  dependencies per pack (ecosystem, package, version, optional, skills, install,
+  note).
+
 ## [agentbundle][0.13.0] — 2026-07-26
 
 ### Added

--- a/packages/agentbundle/AGENTS.md
+++ b/packages/agentbundle/AGENTS.md
@@ -20,3 +20,12 @@ runs on tag push only (`push: tags: agentbundle-v*`); it does not run on merge.
 **Version rule:** the next version after what is currently on PyPI. Check
 `pip index versions agentbundle` before choosing a version number to avoid
 collisions with any prior research-branch publish.
+
+## Engine-Change-RFC requirement
+
+Any PR that touches `packages/agentbundle/**` must include an
+`Engine-Change-RFC: <RFC-NNNN or ADR-NNNN>` trailer in at least one commit
+message. The `lint-catalogue-curation-guard` tool enforces this on every
+build; without the trailer the build will fail. Cite the RFC or ADR that
+governs the change — or ADR-0056 for general engine additions — and place the
+trailer on its own line after the commit message body.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.20.0] — 2026-07-27
+
+### Added
+
+- **`agentbundle docs <pack>`** — new CLI verb that reads pack documentation
+  from `packs/<pack>/docs/` in the catalogue source. Supports `--list` to
+  enumerate available files and an optional `<file>` positional to display a
+  specific file by stem. Works across all four source types (local path, editable
+  install, git+https, Artifactory archive). Markdown rendered as plain text with
+  ANSI bold headings on a TTY.
+
+- **`[pack.runtime-dependencies]` in pack schema.** New array under `[pack]`
+  for declaring external runtime dependencies (pip packages, npm modules, etc.)
+  required by a pack's skills. Each entry carries `ecosystem` (required, one of
+  pypi/npm/cargo/go/homebrew/apt/system), `package` (required), `version`,
+  `optional`, `skills`, `install`, and `note`.
+
 ## [0.19.0] — 2026-07-27
 
 Supersedes the accidental research-branch 0.18.0 PyPI publish. Contains all

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -199,6 +199,30 @@
             "pattern": "^[^/].*"
           }
         },
+        "runtime-dependencies": {
+          "type": "array",
+          "description": "External runtime dependencies required by this pack's skills.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ecosystem", "package"],
+            "properties": {
+              "ecosystem": {
+                "type": "string",
+                "enum": ["pypi", "npm", "cargo", "go", "homebrew", "apt", "system"]
+              },
+              "package": {"type": "string"},
+              "version": {"type": "string"},
+              "optional": {"type": "boolean", "default": false},
+              "skills": {
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              "install": {"type": "string"},
+              "note": {"type": "string"}
+            }
+          }
+        },
         "layout": {
           "type": "object",
           "additionalProperties": false,

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -328,6 +328,29 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sp.set_defaults(func=_lazy("show"))
 
+    # --- docs --- (catalogue query; reads packs/<pack>/docs/)
+    sp = subparsers.add_parser(
+        "docs",
+        help=(
+            "Read pack documentation from the catalogue source. "
+            "Displays index.md by default; use --list to enumerate files."
+        ),
+    )
+    sp.add_argument("pack", help="Pack name to read docs for (e.g. core).")
+    sp.add_argument(
+        "file",
+        nargs="?",
+        default=None,
+        help="Documentation file stem to display (e.g. 'concept'). Default: index.",
+    )
+    sp.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_docs",
+        help="List available documentation files for the pack.",
+    )
+    sp.set_defaults(func=_lazy("docs"))
+
     # --- scaffold --- (no --scope; always repo-targeted)
     sp = subparsers.add_parser(
         "scaffold",

--- a/packages/agentbundle/agentbundle/commands/docs.py
+++ b/packages/agentbundle/agentbundle/commands/docs.py
@@ -1,0 +1,117 @@
+"""``agentbundle docs <pack>`` subcommand.
+
+Display pack documentation from the pack's docs/ directory.
+
+  agentbundle docs <pack>           — display index.md
+  agentbundle docs <pack> --list    — list available .md files by stem
+  agentbundle docs <pack> <file>    — display a specific file by stem
+
+Resolution uses the same four-layer source chain as install. The docs/
+directory travels inside Artifactory archives, so this verb works across
+all four source types (local path, editable install, git+https, archive).
+
+Exit codes:
+  0  — success
+  1  — catalogue unavailable, pack not found, no docs/ directory, or file
+       not found
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+_BOLD_ON = "\x1b[1m"
+_BOLD_OFF = "\x1b[0m"
+
+
+def run(args: "argparse.Namespace") -> int:
+    from agentbundle.catalogue import CatalogueError, resolve_catalogue
+    from agentbundle.commands._common import resolve_catalogue_uri
+    from agentbundle.commands.show import _find_pack_dir
+
+    pack_name: str = args.pack
+    file_stem: str | None = getattr(args, "file", None)
+    list_mode: bool = getattr(args, "list_docs", False)
+
+    try:
+        catalogue_dir = resolve_catalogue(resolve_catalogue_uri(args))
+    except CatalogueError as exc:
+        print(f"docs: {exc}", file=sys.stderr)
+        return 1
+
+    match = _find_pack_dir(catalogue_dir, pack_name)
+    if match is None:
+        print(f"docs: pack {pack_name!r} not found in catalogue", file=sys.stderr)
+        return 1
+
+    pack_dir, _ = match
+    docs_dir = pack_dir / "docs"
+    if not docs_dir.is_dir():
+        print(f"docs: {pack_name}: no docs directory in pack source", file=sys.stderr)
+        return 1
+
+    md_files = sorted(
+        p for p in docs_dir.iterdir()
+        if p.suffix == ".md" and not p.name.startswith("_")
+    )
+
+    if list_mode:
+        for f in md_files:
+            print(f.stem)
+        return 0
+
+    stem = file_stem or "index"
+    target: Path | None = None
+    for f in md_files:
+        if f.stem == stem:
+            target = f
+            break
+
+    if target is None:
+        available = ", ".join(f.stem for f in md_files) or "none"
+        print(
+            f"docs: {pack_name}: file {stem!r} not found. Available: {available}",
+            file=sys.stderr,
+        )
+        return 1
+
+    text = target.read_text(encoding="utf-8")
+    tty = sys.stdout.isatty()
+    print(_render_md(text, tty=tty), end="")
+    return 0
+
+
+def _render_md(text: str, *, tty: bool) -> str:
+    """Render Markdown as plain text, optionally with ANSI bold headings.
+
+    Preserves code blocks verbatim. Strips heading # markers (bold on tty,
+    plain text otherwise). Strips link syntax [text](url) to bare text.
+    """
+    import re
+
+    lines = text.splitlines(keepends=False)
+    out: list[str] = []
+    in_code = False
+
+    for line in lines:
+        if line.startswith("```"):
+            in_code = not in_code
+            out.append(line)
+            continue
+        if in_code:
+            out.append(line)
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            content = m.group(2)
+            out.append(f"{_BOLD_ON}{content}{_BOLD_OFF}" if tty else content)
+            continue
+        processed = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", line)
+        out.append(processed)
+
+    return "\n".join(out) + ("\n" if out else "")

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.19.0"
+CLI_VERSION = "0.20.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.19.0"
+version = "0.20.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -10,6 +10,7 @@ See `AGENTS.local.md` for broader self-host context.
 | `pack.toml` | Pack metadata — version, description, adapter-contract, categories |
 | `.claude-plugin/plugin.json` | Claude plugin manifest source (must match `pack.toml` version, stay schema-valid) |
 | `seeds/` | Adopter scaffold templates (brownfield install) |
+| `docs/` | Concept anchor and pack guides — never projected or installed; travels in Artifactory packages |
 | `.apm/skills/` | Skill sources → projected per adapter |
 | `.apm/agents/` | Agent sources → projected per adapter |
 | `.apm/hooks/` | Hook-body sources → projected per adapter |
@@ -140,7 +141,6 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 ```
 Windows CI (Python 3.11, cp1252 default) crashes on any Unicode character without this guard. `errors="strict"` on stdout surfaces encoding bugs immediately; `errors="backslashreplace"` on stderr prevents diagnostic loss.
 Any `subprocess.run` call with `text=True` must also pass `encoding="utf-8"` — child scripts reconfigured to UTF-8 produce bytes undefined in cp1252.
-
 
 ## Skill reference files
 


### PR DESCRIPTION
## Summary

- **`agentbundle docs <pack>`** — new CLI verb reading `packs/<pack>/docs/` from the catalogue source. `--list` enumerates files; optional `<file>` positional displays a specific file by stem. Works across all four source types (local path, editable install, git+https, Artifactory archive). stdlib-only Markdown rendering with ANSI bold headings on a TTY.
- **`[pack.runtime-dependencies]` schema field** — added to `contracts/pack.schema.json` and the bundled `_data/` copy (byte-identical). Declares external runtime deps per pack: `ecosystem` (enum: pypi/npm/cargo/go/homebrew/apt/system), `package`, `version`, `optional`, `skills`, `install`, `note`.
- **`docs/` row in `packs/AGENTS.md`** — layout table now documents the `docs/` directory after `seeds/`.

Version bumped: 0.19.0 → 0.20.0.

## Test plan

- [x] `diff contracts/pack.schema.json packages/agentbundle/agentbundle/_data/pack.schema.json` exits 0
- [x] `agentbundle docs core` — renders index.md as plain text
- [x] `agentbundle docs core --list` — lists `index`
- [x] `agentbundle docs atlassian` — smoke test second pack with docs
- [x] `agentbundle docs nonexistent` — exits 1 with "pack not found" message
- [x] `python -m pytest packages/agentbundle/` — all pass (exit 0)
- [x] `python tools/catalogue/pre_pr_catalogue.py` — all checks passed

## Deferred

None. `[pack.runtime-dependencies]` is schema-only; no `agentbundle` command reads it yet — that's the next step when a consumer is built.