### PR TITLE
fix(ci): Windows portability + credbroker skip guards

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.20.1] — 2026-07-27
+
+### Fixed
+
+- **Windows portability.** The CLI entry point now reconfigures stdout/stderr to
+  UTF-8 with `backslashreplace` at startup, preventing `UnicodeEncodeError` on
+  Windows consoles (cp1252) when output includes non-ASCII characters (⚠, →).
+- **Windows sandbox isolation in tests.** The test suite's autouse fixture now
+  sets `USERPROFILE` alongside `HOME`, ensuring `scope.resolve_user_root()` uses
+  the sandbox on Windows (where `Path("~").expanduser()` reads `USERPROFILE`).
+- **Editable-install detection on Windows.** `url2pathname` can return a path
+  with a spurious leading `/` before the drive letter (e.g. `/C:\repo`); that
+  prefix is now stripped before constructing the `Path`.
+- **NTFS reparse-point safety.** `is_symlink()` calls in the pack-floor install
+  and seed-delivery paths are now wrapped in `try/except OSError`, skipping the
+  entry conservatively when the reparse point cannot be interrogated.
+
 ## [0.20.0] — 2026-07-27
 
 ### Added

--- a/packages/agentbundle/README.md
+++ b/packages/agentbundle/README.md
@@ -12,6 +12,8 @@
 pip install agentbundle
 ```
 
+Requires Python 3.11+. Runs on macOS, Linux, and Windows.
+
 **Install into a repo** — so everyone who clones it gets the pack. `core` is the flagship pack, the loop itself:
 
 ```bash

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -936,6 +936,13 @@ def _normalise_path_separators(args: argparse.Namespace) -> None:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    # Windows cp1252 consoles can't represent non-ASCII chars (⚠, →, etc.).
+    # Reconfigure to UTF-8 with backslash-escape fallback so the process
+    # never crashes on non-ASCII output regardless of console code page.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
     parser = _build_parser()
     args = parser.parse_args(argv)
     if not getattr(args, "func", None):

--- a/packages/agentbundle/agentbundle/commands/_common.py
+++ b/packages/agentbundle/agentbundle/commands/_common.py
@@ -100,13 +100,21 @@ def _classify_seeds(seeds_dir: Path, root: Path) -> list[SeedDelivery]:
     from agentbundle import safety
 
     footer_path = seeds_dir / "_agents-footer.md"
-    footer_ok = footer_path.is_file() and not footer_path.is_symlink()
+    try:
+        footer_is_symlink = footer_path.is_symlink()
+    except OSError:
+        footer_is_symlink = True  # can't determine; skip conservatively
+    footer_ok = footer_path.is_file() and not footer_is_symlink
 
     seed_files: list[Path] = []
     for dirpath, _dirnames, filenames in os.walk(seeds_dir, followlinks=False):
         for fname in filenames:
             fpath = Path(dirpath) / fname
-            if fpath.is_symlink():
+            try:
+                fpath_is_symlink = fpath.is_symlink()
+            except OSError:
+                fpath_is_symlink = True  # can't determine; skip conservatively
+            if fpath_is_symlink:
                 continue
             seed_files.append(fpath)
 

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -1648,7 +1648,11 @@ def _deliver_user_scope_floor(
     # Reject a symlinked primitive dir itself (os.walk(top=symlink) enumerates
     # the link target's real files, which the per-entry is_symlink() skip below
     # would not catch) — see collect_pack_root_bins for the bin/ twin.
-    has_lib = lib_src_root.is_dir() and not lib_src_root.is_symlink()
+    try:
+        lib_src_is_symlink = lib_src_root.is_symlink()
+    except OSError:
+        lib_src_is_symlink = True  # can't determine; skip conservatively
+    has_lib = lib_src_root.is_dir() and not lib_src_is_symlink
     if not bin_sources and not has_lib:
         # No floor content in this pack — nothing to deliver, and no reason to
         # gate the install on the floor dirs' modes.
@@ -1686,7 +1690,11 @@ def _deliver_user_scope_floor(
             )
             for fname in sorted(filenames):
                 src = Path(dirpath) / fname
-                if src.is_symlink():
+                try:
+                    src_is_symlink = src.is_symlink()
+                except OSError:
+                    src_is_symlink = True  # can't determine; skip conservatively
+                if src_is_symlink:
                     continue
                 rel = src.relative_to(lib_src_root)
                 relpath = (Path(".agentbundle") / "lib" / rel).as_posix()

--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -294,7 +294,11 @@ def _enclosing_git_root(start: Path) -> Path | None:
     """
     cur = start
     while True:
-        if (cur / ".git").exists():
+        try:
+            exists = (cur / ".git").exists()
+        except OSError:
+            exists = False
+        if exists:
             return cur
         if cur.parent == cur:
             return None
@@ -354,7 +358,12 @@ def _detect_editable_source(dist: object, *, stream: TextIO | None = None) -> st
         return None
     if parts.netloc not in ("", "localhost"):
         return None
-    pkg_path = Path(url2pathname(unquote(parts.path)))
+    raw = url2pathname(unquote(parts.path))
+    # url2pathname on some Windows Python builds returns "/C:\path" with a
+    # spurious leading slash before the drive letter; strip it.
+    if sys.platform == "win32" and len(raw) >= 3 and raw[0] == "/" and raw[2] == ":":
+        raw = raw[1:]
+    pkg_path = Path(raw)
     try:
         pkg_root = pkg_path.resolve(strict=True)
     except OSError:

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.20.0"
+CLI_VERSION = "0.20.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.20.0"
+version = "0.20.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/conftest.py
+++ b/packages/agentbundle/tests/conftest.py
@@ -39,7 +39,7 @@ def _isolate_user_config_dir(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(sandbox / ".config"))
     monkeypatch.setenv("APPDATA", str(sandbox / "AppData" / "Roaming"))
     # Windows: Path("~").expanduser() reads USERPROFILE, not HOME.
-    # AGENTBUNDLE_USER_ROOT is checked first by scope.resolve_user_root()
-    # and takes precedence on all platforms, so this one env var is enough.
-    monkeypatch.setenv("AGENTBUNDLE_USER_ROOT", str(sandbox))
+    # Tests that need a different home (e.g. unittest.TestCase with
+    # patch.dict) override this in setUp — patch.dict takes precedence.
+    monkeypatch.setenv("USERPROFILE", str(sandbox))
     return sandbox

--- a/packages/agentbundle/tests/conftest.py
+++ b/packages/agentbundle/tests/conftest.py
@@ -38,4 +38,8 @@ def _isolate_user_config_dir(
     monkeypatch.setenv("HOME", str(sandbox))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(sandbox / ".config"))
     monkeypatch.setenv("APPDATA", str(sandbox / "AppData" / "Roaming"))
+    # Windows: Path("~").expanduser() reads USERPROFILE, not HOME.
+    # AGENTBUNDLE_USER_ROOT is checked first by scope.resolve_user_root()
+    # and takes precedence on all platforms, so this one env var is enough.
+    monkeypatch.setenv("AGENTBUNDLE_USER_ROOT", str(sandbox))
     return sandbox

--- a/packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py
+++ b/packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py
@@ -130,9 +130,14 @@ def _assert_no_relative_import_error(result: subprocess.CompletedProcess, entry:
         and not any(mod in stderr for mod in credential_area_modules)
     )
     # Scripts with custom dependency guards emit "error: missing dependency '<pkg>'"
-    # instead of ModuleNotFoundError — same out-of-scope category.
+    # instead of ModuleNotFoundError — same out-of-scope category. setup.py emits
+    # "credbroker not found. …" when credbroker is absent (precondition failure,
+    # not the relative-import bug this test owns).
     custom_dep_guard = (
-        "error: missing dependency" in stderr
+        (
+            "error: missing dependency" in stderr
+            or "credbroker not found." in stderr
+        )
         and "pip install" in stderr
     )
     if bare_module_not_found or custom_dep_guard:

--- a/packages/agentbundle/tests/integration/test_show_cmd.py
+++ b/packages/agentbundle/tests/integration/test_show_cmd.py
@@ -386,4 +386,4 @@ def test_show_help_documents_format():
 
 def _write_state(path: Path, state: State) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(dump_state(state), encoding="utf-8")
+    path.write_text(dump_state(state), encoding="utf-8", newline="\n")

--- a/packages/agentbundle/tests/unit/test_credential_setup_skill.py
+++ b/packages/agentbundle/tests/unit/test_credential_setup_skill.py
@@ -52,6 +52,8 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
     """AC19: setup.py refuses the reserved `sso` namespace; stderr names
     the reserved set. Run the script via subprocess against the projected
     sibling shim under a tmp_path skill dir."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     # Build a tmp skill dir with the shim siblings + setup.py so the
     # relative import (`from .credentials_shim ...`) resolves.
     skill_dir = tmp_path / "credential-setup"
@@ -98,6 +100,8 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
 def test_ac18_argv_ban_refused(tmp_path):
     """AC18 / argv-ban: setup.py refuses --token / --api-token / etc.
     on the command line."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
     (skill_dir / "__init__.py").write_text("")
@@ -120,6 +124,8 @@ def test_ac18_no_token_in_stdout(tmp_path, monkeypatch):
     """AC18: when the user enters a secret, it never appears on stdout —
     only stderr announcements. We simulate via in-process import after
     projecting the shim siblings into a temp package."""
+    if subprocess.run([sys.executable, "-c", "import credbroker"], capture_output=True).returncode != 0:
+        pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
     (skill_dir / "__init__.py").write_text("")

--- a/workspace.toml
+++ b/workspace.toml
@@ -565,14 +565,6 @@ open = [
 
   # 4 tests fail locally because credbroker is not installed (`pip install -e ./packages/credbroker`
   # required). Pre-existing on origin/main (confirmed 2026-07-27):
-  #   test_credential_user_scope_invocation.py::test_entry_point_imports_resolve_under_user_scope_layout
-  #   test_credential_setup_skill.py::test_ac18_argv_ban_refused
-  #   test_credential_setup_skill.py::test_ac18_no_token_in_stdout
-  #   test_credential_setup_skill.py::test_ac19_reserved_sso_namespace_refused
-  # Fix: install credbroker in local/CI test env, or add pytest.importorskip guard to each test.
-  # Unblocks when: CI/local env includes credbroker install, or tests gain skip guards.
-  {slug = "pre-existing-credbroker-test-not-installed", source = "pre-flight/2026-07-27"},
-
   # RFC-0065 D5 (source-author review 2026-07-18). Azure shipped contract-complete
   # in iac-terraform v1 (four provider files + providers/azure.md) but no worked
   # example has passed terraform init -backend=false && fmt -check && validate. The


### PR DESCRIPTION
## Summary

- **`AGENTBUNDLE_USER_ROOT` in autouse fixture** (`tests/conftest.py`): `scope.resolve_user_root()` checks this env var first; without it, Windows tests bypass the sandbox via `USERPROFILE`/`Path("~").expanduser()`, causing `test_degrade_installed_user_scope_only` to fail with empty stdout.
- **cp1252 console encoding** (`cli.py`): reconfigure stdout/stderr to UTF-8 with `backslashreplace` at `main()` entry so non-ASCII chars (⚠, →) don't crash on Windows consoles.
- **`url2pathname` leading-slash bug** (`source_defaults.py`): strip spurious `/C:\path` prefix on Windows; guard `_enclosing_git_root`'s `.git` exists check with `try/except OSError` for NTFS reparse points.
- **Symlink reparse point safety** (`commands/install.py`, `commands/_common.py`): wrap `is_symlink()` calls in `try/except OSError`, skipping conservatively on error.
- **CRLF line endings** (`test_show_cmd.py`): write state file with `newline="\n"` to prevent hash mismatches on Windows.
- **Credbroker skip guards** (`test_credential_setup_skill.py`, `test_credential_user_scope_invocation.py`): replace `pytest.importorskip` with subprocess-based check immune to `sys.modules` pollution from `test_linear_primitive.py`; extend `custom_dep_guard` for the `credbroker not found.` error shape. Supersedes #742.

## Test plan

- [ ] `test_degrade_installed_user_scope_only` passes (was failing on Windows Gate A)
- [ ] `test_credential_setup_skill.py` credbroker tests skip (not fail) when credbroker absent
- [ ] `test_credential_user_scope_invocation.py` credbroker entry-point test passes
- [ ] Full suite green on all CI gates