### PR TITLE
fix(skills): complete output rendering directive coverage — audit and fill gaps

### DIFF
--- a/.agents/skills/adapt-to-project/SKILL.md
+++ b/.agents/skills/adapt-to-project/SKILL.md
@@ -9,6 +9,13 @@ description: Use this skill to walk the adopter through the four classes of post
 > 2–4 are LLM-judgment writes the skill performs directly under the
 > per-scope path-jail.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Invoke this skill **inside an adopter's repository** after they have

--- a/.agents/skills/assimilate-repo/SKILL.md
+++ b/.agents/skills/assimilate-repo/SKILL.md
@@ -12,6 +12,12 @@ RFC** of per-candidate verdicts — resumable, idempotent, and safe under parall
 git worktrees. It reuses `assimilate-primitive`'s per-unit safety + craft for
 each `assimilate` verdict; its own job is the **survey, the ledger, and the RFC**.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Establish the charter anchor.** Read `docs/CHARTER.md` from the running

--- a/.agents/skills/author-brief/SKILL.md
+++ b/.agents/skills/author-brief/SKILL.md
@@ -12,6 +12,10 @@ then queue it so `workspace-status` can surface it immediately.
 and does not set `Status: Ready`. Those are `receive-brief`'s job. The two
 skills have distinct entry points and must stay distinct.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - The user has an email thread, a prose description, a Linear Issue body, or

--- a/.agents/skills/bug-fix/SKILL.md
+++ b/.agents/skills/bug-fix/SKILL.md
@@ -11,6 +11,11 @@ falsify rival hypotheses before asserting a cause, identify root vs
 symptom, close the coverage gap that let it through, minimum diff,
 commit body documents why.
 
+## Output rendering
+
+Code change — Show edits as a fenced ```diff block with +/− lines. Never describe the change in prose or a table.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## When to invoke
 
 Even a one-line fix benefits from walking this discipline; it forces

--- a/.agents/skills/capture-work/SKILL.md
+++ b/.agents/skills/capture-work/SKILL.md
@@ -16,6 +16,11 @@ revisiting this one.
 never invents a dependency. The user reviews the complete proposed change before
 anything is written.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - A session produced a list of "things we should do later" — deferrals,

--- a/.agents/skills/contract-acquisition/SKILL.md
+++ b/.agents/skills/contract-acquisition/SKILL.md
@@ -52,6 +52,12 @@ its *contract*.
 > **same tiered protocol** (T0 version → T1 type-checker / introspection oracle
 > → T2 curated skill → T3 versioned docs → runtime probe), not just one tier.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When it fires
 
 This skill is **user- and agent-invoked** (it has an activation surface, unlike

--- a/.agents/skills/new-guide/SKILL.md
+++ b/.agents/skills/new-guide/SKILL.md
@@ -15,6 +15,11 @@ Create or substantially revise one user-facing documentation surface. Use Diáta
 to determine the page's job. Use conversation-first design to determine what the
 reader encounters first.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Prerequisites
 
 - Read the actual skills, commands, or workflows the page documents.

--- a/.agents/skills/new-spec/SKILL.md
+++ b/.agents/skills/new-spec/SKILL.md
@@ -8,6 +8,10 @@ description: Use this skill when the user wants to start a new feature with a sp
 Create a new feature spec under `docs/specs/<feature>/` with both `spec.md`
 and `plan.md`.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 The spec is the contract; the plan is the strategy. Even a one-day feature

--- a/.agents/skills/propose-catalogue-pack/SKILL.md
+++ b/.agents/skills/propose-catalogue-pack/SKILL.md
@@ -12,6 +12,11 @@ shell to convention, and route the decision through an RFC — or reject it.
 Justification-first; the scaffold is the reward for clearing the bar, not the
 starting point.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Test additivity + fit against the *local* charter.** Read this catalogue's

--- a/.agents/skills/receive-brief/SKILL.md
+++ b/.agents/skills/receive-brief/SKILL.md
@@ -14,6 +14,11 @@ independently-shippable slices, and **execute** each slice through the normal
 `new-spec` → `work-loop` pipeline. The brief becomes a live tracker whose
 coverage rolls up from the specs it spawned.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Invoke when the unit of work that arrives is **bigger than one feature** and

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -18,6 +18,14 @@ verifiable termination criteria.
 > reset. (Reviewers also "surface" findings in the descriptive sense
 > — "raised" — when they return their report; context disambiguates.)
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line, file:line anchor aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
+
 ## When this skill applies
 
 - Implementing a spec from `docs/specs/`.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,7 +55,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.6.1"
+      "version": "0.6.2"
     },
     {
       "author": {
@@ -81,7 +81,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": {
@@ -107,7 +107,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.3.4"
+      "version": "0.3.5"
     },
     {
       "author": {
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.15.2"
+      "version": "0.15.3"
     },
     {
       "author": {
@@ -212,7 +212,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "1.1.2"
+      "version": "1.1.3"
     },
     {
       "author": {
@@ -239,7 +239,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "1.6.1"
+      "version": "1.6.2"
     },
     {
       "author": {
@@ -265,7 +265,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "author": {
@@ -292,7 +292,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "author": {
@@ -397,7 +397,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": {
@@ -448,7 +448,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.13.1"
+      "version": "0.13.2"
     },
     {
       "author": {
@@ -475,7 +475,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     {
       "author": {
@@ -528,7 +528,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ]
 }

--- a/.claude/skills/adapt-to-project/SKILL.md
+++ b/.claude/skills/adapt-to-project/SKILL.md
@@ -9,6 +9,13 @@ description: Use this skill to walk the adopter through the four classes of post
 > 2–4 are LLM-judgment writes the skill performs directly under the
 > per-scope path-jail.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Invoke this skill **inside an adopter's repository** after they have

--- a/.claude/skills/assimilate-repo/SKILL.md
+++ b/.claude/skills/assimilate-repo/SKILL.md
@@ -12,6 +12,12 @@ RFC** of per-candidate verdicts — resumable, idempotent, and safe under parall
 git worktrees. It reuses `assimilate-primitive`'s per-unit safety + craft for
 each `assimilate` verdict; its own job is the **survey, the ledger, and the RFC**.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Establish the charter anchor.** Read `docs/CHARTER.md` from the running

--- a/.claude/skills/author-brief/SKILL.md
+++ b/.claude/skills/author-brief/SKILL.md
@@ -12,6 +12,10 @@ then queue it so `workspace-status` can surface it immediately.
 and does not set `Status: Ready`. Those are `receive-brief`'s job. The two
 skills have distinct entry points and must stay distinct.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - The user has an email thread, a prose description, a Linear Issue body, or

--- a/.claude/skills/bug-fix/SKILL.md
+++ b/.claude/skills/bug-fix/SKILL.md
@@ -11,6 +11,11 @@ falsify rival hypotheses before asserting a cause, identify root vs
 symptom, close the coverage gap that let it through, minimum diff,
 commit body documents why.
 
+## Output rendering
+
+Code change — Show edits as a fenced ```diff block with +/− lines. Never describe the change in prose or a table.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## When to invoke
 
 Even a one-line fix benefits from walking this discipline; it forces

--- a/.claude/skills/capture-work/SKILL.md
+++ b/.claude/skills/capture-work/SKILL.md
@@ -16,6 +16,11 @@ revisiting this one.
 never invents a dependency. The user reviews the complete proposed change before
 anything is written.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - A session produced a list of "things we should do later" — deferrals,

--- a/.claude/skills/contract-acquisition/SKILL.md
+++ b/.claude/skills/contract-acquisition/SKILL.md
@@ -52,6 +52,12 @@ its *contract*.
 > **same tiered protocol** (T0 version → T1 type-checker / introspection oracle
 > → T2 curated skill → T3 versioned docs → runtime probe), not just one tier.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When it fires
 
 This skill is **user- and agent-invoked** (it has an activation surface, unlike

--- a/.claude/skills/new-guide/SKILL.md
+++ b/.claude/skills/new-guide/SKILL.md
@@ -15,6 +15,11 @@ Create or substantially revise one user-facing documentation surface. Use Diáta
 to determine the page's job. Use conversation-first design to determine what the
 reader encounters first.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Prerequisites
 
 - Read the actual skills, commands, or workflows the page documents.

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -8,6 +8,10 @@ description: Use this skill when the user wants to start a new feature with a sp
 Create a new feature spec under `docs/specs/<feature>/` with both `spec.md`
 and `plan.md`.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 The spec is the contract; the plan is the strategy. Even a one-day feature

--- a/.claude/skills/propose-catalogue-pack/SKILL.md
+++ b/.claude/skills/propose-catalogue-pack/SKILL.md
@@ -12,6 +12,11 @@ shell to convention, and route the decision through an RFC — or reject it.
 Justification-first; the scaffold is the reward for clearing the bar, not the
 starting point.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Test additivity + fit against the *local* charter.** Read this catalogue's

--- a/.claude/skills/receive-brief/SKILL.md
+++ b/.claude/skills/receive-brief/SKILL.md
@@ -14,6 +14,11 @@ independently-shippable slices, and **execute** each slice through the normal
 `new-spec` → `work-loop` pipeline. The brief becomes a live tracker whose
 coverage rolls up from the specs it spawned.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Invoke when the unit of work that arrives is **bigger than one feature** and

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -18,6 +18,14 @@ verifiable termination criteria.
 > reset. (Reviewers also "surface" findings in the descriptive sense
 > — "raised" — when they return their report; context disambiguates.)
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line, file:line anchor aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
+
 ## When this skill applies
 
 - Implementing a spec from `docs/specs/`.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [user-guide-diataxis][0.2.1] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `new-guide`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [product-strategy][0.2.2] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `write-prfaq`, `define-content-strategy`, `run-bcg-matrix`, `run-swot`, `synthesize-stakeholder-research`, `define-ux-strategy`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [product-engineering][0.13.2] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `identify-opportunities`, `frame-intent`, `decompose-intent`, `diverge-solutions`, `voice-and-microcopy`, `frame-domain`, `lean-canvas`, `align-value-stream`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [linear][0.1.4] — 2026-07-27
+
+### Changed
+
+- **Output rendering directive added to `linear`.** Skill now declares rendering shape for inline output. No functional change.
+
+## [frontend-engineering][0.1.1] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `fe-performance`, `component-contract`, `a11y-engineering`, `rendering-strategy`, `fe-status`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [figma][0.2.1] — 2026-07-27
+
+### Changed
+
+- **Output rendering directive added to `figma`.** Skill now declares rendering shape for inline output. No functional change.
+
+## [experience-design][1.6.2] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `design-principles`, `informational-design`, `content-design`, `tone-of-voice`, `design-system`, `creative-direction`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [desk-research][1.1.3] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `decision-archaeology`, `desk-research`, `desk-research-project-start`, `build-outline`, `source-map`, `identify-perspectives`, `desk-research-project-check`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [contracts][0.3.5] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `api-contract`, `event-contract`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [catalogue-curation][0.1.4] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `assimilate-repo`, `propose-catalogue-pack`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [atlassian][0.6.2] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `confluence-crawler`, `jira-align`, `jira`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [core][0.15.3] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `work-loop`, `receive-brief`, `contract-acquisition`, `capture-work`, `author-brief`, `adapt-to-project`, `new-spec`, `bug-fix`.** Skills now declare rendering shape for inline output. No functional change.
+
 ## [frontend-engineering][0.1.0] — 2026-07-27
 
 ### Added

--- a/packs/atlassian/.apm/skills/confluence-crawler/SKILL.md
+++ b/packs/atlassian/.apm/skills/confluence-crawler/SKILL.md
@@ -14,6 +14,10 @@ metadata:
 
 Crawl a Confluence space (Cloud or Server/Data Center) and write each page as Markdown with YAML frontmatter.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Instructions
 
 You are a Confluence export agent. The heavy lifting — authentication, REST pagination, macro conversion, link rewriting, idempotency — lives in `scripts/`. Do not re-implement any of that logic; just invoke the scripts with the right arguments and report the result.

--- a/packs/atlassian/.apm/skills/jira-align/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira-align/SKILL.md
@@ -14,6 +14,11 @@ metadata:
 A thin, uniform interface to Jira Align's REST API 2.0. Works against both
 Atlassian Cloud (`*.jiraalign.com`) and self-hosted / on-prem installs.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Instructions
 
 You are a Jira Align query agent. Authentication, pagination, retries, and

--- a/packs/atlassian/.apm/skills/jira/SKILL.md
+++ b/packs/atlassian/.apm/skills/jira/SKILL.md
@@ -17,6 +17,12 @@ Atlassian Cloud (`*.atlassian.net`) and self-hosted Server / Data Center
 installs. **This is for Jira (the issue tracker), not Jira Align (the
 portfolio product) — those are separate skills with separate credentials.**
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## Instructions
 
 You are a Jira query agent. Authentication, pagination, retries, ADF

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, jira-brief-intake, jira-align-brief-intake, jira-story-triage, and jira-team-status workflows that compose them."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.6.1"
+version = "0.6.2"
 description = "Atlassian primitives: jira / jira-align / confluence-crawler (credentialed CLI), plus the flow-metrics, ai-adoption-report, jira-defect-flow, jira-brief-intake, jira-align-brief-intake, jira-story-triage, and jira-team-status workflows that compose them."
 readme = "README.md"
 display_name = "Atlassian"

--- a/packs/catalogue-curation/.apm/skills/assimilate-repo/SKILL.md
+++ b/packs/catalogue-curation/.apm/skills/assimilate-repo/SKILL.md
@@ -12,6 +12,12 @@ RFC** of per-candidate verdicts — resumable, idempotent, and safe under parall
 git worktrees. It reuses `assimilate-primitive`'s per-unit safety + craft for
 each `assimilate` verdict; its own job is the **survey, the ledger, and the RFC**.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Establish the charter anchor.** Read `docs/CHARTER.md` from the running

--- a/packs/catalogue-curation/.apm/skills/propose-catalogue-pack/SKILL.md
+++ b/packs/catalogue-curation/.apm/skills/propose-catalogue-pack/SKILL.md
@@ -12,6 +12,11 @@ shell to convention, and route the decision through an RFC — or reject it.
 Justification-first; the scaffold is the reward for clearing the bar, not the
 starting point.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Procedure
 
 1. **Test additivity + fit against the *local* charter.** Read this catalogue's

--- a/packs/catalogue-curation/.claude-plugin/plugin.json
+++ b/packs/catalogue-curation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "catalogue-curation",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Catalogue-operator skills: assimilate external primitives, survey repos, propose packs, and export white-label / attributed derivatives of the catalogue."
 }

--- a/packs/catalogue-curation/pack.toml
+++ b/packs/catalogue-curation/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "catalogue-curation"
-version = "0.1.3"
+version = "0.1.4"
 description = "Catalogue-operator skills: assimilate external primitives, survey repos, propose packs, and export white-label / attributed derivatives of the catalogue."
 readme = "README.md"
 display_name = "Catalogue Curation"

--- a/packs/contracts/.apm/skills/api-contract/SKILL.md
+++ b/packs/contracts/.apm/skills/api-contract/SKILL.md
@@ -11,6 +11,10 @@ description: Use when generating an OpenAPI 3.1 API contract from requirements, 
 > plug in its own standard as a base+delta bundle without forking this skill —
 > see [references/standards-authoring.md](references/standards-authoring.md).
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## Your Role
 
 You are an API contract author inside an SDLC pipeline, following the active standard's API-first principle.

--- a/packs/contracts/.apm/skills/event-contract/SKILL.md
+++ b/packs/contracts/.apm/skills/event-contract/SKILL.md
@@ -13,6 +13,10 @@ description: Use when authoring an AsyncAPI event contract from requirements, us
 > base+delta bundle without forking this skill — see
 > [references/standards-authoring.md](references/standards-authoring.md).
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## Your Role
 
 You are an event contract author inside an SDLC pipeline, treating event types as first-class API contracts following the active standard's design rules.

--- a/packs/contracts/.claude-plugin/plugin.json
+++ b/packs/contracts/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "contracts",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Contract-authoring skills: OpenAPI 3.1 (api-contract) and AsyncAPI events (event-contract)."
 }

--- a/packs/contracts/pack.toml
+++ b/packs/contracts/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "contracts"
-version = "0.3.4"
+version = "0.3.5"
 description = "Contract-authoring skills: OpenAPI 3.1 (api-contract) and AsyncAPI events (event-contract). User-scope default — contract style is portable across projects."
 readme = "README.md"
 display_name = "Contracts"

--- a/packs/core/.apm/skills/adapt-to-project/SKILL.md
+++ b/packs/core/.apm/skills/adapt-to-project/SKILL.md
@@ -9,6 +9,13 @@ description: Use this skill to walk the adopter through the four classes of post
 > 2–4 are LLM-judgment writes the skill performs directly under the
 > per-scope path-jail.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Invoke this skill **inside an adopter's repository** after they have

--- a/packs/core/.apm/skills/author-brief/SKILL.md
+++ b/packs/core/.apm/skills/author-brief/SKILL.md
@@ -12,6 +12,10 @@ then queue it so `workspace-status` can surface it immediately.
 and does not set `Status: Ready`. Those are `receive-brief`'s job. The two
 skills have distinct entry points and must stay distinct.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - The user has an email thread, a prose description, a Linear Issue body, or

--- a/packs/core/.apm/skills/bug-fix/SKILL.md
+++ b/packs/core/.apm/skills/bug-fix/SKILL.md
@@ -11,6 +11,11 @@ falsify rival hypotheses before asserting a cause, identify root vs
 symptom, close the coverage gap that let it through, minimum diff,
 commit body documents why.
 
+## Output rendering
+
+Code change — Show edits as a fenced ```diff block with +/− lines. Never describe the change in prose or a table.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## When to invoke
 
 Even a one-line fix benefits from walking this discipline; it forces

--- a/packs/core/.apm/skills/capture-work/SKILL.md
+++ b/packs/core/.apm/skills/capture-work/SKILL.md
@@ -16,6 +16,11 @@ revisiting this one.
 never invents a dependency. The user reviews the complete proposed change before
 anything is written.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - A session produced a list of "things we should do later" — deferrals,

--- a/packs/core/.apm/skills/contract-acquisition/SKILL.md
+++ b/packs/core/.apm/skills/contract-acquisition/SKILL.md
@@ -52,6 +52,12 @@ its *contract*.
 > **same tiered protocol** (T0 version → T1 type-checker / introspection oracle
 > → T2 curated skill → T3 versioned docs → runtime probe), not just one tier.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When it fires
 
 This skill is **user- and agent-invoked** (it has an activation surface, unlike

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -8,6 +8,10 @@ description: Use this skill when the user wants to start a new feature with a sp
 Create a new feature spec under `docs/specs/<feature>/` with both `spec.md`
 and `plan.md`.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 The spec is the contract; the plan is the strategy. Even a one-day feature

--- a/packs/core/.apm/skills/receive-brief/SKILL.md
+++ b/packs/core/.apm/skills/receive-brief/SKILL.md
@@ -14,6 +14,11 @@ independently-shippable slices, and **execute** each slice through the normal
 `new-spec` → `work-loop` pipeline. The brief becomes a live tracker whose
 coverage rolls up from the specs it spawned.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Invoke when the unit of work that arrives is **bigger than one feature** and

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -18,6 +18,14 @@ verifiable termination criteria.
 > reset. (Reviewers also "surface" findings in the descriptive sense
 > — "raised" — when they return their report; context disambiguates.)
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line, file:line anchor aligned.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
+
 ## When this skill applies
 
 - Implementing a spec from `docs/specs/`.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.2"
+version = "0.15.3"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/desk-research/.apm/skills/build-outline/SKILL.md
+++ b/packs/desk-research/.apm/skills/build-outline/SKILL.md
@@ -8,6 +8,10 @@ description: Decompose a research question into the sub-questions a thorough ans
 The pre-research scaffold. Decomposes a question into sub-questions so
 the synthesis step has a structure to fill.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 - Before standard or deep `/desk-research` on a broad question.

--- a/packs/desk-research/.apm/skills/decision-archaeology/SKILL.md
+++ b/packs/desk-research/.apm/skills/decision-archaeology/SKILL.md
@@ -8,6 +8,11 @@ description: Reconstruct the rationale for a past decision by walking time-order
 Reconstructs *why* a past decision was made by following its
 artifact trail in chronological order.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 - "Why did we choose X over Y?" type questions.

--- a/packs/desk-research/.apm/skills/desk-research-project-check/SKILL.md
+++ b/packs/desk-research/.apm/skills/desk-research-project-check/SKILL.md
@@ -11,6 +11,11 @@ makes a recommendation. It is deliberately **passive**: it reads, judges, and
 reports; it never advances the lifecycle and never computes a number. The human
 decides what to do with the signal.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## When to invoke
 
 Inside an existing project folder, on phrasing like *"is this project

--- a/packs/desk-research/.apm/skills/desk-research-project-start/SKILL.md
+++ b/packs/desk-research/.apm/skills/desk-research-project-start/SKILL.md
@@ -14,6 +14,11 @@ This skill scaffolds the project folder, records the question and a (possibly
 empty) working hypothesis, and sets the project to its first phase. It writes no
 findings — it sets up the place the rest of the lifecycle works in.
 
+## Output rendering
+
+Tree / hierarchy — Render hierarchies as an ASCII tree (├─ └─ │) inside a fenced block, not as nested bullets.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Explicit project-lifecycle phrasing only: *"start a research project on X"*,

--- a/packs/desk-research/.apm/skills/desk-research/SKILL.md
+++ b/packs/desk-research/.apm/skills/desk-research/SKILL.md
@@ -12,6 +12,12 @@ prompt's depth and discipline signals, dispatches retrievers, synthesises
 findings with citations and per-finding confidence ratings, and (in deep
 mode) adversarially reviews its own output.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## When to invoke
 
 Any prompt that asks the model to find out, look up, investigate,

--- a/packs/desk-research/.apm/skills/identify-perspectives/SKILL.md
+++ b/packs/desk-research/.apm/skills/identify-perspectives/SKILL.md
@@ -9,6 +9,11 @@ The first step in the decision pipeline. Enumerates the named camps on
 a contested topic so downstream skills can survey sources per camp and
 compare hypotheses across them.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## When to invoke
 
 - At the start of the decision pipeline, before `/source-map`.

--- a/packs/desk-research/.apm/skills/source-map/SKILL.md
+++ b/packs/desk-research/.apm/skills/source-map/SKILL.md
@@ -11,6 +11,10 @@ Discovers and curates the sources a research artifact will eventually
 cite. Runs upstream of `/desk-research` standard / deep mode and upstream of
 the decision pipeline; can also run standalone before any synthesis.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## When to invoke
 
 - Before standard or deep research on an unfamiliar topic.

--- a/packs/desk-research/.claude-plugin/plugin.json
+++ b/packs/desk-research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "desk-research",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 }

--- a/packs/desk-research/pack.toml
+++ b/packs/desk-research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "desk-research"
-version = "1.1.2"
+version = "1.1.3"
 description = "Evidence-grounded research portable across every repo. Eleven skills (scoping, source curation, synthesis, adversarial review, decision support, rationale reconstruction, plus a four-skill project-mode lifecycle for sustained multi-week investigations) plus two retrieval subagents; methodology grounded in seven convergent disciplines (STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE)."
 readme = "README.md"
 display_name = "Desk Research"

--- a/packs/experience-design/.apm/skills/content-design/SKILL.md
+++ b/packs/experience-design/.apm/skills/content-design/SKILL.md
@@ -7,6 +7,11 @@ description: "Use when a designer or product person needs to decide what a surfa
 
 Produces a **content brief** — a text-first document answering "what does this surface need to say, for whom, in what form, to achieve what objective" — before any wireframe or screen flow is started. The brief is the durable artifact: it lets every later design and copy choice point back to a content decision, not a fresh opinion. This skill fills the first link in the design thread between `journey-mapping` and `user-flow`: it runs after a journey exists (or elicits one inline) and before screens are sequenced.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Confirm all four before drafting; if any fails, push back and resolve it first.

--- a/packs/experience-design/.apm/skills/creative-direction/SKILL.md
+++ b/packs/experience-design/.apm/skills/creative-direction/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a designer or stakeholder has a felt "vibe" but no named d
 
 Turns a vague "vibe" into a small set of **named, ranked emotional and brand goals**, each grounded in a stable referent, and records them in an creative-direction doc the rest of the build references. The doc is the durable artifact: it lets every later choice point back to a goal and its referent, not a fresh opinion.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Confirm all four before drafting; if any fails, push back and resolve it first.

--- a/packs/experience-design/.apm/skills/design-principles/SKILL.md
+++ b/packs/experience-design/.apm/skills/design-principles/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a design team needs shared, durable decision rules — con
 
 Converts journey-map peak moments and highest-opportunity pains into **3–5 named design principles** — decision rules that resolve disputes, survive sprint boundaries, and let every later screen point back to a principle rather than relitigating taste. The principles are **not brand values** (those belong in `creative-direction`) and **not interaction heuristics** (Nielsen's apply universally; these are specific to this product and this audience).
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Confirm all three before drafting:

--- a/packs/experience-design/.apm/skills/design-system/SKILL.md
+++ b/packs/experience-design/.apm/skills/design-system/SKILL.md
@@ -10,6 +10,10 @@ named aesthetic direction. You ship the *method* to derive values and a
 portable serialization shape — never a reprinted palette, spacing, or type
 table. The reader produces the numbers.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Before drafting, confirm:

--- a/packs/experience-design/.apm/skills/informational-design/SKILL.md
+++ b/packs/experience-design/.apm/skills/informational-design/SKILL.md
@@ -7,6 +7,11 @@ description: "Use when designing an informational surface — an article page, a
 
 Converts the editorial structure and reading goal into a **structural specification for an informational surface** — the typographic hierarchy, the reading-pattern calibration, the editorial grid, and the "what's next" chain that sustains reader engagement after the primary content is consumed. This skill uses **typography as the primary design tool**; layout, grid, and navigation are typography's support structure. It does not write the content (that is `content-design`) and does not derive tokens or color (that is `design-system` and `creative-direction`).
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Confirm all three before specifying:

--- a/packs/experience-design/.apm/skills/tone-of-voice/SKILL.md
+++ b/packs/experience-design/.apm/skills/tone-of-voice/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a designer, copywriter, or builder has a felt "copy vibe" 
 
 Turns a vague "copy vibe" into a small set of **named, ranked copy goals**, each grounded in a stable referent, and records them — along with arbitration rules — in a tone-of-voice doc the rest of the build references. The doc is the durable artifact: every later copy choice points back to a goal and its referent rather than relitigating voice on each surface. This skill is the copy twin of `creative-direction`: same interrogation rhythm applied to what the product *says* rather than how it *looks*.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Confirm all four before drafting; if any fails, push back and resolve it first.

--- a/packs/experience-design/.claude-plugin/plugin.json
+++ b/packs/experience-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience-design",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "The design/UX seat for product teams \u2014 the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (journey-mapping \u2192 user-flow \u2192 service-blueprint) and map the inside-out sibling (process-mapping); copy and content skills name surface voice goals (copy-direction, tone-of-voice) and content structure (content-design); craft skills design each screen (creative-direction, design-token-taxonomy, design-system-foundations, information-architecture, interaction-design) and critique it (design-review), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps \u2014 points to WCAG / Design Tokens Community Group (DTCG) / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 }

--- a/packs/experience-design/pack.toml
+++ b/packs/experience-design/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "experience-design"
-version = "1.6.1"
+version = "1.6.2"
 description = "The design/UX seat for product teams — the grown-up successor to design-craft. Connective skills walk the thread from outcome to realization (journey-mapping → content-design → copy-direction → tone-of-voice → user-flow → service-blueprint) and map the inside-out sibling (process-mapping); craft skills design each screen (creative-direction, design-token-taxonomy, design-system-foundations, information-architecture, interaction-design) and critique it (design-review), all held to one shared quality-floor (handle-all-states, accessibility floor, reduced-motion). A forked-context experience-reviewer gives the design step an independent design-time review. Pure method: no stack, no values tables, no pixel comps — points to WCAG / Design Tokens Community Group (DTCG) / Apple HIG / Material 3 / APQC / BPMN, never reprints them."
 readme = "README.md"
 display_name = "Experience Design"

--- a/packs/figma/.apm/skills/figma/SKILL.md
+++ b/packs/figma/.apm/skills/figma/SKILL.md
@@ -15,6 +15,12 @@ A thin, uniform interface to the Figma REST API. Figma is SaaS-only
 (`api.figma.com`); there is no on-prem flavor and no flavor branching
 in this client.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Diagram / flow — For relationships or flow, emit a fenced ```mermaid block (it renders in chat and artifacts). If the surface is terminal-only, fall back to an ASCII box-and-arrow sketch.
+
 ## Instructions
 
 You are a Figma query agent. Authentication, retries, image downloads,

--- a/packs/figma/.claude-plugin/plugin.json
+++ b/packs/figma/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "figma",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 }

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "figma"
-version = "0.2.0"
+version = "0.2.1"
 description = "Figma REST API primitive (credentialed CLI). Reads files / nodes / metadata / versions / comments / variables / dev resources, renders frame images, posts comments, and converts FigJam connector graphs to Mermaid."
 readme = "README.md"
 display_name = "Figma"

--- a/packs/frontend-engineering/.apm/skills/a11y-engineering/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/a11y-engineering/SKILL.md
@@ -21,6 +21,13 @@ when:
 
 ---
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line, file:line anchor aligned.
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## The two automated-tooling gaps
 
 Automated accessibility tools (pa11y, axe-core) cap at `wcag21aa`. Two WCAG

--- a/packs/frontend-engineering/.apm/skills/component-contract/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/component-contract/SKILL.md
@@ -22,6 +22,12 @@ caller's needs — it is the wrong order.
 
 ---
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## The API-first principle
 
 A component's public interface is its most durable artifact. The implementation

--- a/packs/frontend-engineering/.apm/skills/fe-performance/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/fe-performance/SKILL.md
@@ -16,6 +16,12 @@ build (the GATES section of `frontend-engineering` covers that). Load
 
 ---
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line, file:line anchor aligned.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## CWV causality model
 
 Before profiling, understand what each metric measures and what typically

--- a/packs/frontend-engineering/.apm/skills/fe-status/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/fe-status/SKILL.md
@@ -13,6 +13,12 @@ use `frontend-engineering` in `create` mode instead.
 
 ---
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+
 ## What to look for
 
 Read the following artifacts in the order listed. Stop when the summary

--- a/packs/frontend-engineering/.apm/skills/rendering-strategy/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/rendering-strategy/SKILL.md
@@ -17,6 +17,11 @@ Load `rendering-strategy` when:
 
 ---
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Rendering model decision framework
 
 | Model | When to use | CWV profile | Data pattern | Personalization | Key tradeoffs |

--- a/packs/frontend-engineering/.claude-plugin/plugin.json
+++ b/packs/frontend-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-engineering",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 }

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "frontend-engineering"
-version = "0.1.0"
+version = "0.1.1"
 description = "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 readme = "README.md"
 display_name = "Frontend Engineering"

--- a/packs/linear/.apm/skills/linear/SKILL.md
+++ b/packs/linear/.apm/skills/linear/SKILL.md
@@ -15,6 +15,11 @@ A thin, uniform interface to the Linear GraphQL API. Linear is SaaS-only
 (`api.linear.app`); there is no on-prem flavour and no flavour branching
 in this client.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Instructions
 
 You are a Linear query agent. Authentication and credential resolution live in

--- a/packs/linear/.claude-plugin/plugin.json
+++ b/packs/linear/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "linear",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Linear primitives: linear (credentialed GraphQL CLI), plus the linear-brief-intake and linear-brief-sync workflows that compose it with receive-brief."
 }

--- a/packs/linear/pack.toml
+++ b/packs/linear/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "linear"
-version = "0.1.3"
+version = "0.1.4"
 description = "Linear primitives: linear (credentialed GraphQL CLI), plus the linear-brief-intake and linear-brief-sync workflows that compose it with receive-brief."
 readme = "README.md"
 display_name = "Linear"

--- a/packs/product-engineering/.apm/skills/align-value-stream/SKILL.md
+++ b/packs/product-engineering/.apm/skills/align-value-stream/SKILL.md
@@ -15,6 +15,11 @@ read and edit*, never a running service. The slices it rolls up are produced by
 `decompose-intent`'s business-unit branch; its spine is **currency** — a stale
 map is the dominant failure mode. Depth lives in `references/`.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Before aligning, confirm:

--- a/packs/product-engineering/.apm/skills/decompose-intent/SKILL.md
+++ b/packs/product-engineering/.apm/skills/decompose-intent/SKILL.md
@@ -13,6 +13,11 @@ unit your delivery loop can build. At `app` Scale the leaf feature intent *is* a
 no new machinery. The recursion + the brief projection are in
 `references/recursive-decomposition.md`.
 
+## Output rendering
+
+Tree / hierarchy — Render hierarchies as an ASCII tree (├─ └─ │) inside a fenced block, not as nested bullets.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Before decomposing, confirm:

--- a/packs/product-engineering/.apm/skills/diverge-solutions/SKILL.md
+++ b/packs/product-engineering/.apm/skills/diverge-solutions/SKILL.md
@@ -9,6 +9,12 @@ Turn a known opportunity into ≥3 structured, comparable solution options — s
 `place-bet` (step 5) has the full option space to reason against, not just the
 first idea that came to mind.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Confirm the input is an **initiative- or capability-scope opportunity**, not a

--- a/packs/product-engineering/.apm/skills/frame-domain/SKILL.md
+++ b/packs/product-engineering/.apm/skills/frame-domain/SKILL.md
@@ -29,6 +29,11 @@ does not re-implement retrieval. It is **prompt-only** (Charter Principle 3):
 there is no engine, script, or filename generator — the agent following this body
 writes the artifacts and their paths.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Before framing, confirm:

--- a/packs/product-engineering/.apm/skills/frame-intent/SKILL.md
+++ b/packs/product-engineering/.apm/skills/frame-intent/SKILL.md
@@ -13,6 +13,11 @@ document. This is the entry point of the
 product-engineering loop: frame here, then `de-risk-intent`, then
 `decompose-intent`. The intent model is in `references/intent-model.md`.
 
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## When to invoke
 
 Before framing, confirm:

--- a/packs/product-engineering/.apm/skills/identify-opportunities/SKILL.md
+++ b/packs/product-engineering/.apm/skills/identify-opportunities/SKILL.md
@@ -10,6 +10,11 @@ functional, emotional, and social — score each via the Ulwick formula, and
 produce a ranked opportunity list that feeds `diverge-solutions`.
 Step 2 of the PE shaping sequence.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Confirm the input is **problem-space, not solution-space.** If the topic

--- a/packs/product-engineering/.apm/skills/lean-canvas/SKILL.md
+++ b/packs/product-engineering/.apm/skills/lean-canvas/SKILL.md
@@ -8,6 +8,11 @@ description: Use when a product engineer or PM is ready to produce an initiative
 Elicit an initiative brief through an adapted Lean Canvas and produce one
 shareable file: `docs/product/initiatives/<ini-slug>.md`.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Confirm the scope is **initiative-level** (quarters-long, cross-repo outcome).

--- a/packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md
+++ b/packs/product-engineering/.apm/skills/voice-and-microcopy/SKILL.md
@@ -31,6 +31,12 @@ skill is still fully useful: it writes copy for the states you name directly
 
 > **Scope boundary — surface type is the dividing line.** For marketing/acquisition copy voice and positioned copy (hero headlines, above-fold narrative, taglines, announcement copy), use the `experience-design` pack's `tone-of-voice` skill; `voice-and-microcopy` covers product UI copy states (error, empty state, button labels, form labels). **Onboarding tri-point:** onboarding narrative arc and structure → `content-design` (experience-design pack); onboarding copy voice and register → `tone-of-voice` (experience-design pack); onboarding UI-state strings (loading, error, empty) → `voice-and-microcopy` (this skill).
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 Before writing, confirm:

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Shape product intent into shippable specs \u2014 and into the words users read. Habits \u2014 frame-intent, de-risk-intent, decompose-intent \u2014 over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels \u2014 Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds \u2014 at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `ux-writing` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief \u2014 diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks \u2014 no engine. Markdown skills + agent definitions, user-scope."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-engineering"
-version = "0.13.1"
+version = "0.13.2"
 description = "Shape product intent into shippable specs — and into the words users read. Habits — frame-intent, de-risk-intent, decompose-intent — over a recursive, level-tagged `intent` (product-vision, product-strategy, capability, and feature intents are the same artifact at different levels — Level is an open recognized set decoupled from Scale): outcome+opportunity framing, a choosable prototype-approach to de-risk the riskiest assumption, and decomposition into the briefs/specs your delivery loop already builds — at app scale, or sliced per component across a business-unit value stream coordinated by `align-value-stream`. `ux-writing` adds the content layer: characterize a product's voice and write blame-free, actionable UI copy. Upstream of the build loop, the `discovery-loop` (run by the `discovery-lead` agent) turns a raw idea into a build-ready decision brief — diverging across candidate product shapes, converging through a lens roster with two discovery reviewers, and emitting a connected hypothesis with validation hooks — no engine. Markdown skills + agent definitions, user-scope."
 readme = "README.md"
 display_name = "Product Engineering"

--- a/packs/product-strategy/.apm/skills/define-content-strategy/SKILL.md
+++ b/packs/product-strategy/.apm/skills/define-content-strategy/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a strategist needs to set the organizational content direc
 
 Produces a **content strategy** — a governance and structural document grounded in the Halvorson content strategy quad (Brain Traffic, 2018 revision): Purpose + Process + Structure + Governance. This is the organizational/governance layer above per-surface content design — it defines why content exists, how it is made and maintained, how it is structured, and how it stays consistent. The artifact feeds the experience-design pack's `content-design` skill and the design-thread `map-screen-flow` step. See `references/agentbundle-layout.md` for artifact path.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **Business goals and audience are known** — content strategy is derived from the organization's goals and its understanding of its audience; it cannot precede them.

--- a/packs/product-strategy/.apm/skills/define-ux-strategy/SKILL.md
+++ b/packs/product-strategy/.apm/skills/define-ux-strategy/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a strategist needs to set the experience direction before 
 
 Produces a **UX strategy** — a three-layer document (Vision, Goals + Measures, Plan) that bridges business strategy and experience design. Draws on the NN/g three-layer UX strategy model, Jaime Levy's four-tenets framework (business strategy + value innovation + validated user research + killer UX), and Gothelf/Seiden OKR-linked UX framing. Sits upstream of the experience-design pack's `journey-mapping`. See `references/agentbundle-layout.md` for artifact path.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **Market strategy and business goals are known** — UX strategy translates those goals into experience direction; it cannot precede the business strategy it is derived from.

--- a/packs/product-strategy/.apm/skills/run-bcg-matrix/SKILL.md
+++ b/packs/product-strategy/.apm/skills/run-bcg-matrix/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a strategist needs to assess portfolio position and derive
 
 Produces a **portfolio position analysis** using the BCG Growth-Share Matrix — four quadrants: Stars (high growth, high share), Cash Cows (low growth, high share), Question Marks (high growth, low share), and Dogs (low growth, low share). Investment implications flow from quadrant position. See `references/agentbundle-layout.md` for artifact path.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **A multi-product or multi-business-unit portfolio exists** — at least two offerings must be mappable; single-product analysis belongs in SWOT.

--- a/packs/product-strategy/.apm/skills/run-swot/SKILL.md
+++ b/packs/product-strategy/.apm/skills/run-swot/SKILL.md
@@ -7,6 +7,12 @@ description: Use when a strategist needs a structured situation synthesis before
 
 Produces a **SWOT analysis** — an inside-out / outside-in situation map that organizes Strengths, Weaknesses, Opportunities, and Threats before the strategy direction is set. Uses the SWOT framework; see `references/agentbundle-layout.md` for artifact path resolution.
 
+## Output rendering
+
+Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **A defined scope exists** — organization, product line, or market entry; SWOT without a scope boundary produces noise.

--- a/packs/product-strategy/.apm/skills/synthesize-stakeholder-research/SKILL.md
+++ b/packs/product-strategy/.apm/skills/synthesize-stakeholder-research/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a strategist needs to turn existing stakeholder research i
 
 Produces a **stakeholder synthesis** — a strategic narrative that organizes stakeholder perspectives (executive, user, regulator, partner) by theme, not by stakeholder group, to surface the strategic signals that cross-cut viewpoints. Consumes desk-research pack outputs; does not produce primary research. See `references/agentbundle-layout.md` for artifact path.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **Research inputs exist.** Check `docs/research/` or adopter-supplied paths for desk-research project outputs (research briefs, synthesis memos, interview summaries). If none are found, surface: `"run desk-research project first — no research inputs found"` and stop.

--- a/packs/product-strategy/.apm/skills/write-prfaq/SKILL.md
+++ b/packs/product-strategy/.apm/skills/write-prfaq/SKILL.md
@@ -7,6 +7,11 @@ description: Use when a strategist needs to write the press release before the p
 
 Produces a **PRFAQ** — a press release written as if the product already exists, followed by a customer FAQ and an internal FAQ — using the Amazon PRFAQ format as the direction-setting convention. The press release forces specificity about who the customer is, what problem they have, and how the product solves it in their terms. See `references/agentbundle-layout.md` for artifact path.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## When to invoke
 
 1. **A product concept exists but has not yet been committed to engineering** — PRFAQ is a pre-spec forcing function, not a post-spec documentation exercise.

--- a/packs/product-strategy/.claude-plugin/plugin.json
+++ b/packs/product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-strategy",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The strategy seat upstream of product engineering and experience design \u2014 SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis (Pillar 1); UX strategy with NN/g three-layer model, Jaime Levy four tenets, and Gothelf/Seiden OKR-linked UX framing (Pillar 2); content strategy via the Halvorson quad: Purpose + Process + Structure + Governance (Pillar 3). Pure method: no growth tooling, no primary research production, no stack tokens."
 }

--- a/packs/product-strategy/pack.toml
+++ b/packs/product-strategy/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-strategy"
-version = "0.2.1"
+version = "0.2.2"
 description = "The strategy seat upstream of product engineering and experience design. Pillar 1 — Market & competitive strategy: SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, and stakeholder-research synthesis — seven frameworks that produce committed artifacts in docs/product/shaping/ and feed the PE pack's shaping queue. Pillar 2 — UX strategy: defines the experience vision, goals/measures, and plan (NN/g three-layer model · Jaime Levy four tenets · Gothelf/Seiden OKR-linked UX framing) upstream of journey-mapping. Pillar 3 — Content strategy: the Halvorson quad (Purpose + Process + Structure + Governance) — the organizational/governance layer above per-surface content-design. Pure method: no growth tooling, no primary research production, no stack tokens — references canonical frameworks by name, never reprints them."
 readme = "README.md"
 display_name = "Product Strategy"

--- a/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
+++ b/packs/user-guide-diataxis/.apm/skills/new-guide/SKILL.md
@@ -15,6 +15,11 @@ Create or substantially revise one user-facing documentation surface. Use Diáta
 to determine the page's job. Use conversation-first design to determine what the
 reader encounters first.
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.
+
 ## Prerequisites
 
 - Read the actual skills, commands, or workflows the page documents.

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "user-guide-diataxis"
-version = "0.2.0"
+version = "0.2.1"
 description = "Di\u00e1taxis-shaped user-guide skeleton: guides/ + tutorials/how-to/reference/explanation seed READMEs, new-guide skill."
 readme = "README.md"
 display_name = "User Guide (Diátaxis)"

--- a/tools/add-rendering-directives.py
+++ b/tools/add-rendering-directives.py
@@ -64,6 +64,14 @@ SKILLS: dict[str, list[str]] = {
     # core
     "workspace-status":             ["status-list", "table", "mermaid", "progress"],
     "frontend-engineering":         ["table"],
+    "work-loop":                    ["status-list", "severity-list", "table", "narrative", "progress"],
+    "receive-brief":                ["table", "key-value"],
+    "contract-acquisition":         ["table", "key-value", "narrative"],
+    "capture-work":                 ["table", "key-value"],
+    "author-brief":                 ["key-value"],
+    "adapt-to-project":             ["status-list", "table", "key-value", "narrative"],
+    "new-spec":                     ["key-value"],
+    "bug-fix":                      ["diff", "table"],
     # governance-extras
     "rfc-status":                   ["table"],
     "new-adr":                      ["key-value"],
@@ -75,11 +83,20 @@ SKILLS: dict[str, list[str]] = {
     # catalogue-curation
     "assimilate-primitive":         ["severity-list"],
     "export-catalogue":             ["status-list"],
+    "assimilate-repo":              ["table", "status-list", "narrative"],
+    "propose-catalogue-pack":       ["table", "narrative"],
     # desk-research
     "compare-hypotheses":           ["table"],
     "desk-research-project-digest": ["table"],
     "desk-research-project-status": ["key-value"],
     "desk-research-project-synthesize": ["narrative", "key-value"],
+    "decision-archaeology":         ["narrative", "key-value"],
+    "desk-research":                ["table", "narrative", "status-list"],
+    "desk-research-project-start":  ["tree", "key-value"],
+    "build-outline":                ["narrative"],
+    "source-map":                   ["table"],
+    "identify-perspectives":        ["narrative", "table"],
+    "desk-research-project-check":  ["narrative", "status-list"],
     # converters
     "file-to-markdown":             ["key-value"],
     "markdown-to-docx":             ["key-value"],
@@ -98,10 +115,24 @@ SKILLS: dict[str, list[str]] = {
     "place-bet":                    ["table"],
     "plan-validation":              ["key-value"],
     "new-package":                  ["tree"],
+    "identify-opportunities":       ["table", "key-value"],
+    "frame-intent":                 ["key-value", "narrative"],
+    "decompose-intent":             ["tree", "key-value"],
+    "diverge-solutions":            ["table", "narrative", "key-value"],
+    "voice-and-microcopy":          ["table", "narrative", "key-value"],
+    "frame-domain":                 ["narrative", "key-value"],
+    "lean-canvas":                  ["table", "key-value"],
+    "align-value-stream":           ["table", "key-value"],
     # product-strategy
     "run-pestle-analysis":          ["table"],
     "run-porters-five-forces":      ["table"],
     "run-okr-cascade":              ["table"],
+    "write-prfaq":                  ["narrative", "key-value"],
+    "define-content-strategy":      ["narrative", "key-value"],
+    "run-bcg-matrix":               ["table", "key-value"],
+    "run-swot":                     ["table", "narrative", "key-value"],
+    "synthesize-stakeholder-research": ["narrative", "key-value"],
+    "define-ux-strategy":           ["narrative", "key-value"],
     # iac-terraform
     "generate-iac":                 ["table", "status-list"],
     "reconcile-iac":                ["table", "key-value"],
@@ -123,6 +154,16 @@ SKILLS: dict[str, list[str]] = {
     # experience-design (additional severity-list producers)
     "design-review":                ["severity-list"],
     "devils-advocate":              ["severity-list"],
+    # experience-design (additional)
+    "design-principles":            ["narrative", "key-value"],
+    "informational-design":         ["table", "narrative"],
+    "content-design":               ["table", "key-value"],
+    "tone-of-voice":                ["key-value", "narrative"],
+    "design-system":                ["narrative"],
+    "creative-direction":           ["key-value", "narrative"],
+    # contracts
+    "event-contract":               ["table"],
+    "api-contract":                 ["table"],
     # atlassian
     "jira-team-status":             ["table"],
     "ai-adoption-report":           ["table", "key-value"],
@@ -132,11 +173,25 @@ SKILLS: dict[str, list[str]] = {
     "jira-defect-flow":             ["table"],
     "jira-story-triage":            ["table"],
     "confluence-publisher":         ["key-value"],
+    "confluence-crawler":           ["key-value"],
+    "jira-align":                   ["table", "key-value"],
+    "jira":                         ["table", "key-value", "status-list"],
     # linear
     "linear-brief-sync":            ["diff"],
     "linear-brief-intake":          ["table"],
+    "linear":                       ["table", "key-value"],
     # github
     "github-brief-intake":          ["table"],
+    # figma
+    "figma":                        ["table", "key-value", "mermaid"],
+    # user-guide-diataxis
+    "new-guide":                    ["narrative", "key-value"],
+    # frontend-engineering (additional)
+    "fe-performance":               ["table", "severity-list", "key-value"],
+    "component-contract":           ["table", "key-value", "narrative"],
+    "a11y-engineering":             ["table", "severity-list", "status-list", "key-value"],
+    "rendering-strategy":           ["table", "narrative"],
+    "fe-status":                    ["status-list", "key-value", "table"],
 }
 
 


### PR DESCRIPTION
## Summary

- Extended `tools/add-rendering-directives.py` with 50 additional skill mappings missed by the initial pass
- Patched all source (`.apm/`) and projected (`.claude/`, `.agents/`) SKILL.md files for 12 packs: atlassian, catalogue-curation, contracts, core, desk-research, experience-design, figma, frontend-engineering, linear, product-engineering, product-strategy, user-guide-diataxis
- 8 legitimately side-effect-only skills correctly have no `## Output rendering` section: `operational-safety`, `security-checklists`, `init-project`, `credential-setup`, `update-conventions`, `responsive-layout`, `token-architecture`, `css-architecture`
- Patch-bumped all 12 affected packs; pre-PR catalogue gate passes clean

## Test plan

- [ ] Pre-PR catalogue gate: `python tools/catalogue/pre_pr_catalogue.py` — clean
- [ ] Zero output-producing skills missing directive: `find packs -path "*/.apm/skills/*/SKILL.md" -exec grep -rL "## Output rendering" {} \;` returns only the 8 intentional side-effect-only skills
- [ ] CI green