### PR TITLE
fix(security): close cp1252 crash in sso-broker and symlink traversal in seeds lint (agentbundle 0.20.2, credbroker 0.3.0)

### DIFF
--- a/.agentbundle/bin/sso-broker.py
+++ b/.agentbundle/bin/sso-broker.py
@@ -39,6 +39,16 @@ import urllib.request
 # ``_sso_*`` modules' ``from .credentials_shim import Tier2HardFailError``
 # resolves under user-scope install.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: stdout defaults to errors="strict" — a
+    # non-ASCII write (em-dash messages, cookie-jar data) raises
+    # UnicodeEncodeError on a legacy cp1252 console. Reconfigure both streams
+    # before any output, including the platform-backend import below. Guarded:
+    # a StringIO test-harness replacement or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = pathlib.Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.20.2] — 2026-07-27
+
+### Fixed
+
+- **Seeds-lint symlink hardening.** `catalogue lint` with `lint-seeds = true`
+  now uses `os.walk(followlinks=False)` instead of `Path.rglob("*")` for the
+  seeds walk. On Python 3.11/3.12, `rglob` traverses into symlinked
+  directories and reads their contents; `os.walk` with `followlinks=False`
+  does not, closing a traversal gap for packs that ship a symlinked directory
+  under `seeds/`.
+- **`sso-broker.py` Windows console hardening.** The broker script
+  (`packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py`) now
+  reconfigures stdout and stderr to UTF-8 inside the file-path-invocation
+  bootstrap gate, matching the fix applied to the other credentialed CLIs in
+  0.20.1. Without this, em-dash messages on a Windows cp1252 console raised
+  `UnicodeEncodeError` before the script could run.
+
 ## [0.20.1] — 2026-07-27
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import ast
 import json
+import os
 import re
 import sys
 import tomllib
@@ -1352,17 +1353,21 @@ class _PackRules:
         if not seeds_dir.is_dir():
             return []
         diags: list[Diagnostic] = []
-        for path in sorted(seeds_dir.rglob("*")):
-            if not path.is_file():
-                continue
-            for violation in _seeds_check_file(path, seeds_dir):
-                diags.append(_diag(
-                    DiagnosticCode.CAT_L029,
-                    Severity.ERROR,
-                    violation,
-                    pack=self._name,
-                    path=str(path),
-                ))
+        # os.walk(followlinks=False) avoids traversing into symlinked
+        # directories, which rglob does on Python 3.11/3.12 (3.13 fixed it).
+        for dirpath_str, _dirs, filenames in os.walk(seeds_dir, followlinks=False):
+            for fname in sorted(filenames):
+                path = Path(dirpath_str) / fname
+                if path.is_symlink():
+                    continue
+                for violation in _seeds_check_file(path, seeds_dir):
+                    diags.append(_diag(
+                        DiagnosticCode.CAT_L029,
+                        Severity.ERROR,
+                        violation,
+                        pack=self._name,
+                        path=str(path),
+                    ))
         return diags
 
     def _check_first_value(self) -> list[Diagnostic]:

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.20.1"
+CLI_VERSION = "0.20.2"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.20.1"
+version = "0.20.2"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
@@ -730,6 +730,63 @@ def test_check_seeds_clean(tmp_path, monkeypatch):
     assert not any(d.code == "CAT-L029" for d in result.diagnostics)
 
 
+def test_check_seeds_symlinked_dir_skipped(tmp_path, monkeypatch):
+    """A symlinked directory inside seeds/ must not be traversed by the linter.
+
+    On Python 3.11/3.12, Path.rglob() follows symlinked directories;
+    os.walk(followlinks=False) does not. This test pins the fix: files
+    reachable only through a symlinked dir produce no CAT-L029 violations.
+
+    Skipped on platforms where os.symlink is unavailable (some Windows configs).
+    """
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    pack_dir = _add_pack_with_seeds(tmp_path, "pack-a", lint_seeds=True,
+                                    seeds={"AGENTS.md": "<project-name>"})
+    # Plant a symlinked directory inside seeds/ pointing to /etc (or tmp).
+    # On Windows, creating symlinks may require elevated privileges — skip.
+    link = pack_dir / "seeds" / "evil-link"
+    target = tmp_path / "outside"
+    target.mkdir()
+    (target / "passwd").write_text("root:x:0:0\n", encoding="utf-8")
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this platform/filesystem")
+    result = lint_catalogue(tmp_path)
+    l029 = [d for d in result.diagnostics if d.code == "CAT-L029"]
+    # The planted AGENTS.md is clean → should be zero violations.
+    # If the symlinked dir were traversed, "passwd" would produce an
+    # "unknown seed file" violation.
+    assert not l029, (
+        "symlinked directory inside seeds/ must not be traversed: "
+        + "; ".join(d.message for d in l029)
+    )
+
+
+def test_check_seeds_symlinked_file_skipped(tmp_path, monkeypatch):
+    """A symlinked file inside seeds/ must not be read by the linter."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    pack_dir = _add_pack_with_seeds(tmp_path, "pack-a", lint_seeds=True,
+                                    seeds={"AGENTS.md": "<project-name>"})
+    outside = tmp_path / "outside.md"
+    outside.write_text("<project-name>", encoding="utf-8")
+    link = pack_dir / "seeds" / "AGENTS.md"
+    link.unlink()
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this platform/filesystem")
+    # The symlinked AGENTS.md is skipped → no violation (it could have been
+    # a clean file, so no violation is expected either way; the key invariant
+    # is that we do not read through a symlink).
+    result = lint_catalogue(tmp_path)
+    assert not any(d.code == "CAT-L029" for d in result.diagnostics)
+
+
 # ---------------------------------------------------------------------------
 # Task 4 — _PackRules._check_first_value() (CAT-L030)
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_sso_broker_verbs.py
+++ b/packages/agentbundle/tests/unit/test_sso_broker_verbs.py
@@ -482,6 +482,27 @@ def test_ac17_broker_lives_at_canonical_path():
     assert BROKER_PY.parent.name == "adapter-root-bins"
 
 
+def test_stdio_utf8_hardening_present():
+    """Windows cp1252 console hardening must be present and correctly ordered.
+
+    Source-asserted (not behavioral): reproducing a cp1252 console is not
+    portable, but the structure — reconfigure inside the file-path-invocation
+    gate, before any output — is verifiable from source bytes.
+
+    Mirrors the pattern in figma/test_exit_codes.py and
+    atlassian/test_exit_codes.py for the other credentialed CLIs.
+    """
+    src = BROKER_PY.read_text(encoding="utf-8")
+    assert 'reconfigure(encoding="utf-8")' in src, (
+        "stdout/stderr UTF-8 hardening missing from sso-broker.py"
+    )
+    gate_pos = src.index('if __package__ in (None, "") and __spec__ is None:')
+    reconfigure_pos = src.index('reconfigure(encoding="utf-8")')
+    assert gate_pos < reconfigure_pos, (
+        "UTF-8 hardening must sit inside the file-path-invocation gate"
+    )
+
+
 # ----------------------------------------------------------------------
 # URL scheme allowlist on `test` (B310 / SSRF-adjacent hardening).
 # ----------------------------------------------------------------------

--- a/packages/credbroker/CHANGELOG.md
+++ b/packages/credbroker/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.3.0] — 2026-07-27
+
+### Fixed
+
+- **`sso-broker` Windows console hardening.** The companion `sso-broker.py`
+  script now reconfigures stdout and stderr to UTF-8 inside its
+  file-path-invocation bootstrap gate. On a Windows cp1252 console, the
+  previous code raised `UnicodeEncodeError` when the script emitted em-dash
+  messages before the Python import guard ran. The fix mirrors the pattern
+  applied to the other credentialed CLIs (figma, confluence-crawler,
+  confluence-publisher, jira, jira-align) in agentbundle 0.20.1.
+
 ## [0.2.0] — 2026-06-16
 
 ### Added

--- a/packages/credbroker/pyproject.toml
+++ b/packages/credbroker/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "credbroker"
-version = "0.2.0"
+version = "0.3.0"
 description = "Standalone, pip-installable credential resolver for credentialed agent skills (env -> OS keyring -> dotfile, with an optional encrypted-at-rest vault)."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/credbroker/tests/unit/test_sso_broker_verbs.py
+++ b/packages/credbroker/tests/unit/test_sso_broker_verbs.py
@@ -482,16 +482,15 @@ def test_ac17_broker_lives_at_canonical_path():
     assert BROKER_PY.parent.name == "adapter-root-bins"
 
 
-def test_stdio_utf8_hardening_present():
-    """Windows cp1252 console hardening must be present and correctly ordered.
+# ----------------------------------------------------------------------
+# Windows cp1252 console hardening.
+# ----------------------------------------------------------------------
 
-    Source-asserted (not behavioral): reproducing a cp1252 console is not
+
+def test_stdio_utf8_hardening_present() -> None:
+    """Source-asserted (not behavioral): reproducing a cp1252 console is not
     portable, but the structure — reconfigure inside the file-path-invocation
-    gate, before any output — is verifiable from source bytes.
-
-    Mirrors the pattern in figma/test_exit_codes.py and
-    atlassian/test_exit_codes.py for the other credentialed CLIs.
-    """
+    gate, before any output — is verifiable from source bytes."""
     src = BROKER_PY.read_text(encoding="utf-8")
     assert 'reconfigure(encoding="utf-8")' in src, (
         "stdout/stderr UTF-8 hardening missing from sso-broker.py"

--- a/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
+++ b/packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py
@@ -39,6 +39,16 @@ import urllib.request
 # ``_sso_*`` modules' ``from .credentials_shim import Tier2HardFailError``
 # resolves under user-scope install.
 if __package__ in (None, "") and __spec__ is None:
+    # Windows console hardening: stdout defaults to errors="strict" — a
+    # non-ASCII write (em-dash messages, cookie-jar data) raises
+    # UnicodeEncodeError on a legacy cp1252 console. Reconfigure both streams
+    # before any output, including the platform-backend import below. Guarded:
+    # a StringIO test-harness replacement or pythonw's None has no reconfigure().
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
     _here = pathlib.Path(__file__).resolve().parent
     sys.path.insert(0, str(_here.parent))
     __package__ = _here.name


### PR DESCRIPTION
## Summary

- **`sso-broker.py` cp1252 fix**: The broker script was the only credentialed CLI missing the `reconfigure(encoding="utf-8")` call inside its file-path-invocation bootstrap gate. On a Windows cp1252 console, em-dash messages raised `UnicodeEncodeError` before the script could run. All six other CLIs (figma, confluence-crawler, confluence-publisher, jira, jira-align, and the main agentbundle CLI) had this fix; `sso-broker.py` didn't.
- **Seeds-lint symlink hardening**: `catalogue lint` with `lint-seeds = true` used `Path.rglob("*")` to walk the seeds directory. On Python 3.11/3.12, `rglob` follows symlinked directories; `os.walk(followlinks=False)` does not. Changed to `os.walk` + per-file `is_symlink()` guard, closing the traversal gap.
- **Two new tests**: source-assertion for `sso-broker.py` UTF-8 hardening (in `test_sso_broker_verbs.py`); symlinked-dir and symlinked-file guard tests for CAT-L029 (in `test_catalogue_tooling_lint.py`).
- **Version bumps**: agentbundle 0.20.1 → 0.20.2 (patch); credbroker 0.2.0 → 0.3.0 (minor, carries the sso-broker fix as the broker's companion script).

## What was not broken (verified)

- CRLF/LF: `test_writers_emit_lf.py` AST gate passes — all writers already use `newline="\n"`
- Source defaults: `test_source_defaults.py` comprehensive and passing

## Test plan

- [x] `test_sso_broker_verbs.py::test_stdio_utf8_hardening_present` — new, passes
- [x] `test_catalogue_tooling_lint.py::test_check_seeds_symlinked_dir_skipped` — new, passes
- [x] `test_catalogue_tooling_lint.py::test_check_seeds_symlinked_file_skipped` — new, passes
- [x] Full `test_sso_broker_verbs.py` and `test_catalogue_tooling_lint.py` suites — 154 tests, all pass
- [x] `test_writers_emit_lf.py` — still passes after `lint.py` change (no bare text writer added)