### PR TITLE
docs(packs): add DESIGN.md + rewrite READMEs and journey pages for six packs

### DIFF
--- a/packs/architect/DESIGN.md
+++ b/packs/architect/DESIGN.md
@@ -1,0 +1,199 @@
+# Architect Pack — Design Document
+
+Living design reference for the architect pack. Records the philosophy, architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** [ADR-0010](../../docs/adr/0010-reference-architecture-foundation.md) (reference architecture foundation), [ADR-0030](../../docs/adr/0030-consolidated-pack-output-layout-contract.md) (consolidated pack output layout), [ADR-0035](../../docs/adr/0035-architect-design-phase-grounded-in-platform-reality-dual-consumed-serverless-lens-and-contract-grounding.md) (architect-design grounded in platform reality)
+
+---
+
+## TL;DR
+
+The architect pack converts architecture conversations into grounded, independently-reviewed design artifacts. It runs in three stages — concept (Stage 0), full design doc (Stage 1), and review-converged artifact (Stage 2) — with a human gate after the concept so the agent never writes a polished document for the wrong problem. Every skill is workspace-agnostic with no required configuration: each skill detects its own mode from the user's input, produces artifacts inline by default, and offers to save. The `design-reviewer` subagent reads finished artifacts in a forked context with no authoring memory — for the same structural reason core's adversarial-reviewer runs cold — making the review genuinely adversarial rather than charitable.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to provide. It doesn't, by design:
+
+- **More subagents.** The pack ships exactly one subagent — `design-reviewer`, the forked-context review lens (RFC-0032). Design authoring and diagramming stay skills; only the review lens earns an isolated context, mirroring the code side's authoring-skill + reviewer-agent split. No further agents without an RFC.
+- **Workspace-type profiles or configuration files.** No `.architectrc`, no workspace-type detection, no install-time profiling. The skills work on first invocation in any workspace with zero setup.
+- **Integration or publishing skills.** Confluence export, Figma integration, Structurizr rendering — a separate, later pack.
+- **Enterprise architecture platform skills.** ArchiMate, TOGAF, Wardley Mapping, graph-extraction, EA repository tooling — the personal architecture seat, not the EA platform layer.
+- **Any coupling to a specific folder layout.** The pack must work in any workspace: code repos, knowledge bases, scratch directories.
+
+---
+
+## 1. The problem
+
+### Why architecture work without method goes wrong
+
+Architecture conversations without structure produce two failure modes that compound:
+
+1. **Concept drift.** The engineer describes a problem; the agent produces a polished document for a slightly different problem — one that fit the agent's model better than the stated problem. The mismatch only becomes visible when the doc is reviewed or used as the basis for implementation.
+
+2. **Hollow alternatives.** A design doc where alternatives are strawmen (dismissed in one line without real reasoning) does not record a decision — it records advocacy. Future engineers reading it cannot determine whether the chosen approach was actually compared against real candidates.
+
+The three-stage model (§2), the grounding discipline (§3), and the forked reviewer (§5) each address one of these failure modes directly.
+
+---
+
+## 2. The three-stage model
+
+### Stage 0 — concept
+
+Before the full design doc is written, the agent drafts a ½-page concept: problem, constraints, 1–2 candidate shapes, provider or provider-class, and the top 2–3 quality attributes ranked by business importance × architectural risk. **Stage 0 is a valid stopping point.** The user approves the concept — or redirects — before any full write-up begins.
+
+The concept gate costs one short read, 5–10 minutes. Redirecting at the concept gate costs nothing. Redirecting after a full Stage 1 doc costs a full write-up cycle. The asymmetry is the point.
+
+### Stage 1 — full design doc
+
+After the concept is approved, the agent writes the full Google-style design doc: TL;DR → Context → Goals and Non-goals → Proposal → Alternatives Considered → Risks → Rollout → Open Questions. The doc is self-checked against `references/design-doc-rubric.md` before it is shown to the user.
+
+### Stage 2 — convergence loop
+
+After the full draft, the agent runs `references/convergence-loop.md`: obtain a review pass, auto-resolve mechanical findings, re-review, repeat to the pass cap or stasis escape. Judgment findings (tradeoffs, low-confidence claims, genuine open questions) are surfaced explicitly — never auto-resolved.
+
+### Why Stage 0 is mandatory, not optional
+
+Skipping Stage 0 ("just write the proposal section") collapses context, non-goals, and alternatives into a single advocacy document. A proposal without context is a design doc without a problem statement; it cannot be falsified. The concept is *shaping* — the minimum information needed to confirm that a full write-up will solve the right problem.
+
+---
+
+## 3. The grounding discipline
+
+### Reference architecture
+
+`reference.md` is the repo's normative grounding artifact — the golden-path file describing the stack, chosen patterns, and architectural constraints for a codebase. Before shaping a concept, `architect-design` checks what architecture context is reachable: an in-repo `reference.md`, an enterprise knowledge surface, or nothing. It states which surface it found in the concept; the absence of a surface is itself a visible signal.
+
+If no `reference.md` exists, `architect-design` offers to create one. A design grounded against a known stack produces far tighter proposals than design against an implicit assumption of what the stack probably is. See ADR-0010.
+
+### Platform contract grounding
+
+For every managed service on a critical path, `architect-design` grounds its binding contract — non-configurable limits, scaling floors, cold-start behaviour, network requirements — in an authoritative source before including it in the concept or doc. It carries source and confidence on each load-bearing figure.
+
+This discipline was added after two field builds independently produced structurally fatal designs grounded in model memory rather than the service's actual contract (ADR-0035). The discipline is scoped to load-bearing critical-path claims, not every service mention. A claim the agent cannot ground is flagged, not asserted.
+
+---
+
+## 4. The seven design principles
+
+These principles are load-bearing. The skills assume them and cannot bypass them.
+
+1. **Workspace-agnostic.** No assumptions about folder structure, artifact genre, or workspace type. The pack works in a code repo, a knowledge base, or a scratch directory.
+
+2. **No required configuration.** No config files, profiles, or workspace-type detection beyond simple file-existence heuristics. Each skill works on first invocation with zero setup.
+
+3. **No required composition.** Each skill stands alone. Installing one does not require installing the others. Rubrics are duplicated across skills (with notes flagging the duplication) rather than shared via inter-skill references — skill autonomy beats DRY at this scale.
+
+4. **Inline-first, file-write opportunistic.** Skills produce artifacts in the conversation by default. Saving to disk is an offer with a suggested path based on what already exists nearby, never a forced step.
+
+5. **Mode detection inside each skill.** Each skill reads the user's input and routes to the right mode. The user does not flag intent. If two modes plausibly fit, the skill asks once.
+
+6. **Mermaid only for diagrams.** No PlantUML, Structurizr, or Figma integration. Mermaid renders in chat, artifacts, GitHub, Confluence, Azure DevOps Wiki, and GitLab — consistent-renderer wins over notation richness.
+
+7. **Progressive disclosure.** `SKILL.md` stays under ~100 lines. Templates, syntax cheatsheets, rubrics, and cloud and platform references live in `references/` and `assets/` and load on demand based on what the user mentions.
+
+---
+
+## 5. The review architecture
+
+### Why design-reviewer runs forked
+
+The `design-reviewer` subagent runs in a forked context with no access to the authoring session. The reasoning is structurally identical to core's adversarial-reviewer:
+
+An agent that reviews its own work in the same session is primed to read the artifact charitably — it knows what was intended, which means it interprets gaps as "the reader will understand" and inconsistencies as "acceptable trade-offs I already considered." A reviewer that has never seen the authoring rationale reads the artifact as a stakeholder would: with no benefit of the doubt.
+
+### What design-reviewer covers
+
+`design-reviewer` runs the same verdict and severity-tagged critique as `architect-review`, but in a fresh session seeded only with the artifact, the agreed concept, and the stated constraints. It never rewrites — it flags. Its tools are `Read, Grep, Glob`: it can read the artifact and the repo, but it cannot change either.
+
+### The two review rungs
+
+`architect-review` runs inline in the current thread — useful when speed matters more than independence, when reviewing someone else's artifact, or when the author wants immediate findings to iterate on. `design-reviewer` runs in a forked context — the preferred rung when the design is shared for stakeholder review or used as the basis for implementation. The convergence loop in `architect-design` uses `design-reviewer` by default; `architect-review` is the fallback when the forked subagent is not available.
+
+---
+
+## 6. Output format conventions
+
+### architect-design
+
+Rationale and narrative use short `##` headings and 2–3 sentence paragraphs — not prose forced into tables. Single-record summaries (the concept, the knowledge surface check) use aligned key: value format. Mermaid blocks appear for structural reasoning that genuinely needs a picture; every diagram earns its place by being referenced from the prose.
+
+### architect-diagram
+
+Fenced ` ```mermaid ` blocks that render in chat and artifacts. Terminal-only surfaces fall back to ASCII box-and-arrow sketches. Notation is routed by intent (`references/notation-routing.md`) — never defaulted to the notation the user named if the intent disagrees.
+
+### architect-review
+
+Findings are led by severity glyph — 🟥 blocker, 🟧 major, 🟨 minor, ⚪ advisory — worst first, one finding per line. Verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT) appears first, before findings. A "what's working" section closes the review: specific strengths the author should preserve, not flattery.
+
+---
+
+## 7. Path resolution model
+
+Output artifacts resolve through the `[architecture]` section of an adopter-owned `agentbundle-layout.toml`. Resolution order: (1) repo-root `./agentbundle-layout.toml` `[architecture] output_dir`; (2) user-profile `~/.agentbundle/agentbundle-layout.toml` `[architecture] output_dir`; (3) two-branch elicitation when neither resolves (repo branch or personal/vault branch — never a silent default).
+
+Each design effort gets its own per-effort folder: `<output_dir>/<topic-slug>/`. The concept, design doc, and diagrams for a single effort live inside that folder together. ADR-0030 records the pack output layout contract.
+
+Saving is always an offer, never automatic. The skill resolves the path, surfaces the full absolute path to the user, and writes only on confirmation.
+
+---
+
+## 8. Cross-pack dependencies
+
+### Upstream: experience-design
+
+The backstage column of a `service-blueprint` artifact (experience-design pack) is the slicing instrument for architecture work. When a service blueprint exists, `architect-design` should read it before proposing a backend design — it encodes the frontstage obligations the backend must fulfill.
+
+### Downstream: core
+
+Architecture design docs produced by `architect-design` become the `reference.md` input for the core pack's `work-loop`. When a design doc exists, `work-loop` reads it to orient against the current architectural intent before implementation begins.
+
+---
+
+## 9. Safety invariants
+
+1. **`design-reviewer` is read-only.** It flags, never rewrites. Any suggestion to have the reviewer apply its own findings is out of scope.
+
+2. **No platform contract from model memory.** For every load-bearing managed-service claim on a critical path, the skill must cite a grounded source. A claim the agent cannot ground is flagged as lower-confidence, never asserted as fact. See ADR-0035.
+
+3. **Stage 0 is mandatory before Stage 1.** A proposal-only output (no problem statement, no alternatives) is advocacy, not a design doc. The skill pushes back; it does not produce advocacy on request.
+
+4. **Mode detection is internal.** Users describe what they want; skills route. If the user names a notation but the intent disagrees, the skill offers the right notation rather than following the user's label.
+
+5. **Mermaid only.** No skill in this pack emits PlantUML, Structurizr, Figma export syntax, or any other diagramming format.
+
+---
+
+## 10. Design decisions and rationale log
+
+### Why the concept gate exists (Stage 0) — from day one
+
+Writing a full design doc for the wrong problem costs a full write-up cycle and one round of redirects. Writing a ½-page concept and redirecting before the doc is started costs ten minutes. The asymmetry is so large that skipping the gate to save time reliably costs more time. The gate is load-bearing in the skill, not a suggestion.
+
+**Alternative considered:** skip Stage 0 and write the full doc from the user's description, with the user redirecting via revision. Rejected because revision pressure on a finished document is much weaker than redirect pressure on a concept — authors attach to finished artifacts, and reviewers read more carefully before work has been done.
+
+### Why design-reviewer runs forked — from day one
+
+The cold-context constraint is what makes the review adversarial in a meaningful sense. An agent that reviews its own work in the same session cannot be adversarial — it knows what it intended. The fresh-context constraint forces the reviewer to read the artifact as a stakeholder would. This is structurally identical to core's adversarial-reviewer rationale; see Core Pack DESIGN.md §15 for the parallel decision.
+
+**Alternative considered:** run the review inline in the same thread with access to the authoring session's chain of thought, so it can review the design and the decision trail. Rejected because a reviewer that knows what was intended will systematically read gaps charitably. The value of the review comes from genuine ignorance of intent.
+
+### Why Mermaid only, not PlantUML or Structurizr — from day one
+
+Mermaid renders consistently in chat, GitHub, Confluence, Azure DevOps Wiki, and GitLab — the environments where architecture artifacts actually live. PlantUML requires a server or local Java dependency; Structurizr requires a specific tool and licensing. The consistent-rendering constraint wins over notation richness. Users who need PlantUML or Structurizr have a toolchain reason; they don't need this pack.
+
+**Alternative considered:** support PlantUML as a second notation with a flag. Rejected because adding a second notation doubles the reference surface (syntax, rubric, export guidance) for a feature most users don't need, and the primary benefit (richer notation) does not outweigh the rendering consistency loss.
+
+### Why user-scope by default — from day one
+
+Architecture method is the same across repos; only the artifacts differ. Installing per-repo would require reinstallation on every new project without any change to the skills. Output artifacts still land in the repo via `agentbundle-layout.toml` — the skills don't need to be repo-installed to write to a repo path. The same reasoning applies as in experience-design and desk-research.
+
+**Alternative considered:** repo-scope to colocate the skill definitions with the artifacts they produce. Rejected because it creates installation friction for engineers working across multiple repos and doesn't improve artifact colocation.
+
+### Why platform contract grounding is scoped to load-bearing critical-path claims (ADR-0035, 2026-06-24)
+
+Checking every managed service mention against an authoritative source would make design sessions prohibitively slow. The ADR-0035 field report showed that both structurally fatal design misses were on the critical path and would have been caught by a single grounding check. The scoping rule (load-bearing + critical path) is the minimum that catches both failure classes without imposing a full audit on every service in the diagram.
+
+**Alternative considered:** require grounding for every managed service mentioned in the design, not just critical-path ones. Rejected because it imposes a research burden that would make `architect-design` unusable for quick back-of-envelope designs and produces lower-quality grounding by spreading attention across many services rather than focusing on the critical path.

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -1,189 +1,86 @@
 # architect
 
-Three things your agent can do for you in any project:
-
-- **Shape a system concept** — talk a design decision through and turn it
-  into a design doc.
-- **Draw a system** — get a diagram of an architecture, a flow, or a data
-  model.
-- **Review an architecture** — hand it an existing design and get a verdict
-  with specific findings.
-
-Installed to user scope by default, so they travel across every workspace
-and engagement, not just one repo. Under the hood these are peer skills plus
-one review subagent (the tables below) — but you don't need to know that to
-start.
-
-| Skill | What it does |
-| --- | --- |
-| `architect-design` | Shapes a one-page concept first, then drafts a Google-style design doc (TL;DR → context → goals → proposal → alternatives → risks → rollout → open questions) with Mermaid inline — **well-architected by construction** for the chosen provider (AWS / Azure / GCP, primitives providers like Hetzner, or local-first) and **converged against review** (auto-resolve mechanical findings, surface the judgment calls). |
-| `architect-diagram` | Produces Mermaid diagrams routed by intent (C4, flowchart, sequence, state, ER). Cloud-aware (AWS / Azure / GCP, and primitives providers like Hetzner) and agentic-platform-aware (Bedrock AgentCore, AI Foundry, Vertex Agent Engine). |
-| `architect-review` | Critiques an existing design doc or diagram with severity-tagged findings, genre-aware rubric routing, and a one-line verdict (SHIP IT / SHIP WITH CHANGES / MAJOR REWRITE / WRONG ARTIFACT). Adds a **well-architected / lens mode** (concern + workload-class lenses, incl. GenAI/agentic) that emits a risk register with each finding tagged **mechanical / judgment**. Runs **inline**, in the current thread. |
-
-| Subagent | What it does |
-| --- | --- |
-| `design-reviewer` | A **read-only, forked-context** sibling of `architect-review`: the same verdict + severity- and mechanical/judgment-tagged critique, but run in an isolated context that has not seen the authoring — so it cannot mark its own homework. This is the **fresh-context (preferred) rung** of `architect-design`'s convergence loop; it flags, never rewrites (tools are `Read, Grep, Glob`). Use it when an independent review matters more than an in-thread one. |
-
-## Install
-
-Default scope is **user** — installed under `~/.claude/skills/`
-(or the equivalent for your adapter) so the skills load in every
-workspace.
-
-**Which route?** Use the **Claude plugin** route if you're in Claude Code
-and haven't set up a CLI; the **CLI** (`agentbundle`) route if you want a
-pinned, scriptable install; the **APM** route if your team standardizes on
-APM. All three land the same skills.
-
-```bash
-# CLI route — <catalogue> is your catalogue URI: a local clone path
-# or a git+https://… URL.
-agentbundle install --pack architect <catalogue>
-
-# APM route
-apm install architect
-```
-
-For the Claude plugin route, add the marketplace first:
-
-```bash
-claude plugin marketplace add eugenelim/agent-ready-repo
-claude plugin install architect@agent-ready-repo
-```
-
-Scope can be flipped to repo-local if you want the skills pinned to
-one workspace:
-
-```bash
-agentbundle install --pack architect <catalogue> --scope repo
-```
-
-Adapters supported: `claude-code`, `codex`, `copilot`, `kiro-ide`,
-`kiro-cli`, `cursor`, `gemini`. Pure-markdown `SKILL.md` surface; no
-Claude-specific primitives.
-
-## Design principles
-
-These principles are load-bearing — the skills assume them.
-
-- **Workspace-agnostic.** No assumptions about folder structure,
-  artifact genres, ontology, or whether this is a code repo, a
-  knowledge base, or a scratch directory.
-- **No required configuration.** No config files, no profiles, no
-  workspace-type detection beyond simple file-existence heuristics.
-  Each skill works on first invocation with zero setup.
-- **No required composition.** Each skill stands alone. Installing
-  one doesn't require installing the others. Rubrics are duplicated
-  across skills (with notes flagging the duplication) rather than
-  shared via inter-skill references — skill autonomy beats DRY at
-  this scale.
-- **Inline-first, file-write opportunistic.** Skills produce
-  artifacts in the conversation by default. Saving to disk is an
-  *offer* with a suggested path based on what already exists
-  nearby, never a forced step.
-- **Mode detection inside each skill.** Each skill reads the user's
-  input and routes; the user does not flag intent.
-- **Mermaid only for diagrams.** No PlantUML, Structurizr, or Figma
-  integration in this pack.
-- **Progressive disclosure.** `SKILL.md` stays under ~100 lines.
-  Templates, syntax cheatsheets, rubrics, and cloud / platform
-  references live in `references/` and `assets/` and load on demand
-  based on what the user mentions.
-
-## What's NOT in this pack
-
-By design — these belong elsewhere or in a later pack:
-
-- **More subagents.** The pack ships exactly one — `design-reviewer`,
-  the forked-context review lens above (RFC-0032). Design *authoring*
-  and *diagramming* stay skills; only the review lens earns an isolated
-  context, mirroring the code side's authoring-skill + reviewer-agent
-  split. No further agents without an RFC.
-- **Workspace-type profiles or `.architectrc` config files.**
-- **Integration / publishing skills** (Confluence, Figma,
-  Structurizr) — a separate later pack.
-- **ArchiMate / TOGAF / Wardley / graph-extraction skills** — EA
-  platform layer, not personal.
-- **Coupling to any specific folder layout** — the pack must work
-  in any workspace.
-
-## License
-
-Licensed under the repo's dual `MIT OR Apache-2.0` — see
-[`LICENSE-MIT`](../../LICENSE-MIT) and
-[`LICENSE-APACHE`](../../LICENSE-APACHE) at the repo root. The pack
-ships no separate `LICENSE` file; the third-party works credited
-below remain under their own (MIT) terms.
-
-## Layout
-
-```
-packs/architect/
-├── README.md
-├── pack.toml
-├── .claude-plugin/plugin.json
-├── .apm/agents/
-│   └── design-reviewer.md              # forked-context review lens (RFC-0032)
-└── .apm/skills/
-    ├── architect-design/
-    │   ├── SKILL.md
-    │   ├── references/
-    │   │   ├── design-doc-rubric.md
-    │   │   ├── alternatives.md
-    │   │   ├── nfr-checklist.md
-    │   │   ├── well-architected-pillars.md
-    │   │   ├── quality-attribute-scenarios.md
-    │   │   ├── tradeoffs-and-sensitivity.md
-    │   │   ├── cloud-primitives.md
-    │   │   ├── local-dev.md
-    │   │   ├── cross-cutting-questions.md
-    │   │   ├── lens-genai-agentic.md
-    │   │   ├── convergence-loop.md          # design-only: the loop procedure
-    │   │   └── leading-edge-domains.md      # design-only: novel-domain method
-    │   └── assets/
-    │       ├── design-doc.md
-    │       └── concept.md                   # the one-page Stage-0 concept
-    ├── architect-diagram/
-    │   ├── SKILL.md
-    │   ├── references/
-    │   │   ├── notation-routing.md
-    │   │   ├── diagram-rubric.md
-    │   │   ├── cloud-patterns.md
-    │   │   ├── mermaid-{flowchart,sequence,c4,state,er,architecture-beta}.md
-    │   │   ├── cloud-{aws,azure,gcp,primitives}.md
-    │   │   └── agentic-{bedrock-agentcore,ai-foundry,vertex-agent-engine}.md
-    │   └── assets/
-    │       └── c4-container.mmd
-    └── architect-review/
-        ├── SKILL.md
-        ├── references/
-        │   ├── rubric-{design-doc,c4-diagram,sequence-diagram,state-diagram,er-diagram,generic}.md
-        │   ├── rubric-well-architected.md   # WA-mode rubric + mechanical/judgment test
-        │   ├── well-architected-pillars.md  # ┐
-        │   ├── quality-attribute-scenarios.md #  │ duplicated from architect-design
-        │   ├── tradeoffs-and-sensitivity.md #  │ (skill autonomy beats DRY),
-        │   ├── cloud-primitives.md          #  │ each with a one-line note
-        │   ├── local-dev.md                 #  │
-        │   ├── cross-cutting-questions.md   #  │
-        │   └── lens-genai-agentic.md        # ┘
-        └── assets/
-            ├── critique.md
-            └── risk-register.md             # WA-mode output shape
-```
-
-Rubrics and well-architected references are deliberately duplicated
-between `architect-design` and `architect-review` rather than shared via
-inter-skill references. Each duplicated file carries a one-line note. The
-duplication is the principle, not the bug — each skill stands alone.
-
-## Usage
-
-Ask your agent, for example:
-
-- "Design the architecture for a multi-tenant billing service on AWS." (`architect-design`)
-- "Draw a Mermaid component diagram for this design." (`architect-diagram`)
-- "Review this architecture against the well-architected rubric." (`architect-review`)
+Concept to reviewed design doc — workspace-agnostic.
 
 ---
 
+## Start here
+
+Type `architect-design` and describe the problem — what you're building, for whom, and the key constraint.
+
+```text
+architect-design
+
+  Knowledge surface: docs/architecture/reference.md
+
+  Problem      Billing engine for a multi-tenant SaaS.
+  Constraint   No shared state between tenants.
+  Candidates   Event-sourced ledger; relational schema + row-level security
+
+Approve this shape? ›
+```
+
+On any session return, type `architect-design [path]` to continue.
+
+```text
+architect-design docs/design/multi-tenant-billing/design.md
+
+  Stage 1  in progress — §3 Proposal (last saved)
+```
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|-------------|
+| `architect-design` | Frame a concept, write a Google-style design doc, and converge it against review |
+| `architect-diagram` | Draw a Mermaid diagram — C4, sequence, state, ER, or flowchart |
+| `architect-review` | Critique a design doc or diagram with severity-tagged findings |
+
+---
+
+## How a session runs
+
+```text
+architect-design [describe the problem]
+
+  Knowledge surface: docs/architecture/reference.md
+
+  Problem      Billing engine for a multi-tenant SaaS.
+  Constraint   No shared state between tenants.
+  Candidates   Event-sourced ledger; relational schema + row-level security
+
+Approve this shape? ›
+```
+
+```text
+architect-design [continue to Stage 1]
+
+  ## TL;DR
+
+  Introduce a dedicated billing service backed by an event-sourced ledger.
+  Tenant isolation is enforced at ingestion by partition key, not at query
+  time by row-level security — a constraint we cannot control in
+  third-party integrations. The relational-plus-RLS alternative is rejected
+  because it couples isolation to every caller's query discipline.
+```
+
+```text
+architect-review docs/design/multi-tenant-billing/design.md
+
+  Verdict: SHIP WITH CHANGES
+
+  🟥  Proposal §4 — trust boundary between billing service and payment
+      processor is unlabeled; required before the integration contract
+      can be implemented.
+  🟧  Alternatives §2 — relational-plus-RLS rejection reason is thin.
+  ⚪  TL;DR sentence 2 could be tightened.
+```
+
+The reviewer runs in a forked context — no authoring memory. You act on its findings, then save.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture invariants, and decision log.  
 → **Go deeper:** the [`architect` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/architect/).

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -82,5 +82,29 @@ The reviewer runs in a forked context — no authoring memory. You act on its fi
 
 ---
 
+## Diagram session
+
+```text
+architect-diagram [C4 component view — billing service]
+
+  Routed: C4 Component
+  Reference: docs/architecture/reference.md
+
+  ```mermaid
+  C4Component
+    Container_Ext(api, "API Gateway", "HTTPS")
+    Container(billing, "Billing Service", "Go · event-sourced")
+    Container(events, "Event Store", "Kafka")
+    Container_Ext(pay, "Payment Processor", "Stripe")
+    Rel(api, billing, "POST /invoice")
+    Rel(billing, events, "append event")
+    Rel(billing, pay, "POST /charge")
+  ```
+```
+
+`architect-diagram` routes by intent — C4 (container, component, context), sequence, state, ER, or flowchart — from a plain description. No notation flag needed.
+
+---
+
 → **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture invariants, and decision log.  
 → **Go deeper:** the [`architect` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/architect/).

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -105,5 +105,15 @@ architect-diagram [C4 component view — billing service]
 
 ---
 
+## Install
+
+```bash
+agentbundle install --pack architect <catalogue>
+```
+
+Adapters: `claude-code`, `kiro-ide`, `codex`, `copilot`, `cursor`, `gemini`. Default scope: user.
+
+---
+
 → **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture invariants, and decision log.  
 → **Go deeper:** the [`architect` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/architect/).

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -43,48 +43,47 @@ architect-design docs/design/multi-tenant-billing/design.md
 ## How a session runs
 
 ```text
-architect-design [describe the problem]
+architect-design [event notification service — at-least-once delivery]
 
   Knowledge surface: docs/architecture/reference.md
 
-  Problem      Billing engine for a multi-tenant SaaS.
-  Constraint   No shared state between tenants.
-  Candidates   Event-sourced ledger; relational schema + row-level security
+  Problem      Events from checkout must reach three downstream services.
+  Constraint   At-least-once delivery; no shared database between subscribers.
+  Candidates   Outbox pattern; Kafka topic per subscriber; webhook relay
 
 Approve this shape? ›
 ```
 
 ```text
-architect-design [continue to Stage 1]
+architect-design docs/design/event-notification/design.md
 
   ## TL;DR
 
-  Introduce a dedicated billing service backed by an event-sourced ledger.
-  Tenant isolation is enforced at ingestion by partition key, not at query
-  time by row-level security — a constraint we cannot control in
-  third-party integrations. The relational-plus-RLS alternative is rejected
-  because it couples isolation to every caller's query discipline.
+  Use the transactional outbox pattern. The service writes event records
+  in the same transaction as the originating write; a poller fans out to
+  each subscriber, and each subscriber tracks its own cursor. Kafka
+  per-subscriber is rejected — it couples all subscribers to broker
+  availability for a sync path that can tolerate async retry.
 ```
 
 ```text
-architect-review docs/design/multi-tenant-billing/design.md
+architect-review docs/design/event-notification/design.md
 
   Verdict: SHIP WITH CHANGES
 
-  🟥  Proposal §4 — trust boundary between billing service and payment
-      processor is unlabeled; required before the integration contract
-      can be implemented.
-  🟧  Alternatives §2 — relational-plus-RLS rejection reason is thin.
-  ⚪  TL;DR sentence 2 could be tightened.
+  🟥  Proposal §3 — subscriber cursor schema is unspecified; needed
+      before the contracts pack can draft the delivery API.
+  🟧  Alternatives §1 — webhook relay rejection rationale is thin.
+  ⚪  TL;DR last sentence is passive voice; tighten.
 ```
 
-The reviewer runs in a forked context — no authoring memory. You act on its findings, then save.
+The reviewer runs in a forked context — no authoring memory. You act on its findings, then proceed.
 
 ---
 
 ## Diagram session
 
-```text
+````text
 architect-diagram [C4 component view — billing service]
 
   Routed: C4 Component
@@ -100,7 +99,7 @@ architect-diagram [C4 component view — billing service]
     Rel(billing, events, "append event")
     Rel(billing, pay, "POST /charge")
   ```
-```
+````
 
 `architect-diagram` routes by intent — C4 (container, component, context), sequence, state, ER, or flowchart — from a plain description. No notation flag needed.
 

--- a/packs/contracts/DESIGN.md
+++ b/packs/contracts/DESIGN.md
@@ -1,0 +1,145 @@
+# Contracts Pack — Design Document
+
+Living design reference for the contracts pack. Records the philosophy, architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing either skill.
+
+**Related ADRs:** [ADR-0008](../../docs/adr/0008-contract-authoring-seam.md) (contract authoring seam), [ADR-0030](../../docs/adr/0030-consolidated-pack-output-layout-contract.md) (consolidated pack output layout)  
+**Related RFCs:** [RFC-0017](../../docs/rfc/0017-pluggable-api-contract-standards.md) (pluggable API contract standards), [RFC-0018](../../docs/rfc/0018-event-asyncapi-authoring-engine.md) (event AsyncAPI authoring engine)
+
+---
+
+## TL;DR
+
+`contracts` is the API-first design seat. Both skills — `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI 2.x) — run a multi-phase method against a pluggable house standard: Zalando by default, replaceable with any base + delta bundle without forking the skill. The contract drives implementation; the pack produces a versioned, validated YAML file the consumer can build against without talking to the author. Consumer-perspective check is built into every session. Human review happens at one gate: G-contract, before the contract feeds any build loop.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **Code generation from contracts.** The pack produces a contract that developers and downstream tooling (code generators, test generators, mock servers, SDK builders) consume. Generating stubs from the contract is a downstream tool concern, not a contract-authoring concern.
+- **Runtime contract validation.** The pack validates the contract structure at authoring time. Whether a running service honors its contract is a separate concern — contract-testing and consumer-driven test suites.
+- **Live API testing.** No HTTP calls, no mock server activation, no test-run integration. The output is a static YAML document, not a running mock.
+- **Protocol-specific implementation stubs.** The pack does not emit framework-specific handler scaffolding, route registration, or serialization code. Those are build-loop outputs.
+
+---
+
+## 1. The contract-first principle
+
+### Why the contract comes first
+
+The API contract is the implementation brief for every consumer of the service. When code is written before the contract, the contract retroactively describes what the producer found convenient to implement — not what consumers need. Consumers who integrate against a convenience API discover missing cases (error shapes, pagination semantics, edge-case behavior) through production failures instead of through the spec.
+
+Writing the contract first inverts the dependency: the contract describes the agreed consumer surface, and the implementation is constrained to fulfill it. This makes the spec a testable commitment rather than an after-the-fact description.
+
+### The consumer-perspective check
+
+Both skills apply a consumer-perspective check built into the method:
+
+- **`api-contract`:** Phase 4 (Error Handling & Status Codes) requires specifying error responses for every operation. A contract that covers only 200 responses is a best-case spec, not a contract. Phase 2 (Design URLs & Methods) requires path and method semantics consistent with the active standard's rules — which are grounded in what the consumer expects from a REST interface.
+- **`event-contract`:** Phase 1 (Model the event domain) requires deciding whether the feature *produces* the event type or merely *consumes* it — a feature that only consumes someone else's event is not a contract authoring event. Phase 3 (Choose categories) assigns category semantics that set ordering and delivery expectations for consumers.
+
+---
+
+## 2. The pluggable house standard
+
+### What "pluggable" means
+
+Both skills carry the *method* — phases, decision rules, design discipline — and apply *data* from the active standard: the specific rules, naming conventions, error format, versioning strategy, and message envelope. The bundled default is the Zalando RESTful API Guidelines for `api-contract`, and the Zalando Events Guidelines for `event-contract`.
+
+An organization can replace the bundled standard by delivering a `base + delta` bundle via `adapt-to-project`'s companion-merge. The delta can disable rules (set to `false`), add house rules (under `adds`), and swap the message envelope (Axis B for event contracts). The skill doesn't need to be forked; the standard is data, not logic.
+
+### Why Zalando guidelines as default
+
+Zalando's guidelines are widely adopted, machine-readable, designed for extension, and explicitly cover the consumer perspective. A team can define a "base + delta" bundle that overrides specific rules without discarding the full standard. This makes them an appropriate default for a pack designed to be adopted across organizations with diverse API conventions.
+
+### How base + delta resolves
+
+If the active standard extends a base, the skill resolves by reading:
+1. Apply the base rules first.
+2. Apply the delta: rules set to `false` are disabled; rules under `adds` are additional constraints.
+3. For event contracts, an envelope override under `components.envelope` swaps Axis B.
+
+Nothing parses the manifest automatically — the skill resolves it by reading.
+
+---
+
+## 3. OpenAPI 3.1 and AsyncAPI 2.x in one pack
+
+### Why one pack covers both
+
+REST and event-driven contracts are designed by the same team at the same moment — when the service's boundaries are being defined, before implementation starts. Separating them into two packs would create unnecessary friction: teams building event-driven services alongside REST endpoints would need to install two packs to cover one design session.
+
+Both skills share the same house standard (Zalando by default), the same gate (G-contract), and the same output model (a versioned YAML file committed alongside the service). Their methods are distinct; their contract-first principle is identical.
+
+### Why OpenAPI 3.1, not 3.0
+
+OpenAPI 3.1 aligns with JSON Schema 2020-12, enabling better schema reuse and unambiguous nullable field semantics. The `nullable: true` workaround in 3.0 is a known source of tooling inconsistency; 3.1's `type: ["string", "null"]` is explicit and standards-conformant.
+
+### Why AsyncAPI 2.x, not 3.0
+
+AsyncAPI 3.0 is still maturing; 2.x has broader tooling support and is the current stable version for event contract authoring. The version is governed by the manifest's `output target` field — when the ecosystem matures, adopters can update their standard manifest without forking the skill.
+
+---
+
+## 4. Human gate design
+
+### G-contract — the one gate
+
+| Gate | When | Duration | What to check |
+|------|------|----------|---------------|
+| **G-contract** | After `api-contract` or `event-contract` produces the first complete draft | 10–20 min | Are all error codes specified? Does the contract read from the consumer's perspective? Are schema field names consistent with team conventions? For event contracts: is the producer/consumer boundary explicit? |
+
+### Why one gate, not zero
+
+A contract without a human review creates a commitment consumers build against before the producer has verified it covers the agreed surface. The cost of a missing error code discovered in production is substantially higher than 10–20 minutes of review at contract time.
+
+Zero gates is the wrong default because the contract is the implementation brief for every consumer — it is not an intermediate artifact but a public commitment.
+
+### Why one gate, not two
+
+Unlike `work-loop`, which gates at plan time and again at PR merge, `contracts` needs only one gate. The contract is the plan; the implementation is separately gated by the build loop (`work-loop`'s G-pr). Duplicating the contract review gate would pay the cost of G-pr twice for the same artifact.
+
+---
+
+## 5. Safety invariants
+
+These constraints must never be violated by any skill in the contracts pack or any skill that extends it.
+
+1. **Consumer-perspective check is non-negotiable.** No skill may produce a contract that specifies only success responses. Every operation requires at minimum the standard error codes the active standard mandates.
+
+2. **The active standard is data, not a hardcoded rule set.** No rule number, naming convention, or error format may be hardcoded into the skill logic. All such rules come from the active standard's manifest and rule files.
+
+3. **The event authoring boundary is produce-only.** `event-contract` must not author a contract for a stream the feature only consumes. A fabricated contract for a stream the feature doesn't own will drift from the producer's real contract, creating a false commitment.
+
+4. **Versioned output files.** Both skills emit versioned YAML files. A contract without a version is not ready to commit — consumers cannot detect incompatible changes without a semantic version they can check.
+
+5. **No stack-specific stubs.** Neither skill emits framework-specific code. The output is a YAML document; code generation belongs downstream.
+
+---
+
+## 6. Design decisions and rationale log
+
+### Why Zalando guidelines as the bundled default (from v0.1)
+
+Zalando's guidelines are: (a) widely adopted — many API platforms have trained their teams on them; (b) consumer-perspective explicit — they treat the consumer as the primary stakeholder, not the implementor; (c) designed for extension — the base + delta model is a design goal, not a retrofit. An organization that uses a different standard can deliver it as a delta bundle without forking the skill. A bundled default that assumes no standard is less useful than one that assumes a well-known standard the adopter can override.
+
+**Alternative considered:** ship no bundled standard, require the adopter to supply one. Rejected because it creates an installation friction point that discourages the pack's primary use case (quick first-value: run `api-contract` on a service description and get a validated spec). The bundled default is a useful starting point, not a prescription.
+
+### Why OpenAPI 3.1 instead of 3.0 (from v0.1)
+
+OpenAPI 3.0's `nullable: true` extension is not part of the JSON Schema standard; it creates tooling inconsistency where code generators and validators interpret it differently. OpenAPI 3.1's `type: ["string", "null"]` follows JSON Schema 2020-12 exactly and resolves the inconsistency. Improved schema reuse (via `$defs` and relative `$ref`) was an additional benefit.
+
+**Alternative considered:** support both 3.0 and 3.1 with a version flag. Rejected because maintaining two code paths in the skill and the active standard's rule files creates ongoing complexity without meaningful benefit — 3.0-era tools now have mature 3.1 support.
+
+### Why AsyncAPI 2.x instead of 3.0 (from v0.1)
+
+AsyncAPI 3.0 introduced breaking changes to the channel/operation model and had immature tooling support at the time of authoring. The version is governed by the manifest's output target field — adopters who need 3.0 can update their standard manifest's output target. The skill method does not hardcode the version; the manifest does.
+
+**Alternative considered:** target AsyncAPI 3.0 only. Rejected because the tooling ecosystem (validators, code generators, documentation renderers) was not stable at 3.0 at the time of authoring. Choosing a version with immature tooling would break the pack's core value: a validated contract that downstream tooling can consume without modification.
+
+### Why one pack for OpenAPI and AsyncAPI, not two (from v0.1)
+
+Service boundary design is a single design session. When a team defines a service, they decide its REST interface and its event interface simultaneously. Requiring two pack installations for one design session creates unnecessary friction and a gap where teams design the REST contract but skip the event contract because of the additional step.
+
+**Alternative considered:** separate `api-contracts` and `event-contracts` packs. Rejected because the install and invoke surface would double for teams that need both, and the shared concepts — active standard, G-contract gate, versioned YAML output — are not costly to maintain in one pack.

--- a/packs/contracts/README.md
+++ b/packs/contracts/README.md
@@ -1,30 +1,80 @@
 # contracts
 
-Contract-authoring skills for API and event design. `api-contract` drives
-OpenAPI 3.1; `event-contract` drives AsyncAPI events.
-
-## What's inside
-
-- `api-contract` — author and review OpenAPI 3.1 contracts.
-- `event-contract` — author and review AsyncAPI event contracts.
-
-## Install
-
-`contracts` is **user-scope by default** — contract style is portable across
-projects.
-
-```
-agentbundle install --pack contracts <catalogue>
-```
-
-## Usage
-
-Ask your agent, for example:
-
-- "Draft an OpenAPI 3.1 contract for the orders service: create, get, cancel."
-- "Review this OpenAPI spec for breaking changes against the previous version."
-- "Design an AsyncAPI contract for the `order.placed` event stream."
+API-first design — OpenAPI 3.1 and AsyncAPI contracts before implementation.
 
 ---
 
+## Start here
+
+Type `api-contract` and describe the API surface — resources, actions, and the consumers who will call it.
+
+```text
+api-contract [orders service: create, get, cancel]
+
+  Endpoint              Method   Schema
+  /orders               POST     OrderCreate → OrderResponse
+  /orders/{order_id}    GET      → OrderResponse
+  /orders/{order_id}    DELETE   → (204 No Content)
+
+  Error responses: 400, 404, 409, 500 (Problem schema)
+```
+
+No orient command in this pack. On any session return, open the contract file directly and continue: `api-contract [path to existing spec]` to review or extend.
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|-------------|
+| `api-contract` | Author or review an OpenAPI 3.1 contract — endpoints, schemas, error codes, consumer-perspective check |
+| `event-contract` | Author or review an AsyncAPI 2.x event contract — channels, message shapes, producer/consumer boundary |
+
+---
+
+## How a session runs
+
+```text
+api-contract [orders service: create, get, cancel]
+
+  Endpoint              Method   Schema
+  /orders               POST     OrderCreate → OrderResponse
+  /orders/{order_id}    GET      → OrderResponse
+  /orders/{order_id}    DELETE   → (204 No Content)
+
+  Error responses: 400, 404, 409, 500 (Problem schema)
+  House standard: Zalando (default)
+```
+
+```text
+  Consumer-perspective check
+
+  ● All endpoints secured (Bearer token)
+  ● Error shapes consistent (Problem schema)
+  ⚠ POST /orders: missing 409 Conflict for duplicate order_id
+
+  G-contract ›
+```
+
+```text
+event-contract [order.placed event]
+
+  Channel                     Message           Category
+  orders/order.placed.v1      OrderPlacedV1     business-event
+
+  Envelope: CloudEvents (structured mode)
+  Payload:  order_id · customer_id · items[] · total_amount
+```
+
+---
+
+## Cross-pack
+
+**Upstream — `architect`:** Contracts inform architecture. When an OpenAPI or AsyncAPI contract exists, `architect-design` reads it as a boundary specification before proposing a backend shape.
+
+**Downstream — `core`:** Contracts feed the build loop via `contract-acquisition`. When `work-loop` hits an unfamiliar API surface, `contract-acquisition` grounds the implementation against the contract before code is written.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.  
 → **Go deeper:** the [`contracts` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/contracts/).

--- a/packs/contracts/README.md
+++ b/packs/contracts/README.md
@@ -19,7 +19,7 @@ api-contract [orders service: create, get, cancel]
   Error responses: 400, 404, 409, 500 (Problem schema)
 ```
 
-No orient command in this pack. On any session return, open the contract file directly and continue: `api-contract [path to existing spec]` to review or extend.
+On any session return, continue with `api-contract [path to existing spec]` to review or extend — no separate orient needed.
 
 ---
 
@@ -44,9 +44,7 @@ api-contract [orders service: create, get, cancel]
 
   Error responses: 400, 404, 409, 500 (Problem schema)
   House standard: Zalando (default)
-```
 
-```text
   Consumer-perspective check
 
   ● All endpoints secured (Bearer token)

--- a/packs/desk-research/DESIGN.md
+++ b/packs/desk-research/DESIGN.md
@@ -1,0 +1,198 @@
+# Desk Research Pack — Design Document
+
+Living design reference for the desk-research pack. Records the philosophy, architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** [ADR-0029](../../docs/adr/0029-research-two-axes-depth-and-lifecycle.md) (two axes), [ADR-0030](../../docs/adr/0030-consolidated-pack-output-layout-contract.md) (output layout)
+
+---
+
+## TL;DR
+
+`desk-research` is the evidence layer. It has two independent axes: depth (quick → deep/exhaustive) and lifecycle (single-session vs. sustained project). Source-first ordering — map sources before retrieving, primary before secondary — prevents the most common triangulation failure. GRADE confidence grading makes the epistemic state explicit rather than hiding gaps behind authoritative-sounding prose. Two read-only subagents (`evidence-retriever`, `source-extractor`) preserve main-session context by collapsing raw fetched material into a synthesis before returning. The pack is user-scope by default: research method is portable; artifacts are per-repo and resolved through the adopter's `agentbundle-layout.toml`.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **Live web monitoring** — the pack retrieves on demand; it does not watch sources and alert on changes.
+- **Primary interview research** — discussion guides, interview scripts, and moderated research belong to a dedicated UX research workflow, not to desk research.
+- **Quantitative analysis** — statistics, experimental design, and data modelling are outside scope. The pack reads quantitative findings and grades their evidence quality, but does not produce statistical analysis.
+- **Automatic citation management integration** — the pack produces cited Markdown artifacts; syncing them to external reference managers is an adopter concern, not a pack concern.
+
+---
+
+## 1. The two-axis model
+
+### What the axes are
+
+The pack separates two dimensions that are easy to conflate:
+
+- **Depth axis** — how thoroughly to investigate a single question. Four modes: `quick` (≤5 fetches, inline answer), `standard` (cited survey, ≥3 sources per claim), `applied` (practitioner grey-literature calibration), `deep` (standard + adversarial review via `devils-advocate`).
+- **Lifecycle axis** — whether an investigation is a single session or a sustained project. Session mode: one invocation of `desk-research`, produces a typed artifact or an inline answer. Project mode: a multi-week lifecycle — scaffold → capture → digest → synthesize → feedback — that accumulates a corpus over time.
+
+### Why they are orthogonal
+
+A quick session lookup and an exhaustive multi-week investigation are not on the same scale — they are different shapes of work. Forcing one into the other either requires premature closure (a project question answered in one pass) or unnecessary scaffolding (a quick lookup going through project scaffolding).
+
+The lifecycle axis is equally independent of depth: a project can accumulate sources at `standard` depth or at `applied` depth or at `deep` depth. The depth setting on each per-source retrieval pass is independent of the project's lifecycle phase.
+
+### Entry points by axis
+
+| Axis | Entry points |
+|------|--------------|
+| Session | `desk-research` (all depth modes) |
+| Session — decision support | `source-map`, `build-outline`, `identify-perspectives`, `compare-hypotheses`, `devils-advocate`, `decision-archaeology` |
+| Project | `desk-research-project-start` → `desk-research-project-status` / `desk-research-project-check` → `desk-research-project-digest` → `desk-research-project-synthesize` |
+
+---
+
+## 2. Source-first ordering
+
+### The principle
+
+Canonical sources are identified before retrieval begins; primary sources are retrieved before secondary. This is what `source-map` enforces.
+
+### Why
+
+The most common triangulation failure mode is synthesizing secondary summaries that each independently cite the same primary — and treating that as three independent data points. A synthesis that samples three blog posts about the same DORA report has not triangulated; it has cited the same finding three times.
+
+Source-first ordering catches this by mapping the primary source landscape before any retrieval is dispatched. When retrieval starts from primary sources, secondary sources are encountered as signals pointing to primaries rather than as independent claims.
+
+### What counts as independent
+
+Per the applied-mode practitioner-independence rule: three sources from the same vendor count as one independent; three sources in the same employer cohort count as one; three reblogs of the same original post count as one. Independence is asserted on the chain back to the origin, not on the number of URLs.
+
+---
+
+## 3. GRADE confidence grading
+
+### The grading schema
+
+Every material finding in a standard/applied/deep synthesis carries a confidence tag from the closed set: `[high]` / `[moderate]` / `[low]` / `[uncertain]`. The schema is codified in `references/confidence-schema.md` — the skill body references it; it does not reprint it.
+
+### Why GRADE, not a subjective tier
+
+GRADE grades reflect the quality of the evidence (study design, consistency, directness, precision) — not the author's degree of confidence in their own opinion. This is the same discipline systematic reviews use. Using GRADE-style grades makes the distinction between "well-supported by multiple independent studies" and "one vendor blog post" explicit in the artifact, rather than hiding it behind authoritative-sounding prose.
+
+### The gap distinction
+
+Confidence grades tag claims the research *did* make. Gaps are questions the research *could not answer at all*. Conflating the two — treating a gap as an `[uncertain]` finding — is a category error: `[uncertain]` means *a claim exists, but weak grounds for it*; a gap means *no claim exists, because the evidence isn't there*. Every non-quick synthesis carries a `## Known unknowns` section that separates known-unknowns (answerable in principle; name the evidence) from unknowables (not answerable from available evidence; name why).
+
+Honest gaps are better than false confidence. A synthesis that names its limits precisely is more useful to a decision than a synthesis that asserts completeness.
+
+---
+
+## 4. The seven convergent disciplines
+
+The methodology grounds the pack's behaviour in seven disciplines that each contribute a distinct structural obligation:
+
+| Discipline | Contribution |
+|---|---|
+| STORM | Co-STORM moderator pass — scan retrieved-but-uncited material before declaring done |
+| PRISMA | Systematic inclusion/exclusion criteria; population-level claim discipline |
+| ACH (Analysis of Competing Hypotheses) | Inconsistency-weighted hypothesis adjudication |
+| Wikipedia V/RS/NPOV | Verifiability, Reliable Sources, Neutral Point of View — citation-forcing and source-tier discipline |
+| OSINT | Source enumeration before retrieval; triangulation from independent primaries |
+| GIJN | Practitioner investigative methodology; anti-patterns and survivorship bias detection |
+| GRADE | Confidence grading keyed to evidence quality |
+
+These are convergent: each one closes a gap the others leave open. No single discipline covers all seven obligations. The pack's synthesis procedure is the convergence point — it does not pick one discipline and ignore the rest.
+
+---
+
+## 5. Subagent architecture
+
+### Two read-only retrievers
+
+`evidence-retriever` and `source-extractor` are dispatched by `desk-research` in standard and deep modes. They are not entry points — they are not invoked directly by the user.
+
+- `evidence-retriever` — fetches web and local material, synthesises findings, returns a per-question synthesis with citations.
+- `source-extractor` — given a list of candidate URLs or local paths, fetches each, extracts substantive content, returns a per-source synthesis.
+
+Both are read-only by contract: they never write to the repo, never modify files, and never execute code.
+
+### Why subagents, not inline retrieval
+
+Standard and deep mode can require many fetches across many sources. Dispatching these as subagents preserves main-session context — the raw fetched material is collapsed into a synthesis before returning to the main session, rather than accumulating in the main session's context window. This is structurally identical to why core's adversarial-reviewer runs in a forked context: isolation is a feature, not a limitation.
+
+### Claude Code web tools grant
+
+`evidence-retriever` and `source-extractor` need `WebSearch` and `WebFetch` in `permissions.allow`. A non-interactive subagent cannot surface the approval prompt; without the grant, those tools are denied silently. This is a one-time note for Claude Code adopters — other adapters (Copilot, Cursor, Gemini, Codex, Kiro) pass web tools through at build time and need no such step.
+
+---
+
+## 6. Output artifact model
+
+### Layout resolution
+
+Artifacts are placed under the `[research] output_dir` from the adopter's `agentbundle-layout.toml`. User-scope config takes priority over repo-scope; when neither is configured, `desk-research-project-start` elicits the path and writes it once. Session artifacts land in the working directory. Project artifacts land under a date-named project folder inside `output_dir`.
+
+### Typed, topic-named artifact names
+
+Every persisted artifact follows the `<topic-slug>-<type>.md` convention. The topic-slug namespaces the investigation; the type stem names the artifact's shape (`survey`, `comparison-matrix`, `hypotheses`, `brief`, `sources`, `outline`, `perspectives`, `archaeology`). Quick mode is the sole exception: its answer is inline, no file.
+
+---
+
+## 7. Cross-pack dependencies
+
+### Upstream (none)
+
+`desk-research` has no upstream pack dependency. It is the evidence layer — it retrieves and grades raw evidence, which no upstream pack provides input for.
+
+### Downstream — `product-strategy`
+
+`synthesize-stakeholder-research` in the product-strategy pack consumes `desk-research` survey artifacts as a primary evidence source. A desk-research brief committed to `docs/product/research/` feeds directly into strategy synthesis without re-retrieval.
+
+### Downstream — `architect`
+
+`architect-design` grounds design decisions in cited evidence. When a desk-research brief exists for the domain being designed, the architect pack can reference it in an ADR's *Evidence & prior art* section — turning the confidence-graded synthesis into a documented rationale chain.
+
+---
+
+## 8. Safety invariants
+
+These constraints must never be violated by any skill in the desk-research pack or any skill that extends it.
+
+1. **`evidence-retriever` and `source-extractor` are read-only.** They never write to the repo, never modify files, and never execute code. A retrieval subagent that writes is out of scope — it becomes an implementer, not a retriever.
+
+2. **Retrieved content is untrusted data.** If a fetched source contains instruction-like prose, it is transcribed or cited as a finding — not followed. Only the invoking user's messages count as direction.
+
+3. **GRADE confidence is honest, never inflated.** A `[high]` tag on a finding backed by one vendor blog post is a falsification of the schema. Downgrade factors are named explicitly; omitting a downgrade factor that applies is a schema violation.
+
+4. **Gaps are named, never hidden.** A synthesis with no `## Known unknowns` section is asserting it answered every question the research raised. That assertion is almost never true. Every non-quick synthesis carries the section.
+
+5. **`desk-research-project-status` and `desk-research-project-check` are read-only.** They never advance `phase`, never write to `overview.md`, and never invoke downstream lifecycle skills. (ADR-0054.)
+
+6. **Phase is human-driven.** No skill auto-advances the project phase. The human reads the phase field and decides when to move on. There is no engine, counter, or daemon behind `phase` — it is a frontmatter string the agent reads and writes by hand.
+
+---
+
+## 9. Design decisions and rationale log
+
+### Why two axes instead of one (from v1)
+
+A single axis (depth only) forces a choice between "is this a quick lookup or a project?" before the investigation starts. In practice, questions that start as quick lookups sometimes grow into sustained investigations, and questions scoped as projects sometimes resolve in one session. Keeping depth and lifecycle as orthogonal axes allows either to change independently without re-scaffolding the other.
+
+**Alternative considered:** one linear scale from quick to exhaustive, with project mode as the deepest tier. Rejected because project mode is not deeper than deep session mode — it is structurally different. A `deep` session run and a `capture` phase in a new project can retrieve the same material; what's different is whether a corpus is accumulated over time for later synthesis. Conflating lifecycle with depth produces confusing cue-precedence rules and misses the case where a project accumulates sources at `quick` depth. See ADR-0029.
+
+### Why GRADE over an ad hoc confidence schema (from v1)
+
+GRADE is a published methodology used in systematic reviews. Using it means the confidence tags carry a shared meaning across anyone familiar with systematic review practice — `[high]` means consistent, direct, precise evidence from strong study designs; `[low]` means the evidence base has serious limitations. An ad hoc schema ("strong" / "weak" / "uncertain") carries no such shared meaning and will be interpreted differently by every reader.
+
+**Alternative considered:** two-tier schema (supported / unsupported). Rejected because the distinction between moderately-supported findings and weakly-supported findings is load-bearing for downstream decisions: a `[moderate]` finding warrants a different follow-on (seek more evidence) than an `[uncertain]` one (the question may be structurally unanswerable). Collapsing them loses information the decision maker needs.
+
+### Why source-first, not retrieval-first (from v1)
+
+The retrieval-first pattern — "fetch whatever the search engine returns" — is fast but produces systematically bad triangulation. A keyword search returns dozens of secondary blog posts that each cite the same primary. Fetching all of them and treating each as an independent source produces false triangulation: the same primary data point counted many times.
+
+Source-first (run `source-map` before dispatching retrievers) forces the agent to identify the primary landscape first and retrieve from it. Secondary sources then serve their correct purpose — as pointers to primaries, not as independent evidence.
+
+**Alternative considered:** let the agent identify primaries during synthesis by tracing citation chains in the retrieved material. Rejected because citation chain tracing on arbitrary retrieved text is brittle — citations are often absent, malformed, or cut off by retriever extraction limits. Source-mapping is more reliable when done before retrieval than inferred after.
+
+### Why user-scope by default (from v1)
+
+Research method is the same across repos; only the artifacts differ. Installing per-repo would require reinstallation on every new project without any change to the skills. The scope decision mirrors `experience-design` (the method is portable; the knowledge surface is not project-specific). Compare with `core`, which is repo-scope because `work-loop`'s gate commands (`lint`, `typecheck`, `tests`) are project-specific.
+
+**Alternative considered:** repo-scope, so research artifacts colocate with the code they inform. Rejected because artifact placement is already controlled by `agentbundle-layout.toml` — artifacts land in the repo regardless of whether the skill is installed user-scope or repo-scope. The scope decision affects only where the skill files live, not where the output goes.

--- a/packs/desk-research/README.md
+++ b/packs/desk-research/README.md
@@ -25,6 +25,14 @@ On any session return, type `desk-research-project-status` to orient to an activ
 
 ---
 
+## Two modes
+
+**Ad-hoc** — one question, one session. Type `desk-research` and pick a depth (quick through deep). The agent maps sources, dispatches retrieval, and returns a confidence-graded synthesis in minutes. Use this for a lookup, a fact-check, or a brief.
+
+**Project mode** — a sustained investigation that spans days or accumulates a corpus. Start with `desk-research-project-start`. The project skills track a working hypothesis across sessions, let you checkpoint coverage (`desk-research-project-check`), compress the corpus into a digest, and end in a synthesis brief graded by evidence quality. Use this when a single session would underserve the question.
+
+---
+
 ## Entry points
 
 | Say this | What happens |

--- a/packs/desk-research/README.md
+++ b/packs/desk-research/README.md
@@ -1,47 +1,100 @@
 # desk-research
 
-Evidence-grounded research that travels with you across every repo. Seven
-skills — scoping, source curation, synthesis, adversarial review, decision
-support, and rationale reconstruction — plus two read-only retrieval
-subagents. The methodology is grounded in seven convergent disciplines
-(STORM, PRISMA, ACH, Wikipedia V/RS/NPOV, OSINT, GIJN, GRADE).
-
-## What's inside
-
-- Skills for the full research loop: `desk-research`, `source-map`,
-  `build-outline`, `compare-hypotheses`, `identify-perspectives`,
-  `devils-advocate`, `decision-archaeology`.
-- `evidence-retriever` and `source-extractor` subagents (read-only).
-
-## Install
-
-`desk-research` is **user-scope by default** — research method is portable, not
-project-specific.
-
-```
-agentbundle install --pack desk-research <catalogue>
-```
-
-It projects to every shipped adapter that supports the skill primitive
-(Claude Code, Codex, Copilot, Cursor, Gemini, Kiro).
-
-> **Claude Code only — grant web tools to the retrieval subagents.** On Claude
-> Code, add **`WebSearch`** and **`WebFetch`** to your `permissions.allow` so the
-> `evidence-retriever` and `source-extractor` subagents can do live web
-> retrieval — a non-interactive subagent cannot surface the approval prompt, so
-> without the grant those tools are denied. This is a one-time note, not
-> bundle-managed machinery: `permissions.allow` is yours to own. Other adapters
-> (Copilot, Cursor, Gemini, Codex, Kiro) pass the web tools through or bake them
-> in at build time and need no such step.
-
-## Usage
-
-Ask your agent, for example:
-
-- "Research how teams measure deployment frequency, and map the sources."
-- "Synthesise these five papers into a one-page briefing with citations."
-- "Run a devil's-advocate pass on the claim that X causes Y."
+evidence-grounded desk research — portable across every repo.
 
 ---
 
+## Start here
+
+Type `desk-research` and describe what you're trying to find out.
+
+```text
+  ● evidence-retriever   running  DORA 2023 State of DevOps
+  ✓ source-extractor     done     accelerate.io — 3 findings extracted
+  ✓ synthesis            done     8 claims graded · 2 gaps named
+```
+
+On any session return, type `desk-research-project-status` to orient to an active project.
+
+```text
+  Project    2026-07-15-deployment-frequency
+  Phase      digest
+  Hypothesis  Trunk-based development is the primary predictor
+  Next        desk-research-project-digest
+```
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|--------------|
+| `desk-research` | Single-session research — scoping, retrieval, synthesis in one pass |
+| `source-map` | Map canonical sources before retrieval begins |
+| `build-outline` | Build a research outline from the source map |
+| `identify-perspectives` | Map stakeholder perspectives before synthesis |
+| `compare-hypotheses` | Competing-hypotheses pipeline — scored matrix |
+| `devils-advocate` | Steelman the opposing case |
+| `decision-archaeology` | Reconstruct why a prior decision was made |
+| `desk-research-project-start` | Initialize a sustained multi-week research project |
+| `desk-research-project-status` | Orient to an active project — phase, hypothesis, what's next |
+| `desk-research-project-check` | Snapshot progress — sources captured, coverage, gaps |
+| `desk-research-project-digest` | Summarize corpus into a synthesis matrix |
+| `desk-research-project-synthesize` | Synthesize digest into a confidence-graded brief |
+
+`evidence-retriever` and `source-extractor` are read-only retrieval subagents dispatched automatically by `desk-research` — they are not invoked directly.
+
+---
+
+## How a session runs
+
+```text
+desk-research "What drives deployment frequency in platform engineering teams?"
+
+  ● evidence-retriever   running  DORA 2023 State of DevOps
+  ✓ source-extractor     done     accelerate.io — 3 findings extracted
+  ● evidence-retriever   running  Google Cloud DevOps metrics
+  ○ synthesis            idle
+```
+
+```text
+desk-research-project-start "competitive landscape for platform tooling"
+
+  project  docs/product/research/2026-07-27-platform-tooling/
+
+  ├─ overview.md          phase: capture
+  └─ sources/
+
+  Question    Competitive landscape for platform tooling
+  Hypothesis  (none yet — to be formed as evidence accumulates)
+  Next        desk-research to fill sources/, then desk-research-project-digest
+```
+
+```text
+desk-research-project-synthesize
+
+  brief  platform-tooling-brief.md
+
+  Bottom line:  Build-vs-buy splits sharply at team size 50; below that, buy dominates.
+
+    Claim                                              Grade      Sources
+    Team-size 50 as buy/build threshold               [high]      4 independent
+    TCO advantage erodes above 200 engineers          [moderate]  3; downgrade: vendor-sourced
+    OSS viable only with dedicated maintainer         [moderate]  3; downgrade: survivorship bias
+
+  Known unknowns
+    Known-unknown: data at 50–200 engineer range. Would close by: mid-size org survey.
+```
+
+---
+
+## Cross-pack
+
+**Downstream — `product-strategy`:** `synthesize-stakeholder-research` in the product-strategy pack consumes `desk-research` survey artifacts as a primary evidence source.
+
+**Downstream — `architect`:** design decisions grounded in a `desk-research` brief carry a cited rationale chain that `architect-design` can reference in ADRs.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.  
 → **Go deeper:** the [`desk-research` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/desk-research/).

--- a/packs/desk-research/README.md
+++ b/packs/desk-research/README.md
@@ -9,6 +9,8 @@ evidence-grounded desk research — portable across every repo.
 Type `desk-research` and describe what you're trying to find out.
 
 ```text
+desk-research "What drives deployment frequency in high-performing teams?"
+
   ● evidence-retriever   running  DORA 2023 State of DevOps
   ✓ source-extractor     done     accelerate.io — 3 findings extracted
   ✓ synthesis            done     8 claims graded · 2 gaps named

--- a/packs/desk-research/pack.toml
+++ b/packs/desk-research/pack.toml
@@ -78,7 +78,7 @@ skills = ["desk-research", "source-map", "build-outline", "identify-perspectives
 # writes a user `[research]` section by hand or via elicitation
 # (see the skill's references/agentbundle-layout.md).
 [pack.layout.repo]
-output_dir = ".context/desk-research"
+output_dir = "docs/product/research"
 
 # enriched-pack-manifest (RFC-0031 / ADR-0021): catalogue-facing links
 # + maintainer, including the `documentation` link to the per-pack guide home.

--- a/packs/governance-extras/DESIGN.md
+++ b/packs/governance-extras/DESIGN.md
@@ -1,0 +1,190 @@
+# Governance Extras Pack — Design Document
+
+Living design reference for the governance-extras pack. Records the philosophy, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** [ADR-0027](../../docs/adr/0027-adr-format-is-madr-aligned-but-lean.md) (ADR format is MADR-aligned but lean), [ADR-0030](../../docs/adr/0030-consolidated-pack-output-layout-contract.md) (consolidated pack output layout contract)  
+**Related RFCs:** (none — governance-extras provides the RFC mechanism itself)
+
+---
+
+## TL;DR
+
+`governance-extras` installs the governance layer on top of `core`: structured RFCs for cross-cutting proposals, ADRs for closed architectural decisions, and CONVENTIONS.md edits through tracked RFC review. Every skill previews its output and target path before writing anything — you confirm before any file is created. The scope is repo-only (governance records are per-project) and the dependency on `core` is required (the scaffold targets `docs/`, which only makes sense after core is in place). RFC and ADR are separate artifacts by design: an RFC is a live discussion; an ADR is a closed, immutable record. They serve different purposes and must not be conflated.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **Live governance dashboards.** `rfc-status` is a read-only point-in-time scan of `docs/rfc/`. It does not maintain a live dashboard, send notifications, or integrate with an issue tracker. It reads what's in the repo and reports it.
+- **RFC comment thread management.** Responding to reviewer comments, threading replies, and tracking per-reviewer objections are a wiki or issue tracker's job. This pack writes structured RFC documents; comment threads live outside the repo.
+- **Automated decision enforcement.** CONVENTIONS.md is documentation — a shared understanding of how the project works. It is not a validator, a lint rule, or a CI gate. The pack writes the document; enforcement is the team's job.
+- **Team approval workflows.** This pack writes RFC and ADR files. It does not create GitHub review requests, post to Slack, or orchestrate multi-person sign-off. The human gates (G-draft, G-accept, G-merge) are the adopter's checkpoints — the pack cannot substitute for the human work of circulating a document and getting a decision.
+
+---
+
+## 1. Why decisions need paper trails
+
+### The problem this pack solves
+
+Software teams make hundreds of architectural decisions over a project's lifetime. Most of those decisions are made in a chat thread, a meeting, or a conversation at a whiteboard — and the reasoning evaporates within a week. What survives is the decision itself (visible in the code or config) but not the *why*: the alternatives considered, the constraints that drove the choice, and the conditions under which the decision should be revisited.
+
+This creates a class of repeated failure:
+
+1. **Re-litigating closed decisions.** Without a record, a new team member or a team six months later re-opens the same debate. The original team spends time relitigating a settled question instead of moving forward.
+2. **Overbuilding around an outdated constraint.** A decision made under a specific constraint ("we chose this because we were on AWS Lambda at the time") accumulates downstream assumptions. When the constraint changes, no one knows which decisions were contingent on it.
+3. **Cargo-culting patterns.** Without rationale, a convention looks arbitrary. Teams follow it for the wrong reasons or abandon it without realizing the cost.
+
+`governance-extras` addresses this by making the paper trail a first-class product of the development loop. An RFC is written before cross-cutting work begins; an ADR is written after a decision is made. Both are committed to the repo, versioned alongside the code they govern.
+
+### Decisions outlive their authors
+
+The ADR exists to answer "why did we choose this?" when the author is gone. This is the single most important property of the artifact. An ADR that does not carry the honest forces behind the decision — the alternatives that were seriously considered, the constraint that made the chosen option win, the condition under which the decision should be revisited — is worse than no ADR. It gives the next reader false confidence that the decision is documented while leaving them unable to evaluate whether it still applies.
+
+The quality bar for an ADR is not "the decision is recorded." It is "a future engineer can reconstruct the reasoning from this document without speaking to anyone who was in the room."
+
+---
+
+## 2. RFC and ADR as separate artifacts
+
+### Why two artifact types
+
+The pack ships two distinct governance artifact types — RFC and ADR — because they serve structurally different purposes that cannot be collapsed into one form:
+
+**RFC (Request For Comments):** A *discussion* artifact. An RFC is for "should we do X?" — a cross-cutting proposal that needs input before anyone builds. The RFC is a live document during its comment period: it evolves as objections are raised and addressed. When the comment period closes, the RFC's status is updated (Accepted, Rejected, or Deferred) and its body is frozen. The RFC is the debate; the ADR is the verdict.
+
+**ADR (Architecture Decision Record):** A *record* artifact. An ADR is for "we decided X" — a closed, immutable record of a decision that was made. ADRs do not have comment periods. They record the decision, the forces that drove it, the alternatives that were considered and rejected, and the conditions under which the decision should be revisited. Once accepted, the ADR body is immutable — a reversal is a new ADR that supersedes the old one, never an edit.
+
+### Why they must not be conflated
+
+An RFC that is used to record a decision (instead of proposing one) produces a document that looks like a debate but carries a predetermined conclusion — misleading to every future reader who tries to evaluate whether the decision is still sound.
+
+An ADR that is used to open a debate (instead of recording a closed one) produces a document with no clear decision — defeating the purpose of the ADR index entirely.
+
+The pattern the pack enforces: an RFC that gets accepted generates an ADR. The RFC is the record of the debate; the ADR is the record of the outcome. They are different documents because they are different things.
+
+---
+
+## 3. The preview-before-write contract
+
+### What it is
+
+Every skill in this pack that writes a file — `new-rfc`, `new-adr` — shows you the output before creating anything on disk:
+
+- The identifier (RFC-NNNN or ADR-NNNN)
+- The target path (absolute and repo-relative)
+- The index path that will gain a row
+- A content preview of the drafted document
+
+The file is not created until you confirm. This is not optional behavior or a flag — it is the structural shape of every write skill in the pack.
+
+### Why it exists
+
+Governance documents are shared artifacts. An RFC or ADR committed to the repo is immediately visible to every contributor who reads `docs/rfc/` or `docs/adr/`. A file created before the author has approved its content creates a window where the repo's governance record is in a half-formed state.
+
+The preview gate is cheap — it costs one confirmation before a file is written — and it eliminates the failure mode of the wrong content going to a shared location. The cost of fixing a bad ADR after it's committed (triggering a supersession record, updating the index, explaining the correction) is always higher than the cost of reading a preview.
+
+---
+
+## 4. The two critique tracks in new-adr
+
+### Why two tracks
+
+`new-adr` runs two critique passes on every ADR it produces:
+
+1. **Standard critique.** The usual review: is the decision clear? are the alternatives honestly stated? is the rationale sound? are the consequences — including the negative ones — named?
+
+2. **Adversarial critique (the strongest case against the decision).** This is the question the ADR must answer before it can be considered complete: what would a thoughtful, well-informed opponent say? What is the strongest case for *not* taking this decision? What assumption, if false, would make this decision wrong?
+
+### Why the adversarial track is not optional
+
+A critique that only validates the decision has been recorded — the decision is clear, the alternatives are named — produces an ADR that is formally complete but intellectually weak. The next engineer who reads it to evaluate whether the decision still applies has no basis for challenge: the document presents the reasoning without the strongest counterargument.
+
+The adversarial track forces the decision to be held against its strongest opponent. An ADR that survives the adversarial critique is an ADR the next reader can trust — not because the decision is beyond challenge, but because the strongest challenge has been named and acknowledged.
+
+This mirrors the `adversarial-reviewer`'s role in core's build loop: the value of the review comes from genuine adversarial intent, not from confirming the work was done.
+
+---
+
+## 5. Repo scope by design
+
+### Why governance is per-project
+
+`governance-extras` installs at repo scope only. This is not a configuration option — `allowed-scopes = ["repo"]` is declared in `pack.toml`.
+
+The reason is structural: governance records are inherently project-specific. An ADR recording why this project uses Postgres is not useful in a different project. An RFC proposing a change to this project's CONVENTIONS.md governs only this project. Unlike `architect` (whose method is portable across projects) or `desk-research` (whose methodology applies regardless of project), governance records carry the context of a specific project's history, constraints, and team decisions.
+
+Installing governance-extras at user scope would make every skill write to a user-global location — which is the wrong place for records whose meaning depends on the project they govern.
+
+### Why core is a required dependency
+
+`governance-extras` writes to `docs/rfc/`, `docs/adr/`, and `docs/CONVENTIONS.md`. These paths only have meaning after `core` has scaffolded the repo structure. An RFC in a repo with no `docs/` directory, no `CONVENTIONS.md`, and no established work loop is documentation in search of a process.
+
+The dependency is version-pinned at `^0.1` — a soft floor that allows `core` to evolve without blocking governance-extras updates, while ensuring the basic scaffold is in place. The dependency is enforced at install time.
+
+---
+
+## 6. MADR-aligned but lean (ADR-0027)
+
+### The format decision
+
+ADRs in this pack follow a lean MADR-aligned format. "MADR" (Markdown Architectural Decision Records) is an established ADR template format with a defined set of sections. "Lean" means the pack omits sections that add ceremony without adding information for a small team.
+
+The core sections (Decision, Context, Consequences, Alternatives considered) are always present. Optional sections (Decision drivers, Decision summary, Confirmation) are offered but not required — include each when it earns its place.
+
+### What "earn its place" means
+
+The Decision summary is a first-screen TL;DR placed before Context. It earns its place on a long ADR where the actual decision is not visible on the first screen — a multi-line title, a paragraph of metadata, and a long Context can push it off screen. On a short ADR, a five-line Decision summary is pure redundancy. The decision whether to include it is made per-ADR, not as a policy.
+
+The same principle applies to every optional section: include it when a reader of the final ADR would benefit from it; omit it when it would repeat content already in a required section.
+
+### Why lean over full MADR
+
+Full MADR is designed for large teams and high-ceremony environments. Every section is required; the template is comprehensive. For a small team or a solo project, the overhead of maintaining every MADR field on every ADR produces documents that are formally complete but tediously redundant — teams start copying boilerplate rather than writing decisions. The lean variant keeps the load-bearing structure (decision + alternatives + consequences) without the process overhead. See ADR-0027 for the full format decision and the alternatives considered.
+
+---
+
+## 7. Safety invariants
+
+These constraints must never be violated by any skill in this pack or any skill that extends it.
+
+1. **Preview before write, always.** No skill may create a file in `docs/rfc/`, `docs/adr/`, or any governance location without first displaying the identifier, target path, and content preview and receiving explicit author confirmation.
+
+2. **ADR bodies are immutable after acceptance.** No skill may edit an accepted ADR's body. A reversal is a new ADR that supersedes the old one, never an in-place edit. The old ADR's body stays as history; only the status line changes.
+
+3. **RFC and ADR must not be conflated.** No skill may use an RFC as an ADR or vice versa. An RFC that gets accepted generates an ADR; the two are separate files with separate purposes.
+
+4. **CONVENTIONS.md changes go through RFC.** `update-conventions` routes conventions edits through `new-rfc`, not through a direct PR. Trivial fixes (typos, broken links) are the only exception.
+
+5. **Adversarial critique track is not optional.** Every ADR produced by `new-adr` includes the adversarial critique — the strongest case against the decision. An ADR that omits the adversarial track is not complete.
+
+6. **`rfc-status` is read-only.** It never creates or modifies RFC files, RFC index entries, or any governance artifact. Any invocation path that would cause `rfc-status` to write a file is out of scope.
+
+---
+
+## 8. Design decisions and rationale log
+
+### Why RFC and ADR are separate artifacts (from v1)
+
+The alternative was a single governance document type that serves both discussion and record functions — an "RFC/ADR hybrid" that starts as a live debate and transitions to a frozen record. This was rejected because the two lifecycle states (live and frozen) have incompatible properties: a live document should evolve as new objections emerge; a frozen document should never change. A hybrid would require the document to stop evolving at a specific transition point, creating a sharp discontinuity that is harder to enforce than keeping the artifacts separate.
+
+**Alternative considered:** single document type with a lifecycle state transition (Draft → Open → Accepted, at which point the body freezes). Rejected because the single-document model obscures the structural difference between "this is a proposal being debated" and "this is a record of what was decided." Separate artifacts make the lifecycle states first-class rather than emergent from a status field.
+
+### Why preview-before-write is structural, not optional (from v1)
+
+The alternative was a `--dry-run` flag the author could pass to see the preview. This was rejected because a flag-based preview is a user opt-in, and the failure mode of not opting in (creating a file before reviewing it in a shared governance location) is worse than the friction of a mandatory confirmation step.
+
+**Alternative considered:** `--dry-run` flag as in the current `agentbundle install` flow. Rejected because governance documents go to a shared location immediately: unlike an install preview (which affects only the local repo), an RFC or ADR preview is the last chance to catch a formatting error or a wrong path before the document is part of the team's governance record. The mandatory confirmation is the cheapest possible gate.
+
+### Why MADR-aligned but lean, not full MADR (ADR-0027, from v1)
+
+Full MADR requires every section for every ADR, which creates ceremony overhead that disproportionately burdens small teams and solo projects. The lean variant keeps the sections that carry the decision (context, decision, consequences, alternatives) and makes the rest optional with a clear "earn its place" test.
+
+**Alternative considered:** full MADR compliance, with every section required. Rejected because in practice, teams facing required empty sections fill them with placeholder text ("N/A", "none") that trains readers to skip sections they might otherwise benefit from. An optional section that is present when it adds value is more useful than a required section that is present with boilerplate.
+
+### Why repo scope is not configurable (from v1)
+
+The alternative was allowing `--scope user` as an option, letting a designer or architect maintain a personal governance log across multiple projects. This was rejected because a governance record's meaning depends on the project it governs. An ADR for "use Postgres as the primary store" does not belong in a user-level configuration that spans projects with different stores. The meaning of the record is project-bound; the scope must be too.
+
+**Alternative considered:** user-scope as an opt-in flag. Rejected because governance documents are inherently shared artifacts — their value comes from being committed to the project repo, not from living in a personal configuration. A user-scope governance document is a personal note, not a governance record.

--- a/packs/governance-extras/README.md
+++ b/packs/governance-extras/README.md
@@ -1,53 +1,124 @@
 # governance-extras
 
-What this pack helps your team do — and keep a durable record of:
-
-- **Record a decision you've made** — capture *what* you chose and *why*, so
-  it outlives the people who made it.
-- **Propose a change for discussion** — put a proposal in front of reviewers
-  before anyone builds it.
-- **Change your team's rules through review** — update shared conventions
-  deliberately, not by drift.
-
-It layers on top of `core`, adding the skills and templates that give those
-outcomes a home: **`new-adr`** (record a decision), **`new-rfc`** (propose a
-change), **`update-conventions`** (change the rules), and **`rfc-status`** (see
-where proposals stand). *ADR = Architecture Decision Record; RFC = Request For
-Comments* — you introduce them once you need them, not before.
-
-## Install
-
-`governance-extras` installs at **repo scope** — decision records are
-per-project — which means **installing it adds capabilities and files to the
-current project**: the skills, plus RFC/ADR templates and seed READMEs
-scaffolded into `docs/`. It **requires `core`** (`^0.1`); install `core` first
-or alongside.
-
-```
-# <catalogue> is your catalogue URI: a local clone path or a git+https://… URL.
-agentbundle install --pack governance-extras <catalogue>
-```
-
-**Preview before you commit.** Because this writes into your project, run a
-dry-run first to see exactly which files it would create — it prints a per-file
-plan and writes nothing:
-
-```
-agentbundle install --pack governance-extras <catalogue> --dry-run
-```
-
-## Usage
-
-Ask your agent, for example:
-
-- "Record an ADR for the decision to use Postgres over DynamoDB."
-- "Draft an RFC proposing we adopt trunk-based development."
-- "Update our conventions to require conventional-commit messages."
-
-Each skill shows you a preview of what it will write — the identifier, the
-target path, and the content — and waits for your confirmation before creating
-the file or updating any index.
+decisions committed, proposals structured, conventions tracked.
 
 ---
 
+## Start here
+
+Type `new-rfc` and describe the change you want to propose.
+
+```text
+new-rfc [adopt trunk-based development]
+
+  identifier   RFC-0043
+  title        Trunk-based development over feature branches
+  status       Draft
+  target       docs/rfc/0043-trunk-based-development.md
+
+  Proposer     Reduces integration latency; CI catches regressions fast
+  Objector     Long-lived branches give teams isolation; trunk conflicts are costly
+
+Approve? ›
+```
+
+On any session return, type `rfc-status` to see where proposals stand.
+
+```text
+rfc-status
+
+  Active:
+
+  | State | RFCs                                       |
+  |-------|--------------------------------------------|
+  | Draft | RFC-0043: Trunk-based development          |
+  | Open  | RFC-0042: Conventional commits adoption    |
+
+  Resolved:
+
+  | State    | Count |
+  |----------|------:|
+  | Accepted |    12 |
+  | Rejected |     2 |
+
+  RFC candidates: 3 entries
+```
+
+---
+
+## Entry points
+
+| Say this               | What happens                                            |
+|------------------------|---------------------------------------------------------|
+| `rfc-status`           | Orient — RFC landscape by status and findings count     |
+| `new-rfc`              | Propose a cross-cutting change through a structured RFC |
+| `new-adr`              | Record an architectural decision with critique tracks   |
+| `update-conventions`   | Evolve CONVENTIONS.md through tracked RFC review        |
+
+---
+
+## How a session runs
+
+```text
+rfc-status
+
+  Active:
+
+  | State | RFCs                                       |
+  |-------|--------------------------------------------|
+  | Draft | RFC-0043: Trunk-based development          |
+
+  Resolved:
+
+  | State    | Count |
+  |----------|------:|
+  | Accepted |    12 |
+  | Rejected |     2 |
+
+  RFC candidates: 3 entries
+```
+
+```text
+new-rfc [adopt trunk-based development]
+
+  identifier   RFC-0043
+  title        Trunk-based development over feature branches
+  status       Draft
+  target       docs/rfc/0043-trunk-based-development.md
+
+  Proposer     Reduces integration latency; CI catches regressions fast
+  Objector     Long-lived branches give teams isolation; trunk conflicts are costly
+
+Approve? ›
+```
+
+```text
+new-adr [primary store: Postgres over DynamoDB]
+
+  identifier   ADR-0027
+  title        Primary store: Postgres over DynamoDB
+  status       Proposed
+  target       docs/adr/0027-primary-store-postgres.md
+
+  Decision     Use Postgres as the primary relational store
+  Tradeoff     Operational overhead vs. DynamoDB's managed scaling
+
+Approve? ›
+```
+
+The agent previews each draft before writing. Approve — RFC first, then ADR.
+
+---
+
+## Cross-pack
+
+**Requires — `core`:** governance-extras layers on top of core. The RFC and ADR templates scaffold into `docs/` — the same directory core's `work-loop` reads for specs and specs' plans. Install `core` first or alongside.
+
+**Downstream — `work-loop`:** When an RFC is accepted, a `work-loop` run implements it. The RFC's follow-on artifacts (specs, CONVENTIONS.md edits) become queue entries in `workspace.toml`.
+
+**Downstream — `architect`:** ADRs record why the architecture is the way it is. The `architect` pack's `architect-design` skill reads `docs/adr/` as the settled-decisions context — it doesn't re-debate what the ADRs already closed.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.  
 → **Go deeper:** the [`governance-extras` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/governance-extras/).

--- a/packs/governance-extras/README.md
+++ b/packs/governance-extras/README.md
@@ -27,21 +27,8 @@ On any session return, type `rfc-status` to see where proposals stand.
 ```text
 rfc-status
 
-  Active:
-
-  | State | RFCs                                       |
-  |-------|--------------------------------------------|
-  | Draft | RFC-0043: Trunk-based development          |
-  | Open  | RFC-0042: Conventional commits adoption    |
-
-  Resolved:
-
-  | State    | Count |
-  |----------|------:|
-  | Accepted |    12 |
-  | Rejected |     2 |
-
-  RFC candidates: 3 entries
+  Active: RFC-0043 (Draft) · RFC-0042 (Open)
+  Resolved: 14  ·  Candidates: 3
 ```
 
 ---

--- a/packs/governance-extras/README.md
+++ b/packs/governance-extras/README.md
@@ -46,6 +46,16 @@ rfc-status
 
 ---
 
+## RFCs and ADRs
+
+**RFC (Request for Comments)** — a structured proposal for any cross-cutting change: a new convention, an architectural direction, a team process. An RFC is not a decision; it's the case for a decision. It carries a proposer perspective (why this is worth doing) and a genuine objector perspective (the strongest case against it). You can seed `new-rfc` with context — pass a desk-research brief, an architect design doc, or any prior analysis and the skill folds them in as the factual grounding instead of inventing the case from scratch. Accepted RFCs can be amended with a signed cover note (erratum) — a compact correction that does not reopen the full RFC cycle.
+
+`rfc-status` reads the full `docs/rfc/` landscape: active RFCs by lifecycle state (Draft / Open / Accepted / Rejected / Deferred), resolved counts, and any unproposed findings sitting in the candidate register waiting to become RFCs.
+
+**ADR (Architecture Decision Record)** — the record of a decision already made. It captures the decision, the alternatives that were considered and why they were rejected, and the consequences. ADRs are immutable once merged; when a decision is reversed, the original ADR is superseded, not deleted. `new-adr` runs two critique tracks — a standard context / consequences analysis and an adversarial pass that argues against the decision — so the final record honestly names what was left on the table. If an RFC preceded the decision, the ADR links back to it.
+
+---
+
 ## Entry points
 
 | Say this               | What happens                                            |

--- a/packs/product-engineering/DESIGN.md
+++ b/packs/product-engineering/DESIGN.md
@@ -1,0 +1,206 @@
+# Product Engineering Pack — Design Document
+
+Living design reference for the product-engineering pack. Records the philosophy, architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** ADR-0019 (product intent ontology and brief projection), ADR-0043 (discovery coordinator is agent + skill + sidecar — no engine), ADR-0033 (intent Level is an open recognized set decoupled from Scale)
+
+---
+
+## TL;DR
+
+`product-engineering` is the upstream shaping seat. Every product idea gets one path — frame → de-risk → decompose — over a single recursive artifact (the `intent`) that spans every altitude from product-vision to feature. `discovery-loop` is the supervised peer of `work-loop`: it diverges across candidate shapes, drives a lens roster to convergence, pauses at four human consent gates, emits a connected hypothesis with validation hooks, and hands the brief to the delivery loop at G3. The whole capability is content, not runtime — a `discovery-lead` agent definition, this skill, and a carried sidecar schema, executed by the harness an adopter already runs. `ux-writing` is the content layer: it writes the words users read in the UI, keyed to the per-screen state matrix produced by `experience-design`.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **Live tracker API sync.** The pack ships the one-way projection mapping (intent tree → Linear / Jira Align records). A live, bidirectional sync is a separate, later pack.
+- **Wire-contract authoring.** That's the spec stage's `Contract:` seam in the `contracts` pack. This pack stays behavioral — it does not author interface contracts or API schemas.
+- **Monorepo-vs-polyrepo structuring.** That decision lives in `monorepo-extras` (`new-package`). This pack meets it only at "where the shared contract lives" inside a value-stream meta-repo.
+- **Subagents beyond the discovery roster.** The discovery roster is loop-scoped and capped: two required reviewers (threat + reliability) plus optional UX/research/architect lenses if installed. Shaping is a skill, not a multi-agent mesh; the harness handles the mesh layer.
+
+---
+
+## 1. The intent model
+
+### One artifact at every altitude
+
+The `intent` is the single recursive artifact of this pack. A product-vision intent, a product-strategy intent, a capability intent, and a feature intent are the same data structure at different altitudes — outcome + opportunity + assumptions + decomposition pointer. A PRD is a feature intent written as a long-form document; a strategy doc is a product-strategy intent. Nothing changes about the artifact as you descend the tree; only the altitude field changes.
+
+This means decomposition is recursive by construction: `decompose-intent` produces the next level down from whatever level it receives, and stops when the leaf is a unit the delivery loop can build — at `app` Scale, that leaf is an ordinary `core` brief.
+
+### Level is an open recognized set
+
+The recognized set runs `product-vision › product-strategy › capability › feature` and is **open**: an organization may name an intervening level (program epic, initiative, theme, domain bet) and the pack accommodates it without requiring a mapping back to the four canonical names. The recognized members are not exhaustive — they are stable anchors. Inserting `program-epic` between `product-strategy` and `capability` is valid; the intent model assigns it a parent and decomposition works the same way.
+
+This is different from a flag-parameterized enum. An open set means the altitude field accepts any string the organization recognizes, not only the four names the pack ships with.
+
+### Scale resolved at intake, decoupled from Level
+
+`Scale` (app ↔ business-unit) is resolved once at intake — inferred from the workspace and confirmed with the user — and stamped on the `docs/product/` root. It determines *where* decomposition fans out (same repo vs. per-component cross-repo briefs) but not *what altitude* the intent lives at. A business-unit capability intent and an app capability intent are the same level; they decompose differently. Decoupling the two axes prevents Scale from silently constraining the altitude the framing picks.
+
+---
+
+## 2. The discovery loop
+
+### The loop model
+
+```
+   raw idea
+      │
+    G0 ── frame-intent ─────────────────── intent
+      │
+    G1 ── de-risk-intent ─── explore-options ─── candidates
+      │
+   G1.5 ── lens roster ─────────────────── filtered candidates
+      │
+    G2 ── discovery reviewers ──────────── decision-brief
+      │
+    G3 ── decompose-intent ──────────────── briefs → work-loop
+```
+
+The loop cannot advance past a consent gate (G0, G1.5, G2, G3) without a harness-attested human verdict. Between consent gates, non-consent steps (G1, the convergence loop) auto-advance unless a risk trigger fires.
+
+### Content, not runtime
+
+The whole discovery capability is content: a `discovery-lead` agent definition, the `discovery-loop` skill, and a carried sidecar schema in plain files. The harness an adopter already runs executes it. What the pack does not ship — and must not ship — is a runtime coordinator, message bus, convergence solver, or state-machine engine. The recursion is data (status fields per node); the bounds are counters; the verdict set is status edits plus a recorded row in the decision log.
+
+This is the no-engine principle (ADR-0043): the spike confirmed that a single reasoning context over plain files can run the discovery loop without a coordinator service. The depth/breadth bounds are explicit — the loop pauses and confirms when it hits them rather than auto-terminating.
+
+### Converged ≠ validated
+
+The brief the loop emits is a **connected hypothesis**. Every load-bearing assumption carries a validation hook: the predeclared kill condition plus the real-world activity that would confirm or enrich it. Desk-grounding is not validation; the loop says so structurally by flagging surviving bets whose only evidence is desk research as `to-validate`, not `grounded`.
+
+---
+
+## 3. Human gate design
+
+### The four gates
+
+| Gate | When | Duration | What to check |
+|------|------|----------|---------------|
+| **G0** | After `frame-intent` emits the initial framing | 10–15 min | Is the problem specific enough to eliminate candidates? Is the user named? Is the outcome measurable? |
+| **G1.5** | After `explore-options` and the first lens-roster pass | 15–20 min | Which candidates survived? Is the field differentiated? Is anything missing? |
+| **G2** | After the full lens-roster pass on surviving candidates | 20–30 min | Did the discovery reviewers flag anything blocking? Does the hypothesis have a validation hook? Is the decomposition sized for one loop iteration? |
+| **G3** | After the reconciliation record is ratified | 5 min | Is the brief complete? Is there anything you are not prepared to build? |
+
+### Why four gates, not two
+
+`work-loop` has two gates because delivery has two human-irreplaceable decisions: agree the plan before code starts, and approve the diff before it merges. Discovery has more because the option space is open when the loop begins and must be narrowed across several human acts before a build commitment is valid.
+
+G0 is the framing gate: a vague problem means the divergence step explores the wrong space — no amount of convergence fixes a bad framing. G1.5 is the option-space gate: the last cheap moment to expand or reject candidates before the lens roster runs on the survivors. G2 is the reconciliation gate: is the brief complete and are the reviewers clean? G3 is the commit gate: am I ready to build this, not just "is the brief complete?" These are two distinct decisions — collapsing them removes the deliberate pause between "this is a good brief" and "I am ready to act on it."
+
+### Consent gates are a pause, not a runtime
+
+A consent gate is a file write and a wait. `discovery-lead` sets `status: awaiting-human` on the sidecar, emits an option card, and stops. The harness surfaces the option card; the human's typed verdict is written to the append-only decision log through a channel the agent has no token for. The next round reads the log and resumes. There is no gate service, no webhook, no timeout — just a file and a convention.
+
+---
+
+## 4. The sidecar
+
+### What it is
+
+The sidecar is the coordination artifact the discovery loop carries through every phase. It is a versioned plain file (schema in `references/sidecar-schema.md`) that holds:
+
+- The intent tree — one node per initiative and sub-idea, each with `status`, `round`, `cost_spent`
+- The decision log — append-only, per-row actor attestation, SHA-256 hash-chain
+- The convergence slots — one per lens (intent, domain-framing, assumption-test, decision-brief)
+- The open-questions queue — the only channel through which parallel lens-agents coordinate without chat
+
+### Where it lives
+
+The sidecar lives in the harness's own store or branch, **never the product repo's main line**. This is a deliberate separation: working discovery state (including sensitive strategic assumptions and preliminary architecture decisions) is not a committed artifact until G3. After G3, the decision brief is promoted into `docs/product/` as a durable artifact; the sidecar remains in the harness store.
+
+### Why the sidecar, not a database
+
+A plain versioned file is readable by any tool, diff-able in review, and requires no service to maintain. The sidecar's append-only decision log is the audit trail; the `schema_version` field provides migration compatibility. A database would require an operator, a connection, and a migration story — none of which the no-engine principle permits.
+
+---
+
+## 5. The ux-writing content layer
+
+### What it covers
+
+`ux-writing` writes the words users read in the UI: error messages, empty states, button labels, form labels. It is a method, not a word bank — voice characterization along a few axes (humor, formality, respect, enthusiasm), per-state formulas (blame-free + actionable), and a content checklist before copy ships.
+
+### The design-seat pairing
+
+`ux-writing` is the content layer of the design seat:
+
+- **`experience-design`'s `user-flow`** produces the per-screen state matrix (one row per screen × state). Pass that matrix to `ux-writing` and it writes copy keyed to every cell — one string per screen/state combination.
+- **`experience-design`'s `tone-of-voice`** sets the brand register: ranked copy goals and arbitration rules. `ux-writing` receives the voice direction and applies it per state.
+- **Without a screen flow**, `ux-writing` is still fully useful: it detects absent and names states inline. The pairing is additive, not required.
+
+### Scope boundary
+
+`ux-writing` covers product UI copy: error states, empty states, button labels, loading messages. Marketing and acquisition copy (hero headlines, above-fold narrative, taglines) belongs to `experience-design`'s `tone-of-voice`. Onboarding narrative arc and structure belongs to `experience-design`'s `content-design`. Documentation prose belongs to `new-guide`. The boundary is the surface type: UI state copy lives here; everything else does not.
+
+---
+
+## 6. Cross-pack dependencies
+
+### Upstream: product-strategy
+
+The `product-strategy` pack is the strategic anchor this pack builds on. Before `frame-situation` or `frame-intent` runs, a strategist may have committed altitude-0 artifacts to `docs/product/shaping/`: OKR cascade (`okr-cascade.md`), market context, portfolio position, stakeholder synthesis. `frame-situation` routes strategy-typed shaping-queue entries into the six-step shaping sequence; `frame-intent` uses market context as grounding when present. Both inputs are optional — the skills degrade gracefully when absent.
+
+### Downstream: core (the G3 handoff)
+
+At G3, `discovery-loop` hands the ratified decision brief to the delivery loop unchanged. The hand-off interface is `receive-brief` → `new-spec` → `work-loop`. No new machinery. At `app` Scale each leaf brief is an ordinary `core` brief; at `business-unit` Scale each leaf brief is a per-component slice that crosses into its component repo where the same delivery loop takes over.
+
+### Downstream: experience-design
+
+The per-screen state matrix from `experience-design`'s `user-flow` is the hand-off artifact `ux-writing` consumes. Each cell in the matrix (screen × state) maps to a copy string. The two packs are designed to meet at this interface. When discovery includes UX lens work, `experience-design` skills run inside the convergence loop as optional lens participants; when they are absent, the discovery floor degrades gracefully to product-only discovery.
+
+---
+
+## 7. Safety invariants
+
+These constraints must never be violated by any skill in this pack or any skill that extends it.
+
+1. **No engine, no hooks, no validators, no runtime hub.** The coordination is a file write and a convention. Any skill that ships a coordinator process, message bus, or convergence service violates the no-engine principle.
+
+2. **The loop cannot advance past a consent gate without a harness-attested human verdict.** A gate is not passed because the agent judged the work ready. The loop's self-assessment is inadmissible as gate evidence.
+
+3. **The security lens is non-degradable on a security boundary.** `discovery-threat-reviewer`'s depth keys on a risk trigger; a security-boundary crossing with only baseline depth surfaces to the human rather than degrading silently. Degrading silently is not a valid fallback.
+
+4. **Sidecar goes to the harness store, never the product repo's main line.** Working discovery state — including sensitive assumptions, preliminary architecture decisions, and unratified candidates — is not committed until G3.
+
+5. **Converged ≠ validated.** The decision brief emitted at G3 is a connected hypothesis. Every load-bearing assumption carries a validation hook. A brief that omits the validation hook on a to-validate assumption is not a valid G3 output.
+
+6. **A lens only proposes; only the controller promotes.** A lens agent writes to its own slot; it does not promote ratified slots, write trusted edges, or self-assert `ratified-by: human` rows. The integrity of the decision log depends on this.
+
+---
+
+## 8. Design decisions and rationale log
+
+### Why Level is an open recognized set (ADR-0033)
+
+Organizations operate with different altitude names between vision and feature: program epics, domain bets, initiatives, themes, product areas. A closed four-tier hierarchy would require every organization to map their naming to the pack's names — friction without benefit. An open set names the recognized anchors (`product-vision › product-strategy › capability › feature`) but permits insertion of org-specific levels. The recognized members retain their semantics; the org adds what it needs above, below, or between them without breakage.
+
+**Alternative considered:** a closed four-tier hierarchy with a `custom-level` escape hatch (a string field on the intent for orgs that don't fit). Rejected because the escape hatch becomes the default within one sprint — teams stop using the recognized names and the recognized semantics evaporate. An open set with documented anchors preserves the semantics for orgs that use them while not blocking orgs that don't.
+
+### Why Scale is decoupled from Level (ADR-0033)
+
+Scale (app vs. business-unit) determines *where* decomposition fans out — same repo versus per-component cross-repo briefs. Level determines *what altitude* the intent lives at. Before decoupling, Scale implicitly suggested a Level ceiling: a business-unit brief was assumed to be `capability` level. This made it impossible to author a business-unit `feature` intent (a cross-component feature that is still a feature, not a capability). Decoupling removes the implicit ceiling: Scale stamps on the `docs/product/` root once; Level is picked per intent without Scale bias.
+
+**Alternative considered:** keep the coupled model and document the suggested altitude per Scale. Rejected because "suggested" always becomes "required" in practice — the documentation overhead of the exception is higher than the cost of the decoupling.
+
+### Why habits, not infrastructure (ADR-0043)
+
+The discovery loop's coordination is a file write plus a plain-text convention, not a service. The spike confirmed this: a single reasoning context walking a status-annotated plan tree over plain files runs the discovery loop without a coordinator service, message bus, or state-machine engine. The no-engine principle keeps the pack content-only — no process to start, no service to maintain, no version mismatch between the loop's runtime and the adapters that run it. The only code the pack ships is a ~60-line connectedness lint; everything else is content.
+
+**Alternative considered:** a lightweight coordinator microservice that handles persistence, gate-enforcement, and concurrent lens coordination. Rejected because: (a) every adopter would need to operate the service, creating a dependency the pack's user-scope install doesn't warrant; (b) it introduces a versioning seam between the pack and the coordinator; (c) the spike confirmed the in-context model is viable at the depth/breadth bounds the pack documents. Scheduling many concurrent or long-parked threads across initiatives remains the harness's job.
+
+### Why four gates, not two (from day one)
+
+`work-loop` has two gates because delivery has two irreducible human decisions: agree the spec before code starts, and approve the diff before it merges. Discovery starts with an open option space and must narrow it across multiple acts before a build commitment is valid. Collapsing G0 and G1.5 means an unconverged framing drives a full lens-roster run — expensive work on candidates that a ten-minute framing review would have eliminated. Collapsing G2 and G3 removes the deliberate gap between "is this brief complete?" (a quality question) and "am I ready to build this?" (a commitment question). They are different cognitive acts; conflating them degrades both.
+
+**Alternative considered:** two gates mirroring `work-loop` — one before divergence (approve the framing), one before handoff (approve the brief). Rejected because a single mid-loop consent point means either the diverge step runs without framing approval (high waste on bad framings) or the convergence step runs without candidate confirmation (converges on a candidate the human would have redirected at G1.5). The asymmetry in cost — cheap gate vs. expensive loop iteration — strongly favors more gates, not fewer.
+
+### Why ux-writing lives in product-engineering, not experience-design (from v1)
+
+`ux-writing` writes the words users read in the product UI. It is a product-engineering skill because the decision of what to say in an error or empty state is a product-content decision, not a design-methods decision. `experience-design` sets the surface intent (what the screen is trying to accomplish) and derives the state matrix (what states exist per screen); `ux-writing` writes the copy for each state. The two packs meet at the state matrix interface. Placing `ux-writing` in `experience-design` would create a pack that conflates method (how to structure screens) with content (what words go in them) — and would make the content layer unavailable to teams that want to write copy without running the full design sequence.
+
+**Alternative considered:** place `ux-writing` in `experience-design` as a terminal craft step, after `interaction-design`. Rejected because: (a) product teams write copy without running a full design thread — the content layer should be independently usable; (b) the design seat's method principle is "derive, never prescribe" with no values tables — `ux-writing`'s copy output is content, not method, and doesn't fit that principle; (c) the product-engineering pack already owns the product-content layer (`decompose-intent` produces feature intents; `ux-writing` writes the words those features render).

--- a/packs/product-engineering/README.md
+++ b/packs/product-engineering/README.md
@@ -1,155 +1,97 @@
 # product-engineering
 
-Product-shaping skills — the upstream that turns an idea into the specs your
-delivery loop already builds. Installed to **user scope** so they travel across
-every workspace, like `architect` and `desk-research`.
-
-The pack is built on one artifact and a set of habits. The artifact is an
-**`intent`**: a level-tagged statement of an outcome and the opportunity behind
-it. A *product-vision intent*, a *product-strategy intent*, a *capability
-intent*, and a *feature intent* are the same artifact at different levels — and a
-PRD is just a feature intent written as a document. `Level` is an **open
-recognized set** (`product-vision › product-strategy › capability › feature`)
-**decoupled from `Scale`**: Scale suggests a starting altitude but no longer
-stamps one. Intents form a recursive tree whose leaf is a shippable spec.
-
-| Skill | What it does |
-| --- | --- |
-| `frame-intent` | Author an `intent` at any altitude in the open recognized set — `product-vision` / `product-strategy` / `capability` / `feature` — outcome (a steerable input metric, a lagging outcome, and a guardrail) + the opportunity. Resolves **Scale** (app ↔ business-unit) at intake (Scale *suggests* the starting altitude, decoupled from `Level`), and offers current-state inputs (a process or journey map) only when the work is brownfield. |
-| `de-risk-intent` | Name the riskiest assumption, predeclare the **kill condition** in the test's own currency, and run it under a **choosable prototype-approach** — `validate-first` (predeclare, then test) or `prototype-led` (build to learn; the build *is* the test) — to a survive/kill verdict. |
-| `decompose-intent` | Break an intent into the next level down — child intents, or a spec/slice at the leaf — and project the tree **one-way** onto your tracker (`none` / Linear / Jira Align). At app scale the leaf *is* an ordinary `core` brief; at business-unit scale it **slices the feature intent per component** into one brief per repo (each carrying `parent-intent:` + a version-pinned contract reference). |
-| `align-value-stream` | Stand up and keep current a **value-stream meta-repo** — a coordinating repo with no app code that holds the cross-component artifacts a polyrepo has nowhere else to put: the Backstage **federated catalog**, the shared-contract authority (referenced by version, never forked), the C4/bounded-context architecture, and the **cross-component delivery rollup**. Business-unit scale only. |
-| `ux-writing` | Shape the **words a user reads** in the UI. Characterize the product's **voice** along a few axes (humor / formality / respect / enthusiasm), write the recurring UI states — **error, empty, button, label** — from blame-free, actionable formulas, and run a **content checklist** before copy ships. The content layer of the pack; a method, not a word bank. |
-
-## Install
-
-Default scope is **user** — installed under `~/.claude/skills/` (or your
-adapter's equivalent) so the skills load in every workspace.
-
-```bash
-# <catalogue> is your catalogue URI: a local clone path or a git+https://… URL.
-agentbundle install --pack product-engineering <catalogue>   # CLI route
-apm install product-engineering                               # APM route
-```
-
-For the Claude plugin route, add the marketplace first:
-
-```bash
-claude plugin marketplace add eugenelim/agent-ready-repo
-claude plugin install product-engineering@agent-ready-repo
-```
-
-Flip to repo scope to pin the skills to one workspace:
-
-```bash
-agentbundle install --pack product-engineering <catalogue> --scope repo
-```
-
-Adapters: `claude-code`, `kiro-ide`, `codex`, `copilot`, `cursor`, `gemini`.
-Pure-markdown `SKILL.md` surface; no adapter-specific primitives.
-
-## How it composes
-
-The pack is the **upstream** of the delivery loop, not a replacement for it. A
-feature intent at app scale *is* a `core` **brief** — `receive-brief` →
-`new-spec` → `work-loop` take it from there, unchanged. At business-unit scale
-the feature intent is **sliced per component** into one brief per repo, each
-crossing into its component repo where the same loop takes over; the meta-repo
-then **rolls up** whether the whole feature is delivered across all components.
-The detailed wire contract is pinned later, at the spec stage, via the existing
-`Contract:` seam; the pack stays behavioral. System design hands off to
-`architect`.
-
-## Design principles
-
-- **Habits, not infrastructure.** Skills + `references/` + `assets/` templates. No
-  engine, no hooks, no validators, no subagents, no runtime hub.
-- **One artifact, every level.** The recursive `intent` spans solo→business-unit;
-  decomposition is recursive and assumptions are de-risked per intent at its level.
-- **Modes are lightweight.** One global axis — **Scale** — resolved at intake;
-  **maturity**, **reversibility**, and the **prototype-approach** are per-intent
-  flags, never global ceremony.
-- **Never mandate a schema.** The `intent` template is a prompt sheet; a
-  half-formed intent is normal input.
-- **Progressive disclosure.** `SKILL.md` stays under 100 lines; the intent model,
-  intake, mode tables, and projection profiles live in `references/`.
-
-## What's NOT in this pack
-
-By design — these belong elsewhere or in a later phase:
-
-- **A runtime hub / live coverage API.** The business-unit layer is a
-  coordinating *repo* you read and edit, never a service that polls component
-  repos. The cross-component rollup is a **markdown snapshot, not a live feed**;
-  there is **no atomic cross-repo commit and no shared release train** (the
-  inherent cost of polyrepo, stated honestly, not engineered away).
-- **Live tracker API sync.** The pack ships the one-way *mapping*; a live
-  Linear/Jira-Align integration is a separate, later pack.
-- **Wire-contract authoring.** That's the spec stage's `Contract:` seam (the
-  `contracts` pack / `new-spec`), reused — not duplicated here.
-- **Monorepo-vs-polyrepo structuring.** That decision lives in `monorepo-extras`
-  (`new-package`); this pack meets it only at "where the shared contract lives."
-- **Subagents.** The three review lenses stay capped at three; shaping is a skill.
-
-## Layout
-
-```
-packs/product-engineering/
-├── README.md
-├── pack.toml
-├── .claude-plugin/plugin.json
-└── .apm/skills/
-    ├── frame-intent/        (SKILL.md + references/ + examples/ + assets/intent-template.md)
-    ├── de-risk-intent/      (SKILL.md + references/)
-    ├── decompose-intent/    (SKILL.md + references/)
-    ├── align-value-stream/  (SKILL.md + references/ + assets/rollup-template.md)  ← business-unit scale
-    └── ux-writing/ (SKILL.md + references/ + assets/voice-chart-template.md)  ← content layer
-```
-
-The intent, rollup, and voice-chart **templates travel with their skills** (in
-each skill's `assets/`), not as repo `seeds/` — so the pack ships no `seeds/` and
-stays user-scope. The skills copy their template into the project's
-`docs/product/{intents,rollups,voice}/<slug>.md` at runtime.
-
-## Usage
-
-Ask your agent, for example:
-
-- "Frame the intent for a self-serve onboarding flow." (`frame-intent`)
-- "De-risk the riskiest assumption in this intent with a prototype." (`de-risk-intent`)
-- "Decompose this intent into shippable specs." (`decompose-intent`)
-- "Stand up a value-stream meta-repo to coordinate these components." (`align-value-stream`)
-- "Characterize our product voice, then write the empty-state and error copy." (`ux-writing`)
-
-## Cross-pack: `product-strategy`
-
-The `product-strategy` pack is the **upstream provider** of the strategic context this pack consumes. Before `frame-situation` runs, a strategist using the `product-strategy` pack may have committed altitude-0 artifacts to `docs/product/shaping/`: OKR cascade (`okr-cascade.md`), market context (`macro-environment.md`, `competitive-landscape.md`), portfolio position (`portfolio-position.md`, `swot-analysis.md`), and stakeholder synthesis (`stakeholder-synthesis.md`). These are optional inputs — `frame-situation` routes strategy-typed shaping-queue entries (written by `run-okr-cascade`) into its six-step shaping sequence; `frame-intent` uses the market context as grounding when present. See the [`product-strategy` pack README](../product-strategy/README.md).
+From raw idea to build-ready decision brief.
 
 ---
 
+## Start here
+
+Type `frame-intent` and describe a product problem — any altitude, any level of clarity.
+
+```text
+frame-intent
+
+  Level    feature
+  Problem  New users don't understand the product's value in the first session.
+  User     First-time user arriving after sign-up with no prior context.
+  Outcome  Activation rate rises; first-session drop-off decreases.
+```
+
+On any session return, type `discovery-loop` to orient.
+
+```text
+discovery-loop
+
+  Initiative  self-serve-onboarding
+
+  Slot               Status
+  intent             ratified
+  explore-options    done — 4 candidates
+  domain-framing     done
+  assumption-test    in progress
+  decision-brief     pending G2
+```
+
+---
+
+## Entry points
+
+| Say this | What happens |
+|----------|-------------|
+| `discovery-loop` | Start or resume a supervised end-to-end discovery |
+| `frame-intent` | Frame a product problem at any altitude |
+| `de-risk-intent` | Surface the riskiest assumption and design a prototype approach |
+| `decompose-intent` | Break the intent into delivery briefs and specs |
+| `ux-writing` | Characterize the product voice and write per-state UI copy |
+| `lean-canvas` | Elicit an initiative brief through an adapted Lean Canvas |
+| `diverge-solutions` | Generate structured comparable solution options |
+| `place-bet` | Commit to a direction with a structured betting table |
+| `map-capabilities` | Translate a committed bet into a Capability Map |
+
+---
+
+## How a session runs
+
+```text
+frame-intent [describe your product problem]
+
+  Level    feature
+  Problem  New users don't understand the product's value in the first session.
+  User     First-time user arriving after sign-up with no prior context.
+  Outcome  Activation rate rises; first-session drop-off decreases.
+```
+
+```text
+de-risk-intent
+
+  Assumption   Users who finish the wizard go on to activate the core feature.
+  Kill cond.   < 4 of 6 target users reach core-feature first-use in prototype.
+  Approach     validate-first — predeclare the line, then run prototype sessions.
+  Hook         Conduct 6 moderated prototype sessions with target user profile.
+```
+
+```text
+decompose-intent
+
+  onboarding-activation
+  ├─ onboarding/step-1-welcome      (app — brief ready)
+  ├─ onboarding/step-2-connect      (app — brief ready)
+  └─ onboarding/step-3-first-action (app — brief ready)
+```
+
+The agent writes a brief for each leaf. Pass any brief to `receive-brief` → `work-loop` to begin the delivery loop.
+
+---
+
+## Cross-pack
+
+**Upstream — `product-strategy`:** OKR gaps and opportunity assessments from `product-strategy` feed `frame-situation` and `frame-intent` as strategic anchors. Absent means both skills degrade gracefully.
+
+**Downstream — `core`:** Each brief produced by `decompose-intent` is a `core` brief — hand it to `receive-brief` → `new-spec` → `work-loop` to begin the delivery loop unchanged.
+
+**Downstream — `experience-design`:** The per-screen state matrix from `user-flow` feeds `ux-writing`. Pass it to write per-state copy for every screen × state cell.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.  
 → **Go deeper:** the [`product-engineering` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/product-engineering/).
-
----
-
-## Cross-pack: `experience-design`
-
-`ux-writing` is the **content layer of the design seat** — the words
-live here, in `product-engineering`, while the design methods, screen flow, and
-per-screen briefs live in the `experience-design` pack. The two packs read as one seat:
-
-- **`experience-design`'s `user-flow`** produces the per-screen state matrix
-  (one row per screen × state: empty / loading / error / success / partial /
-  disabled / permission-denied). Pass that matrix to `ux-writing` and
-  it writes copy keyed to every cell.
-- **Without a screen flow**, `ux-writing` is still fully useful —
-  it degrades to naming the states inline. The pairing is additive, not required.
-
-Install both packs to run the full design-to-copy thread:
-
-```bash
-# install takes one pack per invocation — run it twice.
-agentbundle install --pack experience-design <catalogue>
-agentbundle install --pack product-engineering <catalogue>
-```
-
-→ See the [`experience-design` pack README](../experience-design/README.md).

--- a/packs/product-engineering/README.md
+++ b/packs/product-engineering/README.md
@@ -17,10 +17,10 @@ frame-intent
   Outcome  Activation rate rises; first-session drop-off decreases.
 ```
 
-On any session return, type `discovery-loop` to orient.
+On any session return, type `discovery-loop [initiative-name]` to resume where you left off.
 
 ```text
-discovery-loop
+discovery-loop self-serve-onboarding
 
   Initiative  self-serve-onboarding
 
@@ -28,8 +28,10 @@ discovery-loop
   intent             ratified
   explore-options    done — 4 candidates
   domain-framing     done
-  assumption-test    in progress
+  assumption-test    in progress ← current
   decision-brief     pending G2
+
+  Proceed to assumption-test? ›
 ```
 
 ---

--- a/packs/product-engineering/README.md
+++ b/packs/product-engineering/README.md
@@ -83,6 +83,26 @@ The agent writes a brief for each leaf. Pass any brief to `receive-brief` → `w
 
 ---
 
+## Where artifacts land
+
+```text
+docs/
+├── product/
+│   ├── intents/          ← frame-intent, de-risk-intent, decompose-intent
+│   │   └── <slug>.md
+│   ├── rollups/          ← align-value-stream (business-unit scale)
+│   │   └── <slug>.md
+│   └── voice/            ← ux-writing
+│       └── <slug>.md
+└── discovery/            ← discovery-loop (sidecar + initiative tree)
+    └── <initiative-slug>/
+        └── _state/
+```
+
+The base paths are configurable — `[product] output_dir` and `[discovery] output_dir` in your repo's `agentbundle-layout.toml`. Defaults to `docs/product/` and `docs/discovery/`.
+
+---
+
 ## Cross-pack
 
 **Upstream — `product-strategy`:** OKR gaps and opportunity assessments from `product-strategy` feed `frame-situation` and `frame-intent` as strategic anchors. Absent means both skills degrade gracefully.

--- a/packs/product-strategy/DESIGN.md
+++ b/packs/product-strategy/DESIGN.md
@@ -1,0 +1,164 @@
+# Product Strategy Pack — Design Document
+
+Living design reference for the product-strategy pack. Records the philosophy, pillar architecture, invariants, and key decisions so the reasoning survives beyond individual PRs and applies when extending or replacing any skill.
+
+**Related ADRs:** [ADR-0053](../../docs/adr/0053-product-strategy-pack-scope.md) (scope and discipline boundaries), [ADR-0030](../../docs/adr/0030-consolidated-pack-output-layout-contract.md) (consolidated pack output layout contract), [ADR-0009](../../docs/adr/0009-product-brief-layer.md) (product brief layer)
+
+---
+
+## TL;DR
+
+`product-strategy` is the strategy seat upstream of every product initiative. It runs three pillars — market and competitive analysis, UX strategy, and content strategy — each producing committed artifacts in `docs/product/shaping/` that downstream packs read by path. The PRFAQ is the altitude-0 forcing function: the most tangible first step, and the artifact every initiative brief traces its strategic rationale back to. The OKR cascade is the bridge to `product-engineering` (gap entries feed the PE shaping queue). `ux-strategy.md` and `content-strategy.md` are the bridge to `experience-design` (read by `journey-mapping` and `content-design`). No growth tooling, no primary research production, no per-surface content design — those belong downstream.
+
+---
+
+## Non-Goals
+
+Things a reasonable reader might expect this pack to solve. It doesn't, by design:
+
+- **Growth strategy.** AARRR funnels, product-led growth, PMF testing, and cohort retention loops are deferred to a follow-on `growth` pack (RFC-0063 OQ1). Growth is downstream of strategy, not coextensive with it.
+- **Primary research production.** This pack consumes desk-research project outputs via `synthesize-stakeholder-research`; it does not produce interview guides, discussion scripts, or survey templates. Research production belongs in the `desk-research` pack.
+- **Per-surface content design.** `define-content-strategy` covers the organizational and governance layer above content (Purpose + Process + Structure + Governance). Per-screen copy intent belongs in the `experience-design` pack's `content-design` skill; per-state string writing belongs in the `product-engineering` pack's `ux-writing` skill.
+- **Analytics and CRO tooling.** Measurement frameworks, A/B testing sequencing, and conversion rate optimization belong downstream of the strategy this pack sets.
+
+---
+
+## 1. The strategy seat
+
+### Why upstream of everything
+
+Strategy artifacts — the SWOT, the PRFAQ, the OKR cascade, the UX strategy — are pre-conditions for product engineering and design, not concurrent activities. Running `journey-mapping` without a UX strategy is possible, but the output is grounded in the journey author's assumptions rather than a committed experience direction. Running `frame-situation` without OKR-derived gaps means the shaping queue fills with team-driven work that may not connect to company objectives.
+
+This pack's position upstream of both `product-engineering` and `experience-design` is the architectural invariant. Skills in this pack write artifacts that downstream packs read by path; this is a one-way dependency. No skill in this pack reads from the PE or experience-design packs.
+
+### The committed artifact model
+
+Every skill in this pack writes a durable artifact to `docs/product/shaping/`. The artifact path is resolved via the `[strategy]` section of the adopter-owned `agentbundle-layout.toml` — the same consolidated layout contract used across all artifact-writing packs (ADR-0030).
+
+The committed model is the point: strategy artifacts must outlive sessions. A SWOT that exists only in a chat log cannot be read by `run-okr-cascade` in the next session. A PRFAQ that isn't committed cannot be referenced by the initiative briefs that trace their strategic rationale back to it.
+
+---
+
+## 2. Three pillars
+
+### Pillar 1 — Market and competitive strategy
+
+Seven skills produce the situation picture and routing artifacts:
+
+| Skill | Framework | Artifact |
+|-------|-----------|---------|
+| `run-pestle-analysis` | PESTLE — Political, Economic, Social, Technological, Legal, Environmental | `macro-environment.md` |
+| `run-porters-five-forces` | Porter's Five Forces | `competitive-landscape.md` |
+| `run-bcg-matrix` | BCG Matrix — Stars, Cash Cows, Question Marks, Dogs | `portfolio-position.md` |
+| `run-swot` | SWOT — Strengths, Weaknesses, Opportunities, Threats | `swot-analysis.md` |
+| `run-okr-cascade` | OKR cascade — company → team → shaping-queue gaps | `okr-cascade.md` + `workspace.toml` entries |
+| `write-prfaq` | PRFAQ — press release + FAQ as altitude-0 forcing function | `prfaq.md` |
+| `synthesize-stakeholder-research` | Research synthesis — strategic narrative by theme | `stakeholder-synthesis.md` |
+
+The intended sequence is upstream-to-downstream: macro environment → competitive landscape → portfolio position → situation synthesis (SWOT) → altitude-0 direction (PRFAQ) → gap routing (OKR cascade). `synthesize-stakeholder-research` runs at the start when prior desk-research outputs exist.
+
+### Pillar 2 — UX strategy
+
+`define-ux-strategy` produces a three-layer document (Vision → Goals + Measures → Plan) that bridges the business strategy from Pillar 1 to the experience design work downstream. It uses the NN/g three-layer UX strategy model, Jaime Levy's four-tenets framework, and Gothelf/Seiden OKR-linked UX framing.
+
+The artifact — `ux-strategy.md` — is read by the experience-design pack's `journey-mapping` as the stated strategic rationale for the journey. When absent, `journey-mapping` degrades gracefully but the journey has no explicit strategy anchor.
+
+### Pillar 3 — Content strategy
+
+`define-content-strategy` produces the organizational and governance layer above per-surface content work: Purpose (why content exists), Process (how it is produced), Structure (how it is organized), and Governance (who decides). This is the Halvorson content strategy quad.
+
+The artifact — `content-strategy.md` — is read by the experience-design pack's `content-design` skill for organizational governance intent. It sets the constraints `content-design` operates within, not the per-surface copy itself.
+
+---
+
+## 3. The PRFAQ as altitude-0 forcing function
+
+### Why the PRFAQ is the first-value skill
+
+The PRFAQ forces specificity before any engineering begins. A strategist who cannot write a specific headline — naming the customer, the problem, and the benefit in one sentence — does not yet understand the product well enough to brief engineers or designers. The press-release format is the pressure: a press release that names no measurable benefit is obviously broken.
+
+Every initiative brief in the PE pack traces its strategic rationale back to the PRFAQ. Without a committed PRFAQ, initiative briefs are grounded in the team's interpretation of the strategy — which diverges across team members and sessions.
+
+### Why it precedes market analysis in the start-here path
+
+The README puts `write-prfaq` as the first command, before the market analysis sequence. This is deliberate: a product concept that can't be stated as a specific press release is not ready for market analysis. The PRFAQ surfaces what you don't know about the concept before session time is spent analyzing a market for an underspecified product.
+
+Teams that run market analysis first often use the analysis to confirm a concept they haven't yet examined critically. The PRFAQ-first order inverts this: pressure-test the concept, then validate it against the market picture.
+
+---
+
+## 4. OKR cascade and the PE bridge
+
+### The gap-routing contract
+
+`run-okr-cascade` is the primary bridge from this pack to `product-engineering`. Its output is not just a document — it is a workspace state change. Each identified gap becomes a `{type = "strategy"}` entry in the active initiative's `["ini-NNN".shaping_queue].backlog` array in `workspace.toml`.
+
+The PE pack's `workspace-status` reads these entries and surfaces them as strategy-driven shaping items. The PE pack's `frame-situation` picks them up and shapes them into briefs. This cross-pack routing is documented in each skill's `references/cross-pack-routing.md`.
+
+### Why gaps, not features
+
+The OKR cascade identifies gaps between current state and OKR targets. It does not produce a feature list. Features are decisions made after shaping; gaps are facts about the current state. A strategy that outputs features has already made the implementation decisions; a strategy that outputs gaps leaves those decisions to the product engineers who shape them.
+
+---
+
+## 5. UX and content strategy bridge to experience-design
+
+### The anchor contract
+
+`ux-strategy.md` and `content-strategy.md` are the two strategy anchors the experience-design pack reads. Their relationship is one-directional and path-based: the experience-design pack reads them by path; it does not write them. If neither artifact exists, the experience-design pack degrades gracefully — `journey-mapping` runs without a strategy anchor, producing a journey grounded only in the stated user and outcome.
+
+### Why set strategy before design
+
+Setting the UX strategy before `journey-mapping` ensures the journey is designed to serve the stated experience goals, not the team's instinct about what the product should feel like. A journey map derived from a UX strategy is traceable to a business objective; a journey map derived only from user research is traceable to a researcher's synthesis.
+
+The same logic applies to content strategy and `content-design`: without a committed organizational governance layer, per-surface content decisions are made locally and diverge over time. `content-strategy.md` sets the rules that keep local decisions coherent.
+
+---
+
+## 6. What "method" means in practice
+
+### Pure method, no values
+
+This pack ships canonical framework names and procedural steps, not values. No token tables, no organizational templates, no benchmark numbers. This mirrors the design principle in `experience-design` (§3): values are always project-specific; the method to derive them is not.
+
+A SWOT that ships with example strengths produces a SWOT with those examples cargo-culted in. A SWOT that only ships the four-quadrant structure and the procedure for filling it produces a SWOT grounded in the actual organization.
+
+### Frameworks are named, not reprinted
+
+Each skill references its source framework by name (SWOT, Porter's Five Forces, Halvorson content strategy quad) and defines the procedure for applying it. The frameworks themselves are not reprinted — they are published and authoritative. Reprinting them would create a maintenance burden and an accuracy risk.
+
+---
+
+## 7. Safety invariants
+
+1. **No skill writes to downstream pack output paths.** Skills in this pack write only to `docs/product/shaping/` (or the configured strategy output path). No skill writes to `docs/design/`, initiative task lists, or any PE-owned path other than the shaping-queue backlog array in `workspace.toml`.
+
+2. **The cascade writes gaps, not features.** `run-okr-cascade` outputs `{type = "strategy"}` gap entries. It does not output `{type = "feature"}` entries or write to `work_queue`. Gap entries are for `frame-situation` to shape into briefs; they are not execution-ready tasks.
+
+3. **Artifacts commit before downstream use.** No downstream pack references a strategy artifact that has not been committed to `docs/product/shaping/`. An uncommitted SWOT is not a strategic anchor.
+
+4. **No growth tooling.** No skill in this pack implements AARRR, PMF testing, or cohort-level retention analysis. These belong in a follow-on `growth` pack.
+
+5. **No primary research production.** `synthesize-stakeholder-research` consumes desk-research outputs; it does not produce interview guides, discussion scripts, or survey templates.
+
+---
+
+## 8. Design decisions and rationale log
+
+### Why PRFAQ-first in the start-here path (2026-07-27)
+
+The start-here command is `write-prfaq`, not `run-swot` or `run-pestle-analysis`. The rationale: a product concept that cannot be stated as a specific press release is not ready for market analysis. Teams that run market analysis first tend to use the analysis to confirm a concept they haven't yet examined critically. PRFAQ-first surfaces the underspecified areas of the concept before market analysis begins, so the analysis is shaped around real questions rather than rationalizing a predetermined direction.
+
+**Alternative considered:** start with `run-swot` as the most comprehensive situation artifact. Rejected because SWOT is a synthesis skill — it consumes PESTLE, Porter's, and BCG outputs. Starting with SWOT before any market analysis exists means the agent produces a SWOT grounded in assumptions, not analysis. PRFAQ-first avoids this by not implying a market analysis sequence at all for teams that only need altitude-0 direction.
+
+### Why UX and content strategy are in this pack, not experience-design (from pack inception)
+
+`define-ux-strategy` and `define-content-strategy` produce organizational and governance artifacts that a product strategist authors, not artifacts that experience designers author. The UX strategy names the experience vision and the OKR-linked goals — decisions made at the strategy level before design begins. Placing these skills in `experience-design` would blur the upstream/downstream boundary and imply that design teams are responsible for setting the experience objectives their own work is measured against.
+
+**Alternative considered:** place `define-ux-strategy` in `experience-design` as the first step of the design thread, with `journey-mapping` consuming it in the same session. Rejected because it collapses the strategy-to-design boundary: the UX strategy is set by a product strategist (or strategy/design collaboration), not by the designer running the thread. The strategy artifact must exist before the design thread starts, not be produced as the first step of it.
+
+### Why no growth tooling in this pack (from pack inception)
+
+Growth strategy (AARRR, PLG, PMF testing, cohort retention) is a distinct discipline with a distinct audience and distinct tooling. Including it here would expand the scope from "upstream strategy that all initiatives share" to "all strategic and growth work" — a scope boundary that loses its shape. RFC-0063 deferred growth to OQ1 as a follow-on pack.
+
+**Alternative considered:** add AARRR as a Pillar 4 skill. Rejected because AARRR is a growth measurement framework, not a market analysis or direction-setting framework. The three pillars of this pack produce pre-engineering artifacts that survive the strategy horizon; AARRR produces metrics that live in the measurement layer, which is post-engineering.

--- a/packs/product-strategy/README.md
+++ b/packs/product-strategy/README.md
@@ -1,62 +1,103 @@
 # product-strategy
 
-The strategy seat upstream of product engineering and experience design. Installed to **user scope** so the skills travel across every workspace.
+The strategy seat upstream of every initiative — committed artifacts.
 
-## Three pillars
+---
 
-**Pillar 1 — Market & competitive strategy** (7 skills): canonical frameworks that turn a market situation into committed artifacts in `docs/product/shaping/`. The OKR cascade feeds strategy-gap entries directly into the PE pack's `frame-situation` shaping queue.
+## Start here
 
-| Skill | Framework | Artifact |
-|---|---|---|
-| `run-swot` | SWOT — Strengths, Weaknesses, Opportunities, Threats | `swot-analysis.md` |
-| `run-porters-five-forces` | Porter's Five Forces — Supplier Power, Buyer Power, New Entrants, Substitutes, Rivalry | `competitive-landscape.md` |
-| `run-pestle-analysis` | PESTLE — Political, Economic, Social, Technological, Legal, Environmental | `macro-environment.md` |
-| `run-bcg-matrix` | BCG Matrix — Stars, Cash Cows, Question Marks, Dogs | `portfolio-position.md` |
-| `run-okr-cascade` | OKR cascade — company → team → shaping-queue gaps | `okr-cascade.md` + `workspace.toml` entries |
-| `write-prfaq` | PRFAQ — press release + FAQ as altitude-0 forcing function | `prfaq.md` |
-| `synthesize-stakeholder-research` | Research synthesis — strategic narrative by theme across stakeholder groups | `stakeholder-synthesis.md` |
+Type `write-prfaq` and describe the product concept you want to pressure-test.
 
-**Pillar 2 — UX strategy** (1 skill): sets the experience vision, goals/measures, and plan before design begins.
+```text
+write-prfaq
 
-| Skill | Frameworks | Artifact |
-|---|---|---|
-| `define-ux-strategy` | NN/g three-layer model · Jaime Levy four tenets · Gothelf/Seiden OKR-linked UX framing | `ux-strategy.md` |
+  Headline:  [Company] ships workspace.toml — product engineers who
+             coordinate AI agent work across sessions.
 
-**Pillar 3 — Content strategy** (1 skill): the organizational/governance layer above per-surface content design.
+  Customer:  A solo engineer shipping a 3-person startup's backlog
+             with AI coding agents.
+  Problem:   Every session starts blind. The agent doesn't know
+             what was decided, what's blocked, or what ships next.
+  Solution:  workspace.toml — a version-controlled queue the agent
+             reads at session start. One grep, full context.
 
-| Skill | Framework | Artifact |
-|---|---|---|
-| `define-content-strategy` | Halvorson content strategy quad — Purpose + Process + Structure + Governance | `content-strategy.md` |
-
-## Pack chain position
-
-```
-product-strategy (this pack)
-        ↓                          ↓                      ↓
-product-engineering          experience-design        content-design skill
-(product-vision intent)  (journey → screen → services)  (experience-design)
+  draft  docs/product/shaping/prfaq.md
 ```
 
-`run-okr-cascade` → writes `{type = "strategy"}` gaps → `["ini-NNN".shaping_queue].backlog` in `workspace.toml` → PE pack's `frame-situation` reads them.
+On any session return, ask the agent what's in `docs/product/shaping/` — or continue directly with `run-swot`.
 
-## Install
+---
 
-Default scope is **user** — installed under `~/.claude/skills/` (or your adapter's equivalent) so the skills load in every workspace.
+## Entry points
 
-```bash
-# <catalogue> is your catalogue URI: a local clone path or a git+https://… URL.
-agentbundle install --pack product-strategy <catalogue>   # CLI route
+| Say this | What happens |
+|----------|--------------|
+| `write-prfaq` | Draft the press release + FAQ before the product exists — the altitude-0 forcing function |
+| `run-pestle-analysis` | Scan the macro environment across six lenses — Political, Economic, Social, Technological, Legal, Environmental |
+| `run-porters-five-forces` | Map the competitive landscape — supplier and buyer power, new entrants, substitutes, rivalry |
+| `run-bcg-matrix` | Position each initiative in the portfolio matrix — Stars, Cash Cows, Question Marks, Dogs |
+| `run-swot` | Synthesize the situation picture — Strengths, Weaknesses, Opportunities, Threats |
+| `run-okr-cascade` | Cascade company OKRs to team level, identify gaps, and route them to the PE shaping queue |
+| `synthesize-stakeholder-research` | Synthesize desk-research outputs into a committed strategic narrative by theme |
+| `define-ux-strategy` | Set the experience vision, goals with measures, and plan — upstream of journey-mapping |
+| `define-content-strategy` | Set the organizational and governance layer for content — upstream of content-design |
+
+---
+
+## How a session runs
+
+```text
+run-swot
+
+  Quadrant       Items
+  ─────────────  ──────────────────────────────────────────────────
+  Strengths      Developer-first positioning; fast iteration cycle
+  Weaknesses     Low brand awareness outside early-adopter segment
+  Opportunities  AI-native distribution; enterprise channel open
+  Threats        Funded competitor entering adjacent market
+
+  Approve the situation picture? ›
 ```
 
-Or via your adapter's plugin marketplace UI.
+```text
+write-prfaq
 
-## What is NOT in this pack
+  Headline:  [Company] ships workspace.toml — product engineers who
+             coordinate AI agent work across sessions.
 
-- **Growth strategy** — AARRR, product-led growth, PMF testing; deferred to a follow-on `growth` pack (RFC-0063 OQ1)
-- **Primary research production** — no interview guides, discussion scripts, or survey templates; `synthesize-stakeholder-research` consumes desk-research pack outputs
-- **Per-surface content design** — that is the `content-design` skill in the experience-design pack; this pack covers the organizational/governance layer only
-- **Analytics or CRO tooling** — measurement and experimentation belong downstream of strategy
+  Customer:  A solo engineer shipping a 3-person startup's backlog
+             with AI coding agents.
+  Problem:   Every session starts blind. The agent doesn't know
+             what was decided, what's blocked, or what ships next.
+  Solution:  workspace.toml — a version-controlled queue the agent
+             reads at session start. One grep, full context.
 
-## Artifact output path
+  Approve the PRFAQ? ›
+```
 
-All artifacts commit to `docs/product/shaping/` by default. Configure the base path via the `[strategy]` section in your repo's (or user-profile) `agentbundle-layout.toml` (adopter-owned; never shipped with this pack — see each skill's `references/agentbundle-layout.md`).
+```text
+run-okr-cascade
+
+  Gap slug              KR                        Priority
+  ──────────────────    ──────────────────────    ──────────
+  retention-cohort      Retain 60% at week 4      High
+  activation-depth      3 features in 14 days     High
+  channel-enterprise    ARR from enterprise        Medium
+
+  3 gaps → workspace.toml  [ini-001.shaping_queue].backlog
+```
+
+The gaps appear in `workspace-status` for product engineers to pick up via `frame-situation`.
+
+---
+
+## Cross-pack
+
+**Downstream — `product-engineering`:** `run-okr-cascade` writes `{type = "strategy"}` gap entries to `workspace.toml`. The PE pack's `frame-situation` reads them from the shaping queue.
+
+**Downstream — `experience-design`:** `define-ux-strategy` produces `ux-strategy.md` and `define-content-strategy` produces `content-strategy.md`. Both are strategic anchors the experience-design pack's `journey-mapping` and `content-design` read from.
+
+---
+
+→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, pillars, invariants, and decision log.  
+→ **Go deeper:** the [`product-strategy` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/product-strategy/).

--- a/packs/product-strategy/README.md
+++ b/packs/product-strategy/README.md
@@ -30,17 +30,17 @@ On any session return, ask the agent what's in `docs/product/shaping/` — or co
 
 ## Entry points
 
-| Say this | What happens |
-|----------|--------------|
-| `write-prfaq` | Draft the press release + FAQ before the product exists — the altitude-0 forcing function |
-| `run-pestle-analysis` | Scan the macro environment across six lenses — Political, Economic, Social, Technological, Legal, Environmental |
-| `run-porters-five-forces` | Map the competitive landscape — supplier and buyer power, new entrants, substitutes, rivalry |
-| `run-bcg-matrix` | Position each initiative in the portfolio matrix — Stars, Cash Cows, Question Marks, Dogs |
-| `run-swot` | Synthesize the situation picture — Strengths, Weaknesses, Opportunities, Threats |
-| `run-okr-cascade` | Cascade company OKRs to team level, identify gaps, and route them to the PE shaping queue |
-| `synthesize-stakeholder-research` | Synthesize desk-research outputs into a committed strategic narrative by theme |
-| `define-ux-strategy` | Set the experience vision, goals with measures, and plan — upstream of journey-mapping |
-| `define-content-strategy` | Set the organizational and governance layer for content — upstream of content-design |
+| Say this | Give it | What happens |
+|----------|---------|--------------|
+| `write-prfaq` | A product concept, elevator pitch, or problem statement | Drafts the press release + FAQ before the product exists — the altitude-0 forcing function |
+| `run-pestle-analysis` | The scope: organization, market entry, or product line | Scans the macro environment across six lenses — Political, Economic, Social, Technological, Legal, Environmental |
+| `run-porters-five-forces` | The industry and the competitive reference point | Maps the competitive landscape — supplier and buyer power, new entrants, substitutes, rivalry |
+| `run-bcg-matrix` | A list of initiatives or products with their relative market position | Positions each in the portfolio matrix — Stars, Cash Cows, Question Marks, Dogs |
+| `run-swot` | Scope alone (elicits inline), or prior PESTLE / Porter's / BCG artifacts | Synthesizes the situation picture — Strengths, Weaknesses, Opportunities, Threats |
+| `run-okr-cascade` | Company OKRs (text, doc, or described inline) | Cascades to team level, identifies gaps, and routes them to the PE shaping queue in `workspace.toml` |
+| `synthesize-stakeholder-research` | One or more `desk-research-project-synthesize` briefs | Converts research evidence into a committed strategic narrative by theme |
+| `define-ux-strategy` | The approved PRFAQ and market situation (optional but improves grounding) | Sets the experience vision, goals with measures, and plan — upstream of `journey-mapping` |
+| `define-content-strategy` | Organizational context and any prior strategy artifacts | Sets the governance layer for content — Purpose, Process, Structure, Governance — upstream of `content-design` |
 
 ---
 

--- a/packs/product-strategy/README.md
+++ b/packs/product-strategy/README.md
@@ -24,7 +24,7 @@ write-prfaq
   draft  docs/product/shaping/prfaq.md
 ```
 
-On any session return, ask the agent what's in `docs/product/shaping/` — or continue directly with `run-swot`.
+On any session return, type `workspace-status` to see the strategy queue.
 
 ---
 

--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -1,7 +1,7 @@
 ---
 pack: architect
 scope: user
-tagline: "Design docs, diagrams, and reviews — workspace-agnostic."
+tagline: "Concept to reviewed architecture doc — any workspace."
 prerequisitePacks: []
 contract:
   useItWhen: "You need a technical design doc, architecture diagram, or design critique for your codebase."
@@ -10,7 +10,7 @@ contract:
   yourDecisions:
     - "Approve the Stage 0 concept"
     - "Review the design and independent critique"
-whatChanges: "After installing architect, every architecture artifact gets a method: `architect-design` produces Google-style design docs grounded against your repo's `reference.md`, `architect-diagram` draws the system in Mermaid (C4, sequence, state, ER, deployment), and `architect-review` critiques any design artifact with a severity-tagged rubric. The forked-context `design-reviewer` subagent gives every design an independent read — a reviewer that has not seen the authoring session."
+whatChanges: "After installing architect, every design decision gets a method: `architect-design` shapes a Stage 0 concept before any full write-up begins, writes the complete Google-style doc, and converges it against review; `architect-diagram` draws any system in Mermaid (C4, sequence, state, ER, or flowchart); `architect-review` critiques any design artifact with severity-tagged findings. The `design-reviewer` subagent reads finished artifacts cold — no authoring context — so the review cannot mark its own homework. You decide at two gates: the Stage 0 concept before the full doc is written, and the independent review findings before the doc is shared or acted on."
 skills:
   - name: architect-design
     description: "Authors a Google-style technical design doc: Stage 0 concept → Stage 1 full write-up → Stage 2 review-ready artifact, grounded against the repo's reference architecture."
@@ -59,34 +59,85 @@ relatedJourneys:
   - experience-design
 ---
 
-### 1. Ground the design in the reference architecture
+| Say this | What happens |
+|----------|-------------|
+| `architect-design` | Frame a concept, write a Google-style design doc, and converge it against review |
+| `architect-diagram` | Draw a Mermaid diagram — C4, sequence, state, ER, or flowchart |
+| `architect-review` | Critique a design doc or diagram with severity-tagged findings |
 
-- **Agent does:** checks for a `reference.md` in the repo — the golden-path file that describes the stack, patterns, and constraints the architecture skills design against — and offers to create it if one doesn't exist.
-- **You do:** confirm the reference is accurate for this task; update it before the design session starts if it is stale or missing a key constraint.
-- **Output:** a current, grounded `reference.md` the design skills can rely on.
+---
+
+### 1. Ground in the reference architecture
+
+Type `architect-design` — the skill checks what architecture context exists in the repo and states what it found before framing begins.
+
+```text
+architect-design
+
+  Knowledge surface: docs/architecture/reference.md
+
+  Stack       Node.js 20 · PostgreSQL 15 · S3
+  Patterns    CQRS; event-sourced ledger for financial data
+  Concern     Multi-tenancy, tenant data isolation
+```
+
+- **Output:** the architecture context the design will be grounded against, or an offer to create `reference.md` if none exists.
 
 ---
 
 ### 2. Frame the Stage 0 concept
 
-- **You provide:** a description of the design problem.
-- **Agent does:** runs `architect-design` in Stage 0 mode, producing a half-page concept that frames the problem, names constraints, and proposes a candidate approach with at least one alternative.
-- **You decide:** approve the concept at the G-concept gate, or redirect before the full write-up begins; if the alternatives section feels thin, ask for one more before approving.
-- **Output:** an approved Stage 0 concept.
+Type `architect-design [describe the problem]` — the agent shapes a ½-page concept covering the problem, constraints, and candidate approaches, then stops for your approval before the full doc is written.
+
+```text
+  concept  docs/design/multi-tenant-billing/concept.md
+
+  Problem      Billing engine for a multi-tenant SaaS.
+  Constraint   No shared state between tenants.
+  Candidates   Event-sourced ledger; relational schema + row-level security
+
+Approve this shape? ›
+```
+
+- **You decide:** approve the concept or redirect — a one-sentence redirect here saves a full write-up cycle.
+- **Output:** `docs/design/multi-tenant-billing/concept.md` — the approved Stage 0 concept.
 
 ---
 
 ### 3. Write the full design document
 
-- **Agent does:** writes the full Stage 1 design document — problem statement, alternatives with rejection reasoning, proposed design, open questions, and success criteria — grounded against `reference.md` throughout.
-- **You do:** watch the document take shape; if the alternatives section omits an approach the team has already discussed and ruled out, mention it; note any scope drift from the approved concept.
-- **Output:** a full Stage 1 design document ready for independent review.
+The agent writes the complete Google-style doc — TL;DR, Context, Goals, Proposal, Alternatives, Risks, Rollout, Open Questions — self-checked against the design-doc rubric before you see it.
+
+```text
+  docs/design/multi-tenant-billing/design.md
+
+  ## TL;DR
+
+  Introduce a dedicated billing service backed by an event-sourced ledger.
+  Tenant isolation is enforced at ingestion by partition key, not at query
+  time by row-level security — a constraint we cannot control in
+  third-party integrations.
+```
+
+- **Output:** `docs/design/multi-tenant-billing/design.md` — the full design doc, rubric-clean and ready for independent review.
 
 ---
 
 ### 4. Review independently
 
-- **Reviewer does:** reads the design cold in a forked context (`design-reviewer`) — a reviewer that has not seen the authoring session — and returns findings grouped by severity: Blockers, Concerns, Nits.
-- **You do:** read the findings as they land; give a one-sentence steer on any Blocker you disagree with.
-- **You decide:** for each Blocker, fix it or provide a one-sentence reason it doesn't apply; apply or defer Concerns and Nits with a reason.
-- **Output:** a design doc with a clean independent review, or concerns surfaced clearly to you.
+Type `architect-review` — the forked-context `design-reviewer` subagent reads the artifact cold with no authoring memory and returns severity-tagged findings.
+
+```text
+architect-review docs/design/multi-tenant-billing/design.md
+
+  Verdict: SHIP WITH CHANGES
+
+  🟥  Proposal §4 — trust boundary between billing service and payment
+      processor is unlabeled; required before the integration contract
+      can be implemented.
+  🟧  Alternatives §2 — relational-plus-RLS rejection reason is thin.
+  ⚪  TL;DR sentence 2 could be tightened.
+```
+
+- **You decide:** for each Blocker, apply the fix or give a one-sentence reason it doesn't apply; apply or defer Concerns and Nits with a reason.
+- **Output:** a review-clean design doc ready to share with stakeholders or hand to the build loop.

--- a/web/src/content/journeys/contracts.md
+++ b/web/src/content/journeys/contracts.md
@@ -1,7 +1,7 @@
 ---
 pack: contracts
 scope: user
-tagline: "OpenAPI 3.1 and AsyncAPI — API-first design."
+tagline: "API-first design — OpenAPI 3.1 and AsyncAPI contracts before implementation."
 prerequisitePacks: []
 contract:
   useItWhen: "You are designing an API or event-driven interface and need a machine-readable contract before implementation starts."
@@ -9,7 +9,7 @@ contract:
   youReceive: "A validated OpenAPI 3.1 or AsyncAPI 2.x contract file, versioned and ready to commit."
   yourDecisions:
     - "Review the contract before it drives implementation"
-whatChanges: "After installing contracts, API design starts from the contract, not the code. `api-contract` produces a validated OpenAPI 3.1 spec from requirements, user stories, or a domain model. `event-contract` produces an AsyncAPI 2.x spec for event-driven interfaces. Both skills apply a pluggable house standard — the Zalando guidelines by default, your own base + delta bundle without forking the skill."
+whatChanges: "After installing contracts, every API or event-driven interface starts from the contract, not the code. `api-contract` produces a validated OpenAPI 3.1 spec from requirements or a domain model; `event-contract` produces an AsyncAPI 2.x spec for event-driven interfaces. Both skills apply a pluggable house standard — Zalando by default, replaceable with your own base + delta bundle. A consumer-perspective check is built in; the contract drives implementation, not the other way."
 skills:
   - name: api-contract
     description: "Authors an OpenAPI 3.1 contract from requirements or user stories — endpoints, request/response schemas, error codes, and the consumer-perspective check built in."
@@ -43,25 +43,63 @@ relatedJourneys:
   - core
 ---
 
+| Say this | What happens |
+|----------|-------------|
+| `api-contract` | Author or review an OpenAPI 3.1 contract — endpoints, schemas, error codes |
+| `event-contract` | Author or review an AsyncAPI 2.x event contract — channels and message shapes |
+
+---
+
 ### 1. Author the contract
 
-- **You provide:** a description of the API surface — resources, actions, consumers, and any house naming conventions.
-- **Agent does:** runs `api-contract` or `event-contract` with the pluggable house standard configured (Zalando guidelines by default), producing a first-draft contract: endpoints, request/response schemas, error codes, and a consumer-perspective check.
-- **You do:** watch the draft take shape and note corrections as they arise — don't wait for the full draft to redirect on a naming convention or a missing error case; if you know the consumer will call this API in a specific way, say so before the agent finalizes the response schemas.
-- **Output:** a first-draft contract ready for consumer-perspective review.
+Type `api-contract` and describe the API surface — resources, actions, and the consumers who will call it.
+
+```text
+api-contract [orders service: create, get, cancel]
+
+  Endpoint              Method   Schema
+  /orders               POST     OrderCreate → OrderResponse
+  /orders/{order_id}    GET      → OrderResponse
+  /orders/{order_id}    DELETE   → (204 No Content)
+
+  Error responses: 400, 404, 409, 500 (Problem schema)
+```
+
+- **Output:** a first-draft OpenAPI 3.1 contract — endpoints, schemas, and error responses taking shape.
 
 ---
 
 ### 2. Review from the consumer's perspective
 
-- **Agent does:** runs a self-review against the house standard and surfaces the contract for your review at the G-contract gate.
-- **You decide:** read through the error responses first — the most common failure mode is a contract that specifies the happy path thoroughly but skips 400, 404, or 500 cases; name any missing error cases explicitly, and correct naming inconsistencies before implementation begins.
-- **Output:** a ratified contract that covers the consumer's full perspective, including all error codes.
+The agent runs a consumer-perspective check against the house standard and surfaces the contract at the G-contract gate.
+
+```text
+  Consumer-perspective check
+
+  ● All endpoints secured (Bearer token)
+  ● Error shapes consistent (Problem schema)
+  ⚠ POST /orders: missing 409 Conflict for duplicate order_id
+
+  G-contract ›
+```
+
+- **You decide:** approve the contract — check error codes first; a contract covering only 200 responses is incomplete.
+- **Output:** a ratified contract covering the consumer's full perspective, including all error codes.
 
 ---
 
 ### 3. Commit the versioned contract
 
-- **Agent does:** emits the ratified contract as a versioned OpenAPI 3.1 or AsyncAPI 2.x file, ready to commit alongside the implementation it governs.
-- **You do:** confirm the contract file is placed alongside the service it governs — not in a separate repository or a documentation folder that would diverge from the service over time.
-- **Output:** a versioned contract file committed alongside its implementation.
+The agent emits the ratified contract as a versioned YAML file. For event-driven interfaces, run `event-contract` through the same review flow before committing.
+
+```text
+event-contract [order.placed event]
+
+  Channel                     Message           Category
+  orders/order.placed.v1      OrderPlacedV1     business-event
+
+  Envelope: CloudEvents (structured mode)
+  Payload:  order_id · customer_id · items[] · total_amount
+```
+
+- **Output:** versioned OpenAPI 3.1 or AsyncAPI 2.x contract files committed alongside the services they govern.

--- a/web/src/content/journeys/desk-research.md
+++ b/web/src/content/journeys/desk-research.md
@@ -10,7 +10,7 @@ contract:
   yourDecisions:
     - "Set scope and depth"
     - "Review the synthesized brief"
-whatChanges: "After installing research, every question your agent takes on is grounded before it answers. `/desk-research` runs scoping, source curation, and synthesis in one session across four depth modes. For sustained investigations, the four `desk-research-project-*` skills run a multi-week lifecycle that accumulates a corpus and ends in a brief you can hand to a decision."
+whatChanges: "After installing desk-research, every question your agent takes on is evidence-grounded before it answers. `desk-research` runs scoping, source curation, and synthesis in one session across four depth modes. For sustained investigations, the four `desk-research-project-*` skills run a lifecycle that accumulates a corpus and ends in a confidence-graded brief. Gaps are named explicitly — honest gaps are better than false confidence."
 skills:
   - name: desk-research
     description: "The primary desk-research skill. Runs scoping, source curation, and synthesis in a single session, selecting depth from four modes — shallow through exhaustive."
@@ -86,27 +86,75 @@ relatedJourneys:
   - core
 ---
 
+| Say this | What happens |
+|----------|--------------|
+| `desk-research` | Single-session research — scoping, retrieval, synthesis in one pass |
+| `source-map` | Map canonical sources before retrieval begins |
+| `build-outline` | Build a research outline from the source map |
+| `identify-perspectives` | Map stakeholder perspectives before synthesis |
+| `compare-hypotheses` | Competing-hypotheses pipeline — scored matrix |
+| `devils-advocate` | Steelman the opposing case |
+| `decision-archaeology` | Reconstruct why a prior decision was made |
+| `desk-research-project-start` | Initialize a sustained multi-week research project |
+| `desk-research-project-status` | Orient to an active project — phase, hypothesis, what's next |
+| `desk-research-project-check` | Snapshot progress — sources captured, coverage, gaps |
+| `desk-research-project-digest` | Summarize corpus into a synthesis matrix |
+| `desk-research-project-synthesize` | Synthesize digest into a confidence-graded brief |
+
+---
+
 ### 1. Scope the question
 
-- **You provide:** the question and chosen depth mode (shallow through exhaustive).
-- **Agent does:** activates `desk-research` or `desk-research-project-start`; identifies the question type and maps the source space; emits a scope statement.
-- **You do:** read the scope statement before retrieval begins; if the agent's framing misses the real question, redirect with one sentence — a bad scope leads to a confident answer to the wrong question.
-- **You decide:** set scope and depth — the direction for everything that follows.
-- **Output:** a scoped question with chosen depth mode confirmed.
+Type `desk-research` and describe what you want to find out — the agent maps the source space and surfaces its scoping assumptions before retrieving anything.
+
+```text
+desk-research "What drives deployment frequency in platform engineering teams?"
+
+  Mode:     standard
+  Sources:  DORA reports, Google Cloud DevOps research, academic CS
+  Scope:    peer-reviewed + grey literature, 2019–2024
+
+  Approve scope? ›
+```
+
+- **You decide:** approve scope and depth before retrieval begins — a bad scope returns a synthesis that answers the wrong question.
+- **Output:** a confirmed scope statement with chosen depth mode.
 
 ---
 
 ### 2. Curate sources
 
-- **Agent does:** runs `source-map` to identify the canonical sources for the question domain; dispatches retrieval subagents to fetch and synthesize source material.
-- **You do:** watch the source list take shape; if a key source is missing — a specific industry report, a primary author's paper, an internal standard you know exists — name it explicitly; the agent doesn't know your domain.
+The agent runs `source-map` to identify the canonical sources for the domain, then dispatches retrieval subagents to fetch and extract material.
+
+```text
+  ● evidence-retriever   running  DORA 2023 State of DevOps
+  ✓ source-extractor     done     accelerate.io — 3 findings extracted
+  ● evidence-retriever   running  Google Cloud DevOps metrics guide
+  ○ synthesis            idle
+```
+
 - **Output:** a curated source set with fetched material ready for synthesis.
 
 ---
 
 ### 3. Synthesize and grade
 
-- **Agent does:** synthesizes a brief graded by confidence (GRADE A–D), citing each claim to its source; marks unsupported claims as explicit gaps.
-- **You do:** read the confidence grades first — a GRADE-C synthesis needs a different follow-on (narrow the question, run another retrieval pass) than a GRADE-A; check that each claim has a source citation and is not an unsupported assertion.
-- **You decide:** review the synthesized brief — act on it, narrow the question, or run another retrieval pass.
-- **Output:** a confidence-graded synthesis brief with cited sources and explicit gap map.
+The agent synthesizes findings into a brief — every claim carries a GRADE confidence tag and a source citation; gaps are named in a `## Known unknowns` section.
+
+```text
+  brief  deployment-frequency-brief.md
+
+  Bottom line:  Trunk-based development and automated testing pipelines
+                are the strongest predictors of deployment frequency.
+
+    Claim                                              Grade      Sources
+    Trunk-based development → 4× deployment rate     [high]      4 independent
+    Test automation → 2× deployment rate              [high]      3 independent
+    Platform team structure → moderate effect         [moderate]  3; downgrade: org-confound
+
+  Known unknowns
+    Known-unknown: effect isolated to platform eng. Would close by: segmented DORA data.
+```
+
+- **You decide:** review the synthesized brief — if confidence is low, narrow the question or run another retrieval pass before acting on findings.
+- **Output:** a confidence-graded brief with cited sources and explicit gap map.

--- a/web/src/content/journeys/discovery.md
+++ b/web/src/content/journeys/discovery.md
@@ -117,52 +117,126 @@ relatedJourneys:
   - core
 ---
 
+| Say this | What happens |
+|----------|-------------|
+| `discovery-loop` | Start or resume a supervised end-to-end discovery |
+| `frame-intent` | Frame a product problem at any altitude |
+| `de-risk-intent` | Surface the riskiest assumption and design a prototype approach |
+| `decompose-intent` | Break the converged intent into delivery briefs and specs |
+| `ux-writing` | Characterize the product voice and write per-state UI copy |
+
+---
+
 ### 1. Shape intent
 
-- **You provide:** a product idea or problem description.
-- **Agent does:** activates `discovery-loop`, runs `frame-intent` to establish product framing (problem, user, outcome), and emits an intent document.
-- **You do:** read the intent document — the framing is only a page; give concrete corrections if the problem statement is too vague ("users want to collaborate faster" → "the PM can't see which stories are blocked without checking three tools").
-- **You decide:** give G0 consent once the framing is specific enough to eliminate candidates — this gate sets the direction for everything that follows.
+Type `frame-intent` and describe the product problem — any altitude, any level of clarity.
+
+```text
+frame-intent
+
+  Level    feature
+  Problem  New users don't understand the product's value in the first session.
+  User     First-time user arriving after sign-up with no prior context.
+  Outcome  Activation rate rises; first-session drop-off decreases.
+
+Ratify framing? ›
+```
+
+- **You decide:** G0 — ratify the framing before the loop diverges. A vague problem means the loop explores the wrong space.
 - **Output:** an intent document with a specific problem, named user, and measurable outcome.
 
 ---
 
 ### 2. Diverge across candidates
 
-- **Agent does:** runs `explore-options` to generate candidate product shapes with distinct tradeoff profiles.
-- **You do:** watch candidates appear; if a candidate is obviously out-of-scope or repeats a prior approach, say so before the lens roster runs — it saves a review cycle.
-- **Output:** a set of candidate product shapes with distinct tradeoff profiles.
+Type `discovery-loop` and let the agent run `explore-options` to generate candidate product shapes with distinct tradeoff profiles.
+
+```text
+explore-options
+
+  Shape   Mechanic                      Riskiest assumption
+  A       Guided setup wizard           Users complete wizard without abandoning
+  B       API-first self-serve          Users tolerate high first-session cost
+  C       Community-driven templates    Template quality drives first activation
+  D       In-app explainer video        Passive exposure converts without action
+```
+
+- **Output:** a set of candidate product shapes with distinct tradeoff profiles — each with a named riskiest assumption.
 
 ---
 
 ### 3. Run the lens roster
 
-- **Reviewer does:** runs two discovery reviewers — threat and reliability — against each surviving candidate; each reads cold and returns findings; candidates that fail are eliminated.
-- **You do:** monitor the review output; if a candidate you want to keep is eliminated, read the finding — sometimes it rests on a false premise you can correct with one sentence.
-- **Output:** a filtered candidate set with review findings attached.
+The `discovery-lead` agent runs `discovery-threat-reviewer` and `discovery-reliability-reviewer` against each surviving candidate; each reads cold and returns findings.
+
+```text
+discovery-threat-reviewer
+
+  Concern  Shape A: wizard collects account data before trust is established
+  Blocker  Shape B: token stored at rest without encryption boundary named
+
+discovery-reliability-reviewer
+
+  Concern  Shape C: community template freshness has no defined staleness bound
+```
+
+- **Output:** a filtered candidate set with review findings attached; candidates with Blockers are eliminated.
 
 ---
 
 ### 4. Check mid-discovery
 
-- **Agent does:** surfaces the surviving candidates for a mid-course review.
-- **You do:** review which candidates remain and whether the field feels right; if only one candidate survives and it feels too easy, consider asking the agent to re-explore from a different angle.
-- **You decide:** confirm the surviving candidates at the mid-discovery check (G1.5), or direct a re-exploration — this is the last moment to expand the option space cheaply.
+The agent surfaces the surviving candidates for your mid-course review.
+
+```text
+discovery-loop [G1.5]
+
+  Candidate   Status       Note
+  Shape A     surviving    concern addressed — trust framing added
+  Shape C     surviving    staleness concern open — carried to convergence
+  Shape B     eliminated   token-at-rest blocker
+  Shape D     eliminated   no commitment signal detected
+
+Mid-discovery check — confirm candidates? ›
+```
+
+- **You decide:** G1.5 — confirm the surviving candidates or direct a re-exploration. This is the last cheap moment to expand the option space.
 - **Output:** a confirmed candidate field ready for convergence.
 
 ---
 
 ### 5. Converge on the candidate
 
-- **Agent does:** runs `de-risk-intent` to surface the riskiest assumption and design a prototype approach to test it; then runs `decompose-intent` to decompose the chosen direction into specs and briefs for the delivery loop.
-- **You do:** watch the assumption-test take shape; if the prototype approach is too expensive or won't actually test the assumption, redirect — a bad de-risk approach means an untested assumption at the brief's core.
-- **Output:** a de-risked candidate with decomposition into delivery briefs.
+The agent runs `de-risk-intent` to surface the riskiest assumption and design a test, then `decompose-intent` to break the winning shape into delivery briefs.
+
+```text
+de-risk-intent
+
+  Assumption   Users complete the wizard without abandoning at step 2.
+  Kill cond.   < 4 of 6 target users reach step 3 in a moderated prototype session.
+  Approach     validate-first — predeclare the line, then run sessions.
+  Hook         Conduct 6 moderated prototype sessions with target user profile.
+```
+
+- **Output:** a de-risked candidate with a predeclared kill condition and a named validation hook; then a decomposition into delivery briefs.
 
 ---
 
 ### 6. Reconcile and commit
 
-- **Agent does:** presents the full discovery sidecar — intent, assumption-test, validated candidate, and decomposition.
-- **You do:** read the full brief — all sections; G2 is "is this brief complete?" and G3 is "am I ready to build this?" — these are two distinct decisions.
-- **You decide:** ratify the reconciliation record at G2; commit the brief to the delivery loop at G3.
-- **Output:** a ratified decision brief handed to the delivery loop.
+The agent presents the full discovery sidecar — intent, assumption-test, validated candidate, and decomposition — for your final review.
+
+```text
+discovery-loop [G2]
+
+  Section          Status     Notes
+  intent           ratified   feature level, onboarding-activation
+  assumption-test  done       validate-first, 6 sessions, line predeclared
+  candidates       1 of 4     Shape A survived
+  decision-brief   ready      validation hook attached
+
+Reconcile? ›
+```
+
+- **You decide:** G2 — is the brief complete? Then G3 — am I ready to build this? These are two distinct decisions; read the brief in full before ratifying either.
+- **Output:** a ratified decision brief with a connected hypothesis and validation hooks — ready for the delivery loop.

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -1,7 +1,7 @@
 ---
 pack: governance-extras
 scope: repo
-tagline: "Decision trail — RFCs, ADRs, and conventions for long-lived repos."
+tagline: "decisions committed, proposals structured, conventions tracked."
 prerequisitePacks: []
 contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
@@ -11,7 +11,7 @@ contract:
     - "Review the RFC draft before circulation"
     - "Accept, reject, or defer the RFC"
     - "Merge the ADR"
-whatChanges: "After installing governance-extras, cross-cutting changes go through a structured RFC before anyone builds anything, architectural decisions are recorded in ADRs with critique tracks, and CONVENTIONS.md evolves through tracked updates. Every significant 'why did we choose this?' question has an answer that survives personnel changes."
+whatChanges: "After installing governance-extras, cross-cutting changes go through a structured RFC before anyone builds anything. Architectural decisions are recorded in ADRs with honest critique tracks. CONVENTIONS.md evolves through tracked updates, not drift. Every significant 'why did we choose this?' has an answer that survives personnel changes."
 skills:
   - name: new-rfc
     description: "Proposes a cross-cutting change through an RFC with structured proposer and objector perspectives — the front door for changes that affect more than one person or system."
@@ -75,27 +75,82 @@ relatedJourneys:
   - core
 ---
 
+| Say this               | What happens                                            |
+|------------------------|---------------------------------------------------------|
+| `rfc-status`           | Orient — RFC landscape by status and findings count     |
+| `new-rfc`              | Propose a cross-cutting change through a structured RFC |
+| `new-adr`              | Record an architectural decision with critique tracks   |
+| `update-conventions`   | Evolve CONVENTIONS.md through tracked RFC review        |
+
+---
+
 ### 1. Draft the RFC
 
-- **You provide:** the cross-cutting change or problem to address, and any known stakeholders or alternatives.
-- **Agent does:** activates `new-rfc`, drafts the problem statement, and structures the proposer and objector perspectives.
-- **You do:** read the RFC draft; the most common error is confusing the solution with the problem — the RFC should name what's broken or missing; if the draft leads with the solution, redirect to reframe around the underlying need.
-- **You decide:** review the RFC draft at G-draft before circulating to stakeholders.
-- **Output:** a circulated RFC draft with a clear problem statement and genuine adversarial perspectives.
+Type `new-rfc` and describe the change you want to propose — the agent structures the proposal, models the proposer and objector perspectives, and previews the draft before writing anything.
+
+```text
+new-rfc [adopt trunk-based development]
+
+  identifier   RFC-0043
+  title        Trunk-based development over feature branches
+  status       Draft
+  target       docs/rfc/0043-trunk-based-development.md
+
+  Proposer     Reduces integration latency; CI catches regressions fast
+  Objector     Long-lived branches give teams isolation; trunk conflicts are costly
+
+Approve? ›
+```
+
+- **You decide:** review the RFC draft at G-draft before circulating — the most common error is naming the solution in the problem statement; redirect to reframe around the underlying need.
+- **Output:** `docs/rfc/0043-trunk-based-development.md` — a circulated RFC draft with a clear problem statement and genuine adversarial perspectives.
 
 ---
 
 ### 2. Manage the comment period
 
-- **Agent does:** documents each objection and drafts responses, keeping the RFC's objector section updated as the conversation evolves.
-- **You do:** manage the comment period — keep it time-boxed, ensure genuine objections get genuine responses, and prevent accumulation without resolution; an RFC with no decision date is a governance failure.
-- **Output:** a resolved objection record with all objections addressed or explicitly set aside.
+Type `rfc-status` at any point during the comment period to see where the RFC stands — the agent keeps the RFC's objector section updated as feedback arrives.
+
+```text
+rfc-status
+
+  Active:
+
+  | State | RFCs                                       |
+  |-------|--------------------------------------------|
+  | Open  | RFC-0043: Trunk-based development          |
+
+  Resolved:
+
+  | State    | Count |
+  |----------|------:|
+  | Accepted |    12 |
+  | Rejected |     2 |
+
+  RFC candidates: 3 entries
+```
+
+- **Output:** a resolved objection record — all objections addressed or explicitly set aside with a reason.
 
 ---
 
 ### 3. Decide and record
 
-- **Agent does:** updates the RFC status with the decision; if accepted, runs `new-adr` to record the architectural decision.
-- **You do:** verify the ADR captures the actual decision and the honest forces behind it — not a post-hoc rationalization; merge the ADR as part of the same PR or directly following one.
+Close the comment period, state your decision, and type `new-adr` to lock in the architectural record — the agent previews the ADR before writing.
+
+```text
+new-adr [branching strategy: trunk-based development]
+
+  identifier   ADR-0028
+  title        Branching strategy: trunk-based development
+  status       Proposed
+  target       docs/adr/0028-branching-strategy-trunk-based.md
+
+  Decision     Use trunk-based development over long-lived feature branches
+  Tradeoff     Requires disciplined CI; enables faster integration loop
+
+Approve? ›
+```
+
 - **You decide:** accept, reject, or defer the RFC at G-accept; then merge the ADR at G-merge.
-- **Output:** a decided RFC and, if accepted, a merged ADR with honest rationale.
+- **Output:** a decided RFC and, if accepted, a merged ADR with honest rationale — linked from the RFC that produced it.

--- a/web/src/content/journeys/product-strategy.md
+++ b/web/src/content/journeys/product-strategy.md
@@ -1,7 +1,7 @@
 ---
 pack: product-strategy
 scope: user
-tagline: "Market, UX, and content strategy — committed artifacts upstream of every initiative."
+tagline: "Strategy seat upstream of every initiative — committed artifacts."
 prerequisitePacks:
   - product-engineering
 contract:
@@ -12,7 +12,7 @@ contract:
     - "Approve the market situation picture"
     - "Approve the PRFAQ"
     - "Approve the OKR cascade and gap routing"
-whatChanges: "After installing product-strategy, the altitude-0 work above every initiative has a committed artifact set instead of planning-meeting notes. Nine skills span the full strategy layer: market context (PESTLE, Porter's Five Forces), portfolio position (BCG Matrix, SWOT), altitude-0 forcing function (PRFAQ), OKR cascade with direct routing to the PE pack's shaping queue, and the experience and content direction that the experience-design pack reads from. Every artifact commits to `docs/product/shaping/` where downstream packs — product-engineering and experience-design (including its content-design skill) — can reference it by path. Strategy skills fill the Strategy section of the Digital Experience Contract — the shared schema that connects strategy outcomes to experience design and frontend implementation."
+whatChanges: "After installing product-strategy, every initiative starts with a committed artifact set instead of planning-meeting notes. Nine skills span the full strategy layer: market situation (PESTLE, Porter's, BCG, SWOT), altitude-0 direction (PRFAQ), OKR routing to the PE shaping queue, and the UX and content strategy anchors the experience-design pack reads from. Every artifact commits to `docs/product/shaping/` — the shared path downstream packs reference by name. The OKR cascade writes directly to `workspace.toml`, where product engineers pick up strategy-driven shaping items via `workspace-status`."
 skills:
   - name: synthesize-stakeholder-research
     description: "Converts desk-research project outputs into a strategic narrative by theme — committed as stakeholder-synthesis.md. Surfaces a 'run desk-research project first' prompt if no research inputs are found."
@@ -93,36 +93,104 @@ relatedJourneys:
   - core
 ---
 
-### 1. Build and gate the market situation
-
-- **You provide:** the market and organizational context — company OKRs, any prior desk-research project outputs, and the scope of the initiative or strategic question to address.
-- **Agent does:** runs synthesize-stakeholder-research if prior desk-research outputs exist; then runs run-pestle-analysis, run-porters-five-forces, and run-bcg-matrix; synthesizes all inputs into a committed SWOT as the capstone situation picture; commits each artifact to docs/product/shaping/.
-- **You do:** before moving forward, confirm the SWOT reads as a synthesis of the prior analyses — redirect if it introduces claims you can't trace back to PESTLE, Porter's, or BCG.
-- **You decide:** approve the market situation picture.
-- **Output:** committed PESTLE, Porter's Five Forces, BCG matrix, and SWOT — the grounded situation picture all downstream artifacts build on.
-
----
-
-### 2. Commit the altitude-0 direction
-
-- **Agent does:** runs write-prfaq to draft the press release + FAQ — naming the specific person, the measurable benefit, and the hardest objection a skeptical stakeholder would raise; commits to docs/product/shaping/prfaq.md.
-- **You do:** read the PRFAQ; if the press release doesn't name a specific person or deliver a measurable benefit, or doesn't connect to the approved situation picture, redirect before the cascade and experience direction are set against an unspecific vision.
-- **You decide:** approve the PRFAQ.
-- **Output:** committed prfaq.md — the altitude-0 forcing function that initiative briefs trace back to as their strategic rationale.
+| Say this | What happens |
+|----------|--------------|
+| `run-pestle-analysis` | Scan the macro environment: Political, Economic, Social, Technological, Legal, Environmental |
+| `run-porters-five-forces` | Map competitive forces: supplier/buyer power, new entrants, substitutes, rivalry |
+| `run-bcg-matrix` | Position each initiative in the portfolio: Stars, Cash Cows, Question Marks, Dogs |
+| `run-swot` | Synthesize the situation picture: Strengths, Weaknesses, Opportunities, Threats |
+| `run-okr-cascade` | Cascade OKRs, identify gaps, and route them to the PE shaping queue |
+| `write-prfaq` | Draft the press release + FAQ before the product exists |
+| `synthesize-stakeholder-research` | Synthesize desk-research outputs into a strategic narrative by theme |
+| `define-ux-strategy` | Set the experience vision, goals, and plan — upstream of journey-mapping |
+| `define-content-strategy` | Set the content governance layer — upstream of content-design |
 
 ---
 
-### 3. Cascade strategy gaps to the shaping queue
+### 1. Analyze the market situation
 
-- **Agent does:** runs run-okr-cascade to derive team-level OKRs from company targets, identify gaps between current state and each target, and prepare strategy-type entries for workspace.toml; each gap becomes a {type = "strategy"} entry ranked by OKR weight.
-- **You do:** review the gap list; confirm each gap reflects an actual gap (not a feature the team wants regardless of OKRs), is ranked by OKR weight, and is specific enough for frame-situation to scope into a shaping brief without re-scoping from scratch.
-- **You decide:** approve the OKR cascade and gap routing.
-- **Output:** strategy-type gap entries written to workspace.toml — signaling strategy-driven shaping items to product engineers via workspace-status.
+Run the market analysis sequence — `run-pestle-analysis` (macro environment) → `run-porters-five-forces` (competitive landscape) → `run-bcg-matrix` (portfolio position) — then `run-swot` to synthesize all three into the capstone situation picture.
+
+```text
+run-swot
+
+  Quadrant       Items
+  ─────────────  ──────────────────────────────────────────────────
+  Strengths      Developer-first positioning; fast iteration cycle
+  Weaknesses     Low brand awareness outside early-adopter segment
+  Opportunities  AI-native distribution; enterprise channel open
+  Threats        Funded competitor entering adjacent market
+
+  Approve the situation picture? ›
+```
+
+- **You decide:** approve the SWOT before the PRFAQ and OKR cascade build on it — a vague situation picture means downstream artifacts build on ungrounded assumptions.
+- **Output:** `docs/product/shaping/swot-analysis.md` — the capstone situation picture built from `macro-environment.md`, `competitive-landscape.md`, and `portfolio-position.md`.
+
+---
+
+### 2. Commit altitude-0 direction
+
+Type `write-prfaq` and describe the product concept; the agent drafts the press release and FAQ, naming the specific customer, the measurable benefit, and the hardest objection a skeptical stakeholder would raise.
+
+```text
+write-prfaq
+
+  Headline:  [Company] ships workspace.toml — product engineers who
+             coordinate AI agent work across sessions.
+
+  Customer:  A solo engineer shipping a 3-person startup's backlog
+             with AI coding agents.
+  Problem:   Every session starts blind. The agent doesn't know
+             what was decided, what's blocked, or what ships next.
+  Solution:  workspace.toml — a version-controlled queue the agent
+             reads at session start. One grep, full context.
+
+  Approve the PRFAQ? ›
+```
+
+- **You decide:** approve the PRFAQ — if the press release doesn't name a specific person or deliver a measurable benefit, redirect before the cascade sets gaps against an underspecified vision.
+- **Output:** `docs/product/shaping/prfaq.md` — the altitude-0 forcing function initiative briefs trace back to.
+
+---
+
+### 3. Cascade OKRs to the shaping queue
+
+Type `run-okr-cascade`; the agent derives team-level OKRs from company targets, identifies gaps between current state and each target, and prepares strategy-type entries for `workspace.toml`.
+
+```text
+run-okr-cascade
+
+  Gap slug              KR                        Priority
+  ──────────────────    ──────────────────────    ──────────
+  retention-cohort      Retain 60% at week 4      High
+  activation-depth      3 features in 14 days     High
+  channel-enterprise    ARR from enterprise        Medium
+
+  Approve and write to workspace.toml? ›
+```
+
+- **You decide:** approve the gap list — confirm each gap reflects an actual OKR delta, is ranked by OKR weight, and is specific enough for `frame-situation` to scope without re-scoping from scratch.
+- **Output:** `docs/product/shaping/okr-cascade.md` and strategy-type entries in `workspace.toml` — gaps product engineers pick up from `workspace-status`.
 
 ---
 
 ### 4. Set experience and content direction
 
-- **Agent does:** runs define-ux-strategy to produce a committed ux-strategy.md — experience vision, goals with measures, and plan, grounded in the approved market situation and PRFAQ; runs define-content-strategy to produce a committed content-strategy.md using the Halvorson quad (Purpose + Process + Structure + Governance).
-- **You do:** review both artifacts before sharing with design and content teams; confirm ux-strategy.md connects to the approved PRFAQ; confirm content-strategy.md names specific decisions — channel priority, ownership model, update cadence — not aspirational intent.
-- **Output:** committed ux-strategy.md and content-strategy.md — the anchors the experience-design pack reads from when journey-mapping and content-design run.
+Type `define-ux-strategy` to commit the experience vision, goals with measures, and plan; type `define-content-strategy` to commit the organizational and governance layer for content.
+
+```text
+define-ux-strategy
+
+  Vision:  Reduce session-start friction for engineers who run AI
+           coding agents daily — every agent reads context in under
+           10 seconds.
+
+  Goals:
+    KR-1   Task-completion rate > 80% without re-scoping
+    KR-2   Session-start orient time < 10 s (p75)
+
+  committed  docs/product/shaping/ux-strategy.md
+```
+
+- **Output:** `docs/product/shaping/ux-strategy.md` and `docs/product/shaping/content-strategy.md` — the anchors the experience-design pack reads from when `journey-mapping` and `content-design` run.


### PR DESCRIPTION
## Summary

Applies the pack documentation pattern established in #745 (core and experience-design) to the remaining six packs:

- **architect** — workspace-agnostic design docs, diagrams, and review
- **contracts** — OpenAPI 3.1 and AsyncAPI contract authoring
- **desk-research** — evidence-grounded research with two-axis model
- **governance-extras** — RFCs, ADRs, and conventions for long-lived repos
- **product-engineering** — from raw idea to build-ready decision brief
- **product-strategy** — market, UX, and content strategy

Each pack gets the three-part treatment:
1. **README.md** rewritten in command-driven format: one-line tagline, `## Start here` with mocked terminal output, `## Entry points` table (user-invocable skills only), `## How a session runs` with 2–3 mocked terminal blocks, cross-pack section where relevant
2. **DESIGN.md** created: TL;DR, Non-Goals, numbered design sections, decisions log with `Alternative considered:` per entry
3. **Journey page** updated: entry points table, `### N. Step` format with mocked terminal blocks, `- **Output:**` and `- **You decide:**` labels per linter contract

`packs/discovery` was skipped — the directory does not exist.

## What changed

- 6 `DESIGN.md` files created (new)
- 6 `README.md` files rewritten
- 6 journey pages updated (`architect.md`, `contracts.md`, `desk-research.md`, `discovery.md`, `governance-extras.md`, `product-strategy.md`)

## Test plan

- [x] `python tools/lint-journey-contract.py` — all six new journey pages pass; only pre-existing `atlassian.md` violations remain (unrelated, unchanged)
- [x] Mock terminal outputs verified against each skill's `## Output rendering` section before writing
- [x] No install instructions in any README
- [x] No skill-by-skill inventories in any README
- [x] DESIGN.md files follow core/DESIGN.md and experience-design/DESIGN.md pattern exactly