### PR TITLE
feat(release-engineering,core): fidelity-ladder module + release-loop gap extensions (RFC-0074/0075)

### DIFF
--- a/.agents/skills/operational-safety/references/fidelity-ladder.md
+++ b/.agents/skills/operational-safety/references/fidelity-ladder.md
@@ -1,0 +1,195 @@
+# fidelity-ladder — inner-loop levels and outer-loop environment qualification
+
+> **Loaded when:** the task needs a local-infra-equivalent (inner loop) or must
+> qualify an ephemeral environment for autonomous outer-loop operation.
+> **Module role:** EXECUTE/QUALIFY — constructive guidance for choosing and
+> qualifying environments. The companion module
+> [`environment-isolation.md`](environment-isolation.md) is the REVIEW checklist
+> (auditing whether an existing environment meets the bar); this module specifies
+> how to build or choose one that does. Load both when both questions are live.
+> **Grounded in:** Testcontainers documentation, LocalStack documentation, Docker
+> Compose usage patterns, inner-dev-loop tools (Tilt, Skaffold), Argo Rollouts,
+> k8s NetworkPolicy and RBAC references, AWS multi-account-per-stage pattern
+> (SCP/org-policy enforcement), vCluster (Loft Labs) documentation.
+
+---
+
+## The seven-level fidelity ladder
+
+Levels L0–L3 are **inner-loop** (pre-push, developer-controlled). L4 and above
+are **outer-loop** (post-push, CI-managed). The boundary is the git push / PR-open
+event.
+
+| Level | Name | Technology examples | Coverage | Isolation provability |
+|-------|------|---------------------|----------|-----------------------|
+| L0 | In-memory fake | Hand-rolled stubs, in-process fakes, sqlite-in-memory | Single-process; no network; no external API | **Self-evident** — process boundary |
+| L1 | Contract / protocol test | Pact CDC, JSON Schema validation, gRPC reflection | Provider/consumer contract only; no running service | **Self-evident** — no network stack |
+| L2 | Compose-isolated | Docker Compose multi-service, devcontainer | Multi-service network; host filesystem; no cloud API emulation | **Self-evident** — Docker bridge prevents external egress |
+| L3 | Container-emulated | Testcontainers + LocalStack / Microcks / WireMock | Per-test isolation; cloud API emulation; SDK calls intercepted | **Self-evident** — SDK endpoint override captures all cloud API calls |
+| L4 | k8s namespace-isolated | Namespace-per-PR on a shared cluster (NetworkPolicy + RBAC required) | Real Kubernetes primitives; shared control plane | **Requires policy audit** — no network policy = shared blast radius |
+| L4+ | Virtual cluster | vCluster (Loft Labs) — dedicated API server inside host cluster | Stronger than namespace; softer than dedicated cluster | **Requires audit** — host cluster egress policy must be verified |
+| L5 | Cloud sandbox | Dedicated non-prod cloud account / project + isolated state backend | Real cloud APIs; real IAM; real billing (throttled); no prod credential path | **Programmatically auditable** — SCP/org policies verifiable via API |
+| L6 | Staging / pre-prod | Production-mirror; may carry anonymised prod data | Near-prod fidelity | **Human-supervised; never autonomous-zone** |
+
+---
+
+## Per-level descriptors
+
+```
+Level: L0 — In-memory fake
+Coverage:  single-process logic only
+Isolation: self-evident (process boundary — no network stack)
+Gaps:      no persistence, no real API, no multi-service behavior
+Use when:  testing a single function / adapter boundary in isolation
+Budget:    < 1 s; always in-loop
+```
+
+```
+Level: L1 — Contract / protocol test
+Coverage:  provider–consumer protocol agreement (Pact CDC, gRPC reflection, JSON Schema)
+Isolation: self-evident (no running service; no network calls made)
+Gaps:      no behavioral fidelity beyond the protocol boundary
+Use when:  verifying two components agree on the API shape without running both
+Budget:    < 10 s; always in-loop
+```
+
+```
+Level: L2 — Compose-isolated multi-service
+Coverage:  multi-service network topology; realistic routing between services
+Isolation: self-evident (Docker bridge prevents external egress by default)
+Gaps:      cloud API calls fail or are stubbed; shared containers across tests unless
+           explicit teardown
+Use when:  testing multi-service interactions that don't require real cloud APIs
+Budget:    < 60 s; inner-loop ceiling for most services
+```
+
+```
+Level: L3 — Container-emulated (Testcontainers + LocalStack / Microcks / WireMock)
+Coverage:  cloud API emulation (AWS S3, SQS, DynamoDB, etc.); per-test container lifecycle;
+           SDK calls intercepted before leaving the process
+Isolation: self-evident (SDK endpoint override captures all cloud API calls before they
+           reach a real endpoint)
+Gaps:      behavioral fidelity gaps (complex IAM conditions, cross-service event timing,
+           managed service internals); LocalStack commercial license required for production
+           use post-March 2024 (OSS alternatives: Moto, LocalStack-OSS forks, Microcks)
+Use when:  inner-loop tests that need cloud API behavior without a real account
+Budget:    30 s – 3 min; inner-loop ceiling for cloud-dependent services
+Note:      L3 is the inner-loop ceiling; fidelity gaps here are expected and are exactly
+           what the outer loop exists to catch
+```
+
+```
+Level: L4 — k8s namespace-isolated (requires policy audit)
+Coverage:  real Kubernetes primitives; per-PR namespace on a shared cluster
+Isolation: requires policy audit (shared control plane; NetworkPolicy + RBAC must be
+           present and verified per deployment — absent policies = L2-equivalent isolation)
+Gaps:      shared control plane blast radius; host-cluster egress policy applies to all
+           namespaces; not equivalent to account-level isolation
+Use when:  teams already running Kubernetes that want per-PR ephemeral environments
+           without dedicated cluster provisioning costs
+Qualification: qualifies for the outer loop only after the three-dimension policy audit
+               passes — "namespace isolation" without verified NetworkPolicy does not qualify
+```
+
+```
+Level: L4+ — Virtual cluster / vCluster (requires policy audit)
+Coverage:  own Kubernetes API server and control plane inside a host cluster
+Isolation: requires audit (stronger than namespace; host cluster egress policy still
+           applies; isolation claims are self-reported by vCluster project)
+Gaps:      host cluster egress policy is a shared blast radius; limited independent
+           security audit of isolation boundary in public literature
+Use when:  teams who need stronger-than-namespace isolation without dedicated cluster cost
+Qualification: same three-dimension audit required as L4; host cluster egress policy
+               must be verified in addition to the virtual cluster's own isolation
+```
+
+```
+Level: L5 — Cloud sandbox (the outer-loop qualification floor)
+Coverage:  real cloud APIs; real IAM; real networking; real billing (throttled/capped)
+Isolation: programmatically auditable (dedicated account/project boundary + isolated state
+           backend + no prod credential reachable; SCP/org policies verifiable via API)
+Gaps:      real billing cost; setup/teardown time (minutes); real data risk if
+           misconfigured (data isolation is not free — it must be enforced)
+Use when:  the outer release loop (autonomous zone); ephemeral environments
+Budget:    minutes to hours; outer-loop territory; teardown on cycle end mandatory
+           (see cost-and-teardown module)
+Note:      The `iac-terraform` pack's generate-iac skill scaffolds the account/workspace
+           boundary — the provisioning detail for this level lives there
+Qualification: satisfies all three outer-loop isolation dimensions when:
+               (a) the account/project has no VPC peering to prod,
+               (b) all data is synthetic / purpose-generated,
+               (c) state backends are isolated and not shared with other envs
+```
+
+```
+Level: L6 — Staging / pre-prod
+Coverage:  production-equivalent topology; may carry anonymised production data
+Isolation: human-supervised; never autonomous-zone
+Gaps:      may share blast radius with prod-adjacent services; cross-env contamination
+           risk if anonymisation is incomplete
+Use when:  human-supervised regression, load, or soak testing only
+Budget:    n/a (human-gated; not an outer-loop target)
+```
+
+---
+
+## Inner-loop budget heuristic
+
+**Push up the ladder as high as a sub-5-minute local budget tolerates.**
+
+- **L0–L1:** milliseconds — always in-loop; never skip these.
+- **L2–L3:** seconds to 3 minutes — the inner-loop ceiling for most services.
+- **L4 and above:** CI-managed; these are outer-loop territory, not local builds.
+
+When a task's dependency cannot be represented at L0–L3 within budget, that is the signal
+to defer the integration test to the outer loop (the CI-managed ephemeral environment)
+rather than lowering the budget or cutting the test.
+
+---
+
+## Outer-loop qualification: the three-dimension test
+
+The outer loop's "reversible" label requires all three isolation conditions to hold
+simultaneously. Each maps to a concrete, testable boolean:
+
+| Dimension | Condition | How to test |
+|-----------|-----------|-------------|
+| **Prod reachability** | No route from the ephemeral env to prod endpoints, prod databases, or prod identity stores | Network policy or security group audit confirms no ingress/egress to prod CIDR / prod account; credential scoping confirms the session cannot assume prod IAM roles |
+| **Data isolation** | No real user data accessible from the ephemeral env | Data classification review confirms env storage contains only synthetic, anonymized, or purpose-generated data; no prod snapshot was restored here |
+| **Inter-env isolation** | This ephemeral env cannot affect other running ephemeral or shared staging envs | Env resources (namespaces, accounts, VPCs, state backends) are unique to this cycle; no shared mutable state with other concurrent envs |
+
+**The test is boolean, not scored.** A single `false` is a consent-gate crossing — surface
+to human; do not proceed with autonomous deploy.
+
+---
+
+## Isolation provability classification
+
+| Class | Levels | What this means | Cost at cycle start |
+|-------|--------|-----------------|---------------------|
+| **Self-evident** | L0–L3 | Isolation is structural — process boundary, Docker bridge, or SDK endpoint-override prevents external routing by construction | None — test passes trivially |
+| **Requires policy audit** | L4, L4+ | Isolation depends on network policies and RBAC that must be verified per deployment | Read and confirm the policy config is present and correctly scoped before each cycle |
+| **Programmatically auditable** | L5 | Isolation enforced by cloud org policies (SCPs, GCP Org Policy) and IAM boundaries queryable via API | Policy API call at cycle start; automation-friendly |
+
+A "requires policy audit" environment that hasn't been audited this cycle is **not
+qualified** — surface to human before proceeding autonomously.
+
+---
+
+## LocalStack licensing note
+
+LocalStack ended its Community Edition for commercial use in March 2024. Teams running
+LocalStack in a commercial context must use LocalStack Pro (paid) or choose an OSS
+alternative (Moto, LocalStack-OSS forks, Microcks) with narrower API coverage. This
+module references LocalStack as a technology example, not a mandatory tool; the doctrine
+is intentionally harness-neutral. Choose the emulator that fits your license posture.
+
+---
+
+## Build-pack handoff
+
+When a build pack ships a fidelity-ladder scaffold reference — Testcontainers configuration
+templates, LocalStack bootstrap scripts, Docker Compose service templates — the
+`work-loop` skill's ladder summary section should link to it. This module is the canonical
+level-descriptor reference; the build pack's scaffold reference extends it with
+tool-specific setup detail.

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -947,3 +947,29 @@ unattended doesn't mean *unconsidered*, it means *pre-considered*.
   in-session pass first to validate the approach.
 - **Looping without capturing learnings.** Every loop that ends without updating
   *some* doc, skill, or note is a loop whose lessons are lost.
+
+## Fidelity ladder
+
+When a task needs local-infra-equivalents — a fake, an emulator, a container —
+choose the level that fits the budget: **push up the ladder as high as a sub-5-minute
+local budget tolerates.**
+
+| Tier | Levels | Budget | Notes |
+|------|--------|--------|-------|
+| Always in-loop | L0 (in-memory fake), L1 (contract test) | < 1–10 s | Never skip these |
+| Inner-loop ceiling | L2 (Docker Compose), L3 (Testcontainers / LocalStack) | < 60 s – 3 min | Right ceiling for most services |
+| Outer-loop territory | L4 (k8s namespace), L4+ (vCluster), L5 (cloud sandbox) | minutes+ | CI-managed; not local builds |
+| Human-supervised | L6 (staging / pre-prod) | n/a | Never autonomous-zone |
+
+When a dependency cannot be represented at L0–L3 within budget, defer the integration
+test to the outer loop (the CI-managed ephemeral environment) rather than cutting the
+test or inflating the budget.
+
+The full ladder specification — per-level coverage, isolation gaps, the three-dimension
+outer-loop qualification test, and the provability classification — is in the
+`operational-safety` skill's `fidelity-ladder` reference module.
+
+**Build-pack handoff:** when a build pack ships a fidelity-ladder scaffold reference
+(Testcontainers templates, LocalStack bootstrap, Docker Compose service templates), it
+extends this section with tool-specific detail. Check the installed build pack first;
+fall back to the reference module's technology examples if none is installed.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -502,7 +502,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     {
       "author": {

--- a/.claude/skills/operational-safety/references/fidelity-ladder.md
+++ b/.claude/skills/operational-safety/references/fidelity-ladder.md
@@ -1,0 +1,195 @@
+# fidelity-ladder — inner-loop levels and outer-loop environment qualification
+
+> **Loaded when:** the task needs a local-infra-equivalent (inner loop) or must
+> qualify an ephemeral environment for autonomous outer-loop operation.
+> **Module role:** EXECUTE/QUALIFY — constructive guidance for choosing and
+> qualifying environments. The companion module
+> [`environment-isolation.md`](environment-isolation.md) is the REVIEW checklist
+> (auditing whether an existing environment meets the bar); this module specifies
+> how to build or choose one that does. Load both when both questions are live.
+> **Grounded in:** Testcontainers documentation, LocalStack documentation, Docker
+> Compose usage patterns, inner-dev-loop tools (Tilt, Skaffold), Argo Rollouts,
+> k8s NetworkPolicy and RBAC references, AWS multi-account-per-stage pattern
+> (SCP/org-policy enforcement), vCluster (Loft Labs) documentation.
+
+---
+
+## The seven-level fidelity ladder
+
+Levels L0–L3 are **inner-loop** (pre-push, developer-controlled). L4 and above
+are **outer-loop** (post-push, CI-managed). The boundary is the git push / PR-open
+event.
+
+| Level | Name | Technology examples | Coverage | Isolation provability |
+|-------|------|---------------------|----------|-----------------------|
+| L0 | In-memory fake | Hand-rolled stubs, in-process fakes, sqlite-in-memory | Single-process; no network; no external API | **Self-evident** — process boundary |
+| L1 | Contract / protocol test | Pact CDC, JSON Schema validation, gRPC reflection | Provider/consumer contract only; no running service | **Self-evident** — no network stack |
+| L2 | Compose-isolated | Docker Compose multi-service, devcontainer | Multi-service network; host filesystem; no cloud API emulation | **Self-evident** — Docker bridge prevents external egress |
+| L3 | Container-emulated | Testcontainers + LocalStack / Microcks / WireMock | Per-test isolation; cloud API emulation; SDK calls intercepted | **Self-evident** — SDK endpoint override captures all cloud API calls |
+| L4 | k8s namespace-isolated | Namespace-per-PR on a shared cluster (NetworkPolicy + RBAC required) | Real Kubernetes primitives; shared control plane | **Requires policy audit** — no network policy = shared blast radius |
+| L4+ | Virtual cluster | vCluster (Loft Labs) — dedicated API server inside host cluster | Stronger than namespace; softer than dedicated cluster | **Requires audit** — host cluster egress policy must be verified |
+| L5 | Cloud sandbox | Dedicated non-prod cloud account / project + isolated state backend | Real cloud APIs; real IAM; real billing (throttled); no prod credential path | **Programmatically auditable** — SCP/org policies verifiable via API |
+| L6 | Staging / pre-prod | Production-mirror; may carry anonymised prod data | Near-prod fidelity | **Human-supervised; never autonomous-zone** |
+
+---
+
+## Per-level descriptors
+
+```
+Level: L0 — In-memory fake
+Coverage:  single-process logic only
+Isolation: self-evident (process boundary — no network stack)
+Gaps:      no persistence, no real API, no multi-service behavior
+Use when:  testing a single function / adapter boundary in isolation
+Budget:    < 1 s; always in-loop
+```
+
+```
+Level: L1 — Contract / protocol test
+Coverage:  provider–consumer protocol agreement (Pact CDC, gRPC reflection, JSON Schema)
+Isolation: self-evident (no running service; no network calls made)
+Gaps:      no behavioral fidelity beyond the protocol boundary
+Use when:  verifying two components agree on the API shape without running both
+Budget:    < 10 s; always in-loop
+```
+
+```
+Level: L2 — Compose-isolated multi-service
+Coverage:  multi-service network topology; realistic routing between services
+Isolation: self-evident (Docker bridge prevents external egress by default)
+Gaps:      cloud API calls fail or are stubbed; shared containers across tests unless
+           explicit teardown
+Use when:  testing multi-service interactions that don't require real cloud APIs
+Budget:    < 60 s; inner-loop ceiling for most services
+```
+
+```
+Level: L3 — Container-emulated (Testcontainers + LocalStack / Microcks / WireMock)
+Coverage:  cloud API emulation (AWS S3, SQS, DynamoDB, etc.); per-test container lifecycle;
+           SDK calls intercepted before leaving the process
+Isolation: self-evident (SDK endpoint override captures all cloud API calls before they
+           reach a real endpoint)
+Gaps:      behavioral fidelity gaps (complex IAM conditions, cross-service event timing,
+           managed service internals); LocalStack commercial license required for production
+           use post-March 2024 (OSS alternatives: Moto, LocalStack-OSS forks, Microcks)
+Use when:  inner-loop tests that need cloud API behavior without a real account
+Budget:    30 s – 3 min; inner-loop ceiling for cloud-dependent services
+Note:      L3 is the inner-loop ceiling; fidelity gaps here are expected and are exactly
+           what the outer loop exists to catch
+```
+
+```
+Level: L4 — k8s namespace-isolated (requires policy audit)
+Coverage:  real Kubernetes primitives; per-PR namespace on a shared cluster
+Isolation: requires policy audit (shared control plane; NetworkPolicy + RBAC must be
+           present and verified per deployment — absent policies = L2-equivalent isolation)
+Gaps:      shared control plane blast radius; host-cluster egress policy applies to all
+           namespaces; not equivalent to account-level isolation
+Use when:  teams already running Kubernetes that want per-PR ephemeral environments
+           without dedicated cluster provisioning costs
+Qualification: qualifies for the outer loop only after the three-dimension policy audit
+               passes — "namespace isolation" without verified NetworkPolicy does not qualify
+```
+
+```
+Level: L4+ — Virtual cluster / vCluster (requires policy audit)
+Coverage:  own Kubernetes API server and control plane inside a host cluster
+Isolation: requires audit (stronger than namespace; host cluster egress policy still
+           applies; isolation claims are self-reported by vCluster project)
+Gaps:      host cluster egress policy is a shared blast radius; limited independent
+           security audit of isolation boundary in public literature
+Use when:  teams who need stronger-than-namespace isolation without dedicated cluster cost
+Qualification: same three-dimension audit required as L4; host cluster egress policy
+               must be verified in addition to the virtual cluster's own isolation
+```
+
+```
+Level: L5 — Cloud sandbox (the outer-loop qualification floor)
+Coverage:  real cloud APIs; real IAM; real networking; real billing (throttled/capped)
+Isolation: programmatically auditable (dedicated account/project boundary + isolated state
+           backend + no prod credential reachable; SCP/org policies verifiable via API)
+Gaps:      real billing cost; setup/teardown time (minutes); real data risk if
+           misconfigured (data isolation is not free — it must be enforced)
+Use when:  the outer release loop (autonomous zone); ephemeral environments
+Budget:    minutes to hours; outer-loop territory; teardown on cycle end mandatory
+           (see cost-and-teardown module)
+Note:      The `iac-terraform` pack's generate-iac skill scaffolds the account/workspace
+           boundary — the provisioning detail for this level lives there
+Qualification: satisfies all three outer-loop isolation dimensions when:
+               (a) the account/project has no VPC peering to prod,
+               (b) all data is synthetic / purpose-generated,
+               (c) state backends are isolated and not shared with other envs
+```
+
+```
+Level: L6 — Staging / pre-prod
+Coverage:  production-equivalent topology; may carry anonymised production data
+Isolation: human-supervised; never autonomous-zone
+Gaps:      may share blast radius with prod-adjacent services; cross-env contamination
+           risk if anonymisation is incomplete
+Use when:  human-supervised regression, load, or soak testing only
+Budget:    n/a (human-gated; not an outer-loop target)
+```
+
+---
+
+## Inner-loop budget heuristic
+
+**Push up the ladder as high as a sub-5-minute local budget tolerates.**
+
+- **L0–L1:** milliseconds — always in-loop; never skip these.
+- **L2–L3:** seconds to 3 minutes — the inner-loop ceiling for most services.
+- **L4 and above:** CI-managed; these are outer-loop territory, not local builds.
+
+When a task's dependency cannot be represented at L0–L3 within budget, that is the signal
+to defer the integration test to the outer loop (the CI-managed ephemeral environment)
+rather than lowering the budget or cutting the test.
+
+---
+
+## Outer-loop qualification: the three-dimension test
+
+The outer loop's "reversible" label requires all three isolation conditions to hold
+simultaneously. Each maps to a concrete, testable boolean:
+
+| Dimension | Condition | How to test |
+|-----------|-----------|-------------|
+| **Prod reachability** | No route from the ephemeral env to prod endpoints, prod databases, or prod identity stores | Network policy or security group audit confirms no ingress/egress to prod CIDR / prod account; credential scoping confirms the session cannot assume prod IAM roles |
+| **Data isolation** | No real user data accessible from the ephemeral env | Data classification review confirms env storage contains only synthetic, anonymized, or purpose-generated data; no prod snapshot was restored here |
+| **Inter-env isolation** | This ephemeral env cannot affect other running ephemeral or shared staging envs | Env resources (namespaces, accounts, VPCs, state backends) are unique to this cycle; no shared mutable state with other concurrent envs |
+
+**The test is boolean, not scored.** A single `false` is a consent-gate crossing — surface
+to human; do not proceed with autonomous deploy.
+
+---
+
+## Isolation provability classification
+
+| Class | Levels | What this means | Cost at cycle start |
+|-------|--------|-----------------|---------------------|
+| **Self-evident** | L0–L3 | Isolation is structural — process boundary, Docker bridge, or SDK endpoint-override prevents external routing by construction | None — test passes trivially |
+| **Requires policy audit** | L4, L4+ | Isolation depends on network policies and RBAC that must be verified per deployment | Read and confirm the policy config is present and correctly scoped before each cycle |
+| **Programmatically auditable** | L5 | Isolation enforced by cloud org policies (SCPs, GCP Org Policy) and IAM boundaries queryable via API | Policy API call at cycle start; automation-friendly |
+
+A "requires policy audit" environment that hasn't been audited this cycle is **not
+qualified** — surface to human before proceeding autonomously.
+
+---
+
+## LocalStack licensing note
+
+LocalStack ended its Community Edition for commercial use in March 2024. Teams running
+LocalStack in a commercial context must use LocalStack Pro (paid) or choose an OSS
+alternative (Moto, LocalStack-OSS forks, Microcks) with narrower API coverage. This
+module references LocalStack as a technology example, not a mandatory tool; the doctrine
+is intentionally harness-neutral. Choose the emulator that fits your license posture.
+
+---
+
+## Build-pack handoff
+
+When a build pack ships a fidelity-ladder scaffold reference — Testcontainers configuration
+templates, LocalStack bootstrap scripts, Docker Compose service templates — the
+`work-loop` skill's ladder summary section should link to it. This module is the canonical
+level-descriptor reference; the build pack's scaffold reference extends it with
+tool-specific setup detail.

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -947,3 +947,29 @@ unattended doesn't mean *unconsidered*, it means *pre-considered*.
   in-session pass first to validate the approach.
 - **Looping without capturing learnings.** Every loop that ends without updating
   *some* doc, skill, or note is a loop whose lessons are lost.
+
+## Fidelity ladder
+
+When a task needs local-infra-equivalents — a fake, an emulator, a container —
+choose the level that fits the budget: **push up the ladder as high as a sub-5-minute
+local budget tolerates.**
+
+| Tier | Levels | Budget | Notes |
+|------|--------|--------|-------|
+| Always in-loop | L0 (in-memory fake), L1 (contract test) | < 1–10 s | Never skip these |
+| Inner-loop ceiling | L2 (Docker Compose), L3 (Testcontainers / LocalStack) | < 60 s – 3 min | Right ceiling for most services |
+| Outer-loop territory | L4 (k8s namespace), L4+ (vCluster), L5 (cloud sandbox) | minutes+ | CI-managed; not local builds |
+| Human-supervised | L6 (staging / pre-prod) | n/a | Never autonomous-zone |
+
+When a dependency cannot be represented at L0–L3 within budget, defer the integration
+test to the outer loop (the CI-managed ephemeral environment) rather than cutting the
+test or inflating the budget.
+
+The full ladder specification — per-level coverage, isolation gaps, the three-dimension
+outer-loop qualification test, and the provability classification — is in the
+`operational-safety` skill's `fidelity-ladder` reference module.
+
+**Build-pack handoff:** when a build pack ships a fidelity-ladder scaffold reference
+(Testcontainers templates, LocalStack bootstrap, Docker Compose service templates), it
+extends this section with tool-specific detail. Check the installed build pack first;
+fall back to the reference module's technology examples if none is installed.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [release-engineering][0.1.6] — 2026-07-27
+
+### Added
+
+- **Ephemeral environment qualification** (`release-loop` skill): outer-loop ephemeral
+  environments must meet the L5 isolation floor (dedicated cloud account/project, or an
+  L4/L4+ k8s namespace/vCluster that passes a three-dimension policy audit — prod
+  reachability, data isolation, inter-env isolation). An environment below the floor is
+  a consent-gate crossing; L4/L4+ qualifies only after the policy audit passes.
+- **Polyrepo / value-stream topology** (`release-loop` skill): fleet manifest
+  (`release-fleet.yaml`) schema, canonical e2e host repo definition (Must/Must-NOT rules),
+  five-term harness-neutral deploy sequencing vocabulary (Component / Stage / Gate /
+  Depends-on / Release manifest), and a collect-then-validate pre-deploy phase that
+  runs RFC-0072 D6 provenance verification for every component before `infra-apply`.
+
+## [core][0.15.5] — 2026-07-27
+
+### Added
+
+- **`fidelity-ladder` reference module** (`operational-safety/references/`): seven-level
+  EXECUTE/QUALIFY reference (L0 in-memory fake through L6 staging) with per-level
+  coverage, gaps, budget heuristics, the three-dimension outer-loop qualification test,
+  and an isolation provability classification (self-evident / requires-policy-audit /
+  programmatically-auditable). Companion to the existing `environment-isolation` REVIEW
+  module; new module is constructive (how to choose / build), existing is audit (does it
+  meet the bar).
+- **Fidelity-ladder section** (`work-loop` skill): inner-loop budget heuristic (sub-5-min
+  rule; L0–L1 always; L2–L3 ceiling for most services), seven-level summary table,
+  cross-reference to `operational-safety/references/fidelity-ladder.md`, and a build-pack
+  handoff note.
+
 ## [release-engineering][0.1.5] — 2026-07-27
 
 ### Added

--- a/docs/rfc/0074-fidelity-ladder-and-ephemeral-env-qualification.md
+++ b/docs/rfc/0074-fidelity-ladder-and-ephemeral-env-qualification.md
@@ -1,0 +1,395 @@
+# RFC-0074: Inner-loop fidelity ladder and outer-loop ephemeral environment qualification
+
+<!-- Written for a cold reader who has not read the related RFCs. Coined terms
+are glossed on first use inline. -->
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-07-27
+- **Date closed:** 2026-07-27
+- **Decision weight:** standard <!-- Adds doctrine and a new reference module;
+  no adopter-facing interfaces are frozen. The isolation floor for the
+  "reversible" label is the most load-bearing claim — it constrains what
+  counts as an autonomous-zone action. -->
+- **Related:**
+  - [RFC-0049](0049-the-release-loop-and-company-os.md) (release-loop parent RFC —
+    **Accepted 2026-06-30**; Decision 3 explicitly defers the fidelity-ladder /
+    local-infra-equivalents to build packs as "a separate effort"; the outer loop's
+    isolation requirements are in AC3/AC10(h))
+  - [RFC-0072](0072-release-loop-deploy-doctrine.md) (sibling — G4 artifact format and
+    progressive delivery; **Accepted 2026-07-27**; the outer loop this RFC qualifies
+    ephemeral environments for)
+  - [RFC-0073](0073-slo-authoring-and-error-budget.md) (sibling — SLO-authoring;
+    **Accepted 2026-07-27**)
+  - [`docs/specs/release-loop/spec.md`](../specs/release-loop/spec.md) (AC3 / AC10(h)
+    — the "reversible" label conditioned on isolation; this RFC fills in the
+    qualification criteria those ACs require)
+  - `packs/core/.apm/skills/operational-safety/references/environment-isolation.md`
+    (the existing REVIEW module on isolation; this RFC adds a companion
+    EXECUTE/QUALIFY module to the same directory)
+  - `packs/core/.apm/skills/work-loop/SKILL.md` (the inner loop; gains a
+    fidelity-ladder section per D3)
+
+---
+
+## Reviewer brief
+
+- **Decision:** Whether to (a) adopt a seven-level inner-loop fidelity ladder specifying
+  what local-infra-equivalents each level provides, (b) specify the minimum outer-loop
+  ephemeral environment qualification level required for the "reversible" label to hold
+  under the minimum-regret carve, (c) home the ladder guidance in a new
+  `fidelity-ladder` EXECUTE/QUALIFY reference module added to `operational-safety`
+  (alongside the existing `environment-isolation` REVIEW module), and (d) surface that
+  home in both the `work-loop` and `release-loop` skills as doctrine cross-references.
+- **Recommended outcome:** Accept D1–D5.
+- **Change if accepted:**
+  - A new **`fidelity-ladder.md`** reference module lands in
+    `packs/core/.apm/skills/operational-safety/references/` (D1 / D2 / D4). It is an
+    EXECUTE/QUALIFY module (parallel to `cloud-implementation-craft`) — constructive
+    guidance for what to build, not a review checklist; the existing
+    `environment-isolation` module remains the REVIEW checklist.
+  - The **`work-loop` skill** gains a fidelity-ladder section: a seven-level ladder with
+    expected local-infra-equivalent coverage and a "push up the ladder" heuristic (D3).
+  - The **`release-loop` skill** gains an ephemeral environment qualification section:
+    the minimum isolation level, the qualification test, and the consequence of falling
+    below it (consent-gate crossing) (D2 / D5).
+  - `docs/specs/release-loop/spec.md` AC3 and AC10(h) receive a cross-reference note
+    to this RFC — no AC text changes.
+  - `packs/core/pack.toml` + `.claude-plugin/plugin.json` — patch version bump.
+  - `docs/product/changelog.md` — `[Unreleased]` entry.
+- **Affected surfaces:**
+  - New: `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md`
+  - `packs/core/.apm/skills/work-loop/SKILL.md` — new fidelity-ladder section
+  - `packs/release-engineering/.apm/skills/release-loop/SKILL.md` — new ephemeral
+    environment qualification section
+  - `docs/specs/release-loop/spec.md` — cross-reference notes on AC3 / AC10(h)
+  - `packs/core/pack.toml` + `.claude-plugin/plugin.json` — patch version bump
+  - `docs/product/changelog.md` — `[Unreleased]` entry
+- **Stakes:** Moderate. The "minimum qualification level for the reversible label" claim
+  in D2 constrains adopter behavior — environments that don't meet the floor are consent
+  gates, not autonomous-zone actions. This is correct behavior but must be stated clearly
+  so adopters understand the autonomy envelope.
+- **Review focus:** All decisions resolved in authoring session (D1–D5). D2 is the
+  most load-bearing — confirm the isolation floor is correctly drawn.
+- **Not in scope:** Building any local infra tooling or automation (the ladder is
+  doctrine, not a runtime). Specifying Testcontainers, LocalStack, or Docker Compose
+  configuration in detail (adopter-toolchain config). The `iac-terraform` pack's own
+  workspace isolation (a Terraform concern, not a fidelity-ladder concern). The
+  operate/incident loop.
+
+---
+
+## The ask
+
+**Recommendation:** Add a `fidelity-ladder` EXECUTE/QUALIFY reference module to
+`operational-safety` (in `core`) and cross-reference it from both the `work-loop` and
+`release-loop` skills, closing the gap RFC-0049 D3 deferred.
+
+**Why now (SCQA — Situation / Complication / Question / Answer):**
+
+*Situation:* The operating model has an inner loop (`work-loop`, local build) and an outer
+loop (`release-loop`, ephemeral deploy + e2e). The outer loop's autonomy rests on a single
+claim: the ephemeral environment is "reversible" — network- and data-isolated from prod,
+holds no real user data, cannot reach prod state (AC3 / AC10(h)). The inner loop's
+autonomy rests on a parallel claim: the local build is "self-sufficient" — it runs and
+verifies locally without the real deployed infra, using local-infra-equivalents.
+
+*Complication:* Neither claim has a specification of how to achieve it:
+
+- **Inner-loop gap (RFC-0049 D3 unfulfilled).** The inner loop's local-infra-equivalents
+  are the build pack's obligation (RFC-0049 D3: "fakes → contract tests → Testcontainers →
+  LocalStack → docker-compose"). But no build pack has shipped a fidelity-ladder reference.
+  An implementing `work-loop` agent must re-derive the ladder on every run — deciding
+  whether to use a fake, a container, or an emulator without principled guidance.
+- **Outer-loop gap (AC3 / AC10(h) underspecified).** The release-loop spec says an
+  environment that "cannot be proven isolated is itself a consent-gate crossing." It does
+  not say how to prove isolation. An implementing `release-lead` agent cannot classify a
+  k8s namespace, a LocalStack instance, or a dedicated cloud account as "proven isolated"
+  or "consent-gate" without criteria.
+
+*Question:* Can the ecosystem's settled fidelity-ladder patterns be expressed as
+harness-neutral doctrine that specifies the qualification criteria without prescribing
+a toolchain?
+
+*Answer:* Yes. The ecosystem has converged on a stable seven-level ladder from in-memory
+fakes through dedicated cloud sandbox accounts. Each level has deterministic isolation
+properties against the three qualifying dimensions (prod reachability, data isolation,
+inter-environment contamination). The qualification criteria map directly onto the
+outer loop's three "proven isolated" conditions, producing a clear floor: L5 (dedicated
+cloud account or equivalent — a k8s namespace or vCluster must additionally pass a
+three-dimension policy audit) is the minimum for the outer loop's "reversible" label.
+
+---
+
+## Decisions requested
+
+| ID | Question | Recommendation | Rationale | Decide by | Reviewer action |
+|----|----------|----------------|-----------|-----------|-----------------|
+| D1 | Inner-loop fidelity ladder: (A) adopt a seven-level ladder (L0 in-memory → L1 contract → L2 docker-compose → L3 container-emulated → L4 k8s-namespace → L4+ vCluster → L5 cloud sandbox → L6 staging) with defined local-infra-equivalent coverage and provability classification per level, or (B) leave the ladder entirely to adopter judgment? | **A — seven-level ladder** | RFC-0049 D3 adopted the fidelity-ladder obligation; the levels are the ecosystem's settled vocabulary (Testcontainers, LocalStack, Docker Compose, k8s namespace-per-PR documentation all use this progression). Option B repeats the gap: every adopter re-derives the ladder independently. | This review | Confirmed |
+| D2 | Outer-loop qualification floor: (A) specify L5 (dedicated cloud account / project, or k8s namespace/vCluster that passes a policy audit) as the minimum for the carve's "reversible" label, with a three-dimension qualification test and a provability classification (self-evident / requires-audit / programmatically-auditable), or (B) leave qualification to adopter discretion? | **A — L5 floor with a three-dimension qualification test** | The minimum-regret carve's "reversible" claim is load-bearing (it is what justifies autonomous outer-loop operation). Without a floor, an adopter could run the outer loop against a k8s namespace with no network policy (L2-equivalent isolation) and treat it as "reversible." The consequence of miscategorisation is incorrect autonomy — the loop acts as if the env is expendable when prod reachability remains. L4 (namespace) qualifies conditionally — only after a policy audit — which is the "requires-audit" provability class. | This review | Confirmed |
+| D3 | Inner-loop skill home: (A) add a fidelity-ladder section to the `work-loop` skill cross-referencing the new `fidelity-ladder` reference module, or (B) leave `work-loop` unchanged and wait for a build pack to carry it? | **A — `work-loop` skill gains the ladder section** | RFC-0049 D3 named the inner loop's fidelity ladder as a build pack obligation, but no build pack has shipped. Waiting further leaves the gap open indefinitely. Adding a section to `work-loop` is the inner-loop skill — it owns local build doctrine. When a build pack ships a deeper reference, it extends rather than replaces this section. | This review | Confirmed |
+| D4 | Reference module home: (A) a new `fidelity-ladder.md` EXECUTE/QUALIFY module in `operational-safety/references/` (alongside `environment-isolation.md`), or (B) a section inside the existing `environment-isolation.md` module, or (C) a new standalone skill? | **A — new `fidelity-ladder.md` in `operational-safety/references/`** | Option B conflates REVIEW (does this env meet the bar?) with EXECUTE (how to build an env that meets the bar) — the existing `environment-isolation` module is a REVIEW checklist and should remain so. Option C is premature (one reference file doesn't warrant a skill). A new module in the same directory follows `cloud-implementation-craft`'s EXECUTE precedent in `operational-safety`. | This review | Confirmed |
+| D5 | Outer-loop skill cross-reference: (A) the `release-loop` skill gains an "Ephemeral environment qualification" section with the L5 floor (and the L4/L4+ conditional path via policy audit), the three qualification dimensions, the provability classification, the agent-applicable test, and the consequence of falling below the floor, or (B) leave the consequence implicit in AC3/AC10(h)? | **A — explicit qualification section in `release-loop`** | AC3/AC10(h) state the consequence ("consent-gate crossing") but not the test. An implementing `release-lead` agent needs the test — a concrete, apply-once qualification step — not a prose reminder. The section is harness-neutral: the test is expressed as three boolean properties and a provability classification, not a tool invocation. | This review | Confirmed |
+
+*Default if no objection: adopt D1–D5 and proceed to implementation.*
+
+---
+
+## Problem and goals
+
+### The inner-loop gap: RFC-0049 D3 has no implementing artifact
+
+RFC-0049 D3 adopted "local-infra-equivalents a build-loop obligation — the fidelity
+ladder (fakes → contract tests → Testcontainers → LocalStack → docker-compose)." The
+decision was confirmed and the implementing spec was not required because it was a
+build-pack obligation, not a `core` obligation. But the `iac-terraform` pack — the
+only shipped build-adjacent pack — does not carry a fidelity-ladder reference. The
+`work-loop` skill has no ladder section. An implementing `work-loop` agent reads
+"push the inner loop as high up the fidelity ladder as a sub-5-min budget tolerates"
+(RFC-0049 Proposal) without knowing what the ladder is.
+
+### The outer-loop gap: the qualification test is absent
+
+`release-loop` AC3 states: "A deploy target that cannot be proven isolated is itself a
+consent-gate crossing (it is no longer reversible)." `release-loop` AC10(h) states: "The
+autonomous-zone isolation conditions (no prod reachability, no real data, isolated from
+other ephemeral envs) are the security floor under the 'reversible' label, not just a
+reviewer lens."
+
+Both ACs state the consequence without specifying the test. An implementing `release-lead`
+must determine at runtime whether a given environment satisfies the three isolation
+conditions. Without a qualification checklist, this judgment is free-form and inconsistent
+across adopters and agents.
+
+### Goals
+
+- Specify the seven-level inner-loop fidelity ladder with defined coverage per level.
+- Specify the three qualification dimensions and the L5 floor for the outer loop.
+- Home the ladder guidance in `operational-safety/references/fidelity-ladder.md`.
+- Surface the ladder in `work-loop` and the qualification test in `release-loop`.
+
+---
+
+## Evidence
+
+### The inner-loop fidelity ladder — ecosystem convergence
+
+The ecosystem has converged on a layered vocabulary that appears consistently across
+Testcontainers documentation, LocalStack documentation, Docker Compose usage patterns,
+and the inner-dev-loop tools (Tilt, Skaffold, Telepresence). No single canonical document
+(DORA, Google SRE, CNCF) publishes the full ladder; the most explicit practitioner
+articulations are the NashTech ".NET Fidelity Ladder" series and Martinfowler's practical
+test pyramid. The levels below are a harness-neutral synthesis.
+
+**The inner/outer loop boundary** is the git push / PR-open event. Everything before it
+(L0–L3) is inner-loop territory; everything after it (L4 and above, post-push CI-managed
+ephemeral environments) is outer-loop territory. Tools like Tilt and Skaffold that sync
+code live to a remote cluster straddle this boundary but are conventionally called
+"inner-loop tools" because the developer retains interactive control.
+
+| Level | Name | Technology examples | Coverage | Isolation provability |
+|-------|------|--------------------|-----------|-----------------------|
+| L0 | In-memory fake | Hand-rolled stubs, in-process fakes, sqlite-in-memory | Single-process; no network; no external API | **Self-evident** — process boundary |
+| L1 | Contract / protocol test | Pact CDC, JSON Schema validation, gRPC reflection | Provider/consumer contract only; no running service; protocol boundary | **Self-evident** — no network stack |
+| L2 | Compose-isolated | Docker Compose multi-service, devcontainer | Multi-service network; host filesystem; no cloud API emulation | **Self-evident** — Docker bridge prevents external routing |
+| L3 | Container-emulated | Testcontainers (per-test container lifecycle) + LocalStack / Microcks / WireMock | Per-test isolation; cloud API emulation; SDK calls intercepted before leaving process | **Self-evident** — SDK endpoint override captures all cloud API calls |
+| L4 | k8s namespace-isolated | Namespace-per-PR in a shared cluster with explicit NetworkPolicy + RBAC | Real Kubernetes primitives; shared control plane | **Requires policy audit** — no network policy = shared blast radius with other namespaces |
+| L4+ | Virtual cluster | vCluster (Loft Labs), dedicated API server inside host cluster | Stronger than namespace; softer than dedicated cluster | **Requires audit** — host cluster egress policy must be verified |
+| L5 | Cloud sandbox | Dedicated non-prod cloud account / project (AWS account-per-stage, GCP project-per-env); Terraform workspace with isolated state backend + no prod credential path | Real cloud APIs; real billing (throttled); separate IAM boundary; no prod credentials reachable | **Programmatically auditable** — SCP/org policies enforce the boundary; state backend isolation verifiable |
+| L6 | Staging/pre-prod | Production-mirror environment; may carry anonymised production data | Near-prod fidelity; human-gated; not an autonomous-zone target | Human-supervised; never autonomous |
+
+**Inner-loop budget heuristic:** Run as high up the ladder as a sub-5-minute local budget
+tolerates. L0–L1: milliseconds (always in-loop floor). L2–L3: seconds to 2 minutes
+(comfortable inner ceiling). L4–L4+ straddle the inner/outer boundary — they run in CI,
+not locally. L5 and above are the outer loop's domain.
+
+**LocalStack license note:** LocalStack ended its Community Edition for commercial use in
+March 2024. Teams running LocalStack in a commercial context must use LocalStack Pro
+(paid) or choose an OSS alternative (Moto, Localstack-OSS forks) with narrower API
+coverage. The doctrine references LocalStack as a technology example, not a mandatory
+tool; adopters choose their emulator. This fidelity-ladder reference is intentionally
+harness-neutral.
+
+**LocalStack / Testcontainers fidelity gaps (expected, not defects):** LocalStack emulates
+AWS service APIs at the HTTP layer; behavioral fidelity gaps exist (particularly for
+complex IAM conditions, cross-service event propagation timing, and managed service
+internals). These gaps are why the outer loop exists — they surface what the inner loop
+cannot catch.
+
+### The outer-loop qualification test — three dimensions
+
+The outer loop's "reversible" label requires all three isolation conditions to hold
+simultaneously. Each maps to a concrete, testable boolean:
+
+| Dimension | Condition | How to test |
+|-----------|-----------|-------------|
+| Prod reachability | No route from the ephemeral env to prod endpoints, prod databases, or prod identity stores | Network policy or security group audit confirms no ingress/egress to prod CIDR / prod account; credential scoping confirms the session cannot assume prod IAM roles |
+| Data isolation | No real user data accessible from the ephemeral env | Data classification review confirms the env's database/storage contains only synthetic, anonymized, or purpose-generated data; no prod snapshot was restored here |
+| Inter-env isolation | This ephemeral env cannot affect other running ephemeral envs or shared staging envs | Env resources (namespaces, accounts, VPCs, state backends) are unique to this cycle; no shared mutable state with other concurrent envs |
+
+**L5 as the minimum floor for the outer loop:** An environment at L5 (dedicated cloud
+account / project, or a k8s namespace with verifiable network policies, RBAC boundary,
+and isolated state backend) satisfies all three dimensions if correctly configured. An
+environment at L3 (container-emulated, LocalStack) is typically self-evidently isolated
+for the inner loop but does **not** satisfy the outer-loop isolation claim for arbitrary
+deploys — a LocalStack instance running in CI may share a Docker network with
+prod-credential-bearing processes. An environment at L4 / L4+ (k8s namespace or vCluster)
+requires explicit policy audit; the outcome of the audit determines whether it qualifies.
+
+**The qualification test is boolean, not scored:** The outer loop does not score
+environments against a fidelity rubric. It applies the three-dimension test at cycle start
+as a precondition for entering the autonomous zone. A single `false` is a consent-gate
+crossing — surface to human; do not proceed with autonomous deploy.
+
+### The isolation provability classification
+
+This classification drives the cost of the qualification step at cycle start:
+
+- **Self-evident** (L0–L3): isolation is structural. The process boundary, Docker bridge,
+  or SDK endpoint-override prevents external routing by construction. No policy audit
+  needed — the qualification test passes trivially.
+- **Requires policy audit** (L4 namespace, L4+ vCluster): isolation depends on network
+  policies and RBAC that must be verified per deployment. The qualification test requires
+  reading and confirming the policy configuration is present and correctly scoped.
+- **Programmatically auditable** (L5 dedicated account/project): isolation is enforced by
+  cloud org policies (SCPs, GCP Org Policy) and IAM boundaries that can be queried via API
+  before each cycle. The qualification test is a policy API call, not a human review.
+
+The outer loop's qualification step should apply the test appropriate to the
+environment's provability class. A "requires policy audit" environment that hasn't been
+audited in this cycle is not qualified — surface to human before proceeding.
+
+---
+
+## The fidelity-ladder specification (D1 elaboration)
+
+This is the content that lands in `operational-safety/references/fidelity-ladder.md`.
+Levels L0–L3 are inner-loop (pre-push); L4 and above are outer-loop (post-push, CI-managed).
+
+```
+Level: L0 — In-memory fake
+Coverage:  single-process logic only
+Isolation: self-evident (process boundary — no network stack)
+Gaps:      no persistence, no real API, no multi-service behavior
+Use when:  testing a single function / adapter boundary in isolation
+Budget:    < 1 s; always in-loop
+```
+
+```
+Level: L1 — Contract / protocol test
+Coverage:  provider–consumer protocol agreement (Pact CDC, gRPC reflection, JSON Schema)
+Isolation: self-evident (no running service; no network calls made)
+Gaps:      no behavioral fidelity beyond the protocol boundary
+Use when:  verifying two components agree on the API shape without running both
+Budget:    < 10 s; always in-loop
+```
+
+```
+Level: L2 — Compose-isolated multi-service
+Coverage:  multi-service network topology; realistic routing between services
+Isolation: self-evident (Docker bridge prevents external egress by default)
+Gaps:      cloud API calls fail or are stubbed; shared containers across tests unless
+           explicit teardown
+Use when:  testing multi-service interactions that don't require real cloud APIs
+Budget:    < 60 s; inner-loop ceiling for most services
+```
+
+```
+Level: L3 — Container-emulated (Testcontainers + LocalStack / Microcks / WireMock)
+Coverage:  cloud API emulation (AWS S3, SQS, DynamoDB, etc.); per-test container lifecycle;
+           SDK calls intercepted before leaving the process
+Isolation: self-evident (SDK endpoint override captures all cloud API calls before they
+           reach a real endpoint)
+Gaps:      behavioral fidelity gaps (complex IAM conditions, cross-service event timing,
+           managed service internals); LocalStack commercial license required for production
+           use post-March 2024 (OSS alternatives: Moto, LocalStack-OSS forks, Microcks)
+Use when:  inner-loop tests that need cloud API behavior without a real account
+Budget:    30 s – 3 min; inner-loop ceiling for cloud-dependent services
+Note:      L3 is the inner-loop ceiling; fidelity gaps here are expected and are exactly
+           what the outer loop exists to catch
+```
+
+```
+Level: L4 — k8s namespace-isolated (requires policy audit)
+Coverage:  real Kubernetes primitives; per-PR namespace on a shared cluster
+Isolation: requires policy audit (shared control plane; NetworkPolicy + RBAC must be
+           present and verified per deployment — absent policies = L2-equivalent isolation)
+Gaps:      shared control plane blast radius; host-cluster egress policy applies to all
+           namespaces; not equivalent to account-level isolation
+Use when:  teams already running Kubernetes that want per-PR ephemeral environments
+           without dedicated cluster provisioning costs
+Qualification: qualifies for the outer loop only after the three-dimension policy audit
+               passes — "namespace isolation" without verified NetworkPolicy does not qualify
+```
+
+```
+Level: L4+ — Virtual cluster (vCluster) (requires policy audit)
+Coverage:  own Kubernetes API server and control plane inside a host cluster
+Isolation: requires audit (stronger than namespace; host cluster egress policy still
+           applies; isolation claims are self-reported by vCluster project)
+Gaps:      host cluster egress policy is a shared blast radius; limited independent
+           security audit of isolation boundary in public literature
+Use when:  teams who need stronger-than-namespace isolation without dedicated cluster cost
+```
+
+```
+Level: L5 — Cloud sandbox (the outer-loop qualification floor)
+Coverage:  real cloud APIs; real IAM; real networking; real billing (throttled/capped)
+Isolation: programmatically auditable (dedicated account/project boundary + isolated state
+           backend + no prod credential reachable; SCP/org policies verifiable via API)
+Gaps:      real billing cost; setup/teardown time (minutes); real data risk if
+           misconfigured (data isolation is not free — it must be enforced)
+Use when:  the outer release loop (autonomous zone); ephemeral environments
+Budget:    minutes to hours; outer-loop territory; teardown on cycle end mandatory
+           (see cost-and-teardown module)
+Note:      The `iac-terraform` pack's generate-iac skill scaffolds the account/workspace
+           boundary — the provisioning detail for this level lives there
+Qualification: satisfies all three outer-loop isolation dimensions when:
+               (a) the account/project has no VPC peering to prod,
+               (b) all data is synthetic / purpose-generated,
+               (c) state backends are isolated and not shared with other envs
+```
+
+```
+Level: L6 — Staging / pre-prod
+Coverage:  production-equivalent topology; may carry anonymised production data
+Isolation: human-supervised; never autonomous-zone
+Gaps:      may share blast radius with prod-adjacent services; cross-env contamination risk
+           if anonymisation is incomplete
+Use when:  human-supervised regression, load, or soak testing only
+Budget:    n/a (human-gated; not an outer-loop target)
+```
+
+---
+
+## Drawbacks
+
+- **L5 floor may be too high for small teams.** A dedicated cloud sandbox account is an
+  IaC and billing overhead many small teams won't provision. Mitigated by naming k8s
+  namespace isolation with verifiable network policies + RBAC as a conditionally-qualifying
+  alternative (L4/L4+ via policy audit), lowering the bar for teams already running Kubernetes.
+- **Qualification test is manual on first use.** An implementing agent applies the
+  three-dimension test by reading network policy and IAM configuration — not by running a
+  tool. On first cycle, this is a human-assisted step. Mitigated by making the test
+  explicit (boolean, observable) rather than implicit (trust the adopter's assertion).
+- **L3/L4 blur creates judgment calls.** As noted above, k8s namespace isolation spans
+  the boundary. The qualification test resolves it, but there is one judgment call at the
+  network-policy audit step. Mitigated by the three-dimension test being specific enough
+  to guide the judgment deterministically in most cases.
+- **Inner-loop ladder section in `work-loop` is not a substitute for a build pack.**
+  Adding the ladder to `work-loop` closes the vocabulary gap but not the scaffolding
+  gap — an implementing agent still must choose and configure the tools. When a build
+  pack ships a fidelity-ladder reference with scaffold templates, that replaces this
+  section. This RFC names that handoff explicitly.
+
+## Follow-on artifacts
+
+On acceptance:
+- **New reference module:** `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md` — the seven-level ladder + the three-dimension qualification test per D1/D2.
+- **`work-loop` skill update:** new fidelity-ladder section cross-referencing the module, per D3.
+- **`release-loop` skill update:** new ephemeral environment qualification section (three-dimension test + L5 floor + consequence) per D5.
+- **Spec update:** `docs/specs/release-loop/spec.md` — cross-reference notes on AC3 and AC10(h) pointing to this RFC.
+- **Pack version bump:** `packs/core/pack.toml` + `.claude-plugin/plugin.json` — patch version bump (new reference module in `core`).
+- **Changelog:** `docs/product/changelog.md` — `[Unreleased]` entry.
+- **Future:** When a build pack ships a fidelity-ladder scaffold reference (Testcontainers config templates, LocalStack bootstrap, Docker Compose service templates), the `work-loop` ladder section should link to it — naming the handoff point explicitly so the build pack knows where to hook in.

--- a/docs/rfc/0075-polyrepo-value-stream-release-topology.md
+++ b/docs/rfc/0075-polyrepo-value-stream-release-topology.md
@@ -1,0 +1,388 @@
+# RFC-0075: Polyrepo / value-stream release topology
+
+<!-- Written for a cold reader who has not read the related RFCs. Coined terms
+are glossed on first use inline. -->
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-07-27
+- **Date closed:** 2026-07-27
+- **Decision weight:** standard <!-- Adds doctrine and extends the release-loop
+  skill; no adopter interface is frozen in v1 (the fleet manifest format carries
+  schema_version). The deploy-sequencing vocabulary is the most load-bearing
+  claim — it constrains how adopters declare inter-component dependencies. -->
+- **Related:**
+  - [RFC-0049](0049-the-release-loop-and-company-os.md) (release-loop parent RFC —
+    **Accepted 2026-06-30**; OQ1 names the polyrepo topology and references
+    ADR-0022 for cross-repo artifact referencing; AC9 names the "value-stream
+    cross-repo mechanism (reference-by-version + the read-only courier snapshot)"
+    that this RFC specifies)
+  - [RFC-0072](0072-release-loop-deploy-doctrine.md) (sibling — **Accepted 2026-07-27**;
+    D1 specifies the G4 handoff package that this RFC extends for the multi-component
+    case with the fleet manifest)
+  - [ADR-0022](../adr/0022-value-stream-meta-repo-cross-component-layer.md) (the
+    product-engineering cross-component layer — reference-by-version + courier snapshot;
+    this RFC applies the same pattern to release-loop coordination)
+  - [`docs/specs/release-loop/spec.md`](../specs/release-loop/spec.md) (AC9 references
+    the "value-stream cross-repo mechanism" this RFC specifies)
+
+---
+
+## Reviewer brief
+
+- **Decision:** Whether to specify — as harness-neutral doctrine extensions to the
+  `release-loop` skill — (a) a fleet manifest format for multi-component release
+  coordination, (b) a canonical e2e host repo definition, (c) a five-term harness-neutral
+  vocabulary for multi-service deploy sequencing, (d) the courier snapshot as the
+  cross-repo component version lock mechanism, and (e) a "collect-then-validate" pre-deploy
+  step that the outer loop runs in a polyrepo topology before entering the standard four
+  deploy phases.
+- **Recommended outcome:** Accept D1–D5.
+- **Change if accepted:**
+  - The `release-loop` skill gains a **Polyrepo topology** section with the fleet
+    manifest schema, the e2e host repo definition, the deploy sequencing vocabulary, and
+    the collect-then-validate pre-deploy step (D1–D5).
+  - `docs/specs/release-loop/spec.md` AC9 receives a cross-reference to this RFC as
+    the source of the cross-repo mechanism — no AC text changes (AC9 already mandates
+    the behaviors; this RFC fills in the "how").
+  - `packs/release-engineering/pack.toml` + `.claude-plugin/plugin.json` — patch
+    version bump.
+  - `docs/product/changelog.md` — `[Unreleased]` entry.
+- **Affected surfaces:**
+  - `packs/release-engineering/.apm/skills/release-loop/SKILL.md` — new Polyrepo
+    topology section added; no changes to existing sections
+  - `docs/specs/release-loop/spec.md` — cross-reference note on AC9
+  - `packs/release-engineering/pack.toml` + `.claude-plugin/plugin.json` — patch
+    version bump
+  - `docs/product/changelog.md` — `[Unreleased]` entry
+- **Stakes:** Moderate. The fleet manifest format is an extension of the G4 handoff
+  package (RFC-0072 D1) — it carries `schema_version` for independent evolution. The
+  sequencing vocabulary is the most load-bearing claim: adopters who declare
+  `depends_on` in the fleet manifest are making an explicit ordering commitment. Revising
+  the vocabulary requires a coordinated bump, but the v1 scope is deliberately minimal
+  to keep that surface small.
+- **Review focus:** All decisions resolved in authoring session (D1–D5). D3 (vocabulary)
+  is the most judgment-sensitive — confirm it maps onto real orchestrator primitives
+  without being too narrow.
+- **Not in scope:** Building any cross-repo orchestration runtime. Specifying ArgoCD,
+  Flux, or Spinnaker configuration (adopter toolchain). Changing `work-loop` (the inner
+  loop produces per-component G4 packages unchanged). Replacing ADR-0022 (which covers
+  the product-engineering meta-repo; this RFC covers the release-loop's cross-repo
+  coordination, a parallel but distinct concern). The operate/incident loop.
+
+---
+
+## The ask
+
+**Recommendation:** Extend the `release-loop` skill with a Polyrepo topology section that
+fills in the "value-stream cross-repo mechanism" AC9 references but does not yet specify.
+
+**Why now (SCQA — Situation / Complication / Question / Answer):**
+
+*Situation:* The `release-loop` skill (AC9) acknowledges that in a polyrepo / value-stream
+topology each component repo and the cross-component e2e host repo must install `core` +
+`release-engineering`, and states that "cross-repo artifact referencing uses the
+value-stream cross-repo mechanism (reference-by-version + the read-only courier
+snapshot)." RFC-0049 OQ1 names ADR-0022 (reference-by-version + courier snapshot) as the
+cross-repo mechanism for artifact referencing.
+
+*Complication:* ADR-0022 specifies the **product-engineering** cross-component layer: a
+meta-repo for feature coordination, per-component brief slicing, and a shared contract
+referenced by version. This is the upstream discovery/build coordination pattern. The
+release loop needs a **parallel but distinct** cross-repo mechanism: a way to assemble
+multiple component G4 packages into a jointly-validated fleet, declare inter-component
+deploy ordering, and coordinate the cross-component e2e suite — none of which ADR-0022
+addresses. Without this specification, three things are undefined:
+
+1. The fleet manifest: what the e2e host repo collects from component repos to declare
+   "these versions, deployed together, are what we validated."
+2. The e2e host repo: what it is allowed to contain, what it installs, and what triggers
+   its outer loop.
+3. Multi-service deploy sequencing: how inter-component ordering is declared in a
+   harness-neutral way that maps onto ArgoCD, Flux, Spinnaker, or GitHub Actions without
+   locking to any one tool.
+
+*Question:* Can the cross-component release coordination mechanism be specified as
+harness-neutral doctrine that extends the G4 handoff package pattern without building a
+new runtime or coordinator?
+
+*Answer:* Yes. The ecosystem has converged on a release manifest (version lock file) as the
+cross-component coordination artifact, and on a canonical e2e host repo shape (composition
++ tests + CI config; no component source). The five-term deploy sequencing vocabulary
+(Component, Stage, Gate, Depends-on, Release manifest) maps onto every major orchestrator
+without locking to one. The "collect-then-validate" pre-deploy step re-uses the outer
+loop's existing G4 validation logic applied once per component before the fleet is
+assembled. None of these require a runtime — they are file edits and policy checks, the
+same form the loop already uses.
+
+---
+
+## Decisions requested
+
+| ID | Question | Recommendation | Rationale | Decide by | Reviewer action |
+|----|----------|----------------|-----------|-----------|-----------------|
+| D1 | Fleet manifest format: (A) a version-controlled `release-fleet.yaml` file in the e2e host repo, with a defined schema that enumerates component versions + deploy ordering + phase overrides, extending the G4 handoff package pattern from RFC-0072 D1, or (B) leave fleet coordination format entirely to adopter toolchain? | **A — versioned `release-fleet.yaml` in the e2e host repo** | The G4 handoff package (RFC-0072 D1) is the per-component artifact; the fleet manifest is the multi-component assembly. Without it, the outer loop has no single artifact that records "these component versions, validated together." The courier snapshot pattern from ADR-0022 (reference the authority, carry a snapshot, never fork) applies directly: each component's G4 package is the authority; the fleet manifest carries versioned references to them. | This review | Confirmed |
+| D2 | E2e host repo definition: (A) specify a canonical e2e host repo structure (composition file + test suite + CI config; no component source; must install `core` + `release-engineering` at repo scope; consumes component artifacts from a registry, not source), or (B) leave e2e host repo structure entirely to adopter discretion? | **A — specify the canonical e2e host repo shape** | AC9 says the cross-component e2e host repo "must itself install `core` + `release-engineering`" — this is already doctrine. What's missing is what else it may and must NOT contain. Without specifying that it holds no component source (only registry coordinates), adopters may couple the host repo to component source trees, which defeats the version-independence that the fleet manifest provides. | This review | Confirmed |
+| D3 | Deploy sequencing vocabulary: (A) adopt a five-term harness-neutral vocabulary (Component, Stage, Gate, Depends-on, Release manifest) encoded in the fleet manifest's `deploy_sequence` field, or (B) use an orchestrator-specific vocabulary (ArgoCD sync waves, Spinnaker stage dependencies, Flux reconciliation ordering)? | **A — five-term harness-neutral vocabulary** | The ecosystem has three dominant orchestrators (ArgoCD, Flux, Spinnaker) with mutually incompatible DSLs for ordering (sync waves, HelmRelease `dependsOn`, sub-pipeline invocation). A doctrine RFC that locks to one of these excludes the other two. The five-term vocabulary maps onto all three: `depends_on` maps to ArgoCD sync waves, Flux `HelmRelease.spec.dependsOn`, and Spinnaker's `Pipeline` + `Check Preconditions` stage; `gate` maps to health checks, metric thresholds, or manual judgments in each tool. | This review | Confirmed |
+| D4 | Courier snapshot: (A) specify that the fleet manifest's component references use the same "reference-by-version + read-only courier snapshot" pattern as ADR-0022 — each component entry references its `image_ref` digest + G4 package path; the fleet manifest is the courier snapshot for the assembled fleet, committed alongside and read-only from that point, or (B) reference ADR-0022 without specifying the release-loop form? | **A — specify the release-loop form** | ADR-0022 specifies the product-engineering form (contract version + courier snapshot). The release-loop form is parallel but distinct: the "authority" is the per-component G4 package; the "courier snapshot" is the fleet manifest. Pointing at ADR-0022 without specifying the release-loop form leaves the adopter to derive the adaptation themselves. | This review | Confirmed |
+| D5 | Collect-then-validate pre-deploy step: (A) the outer loop runs a "collect" phase before the standard four deploy phases (infra-apply → service-deploy → smoke → canary) in which it reads each component's G4 package from the fleet manifest, validates each package (provenance check + digest re-check per RFC-0072 D6), and confirms the fleet manifest is consistent with the current registry state — only then advancing to infra-apply, or (B) leave the multi-component validation ordering to adopter judgment? | **A — explicit collect phase before the four standard phases** | RFC-0072 D6 (provenance verification) specifies the per-component validation step. In the polyrepo case, running that step for each component is the minimum before any deploy begins — otherwise, the fleet could deploy a subset of validated components and mix them with unvalidated ones. Making the collect phase explicit in the fleet manifest's `deploy_sequence` makes the multi-component ordering legible and auditable. | This review | Confirmed |
+
+*Default if no objection: adopt D1–D5 and proceed to implementation.*
+
+---
+
+## Problem and goals
+
+### AC9's cross-repo mechanism is named but not specified
+
+`release-loop` AC9 states: "In a polyrepo / value-stream topology each component repo and
+the cross-component-e2e host repo must themselves install `core` + `release-engineering`;
+absent that install the per-repo reuse is not sound and the loop surfaces the gap (fail-
+closed). Cross-repo artifact referencing (other components' contracts / specs / built
+versions) uses the value-stream cross-repo mechanism (reference-by-version + the read-only
+courier snapshot), not a new coordinator."
+
+RFC-0049 OQ1 adds: "the cross-component e2e runs in its `core`-bearing host repo" and
+references ADR-0022 (reference-by-version + the read-only courier snapshot) as the
+artifact-referencing mechanism. ADR-0022 specifies the product-engineering form — a
+meta-repo for feature coordination, brief slicing, and contract versioning — not the
+release-loop form. The release-loop's cross-repo mechanism needs its own specification:
+what the fleet manifest is, what the e2e host repo contains, and how multi-service deploy
+ordering is declared.
+
+### Goals
+
+- Specify the fleet manifest format as the cross-component release coordination artifact.
+- Specify the canonical e2e host repo structure.
+- Specify the five-term deploy sequencing vocabulary.
+- Specify the collect-then-validate pre-deploy step for the polyrepo outer loop.
+- Cross-reference the result from AC9 of the release-loop spec.
+
+---
+
+## Evidence
+
+### The fleet manifest / release manifest pattern
+
+The ecosystem has converged on a version lock file (release manifest) as the
+cross-component coordination artifact. Examples: `release-please` manifest
+(`release-please-config.json` + `.release-please-manifest.json`), Renovate's
+dependency lock, and the Git-ops config-repo pattern (Flux, ArgoCD). The common pattern:
+
+- Each component repo's CI produces an immutable versioned artifact (OCI image with digest,
+  Helm chart in OCI registry) and pushes it to a registry.
+- A config / integration repo holds a manifest file recording the pinned version of every
+  component: `{"auth-service": "1.4.2@sha256:...", "billing-api": "2.0.0@sha256:..."}`.
+- CI in each component repo opens a bot PR against the config repo to bump its entry.
+- The integration pipeline validates the manifest by composing those versions and running
+  the e2e suite.
+
+This file is the "courier snapshot" from ADR-0022's pattern applied to the release loop:
+it captures the exact component set that was jointly validated, immutably.
+
+### The e2e host repo pattern
+
+The settled structure for cross-component testing (Codefresh, CircleCI, and GitHub Actions
+cross-repo dispatch documentation; confirmed by practitioner survey across integration
+testing guides):
+
+- **Composition file** — a Docker Compose file, Helm umbrella chart, or Kustomize overlay
+  that references versioned artifacts (images by digest, charts by version) from the fleet
+  manifest. Component source is never imported — only registry coordinates.
+- **Test suite** — end-to-end tests treating the composed system as a black box (Cypress,
+  Playwright, k6, Karate). No per-component unit or integration tests.
+- **CI configuration** — a workflow triggered by the fleet manifest PR merge, or by a
+  `repository_dispatch` event from a component repo's CI carrying the new component version.
+- **No component source.** The host repo installs nothing from component repos at the code
+  level — it consumes only registry-published artifacts.
+
+### Harness-neutral deploy sequencing vocabulary
+
+The five terms map onto the three dominant orchestrators:
+
+| Term | Definition | ArgoCD | Flux | Spinnaker / GHA |
+|------|-----------|--------|------|-----------------|
+| **Component** | A deployable unit with its own repo and version stream | `Application` | `Kustomization` / `HelmRelease` | stage target / service |
+| **Stage** | A named deploy target (staging, canary, production) | project / cluster | namespace | pipeline environment |
+| **Gate** | A blocking decision point (automated or human) | health check / sync status | readiness gate | `Check Preconditions` / `Manual Judgment` |
+| **Depends-on** | Component B must not deploy until component A passes its gate in the same stage | sync wave ordering | `HelmRelease.spec.dependsOn` | `Pipeline` sub-stage + wait |
+| **Release manifest** | A file recording the pinned version of every component for this release | `Application` image tag | image policy marker | `Release` artifact |
+
+### Multi-service deploy ordering — ArgoCD sync waves
+
+ArgoCD's native inter-child ordering mechanism is the `argocd.argoproj.io/sync-wave`
+annotation. Sync waves are integer values — lower numbers sync first; wave N+1 starts only
+after all resources in wave N are healthy. This maps directly onto `depends_on` in the
+fleet manifest's `deploy_sequence` field: a component with `depends_on: [auth-service]`
+is assigned a higher sync wave than `auth-service`. The fleet manifest declares the intent;
+the adopter's orchestrator translates it to tool-specific primitives (sync waves for ArgoCD,
+`dependsOn` for Flux, `Pipeline` sub-stages for Spinnaker, `needs:` for GitHub Actions).
+
+### Cross-repo dispatch limitations
+
+GitHub Actions' `repository_dispatch` (API-triggered, `GITHUB_TOKEN` cannot fire it — a
+PAT or GitHub App token is required) does not provide a native "wait for remote workflow"
+primitive. Teams implement it via polling. This is widely used but not stable for
+high-stakes release pipelines at scale. The doctrine does not prescribe `repository_dispatch`
+as the triggering mechanism — the fleet manifest PR merge, a registry event webhook, or
+a scheduled reconciliation loop are all valid signals. The dispatch implementation is
+adopter toolchain.
+
+---
+
+## The fleet manifest schema (D1 elaboration)
+
+The `release-fleet.yaml` file is committed to the e2e host repo by the release coordinator
+(a bot PR from each component repo's CI bumping its entry, or a human-authored fleet
+cut). It is read-only from merge time onward. Mandatory fields:
+
+```yaml
+schema_version: "1.0"           # semver; outer loop reads this first
+fleet_name: <string>             # e.g. "billing-platform"
+assembled_at: <RFC3339>          # timestamp of fleet assembly
+
+components:                      # one entry per deployable component
+  - name: <string>               # e.g. "auth-service"
+    repo: <org/repo>             # harness-neutral identifier; adopter fills in the URL
+    g4_package_ref: <path or URL> # path to the component's release-handoff.yaml in the
+                                  # component repo at the pinned commit
+    image_ref: "<registry>/<repo>:<tag>@sha256:<hex>"  # combined form; must match
+                                                         # g4_package's component_manifest
+
+deploy_sequence:                 # optional; defaults to parallel if absent
+  - component: auth-service
+    depends_on: []               # no dependency; deploys first
+    gate: auto
+  - component: billing-api
+    depends_on: [auth-service]   # waits for auth-service's gate to pass
+    gate: auto
+  - component: web-frontend
+    depends_on: [billing-api]
+    gate: manual                 # explicit human gate before this component advances
+
+e2e_suite_ref:                   # reference to the e2e test suite in this host repo
+  path: tests/e2e/               # relative path in the host repo
+  runner: <string>               # hint: "playwright" | "cypress" | "k6" | "karate"
+```
+
+**Schema compatibility:** the outer loop reads `schema_version` first. An unknown version
+surfaces to the human; the tolerant reader rule (unknown fields ignored) applies. Adopters
+may extend the schema with additional fields.
+
+**Courier snapshot discipline:** each `g4_package_ref` is a version-pinned, read-only
+reference to the component's authority (its G4 package). The fleet manifest is the courier
+snapshot — it records the assembly for audit purposes. Neither the fleet manifest nor the
+host repo forks the component's G4 package; the package remains the component repo's
+authority.
+
+---
+
+## The e2e host repo specification (D2 elaboration)
+
+**Must contain:**
+- `release-fleet.yaml` (the fleet manifest — this is the outer loop's entry point).
+- A composition file (`docker-compose.yaml`, Helm umbrella chart, or Kustomize overlay)
+  that reads image references from the fleet manifest and composes the deployed fleet
+  locally or against a cluster.
+- An e2e test suite that treats the composed system as a black box — every test assertion
+  goes through service APIs or UI surfaces, never through internal component APIs.
+- CI configuration that triggers the outer loop on fleet manifest merge or
+  `repository_dispatch` / registry-event webhook.
+
+**Must NOT contain:**
+- Component application source code (any component source).
+- Per-component unit or integration tests (those belong in the component repo's inner loop).
+- Credentials or secrets in source (all secrets are broker-mediated per AC10(g)).
+
+**Must install:** `core` + `release-engineering` at repo scope — the same precondition
+as any component repo that runs the outer loop (AC9). This is what makes the reuse of
+`quality-engineer` and `security-reviewer` sound in the host repo.
+
+**Triggering convention (harness-neutral):** the fleet manifest is updated by one of:
+(a) a bot PR from each component repo's CI (opens a PR bumping `components[N].image_ref`
+to the new digest), merged by the adopter's merge policy; or (b) a scheduled
+reconciliation loop that queries each component registry for the latest passing-gate
+version and assembles a new fleet manifest. Option (a) is the more common pattern; option
+(b) is appropriate when components release continuously. The trigger implementation is
+adopter toolchain.
+
+---
+
+## The collect-then-validate pre-deploy step (D5 elaboration)
+
+In the polyrepo outer loop, the standard four deploy phases (infra-apply → service-deploy →
+smoke → canary from RFC-0072 D2) are preceded by a **collect phase**:
+
+```
+Collect phase (before infra-apply):
+  for each component in fleet_manifest.components:
+    1. Read the component's g4_package_ref and fetch its release-handoff.yaml.
+    2. Run RFC-0072 D6 provenance verification against the component's image_ref.
+    3. Confirm the image_ref in the fleet manifest matches the image_ref in the
+       component's G4 package (the fleet manifest's courier snapshot must be
+       consistent with the current registry state).
+    4. If any component fails steps 1–3: surface to human with the specific mismatch;
+       do not proceed to infra-apply.
+  On all-pass: advance to infra-apply with the verified fleet.
+```
+
+The collect phase is the fleet-level equivalent of the per-artifact provenance check from
+RFC-0072 D6. In the single-component case the collect phase is a no-op (one component in
+the fleet manifest; equivalent to the standard G4 validation). In the multi-component case
+it ensures that all component versions in the fleet are jointly provenance-verified before
+any deploy begins.
+
+---
+
+## The monorepo case
+
+In a single-product monorepo the build repo *is* the integrated whole, so there is no e2e
+host repo and no fleet manifest — the single-component G4 package (RFC-0072 D1) is
+sufficient. The collect phase is a no-op (one component). The monorepo case is the
+minimum; the polyrepo fleet manifest is the generalization. Adopters start with the
+minimum and adopt the fleet manifest only when they have multiple component repos that
+must deploy jointly.
+
+---
+
+## Drawbacks
+
+- **Fleet manifest version bumps require coordination.** When a component changes its G4
+  package schema (RFC-0072 D1 schema), the fleet manifest's `g4_package_ref` entries may
+  need updating. Mitigated by the tolerant reader pattern (unknown G4 package fields
+  ignored) and the `schema_version` field enabling soft migration.
+- **Bot PR approach creates merge queue pressure.** If many components release frequently,
+  the bot PR approach generates a high volume of PRs against the host repo. Mitigated by
+  batching fleet manifest bumps (one PR per release window) or adopting the scheduled
+  reconciliation approach (option b in the triggering convention).
+- **No native cross-repo ordering in some orchestrators.** GitHub Actions `repository_dispatch`
+  has no native "wait for remote workflow" primitive. Teams polling for completion introduce
+  latency and fragility. Mitigated by the doctrine not prescribing `repository_dispatch` as
+  the triggering mechanism — registry-event webhooks or the fleet manifest PR merge are
+  more reliable signals.
+- **The collect phase adds latency.** Verifying provenance for N components before
+  any deploy begins adds clock time. Mitigated by the fact that each per-component check
+  is a registry API call (seconds, not minutes) and that the alternative — deploying
+  unverified components — violates AC10(g) supply-chain integrity.
+- **ADR-0022 vs. RFC-0075 confusion risk.** ADR-0022 covers the product-engineering
+  cross-component layer; this RFC covers the release-loop's cross-repo coordination.
+  The two are parallel, not redundant, but adopters may conflate them. Mitigated by
+  naming the distinction explicitly in the skill section and in the AC9 cross-reference.
+
+## Follow-on artifacts
+
+On acceptance:
+- **Skill update:** `packs/release-engineering/.apm/skills/release-loop/SKILL.md` — new
+  Polyrepo topology section per D1–D5 as described in the Reviewer brief. The section
+  includes the fleet manifest schema, the e2e host repo definition, the deploy sequencing
+  vocabulary table, and the collect phase specification.
+- **Spec update:** `docs/specs/release-loop/spec.md` — cross-reference note on AC9
+  pointing to this RFC as the source of the value-stream cross-repo mechanism.
+- **Pack version bump:** `packs/release-engineering/pack.toml` +
+  `.claude-plugin/plugin.json` — patch version bump.
+- **Changelog:** `docs/product/changelog.md` — `[Unreleased]` entry.
+- **Future:** When the operate/incident loop ships, the fleet manifest should carry an
+  `on_call_owner` field per component — the incident loop's equivalent of the
+  release-readiness record's operational-safety verdicts. Noting the hook point here so
+  the fleet manifest schema is designed with that extension in mind.

--- a/docs/specs/release-loop-gap-extensions/plan.md
+++ b/docs/specs/release-loop-gap-extensions/plan.md
@@ -1,0 +1,251 @@
+# Plan: release-loop-gap-extensions
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done
+
+## Self-coverage disposition record
+
+**Resolve:** All fidelity-ladder levels and their properties are specified in RFC-0074
+(grounded by ecosystem evidence — Testcontainers, LocalStack, vCluster, AWS multi-account
+patterns). The fleet manifest schema, e2e host repo definition, and deploy sequencing
+vocabulary are specified in RFC-0075 (grounded by release-please, Flux/ArgoCD patterns).
+Both RFCs are self-contained; no additional domain-grounding check fires.
+
+**Surface (irreducible):** The L4/L4+ "requires policy audit" claim is judgment-sensitive —
+an implementing agent must assess whether the adopter's cluster network policies are correctly
+scoped. This is acknowledged in RFC-0074's Drawbacks section and surfaced explicitly in the
+qualification section's boolean test. It cannot be made self-evident by doctrine alone; the
+surface is the correct response.
+
+**Declined patterns (named at PLAN, binding at REVIEW):**
+
+- *Tempted to create a standalone `fidelity-ladder` skill.* Declining — the reference module
+  is consumed by `work-loop` and `release-loop`; it is not user-invocable. A skill with
+  a `description:` frontmatter field would appear in the skill catalogue, which is incorrect.
+- *Tempted to extend `environment-isolation.md` inline.* Declining — that module is REVIEW
+  (does this environment meet the bar?); the fidelity-ladder is EXECUTE/QUALIFY (how to build
+  one that does). Conflating them corrupts the role distinction that the rest of the
+  `operational-safety/references/` directory maintains.
+- *Tempted to create a `fleet-manifest.md` reference file in `release-engineering`.* Declining
+  — the fleet manifest schema has exactly one consumer today (the Polyrepo topology section).
+  Extracting to a reference file before a second consumer appears is premature.
+- *Tempted to add a coordinator script for fleet manifest assembly.* Declining — ADR-0031
+  prohibits new executables; the fleet assembly is a bot PR / CI workflow, which is
+  adopter toolchain, not a skill artifact.
+
+## Tasks
+
+### T1 — Create `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md`
+
+**Depends on:** none
+**Verification mode:** Visual / manual QA (reference module is a user-consumed artifact; structural
+  presence verified by test -f and grep AC1–AC4)
+**Done when:** File exists; AC1 (`test -f`), AC2 (7+ level entries), AC3 (three provability
+  classes), AC4 (three qualification dimensions) all pass.
+
+**Approach:**
+Create the file as an EXECUTE/QUALIFY module (not REVIEW — no frontmatter `description:`
+field; this is a reference file, not a skill). Structure:
+- Opening: module role (EXECUTE/QUALIFY; loaded when the agent chooses a local-infra-equivalent
+  or qualifies an ephemeral environment for the outer loop); distinction from
+  `environment-isolation.md` (which is REVIEW).
+- Seven-level ladder table: columns — Level, Name, Technology examples, Coverage, Isolation
+  provability; rows L0–L3 (inner-loop) and L4/L4+/L5/L6 (outer-loop boundary and above).
+  Mark L0–L3 as inner-loop, L4+ as outer-loop.
+- Per-level descriptors (structured text blocks matching RFC-0074 §fidelity-ladder-specification):
+  Level, Coverage, Isolation, Gaps, Use when, Budget (where applicable), Note/Qualification.
+- LocalStack license note (March 2024 commercial license change; harness-neutral stance).
+- Inner-loop budget heuristic (sub-5-minute rule; L0–L1 always; L2–L3 ceiling).
+- The three-dimension outer-loop qualification test (table: Dimension / Condition / How to test).
+- Provability classification section: self-evident / requires-policy-audit /
+  programmatically-auditable; which levels map to each class.
+- L5 floor section: why L5 is the minimum; what "correctly configured" means in three boolean
+  conditions; L4/L4+ conditional qualification via policy audit.
+
+**Tests (goal-based):**
+```bash
+test -f packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -c "^Level: L" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+# expected: 8 (L0, L1, L2, L3, L4, L4+, L5, L6)
+grep -i "self-evident" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -i "requires policy audit\|requires-policy-audit" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -i "programmatically auditable\|programmatically-auditable" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -i "prod reachability" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -i "data isolation" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+grep -i "inter-env isolation\|inter.env isolation" packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+```
+
+---
+
+### T2 — Add fidelity-ladder section to `packs/core/.apm/skills/work-loop/SKILL.md`
+
+**Depends on:** none (independent file; can run concurrently with T1)
+**Verification mode:** Visual / manual QA (skill content; grep AC5)
+**Done when:** A "fidelity ladder" or "Fidelity ladder" heading exists in SKILL.md after
+  `## Anti-patterns to refuse`; section cross-references the fidelity-ladder module; section
+  contains the "push up the ladder" budget heuristic and level tokens L0 and L5.
+
+**Approach:**
+Append a new `## Fidelity ladder` section after the existing `## Anti-patterns to refuse`
+section (currently the last section at line ~912). Section content per RFC-0074 D3:
+- When to consult (when the task needs local-infra-equivalents).
+- Brief summary of the seven levels with the inner-loop budget heuristic (sub-5 min floor).
+- Cross-reference pointer: "The full ladder specification — level descriptors, isolation
+  provability classifications, and the outer-loop qualification test — is in
+  `operational-safety/references/fidelity-ladder.md`."
+- The "push up the ladder" heuristic: prefer the highest fidelity level that fits the budget;
+  L0–L1 are always in-loop; L2–L3 are the inner-loop ceiling for most services; L4 and above
+  are CI-managed (outer-loop territory).
+- Build-pack handoff note: when a build pack ships a fidelity-ladder scaffold reference, that
+  replaces this section's ladder detail — note the hook point explicitly.
+
+**Tests (goal-based):**
+```bash
+grep -i "## Fidelity ladder\|## fidelity" packs/core/.apm/skills/work-loop/SKILL.md
+grep -i "fidelity-ladder.md" packs/core/.apm/skills/work-loop/SKILL.md
+# expected: at least one match (cross-reference)
+grep "sub-5\|push up" packs/core/.apm/skills/work-loop/SKILL.md
+# expected: heuristic text present
+grep "L0\|L5" packs/core/.apm/skills/work-loop/SKILL.md
+# expected: level tokens present
+```
+
+---
+
+### T3 — Add two new sections to `release-loop/SKILL.md`
+
+**Depends on:** none (independent file from T1/T2; but both sections go in the same file,
+  so author sequentially in one edit pass)
+**Verification mode:** Visual / manual QA (skill content; grep AC6, AC9–AC11)
+**Done when:** Both sections exist in the file; all grep checks for AC6, AC9, AC10, AC11 pass.
+
+**Approach:**
+Append two new `##` sections after the existing `## Artifact provenance verification` section
+(currently the last section, ending around line 590):
+
+**Section A: `## Ephemeral environment qualification`** (RFC-0074 D5)
+- When to run: at outer-loop cycle start, before the collect phase (or infra-apply in the
+  mono-component case).
+- The L5 floor statement: "An ephemeral environment must meet L5 (dedicated cloud account
+  / project, or a k8s namespace or vCluster that has passed the three-dimension policy
+  audit) for the 'reversible' label to hold under the minimum-regret carve. An environment
+  below this floor is a consent-gate crossing — surface to human; do not proceed with
+  autonomous deploy."
+- The three qualification dimensions (table: Dimension / Condition / How to test), matching
+  the fidelity-ladder module exactly.
+- The provability classification summary (self-evident / requires-audit / programmatically-
+  auditable) with which action each class requires at cycle start.
+- L4/L4+ conditional path: qualifies only after a policy audit per the requires-audit class;
+  absent the audit, treat as a consent gate.
+- Pointer to `operational-safety/references/fidelity-ladder.md` for the full ladder and
+  level descriptors.
+
+**Section B: `## Polyrepo topology`** (RFC-0075 D1–D5)
+- Single-component (monorepo) case: collect phase is a no-op; no fleet manifest needed.
+- Fleet manifest (`release-fleet.yaml`) schema block with all mandatory fields:
+  `schema_version`, `fleet_name`, `assembled_at`, `components[]` (name, repo, g4_package_ref,
+  image_ref), `deploy_sequence[]` (component, depends_on, gate), `e2e_suite_ref`.
+- Courier snapshot discipline note: the fleet manifest is the courier snapshot; `g4_package_ref`
+  is the version-pinned authority pointer; neither the fleet manifest nor the host repo forks
+  component G4 packages.
+- Canonical e2e host repo definition (Must contain / Must NOT contain / Must install).
+- Five-term vocabulary table (Component / Stage / Gate / Depends-on / Release manifest)
+  with orchestrator mapping columns (ArgoCD / Flux / Spinnaker + GHA).
+- Collect-then-validate pre-deploy step specification (pseudocode block): for each component
+  in fleet_manifest.components — fetch g4_package_ref, run RFC-0072 D6 provenance check,
+  confirm image_ref consistency; on all-pass → advance to infra-apply; on any failure →
+  surface to human.
+- ADR-0022 distinction note: "ADR-0022 covers the product-engineering meta-repo for feature
+  coordination; this mechanism covers the release-loop's cross-repo coordination — parallel
+  but distinct."
+- Triggering conventions (bot PR approach vs. scheduled reconciliation).
+
+**Tests (goal-based):**
+```bash
+grep -i "## Ephemeral environment qualification\|## ephemeral" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep "L5" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "consent gate" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -c "Prod reachability\|Data isolation\|Inter-env isolation" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+# expected: 3
+grep -i "## Polyrepo topology\|## polyrepo" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep "schema_version" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep "fleet_name\|assembled_at\|g4_package_ref\|deploy_sequence\|image_ref\|e2e_suite_ref" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+# expected: all present
+grep -i "collect" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "infra-apply" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep "provenance" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "must not contain\|no component source" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -c "Component\|Stage\|Gate\|Depends-on\|Release manifest" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "courier snapshot" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "does not fork\|never fork\|read-only reference" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep -i "requires policy audit\|requires-policy-audit" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+grep "L4+" packs/release-engineering/.apm/skills/release-loop/SKILL.md
+```
+
+---
+
+### T4 — Add cross-reference notes to `docs/specs/release-loop/spec.md`
+
+**Depends on:** none (independent file — cross-reference markers point at RFC numbers, not at skill content)
+**Verification mode:** goal-based (grep AC7, AC12)
+**Done when:** RFC-0074 appears near AC3 and AC10(h) (at least 2 matches); RFC-0075 appears
+  near AC9 (at least 1 match).
+
+**Approach:**
+For AC3 in `docs/specs/release-loop/spec.md`: append `(→ RFC-0074 for the qualification test
+and provability classification)` or equivalent after the AC's final sentence.
+For AC10(h): append `(→ RFC-0074 D2 / D5 for the isolation floor and the three-dimension test)`.
+For AC9: append `(→ RFC-0075 for the fleet manifest schema, e2e host repo definition, and
+deploy sequencing vocabulary)`.
+No AC text changes — these are additive reference markers.
+
+**Tests (goal-based):**
+```bash
+grep -c "RFC-0074" docs/specs/release-loop/spec.md
+# expected: ≥ 2
+grep "RFC-0075" docs/specs/release-loop/spec.md
+# expected: ≥ 1
+```
+
+---
+
+### T5 — Version bumps, changelog, build-self, lint gates, mark spec shipped + RFCs Accepted
+
+**Depends on:** T1, T2, T3, T4
+**Verification mode:** goal-based
+**Done when:** Both packs at their new versions; changelog updated; build-self exits 0;
+  all lint gates pass; this spec's Status is Shipped and all ACs checked; both RFCs Accepted.
+
+**Approach:**
+1. Edit `packs/core/pack.toml`: `version = "0.15.4"` → `"0.15.5"`
+2. Edit `packs/core/.claude-plugin/plugin.json`: `"version": "0.15.4"` → `"0.15.5"`
+3. Edit `packs/release-engineering/pack.toml`: `version = "0.1.5"` → `"0.1.6"`
+4. Edit `packs/release-engineering/.claude-plugin/plugin.json`: `"version": "0.1.5"` → `"0.1.6"`
+5. Add `[Unreleased]` changelog entries to `docs/product/changelog.md`:
+   - `core` 0.15.5: new `fidelity-ladder` reference module in `operational-safety`; new
+     fidelity-ladder section in `work-loop`.
+   - `release-engineering` 0.1.6: new ephemeral environment qualification section and
+     Polyrepo topology section in `release-loop`.
+6. Fix RFC-0074 wording before Accepted flip: change "six-level" → "seven-level" in reviewer
+   brief (line ~38 and ~52) and goals section (line ~167); change "L4 floor" → "L5 floor" in
+   the Ask/Answer paragraph (line ~121) and goals section (line ~168); change "minor version
+   bump" → "patch version bump" in the Reviewer brief Change-if-accepted and Follow-on
+   artifacts sections.
+7. Fix RFC-0075 wording: change "minor version bump" → "patch version bump" in the Reviewer
+   brief Change-if-accepted and Follow-on artifacts sections.
+8. Set RFC-0074 Status: Accepted + Date closed: 2026-07-27
+9. Set RFC-0075 Status: Accepted + Date closed: 2026-07-27
+10. Run `make build-self`
+11. Run `make build-check`
+12. Run `python tools/lint-agents-md.py`
+13. Set this spec Status: Shipped; mark AC1–AC16 `[x]`
+
+**Tests (goal-based):**
+```bash
+grep 'version = "0.15.5"' packs/core/pack.toml
+grep '"version": "0.15.5"' packs/core/.claude-plugin/plugin.json
+grep 'version = "0.1.6"' packs/release-engineering/pack.toml
+grep '"version": "0.1.6"' packs/release-engineering/.claude-plugin/plugin.json
+make build-check
+python tools/lint-agents-md.py
+```

--- a/docs/specs/release-loop-gap-extensions/spec.md
+++ b/docs/specs/release-loop-gap-extensions/spec.md
@@ -1,0 +1,220 @@
+# Spec: release-loop-gap-extensions
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Mode:** full <!-- structural change (new module in core) + multi-feature risk triggers -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0074](../../rfc/0074-fidelity-ladder-and-ephemeral-env-qualification.md) (fidelity-ladder
+    reference module + outer-loop qualification floor — D1–D5)
+  - [RFC-0075](../../rfc/0075-polyrepo-value-stream-release-topology.md) (polyrepo / value-stream
+    release topology — D1–D5)
+  - [RFC-0049](../../rfc/0049-the-release-loop-and-company-os.md) (release-loop parent — Accepted;
+    D3 defers the fidelity-ladder; OQ1/AC9 name the polyrepo mechanism)
+  - [RFC-0072](../../rfc/0072-release-loop-deploy-doctrine.md) (G4 artifact format — Accepted; fleet
+    manifest extends G4 per RFC-0075 D1)
+  - [ADR-0031](../../adr/0031-infra-support-is-doctrine-on-existing-reviewers-not-a-new-reviewer-or-runtime.md)
+    (no new executables; content + doctrine only)
+- **Brief:** none
+- **Contract:** none — doctrine/content changes only; no new `contracts/<type>/` surface.
+- **Shape:** two content/methodology additions across two packs: a new EXECUTE/QUALIFY reference
+  module in `core`'s `operational-safety`, two new sections in `release-loop/SKILL.md`, one new
+  section in `work-loop/SKILL.md`, and cross-reference notes in `docs/specs/release-loop/spec.md`.
+  No new executables, no new runtime, no new skill (the fidelity-ladder guidance lives as a
+  reference module, not a standalone user-invocable skill).
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Implement the two secondary release-loop gaps deferred from the initial gap assessment —
+one in `core`, one in `release-engineering`:
+
+1. **(RFC-0074)** A new `fidelity-ladder` EXECUTE/QUALIFY reference module in
+   `packs/core/.apm/skills/operational-safety/references/`, plus cross-references from
+   the `work-loop` skill (inner-loop ladder section) and the `release-loop` skill (outer-loop
+   qualification floor section). Closes RFC-0049 D3's deferred fidelity-ladder obligation and
+   fills in the qualification test AC3/AC10(h) require but do not specify.
+
+2. **(RFC-0075)** A new Polyrepo topology section in `release-loop/SKILL.md` specifying the
+   fleet manifest format, the canonical e2e host repo definition, the five-term deploy
+   sequencing vocabulary, and the collect-then-validate pre-deploy step. Fills in the
+   "value-stream cross-repo mechanism" AC9 names but does not yet specify.
+
+No executable code. No new reviewer agents. No new runtime. No new top-level directories.
+The three new or updated SKILL.md files plus the new reference module plus cross-reference
+notes are the full deliverable.
+
+**Out of scope:** local infra tooling or automation (the ladder is doctrine, not a runtime);
+ArgoCD, Flux, or Spinnaker configuration (adopter toolchain); changes to `work-loop`'s
+loop mechanics (only a cross-reference section is added); the operate/incident loop; any
+pack other than `core` and `release-engineering`.
+
+## Boundaries
+
+### Always do
+- Content and doctrine only — no executables, no new reviewer agents (ADR-0031).
+- Create `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md` as a new
+  EXECUTE/QUALIFY reference module (parallels `cloud-implementation-craft.md` in the same
+  directory, not `environment-isolation.md` which is REVIEW).
+- Add a fidelity-ladder cross-reference section to `packs/core/.apm/skills/work-loop/SKILL.md`
+  after the existing `## Anti-patterns to refuse` section (the current last section).
+- Add an ephemeral environment qualification section to
+  `packs/release-engineering/.apm/skills/release-loop/SKILL.md` after the existing
+  `## Artifact provenance verification` section (the current last section per RFC-0072).
+- Add a Polyrepo topology section to the same `release-loop/SKILL.md`, after the ephemeral
+  environment section.
+- Add cross-reference notes to `docs/specs/release-loop/spec.md`: RFC-0074 on AC3 and AC10(h);
+  RFC-0075 on AC9. No AC text changes.
+- Bump `packs/core` version `0.15.4` → `0.15.5` in `pack.toml` and `plugin.json`.
+- Bump `packs/release-engineering` version `0.1.5` → `0.1.6` in `pack.toml` and `plugin.json`.
+- Add `[Unreleased]` entries to `docs/product/changelog.md` for both packs.
+- Run `make build-self` to regenerate projections; run `make build-check`,
+  `tools/lint-agent-artifacts.py`, and `tools/lint-agents-md.py`.
+- Set RFC-0074 and RFC-0075 Status: Accepted + Date closed before the PR merges.
+- Set this spec's Status to Shipped and check all ACs `[x]` in the implementing PR.
+
+### Never do
+- Edit the projected `.claude/...` copies directly — `make build-self` reverts them.
+- Extend `environment-isolation.md` inline — that module is REVIEW; the fidelity-ladder
+  module is EXECUTE/QUALIFY. Conflating them corrupts the role distinction.
+- Create a standalone `fidelity-ladder` skill — the reference module is consumed by other
+  skills, not user-invocable; a skill is premature until a second consumer appears.
+- Create a fleet-manifest.md reference file — the schema is fully specified inline in the
+  skill section; extract only when a second consumer appears.
+- Add a new cross-repo coordinator runtime or script (ADR-0031; fleet assembly is doctrine).
+- Touch any pack other than `core` and `release-engineering`.
+- Change `work-loop` loop mechanics, gates, or state machine — only a cross-reference
+  section is added.
+
+## Testing Strategy
+
+Content/methodology change — same verification strategy as the release-loop-doctrine-gaps spec:
+
+- **Projection correctness:** goal-based — `make build-self` then drift/projection gates clean.
+- **Lint conformance:** goal-based — `make build-check` (includes skill-spec lint, catalogue
+  verify, and agents-md hygiene) exits 0. `python tools/lint-agents-md.py` exits 0.
+- **Content presence:** goal-based — `grep` checks against each AC below.
+- **Doctrine correctness:** judgmental — `adversarial-reviewer` spec/plan pass (pre-EXECUTE,
+  structural change trigger fires), and diff pass after EXECUTE.
+
+No TDD (no testable logic added — the deliverables are doctrine documents).
+
+## Acceptance Criteria
+
+### RFC-0074 — Fidelity-ladder reference module
+
+- [x] **AC1 — `fidelity-ladder.md` reference module created.**
+  `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md` exists.
+  Verified by `test -f`.
+
+- [x] **AC2 — Module covers the seven-level ladder (L0–L6 including L4+).**
+  File contains: `L0`, `L1`, `L2`, `L3`, `L4`, `L4+`, `L5`, `L6` as named levels.
+  Verified by `grep -c "^Level: L" fidelity-ladder.md` = 8 (or equivalent level-count match).
+
+- [x] **AC3 — Module names the three provability classes.**
+  File contains: `Self-evident`, `Requires policy audit` (or `requires-policy-audit`),
+  and `Programmatically auditable` (or `programmatically-auditable`) as named classes.
+  Verified by `grep`.
+
+- [x] **AC4 — Module names the three qualification dimensions.**
+  File contains: `Prod reachability`, `Data isolation`, and `Inter-env isolation` (or
+  equivalent headings). Verified by `grep`.
+
+- [x] **AC5 — `work-loop` SKILL.md gains a fidelity-ladder section with heuristic and ladder summary.**
+  `packs/core/.apm/skills/work-loop/SKILL.md` contains a heading with "fidelity" (case-
+  insensitive); section cross-references `operational-safety/references/fidelity-ladder.md`
+  or equivalent path pointer; section body contains the "push up the ladder" budget heuristic
+  (grep for `push up` or `sub-5` or `budget`) and at least the level tokens `L0` and `L5`.
+  Verified by `grep -i "fidelity" SKILL.md`, `grep "sub-5\|push up" SKILL.md`,
+  `grep "L0\|L5" SKILL.md`.
+
+- [x] **AC6 — `release-loop` SKILL.md gains an ephemeral environment qualification section.**
+  `packs/release-engineering/.apm/skills/release-loop/SKILL.md` contains a heading with
+  "Ephemeral" (case-insensitive) and the section body contains: `L5` (the floor level),
+  references to the three qualification dimensions, `consent gate` (the consequence of
+  falling below the floor), the provability classification trio (`self-evident` or
+  `requires policy audit` or `programmatically auditable`), and an `L4`/`L4+` conditional
+  path (policy-audit condition for namespace isolation). Verified by `grep`.
+
+- [x] **AC7 — `docs/specs/release-loop/spec.md` cross-reference notes added (RFC-0074).**
+  The file contains `RFC-0074` at least twice — once near AC3 and once near AC10(h).
+  Verified by `grep -c "RFC-0074" docs/specs/release-loop/spec.md` ≥ 2.
+
+- [x] **AC8 — `packs/core` at version `0.15.5`.**
+  `packs/core/pack.toml` contains `version = "0.15.5"` and
+  `packs/core/.claude-plugin/plugin.json` contains `"version": "0.15.5"`.
+
+### RFC-0075 — Polyrepo topology
+
+- [x] **AC9 — `release-loop` SKILL.md gains a Polyrepo topology section.**
+  `packs/release-engineering/.apm/skills/release-loop/SKILL.md` contains a heading with
+  "Polyrepo" (case-insensitive). Verified by `grep -i "## Polyrepo"`.
+
+- [x] **AC10 — Polyrepo section documents the fleet manifest schema fields.**
+  The section contains: `schema_version`, `fleet_name`, `assembled_at`, `components`,
+  `deploy_sequence` (marked optional — defaults to parallel), `image_ref`, `g4_package_ref`,
+  `e2e_suite_ref`. Verified by `grep`.
+
+- [x] **AC11 — Polyrepo section specifies the collect-then-validate pre-deploy step.**
+  The section describes a "collect" phase (or equivalent name) that runs before
+  `infra-apply`; the phase reads each component's `g4_package_ref`, runs provenance
+  verification, and confirms `image_ref` consistency.
+  Contains: "collect" and "provenance" and "infra-apply".
+  Verified by `grep`.
+
+- [x] **AC11b — Polyrepo section specifies the e2e host repo Must-NOT rule (RFC-0075 D2).**
+  The section states that the e2e host repo must NOT contain component application source code.
+  Contains: "Must NOT contain" (or equivalent phrasing) and "component" and "source".
+  Verified by `grep -i "must not contain\|no component source"`.
+
+- [x] **AC11c — Polyrepo section includes the five-term harness-neutral vocabulary (RFC-0075 D3).**
+  The section contains all five terms: `Component`, `Stage`, `Gate`, `Depends-on`,
+  `Release manifest` as named vocabulary terms (table or list). The two distinctive tokens
+  (`Depends-on` and `Release manifest`) are individually present.
+  Verified by `grep "Depends-on"` and `grep "Release manifest"` each returning ≥ 1 match.
+
+- [x] **AC11d — Polyrepo section includes the courier snapshot discipline note (RFC-0075 D4).**
+  The section contains "courier snapshot" and states that the fleet manifest does not fork
+  component G4 packages (grep for "does not fork" or "never fork" or "read-only reference").
+  Verified by `grep -i "courier snapshot"` and `grep -i "does not fork\|never fork\|read-only reference"`.
+
+- [x] **AC12 — `docs/specs/release-loop/spec.md` cross-reference note added (RFC-0075).**
+  The file contains `RFC-0075` at least once, near AC9.
+  Verified by `grep "RFC-0075" docs/specs/release-loop/spec.md`.
+
+- [x] **AC13 — `packs/release-engineering` at version `0.1.6`.**
+  `packs/release-engineering/pack.toml` contains `version = "0.1.6"` and
+  `packs/release-engineering/.claude-plugin/plugin.json` contains `"version": "0.1.6"`.
+
+### Shared gates
+
+- [x] **AC14 — All lint gates pass.**
+  `make build-check` and `python tools/lint-agents-md.py` both exit 0 after `make build-self`.
+  (`lint-agent-artifacts.py` was consolidated into `make build-check`.)
+
+- [x] **AC15 — Changelog updated.**
+  `docs/product/changelog.md` contains `[Unreleased]` or version entries for both
+  `core` (describing the fidelity-ladder module) and `release-engineering` (describing
+  the ephemeral env qualification + polyrepo topology sections).
+
+- [x] **AC16 — RFC-0074 and RFC-0075 both at Status: Accepted.**
+  Both RFCs have `Status: Accepted` and a `Date closed` set before implementation ships.
+
+## Assumptions
+
+- `packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md` does not yet
+  exist (confirmed: directory listing shows seven existing modules, none named `fidelity-ladder`).
+- `## Anti-patterns to refuse` is the current last section in `work-loop/SKILL.md`
+  (confirmed at line 912); the new fidelity-ladder section is appended after it.
+- `## Artifact provenance verification` is the current last section in `release-loop/SKILL.md`
+  (confirmed at line 573); the ephemeral environment qualification section and Polyrepo topology
+  section are appended after it, in that order.
+- `packs/core` is at version `0.15.4` and `packs/release-engineering` is at `0.1.5`
+  (confirmed from pack.toml and plugin.json).
+- The release-loop spec's AC3 and AC10(h) already mandate the isolation conditions and the
+  consequence (consent-gate crossing); this spec adds only a cross-reference note, not AC text
+  changes.
+- `make build-self` regenerates projected copies from `packs/` source; editing the
+  projected copies directly would be reverted.

--- a/docs/specs/release-loop/spec.md
+++ b/docs/specs/release-loop/spec.md
@@ -242,7 +242,8 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   data-isolated from prod **and from each other**, hold **no real user data**, and
   **cannot reach prod state** — a deploy target that cannot be proven isolated is
   itself a **consent-gate crossing** (it is no longer reversible), not an
-  autonomous-zone action.
+  autonomous-zone action. (→ RFC-0074 for the qualification test and provability
+  classification per isolation level)
 - [x] **AC4 — the carve, human zone (RFC-0049 D2).** The skill binds to **human
   consent gates**: first promotion to **real users or real data**; **data
   migrations** (schema / destructive); **spend over a pre-agreed threshold**;
@@ -349,6 +350,8 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   sound and the loop surfaces the gap** (the same fail-closed posture as AC2's
   detect-and-degrade and AC10(c)'s no-lens surface), while cross-repo *artifact
   referencing* uses ADR-0022 (RFC-0049 OQ1; RFC-0048 § Amendments 2026-06-28).
+  (→ RFC-0075 for the fleet manifest schema, e2e host repo definition, and
+  deploy sequencing vocabulary that specify the "value-stream cross-repo mechanism")
 - [x] **AC10 — the security & integrity contract (mirrors RFC-0053, extended for
   the deploy boundary).** The skill / agent specify, as first-class controls:
   **(a) verdict write-authority** — the prod / irreversible consent verdict is
@@ -417,7 +420,8 @@ of change, and the worked-example validation RFC-0053's coordinator spike used.
   **(h) ephemeral-env isolation is a carve precondition** — the AC3 isolation
   conditions (no prod reachability, no real data, isolated from other ephemeral
   envs) are the security floor under the "reversible" label, not just a reviewer
-  lens; **(i) sidecar data-classification + state-branch integrity (mirrors
+  lens (→ RFC-0074 D2 / D5 for the L5 isolation floor and the three-dimension
+  qualification test); **(i) sidecar data-classification + state-branch integrity (mirrors
   RFC-0053 control 7, the LINDDUN leg).** The release boundary reads **live
   telemetry, e2e output, canary signals, and log lines** — which on a real-data or
   regulated-tier deploy can carry PII, customer identifiers, or secrets — so each

--- a/packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
+++ b/packs/core/.apm/skills/operational-safety/references/fidelity-ladder.md
@@ -1,0 +1,195 @@
+# fidelity-ladder — inner-loop levels and outer-loop environment qualification
+
+> **Loaded when:** the task needs a local-infra-equivalent (inner loop) or must
+> qualify an ephemeral environment for autonomous outer-loop operation.
+> **Module role:** EXECUTE/QUALIFY — constructive guidance for choosing and
+> qualifying environments. The companion module
+> [`environment-isolation.md`](environment-isolation.md) is the REVIEW checklist
+> (auditing whether an existing environment meets the bar); this module specifies
+> how to build or choose one that does. Load both when both questions are live.
+> **Grounded in:** Testcontainers documentation, LocalStack documentation, Docker
+> Compose usage patterns, inner-dev-loop tools (Tilt, Skaffold), Argo Rollouts,
+> k8s NetworkPolicy and RBAC references, AWS multi-account-per-stage pattern
+> (SCP/org-policy enforcement), vCluster (Loft Labs) documentation.
+
+---
+
+## The seven-level fidelity ladder
+
+Levels L0–L3 are **inner-loop** (pre-push, developer-controlled). L4 and above
+are **outer-loop** (post-push, CI-managed). The boundary is the git push / PR-open
+event.
+
+| Level | Name | Technology examples | Coverage | Isolation provability |
+|-------|------|---------------------|----------|-----------------------|
+| L0 | In-memory fake | Hand-rolled stubs, in-process fakes, sqlite-in-memory | Single-process; no network; no external API | **Self-evident** — process boundary |
+| L1 | Contract / protocol test | Pact CDC, JSON Schema validation, gRPC reflection | Provider/consumer contract only; no running service | **Self-evident** — no network stack |
+| L2 | Compose-isolated | Docker Compose multi-service, devcontainer | Multi-service network; host filesystem; no cloud API emulation | **Self-evident** — Docker bridge prevents external egress |
+| L3 | Container-emulated | Testcontainers + LocalStack / Microcks / WireMock | Per-test isolation; cloud API emulation; SDK calls intercepted | **Self-evident** — SDK endpoint override captures all cloud API calls |
+| L4 | k8s namespace-isolated | Namespace-per-PR on a shared cluster (NetworkPolicy + RBAC required) | Real Kubernetes primitives; shared control plane | **Requires policy audit** — no network policy = shared blast radius |
+| L4+ | Virtual cluster | vCluster (Loft Labs) — dedicated API server inside host cluster | Stronger than namespace; softer than dedicated cluster | **Requires audit** — host cluster egress policy must be verified |
+| L5 | Cloud sandbox | Dedicated non-prod cloud account / project + isolated state backend | Real cloud APIs; real IAM; real billing (throttled); no prod credential path | **Programmatically auditable** — SCP/org policies verifiable via API |
+| L6 | Staging / pre-prod | Production-mirror; may carry anonymised prod data | Near-prod fidelity | **Human-supervised; never autonomous-zone** |
+
+---
+
+## Per-level descriptors
+
+```
+Level: L0 — In-memory fake
+Coverage:  single-process logic only
+Isolation: self-evident (process boundary — no network stack)
+Gaps:      no persistence, no real API, no multi-service behavior
+Use when:  testing a single function / adapter boundary in isolation
+Budget:    < 1 s; always in-loop
+```
+
+```
+Level: L1 — Contract / protocol test
+Coverage:  provider–consumer protocol agreement (Pact CDC, gRPC reflection, JSON Schema)
+Isolation: self-evident (no running service; no network calls made)
+Gaps:      no behavioral fidelity beyond the protocol boundary
+Use when:  verifying two components agree on the API shape without running both
+Budget:    < 10 s; always in-loop
+```
+
+```
+Level: L2 — Compose-isolated multi-service
+Coverage:  multi-service network topology; realistic routing between services
+Isolation: self-evident (Docker bridge prevents external egress by default)
+Gaps:      cloud API calls fail or are stubbed; shared containers across tests unless
+           explicit teardown
+Use when:  testing multi-service interactions that don't require real cloud APIs
+Budget:    < 60 s; inner-loop ceiling for most services
+```
+
+```
+Level: L3 — Container-emulated (Testcontainers + LocalStack / Microcks / WireMock)
+Coverage:  cloud API emulation (AWS S3, SQS, DynamoDB, etc.); per-test container lifecycle;
+           SDK calls intercepted before leaving the process
+Isolation: self-evident (SDK endpoint override captures all cloud API calls before they
+           reach a real endpoint)
+Gaps:      behavioral fidelity gaps (complex IAM conditions, cross-service event timing,
+           managed service internals); LocalStack commercial license required for production
+           use post-March 2024 (OSS alternatives: Moto, LocalStack-OSS forks, Microcks)
+Use when:  inner-loop tests that need cloud API behavior without a real account
+Budget:    30 s – 3 min; inner-loop ceiling for cloud-dependent services
+Note:      L3 is the inner-loop ceiling; fidelity gaps here are expected and are exactly
+           what the outer loop exists to catch
+```
+
+```
+Level: L4 — k8s namespace-isolated (requires policy audit)
+Coverage:  real Kubernetes primitives; per-PR namespace on a shared cluster
+Isolation: requires policy audit (shared control plane; NetworkPolicy + RBAC must be
+           present and verified per deployment — absent policies = L2-equivalent isolation)
+Gaps:      shared control plane blast radius; host-cluster egress policy applies to all
+           namespaces; not equivalent to account-level isolation
+Use when:  teams already running Kubernetes that want per-PR ephemeral environments
+           without dedicated cluster provisioning costs
+Qualification: qualifies for the outer loop only after the three-dimension policy audit
+               passes — "namespace isolation" without verified NetworkPolicy does not qualify
+```
+
+```
+Level: L4+ — Virtual cluster / vCluster (requires policy audit)
+Coverage:  own Kubernetes API server and control plane inside a host cluster
+Isolation: requires audit (stronger than namespace; host cluster egress policy still
+           applies; isolation claims are self-reported by vCluster project)
+Gaps:      host cluster egress policy is a shared blast radius; limited independent
+           security audit of isolation boundary in public literature
+Use when:  teams who need stronger-than-namespace isolation without dedicated cluster cost
+Qualification: same three-dimension audit required as L4; host cluster egress policy
+               must be verified in addition to the virtual cluster's own isolation
+```
+
+```
+Level: L5 — Cloud sandbox (the outer-loop qualification floor)
+Coverage:  real cloud APIs; real IAM; real networking; real billing (throttled/capped)
+Isolation: programmatically auditable (dedicated account/project boundary + isolated state
+           backend + no prod credential reachable; SCP/org policies verifiable via API)
+Gaps:      real billing cost; setup/teardown time (minutes); real data risk if
+           misconfigured (data isolation is not free — it must be enforced)
+Use when:  the outer release loop (autonomous zone); ephemeral environments
+Budget:    minutes to hours; outer-loop territory; teardown on cycle end mandatory
+           (see cost-and-teardown module)
+Note:      The `iac-terraform` pack's generate-iac skill scaffolds the account/workspace
+           boundary — the provisioning detail for this level lives there
+Qualification: satisfies all three outer-loop isolation dimensions when:
+               (a) the account/project has no VPC peering to prod,
+               (b) all data is synthetic / purpose-generated,
+               (c) state backends are isolated and not shared with other envs
+```
+
+```
+Level: L6 — Staging / pre-prod
+Coverage:  production-equivalent topology; may carry anonymised production data
+Isolation: human-supervised; never autonomous-zone
+Gaps:      may share blast radius with prod-adjacent services; cross-env contamination
+           risk if anonymisation is incomplete
+Use when:  human-supervised regression, load, or soak testing only
+Budget:    n/a (human-gated; not an outer-loop target)
+```
+
+---
+
+## Inner-loop budget heuristic
+
+**Push up the ladder as high as a sub-5-minute local budget tolerates.**
+
+- **L0–L1:** milliseconds — always in-loop; never skip these.
+- **L2–L3:** seconds to 3 minutes — the inner-loop ceiling for most services.
+- **L4 and above:** CI-managed; these are outer-loop territory, not local builds.
+
+When a task's dependency cannot be represented at L0–L3 within budget, that is the signal
+to defer the integration test to the outer loop (the CI-managed ephemeral environment)
+rather than lowering the budget or cutting the test.
+
+---
+
+## Outer-loop qualification: the three-dimension test
+
+The outer loop's "reversible" label requires all three isolation conditions to hold
+simultaneously. Each maps to a concrete, testable boolean:
+
+| Dimension | Condition | How to test |
+|-----------|-----------|-------------|
+| **Prod reachability** | No route from the ephemeral env to prod endpoints, prod databases, or prod identity stores | Network policy or security group audit confirms no ingress/egress to prod CIDR / prod account; credential scoping confirms the session cannot assume prod IAM roles |
+| **Data isolation** | No real user data accessible from the ephemeral env | Data classification review confirms env storage contains only synthetic, anonymized, or purpose-generated data; no prod snapshot was restored here |
+| **Inter-env isolation** | This ephemeral env cannot affect other running ephemeral or shared staging envs | Env resources (namespaces, accounts, VPCs, state backends) are unique to this cycle; no shared mutable state with other concurrent envs |
+
+**The test is boolean, not scored.** A single `false` is a consent-gate crossing — surface
+to human; do not proceed with autonomous deploy.
+
+---
+
+## Isolation provability classification
+
+| Class | Levels | What this means | Cost at cycle start |
+|-------|--------|-----------------|---------------------|
+| **Self-evident** | L0–L3 | Isolation is structural — process boundary, Docker bridge, or SDK endpoint-override prevents external routing by construction | None — test passes trivially |
+| **Requires policy audit** | L4, L4+ | Isolation depends on network policies and RBAC that must be verified per deployment | Read and confirm the policy config is present and correctly scoped before each cycle |
+| **Programmatically auditable** | L5 | Isolation enforced by cloud org policies (SCPs, GCP Org Policy) and IAM boundaries queryable via API | Policy API call at cycle start; automation-friendly |
+
+A "requires policy audit" environment that hasn't been audited this cycle is **not
+qualified** — surface to human before proceeding autonomously.
+
+---
+
+## LocalStack licensing note
+
+LocalStack ended its Community Edition for commercial use in March 2024. Teams running
+LocalStack in a commercial context must use LocalStack Pro (paid) or choose an OSS
+alternative (Moto, LocalStack-OSS forks, Microcks) with narrower API coverage. This
+module references LocalStack as a technology example, not a mandatory tool; the doctrine
+is intentionally harness-neutral. Choose the emulator that fits your license posture.
+
+---
+
+## Build-pack handoff
+
+When a build pack ships a fidelity-ladder scaffold reference — Testcontainers configuration
+templates, LocalStack bootstrap scripts, Docker Compose service templates — the
+`work-loop` skill's ladder summary section should link to it. This module is the canonical
+level-descriptor reference; the build pack's scaffold reference extends it with
+tool-specific setup detail.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -947,3 +947,29 @@ unattended doesn't mean *unconsidered*, it means *pre-considered*.
   in-session pass first to validate the approach.
 - **Looping without capturing learnings.** Every loop that ends without updating
   *some* doc, skill, or note is a loop whose lessons are lost.
+
+## Fidelity ladder
+
+When a task needs local-infra-equivalents — a fake, an emulator, a container —
+choose the level that fits the budget: **push up the ladder as high as a sub-5-minute
+local budget tolerates.**
+
+| Tier | Levels | Budget | Notes |
+|------|--------|--------|-------|
+| Always in-loop | L0 (in-memory fake), L1 (contract test) | < 1–10 s | Never skip these |
+| Inner-loop ceiling | L2 (Docker Compose), L3 (Testcontainers / LocalStack) | < 60 s – 3 min | Right ceiling for most services |
+| Outer-loop territory | L4 (k8s namespace), L4+ (vCluster), L5 (cloud sandbox) | minutes+ | CI-managed; not local builds |
+| Human-supervised | L6 (staging / pre-prod) | n/a | Never autonomous-zone |
+
+When a dependency cannot be represented at L0–L3 within budget, defer the integration
+test to the outer loop (the CI-managed ephemeral environment) rather than cutting the
+test or inflating the budget.
+
+The full ladder specification — per-level coverage, isolation gaps, the three-dimension
+outer-loop qualification test, and the provability classification — is in the
+`operational-safety` skill's `fidelity-ladder` reference module.
+
+**Build-pack handoff:** when a build pack ships a fidelity-ladder scaffold reference
+(Testcontainers templates, LocalStack bootstrap, Docker Compose service templates), it
+extends this section with tool-specific detail. Check the installed build pack first;
+fall back to the reference module's technology examples if none is installed.

--- a/packs/release-engineering/.apm/skills/release-loop/SKILL.md
+++ b/packs/release-engineering/.apm/skills/release-loop/SKILL.md
@@ -607,3 +607,163 @@ claim. A failed verification is a supply-chain integrity failure — it is a
 surface to human with the specific mismatch detail (which check failed, what the digests
 were); do not proceed to `infra-apply`. Override requires explicit human consent and is
 recorded in the decision log with `ratified_by: human` via the control-(a) attested channel.
+
+## Ephemeral environment qualification
+
+Run this qualification step at outer-loop cycle start — before the collect phase (or before
+`infra-apply` in the single-component case). The check is a precondition for entering the
+autonomous zone; a single `false` is a consent-gate crossing.
+
+**The L5 floor.** An ephemeral environment must meet **L5** (dedicated cloud account /
+project, or an L4/L4+ k8s namespace or vCluster that has passed the three-dimension policy
+audit below) for the "reversible" label to hold under the minimum-regret carve. An environment
+below this floor is a consent-gate crossing — surface to human; do not proceed with
+autonomous deploy.
+
+**The three-dimension qualification test:**
+
+| Dimension | Condition | How to test |
+|-----------|-----------|-------------|
+| **Prod reachability** | No route from the ephemeral env to prod endpoints, prod databases, or prod identity stores | Network policy or security group audit: no ingress/egress to prod CIDR / prod account; credential scoping: session cannot assume prod IAM roles |
+| **Data isolation** | No real user data accessible from the ephemeral env | Data classification review: env storage contains only synthetic, anonymized, or purpose-generated data; no prod snapshot was restored here |
+| **Inter-env isolation** | This ephemeral env cannot affect other running ephemeral or shared staging envs | Env resources (namespaces, accounts, VPCs, state backends) are unique to this cycle; no shared mutable state with other concurrent envs |
+
+**Provability classification — cost of the qualification step:**
+
+- **Self-evident (L0–L3):** isolation is structural; the test passes trivially. Not relevant
+  to the outer loop's ephemeral envs, but noted for the inner/outer boundary.
+- **Requires policy audit (L4 namespace, L4+ vCluster):** NetworkPolicy + RBAC must be
+  verified per deployment. A namespace without verified NetworkPolicy is not qualified —
+  treat as a consent gate. The implementing agent reads and confirms the policy config
+  before each cycle.
+- **Programmatically auditable (L5 dedicated account/project):** SCP/org policies enforcing
+  the account/project boundary are queryable via API. Run the policy check at cycle start.
+
+**L4/L4+ conditional path:** an L4 or L4+ environment qualifies only after the three-dimension
+policy audit passes. "Namespace isolation" without a confirmed NetworkPolicy is L2-equivalent
+blast radius — it does not qualify. If the audit has not been performed this cycle, surface to
+human before proceeding.
+
+The full ladder specification — level descriptors, per-level gaps, inner-loop budget
+heuristic, and LocalStack licensing note — is in the `operational-safety` skill's
+`fidelity-ladder` reference module.
+
+## Polyrepo topology
+
+In a **single-product monorepo** the build repo is the integrated whole: no fleet manifest,
+no e2e host repo. The collect phase below is a no-op (one component). The single-component
+G4 handoff package (see `## The G4 handoff package`) is sufficient.
+
+In a **polyrepo / value-stream topology** — multiple component repos each producing their
+own G4 package — use the artifacts and steps below.
+
+### Fleet manifest (`release-fleet.yaml`)
+
+The fleet manifest is the cross-component release coordination artifact. It lives in the
+e2e host repo, is committed by a bot PR from each component repo's CI, and is read-only
+from merge time onward. It is the "courier snapshot" from the courier snapshot pattern
+(ADR-0022 applied to the release loop): the per-component G4 package is the authority;
+the fleet manifest carries versioned references to them and does not fork component G4
+packages.
+
+Mandatory schema:
+
+```yaml
+schema_version: "1.0"           # outer loop reads this first; unknown version → surface to human
+fleet_name: <string>             # e.g. "billing-platform"
+assembled_at: <RFC3339>          # timestamp of fleet assembly
+
+components:                      # one entry per deployable component
+  - name: <string>               # e.g. "auth-service"
+    repo: <org/repo>             # harness-neutral identifier
+    g4_package_ref: <path or URL> # path to the component's release-handoff.yaml at the pinned commit
+    image_ref: "<registry>/<repo>:<tag>@sha256:<hex>"  # must match g4_package's component_manifest
+
+deploy_sequence:                 # optional; defaults to parallel if absent
+  - component: auth-service
+    depends_on: []
+    gate: auto
+  - component: billing-api
+    depends_on: [auth-service]   # waits for auth-service's gate to pass
+    gate: auto
+  - component: web-frontend
+    depends_on: [billing-api]
+    gate: manual                 # explicit human gate before this component advances
+
+e2e_suite_ref:                   # reference to the e2e test suite in this host repo
+  path: tests/e2e/
+  runner: <string>               # hint: "playwright" | "cypress" | "k6" | "karate"
+```
+
+Schema compatibility: the outer loop reads `schema_version` first. Tolerant reader rule:
+unknown fields are ignored; adopters may extend with additional fields.
+
+### Canonical e2e host repo
+
+**Must contain:**
+- `release-fleet.yaml` (fleet manifest — outer loop entry point).
+- A composition file (`docker-compose.yaml`, Helm umbrella chart, or Kustomize overlay)
+  referencing image digests from the fleet manifest.
+- An e2e test suite treating the composed system as a black box (every assertion goes through
+  service APIs or UI surfaces, never internal component APIs).
+- CI configuration triggering the outer loop on fleet manifest merge or registry-event webhook.
+
+**Must NOT contain:**
+- Component application source code (any component source).
+- Per-component unit or integration tests (those belong in the component repo's inner loop).
+- Credentials or secrets in source (all secrets broker-mediated per AC10(g)).
+
+**Must install:** `core` + `release-engineering` at repo scope — the same precondition as
+any component repo that runs the outer loop.
+
+### Five-term harness-neutral vocabulary
+
+| Term | Definition | ArgoCD | Flux | Spinnaker / GHA |
+|------|-----------|--------|------|-----------------|
+| **Component** | A deployable unit with its own repo and version stream | `Application` | `Kustomization` / `HelmRelease` | stage target / service |
+| **Stage** | A named deploy target (staging, canary, production) | project / cluster | namespace | pipeline environment |
+| **Gate** | A blocking decision point (automated or human) | health check / sync status | readiness gate | `Check Preconditions` / `Manual Judgment` |
+| **Depends-on** | Component B must not deploy until component A passes its gate in the same stage | sync wave ordering | `HelmRelease.spec.dependsOn` | Pipeline sub-stage + wait |
+| **Release manifest** | A file recording the pinned version of every component for this release | `Application` image tag | image policy marker | `Release` artifact |
+
+The `deploy_sequence[].depends_on` field in the fleet manifest carries the intent; the
+adopter's orchestrator translates it to tool-specific primitives.
+
+### Collect-then-validate pre-deploy step
+
+Before `infra-apply`, run a **collect phase** for each component in the fleet manifest:
+
+```
+Collect phase (before infra-apply):
+  for each component in fleet_manifest.components:
+    1. Fetch the component's release-handoff.yaml from g4_package_ref.
+    2. Run RFC-0072 D6 provenance verification against the component's image_ref.
+    3. Confirm the image_ref in the fleet manifest matches the image_ref in the
+       component's G4 package (fleet manifest courier snapshot must be consistent
+       with current registry state).
+    4. If any component fails steps 1–3: surface to human with the specific mismatch;
+       do not proceed to infra-apply.
+  On all-pass: advance to infra-apply with the verified fleet.
+```
+
+In the monorepo/single-component case the collect phase is a no-op.
+
+### Triggering conventions
+
+(a) **Bot PR approach:** each component repo's CI opens a PR bumping
+`components[N].image_ref` to the new digest; the adopter's merge policy merges it.
+(b) **Scheduled reconciliation:** a scheduled loop queries each component registry for the
+latest passing-gate version and assembles a new fleet manifest. Use (b) when components
+release continuously.
+
+The trigger implementation is adopter toolchain — the doctrine does not prescribe
+`repository_dispatch` or any specific mechanism.
+
+### Distinction from ADR-0022
+
+ADR-0022 covers the **product-engineering meta-repo** — feature coordination across repos,
+per-component brief slicing, and shared contract versioning (the upstream discovery/build
+layer). This RFC-0075 mechanism covers the **release-loop's cross-repo coordination** —
+fleet assembly, version validation, and deploy sequencing after G4 packages are produced.
+The two are parallel, not redundant. Both apply the "reference-by-version + read-only
+courier snapshot" pattern to different layers.

--- a/packs/release-engineering/.claude-plugin/plugin.json
+++ b/packs/release-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "release-engineering",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "The SRE/ops outer loop \u2014 deployed end-to-end validation above work-loop's inner build loop. Ships the `release-lead` agent and the `release-loop` skill: deploy the integrated whole to an ephemeral environment, run e2e, observe telemetry, feed deployed findings back to the inner loop (no human relay), redeploy, and iterate until the deployed whole converges \u2014 then stop at the human consent gate for the prod ship (G5), surfaced as a release-readiness record to ratify rather than a bare go/no-go. Autonomy is carved by minimum-regret: the agent runs the inner and outer loops on reversible ephemeral envs unwatched; humans gate the irreversible exits (first real users or data, data migrations, spend over threshold, security/auth-boundary changes, anything irreversible, and the prod ship). Reuses core's operational-safety depth modules + quality-engineer + security-reviewer, consumes the discovery sidecar schema by convention, and ships no new runtime engine and no new reviewer. Completes the company OS: product (discovery) \u2192 engineering (build) \u2192 SRE/ops (release). Markdown skill + agent definition, repo-scope."
 }

--- a/packs/release-engineering/pack.toml
+++ b/packs/release-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "release-engineering"
-version = "0.1.5"
+version = "0.1.6"
 description = "The SRE/ops outer loop — deployed end-to-end validation above work-loop's inner build loop. Ships the `release-lead` agent and the `release-loop` skill: deploy the integrated whole to an ephemeral environment, run e2e, observe telemetry, feed deployed findings back to the inner loop (no human relay), redeploy, and iterate until the deployed whole converges — then stop at the human consent gate for the prod ship (G5), surfaced as a release-readiness record to ratify rather than a bare go/no-go. Autonomy is carved by minimum-regret: the agent runs the inner and outer loops on reversible ephemeral envs unwatched; humans gate the irreversible exits (first real users or data, data migrations, spend over threshold, security/auth-boundary changes, anything irreversible, and the prod ship). Reuses core's operational-safety depth modules + quality-engineer + security-reviewer, consumes the discovery sidecar schema by convention, and ships no new runtime engine and no new reviewer. Completes the company OS: product (discovery) → engineering (build) → SRE/ops (release). Markdown skill + agent definition, repo-scope."
 readme = "README.md"
 display_name = "Release Engineering"


### PR DESCRIPTION
## Summary

- **core 0.15.5** — New `fidelity-ladder` EXECUTE/QUALIFY reference module in `operational-safety/references/`; seven-level ladder (L0–L6 incl. L4+), three-dimension outer-loop qualification test, provability classification, L4/L4+ conditional path, LocalStack licensing note. New `## Fidelity ladder` section in `work-loop/SKILL.md` cross-referencing the module.
- **release-engineering 0.1.6** — New `## Ephemeral environment qualification` section in `release-loop/SKILL.md`: L5 floor, three-dimension test table, provability classifications, consent-gate doctrine. New `## Polyrepo topology` section: `release-fleet.yaml` fleet manifest schema, courier snapshot discipline, canonical e2e host repo definition, five-term harness-neutral vocabulary (ArgoCD/Flux/Spinnaker/GHA mapped), collect-then-validate pre-deploy pseudocode.
- RFC-0074 and RFC-0075 both marked **Accepted** (2026-07-27). Spec `release-loop-gap-extensions` marked **Shipped**.

## Closes

RFC-0049 D3 (fidelity-ladder deferred obligation) and RFC-0049 OQ1/AC9 (polyrepo value-stream mechanism), via RFC-0074 and RFC-0075.

## Test plan

- [x] `make build-check` exits 0 (build-self + skill-spec lint + catalogue verify)
- [x] `python tools/lint-agents-md.py` exits 0
- [x] All 16 ACs in `docs/specs/release-loop-gap-extensions/spec.md` verified by grep + visual QA
- [x] `adversarial-reviewer` diff pass — Clean
- [x] No new executables (ADR-0031 compliant)
- [x] No path-link references in skill bodies (CAT-S003 clean)

## Deferred

Nothing deferred out of this PR. The fleet-manifest.md reference file and standalone fidelity-ladder skill are intentionally declined (single consumer each; premature extraction). Coordinator runtime for fleet assembly is ADR-0031 prohibited.