### PR TITLE
fix(tests): skip credbroker-dependent tests when credbroker is absent

### DIFF
--- a/packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py
+++ b/packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py
@@ -130,9 +130,14 @@ def _assert_no_relative_import_error(result: subprocess.CompletedProcess, entry:
         and not any(mod in stderr for mod in credential_area_modules)
     )
     # Scripts with custom dependency guards emit "error: missing dependency '<pkg>'"
-    # instead of ModuleNotFoundError — same out-of-scope category.
+    # instead of ModuleNotFoundError — same out-of-scope category. setup.py emits
+    # "credbroker not found. …" when credbroker is absent (precondition failure,
+    # not the relative-import bug this test owns).
     custom_dep_guard = (
-        "error: missing dependency" in stderr
+        (
+            "error: missing dependency" in stderr
+            or "credbroker not found." in stderr
+        )
         and "pip install" in stderr
     )
     if bare_module_not_found or custom_dep_guard:

--- a/packages/agentbundle/tests/unit/test_credential_setup_skill.py
+++ b/packages/agentbundle/tests/unit/test_credential_setup_skill.py
@@ -52,6 +52,8 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
     """AC19: setup.py refuses the reserved `sso` namespace; stderr names
     the reserved set. Run the script via subprocess against the projected
     sibling shim under a tmp_path skill dir."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     # Build a tmp skill dir with the shim siblings + setup.py so the
     # relative import (`from .credentials_shim ...`) resolves.
     skill_dir = tmp_path / "credential-setup"
@@ -98,6 +100,8 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
 def test_ac18_argv_ban_refused(tmp_path):
     """AC18 / argv-ban: setup.py refuses --token / --api-token / etc.
     on the command line."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
     (skill_dir / "__init__.py").write_text("")
@@ -120,6 +124,8 @@ def test_ac18_no_token_in_stdout(tmp_path, monkeypatch):
     """AC18: when the user enters a secret, it never appears on stdout —
     only stderr announcements. We simulate via in-process import after
     projecting the shim siblings into a temp package."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
     (skill_dir / "__init__.py").write_text("")

--- a/workspace.toml
+++ b/workspace.toml
@@ -567,16 +567,6 @@ open = [
   # Unblocks when: apm-leak-lint-rfc RFC is approved, or explicit approval obtained.
   {slug = "credbroker-frozen-pack-ref-sweep", source = "spec/apm-internal-ref-sweep"},
 
-  # 4 tests fail locally because credbroker is not installed (`pip install -e ./packages/credbroker`
-  # required). Pre-existing on origin/main (confirmed 2026-07-27):
-  #   test_credential_user_scope_invocation.py::test_entry_point_imports_resolve_under_user_scope_layout
-  #   test_credential_setup_skill.py::test_ac18_argv_ban_refused
-  #   test_credential_setup_skill.py::test_ac18_no_token_in_stdout
-  #   test_credential_setup_skill.py::test_ac19_reserved_sso_namespace_refused
-  # Fix: install credbroker in local/CI test env, or add pytest.importorskip guard to each test.
-  # Unblocks when: CI/local env includes credbroker install, or tests gain skip guards.
-  {slug = "pre-existing-credbroker-test-not-installed", source = "pre-flight/2026-07-27"},
-
   # RFC-0065 D5 (source-author review 2026-07-18). Azure shipped contract-complete
   # in iac-terraform v1 (four provider files + providers/azure.md) but no worked
   # example has passed terraform init -backend=false && fmt -check && validate. The


### PR DESCRIPTION
## Summary

- **Unit tests** (`test_ac18_argv_ban_refused`, `test_ac18_no_token_in_stdout`, `test_ac19_reserved_sso_namespace_refused`): replaced `pytest.importorskip("credbroker")` with a subprocess-based check (`subprocess.run([sys.executable, "-c", "import credbroker"], ...)`). `importorskip` was insufficient because `test_linear_primitive.py` injects a credbroker stub into `sys.modules` earlier in the full suite via `sys.modules.setdefault`, causing `importorskip` to find the stub and not skip — while the subprocess still lacked the real package. The subprocess check spawns a fresh interpreter, bypassing `sys.modules` state.
- **Integration test** (`test_entry_point_imports_resolve_under_user_scope_layout`): extended `_assert_no_relative_import_error`'s `custom_dep_guard` to recognise `"credbroker not found." + "pip install"` as an out-of-scope precondition failure, parallel to the existing `"error: missing dependency"` guard. Only `setup.py` emits this string.
- Removed `workspace.toml [backlog].open` entry `pre-existing-credbroker-test-not-installed`.

## Test plan

- [x] `test_linear_primitive.py` + `test_credential_setup_skill.py` in order (simulates full-suite `sys.modules` pollution): 6 passed, 3 skipped — no failures
- [x] All 20 tests across both affected files: 11 passed, 9 skipped — no failures
- [x] Full suite (`python -m pytest packages/agentbundle/ -q`) running in background