### PR TITLE
fix(skills): add output rendering directives to final four skills

### DIFF
--- a/.agents/skills/init-project/SKILL.md
+++ b/.agents/skills/init-project/SKILL.md
@@ -135,6 +135,10 @@ every feature's low-level design to conform to. The greenfield front door has
 done its job: a recorded foundation, a validated walking skeleton, and the
 normal loop running — instead of a throwaway someone has to clean up later.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## Anti-patterns to refuse
 
 - **Performing discovery / research yourself.** Discovery is fed *in* (stage 2)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.15.3"
+      "version": "0.15.4"
     },
     {
       "author": {
@@ -292,7 +292,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "author": {

--- a/.claude/skills/init-project/SKILL.md
+++ b/.claude/skills/init-project/SKILL.md
@@ -135,6 +135,10 @@ every feature's low-level design to conform to. The greenfield front door has
 done its job: a recorded foundation, a validated walking skeleton, and the
 normal loop running — instead of a throwaway someone has to clean up later.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## Anti-patterns to refuse
 
 - **Performing discovery / research yourself.** Discovery is fed *in* (stage 2)

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [frontend-engineering][0.1.2] — 2026-07-27
+
+### Changed
+
+- **Output rendering directives added to `css-architecture`, `responsive-layout`, `token-architecture`.** Skills now declare rendering shape for inline output. No functional change.
+
+## [core][0.15.4] — 2026-07-27
+
+### Changed
+
+- **Output rendering directive added to `init-project`.** Skill now declares rendering shape for inline output. No functional change.
+
 ## [user-guide-diataxis][0.2.1] — 2026-07-27
 
 ### Changed

--- a/packs/core/.apm/skills/init-project/SKILL.md
+++ b/packs/core/.apm/skills/init-project/SKILL.md
@@ -135,6 +135,10 @@ every feature's low-level design to conform to. The greenfield front door has
 done its job: a recorded foundation, a validated walking skeleton, and the
 normal loop running — instead of a throwaway someone has to clean up later.
 
+## Output rendering
+
+Status list — Lead each row with a status glyph — ● running, ✓ done, ○ idle, ⚠ blocked — status first, one item per line, labels aligned.
+
 ## Anti-patterns to refuse
 
 - **Performing discovery / research yourself.** Discovery is fed *in* (stage 2)

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.3"
+version = "0.15.4"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/packs/frontend-engineering/.apm/skills/css-architecture/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/css-architecture/SKILL.md
@@ -242,3 +242,7 @@ it describes the button's role in the hierarchy, not its current color.
 
 Apply the same rule to CSS custom properties — see `token-architecture` for
 the full naming system.
+
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.

--- a/packs/frontend-engineering/.apm/skills/responsive-layout/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/responsive-layout/SKILL.md
@@ -230,6 +230,10 @@ for column headers. This requires no JS.
 
 ---
 
+## Output rendering
+
+Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
+
 ## Common failures to refuse
 
 | Pattern | Problem | Fix |

--- a/packs/frontend-engineering/.apm/skills/token-architecture/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/token-architecture/SKILL.md
@@ -298,3 +298,7 @@ A token architecture encodes organizational decisions. Before finalizing:
 - [ ] Is the **dark-theme override** kept in sync with the light-theme semantic
   layer? Every new semantic token added to light mode must have a corresponding
   dark override (or an explicit decision that it inherits the light value).
+
+## Output rendering
+
+Key–value / one record — For a single record's fields, use an aligned key: value list, not a two-row table.

--- a/packs/frontend-engineering/.claude-plugin/plugin.json
+++ b/packs/frontend-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-engineering",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 }

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "frontend-engineering"
-version = "0.1.1"
+version = "0.1.2"
 description = "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 readme = "README.md"
 display_name = "Frontend Engineering"


### PR DESCRIPTION
## Summary

- Add `## Output rendering` to `init-project` (`Status list`) — orchestration progress across trigger gate, value gate, foundation, spec, and work-loop handoff.
- Add `## Output rendering` to `css-architecture` (`Rationale / narrative`) — produces analysis reports and annotated recommendations.
- Add `## Output rendering` to `responsive-layout` (`Rationale / narrative`) — produces layout decisions as prose guidance.
- Add `## Output rendering` to `token-architecture` (`Key–value / one record`) — produces token system designs as key-value definitions.
- Patch-bump `core` → 0.15.4 and `frontend-engineering` → 0.1.2.
- Project `init-project` to `.agents/` and `.claude/` adapter layouts via `agentbundle catalogue self-host`.
- Catalogue gate clean; only the four known-exempt skills (`operational-safety`, `security-checklists`, `credential-setup`, `update-conventions`) remain without directives.

## Test plan

- [x] Gap check: `find packs -path "*/.apm/skills/*/SKILL.md" | while read f; do grep -q "Output rendering" "$f" || echo "MISSING: $f"; done` — only the four exempt skills
- [x] `python tools/catalogue/pre_pr_catalogue.py` — `catalogue verify: ok`