### PR TITLE
docs(packs): add DESIGN.md + rewrite READMEs and journey pages for core and experience-design

### DIFF
--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -33,10 +33,6 @@ See `AGENTS.local.md` for broader self-host context.
 | `[pack.first-value]` | — | First-value install metadata |
 | `[pack.adaptation]` | — | Adaptation inference rules |
 
-## Pack design model
-
-intent → user journey → stage → capability → output
-
 ## Primary workflow (any catalogue)
 
 Run after any pack change. If `agentbundle` is not installed: `pip install agentbundle`.
@@ -102,10 +98,6 @@ Edit `.apm/skills/<name>/SKILL.md`. Run `make build-self` to project. Run `agent
 - **`description` is the trigger surface** — body must not restate when to invoke. **Hard cap: 1024 chars** (Kiro's frontmatter parser silently truncates at the byte boundary; `agentbundle catalogue lint --deep` enforces this).
 - **Declare output rendering directives** — `## Output rendering` before the first procedural `##` for skills that surface structured output. Catalog: `guides/core/reference/output-rendering.md`.
 
-## Personal information
-
-**Never include personal information in pack content.** This means no real names, email addresses, usernames, account IDs, phone numbers, or any other PII in `.apm/**`, `seeds/**`, `pack.toml`, or any other in-tree file. Use placeholder values (e.g. `example@example.com`, `<your-org>`) in templates and example config. The CI credential scan (`Gate C`) blocks real bearer tokens; the same discipline applies to all personal data.
-
 ## Eval coverage
 
 A non-cosmetic pack update must also update the pack's eval harness:
@@ -141,6 +133,12 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 ```
 Windows CI (Python 3.11, cp1252 default) crashes on any Unicode character without this guard. `errors="strict"` on stdout surfaces encoding bugs immediately; `errors="backslashreplace"` on stderr prevents diagnostic loss.
 Any `subprocess.run` call with `text=True` must also pass `encoding="utf-8"` — child scripts reconfigured to UTF-8 produce bytes undefined in cp1252.
+
+## Authoring README.md and DESIGN.md
+
+**README** (for adopters): states the pack's intent and the user journey it serves — not a contributor capability reference, not a skill inventory. Structure: outcome sentence → first-workflow command with mock → `| Say this | What happens |` entry points table → 2–3 terminal session mocks → cross-pack dependencies → links.
+
+**DESIGN.md** (for contributors, living reference not proposal): create when the pack has non-obvious philosophy, a method shape skill authors must not break, or decisions that get re-litigated in PRs. Structure: ADR/RFC header → TL;DR (3–5 prose sentences) → Non-Goals bullets → numbered sections (philosophy, method, invariants, decisions) → decisions log with `Alternative considered:` per entry. Update same-PR on any conflicting skill change — drift is a bug.
 
 ## Skill reference files
 

--- a/packs/core/DESIGN.md
+++ b/packs/core/DESIGN.md
@@ -1,0 +1,461 @@
+# Core Pack — Design Document
+
+Living design reference for the core pack. Records the philosophy, architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** [ADR-0014](../../docs/adr/0014-rigor-scales-with-risk-work-loop-modes.md) (mode selection), [ADR-0005](../../docs/adr/0005-supervisor-topological-default-and-write-gate.md) (supervisor write-gate), [ADR-0006](../../docs/adr/0006-doc-drift-construction-and-judgment.md) (doc drift)  
+**Related RFC:** [RFC-0025](../../docs/rfc/0025-work-loop-light-mode.md) (light mode)
+
+---
+
+## TL;DR
+
+`work-loop` is a supervised coding loop that replaces agent self-assessment with verifiable termination criteria. It runs in a fixed shape — plan → execute → gates → review → decide — and cannot exit without two human approvals: plan sign-off before a line is written, and PR merge after adversarial review is clean. Risk (not file count) determines mode; the adversarial reviewer always runs cold with no build memory; parallel writes are gated by default; spec drift is resolved in the PR, not after it.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **LLM capability gaps** — the loop does not correct bad code. If the agent can't implement something correctly, it surfaces that to the human rather than iterating forever. Termination is designed in (§9).
+- **Judgment calls about feature design** — the loop verifies implementation against the spec, not the spec against user need. That's the brief layer's job (§11).
+- **Parallel write coordination as a default** — DAG-independent tasks can make incompatible implicit decisions that survive textual merge. Parallel writes are gated; the default is sequential topological order (§12).
+
+---
+
+## 1. The problem
+
+### Why the loop exists
+
+LLMs self-assess unreliably. Left to run open-ended, an agent will declare the task done when it *feels* done — not when objective criteria pass. Two failure modes dominate:
+
+1. **Premature closure** — the agent calls it done when tests would have caught an error, when the spec says something different from what was implemented, or when a scope assumption turned out to be wrong. Without a gate, this reaches the human's review as a fait accompli.
+
+2. **Scope creep** — without a plan gate, the agent faithfully executes the wrong intent: refactors surrounding code "while I'm here," adds a helper that a second caller might eventually want, cleans up style inconsistencies that weren't asked for. The diff becomes unreadable, the real change gets buried.
+
+`work-loop` replaces "feel" with verifiable termination criteria and replaces trust with observable gates.
+
+---
+
+## 2. The loop model
+
+### The invariant
+
+```
+   ┌─────────────────────────────────────────────────────────┐
+   │                                                         │
+   ▼                                                         │
+PLAN  ──►  EXECUTE  ──►  GATES  ──►  REVIEW  ──►  DECIDE    │
+                          │           │            │         │
+                          │           │            └── findings? ──┐
+                          │           │                            │
+                          └─ failed? ─┴── findings? ────── fix ────┘
+                                                              │
+                                                              └── back to GATES
+```
+
+**This shape is the invariant.** Phases run in order; no phase is skippable; the loop cannot exit at EXECUTE or GATES. The only permitted shortcuts are: (a) a trivial one-line edit that doesn't need the loop at all, and (b) light mode, which trims reviewer fan-out but preserves the shape.
+
+### Phase responsibilities
+
+| Phase | Who | What it does |
+|-------|-----|--------------|
+| PLAN | Agent | Reads workspace context, checks risk triggers, writes the trio + assumptions, surfaces to human for sign-off. |
+| EXECUTE | Agent | Implements against the spec, one logical task at a time. |
+| GATES | Agent | Runs lint + typecheck + tests after each logical change. Gate failure → fix → re-run. Never surfaced to human as a blocker unless the fix is beyond the loop's capability. |
+| REVIEW | Adversarial reviewer | Reads the diff cold, in a fresh session with no build context. Returns findings grouped by severity. |
+| DECIDE | Agent | Assesses findings, applies fixes, re-runs gates, iterates until clean. Declares done or surfaces to human if stuck. |
+
+### What "surface" means
+
+Throughout this skill, **surface** means: stop the current loop, emit a short description of the situation in the final message (what happened, what you tried, what state things are in), and wait for human direction. It is the project's house verb for "stop and report." Do not retry, do not redispatch, do not silently reset.
+
+---
+
+## 3. Mode selection
+
+### Light vs. full
+
+`work-loop` has two modes chosen by the **risk of the work, not its file count**. A two-file familiar change is light. A one-file auth change is full.
+
+**Risk triggers — any one routes to full mode:**
+
+- **Unfamiliar** — territory the agent doesn't know well.
+- **Multi-person** — more than one person builds or reviews it.
+- **Multi-feature or dependent tasks** — it decomposes a multi-feature brief, or its tasks depend on one another.
+- **Compliance, governance, or security boundary** — auth, secrets, user input, deserialization, file/network I/O.
+- **Structural or public-interface change** — new module, layer, or boundary; or a public/published interface.
+- **Destructive or irreversible operation** — deletes data, force-pushes, drops tables.
+- **New dependency** — adds a dependency.
+
+No trigger fires → light mode.
+
+### What each mode changes
+
+| Aspect | Light mode | Full mode |
+|--------|-----------|-----------|
+| Spec | Lean inline (trio + short task list) | Full `new-spec` document |
+| `adversarial-reviewer` passes | Single bounded pass; one re-review of the fix, then escalates | Iterated to clean (max 5 iterations) |
+| `quality-engineer` | Not run by default | Runs at end-of-session checklist |
+| `loop-cohort` state machine | Not used | Used |
+| Task count | Single logical task | Multi-task via supervisor |
+
+### Why risk, not file count
+
+The old rule (">1 file → full mode") was risk-blind. A three-file config tweak to a familiar system paid compliance-grade cost; a one-file change to an auth path did not. The risk-trigger set replaces the file-count rule because each trigger maps to a gate the repo already maintains — the trigger set's exhaustiveness argument is that it covers every boundary where the cost of a mistake is meaningfully higher than the cost of the gate. See ADR-0014 for the full rationale and the RFC-0025 experiment data.
+
+---
+
+## 4. Human gate design
+
+### The two gates
+
+| Gate | When | Duration | What to check |
+|------|------|----------|---------------|
+| **G-plan** | After the trio is written, before EXECUTE starts | 5–10 min | Is the trio complete? Are risk triggers correct? Is the scope bounded? Are assumptions plausible? |
+| **G-pr** | After REVIEW is clean, before merge | 10–20 min | Is adversarial review marked clean? Does implementation match the spec? Is there anything in the diff that wasn't in the plan? |
+
+### Why two gates, not one
+
+A single post-implementation gate catches everything too late. The cost of a bad plan is one full loop iteration — catching it at G-plan is the cheapest possible intervention. The cost of approving a bad plan is exactly that: you've paid for an implementation you didn't want.
+
+G-pr is not redundant with G-plan. G-plan checks intent; G-pr checks fidelity. An agent can execute a good plan faithfully and still introduce a Blocker the adversarial reviewer caught. G-pr is the last line of defense before the loop's output goes to release.
+
+### The "cheapest gate" principle
+
+G-plan is the cheapest gate in the system — 5–10 minutes of focused reading against a trio and a short task list, before a single line of code is written. Skipping it to save 5 minutes means any scope error discovered during EXECUTE costs a full iteration. The asymmetry strongly favors always reading the plan.
+
+### Gate consequence model
+
+A bad G-plan approval → the agent executes it faithfully. The agent cannot detect that the intent was wrong; it only knows the spec. A bad G-pr approval → the diff goes to release with the Blocker intact. Neither gate protects against the other's failure.
+
+---
+
+## 5. The trio
+
+### Format
+
+The trio is the minimum viable spec. Three sentences:
+
+```
+Problem:  <one sentence — what is broken or missing, and for whom>
+User:     <one sentence — the specific user this change serves>
+Success:  <one sentence — what observable outcome means done>
+```
+
+### What makes a good trio
+
+- **Problem** names a concrete failure or gap, not a solution. "The export crashes above 50k rows" is a problem. "We need to add streaming to the export" is a solution disguised as a problem.
+- **User** names a specific person or role, not "users" or "the system." "Engineer shipping the bulk-export feature" is a user. "Users who export data" is not.
+- **Success** is falsifiable. "1M rows under 2 GB peak RSS" is falsifiable. "The export works well" is not.
+
+### What a bad trio means
+
+A trio that can't be falsified, doesn't name a real user, or describes a solution instead of a problem is an indicator that the scope isn't understood yet. The right response is to redirect the agent with a one-sentence correction — not approve and hope it self-corrects during EXECUTE.
+
+---
+
+## 6. Self-coverage gate
+
+### Why it exists
+
+Between human gates, the agent should resolve everything a referent (tests, linter, spec) can resolve, and surface only the irreducible — situations where the test can't tell you if the change is correct, or where the spec is ambiguous about the right behavior.
+
+Without a self-coverage gate, agents surface too eagerly: every failing test becomes a "blocked, need direction" when most failing tests are just fixable. This trains humans to ignore surface messages and defeats the purpose of the gate.
+
+### The resolve-vs-surface discipline
+
+At PLAN, REVIEW, and DECIDE, the agent opens a disposition record. For each surfacing candidate:
+
+- **Resolve** if a referent can settle it (test failure, lint error, spec says X, contract says Y).
+- **Surface** only if the situation is irreducible — a genuine conflict between the spec and a discovered constraint, a gate failure the agent can't fix within the scope of the plan, or a question the human needs to answer before work can proceed.
+
+The record is closed at DECIDE. Done-checklist refusal: don't declare done until every REVIEW finding has a disposition in the record.
+
+---
+
+## 7. Adversarial review architecture
+
+### Fresh context — why it matters
+
+The adversarial reviewer runs in a forked context with no memory of the build session. This is the most important design property of the review phase.
+
+An agent that reviews its own work in the same session cannot be adversarial. It knows what it intended, which primes it to interpret ambiguous evidence charitably. The fresh-context constraint forces the reviewer to read the diff as a stranger would — which is exactly how the next engineer to maintain this code will read it.
+
+### Cold read — what it catches
+
+A cold read reliably catches things the build-session agent systematically misses:
+- Assumptions that the build agent made unconsciously and never stated
+- Scope that crept in during EXECUTE and didn't make it back to the spec
+- Interface contracts that look correct to the author but are ambiguous to a reader
+- Missing edge cases that the author's mental model filtered out
+
+### The three specialist reviewers
+
+| Reviewer | When it fires | What it checks |
+|----------|--------------|----------------|
+| `adversarial-reviewer` | Every diff, after gates pass | Spec/implementation drift, missing edge cases, scope creep, false assumptions |
+| `security-reviewer` | When the diff crosses a security boundary | OWASP Top 10:2025, ASVS 5.0, STRIDE + LINDDUN; boundary-keyed module loading |
+| `quality-engineer` | Full mode, end-of-session checklist | Testability, observability, reliability, maintainability; drafts tests on request |
+
+**Default selection:** `adversarial-reviewer` runs on every diff. The other two fire on risk — security when the change touches auth, secrets, user input, deserialization, file/network I/O, dependencies, or LLM/agent code; quality-engineer in full mode, not light.
+
+### Depth modules: security-checklists and operational-safety
+
+Two skills extend the reviewer pair with boundary-keyed content loaded inline — they are not entry points and are never invoked directly:
+
+- **`security-checklists`** — loaded by `security-reviewer` when the diff crosses a named security boundary (auth, secrets, user input, deserialization, file/network I/O, LLM/agent code). Provides the matching boundary module's checklist items, drawn from OWASP 2025, ASVS 5.0, and CWE Top 25.
+- **`operational-safety`** — loaded by `quality-engineer` when the change is infra-touching or involves a destructive operation (migrations, force-pushes, table drops, infra config). Provides failure-mode-keyed checklists for pre/post conditions, rollback procedures, and observability requirements.
+
+Both skills degrade gracefully — if neither trigger fires, neither loads. The reviewer skill works at its baseline checklist depth; the depth module only adds when the boundary matches.
+
+### Why parallel reviewers are read-safe
+
+Parallel *readers* don't write to the repo. Reviewer fan-out is safe; parallel implementer *writes* are not (see §12 on supervisor mode). The risk asymmetry is: two reviewers seeing the same diff and disagreeing is recoverable (you adjudicate); two implementers making incompatible edits to the same conceptual interface is not (the merged state may be silently wrong).
+
+---
+
+## 8. Mechanical gates
+
+### What runs and when
+
+After each logical change during EXECUTE:
+
+```
+1. Lint          (format + static analysis)
+2. Typecheck     (if the project has a type system)
+3. Tests         (unit, integration — whatever the project's test command runs)
+```
+
+These run before the human sees the diff. The diff is not presented to the human until gates are green and REVIEW is clean.
+
+### Gate failure is an EXECUTE-phase event, not a surface event
+
+When a gate fails, the agent fixes the issue and re-runs the gate. This is not surfaced to the human. The human should only see the result of a passing gate — gate-failure details belong in the agent's working log, not in the final message.
+
+**Exception:** if the agent cannot fix the gate failure within the scope of the plan (the fix requires changing something out-of-scope, or the failure is caused by a pre-existing problem unrelated to this change), that is surfaced as a blocked situation.
+
+### Why gates run before the diff is seen
+
+Running gates before presenting the diff to the human avoids a common failure mode: the human approves a diff that would have been caught by lint or tests, and the CI run fails after merge. The loop's job is to give the human a diff that is already verified, not a diff that is pending verification.
+
+---
+
+## 9. Termination
+
+### The loop terminates when
+
+1. REVIEW reports clean (no Blockers; Concerns and Nits are resolved or explicitly deferred to a follow-up)
+2. All gates pass
+3. The spec and implementation are aligned (if implementation diverged, the spec was updated in the same PR)
+4. The done-checklist refusal is satisfied
+
+### When the loop surfaces instead of terminating
+
+- Max iterations reached (default 5 in full mode; 1 re-review in light mode before escalation)
+- Gate failure that can't be fixed within scope
+- A REVIEW Blocker that contradicts the approved spec (requires human adjudication)
+- A discovery mid-EXECUTE that changes the scope of the plan
+
+### Spec drift is a bug
+
+If the implementation diverges from the spec, the spec must update in the same PR. A spec that describes what was planned but not what was built is worse than no spec — it actively misleads future readers. Drift is not deferred to a follow-up; it is resolved in the current loop.
+
+---
+
+## 10. The workspace model
+
+### The cold-start problem
+
+Without persistent context, every session starts blind. The agent doesn't know what was decided last session, what's in progress, what's blocked, or what the current priorities are. Teams working this way spend 10–15 minutes at session start reconstructing context that was already established.
+
+`workspace.toml` is the coordination artifact that solves the cold-start problem for a single-engineer or small-team workflow.
+
+### The queue model
+
+```
+[backlog]           ← unscheduled ideas and follow-ons
+[initiative.N]
+  shaping_queue     ← needs framing (author-brief, frame-intent)
+  work_queue        ← ready to build (spec approved, unblocked)
+  done              ← shipped items
+```
+
+Items flow left to right: from backlog → shaping → work → done. `workspace-status` reads this structure and surfaces what's actionable right now.
+
+### Orient and close
+
+**Every session starts with `workspace-status`.** It replaces reading multiple product docs by hand — you get a ready/blocked/done summary in one shot.
+
+**Every session ends with `capture-work`.** Follow-ons, deferred scope, and discovered issues get queued in `workspace.toml` so they survive the session. Without capture-work, follow-ons live in the chat log and are effectively lost.
+
+This orient/close discipline is the habit that makes workspace.toml accurate over time. A workspace.toml that is only written once and never updated is stale within a week.
+
+---
+
+## 11. The brief chain
+
+### Entry points and when to use each
+
+| Entry point | Use when |
+|-------------|----------|
+| `author-brief` | You have unstructured input — an idea, email, Linear issue — and need to turn it into a DoR-compliant brief queued in workspace.toml. |
+| `receive-brief` | A well-formed brief already exists and you want to decompose it into specs ready for `work-loop`. |
+| `new-spec` | You want to author a single feature spec directly, without a brief layer. |
+| `work-loop` | A spec exists (or you give it one inline) and you want to implement it. |
+| `bug-fix` | You have a specific bug. Skip the brief — go straight to diagnosis and fix. |
+| `init-project` | You're starting a fresh repo and need the full agent-ready-repo structure, conventions, and AGENTS.md seeded. |
+| `adapt-to-project` | You're onboarding an existing (brownfield) repo — derives the work-loop configuration from what the repo already does. |
+
+### Why the brief layer exists
+
+The brief layer separates "what should we build?" from "how do we build it?" `author-brief` produces a DoR-compliant brief — outcome, appetite, constraints — that answers the first question. `work-loop` operates on a spec that answers the second. Running `work-loop` directly on a vague idea collapses both questions into one and produces a spec that describes a solution to a problem that wasn't clearly stated.
+
+### Inline depth skills
+
+Two skills extend `work-loop`'s EXECUTE phase inline rather than being entry points. They are not invoked directly; `work-loop` loads them selectively based on the task shape:
+
+- **`contract-acquisition`** — fires when the implementation touches an unfamiliar API or library. Grounds the interface contract (method signatures, auth model, error shapes) before code is written. Prevents guessed signatures that compile locally but fail against the real service.
+- **`frontend-engineering`** — fires when the task output is HTML/CSS/JS. Establishes design intent and craft rules (layout model, type scale decisions, animation contracts) as a pre-flight before the first line of markup. Acts as the bridge between the experience-design pack's output artifacts and the code that implements them.
+
+Neither skill appears in the entry points table because neither is an entry point. They extend an in-progress `work-loop` run; they are not how you start work.
+
+### DoR — definition of ready
+
+A brief is ready to move to spec when it has:
+- **Outcome** — a user-facing or system change
+- **Appetite** — a time or scope constraint
+- **Key constraints** — what can't change, what's already decided
+
+A brief without appetite is unbounded; a spec derived from it will be unbounded. Appetite is not optional.
+
+---
+
+## 12. Supervisor mode
+
+### The write problem
+
+Two DAG-independent tasks editing different files can make incompatible *implicit decisions* — decisions that survive textual merge and each task's own gates, but break in the integrated state. This is a silent failure: no merge conflict, no test failure, just wrong behavior.
+
+The canonical example: Task A adds a field to a model; Task B adds a query that assumes the field doesn't exist. Both pass their own tests. The merged state queries a field that now exists, gets data it wasn't written to handle, and fails at runtime.
+
+### The default: sequential topological order
+
+Tasks execute in topological order by the full `Depends on:` DAG, sequentially. This is the safe default because:
+- It eliminates the implicit-decision collision class entirely
+- It preserves the DAG's intent (the plan author wrote the dependencies for a reason)
+- It is portable across every adapter (parallel agent primitives vary by tool)
+
+### Opt-in parallel writes
+
+Parallel implementer writes are gated on:
+1. Membership in a measured safe category (file-disjoint in the DAG)
+2. A `git merge-tree` file-disjointness check at runtime
+
+Everything else runs serial. See ADR-0005 for the experiment data and the interference taxonomy.
+
+### Parallel readers are always safe
+
+Reviewer fan-out (multiple reviewers seeing the same diff) is unconstrained. Reviewers don't write to the repo; the only failure mode is two reviewers disagreeing, which is recoverable.
+
+---
+
+## 13. Safety invariants
+
+These constraints must never be violated by any skill in the core pack or any skill that extends it.
+
+1. **The loop cannot self-certify.** A loop that completes without a human seeing the plan and approving the merge is not a loop — it is an autonomous agent. Human gates are structural, not optional.
+
+2. **Blockers must not be merged.** A diff where the adversarial reviewer has flagged an unresolved Blocker must not go to G-pr. The loop iterates until clean or surfaces; it does not unilaterally decide a Blocker is acceptable.
+
+3. **Spec drift is resolved in the PR, not deferred.** If implementation diverges from the spec, the spec updates in the same PR. Drift is a bug; the fix goes in the current loop.
+
+4. **Gate failures are not surfaced to the human as blockers, unless they can't be fixed within scope.** The human's attention is the scarcest resource. Don't spend it on lint errors.
+
+5. **The loop cannot modify its own termination criteria.** The done-checklist is fixed by the skill, not by the loop's runtime judgments about what "done" should mean for this particular task.
+
+6. **`capture-work` runs at session end.** Follow-ons discovered during the loop are queued in workspace.toml, not discarded. Silently dropping scope creep findings is not a valid optimization.
+
+---
+
+## 14. Output format conventions
+
+### The plan — what it contains
+
+```
+mode: light | full
+
+  Problem  <one sentence>
+  User     <one sentence>
+  Success  <one sentence>
+
+  Assumption: <one line per assumption>
+  Risk triggers: <listed if any fire>
+
+  Tasks:
+    1. <task title>  [Depends on: none | task N]
+    2. ...
+
+Approve? ›
+```
+
+Light mode stops after the trio + assumptions + task list. Full mode additionally includes acceptance criteria and a risk-trigger assessment.
+
+### Finding severity labels
+
+All reviewers use the same three severity levels:
+
+| Label | Meaning |
+|-------|---------|
+| **Blocker** | Must fix before merge. The loop iterates. |
+| **Concern** | Should address; human decides whether to apply or defer. |
+| **Nit** | Optional cleanup; agent applies if trivial; otherwise defers. |
+
+### The surface message
+
+When the loop surfaces, the final message format is:
+
+```
+[surface: <situation in one phrase>]
+
+What happened: <one sentence>
+What I tried: <one sentence>
+Current state: <one sentence>
+What I need from you: <one sentence>
+```
+
+This format makes it possible to resume the loop without rereading the entire session. The human can act on a surface message without context.
+
+---
+
+## 15. Design decisions and rationale log
+
+### Why risk-based mode selection, not file count (2026-06-05)
+
+The old ">1 file → full mode" rule made a familiar three-file config change pay compliance-grade cost while a single-file auth change went unscrutinized. The risk-trigger set replaces it because each trigger maps to a gate the repo already maintains. The trigger set's exhaustiveness argument is that it covers every boundary where the cost of a mistake materially exceeds the cost of the gate. Cost data (a reported ~$60 session for a single two-hour loop run with reviewer fan-out) confirmed the problem was real, not theoretical. — ADR-0014
+
+**Alternative considered:** keep the file-count rule but tune the threshold (e.g. ">3 files"). Rejected because the threshold problem is unsolvable — any fixed count is wrong for some class of change, and the count doesn't encode the actual risk dimension (familiarity, security boundary, irreversibility).
+
+### Why the adversarial reviewer has no build context (from day one)
+
+Cold review was a deliberate early choice, not a technical limitation. An agent that reviews in the same session as the build is primed to read the diff charitably. The fresh-context constraint is what makes the review adversarial in a meaningful sense. Removing it to save a session-load would break the one property that makes the reviewer trustworthy.
+
+**Alternative considered:** stateful review — run the reviewer in the same session, giving it access to the build rationale and intermediate decisions. Rejected because a reviewer that knows what the author intended will systematically read ambiguous evidence charitably. The value of the review comes from genuine ignorance of intent.
+
+### Why sequential topological order is the supervisor default (2026-05-29)
+
+The parallel write collision rate in agentic PR data (AgenticFlict: 27.67% textual conflict rate across 142K+ agentic PRs — and that's the loud rate; silent semantic conflicts are additional) made automatic parallel writes untenable as a default. Sequential topological order eliminates the implicit-decision class entirely. Opt-in parallel writes require a file-disjointness gate because the textual conflict rate understates the semantic rate by a measurable factor. — ADR-0005
+
+**Alternative considered:** automatic parallel by default, with post-merge conflict detection. Rejected because silent semantic conflicts (two tasks making incompatible implicit decisions that pass textual merge) are undetectable without running the full integration test suite — and even then the failure mode is a runtime error rather than a merge conflict, which is harder to attribute.
+
+### Why the trio is three fields, not a full PRD (from day one)
+
+A full PRD at plan time creates a waterfall within the loop: the agent writes a large document, the human reviews a large document, the human corrects sections, the agent rewrites sections, and implementation hasn't started yet. The trio (problem / user / success) is the minimum information the agent needs to avoid the two primary failure modes (premature closure, scope creep). Everything else — acceptance criteria, edge cases, implementation notes — emerges during EXECUTE and gets captured either in the plan tasks or in a full spec when risk triggers fire.
+
+**Alternative considered:** require a full spec (acceptance criteria, edge cases, non-functional requirements) before any EXECUTE phase, even in light mode. Rejected because it reintroduces waterfall at the micro level — the spec becomes the bottleneck, and the cost per task increases by a factor of 3–5× for work that doesn't need it. Risk triggers already route high-stakes changes to full `new-spec`; forcing full spec on low-risk work is overhead without matching benefit.
+
+### Why workspace.toml and not a tasks file or issue tracker (2026-06-xx)
+
+A tasks file captures what to do but not the DoR state (is this brief? is the spec approved? is it blocked and why?). An issue tracker requires a network call and browser context to update. workspace.toml is a versioned TOML file in the repo: it's readable by any tool, diff-able in PRs, and greppable. The tradeoff is that it's single-tenant (one person's queue, not a team's board) — the intended use case is a solo engineer or a very small team. Multi-person coordination belongs in the issue tracker; workspace.toml is the local layer.
+
+**Alternative considered:** use the issue tracker (Linear, GitHub Issues) as the single source of truth and skip workspace.toml. Rejected for two reasons: (a) issue trackers require auth and a network call to read at session start — an agent can't reliably orient from them in offline or restricted environments; (b) DoR state (brief drafted, spec approved, blocked reason) doesn't map cleanly to issue tracker fields and would require custom fields per tool, which defeats the portability goal.

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -1,53 +1,87 @@
 # core
 
-The core pack ships the agent-ready-repo skills (work-loop, new-spec,
-new-rfc, …) — including `frontend-engineering`, the depth skill the
-work-loop loads inline whenever a task's primary output is HTML, CSS,
-or JS — the four specialist subagents (adversarial-reviewer,
-security-reviewer, quality-engineer, implementer), the canonical
-session-start and work-loop-check hooks, and the `/adapt-to-project`
-command.
+Supervised coding — from brief to merged PR.
 
-## Install routes and adaptation
+---
 
-`core` ships through three install routes — `agentbundle install`
-(CLI), `claude plugin install` (Claude-plugins), and `apm install`
-(APM). Whichever route an adopter uses, the install→adapt chain ends
-the same way: a `[[packs-installed]]` entry lands in the
-scope-correct `.adapt-install-marker.toml`, the next session of a
-HookIntegrator-covered target tool surfaces a *"N pack(s) pending
-adaptation; run `/adapt-to-project`"* nudge, and the skill adapts the
-brownfield repo (or user-home for user-scope packs) to the project.
+## Start here
 
-APM's HookIntegrator projects the `SessionStart` install-marker hook
-to four of seven supported target tools: `Claude Code`, `Copilot`,
-`Cursor`, and `Gemini`. The remaining three — `Codex`, `OpenCode`,
-and `Windsurf` — silently lack the hook surface in upstream APM
-today; their adopters run the documented manual fallback once after
-install:
+Type `author-brief` and paste any idea, email thread, or issue.
+
+```text
+  brief   docs/product/briefs/data-export.md   (draft)
+  queued  sprint-8/data-export → ready
+```
+
+On any session return, type `workspace-status` to orient.
+
+```text
+● sprint-8/data-export     ready    spec approved · 3 tasks
+⚠ sprint-8/auth-refresh    blocked  needs spec/api-contract
+✓ sprint-7/payment-ui      done     shipped 2026-07-25
+```
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|-------------|
+| `workspace-status` | Orient — what's ready, blocked, and done |
+| `author-brief` | Turn any idea, email, or issue into a queued brief |
+| `work-loop` | Plan → execute → gates → adversarial review → merge |
+| `bug-fix` | Diagnose and fix a specific bug |
+| `new-spec` | Author a spec directly, without the brief layer |
+
+---
+
+## How a session runs
+
+```text
+author-brief [paste your idea]
+
+  brief   docs/product/briefs/data-export.md
+  queued  sprint-8/data-export → ready
+```
+
+```text
+work-loop docs/product/briefs/data-export.md
+
+  mode: light — no risk triggers
+
+    Problem  Streaming export crashes above 50k rows.
+    User     Engineer shipping the bulk-export feature.
+    Success  1M rows under 2 GB peak RSS.
+
+  Approve? ›
+```
+
+```text
+work-loop execute spec/data-export
+
+  ● Lint          ok
+  ● Typecheck     ok
+  ● Tests  246/246 ok
+  ● Review        1 blocker → fixed → clean
+```
+
+The agent opens the PR. Read the description, then merge.
+
+---
+
+---
+
+## Adapters
+
+APM's HookIntegrator projects the install-marker hook to `Claude Code`, `Copilot`, `Cursor`, and `Gemini`. The remaining three — `Codex`, `OpenCode`, and `Windsurf` — lack the hook surface; their adopters run the manual fallback once after install:
 
 ```
 agentbundle adapt --scope <project|user>
 ```
 
-This is the same gesture CLI-route adopters use, and the same gesture
-adopters at HookIntegrator-covered targets can run if they prefer to
-opt out of hooks for safety. See
-[`docs/specs/apm-install-route-parity/spec.md`](../../docs/specs/apm-install-route-parity/spec.md)
-for the contract surface and
-[`docs/rfc/0010-apm-install-route-parity.md`](../../docs/rfc/0010-apm-install-route-parity.md)
-for the design rationale.
-
-## Usage
-
-`core` is the loop itself. Ask your agent, for example:
-
-- "What should I work on next?" (`workspace-status` — orient at session start)
-- "Start a new spec for a rate-limiting feature." (`new-spec`)
-- "Implement this spec with the work-loop." (`work-loop`)
-- "Fix this bug: the importer drops the last row." (`bug-fix`)
-- "Adapt this repo to the installed packs." (`/adapt-to-project`)
+HookIntegrator-covered adopters can also run this to opt out of hooks.
 
 ---
 
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.  
 → **Go deeper:** the [`core` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/core/).

--- a/packs/experience-design/DESIGN.md
+++ b/packs/experience-design/DESIGN.md
@@ -1,0 +1,326 @@
+# Experience Design Pack — Design Document
+
+Living design reference for the experience-design pack. Records the philosophy, method architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** ADR-0054 (experience-status read-only), ADR-0030 (consolidated pack layout)  
+**Related RFCs:** RFC-0064 (pack rename, M3), RFC-0062 (copy-direction, accepted 2026-07-23)
+
+---
+
+## TL;DR
+
+`experience-design` is the design seat for a product team. It runs a walkable method from outcome to realization — journey → content direction → screen flow → aesthetic direction → per-screen craft → independent review — where each step produces a portable artifact the next step consumes. Every skill ships method, never stack code or values: the adopter derives their design from the method and fills in numbers. The quality floor (handle-all-states, WCAG accessibility, reduced-motion) is non-negotiable and referenced by every consuming skill. An independent `experience-reviewer` subagent reads design artifacts cold — no authoring memory — at the end of the thread.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to provide. It doesn't, by design:
+
+- **No stack specifics.** No UI-framework code, no styling-language syntax, no animation library, no fixed spacing/timing/color/motion-curve tables, no token values, no pixel comps. The pack ships the method to derive your design; you choose your tools and fill in the numbers.
+- **No product strategy.** The pack assumes an agreed user and outcome. Framing, opportunity sizing, and UX strategy are upstream (`product-strategy` pack). When that input is absent, `journey-mapping` degrades gracefully but the output is weaker.
+- **No UI copy strings.** Per-state UI copy (button labels, error messages, empty states) is the `voice-and-microcopy` skill's domain in `product-engineering`. This pack sets content intent and copy direction; `voice-and-microcopy` writes the actual strings keyed to the state matrix.
+- **No code review.** `experience-reviewer` reviews design artifacts only — journeys, screen flows, briefs, aesthetic directions. It never reviews code diffs (use core's `adversarial-reviewer`) or architecture docs (use architect's `design-reviewer`).
+- **No persistent runtime.** No hook, engine, validator daemon, or state machine. This pack is habits, not infrastructure. `design-review` is an authoring-time interactive skill; `experience-reviewer` is a one-shot forked subagent.
+
+---
+
+## 1. The design thread
+
+### The full sequence
+
+```
+journey-mapping
+    ↓
+content-design  ←──── tone-of-voice
+    ↓
+user-flow
+    ↓
+design-principles  ←──── creative-direction
+    ↓                          ↓
+information-architecture   design-system
+  (or genre-direct skill)
+    ↓
+interaction-design
+    ↓
+design-review     ←  quality-floor check (authoring-time)
+    ↓
+experience-reviewer  ←  independent cold review
+```
+
+`service-blueprint` and `process-mapping` are parallel to the main thread (they map what backs the screens, and the internal operations behind them) rather than sequential gates.
+
+### Why the sequence exists
+
+Each skill consumes a specific upstream artifact and cannot produce reliable output without it:
+
+- `content-design` needs the journey's key touchpoints to know what the surface is trying to accomplish and for whom.
+- `user-flow` needs the content brief to sequence screens in a way that delivers on the stated content intent, not just the functional path.
+- `creative-direction` needs the journey's emotional arc (the pains, the moments of relief) to ground the aesthetic direction in real user feeling rather than preference.
+- `design-system` needs the named aesthetic direction to derive a token taxonomy that isn't arbitrary.
+- `information-architecture` (and the genre-direct skills) needs both the content brief and the aesthetic direction as constraints.
+- `interaction-design` needs the per-screen brief produced by `user-flow` — which includes the state matrix — to design behavior for the right set of states.
+- `design-review` and `experience-reviewer` need the completed artifacts to review against something concrete.
+
+Skipping a step doesn't save time — it pushes the missing input forward as an implicit assumption, where it gets designed around rather than decided.
+
+### The minimal viable thread
+
+The minimum that makes the output coherent:
+1. `journey-mapping` — the outcome and failure modes
+2. `user-flow` — the screen list and per-screen briefs
+3. One craft pass on each screen (at minimum: `information-architecture` → `interaction-design`)
+4. `experience-reviewer` — the cold review
+
+Everything else in the pack enhances this thread. `experience-status` tells you where you are on it.
+
+---
+
+## 2. The quality floor
+
+### What the floor covers
+
+Every skill in the craft sequence references one shared quality-floor checklist:
+
+1. **Handle all states.** Every screen must be designed for: empty state, loading/skeleton state, populated state, error state, success/confirmation state, and any partial states specific to the surface (partially-loaded, degraded, offline). Missing a state is not a styling gap — it's a functional gap that will surface to users.
+
+2. **Accessibility floor — WCAG 2.2 AA minimum.** Colour contrast ratios, label associations, focus order, reduced-motion respect, touch target sizes. This pack points to WCAG; it does not reprint the standard or fix values. The designer derives conformant values; the floor only sets the target level.
+
+3. **Motion communicates state; honour reduced-motion.** Motion is a communication tool. Every animation must communicate something (state change, hierarchy, feedback). Every animation must respect the user's reduced-motion preference and have a non-motion fallback that communicates the same thing.
+
+### Correctness is the floor, not the ceiling
+
+A design that passes the quality floor is correct. It is not necessarily good. Meeting WCAG AA alone produces accessible-but-tasteless work; handling all states alone produces complete-but-generic work.
+
+The `creative-direction` skill is the gate between correct and good: it grounds visual and brand goals in persona, precedent, and platform conventions — naming a direction that the rest of the craft sequence must satisfy as a coherence constraint. A `creative-direction` doc that only restates correctness goals ("it should be accessible and clear") has not cleared the gate.
+
+This principle applies to every skill in the pack. `design-principles` must name principles that a team would actually dispute, not principles everyone already agrees with. `tone-of-voice` must produce ranked goals that create real copy arbitration, not aspirational adjectives.
+
+---
+
+## 3. The method principle: derive, never prescribe
+
+### Why no values tables
+
+The pack ships method and taxonomy shapes, not values. This is a deliberate scope decision, not a gap:
+
+- **Portability.** Values are always project-specific (a fintech's type scale is not a gaming product's type scale). A pack that ships values forces the adopter to either use them as-is (wrong) or override them everywhere (friction without benefit).
+- **Standards don't need reprinting.** WCAG contrast ratios, Material 3 motion curves, Apple HIG tap target sizes — these are published, maintained, and authoritative. A pack that reprints them creates a maintenance burden and an accuracy risk. The method says what to check and points to where; the adopter follows the live standard.
+- **Method survives stack changes.** The token taxonomy shape (primitive → semantic → component) is stable across design tools, styling preprocessors, and component frameworks. A values table is not.
+
+### What "method" means in practice
+
+Each skill:
+- Names what to decide (e.g. "name each spacing value by semantic role, not by numeric scale")
+- Gives a decision rule (e.g. "every token decision must trace back to a named goal in the aesthetic direction")
+- Points to the standard for the constraint (e.g. "WCAG 2.2 AA for contrast ratios")
+- Leaves values blank (e.g. the taxonomy shape has named slots; the adopter fills the numbers)
+
+### The two kinds of "no stack"
+
+**No framework code.** The pack never emits framework-specific components, utility-class markup, native-platform views, or styling code. These belong in the build loop (`frontend-engineering` in core).
+
+**No tool prescriptions.** The pack never names a specific design tool winner (Figma, Sketch, Penpot). Tool categories appear where relevant (vector-based screen design tool, design-token plugin); specific tools do not.
+
+---
+
+## 4. The connective thread skills
+
+### How the thread flows
+
+The connective skills map the flow from a user's outcome to a set of screens ready for craft:
+
+| Skill | Input | Output | What it settles |
+|-------|-------|--------|-----------------|
+| `journey-mapping` | User, outcome, platform | Journey map (stages × emotions × pains × opportunities) | What the user is trying to accomplish and where it breaks |
+| `content-design` | Journey key touchpoints | Content brief per surface | What the surface says, for whom, to what objective |
+| `tone-of-voice` | Brand/product register | Copy goals + arbitration rules | How the copy sounds; what wins when goals conflict |
+| `user-flow` | Journey + content brief | Screen inventory, transitions, per-screen briefs | Which screens exist, what state each handles, how they connect |
+| `service-blueprint` | Journey + screen flow | Blueprint (frontstage / backstage / support) | What services back each screen action |
+| `process-mapping` | Internal workflow | As-is / to-be process (SIPOC, swimlane, pain register) | What the internal operations look like, where waste is |
+| `design-principles` | Journey insights | 3–5 named principles with arbitration tests | The decision rules that hold screens to a shared standard |
+
+### Platform/surface axis
+
+`journey-mapping` and `user-flow` carry a platform/surface axis — responsive-web, iOS, Android, cross-platform. This affects what the method asks at each stage (iOS has HIG interaction patterns; cross-platform requires explicit divergence documentation). Skills that consume per-screen briefs inherit the platform context from the brief.
+
+### Content-design vs. tone-of-voice vs. voice-and-microcopy
+
+Three skills touch copy; they operate at different layers:
+
+- **`tone-of-voice`** sets the register: ranked emotional and brand goals for copy, grounded in persona and precedent, with arbitration rules. Upstream and organizational — sets the standard all surfaces must meet.
+- **`content-design`** sets surface intent: what this specific surface says, for whom, in what structure. Execution-layer, per-surface — answers "what goes here?" not "how does it sound?"
+- **`voice-and-microcopy`** (product-engineering pack) writes the actual per-state strings. Consumes the state matrix from `user-flow` and the copy direction from tone-of-voice.
+
+Running `tone-of-voice` before `content-design` is correct. Running `content-design` before `user-flow` is correct. Running `voice-and-microcopy` after all three is correct.
+
+---
+
+## 5. The craft sequence
+
+### Why this order
+
+The craft sequence follows a dependency chain where each skill's output constrains the next:
+
+**Design-principles** ← journey insights  
+Principles must derive from real user pain points in the journey. A principle not grounded in a journey moment is an opinion, not a design rule. These are produced before aesthetic work begins because they are the meta-level arbitration rules the aesthetic work must satisfy.
+
+**Creative-direction** ← principles + persona + precedent  
+The aesthetic direction names the emotional and brand goals that visual decisions must serve. It is grounded in three things: the persona (who the user is, what their existing context looks like), stable referents (products or visual traditions that achieve the named goal), and platform conventions (iOS/Material/web norms the design inherits whether it wants to or not). An aesthetic direction not grounded in all three is arbitrary.
+
+**Design-system** ← aesthetic direction  
+The token taxonomy derives from the aesthetic direction. Every token decision must trace back to a named goal in the direction. A token that can't be explained by the direction is a gap in the direction, not a token decision.
+
+**Information-architecture / genre-direct skills** ← content brief + aesthetic direction  
+Hierarchy, reading flow, and wayfinding are set before behavioral design begins. The IA is the skeleton; interaction design is the muscle. Designing interaction without a settled IA produces behaviors that fight the structure.
+
+**Interaction-design** ← per-screen brief + IA  
+The behavioral layer is designed last in the craft sequence because it depends on knowing what states exist (from the per-screen brief's state matrix) and what the structural hierarchy is (from IA).
+
+### The genre-direct skills
+
+Six surface-typed IA skills run in place of the general `information-architecture` skill when the screen has a known surface genre:
+
+| Skill | Surface genre | What's specific |
+|-------|--------------|-----------------|
+| `analytical-design` | Dashboards, reporting surfaces | Widget hierarchy, role-based view architecture, business-question-to-layout map |
+| `conversion-design` | Marketing, acquisition, landing pages | Above-fold contract, scroll story, social-proof architecture |
+| `documentation-design` | Docs, help, reference | Diátaxis content typing, navigation strategy, TTFV architecture |
+| `informational-design` | Editorial, content-first pages | Typographic hierarchy, reading-pattern calibration, editorial grid |
+| `marketplace-design` | Listings, search, transactional surfaces | Listing card IA, filter and facet architecture, transaction bridge |
+| `workspace-design` | Productivity tools, workspace surfaces | Context-persistence architecture, attention zone layout, interrupt design |
+
+The genre-direct skills are not a replacement for `creative-direction` or `design-system` — they are a replacement for `information-architecture` only. The full craft sequence runs; only the IA step changes.
+
+---
+
+## 6. Independent review architecture
+
+### Why the experience-reviewer is forked
+
+The `experience-reviewer` agent runs in a forked context with no access to the authoring session. The reasons are structurally identical to why core's `adversarial-reviewer` runs cold:
+
+An agent that reviews its own work in the same session is primed to read the artifacts charitably — it knows what was intended, which means it interprets gaps as "the reader will understand" and inconsistencies as "acceptable trade-offs I already considered." A reviewer that has never seen the authoring rationale reads the artifacts as a user would: with no benefit of the doubt.
+
+### What the experience-reviewer covers
+
+The reviewer runs five lenses in sequence:
+
+| Lens | What it checks |
+|------|---------------|
+| Quality floor | handle-all-states, WCAG 2.2 AA contrast and labels, reduced-motion guard |
+| Grounded aesthetic fit | Do the screens satisfy the named goals in the aesthetic direction? Are visual decisions traceable to a principle? |
+| Platform fit | Do interactions match platform conventions? (iOS tap targets, Material elevation, web hover/focus patterns) |
+| Cross-brief coherence | Do screens that share a user flow tell a coherent story? Do adjacent screens use the same vocabulary? |
+| Marketing clarity | Fires on `communication_mode: product-copy` artifacts only — tweet test, five-second scan, painkiller-first framing |
+
+### What the experience-reviewer never does
+
+- Reviews code diffs (use core's `adversarial-reviewer`)
+- Reviews architecture design docs (use architect's `design-reviewer`)
+- Rewrites artifacts (read-only by contract — flags only, never fixes)
+- Runs before the minimal viable thread is complete (the reviewer needs a journey + screen flow + at least one per-screen brief to give a useful review)
+
+---
+
+## 7. Output artifact model
+
+### Where artifacts live
+
+Artifact-writing skills resolve their output path through the `[design]` table of the adopter-owned `agentbundle-layout.toml`:
+
+```toml
+[design]
+output_dir = "docs/design"   # resolves to: docs/design/{journeys,screens,briefs,...}/
+```
+
+Each skill writes under a subdirectory of `output_dir`:
+
+| Subdirectory | Written by |
+|---|---|
+| `journeys/` | journey-mapping |
+| `content/` | content-design |
+| `screen-flows/` | user-flow |
+| `blueprints/` | service-blueprint |
+| `processes/` | process-mapping |
+| `aesthetic/` | creative-direction, design-system, design-principles |
+| `screens/` | interaction-design, and the craft/genre skills |
+
+The path is elicited once per repo, written to `agentbundle-layout.toml`, and reused by every subsequent skill. `experience-status` reads from this directory to orient.
+
+### Why user-scope by default
+
+Design method is portable, not project-specific. A designer using the same method across multiple repos should not need to install the pack per-repo. The skills produce per-repo artifacts (they write to `docs/design/` in the repo), but the method itself doesn't change between repos.
+
+This is the same scope decision as `architect` and `desk-research`. Compare with `core`, which is repo-scope because the work-loop's gate commands (`lint`, `typecheck`, `tests`) are project-specific.
+
+---
+
+## 8. Cross-pack dependencies
+
+### Upstream: product-strategy
+
+The `product-strategy` pack is the strategic anchor this pack builds on. Before `journey-mapping` runs, a strategist may have committed:
+
+- `ux-strategy.md` (vision → goals + measures → plan) — read by `journey-mapping` as the stated rationale for the journey.
+- `content-strategy.md` (Halvorson quad: Purpose + Process + Structure + Governance) — read by `content-design` for organizational governance intent.
+
+Both inputs are optional; the skills degrade gracefully when absent. With them, the design thread has explicit strategic grounding; without them, it must infer intent from the stated user and outcome.
+
+### Downstream: product-engineering
+
+The per-screen state matrix produced by `user-flow` is the hand-off artifact `voice-and-microcopy` (product-engineering pack) consumes. Each cell in the matrix (screen × state) maps to a copy string. The two packs are designed to meet at this interface.
+
+### Downstream: architect / contracts
+
+The backstage column of the `service-blueprint` is the slicing instrument handed to the `architect` and `contracts` packs by name. When a service blueprint exists, an architect using `architect-design` should read it before proposing a backend design — it encodes the frontstage obligations the backend must fulfill.
+
+---
+
+## 9. Safety invariants
+
+1. **`experience-reviewer` is read-only.** It flags, never rewrites. Any suggestion to have the reviewer apply its own findings is out of scope — flagging is the deliverable.
+
+2. **`experience-status` is read-only.** It never writes files, never elicits `[design] output_dir` (stops at "not configured"), never advances state. (ADR-0054.)
+
+3. **The quality floor is non-negotiable.** No skill may produce output that explicitly defers the quality floor ("we'll add states later," "accessibility to follow"). The floor is the minimum bar for any output to leave the skill; if the design can't meet it, the skill surfaces to the human rather than shipping below floor.
+
+4. **No values, ever.** No skill may emit a fixed colour value, spacing value, timing curve, or breakpoint table. Method and taxonomy shape only.
+
+5. **No tool winners.** No skill names a specific design tool (Figma, Sketch, Penpot, etc.) as the prescribed tool. Tool categories are allowed ("a vector-based screen design tool"); specific tools are not.
+
+6. **The aesthetic direction must be grounded, not aspirational.** A `creative-direction` output that only lists adjectives ("premium, calm, focused") without named referents (precedent products or traditions that achieve those qualities) has not met the skill's output contract.
+
+---
+
+## 10. Design decisions and rationale log
+
+### Why no values tables (from v1)
+
+The pack ships in two parts: method (what to decide and how) and taxonomy shape (the slot structure for values). Values are intentionally absent because: (a) they are always project-specific, (b) the authoritative standards (WCAG, HIG, Material) already publish them and are better maintained, (c) any values we ship create a false anchor the adopter will optimize against rather than derive from first principles. The method works precisely because it forces derivation.
+
+**Alternative considered:** ship sensible defaults for common stacks (one for web, one for iOS, one for Android). Rejected because "sensible defaults" become cargo-culted values within one sprint. Teams stop asking "does this ratio serve the aesthetic direction?" and start asking "does this match the default?" The method value evaporates.
+
+### Why user-scope by default (from v1)
+
+Design method is the same across repos; only the artifacts differ. Installing per-repo would require reinstallation on every new project without any change to the skills. The scope decision mirrors `architect` (same reasoning: the method is portable, the knowledge surface is not project-specific).
+
+**Alternative considered:** repo-scope to colocate the skill definitions with the artifacts they produce. Rejected because it creates installation friction for cross-repo designers and doesn't improve artifact colocation (artifacts already live in the repo via `agentbundle-layout.toml`; the skills don't need to be repo-installed to write to a repo path).
+
+### Why the experience-reviewer runs forked (from v1)
+
+Structurally identical to core's adversarial-reviewer rationale. An authoring-session reviewer is primed by the authoring intent and cannot read the artifact as a stranger would. The value of the review comes from genuine ignorance of the design rationale. See core DESIGN.md §15 for the parallel decision.
+
+**Alternative considered:** stateful review that has access to the authoring session's reasoning, so it can review the design *and* the decision trail. Rejected for the same reason as in core: a reviewer that knows what was intended will systematically read gaps charitably.
+
+### Why six genre-direct skills instead of one general IA skill with genre flags (from v1)
+
+Each genre has a distinct structural logic that a general IA skill with a flag would produce via branching. A conversion surface's above-fold contract is not a weaker version of a dashboard's widget hierarchy — they are different structural problems. Separate skills make the genre's structural logic explicit and reviewable without reading a flag-driven conditional tree.
+
+**Alternative considered:** one `information-architecture` skill with a `genre:` parameter. Rejected because the genre-specific reasoning (above-fold contract, scroll story, social-proof architecture for conversion; TTFV architecture, Diátaxis typing for documentation) is substantive enough to earn a separate skill definition. A flag-parameterized skill would bury the genre logic; separate skills make it first-class.
+
+### Why correctness is the floor, not the ceiling (from v1)
+
+Meeting the quality floor (WCAG AA, handle-all-states, reduced-motion) is necessary but not sufficient for a good design. A pack that only produced correct designs would produce accessible, complete, and inoffensive work — but work that competes on accessibility alone doesn't win. The `creative-direction` skill is the gate between correct and good: it creates the aesthetic constraint that the rest of the craft sequence must satisfy. Collapsing the two (treating taste as optional) produces work that no one complains about but no one uses.
+
+**Alternative considered:** make `creative-direction` optional — treat aesthetic direction as a nice-to-have for when the team has time. Rejected because without a named aesthetic constraint, every subsequent craft decision becomes a local opinion (each screen looks "reasonable" in isolation; the thread has no visual coherence). The quality floor is a mechanical gate; the aesthetic direction is a coherence gate. Both are required.

--- a/packs/experience-design/README.md
+++ b/packs/experience-design/README.md
@@ -1,169 +1,120 @@
 # experience-design
 
-The design/UX seat for a product team — the grown-up successor to
-`design-craft`. It carries the **whole design thread** as one walkable flow:
-from a customer journey, through the screens that journey implies and the
-services behind them, to how each screen looks and behaves, to an independent
-review and a hand-off to realization. For interaction and visual designers,
-design-eng hybrids, and any agent or person authoring the **design intent** a
-UI build consumes (the design-side twin of `product-engineering`'s product
-intent).
-
-Every skill ships portable **method**, not your stack: no UI-framework code,
-no styling-language syntax, no animation library, and **no values tables** (no
-fixed spacing, timing, color, motion-curve, or breakpoint cheat-sheets, no
-fixed token set, no pixel comps). The skills point to the recognized
-standards — WCAG, the W3C Design Tokens interchange shape, Apple HIG, Material
-3, APQC, BPMN — and ship the method to *derive* your design, never the values.
-
-**Correctness is the floor, not the ceiling.** Accessibility compliance,
-information hierarchy, and usability heuristics (WCAG, Nielsen, Laws of UX)
-are non-negotiable — but meeting them alone produces correct-but-tasteless
-work. The `creative-direction` skill is the gate between the two: it grounds
-goals in persona, precedent, *and* visual voice — surface treatment, type scale
-ambition, color philosophy, and elevation philosophy. A direction doc that only
-names correctness goals has not cleared the gate.
-
-## What's inside
-
-**The connective thread** — map the flow from outcome to realization:
-
-- `journey-mapping` — a customer/end-user journey map (stages × actions /
-  emotions / pains / opportunities), carrying the platform/surface axis.
-- `user-flow` — the journey's screens *sequenced*, with transitions,
-  error/edge flows, the per-screen state matrix, and **one per-screen brief per
-  screen**; ends in a cross-brief consistency pass and a whole-journey steel
-  thread that never degrades to nothing. Optionally hands off to a generative
-  design tool.
-- `service-blueprint` — a service blueprint (frontstage / line-of-visibility /
-  backstage / support); its backstage column is the slicing instrument handed
-  to `architect` / `contracts` by-name.
-- `process-mapping` — the inside-out sibling: an internal business process
-  flow (APQC L3→L4, as-is + to-be, SIPOC, swimlane, pain/waste register).
-- `content-design` — a content brief for a surface: what it should say, for
-  whom, in what form, and to what objective; runs before the screen flow is
-  derived so content intent is set as a constraint before screens are sequenced.
-- `tone-of-voice` — named, ranked copy goals grounded in stable referents;
-  records the copy arbitration rules the rest of the build references.
-
-**The craft** — design each screen, held to one shared floor:
-
-- `design-principles` — 3–5 named decision rules derived from journey-map
-  insights; resolves design disputes and holds screens to a shared standard
-  across sprints, each principle grounded in a journey moment.
-- `creative-direction` — turn a vague "vibe" into named goals **grounded** in
-  persona + precedent + standards + platform conventions; coherence arbitration.
-- `design-system` — derive a token/scale taxonomy from intent.
-- `information-architecture` — hierarchy, reading flow, wayfinding.
-- `interaction-design` — how a screen *behaves*: feedback & timing, input &
-  forms, component state machines, purposeful motion, navigation-as-behavior,
-  gesture, cognitive-law fit. Enriches the per-screen brief.
-- `design-review` — interactive, authoring-time heuristic + taste critique;
-  maps each issue to the principle it violates and rates severity.
-- A shared **`quality-floor` checklist** — handle all states, the
-  accessibility floor (WCAG pointed-to), and "motion communicates state, honor
-  reduced-motion." One floor, referenced by every consuming skill.
-
-**Genre-specific Direct skills** — surface-typed structural IA used when a
-screen has a known surface genre (run before `interaction-design` in place of
-the general `information-architecture` skill):
-
-- `analytical-design` — structural specification for analytical and dashboard
-  surfaces: widget hierarchy, role-based view architecture,
-  business-question-to-layout map.
-- `conversion-design` — structural specification for marketing and acquisition
-  surfaces: above-fold contract, scroll story, social-proof architecture.
-- `documentation-design` — structural specification for documentation surfaces:
-  content hierarchy, navigation strategy, TTFV architecture; Diátaxis content
-  typing.
-- `informational-design` — structural specification for informational and
-  editorial surfaces: typographic hierarchy, reading-pattern calibration,
-  editorial grid.
-- `marketplace-design` — structural specification for marketplace surfaces:
-  listing card IA, filter and facet architecture, transaction bridge.
-- `workspace-design` — structural specification for workspace and productivity
-  surfaces: context-persistence architecture, attention zone layout, interrupt
-  design.
-
-**The independent review:**
-
-- `experience-reviewer` — a forked-context, read-only reviewer agent that gives
-  the design step an independent design-time review (the grounded aesthetic
-  reference + platform fit + cross-brief coherence + the full quality floor),
-  so design can run autonomously between human-value-add gates.
-
-**Session orientation:**
-
-- `experience-status` — orients to the current design thread at a glance: reads
-  design artifacts from the configured output directory and surfaces what exists,
-  what's missing, and which skill to run next.
-
-## Install
-
-`experience-design` is **user-scope by default** — design method is portable, not
-project-specific.
-
-```
-agentbundle install --pack experience-design <catalogue>
-```
-
-It projects to every shipped adapter that supports the skill primitive
-(Claude Code, Codex, Copilot, Cursor, Gemini, Kiro).
-
-## Usage
-
-Ask your agent, for example:
-
-- "Map the customer journey for our onboarding, then derive the screen flow."
-- "Blueprint the services behind this journey's screens."
-- "Map our internal claims-handling process, current-state and target-state."
-- "Design how this form behaves — feedback, validation, and its state machine."
-- "Run a heuristic critique of this screen and rank the findings by severity."
-- "Have the experience-reviewer review this journey and screen flow."
-
-## Where output lives
-
-The artifact-writing skills resolve their durable output path through the
-`[design]` table of the adopter-owned `agentbundle-layout.toml`
-(repo-root first, then user-profile; two-branch elicitation when neither
-resolves — never a silent default). Each skill surfaces the resolved path before
-its first write. See any artifact-writing skill's `references/agentbundle-layout.md`.
-
-## What's NOT in this pack
-
-- **No stack specifics or values tables.** No UI-framework code, no
-  styling-language syntax, no animation library, no fixed
-  spacing/timing/color/motion-curve/breakpoint table, no fixed token set, and
-  no pixel comps. The pack ships the method to derive your design; you choose
-  your tools. The optional design-tool handover is *instructions*, never pixels,
-  and names tool categories, never a winner.
-- **No `seeds/`.** Templates (the creative-direction doc, the per-screen brief,
-  the handover) ride as skill `assets/` and are copied into your repo at
-  runtime, so the pack stays user-scope (RFC-0004 Rail A).
-- **No hook, engine, in-pack validator, daemon, or runtime.** This pack is
-  habits, not infrastructure. `design-review` is an interactive
-  authoring-time **skill**, not a `work-loop` reviewer subagent; the independent
-  fresh-context review is the `experience-reviewer` **agent**, which reviews
-  design artifacts (journeys / screen flows / briefs / aesthetics), never code
-  diffs and never architecture design docs.
-
-## Cross-pack: `product-strategy`
-
-The `product-strategy` pack is the **upstream strategic input** this pack builds on. Before `journey-mapping` or `user-flow` run, a strategist using the `product-strategy` pack may have committed `ux-strategy.md` (vision → goals+measures → plan) and `content-strategy.md` (Halvorson quad: Purpose + Process + Structure + Governance) to `docs/product/shaping/`. When present:
-
-- `journey-mapping` reads `ux-strategy.md` as the strategic anchor for the journey's stated rationale.
-- `content-design` (downstream skill) reads `content-strategy.md` for organizational governance intent — content-design is execution-layer (per-surface); content strategy is governance-layer (organizational intent).
-
-These are optional inputs; the skills degrade gracefully when the upstream artifacts are absent. See the [`product-strategy` pack README](../product-strategy/README.md).
-
-## Cross-pack: `product-engineering`
-
-The **words** a user reads in the UI are the `product-engineering` pack's
-`ux-writing` skill's domain — the design seat's content layer. Pass
-`user-flow`'s per-screen state matrix to `ux-writing` and it
-writes copy keyed to every screen × state cell. See the
-[`product-engineering` pack README](../product-engineering/README.md).
+Walkable design method from outcome to realization — journey, screens, aesthetic, craft, review.
 
 ---
 
+## Start here
+
+Type `journey-mapping` first — describe the user, the outcome, and where the current experience breaks down.
+
+```text
+journey-mapping
+
+  journey  docs/design/journeys/onboarding.md
+
+  Stage 1  Aware          finds product, expectations vague
+  Stage 2  First-session  blank state, no direction, high drop-off
+  Stage 3  Value          first export, relief, converts
+```
+
+On any session return, type `experience-status` to see where the thread is.
+
+```text
+experience-status
+
+Design thread — docs/design
+
+Journey maps (journeys/): 1 found
+  onboarding.md — Onboarding
+
+Screen flows (screens/): 0 found
+
+Steel-thread check:
+  Journey map:   ✓ exists
+  Screen flow:   ✗ missing — run user-flow
+  Briefs:        ✗ missing — run user-flow
+
+What to run next: user-flow
+```
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|--------------|
+| `experience-status` | Orient — where the design thread is, what's next |
+| `journey-mapping` | Map the user's outcome: stages, emotions, pains, opportunities |
+| `content-design` | Set surface intent — what this screen says and for whom |
+| `tone-of-voice` | Set the brand register — copy goals and arbitration rules |
+| `user-flow` | Build the screen inventory — transitions and per-screen state briefs |
+| `creative-direction` | Anchor the aesthetic — grounded in persona and precedent |
+| `design-system` | Derive the token taxonomy from the aesthetic direction |
+| `information-architecture` | Structure a screen — hierarchy, reading flow, wayfinding |
+| `interaction-design` | Design the behavioral layer — states, feedback, animation |
+| `design-review` | Authoring-time critique — quality floor + coherence |
+| `experience-reviewer` | Independent cold review — forked context, read-only |
+
+Genre-direct alternatives to `information-architecture` for known surface types: `analytical-design`, `conversion-design`, `documentation-design`, `informational-design`, `marketplace-design`, `workspace-design`.
+
+---
+
+## How a thread runs
+
+```text
+journey-mapping [paste the user's outcome and context]
+
+  journey  docs/design/journeys/onboarding.md
+
+  Stage 1  Aware          finds product, expectations vague
+  Stage 2  First-session  blank state, no direction, high drop-off
+  Stage 3  Value          first export, relief, converts
+```
+
+```text
+user-flow [link to docs/design/journeys/onboarding.md]
+
+  screens  docs/design/screen-flows/onboarding.md
+
+  /onboarding/welcome  →  /onboarding/connect  →  /onboarding/done
+  States per screen: default · loading · error · success · empty
+```
+
+```text
+experience-reviewer [link to docs/design/screen-flows/onboarding.md]
+
+  Blocker  Welcome screen: empty state not designed
+  Concern  Connect screen: error text has no recovery action
+  Nit      "Get started" → "Connect your first account" (five-second scan)
+```
+
+The reviewer runs forked — no authoring context. You act on its findings, then merge.
+
+---
+
+## What the pack ships
+
+**Connective thread** — from outcome to screen inventory:
+`journey-mapping` → `content-design` / `tone-of-voice` → `user-flow` → `service-blueprint` / `process-mapping`
+
+**Craft sequence** — from structure to behavior:
+`design-principles` → `creative-direction` → `design-system` → `information-architecture` / genre-direct skill → `interaction-design`
+
+**Review** — quality floor, aesthetic fit, cross-brief coherence:
+`design-review` (authoring-time) → `experience-reviewer` (independent cold review)
+
+Every skill ships portable **method**, not your stack: no UI-framework code, no values tables, no fixed token set, no pixel comps.
+
+---
+
+## Cross-pack
+
+**Upstream — `product-strategy`:** When `ux-strategy.md` and `content-strategy.md` exist, `journey-mapping` and `content-design` read them as strategic anchors. Absent means the skills degrade gracefully.
+
+**Downstream — `product-engineering`:** Pass `user-flow`'s per-screen state matrix to `voice-and-microcopy` to write copy keyed to every screen × state cell.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, method architecture, invariants, and decision log.  
 → **Go deeper:** the [`experience-design` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/experience-design/).

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -10,7 +10,7 @@ contract:
   yourDecisions:
     - "Approve the plan"
     - "Merge the PR"
-whatChanges: "After installing core, every coding task in your repo runs through work-loop: plan → execute → verify → adversarial review. You get lint, typecheck, and tests as mechanical gates. Three specialist reviewers read every diff cold. The loop cannot self-certify — it always surfaces to you for plan approval and PR merge. The core pack's frontend-engineering skill fills the Frontend Engineering section of the Digital Experience Contract — the shared schema that enforces continuity from strategy to rendered evidence."
+whatChanges: "After installing core, every coding task in your repo runs through work-loop: plan → execute → verify → adversarial review. Lint, typecheck, and tests are mechanical gates the loop runs before you see the diff. The adversarial reviewer reads the diff cold — no context from the build session. The loop cannot self-certify: it always surfaces to you for plan approval and PR merge."
 skills:
   - name: work-loop
     description: "The build loop. Plans, executes, verifies, and reviews — mechanical gates and human checkpoints the agent cannot bypass."
@@ -88,35 +88,84 @@ relatedJourneys:
   - release
 ---
 
-### 1. Agree on the plan
-
-- **You provide:** the requested change and its important constraints.
-- **Agent does:** activates `work-loop`, checks whether risk triggers require full mode, writes the lean inline spec — the **trio** (problem, user, success criteria) — and surfaces its assumptions.
-- **You decide:** approve the plan, or redirect if the agent overreached the scope or picked the wrong mode. Five to ten minutes of focused reading — the gate that costs least and protects most.
-- **Output:** an agreed, bounded plan.
-
----
-
-### 2. Build and verify
-
-- **Agent does:** implements against the spec, running lint, typecheck, and tests after each logical change; when a gate fails, it fixes the issue and re-runs the gate before continuing.
-- **You do:** watch at key moments — after each logical task, skim the output for file names you didn't expect, for scope creep, and for a surfaced question. Answer quickly if it surfaces; a blocked agent costs more than a fast redirect. If all is well, let it run.
-- **Output:** a green implementation.
+| Say this | What happens |
+|----------|-------------|
+| `workspace-status` | Orient — what's ready, blocked, and done |
+| `author-brief` | Turn any idea, email, or issue into a queued brief |
+| `work-loop` | Plan → execute → gates → adversarial review → merge |
+| `bug-fix` | Diagnose and fix a specific bug |
+| `new-spec` | Author a spec directly, without the brief layer |
 
 ---
 
-### 3. Review independently
+### 1. Orient — every session
 
-- **Reviewer does:** reads the diff cold in a fresh session (`adversarial-reviewer`) with no context from the build, and returns findings grouped by severity — Blockers, Concerns, Nits.
-- **Loop does:** fixes Blockers and re-runs the gates, iterating until the reviewer reports clean.
-- **You do:** monitor the findings as they land; give a one-line steer on any Blocker you disagree with ("this is expected because…"); scan Concerns and Nits and choose to apply or defer.
-- **Output:** a clean review — or concerns surfaced clearly to you.
+Type `workspace-status` to see what's ready to start, what's blocked, and what shipped last session.
+
+```text
+● sprint-8/data-export     ready    spec approved · 3 tasks
+⚠ sprint-8/auth-refresh    blocked  needs spec/api-contract
+✓ sprint-7/payment-ui      done     shipped 2026-07-25
+```
+
+- **Output:** queue state — ready items, blocked items with reason, recent completions.
 
 ---
 
-### 4. Decide the merge
+### 2. Author a brief
 
-- **Agent does:** opens the PR with a description covering what changed, why, what was deferred, and what was found mid-implementation.
-- **You do:** read the description, not just the diff — it tells you what the agent decided when it had choices. Confirm the implementation matches the plan you approved, the spec and code align, and no unexplained scope appeared.
+Type `author-brief` and paste any unstructured input — an idea, email thread, or issue. The agent extracts the outcome, appetite, and key constraints, then queues the brief in `workspace.toml`.
+
+```text
+  brief   docs/product/briefs/data-export.md
+  queued  sprint-8/data-export → ready
+```
+
+- **Output:** `docs/product/briefs/data-export.md` — review the brief before it enters the work loop.
+
+---
+
+### 3. Agree the plan
+
+Type `work-loop docs/product/briefs/data-export.md`. The agent checks risk triggers, writes the spec and plan, surfaces assumptions, and stops for your sign-off before a line of code is written.
+
+```text
+mode: full — new dependency trigger
+  spec  docs/specs/data-export/spec.md
+  plan  docs/specs/data-export/plan.md
+
+  Problem  Streaming export crashes above 50k rows.
+  User     Engineer shipping the bulk-export feature.
+  Success  1M rows under 2 GB peak RSS.
+
+  Assumption: streaming CSV is acceptable; XLSX is deferred.
+
+Approve? ›
+```
+
+- **You decide:** approve spec and plan — 5–10 minutes, the cheapest gate.
+- **Output:** `docs/specs/data-export/spec.md` + `plan.md` — your checkpoint before any code is written.
+
+---
+
+### 4. Execute
+
+Type `work-loop execute spec/data-export`. The agent implements, runs lint / typecheck / tests after each logical change, and hands the diff to `adversarial-reviewer` in a fresh session.
+
+```text
+  ● Lint          ok
+  ● Typecheck     ok
+  ● Tests  246/246 ok
+  ● Review        1 blocker → fixed → clean
+```
+
+- **Output:** code and tests across multiple files — too many to enumerate individually. Review the PR diff.
+
+---
+
+### 5. Merge
+
+The agent opens the PR. Read the description before the diff — it tells you what the agent decided when it had choices, and what was deferred.
+
 - **You decide:** merge, redirect, or defer.
-- **Output:** a merge-ready change.
+- **Output:** a merged change.

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -1,7 +1,7 @@
 ---
 pack: experience-design
 scope: user
-tagline: "The design/UX seat for product teams."
+tagline: "Walkable design method. Outcome to independently-reviewed screens."
 prerequisitePacks: []
 contract:
   useItWhen: "A product team needs a full design thread — from outcome to independently-reviewed screens — before build begins."
@@ -11,7 +11,7 @@ contract:
     - "Approve the customer journey and derived screen list"
     - "Approve the aesthetic direction and token set"
     - "Review the designs after the independent experience-reviewer pass"
-whatChanges: "After installing experience-design, product-engineering work has a full design thread from outcome to realization. `journey-mapping` maps the journey; `content-design` and `tone-of-voice` name what the surface says and how it sounds. `design-principles` records the decision rules that hold screens to a shared standard. `user-flow` derives the screen list. `creative-direction` and `design-system` set the visual constraints. Genre-specific Direct skills (`analytical-design`, `conversion-design`, `documentation-design`, `informational-design`, `marketplace-design`, `workspace-design`) produce surface-appropriate IA before `interaction-design` and `design-review` craft and critique each screen. The forked-context `experience-reviewer` gives every design an independent pass — handle-all-states, WCAG 2.2 AA, reduced-motion. `experience-status` orients to the design thread at a glance — what artifacts exist, what's missing, and which skill to run next. Experience design skills fill the Experience Design section of the Digital Experience Contract — the shared schema that connects strategy intent to rendered evidence."
+whatChanges: "After installing experience-design, every design task runs a fixed thread: journey-mapping to anchor user outcomes, user-flow to derive the screen inventory, a craft sequence (creative-direction → design-system → information-architecture → interaction-design) to design each screen, and an independent experience-reviewer pass that reads design artifacts cold. The quality floor — handle-all-states, WCAG 2.2 AA, reduced-motion — is non-negotiable at every step. You decide at three gates: the journey and screen list, the aesthetic direction, and the post-review pass before design feeds the build loop. experience-status orients to the thread at the start of any session."
 skills:
   - name: journey-mapping
     description: "Maps the current and desired customer journey to derive the key touchpoints and failure modes a product must address."
@@ -121,44 +121,105 @@ relatedJourneys:
   - core
 ---
 
+| Say this | What happens |
+|----------|--------------|
+| `experience-status` | Orient — where the design thread is, what's next |
+| `journey-mapping` | Map the user's outcome: stages, emotions, pains |
+| `content-design` | Set surface intent — what this screen says and for whom |
+| `tone-of-voice` | Set the brand register — copy goals and arbitration rules |
+| `user-flow` | Build the screen inventory with per-screen state briefs |
+| `creative-direction` | Anchor the aesthetic in persona and precedent |
+| `design-system` | Derive the token taxonomy from the aesthetic direction |
+| `interaction-design` | Design states, feedback, and animation per screen |
+| `experience-reviewer` | Independent cold review — forked context, read-only |
+
+---
+
 ### 1. Map the customer journey
 
-- **You provide:** the feature, user, and intended outcome.
-- **Agent does:** runs `journey-mapping` to produce the current-state and desired-state journey map with key failure modes; then runs `content-design` and `tone-of-voice` to set content intent and register before screens are sequenced.
-- **You do:** read the journey map and content brief informally; if the map describes what the current product does rather than what the user is trying to achieve, redirect before the screen flow is derived — a one-sentence correction here saves a full design cycle.
-- **You decide:** approve the customer journey and derived screen list at G-journey — the screen list flows directly from it.
-- **Output:** an approved journey map with content brief and copy direction.
+Type `journey-mapping` and describe the outcome you're designing for — the user, the goal, and where the current experience breaks down.
+
+```text
+journey-mapping
+
+  journey  docs/design/journeys/onboarding.md
+
+  Stage 1  Aware          finds product, expectations vague
+  Stage 2  First-session  blank state, no direction, high drop-off
+  Stage 3  Value          first export, relief, converts
+
+Approve the journey and screen list? ›
+```
+
+- **You decide:** approve the journey map before screens are derived from it — a one-sentence redirect here saves a full design cycle.
+- **Output:** an approved journey map with key failure modes and a derived screen list.
 
 ---
 
 ### 2. Derive the screen flow
 
-- **Agent does:** runs `user-flow` to derive the screen inventory — what screens exist, what state each handles (empty, loading, populated, error), and what the transitions are; produces a per-screen brief for each.
-- **You do:** check that the screen list doesn't add screens not implied by the journey and doesn't miss screens the journey requires; remove any screen not derived from the journey.
-- **Output:** a screen inventory with per-screen briefs derived from the approved journey.
+Type `user-flow`. The agent sequences the screens implied by the journey and builds a per-screen brief for each, including the full state matrix.
+
+```text
+user-flow
+
+  screens  docs/design/screen-flows/onboarding.md
+
+  /onboarding/welcome  →  /onboarding/connect  →  /onboarding/done
+  States per screen: default · loading · error · success · empty
+```
+
+- **Output:** a screen inventory with per-screen briefs, ready for the craft sequence.
 
 ---
 
 ### 3. Establish design intent
 
-- **Agent does:** runs `design-principles` to derive 3–5 named decision rules from the journey map; then runs `creative-direction` to establish the visual character and `design-system` to derive the token set.
-- **You do:** review the design principles alongside the aesthetic direction.
-- **You decide:** approve the aesthetic direction and token set at G-aesthetic; an aesthetic direction that says "clean and professional" is not specific enough — reject tokens that introduce hardcoded values outside the semantic token system.
-- **Output:** approved design principles, aesthetic direction, and token set.
+Type `creative-direction` to anchor the visual direction in persona, precedent, and platform conventions. Type `design-system` to derive the token taxonomy from it.
+
+```text
+creative-direction
+
+  direction  docs/design/aesthetic/onboarding.md
+
+  Goals   Calm confidence, platform-native trust
+  Ref     Linear's focused workspace; Notion's quiet hierarchy
+
+Approve the aesthetic direction? ›
+```
+
+- **You decide:** approve the direction before screens are designed — a vague direction ("clean and modern") is a rejection.
+- **Output:** a named aesthetic direction with a derived token taxonomy.
 
 ---
 
 ### 4. Design each screen
 
-- **Agent does:** runs a structural IA skill on each screen — `information-architecture` for general screens, or a genre-specific skill for dashboards (`analytical-design`), marketing surfaces (`conversion-design`), docs (`documentation-design`), editorial pages (`informational-design`), marketplaces (`marketplace-design`), or workspace tools (`workspace-design`) — then `interaction-design` for states and transitions, and `design-review` as a pre-independent-review self-check.
-- **You do:** watch each screen take shape; if a screen is missing a state — no empty state for a list, no loading state for an async action — name it; catching it here is cheaper than the independent review.
-- **Output:** a self-reviewed screen set with states, transitions, and accessibility checks applied.
+Type `information-architecture` (or a genre-direct skill for dashboards, marketing, docs, or marketplace surfaces), then `interaction-design` per screen.
+
+```text
+interaction-design [/onboarding/welcome]
+
+  screen  docs/design/screens/welcome.md
+  States: default · loading · error · success · empty ✓
+  Motion: entrance · field-focus · submit-feedback ✓
+```
+
+- **Output:** a designed screen set with all states handled and quality floor met.
 
 ---
 
 ### 5. Review independently
 
-- **Reviewer does:** runs the `experience-reviewer` in a forked context — no access to the authoring session — returning findings on the full screen set: handle-all-states violations, WCAG 2.2 AA failures, and aesthetic inconsistencies.
-- **You do:** read the findings; apply Blockers before design intent feeds the build loop — they are the floor every screen must clear; handle-all-states violations are the most common finding.
-- **You decide:** review the designs after the independent experience-reviewer pass.
-- **Output:** a review-clean design set ready to feed the build loop.
+Type `experience-reviewer`. It reads your design artifacts cold — no authoring context — and returns findings across handle-all-states, WCAG 2.2 AA, aesthetic fit, and cross-screen coherence.
+
+```text
+experience-reviewer
+
+  Blocker  Welcome screen: empty state not designed
+  Concern  Connect screen: error text has no recovery action
+  Nit      "Get started" → "Connect your first account"
+```
+
+- **You decide:** act on Blockers before design feeds the build loop.
+- **Output:** a review-clean design set ready for build.

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -348,6 +348,24 @@ const installCommand =
     border-radius: var(--ds-radius-sm);
   }
 
+  /* Terminal-style output blocks — override Shiki's inline background. */
+  .journey-narrative :global(pre) {
+    background-color: var(--ds-hero-bg) !important;
+    border-radius: var(--ds-radius-md);
+    padding: var(--ds-space-5) var(--ds-space-6);
+    margin-bottom: var(--ds-space-5);
+    overflow-x: auto;
+  }
+
+  .journey-narrative :global(pre code) {
+    background: none !important;
+    color: var(--ds-hero-fg) !important;
+    padding: 0;
+    font-size: var(--ds-type-mono-sm);
+    line-height: var(--ds-lead-mono);
+    border-radius: 0;
+  }
+
   .journey-narrative :global(hr) {
     border: none;
     border-top: 1px solid var(--ds-border);


### PR DESCRIPTION
## Summary

- **packs/core/DESIGN.md** (new): Living design reference for the core pack — TL;DR, Non-Goals, loop model, mode selection, human gate design, the trio, self-coverage gate, adversarial review architecture (incl. depth modules `security-checklists` + `operational-safety`), mechanical gates, termination, workspace model, brief chain (incl. `init-project`, `adapt-to-project`, `contract-acquisition`, `frontend-engineering`), supervisor mode, safety invariants, output conventions, decisions log with alternatives considered.
- **packs/experience-design/DESIGN.md** (new): Living design reference for the experience-design pack — TL;DR, Non-Goals, design thread model, quality floor, method principle (derive never prescribe), connective thread skills, craft sequence, genre-direct skills rationale, independent review architecture, output artifact model, cross-pack dependencies, safety invariants, decisions log with alternatives considered.
- **packs/core/README.md**: Rewritten — outcome tagline, `workspace-status` start-here with terminal mock, entry points table, mocked session flow.
- **packs/experience-design/README.md**: Rewritten — outcome tagline, `experience-status` start-here with terminal mock, entry points table, mocked thread flow, cross-pack section.
- **web/src/content/journeys/core.md**: Entry points table added before steps; existing terminal-mock steps preserved.
- **web/src/content/journeys/experience-design.md**: Tagline and `whatChanges` tightened; steps rewritten to brief prose + terminal mocks + minimal labels; entry points table added.
- **web/src/pages/journeys/[journey].astro**: Terminal-style dark CSS for `pre` blocks inside `.journey-narrative` (overrides Shiki inline styles).
- **packs/AGENTS.md**: README.md and DESIGN.md authoring guidance added.

## Test plan

- [ ] `python tools/lint-journey-contract.py` — passes (only pre-existing `atlassian.md` failures)
- [ ] `python tools/lint-web-journey-parity.py` — passes
- [ ] Site builds: `npm run build --prefix web`
- [ ] Journey pages render with terminal-style code blocks at `/journeys/core` and `/journeys/experience-design`