### PR TITLE
fix(artifactory): add channel field, AGENTBUNDLE_NO_REMOTE, and org-fork export guide (0.22.0)

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -122,17 +122,22 @@ Editing them directly trips `make build-check`. Full workflow: [`packs/AGENTS.md
 `docs/guides/**/README.md`.
 
 
-## `docs/guides/` is organized by pack in this repo
+## Two guide trees — maintainer vs adopter
 
-This catalogue organizes user docs **by pack**: `docs/guides/<pack>/{tutorials,how-to,reference,explanation}/`
-for pack-specific guides; `docs/guides/_shared/{quadrant}/` for cross-cutting ones. The four-type Diátaxis
-discipline holds within each pack's subtree. Write guides under the owning pack, or `_shared/` if not
-specific to one pack.
+| Tree | Audience | Ships to adopters? |
+|---|---|---|
+| `docs/guides/` | **Repo maintainers only.** Covers the catalogue's internal tooling, CLI developer workflows, and repo-specific how-tos. Never projected. | No |
+| `guides/` | **Adopters.** Cross-cutting guides live in `guides/_shared/{quadrant}/`; pack-specific guides in `guides/<pack>/{quadrant}/`. Projected by the build pipeline. | Yes |
+
+Write new user-facing guides under `guides/_shared/how-to/` (or the owning pack's subtree).
+Write maintainer-facing guides (tooling, repo setup, CI) under `docs/guides/`.
+
+`docs/guides/` inside this repo uses the older flat `{quadrant}/` layout (pre-by-pack convention).
+The `new-guide` skill is layout-aware and writes under `guides/` by default; pass `--internal` to target `docs/guides/`.
 
 The adopter-facing `user-guide-diataxis` seed scaffold ships a by-quadrant `docs/guides/{quadrant}/` tree
 (an adopter is one product, not a catalogue); `docs/CONVENTIONS.md` §5c is projected and stays
-by-quadrant for adopters. The `new-guide` skill is layout-aware and writes per-pack when the repo
-is organized that way.
+by-quadrant for adopters.
 
 ## Install-test coverage rule
 

--- a/contracts/catalogue.schema.json
+++ b/contracts/catalogue.schema.json
@@ -171,6 +171,10 @@
                 "bundle": {
                   "type": "string",
                   "description": "Catalogue bundle name (required when enabled)."
+                },
+                "channel": {
+                  "type": "string",
+                  "description": "Artifactory channel name (required when enabled = true)."
                 }
               }
             }

--- a/docs/guides/how-to/enterprise-app-store.md
+++ b/docs/guides/how-to/enterprise-app-store.md
@@ -16,6 +16,23 @@ The workflow has two sides:
 - Artifactory repository accessible from the connected host.
 - Bundle identifier, release version, and channel name agreed with your platform team.
 
+## Configuration
+
+Add the Artifactory block to `catalogue.toml`:
+
+```toml
+[distribution.agentbundle.artifactory]
+enabled = true
+base-url = "https://artifactory.example.com"
+repository = "agentbundle-catalogues"
+bundle = "engineering"
+channel = "stable"
+```
+
+Run `agentbundle catalogue sync-defaults --write` after adding or updating this block.
+The generated `install-defaults.toml` baked into the wheel will contain the channel value,
+so downstream installs resolve the correct Artifactory path.
+
 ## Step 1 — Build the dist tree
 
 ```bash
@@ -45,10 +62,10 @@ agentbundle catalogue package \
 Output layout:
 
 ```
-dist/artifactory/catalogues/engineering/releases/1.2.0/stable/
-  engineering-1.2.0.tar.gz
-  engineering-1.2.0.tar.gz.sha256
-  channel.json
+dist/catalogues/engineering/releases/1.2.0/
+  catalogue-1.2.0.tar.gz
+  catalogue-1.2.0.tar.gz.sha256
+  channels/stable.json
 ```
 
 ## Step 4 — Upload to Artifactory
@@ -98,3 +115,11 @@ For automated packaging in CI:
 
 Never embed production Artifactory URLs, credentials, or bearer tokens in workflow YAML. Use
 secrets or a credentials broker.
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `AGENTBUNDLE_HTTP_BEARER_TOKEN` | Bearer token for authenticated HTTPS catalogue sources. Never forwarded across origins; not logged. |
+| `AGENTBUNDLE_NO_REMOTE` | When set to `1`, skips the Artifactory org bootstrap (Layer 3) and editable-install detection (Layer 4). Useful for offline and air-gapped deployments. |
+| `AGENTBUNDLE_CA_BUNDLE` | Path to a PEM CA bundle for corporate TLS. (Upcoming — not yet implemented.) |

--- a/docs/specs/catalogue-hygiene-part1/spec.md
+++ b/docs/specs/catalogue-hygiene-part1/spec.md
@@ -1,7 +1,6 @@
----
-title: Catalogue hygiene — Part 1 (export-boundary convention)
-status: Shipped
----
+# Spec: catalogue-hygiene-part1
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 
 Mode: light (no risk trigger fired — deletion is git-recoverable; AGENTS.md files are docs, not code)
 

--- a/guides/_shared/how-to/configure-catalogue-enterprise-distribution.md
+++ b/guides/_shared/how-to/configure-catalogue-enterprise-distribution.md
@@ -53,25 +53,18 @@ agentbundle catalogue sync-defaults --root . --check
 when they diverge. Add this to your CI pipeline so a stale `install-defaults.toml` fails
 the build before the wheel ships.
 
-## Step 4 — Commit and build
+## Step 4 — Commit and rebuild
 
-Commit `install-defaults.toml` alongside the `catalogue.toml` change, then build your
-agentbundle wheel as usual:
-
-```bash
-cd packages/agentbundle
-python -m build --wheel
-```
-
-Publish `dist/agentbundle-<version>-py3-none-any.whl` to your internal package index.
-Developers install it once:
+Commit `install-defaults.toml` alongside the `catalogue.toml` change, then rebuild and
+republish your agentbundle wheel as usual. Once the updated wheel is on your internal
+index, developers get the right source automatically:
 
 ```bash
-pip install agentbundle --index-url https://pypi.example.com/simple/
+agentbundle install --pack core
 ```
 
-From that point, `agentbundle install --pack core` resolves your Artifactory channel
-automatically. No `config set source` needed.
+No `config set source` needed. A developer who has set `[settings].source` in their user
+config keeps that value (it takes priority at Layer 2).
 
 ## Offline and air-gapped environments
 
@@ -82,8 +75,8 @@ AGENTBUNDLE_NO_REMOTE=1 agentbundle install --pack core /path/to/local-catalogue
 ```
 
 This skips the org Artifactory bootstrap and editable-install detection, falling through
-to the packaged default source or an explicit catalogue argument. Set it in the host's
-shell profile, a CI environment variable, or a wrapper script — no config file needed.
+to the packaged default source or an explicit catalogue argument. Set it in the shell
+profile, a CI environment variable, or a wrapper script — no config file needed.
 
 ## Disabling the bootstrap
 
@@ -93,6 +86,4 @@ to the packaged default source.
 
 ## See also
 
-- [How to package a catalogue for enterprise app-store distribution](../../../docs/guides/how-to/enterprise-app-store.md) — building and uploading the Artifactory release archive.
-- [Flow E — fully disconnected host](../../../docs/guides/how-to/flow-e-disconnected.md) — receive-side extraction and install for air-gapped machines.
 - [`agentbundle` reference](../reference/agentbundle.md) — full source-resolution chain and all env vars.

--- a/guides/_shared/how-to/export-catalogue-org-fork.md
+++ b/guides/_shared/how-to/export-catalogue-org-fork.md
@@ -1,10 +1,10 @@
-# How to export a catalogue for org-fork distribution
+# How to configure a catalogue for enterprise distribution
 
-**Use this when:** Your org maintains a fork of `agentbundle` and you want developers to run `agentbundle install` against your internal Artifactory channel without a manual `config set source` step.
-**Prerequisites:** A `catalogue.toml` with `[distribution.agentbundle.artifactory]` populated; Artifactory accessible from your build host; `agentbundle` ≥ 0.22.0 installed.
-**Result:** An org `agentbundle` wheel whose baked `install-defaults.toml` points to your channel, so every developer who installs from your internal index gets the right source automatically.
+**Use this when:** You maintain a catalogue and want developers to run `agentbundle install` against your internal Artifactory channel without a manual `config set source` step.
+**Prerequisites:** Artifactory accessible from your build host; bundle name and channel agreed with your platform team; `agentbundle` ≥ 0.22.0 installed.
+**Result:** A `catalogue.toml` configured with your Artifactory coordinates, and a regenerated `install-defaults.toml` that bakes those coordinates into the distributed wheel — so every developer who installs from your internal index gets the right source automatically.
 
-The mechanism is the org bootstrap (Layer 3 of the source-resolution chain). When `agentbundle` starts and no explicit source or user config is set, it reads `_data/install-defaults.toml` from the installed wheel and picks up the Artifactory coordinates baked in at publish time. No developer config required.
+The mechanism is the org bootstrap. When `agentbundle` starts with no explicit source and no user config, it reads `_data/install-defaults.toml` from the installed wheel. If that file carries a valid `[organization.artifactory]` block, `agentbundle` resolves the catalogue source from Artifactory without any per-developer configuration.
 
 ## Step 1 — Add `[distribution.agentbundle.artifactory]` to `catalogue.toml`
 
@@ -17,9 +17,9 @@ bundle     = "engineering"
 channel    = "stable"
 ```
 
-All five fields are required when `enabled = true`. Use your real Artifactory hostname,
-the repository key, the bundle name your platform team assigned, and the channel name
-you use when publishing releases (typically `stable`).
+All five fields are required when `enabled = true`. `base-url` must be HTTPS with no
+credentials embedded. `repository`, `bundle`, and `channel` must each match
+`[A-Za-z0-9._-]+` — no path separators.
 
 ## Step 2 — Regenerate `install-defaults.toml`
 
@@ -29,19 +29,19 @@ From your catalogue root:
 agentbundle catalogue sync-defaults --root . --write
 ```
 
-This overwrites `agentbundle/_data/install-defaults.toml` (the path set by
+This rewrites `agentbundle/_data/install-defaults.toml` (the path declared by
 `distribution.agentbundle.install-defaults-output` in `catalogue.toml`). The file is
-committed to your fork — it is not generated at install time.
+committed to your repository — it is not generated at install time.
 
-Verify the output before committing:
+Confirm the channel was written correctly:
 
 ```bash
 grep channel packages/agentbundle/agentbundle/_data/install-defaults.toml
 # → channel = "stable"
 ```
 
-An empty `channel = ""` means the field was missing or blank in `catalogue.toml`.
-Fix it there and rerun.
+If you see `channel = ""`, the `channel` field was absent or blank in `catalogue.toml`.
+Correct it and rerun.
 
 ## Step 3 — Add a CI drift check
 
@@ -49,74 +49,50 @@ Fix it there and rerun.
 agentbundle catalogue sync-defaults --root . --check
 ```
 
-`--check` exits 0 when the on-disk file matches what `--write` would produce and non-zero
-on drift. Add this to your CI pipeline on every push so a stale `install-defaults.toml`
-blocks the build before the wheel ships.
+`--check` exits 0 when the on-disk file matches the current `catalogue.toml`, non-zero
+when they diverge. Add this to your CI pipeline so a stale `install-defaults.toml` fails
+the build before the wheel ships.
 
-## Step 4 — Build the wheel
+## Step 4 — Commit and build
+
+Commit `install-defaults.toml` alongside the `catalogue.toml` change, then build your
+agentbundle wheel as usual:
 
 ```bash
 cd packages/agentbundle
 python -m build --wheel
 ```
 
-The generated `dist/agentbundle-<version>-py3-none-any.whl` bundles the updated
-`install-defaults.toml`. Publish it to your org's internal PyPI index.
-
-## Step 5 — Developer install
-
-Once the wheel is published, developers install it once:
+Publish `dist/agentbundle-<version>-py3-none-any.whl` to your internal package index.
+Developers install it once:
 
 ```bash
 pip install agentbundle --index-url https://pypi.example.com/simple/
 ```
 
-From that point:
+From that point, `agentbundle install --pack core` resolves your Artifactory channel
+automatically. No `config set source` needed.
 
-```bash
-agentbundle install --pack core
-```
+## Offline and air-gapped environments
 
-resolves the catalogue from your Artifactory channel automatically. No `config set source`
-needed. The org bootstrap fires at Layer 3; if the developer has a `[settings].source` set
-in their user config, that takes priority (Layer 2).
-
-## Offline and air-gapped hosts
-
-For developer machines or CI runners that cannot reach Artifactory, set `AGENTBUNDLE_NO_REMOTE=1`:
+For hosts that cannot reach Artifactory, set `AGENTBUNDLE_NO_REMOTE=1`:
 
 ```bash
 AGENTBUNDLE_NO_REMOTE=1 agentbundle install --pack core /path/to/local-catalogue
 ```
 
-This skips the org Artifactory bootstrap (Layer 3) and editable-install detection (Layer 4).
-`agentbundle` falls through to the packaged default source (`[defaults] source` in
-`install-defaults.toml`) or to the explicit catalogue argument. Useful in:
+This skips the org Artifactory bootstrap and editable-install detection, falling through
+to the packaged default source or an explicit catalogue argument. Set it in the host's
+shell profile, a CI environment variable, or a wrapper script — no config file needed.
 
-- CI pipelines that run fully offline against a local copy.
-- Developer machines on restricted networks where Artifactory isn't reachable.
-- Air-gapped infrastructure where no external HTTP is allowed.
+## Disabling the bootstrap
 
-Set the variable in the shell profile, a CI environment variable, or a wrapper script —
-it does not need to appear in any config file.
-
-## Reverting to the public catalogue
-
-Set `enabled = false` in `catalogue.toml`, rerun `sync-defaults --write`, and rebuild.
-Developers who install the updated wheel fall through to the packaged default (Layer 5),
-which resolves the public `agent-ready-repo` catalogue.
-
-## What this does not affect
-
-- `agentbundle catalogue package` — takes its `--bundle`, `--release`, and `--channel`
-  flags at run time. The `catalogue.toml` block drives `install-defaults.toml` only.
-- Developers who have run `agentbundle config set source <url>` — their Layer 2 user
-  config always wins over the org bootstrap.
-- `AGENTBUNDLE_HTTP_BEARER_TOKEN` — the bearer token env var is separate from the
-  bootstrap config; set it per host or per CI job where Artifactory requires auth.
+To revert to the public catalogue, set `enabled = false` in `catalogue.toml`, rerun
+`sync-defaults --write`, and rebuild. Developers who install the updated wheel fall through
+to the packaged default source.
 
 ## See also
 
-- [How to package a catalogue for enterprise app-store distribution](../../../docs/guides/how-to/enterprise-app-store.md) — the Artifactory upload workflow (connected → disconnected host).
-- [Flow E — fully disconnected host](../../../docs/guides/how-to/flow-e-disconnected.md) — receive-side extraction and install.
+- [How to package a catalogue for enterprise app-store distribution](../../../docs/guides/how-to/enterprise-app-store.md) — building and uploading the Artifactory release archive.
+- [Flow E — fully disconnected host](../../../docs/guides/how-to/flow-e-disconnected.md) — receive-side extraction and install for air-gapped machines.
 - [`agentbundle` reference](../reference/agentbundle.md) — full source-resolution chain and all env vars.

--- a/guides/_shared/how-to/export-catalogue-org-fork.md
+++ b/guides/_shared/how-to/export-catalogue-org-fork.md
@@ -1,0 +1,122 @@
+# How to export a catalogue for org-fork distribution
+
+**Use this when:** Your org maintains a fork of `agentbundle` and you want developers to run `agentbundle install` against your internal Artifactory channel without a manual `config set source` step.
+**Prerequisites:** A `catalogue.toml` with `[distribution.agentbundle.artifactory]` populated; Artifactory accessible from your build host; `agentbundle` ≥ 0.22.0 installed.
+**Result:** An org `agentbundle` wheel whose baked `install-defaults.toml` points to your channel, so every developer who installs from your internal index gets the right source automatically.
+
+The mechanism is the org bootstrap (Layer 3 of the source-resolution chain). When `agentbundle` starts and no explicit source or user config is set, it reads `_data/install-defaults.toml` from the installed wheel and picks up the Artifactory coordinates baked in at publish time. No developer config required.
+
+## Step 1 — Add `[distribution.agentbundle.artifactory]` to `catalogue.toml`
+
+```toml
+[distribution.agentbundle.artifactory]
+enabled    = true
+base-url   = "https://artifactory.example.com"
+repository = "agentbundle-catalogues"
+bundle     = "engineering"
+channel    = "stable"
+```
+
+All five fields are required when `enabled = true`. Use your real Artifactory hostname,
+the repository key, the bundle name your platform team assigned, and the channel name
+you use when publishing releases (typically `stable`).
+
+## Step 2 — Regenerate `install-defaults.toml`
+
+From your catalogue root:
+
+```bash
+agentbundle catalogue sync-defaults --root . --write
+```
+
+This overwrites `agentbundle/_data/install-defaults.toml` (the path set by
+`distribution.agentbundle.install-defaults-output` in `catalogue.toml`). The file is
+committed to your fork — it is not generated at install time.
+
+Verify the output before committing:
+
+```bash
+grep channel packages/agentbundle/agentbundle/_data/install-defaults.toml
+# → channel = "stable"
+```
+
+An empty `channel = ""` means the field was missing or blank in `catalogue.toml`.
+Fix it there and rerun.
+
+## Step 3 — Add a CI drift check
+
+```bash
+agentbundle catalogue sync-defaults --root . --check
+```
+
+`--check` exits 0 when the on-disk file matches what `--write` would produce and non-zero
+on drift. Add this to your CI pipeline on every push so a stale `install-defaults.toml`
+blocks the build before the wheel ships.
+
+## Step 4 — Build the wheel
+
+```bash
+cd packages/agentbundle
+python -m build --wheel
+```
+
+The generated `dist/agentbundle-<version>-py3-none-any.whl` bundles the updated
+`install-defaults.toml`. Publish it to your org's internal PyPI index.
+
+## Step 5 — Developer install
+
+Once the wheel is published, developers install it once:
+
+```bash
+pip install agentbundle --index-url https://pypi.example.com/simple/
+```
+
+From that point:
+
+```bash
+agentbundle install --pack core
+```
+
+resolves the catalogue from your Artifactory channel automatically. No `config set source`
+needed. The org bootstrap fires at Layer 3; if the developer has a `[settings].source` set
+in their user config, that takes priority (Layer 2).
+
+## Offline and air-gapped hosts
+
+For developer machines or CI runners that cannot reach Artifactory, set `AGENTBUNDLE_NO_REMOTE=1`:
+
+```bash
+AGENTBUNDLE_NO_REMOTE=1 agentbundle install --pack core /path/to/local-catalogue
+```
+
+This skips the org Artifactory bootstrap (Layer 3) and editable-install detection (Layer 4).
+`agentbundle` falls through to the packaged default source (`[defaults] source` in
+`install-defaults.toml`) or to the explicit catalogue argument. Useful in:
+
+- CI pipelines that run fully offline against a local copy.
+- Developer machines on restricted networks where Artifactory isn't reachable.
+- Air-gapped infrastructure where no external HTTP is allowed.
+
+Set the variable in the shell profile, a CI environment variable, or a wrapper script —
+it does not need to appear in any config file.
+
+## Reverting to the public catalogue
+
+Set `enabled = false` in `catalogue.toml`, rerun `sync-defaults --write`, and rebuild.
+Developers who install the updated wheel fall through to the packaged default (Layer 5),
+which resolves the public `agent-ready-repo` catalogue.
+
+## What this does not affect
+
+- `agentbundle catalogue package` — takes its `--bundle`, `--release`, and `--channel`
+  flags at run time. The `catalogue.toml` block drives `install-defaults.toml` only.
+- Developers who have run `agentbundle config set source <url>` — their Layer 2 user
+  config always wins over the org bootstrap.
+- `AGENTBUNDLE_HTTP_BEARER_TOKEN` — the bearer token env var is separate from the
+  bootstrap config; set it per host or per CI job where Artifactory requires auth.
+
+## See also
+
+- [How to package a catalogue for enterprise app-store distribution](../../../docs/guides/how-to/enterprise-app-store.md) — the Artifactory upload workflow (connected → disconnected host).
+- [Flow E — fully disconnected host](../../../docs/guides/how-to/flow-e-disconnected.md) — receive-side extraction and install.
+- [`agentbundle` reference](../reference/agentbundle.md) — full source-resolution chain and all env vars.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [Unreleased]
+
+### Added
+
+- **`channel` field in `catalogue.toml`** (`distribution.agentbundle.artifactory`): the
+  `channel` field is now required when `enabled = true`. `load_catalogue_config` validates
+  it against the same safe-segment regex used for `repository` and `bundle`, and stores it
+  in `ArtifactoryConfig.channel`. `compile_defaults` now emits the actual channel value
+  instead of an empty string, so generated `install-defaults.toml` files contain the
+  correct channel and Artifactory-sourced installs resolve successfully.
+- **`AGENTBUNDLE_NO_REMOTE` environment variable** (`source_defaults.py`): when set to any
+  truthy value, `resolve_default_source` skips the Artifactory org bootstrap (Layer 3) and
+  editable-install detection (Layer 4), falling through directly to the packaged default
+  (Layer 5). Useful for offline and air-gapped deployments.
+- **`catalogue.schema.json`**: added `channel` as an optional string property in the
+  `artifactory` object block; `additionalProperties: false` now permits the field without
+  breaking `enabled = false` configs.
+
+### Fixed
+
+- `compile_defaults` no longer emits `channel = ""` when Artifactory is enabled. The
+  previous hardcoded empty value made every Artifactory-enabled install-defaults.toml
+  unusable at runtime.
+
+### Documentation
+
+- **`docs/guides/how-to/enterprise-app-store.md`**: corrected the archive output path
+  (`dist/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz`) and the
+  channel descriptor path (`channels/<channel>.json`); added a `[distribution.agentbundle.artifactory]`
+  configuration example with `channel = "stable"`; added an environment variable reference
+  table covering `AGENTBUNDLE_HTTP_BEARER_TOKEN`, `AGENTBUNDLE_NO_REMOTE`, and
+  `AGENTBUNDLE_CA_BUNDLE` (upcoming).
+
 ## [0.21.1] — 2026-07-28
 
 ### Fixed

--- a/packages/agentbundle/DESIGN.md
+++ b/packages/agentbundle/DESIGN.md
@@ -1,104 +1,1030 @@
-# agentbundle — Design Document
-
-Living design reference for the `agentbundle` Python package. Records the architecture, module responsibilities, key invariants, and decisions so the reasoning survives beyond individual PRs.
+# agentbundle design
 
 ---
 
-## TL;DR
+## 1. How agentbundle works
 
-`agentbundle` is a pack installer and catalogue manager. It resolves a catalogue source through a five-layer chain, validates it, fetches pack content, and projects it into the target repo (or user home) for the installed adapter. The resolution chain is stateless, first-match-wins, and fail-closed on malformed config — it never falls back silently.
+### Problem
 
----
+AI agent tooling — skills, hooks, agents, commands — needs to be distributed
+across multiple IDE adapters (Claude Code, Cursor, Kiro IDE, Kiro CLI,
+GitHub Copilot, Codex, Gemini). Each adapter has a different file layout,
+frontmatter schema, and capability surface. A single pack author should not
+have to write and maintain seven versions of the same skill. agentbundle is
+the build and distribution layer that translates one source into the right
+shape per adapter, installs it into the right location, and tracks what
+landed where.
 
-## Module map
+### Core entities
 
-| Module | Responsibility |
-|---|---|
-| `cli.py` / `commands/` | Entry points; thin argument parsing; delegates to handlers |
-| `catalogue.py` | Fetches and caches catalogue content; no source resolution |
-| `source_defaults.py` | Five-layer source resolution chain (see below) |
-| `catalogue_tooling/config.py` | Parses and validates `catalogue.toml` |
-| `catalogue_tooling/defaults.py` | Generates `install-defaults.toml` from `catalogue.toml` |
-| `catalogue_tooling/self_host.py` | Projects pack content into self-hosted adapter layouts |
-| `catalogue_tooling/lint.py` | Structural lint of catalogue layout |
-| `catalogue_tooling/verify.py` | Full 18-step pre-package verification |
-| `catalogue_tooling/package.py` | Builds gzip archive + channel descriptor for Artifactory |
-| `config.py` | User-scope pack config API (`pack_dir`, `load_pack_config`) |
-| `oplog.py` | Per-pack operation log (JSONL, append-only) |
-| `scope.py` | Adapter contract loading; shipped adapter names |
-| `safety.py` | Path-confinement guards used across write paths |
-| `_data/` | Bundled data files: schema, adapter contract, install-defaults |
+**Pack** — the unit of authorship and installation. A pack groups skills,
+agents, hooks, and commands by functional domain (`atlassian`, `github`,
+`linear`, `core`, …). Metadata in `pack.toml`; source artifacts in `.apm/`.
 
----
+**Catalogue** — a collection of packs from one source (git repo, tarball,
+internal Artifactory bundle). Declares layout, build config, and
+distribution settings in `catalogue.toml`.
 
-## Source resolution chain
+**Adapter** — a target IDE or agent tool. agentbundle supports eight at
+contract v0.17: `claude-code`, `kiro-ide`, `kiro-cli`, `kiro` (deprecated
+alias for `kiro-ide`), `copilot`, `codex`, `cursor`, `gemini`.
 
-`resolve_default_source` in `source_defaults.py` implements a five-layer, first-match-wins chain. Higher layers win; a matched layer returns immediately without consulting lower ones.
+**Primitive** — the nine artifact types a pack can ship: `skill`, `agent`,
+`hook-body`, `hook-wiring`, `command`, `kiro-ide-hook`, `shared-libs`,
+`adapter-root-bins`, `user-libs`. The adapter contract maps each
+(primitive × adapter) pair to a projection recipe or `dropped`.
+
+**Scope** — where projected files land: `repo` (current project, tracked by
+`.agentbundle/state.toml` at the repo root) or `user` (home directory,
+tracked by `~/.agentbundle/state.toml`). Each pack declares the scopes it
+supports; the installer enforces them.
+
+### Install flow
 
 ```
-Layer 1  explicit positional arg          pass-through verbatim, no validation
-Layer 2  user [settings].source           validated; skipped if invalid (with stderr warning)
-Layer 3  org Artifactory bootstrap        reads install-defaults.toml; fail-closed on malformed
-Layer 4  editable-install detection       PEP 610 direct_url.json; stderr diagnostic on hit
-Layer 5  packaged default                 [defaults].source in install-defaults.toml; validated
+agentbundle install --pack <name> [<catalogue-uri>]
+        │
+        ▼
+1. Source resolution (five-layer)
+   explicit URI › user config › org Artifactory bootstrap ›
+   editable-install detection (PEP 610) › packaged default
+        │
+        ▼
+2. Catalogue fetch → tempdir
+   local path | git+https:// | catalogue+https:// | archive+https://
+        │
+        ▼
+3. Validate catalogue.toml and pack.toml against JSON schema + business rules
+        │
+        ▼
+4. Build pack for the active adapter
+   render each primitive through the adapter's projection recipe;
+   apply adapter frontmatter mapping
+        │
+        ▼
+5. Tier-classify each output path against the existing state.toml
+   T1: CLI owns it, SHA matches    → overwrite
+   T2: CLI owns it, SHA differs    → write .upstream.<ext> companion
+   T3: not in any pack's state row → refuse
+        │
+        ▼
+6. Write files under path jail (safety.write_jailed)
+        │
+        ▼
+7. persist_state_locked: re-read state, merge new PackState row, os.replace
+        │
+        ▼
+8. Write .adapt-install-marker.toml at scope root
+   (session-start hook surfaces the adapt nudge on next session open)
 ```
 
-**Fail-closed at Layer 3:** if `enabled = true` and any field is malformed, Layer 3 raises `CatalogueError` rather than falling through to Layer 4. This prevents a misconfigured org wheel from silently resolving the public catalogue.
+Profiles install a curated set of packs in a single command; each profile
+declares its own scope and pack list.
 
-**AGENTBUNDLE_NO_REMOTE:** when this env var is set to any truthy value, Layers 3 and 4 are skipped entirely. Control falls directly to Layer 5 (packaged default) or the explicit argument. Used for offline and air-gapped deployments.
+### Tier system
 
----
+Every file the CLI knows about lives in exactly one tier at any point in
+time. Computed by comparing the on-disk SHA with the SHA in state.toml:
 
-## Org bootstrap — how `install-defaults.toml` is generated
+| Tier | Condition | CLI behaviour on upgrade |
+|------|-----------|--------------------------|
+| **T1** | CLI projected it; on-disk SHA matches state | Overwrite freely |
+| **T2** | CLI projected it; on-disk SHA differs (user edited) | Write `.upstream.<ext>` companion; leave original |
+| **T3** | Not recorded in any pack row | Refuse to touch |
 
-`catalogue.toml` declares the org's Artifactory coordinates under `[distribution.agentbundle.artifactory]`:
+### Adapter contract
+
+`_data/adapter.toml` (contract v0.17) is the enumerated source of truth for
+the (primitive × adapter) matrix. It drives:
+
+- which primitives a pack may declare per adapter
+- how each primitive is rendered (projection recipe: `skill-md`,
+  `agent-md`, `merge-json`, `codex-agent-toml`, …)
+- where outputs land (`allowed-prefixes` per adapter per scope)
+- which adapters support user-scope installs
+
+`SPEC_VERSION` in `agentbundle/__init__.py` is parsed from the contract at
+import time. Lint and build gates refuse packs referencing primitives not in
+the contract for the target adapter.
+
+### CLI surface
+
+```
+agentbundle install      --pack <name> | --profile <name>  [<catalogue>]
+agentbundle upgrade      --pack <name>                     [<catalogue>]
+agentbundle uninstall    --pack <name>
+agentbundle list-installed   [--scope repo|user] [--check-drift] [--format table|json]
+agentbundle list-packs       [<catalogue>]
+agentbundle list-profiles    [<catalogue>]
+agentbundle list-targets
+agentbundle show         <pack>
+agentbundle docs         <pack> [<file>]
+agentbundle scaffold     --pack <name> --output <dir>
+agentbundle adapt        <scope>
+agentbundle render       --pack <name> --adapter <name> --output <dir>
+agentbundle config       set source <uri> | set adapter <name> | get | unset
+agentbundle validate     <pack-dir>
+agentbundle catalogue    build | self-host | package | sync-defaults | lint | verify
+agentbundle lint         packs [<path>]
+agentbundle pack         evals run | evals show
+agentbundle init-state   [--scope repo|user]
+```
+
+### State file
+
+`state.toml` at `~/.agentbundle/` (user scope) or `<repo-root>/.agentbundle/`
+(repo scope) records every installed pack. One row per `(pack, adapter)` pair:
 
 ```toml
+[packs.atlassian.claude-code]
+source     = "git+https://github.com/example/catalogue"
+version    = "0.6.3"
+scope      = "user"
+installed  = "2026-07-15T10:22:00Z"
+user_root  = "~/.agentbundle"            # § 4 addition
+files      = { ".claude/skills/jira/SKILL.md" = "sha256:abc…" }
+```
+
+Concurrent writes are serialised by `statelock.persist_state_locked`
+(`O_CREAT|O_EXCL` lockfile + re-read-merge-write-under-lock).
+
+### User config
+
+`~/.agentbundle/config.toml` (managed by `agentbundle config`) stores the
+user's preferred adapter and default catalogue source:
+
+```toml
+[settings]
+adapter = "claude-code"
+source  = "git+https://github.com/example/my-catalogue"
+```
+
+---
+
+## 2. Catalogue capability
+
+### Catalogue structure
+
+```
+catalogue.toml          ← distribution metadata, build config, paths
+packs/
+  <pack-name>/
+    pack.toml           ← pack identity, scopes, allowed-adapters, evals
+    .apm/               ← primitive source tree
+    seeds/              ← scaffold templates (dropped by `agentbundle scaffold`)
+    docs/               ← pack-specific documentation
+    guides/             ← (optional) pack guides mirroring guides/_shared layout
+profiles/
+  <name>.toml           ← curated pack sets
+guides/
+  _shared/              ← cross-cutting guides (any pack can reference)
+  _reference/           ← catalogue-level reference docs
+  <pack-name>/          ← pack-specific guide tree
+```
+
+### `catalogue.toml`
+
+Key sections:
+
+```toml
+[catalogue]
+name                     = "agent-ready-repo"
+display-name             = "Agent Ready Repo"
+description              = "…"
+minimum-agentbundle-version = "0.13.0"
+user-dir                 = "~/.agentbundle"   # § 4 addition — preferred user root
+
+[catalogue.paths]
+packs                    = "packs"
+profiles                 = "profiles"
+marketplace              = ".claude-plugin/marketplace.json"
+build-output             = "dist"
+
+[distribution.agentbundle]
+preferred-adapter        = "claude-code"
+default-source           = "git+https://github.com/example/my-catalogue"
+install-defaults-output  = "packages/agentbundle/agentbundle/_data/install-defaults.toml"
+
+[distribution.agentbundle.artifactory]
+enabled                  = false
+
+[pack-defaults.atlassian]          # § 4 addition — catalogue operator overrides
+url         = "https://jira.yourorg.com/"
+project-key = "INFRA"
+```
+
+### Distribution mechanisms
+
+| URI form | Mechanism |
+|----------|-----------|
+| Local path | Used as-is |
+| `git+https://<host>/<owner>/<repo>[@<ref>]` | GitHub archive tarball, extracted to tempdir — no git subprocess |
+| `catalogue+https://<url>` | Enterprise: SHA-256-verified tarball, origin-locked redirects, member-by-member extraction |
+| `archive+https://<url>` | Same without the origin lock |
+
+All fetches use `urllib.request` only. SSH URIs are not supported.
+
+### Artifactory enterprise distribution
+
+For organisations that cannot use GitHub as a distribution channel (air-gapped
+networks, private IP ranges, internal proxy policies), agentbundle supports
+JFrog Artifactory as the catalogue host. This is the `catalogue+https://`
+path end-to-end.
+
+#### Catalogue author setup
+
+The catalogue declares its Artifactory coordinates in `catalogue.toml`:
+
+```toml
+[distribution.agentbundle.artifactory]
 enabled    = true
 base-url   = "https://artifactory.example.com"
-repository = "agentbundle-catalogues"
-bundle     = "engineering"
+repository = "agent-catalogues"    # Artifactory generic repo name
+bundle     = "my-catalogue"        # logical catalogue bundle name
+channel    = "stable"              # release channel (required when enabled)
+```
+
+`catalogue lint` validates all five fields when `enabled = true`:
+`base-url` must be `https://`, no credentials in the netloc, no query or
+fragment. `repository`, `bundle`, and `channel` must each match
+`[A-Za-z0-9._-]+` and must not be `..`. `channel` is required; an absent
+or empty value raises `CatalogueConfigError` with `channel = "stable"` as
+the example value.
+
+`compile_defaults` bakes the coordinates into `install-defaults.toml`:
+
+```toml
+# _data/install-defaults.toml  (generated)
+[organization.artifactory]
+enabled    = true
+base-url   = "https://artifactory.example.com"
+repository = "agent-catalogues"
+bundle     = "my-catalogue"
 channel    = "stable"
 ```
 
-`agentbundle catalogue sync-defaults --write` calls `compile_defaults` (in `defaults.py`) which reads the validated `CatalogueConfig` and writes `install-defaults.toml`. That file is committed to the fork and baked into the wheel.
+#### URL construction
 
-**Invariant:** `load_catalogue_config` validates `channel` is present, non-empty, and matches `[A-Za-z0-9._-]+` when `enabled = true`. `compile_defaults` emits `art.channel or ""` — so the baked file always carries the real channel value, never an empty placeholder.
-
-The URL constructed at runtime is:
+`read_org_bootstrap` constructs a `catalogue+https://` source URI from the
+baked coordinates:
 
 ```
-catalogue+<base-url>/<repository>/catalogues/<bundle>/channels/<channel>.json
+catalogue+https://<base-url>/<repository>/catalogues/<bundle>/channels/<channel>.json
+```
+
+Example:
+```
+catalogue+https://artifactory.example.com/agent-catalogues/catalogues/my-catalogue/channels/stable.json
+```
+
+This `.json` file is the channel manifest — a JSON document pointing to the
+current bundle archive. The catalogue operator uploads it as part of the
+release process (see `catalogue package`).
+
+#### Runtime source resolution (Layer 3)
+
+At install time, when the user provides no explicit source URI and has no
+`source` in their user config, `resolve_default_source` reaches Layer 3:
+
+```
+Layer 1: explicit CLI arg
+Layer 2: user config  (~/.agentbundle/config.toml [settings].source)
+Layer 3: org Artifactory bootstrap  ← reads install-defaults.toml
+Layer 4: editable-install detection (PEP 610 direct-url.json)
+Layer 5: packaged default source    (install-defaults.toml [defaults].source)
+```
+
+Layer 3 is **fail-closed**: if `organization.artifactory.enabled = true` but
+any field is malformed, `CatalogueError` is raised and the install aborts —
+it never falls through to Layer 4/5 with a corrupt configuration. If
+`enabled = false` (or the section is absent), Layer 3 returns `None` and
+resolution continues.
+
+**`AGENTBUNDLE_NO_REMOTE=1`** skips Layers 3 and 4 entirely, falling straight
+through to Layer 5. Use it on air-gapped hosts or CI environments that cannot
+reach Artifactory — the install resolves the packaged default source without
+any network contact.
+
+#### Fetch security
+
+`https_catalogue.py` handles `catalogue+https://` URIs:
+
+- **SHA-256 verification** — the channel manifest includes the expected
+  digest of the bundle archive; the download is rejected if it doesn't match.
+- **Origin-locked redirects** — HTTP redirects are followed only to the same
+  origin (`netloc`); a redirect to a different host is a hard error.
+- **Member-by-member extraction** — the tarball is not bulk-extracted; each
+  member path is validated against the pack's declared `allowed-prefixes`
+  before being written to disk.
+
+#### Operator checklist
+
+To enable Artifactory distribution:
+
+1. Set `[distribution.agentbundle.artifactory] enabled = true` with all five
+   fields (`base-url`, `repository`, `bundle`, `channel`, `enabled`) in `catalogue.toml`.
+2. Run `agentbundle catalogue sync-defaults` to bake coordinates into
+   `install-defaults.toml`.
+3. Run `agentbundle catalogue package --channel stable` to produce the
+   bundle archive and the `stable.json` channel manifest.
+4. Upload the archive and manifest to Artifactory at the constructed path.
+5. Distribute the updated agentbundle package (which carries the baked
+   `install-defaults.toml`) to users — via PyPI, internal pip mirror, or
+   direct install.
+
+Users install packs with a bare `agentbundle install --pack <name>` — no
+source URI needed. Layer 3 resolves it automatically from the baked
+coordinates.
+
+### install-defaults baking
+
+`catalogue sync-defaults` runs `compile_defaults` and writes
+`install-defaults.toml` into `_data/`. This file ships bundled with
+agentbundle and is read at runtime without contacting the catalogue source.
+
+```toml
+# _data/install-defaults.toml  (generated — do not edit)
+[organization]
+preferred_adapter = "claude-code"
+
+[defaults]
+source = "git+https://github.com/example/my-catalogue"
+
+[pack-defaults.atlassian]         # § 4 addition
+url         = "https://jira.yourorg.com/"
+project-key = "INFRA"
+```
+
+`check_defaults` does a byte-exact drift check; CI fails when
+`install-defaults.toml` is out of sync with `catalogue.toml`.
+
+### Build pipeline
+
+The build processes one pack for one adapter:
+
+1. Walk `.apm/<primitive>/` and load source files.
+2. Apply the adapter's projection recipe per primitive.
+3. Apply adapter frontmatter mapping (source keys → adapter-expected keys).
+4. Compute output paths under `allowed-prefixes`.
+5. Return a footprint: `{relpath: sha256}` for every output file.
+
+Deterministic: same source + adapter + contract → same output.
+
+### Catalogue operator tooling
+
+`agentbundle catalogue` subcommands for pack authors and release engineers:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `lint` | Validate `catalogue.toml`, `pack.toml`(s), and source files against schema + business rules |
+| `verify` | Check a built dist tree matches the source |
+| `build` | Produce a distributable dist tree |
+| `self-host` | Project core packs (+ governance-extras) into the repo's own workspace |
+| `package` | Bundle into a distributable `catalogue+https://` tarball |
+| `sync-defaults` | Regenerate `install-defaults.toml` from `catalogue.toml` |
+
+---
+
+## 3. How packs work
+
+### Pack structure
+
+```
+packs/<name>/
+├── pack.toml          ← identity, install constraints, evals list
+├── README.md
+├── config.toml        ← pack-source config defaults + schema  (§ 4 addition)
+├── AGENTS.md          ← pack-specific agent context
+├── .apm/
+│   ├── skills/        ← one subdirectory per skill; contains SKILL.md [+ assets/]
+│   ├── agents/        ← agent .md files
+│   ├── hooks/         ← hook body scripts (.py or .sh)
+│   ├── hook-wiring/   ← hook wiring .json files
+│   ├── commands/      ← command scripts
+│   └── kiro-ide-hooks/← Kiro IDE–specific hook files
+├── seeds/             ← scaffold templates
+└── docs/              ← pack documentation tree
+```
+
+### `pack.toml`
+
+```toml
+[pack]
+name          = "atlassian"
+version       = "0.6.3"
+description   = "Jira / Confluence skills and workflows."
+display_name  = "Atlassian"
+license       = "Apache-2.0 OR MIT"
+categories    = ["integrations", "project-management"]
+keywords      = ["jira", "confluence"]
+
+[pack.adapter-contract]
+version       = "0.8"    # minimum contract version the pack was authored against
+
+[pack.install]
+default-scope    = "user"
+allowed-scopes   = ["user", "repo"]
+allowed-adapters = ["claude-code", "kiro-ide", "codex", "copilot", "cursor", "gemini"]
+
+[pack.evals]
+skills = ["jira", "jira-align", "jira-brief-intake", "flow-metrics", …]
+
+[pack.links]
+documentation = "https://github.com/example/catalogue/tree/main/guides/atlassian/"
+```
+
+`allowed-adapters` constrains which adapters the build will target. A pack
+that uses only `skill` and `agent` primitives can set a broad list; a pack
+that relies on adapter-specific primitives (e.g. `kiro-ide-hook`) narrows it.
+
+### Primitives in detail
+
+| Primitive | Source location | What the adapters receive |
+|-----------|----------------|---------------------------|
+| `skill` | `.apm/skills/<name>/SKILL.md` | A SKILL.md file at the adapter's configured skills path |
+| `agent` | `.apm/agents/<name>.md` | An agent file at the adapter's agents path; frontmatter remapped per adapter |
+| `hook-body` | `.apm/hooks/<name>.py` | A hook script at the adapter's hook body location |
+| `hook-wiring` | `.apm/hook-wiring/<name>.json` | Merged into the adapter's hook config (e.g. `settings.json` for Claude Code) |
+| `command` | `.apm/commands/<name>.md` | A slash-command file (Claude Code only; `dropped` on all other adapters) |
+| `kiro-ide-hook` | `.apm/kiro-ide-hooks/<name>.md` | Kiro IDE–specific hook file |
+| `shared-libs` | `.apm/shared-libs/` | Shared Python/shell libraries placed at the adapter's lib path |
+| `adapter-root-bins` | `.apm/adapter-root-bins/` | Scripts placed at the adapter's root binary location |
+| `user-libs` | `.apm/user-libs/` | User-scope shared libraries |
+
+Primitives marked `dropped` in the contract for a given adapter are silently
+excluded from the build for that adapter. A `dropped-primitives` warning
+is emitted at install time when a pack ships a primitive the target adapter
+cannot receive.
+
+### Skills
+
+A skill is the primary primitive. Each skill lives in its own subdirectory:
+
+```
+.apm/skills/<slug>/
+├── SKILL.md       ← the skill definition — rendered as-is by all adapters
+└── assets/        ← optional supporting files projected alongside the skill
+```
+
+`SKILL.md` frontmatter declares the skill's name, description (≤ 1024 chars
+for Kiro compatibility), version, and optional metadata:
+
+```markdown
+---
+name: jira
+description: Use this skill to create, update, and query Jira issues.
+---
+
+# Skill: jira
+…
+```
+
+The rendered output for Claude Code lands at `.claude/skills/<slug>/SKILL.md`.
+For Kiro IDE at `.kiro/steering/<slug>.md`. For Copilot at
+`.github/skills/<slug>/SKILL.md`. The adapter contract's projection recipe
+handles path and frontmatter transformation automatically.
+
+### Agents
+
+Agent files live at `.apm/agents/<name>.md` with adapter-specific frontmatter
+keys. The build applies the adapter's frontmatter mapping (declared in
+`_data/adapter.toml`) to translate source keys into the format each adapter
+expects. For example, Claude Code's `description` maps to Kiro's `description`
+unchanged, but Codex expects its agent config under `.codex/agents/<name>.toml`
+in a different schema entirely.
+
+### Hooks
+
+Two complementary primitives:
+
+**`hook-body`** — the executable script (`.py`; `.sh` is also accepted but
+`.py` is preferred for Windows portability). Projected to the adapter's
+hook body location (e.g. `tools/hooks/<name>.py` for Claude Code).
+
+**`hook-wiring`** — the JSON configuration that registers the hook body with
+the adapter's hook mechanism (e.g. merged into `~/.claude/settings.json`
+for Claude Code's `hooks` key). Multiple packs can wire hooks to the same
+event; the `merge-json` recipe handles conflict-free merging.
+
+### Profiles
+
+A profile is a curated set of packs installed in a single command:
+
+```toml
+# profiles/starter.toml
+[profile]
+name        = "starter"
+description = "Core + Atlassian + GitHub — a minimal engagement stack."
+scope       = "user"
+
+[[profile.packs]]
+name = "core"
+
+[[profile.packs]]
+name = "atlassian"
+
+[[profile.packs]]
+name = "github"
+```
+
+Profiles declare their own scope; `--scope` is not allowed alongside
+`--profile`.
+
+### Pack evals
+
+`agentbundle pack evals run` drives the pack's skill-activation evaluations,
+checking that the adapter's agent activates the right skill for a given
+natural-language prompt. The `[pack.evals]` field in `pack.toml` lists the
+skill slugs under test. Results are streamed as JSONL and summarised in a
+table.
+
+---
+
+## 4. Pack config and ops
+
+### Motivation
+
+Pack scripts (skills, hooks, tools) need to read site-specific settings —
+system URLs, credential references, feature flags — that vary between
+catalogue adopters. They also need a record of what they did so that
+subsequent runs and human auditors can inspect history.
+
+Neither `state.toml` (the CLI's install record) nor projected skill files
+are the right home for this: state.toml is owned by the CLI, and projected
+files are managed by the pack author. The user's home directory is the
+natural place for per-pack runtime data.
+
+This section specifies:
+
+- **`pack_dir` / `load_pack_config`** added to `agentbundle.config`.
+- **`agentbundle.oplog`** — atomic JSONL append.
+- **CLI subcommands** — `agentbundle pack-config` and `agentbundle oplog`.
+- **`guides/_shared/reference/pack-config-api.md`** — the pack-author reference.
+
+Both modules are pure I/O layers. Schema parsing and business logic belong
+to the pack script.
+
+**Non-goals:** config encryption, remote config sync, multi-user sharing,
+real-time oplog streaming.
+
+---
+
+### Directory layout
+
+Each catalogue writes its pack directories into its own **user root**. The
+default root is `~/.agentbundle/`; a catalogue declares an alternative in
+`catalogue.toml`. The subdirectory name is the pack slug.
+
+```
+~/.agentbundle/               ← default root for agent-ready-repo catalogue
+├── state.toml                ← existing CLI install record
+├── atlassian/
+│   ├── config.toml           ← pack-specific user config (not source-controlled)
+│   └── ops.jsonl             ← operation log
+├── github/
+│   ├── config.toml
+│   └── ops.jsonl
+├── linear/
+│   └── config.toml
+└── core/
+    └── ops.jsonl
+
+~/agentcommander/             ← custom root declared by agent-commander catalogue
+└── agent-commander/
+    ├── config.toml
+    └── ops.jsonl
+```
+
+Directories are created with mode `0o700`, matching `user_state_path`.
+
+---
+
+### Root resolution
+
+**The authoritative root for each pack lives in `state.toml`.** `PackState`
+gains a `user_root` field written at install time from `catalogue.toml`'s
+`catalogue.user-dir`. This keeps the root under the existing
+`persist_state_locked` machinery and prevents silent mislocation if any
+side-file is deleted.
+
+`pack_dir(pack_name, *, home=None)` resolution order:
+
+0. **`home=` kwarg** — short-circuits everything else. Used in tests to
+   pin the user root to a temp directory without touching env vars.
+1. **`AGENTBUNDLE_USER_ROOT` env var** — routed through
+   `scope.resolve_user_root()`. Test/CI escape hatch; shifts the entire
+   user root.
+2. **`user_root` in the *user*-scope `~/.agentbundle/state.toml` for this
+   pack slug** — written at install time (e.g. `~/agentcommander`). Always
+   the user-scope state.toml, even for packs installed at repo scope;
+   pack config/oplog is a user-home concern regardless of install scope.
+3. **`~/.agentbundle/`** — fallback when the pack is absent from
+   user-scope state.toml (first-run or partial install). Correct
+   first-run behaviour: `load_pack_config` returns `{}`.
+
+`pack_dir` consults any `(pack_slug, *)` row in user-scope state.toml. If
+multiple rows exist for the same slug (different adapters, or two catalogues
+sharing a slug), all rows must agree on `user_root`. If they don't,
+`pack_dir` raises `PackRootConflict` — install-time lint should prevent
+this for catalogues with overlapping slugs.
+
+Directory creation is delegated to a new `safety.make_pack_dir(base, pack_name)`
+that carries the symlink/TOCTOU guard from `user_state_path` **and** jails
+`base` to the user's home via `resolve_user_root()` — a catalogue setting
+`user-dir` outside `$HOME` is rejected before any directory is created.
+
+**`catalogue.toml` extension:**
+
+```toml
+[catalogue]
+user-dir = "~/agentcommander"   # optional; default "~/.agentbundle"
+minimum-agentbundle-version = "0.21.0"   # must be ≥ the release shipping §4
+```
+
+`catalogue lint` requires `minimum-agentbundle-version` ≥ the agentbundle
+release that introduces `user-dir` whenever the key is present.
+
+Schema: add `user-dir` as optional string to the `catalogue` object in
+`_data/catalogue.schema.json`. Add `user_dir: str = "~/.agentbundle"` to
+`CatalogueConfig` in `catalogue_tooling/config.py`.
+
+**`PackState` extension:** add `user_root: str = "~/.agentbundle"` field,
+written at install time via `persist_state_locked`. Pre-field rows
+(installed before this version) are read with the default `"~/.agentbundle"`;
+a subsequent `agentbundle upgrade` rewrites the row with the correct
+`user_root` from the catalogue source.
+
+---
+
+### Config cascade
+
+Three layers, merged in order (later wins):
+
+```
+1. Pack-source defaults    packs/<pack>/config.toml  [defaults]
+2. Catalogue overrides     catalogue.toml  [pack-defaults.<pack>]
+3. User overrides          ~/<root>/<pack>/config.toml
+```
+
+Layers 1 and 2 are **build-time**: `compile_defaults` merges them into
+`install-defaults.toml` under `[pack-defaults.<pack>]`. At runtime,
+`load_pack_config` reads two sources only — baked + user.
+
+#### Pack-source `config.toml`
+
+Each pack ships `packs/<pack-name>/config.toml`:
+
+```toml
+[defaults]
+url         = "https://jira.example.com/"
+project-key = "PROJ"
+
+[schema]
+url         = { type = "string", description = "Jira base URL" }
+project-key = { type = "string", description = "Default Jira project key" }
+```
+
+`[defaults]` feeds into `compile_defaults`. `[schema]` is consumed by
+`catalogue lint` for validation; not read at runtime.
+
+#### Catalogue operator overrides
+
+`[pack-defaults.<pack>]` is a **top-level** section in `catalogue.toml`
+(not under `[distribution.agentbundle]` — pack config is adapter-agnostic):
+
+```toml
+[pack-defaults.atlassian]
+url         = "https://jira.yourorg.com/"
+project-key = "INFRA"
+```
+
+`compile_defaults` merges pack-source defaults with catalogue overrides and
+emits to `install-defaults.toml`. Catalogue values override pack-source
+values; keys present only in pack-source pass through unchanged.
+
+#### User overrides
+
+Users hand-edit `~/<root>/<pack>/config.toml` or use
+`agentbundle pack-config set`. The file is created with mode `0o600`.
+Merge is shallow: `{**baked_defaults, **user_overrides}`. Nested tables:
+the later layer replaces the whole sub-table — prefer flat pack configs.
+
+---
+
+### API additions to `agentbundle.config`
+
+Added to the existing `config.py` (not a new module — the names are
+distinct from everything already there, and a separate module would
+fragment a small surface):
+
+```python
+def pack_dir(pack_name: str, *, home: Path | None = None) -> Path:
+    """Return <user_root>/<pack_name>/, creating it (0o700) on first access.
+
+    Resolution order:
+      0. home= kwarg (test override — short-circuits everything)
+      1. AGENTBUNDLE_USER_ROOT env var (via resolve_user_root)
+      2. user_root from user-scope state.toml for this pack slug
+         (always user-scope state.toml, even for repo-scoped packs)
+      3. ~/.agentbundle/ (fallback for packs not yet in state.toml)
+
+    Raises PackRootConflict when multiple rows for the same slug disagree
+    on user_root. Delegates directory creation to safety.make_pack_dir,
+    which jails base to $HOME and carries the symlink/TOCTOU guard from
+    user_state_path.
+    """
+
+def load_pack_config(
+    pack_name: str,
+    *,
+    path: Path | None = None,
+    home: Path | None = None,
+) -> dict:
+    """Merged pack config: baked catalogue defaults then user overrides.
+
+    Layer 1: _data/install-defaults.toml [pack-defaults.<pack>]  (may be {})
+    Layer 2: <pack_dir>/config.toml user overrides               (may be {})
+
+    Shallow merge. Returns {} when both layers absent.
+    Never raises on a missing file. path= overrides user-config for tests.
+    """
+```
+
+**Usage in pack scripts:**
+
+```python
+from agentbundle.config import load_pack_config
+
+cfg = load_pack_config("atlassian")
+url = cfg.get("url", "https://jira.example.com/")
 ```
 
 ---
 
-## `catalogue.toml` validation model
+### New module: `agentbundle.oplog`
 
-`load_catalogue_config` (`config.py`) runs two passes:
+```python
+def write_entry(
+    pack_name: str,
+    action: str,
+    src: str,
+    dst: str | None = None,
+    *,
+    extra: dict | None = None,
+    home: Path | None = None,
+) -> None:
+    """Atomic JSONL append to <pack_dir>/ops.jsonl.
 
-1. **JSON Schema** — structural validation via `agentbundle.build.validate`. Catches wrong types, unknown keys (`additionalProperties: false`), and missing required fields.
-2. **Business rules** — constraints the schema cannot express: credentials in URLs, path traversal, preferred-adapter against the live contract, channel required when enabled, etc.
+    Creates directory and file on first call. Entry shape (key order):
 
-Both passes raise `CatalogueConfigError` (a subclass of `CatalogueError`). Schema errors list all violations; business rule errors name the specific field and suggest a correction.
+        {"action": "archive", "src": "/path/a", "dst": "/path/b",
+         ...extra, "ts": "2026-07-27T14:32:01.234Z"}
+
+    ts    — UTC ISO-8601 with milliseconds; captured after the payload
+            and emitted as the LAST key so the entry reflects when it
+            was fully assembled.
+    dst   — omitted when None.
+    extra — merged after dst, before ts; reserved keys (ts, action,
+            src, dst, _truncated) in extra raise ValueError before any I/O.
+
+    Oversized entries: if the base fields alone (action + src + dst)
+    exceed PIPE_BUF, raises EntryTooLargeError before any I/O — the
+    caller must shorten src/dst. If extra pushes the total over the cap,
+    extra is dropped and "_truncated": true is written instead — the
+    side-effect is already committed; raising after the fact is wrong.
+    """
+```
+
+**Usage in pack scripts:**
+
+```python
+from agentbundle.oplog import write_entry
+
+write_entry("atlassian", "sync", str(issue_key))
+write_entry("atlassian", "archive", str(src), str(dst),
+            extra={"ticket": "PROJ-42"})
+```
+
+#### Atomicity
+
+**POSIX** (`os.name == "posix"`): `os.open(O_WRONLY | O_CREAT | O_APPEND)`,
+then a **single `os.write()` call**. On Linux and macOS, a single
+`write(2)` to an `O_APPEND` file is positioned atomically by the kernel's
+inode lock — no other writer can interleave within one syscall. A retry
+loop would allow interleaving *between* retries, so the entry must fit in
+one call. Entries are serialised before calling `_append_line`; if the
+serialised length exceeds `PIPE_BUF` (512 bytes minimum per POSIX — 4096
+in practice on Linux/macOS), write raises `EntryTooLargeError` *before*
+any I/O, preserving the atomicity guarantee. Known limitation: NFS-mounted
+home directories — callers on NFS can wrap `write_entry` in a `state_lock`.
+
+**Windows** (`os.name != "posix"`): `statelock.state_lock` with a sibling
+`ops.jsonl.lock`.
+
+```python
+_POSIX = os.name == "posix"
+_PIPE_BUF = 4096   # conservative; POSIX minimum is 512
+
+def _append_line(path: Path, line: bytes) -> None:
+    if len(line) > _PIPE_BUF:
+        raise EntryTooLargeError(len(line), _PIPE_BUF)
+    if _POSIX:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            n = os.write(fd, line)
+            if n != len(line):
+                raise EntryTooLargeError(len(line), n)  # short write — filesystem full
+        finally:
+            os.close(fd)
+    else:
+        from agentbundle.statelock import state_lock
+        with state_lock(path):
+            with open(path, "ab") as f:
+                f.write(line)
+```
+
+**Durability:** no `fsync` per entry — an unflushed tail can be lost on
+crash. Acceptable for an ops log. Callers that need durability call
+`os.fsync` after `write_entry`.
 
 ---
 
-## Security invariants
+### CLI surface
 
-- **No credentials in URLs.** `_check_no_credentials` rejects userinfo in netloc and credential-looking query params (`token`, `password`, `key`, `secret`, `api_key`, `apikey`) in any source or base-url field.
-- **Path confinement.** `_validate_path` and the `safety.py` guards reject absolute paths, `..` traversal, and symlink escapes outside the catalogue root. Applied to every path field in `catalogue.toml` and every write path in `defaults.py`.
-- **Error messages never contain raw credential values.** Errors that reference a base-url with embedded credentials name the field and config path; they do not echo the URL.
-- **Segment grammar.** `repository`, `bundle`, and `channel` in the org bootstrap are validated against `[A-Za-z0-9._-]+` and a `..` rejection before use in URL path construction.
+Pack scripts use the Python API. The CLI subcommands exist for users
+setting up config manually, for shell-based scripts, and for debugging.
+
+#### `agentbundle pack-config`
+
+```
+agentbundle pack-config get <pack> [<key>]
+    Print resolved config (all keys as TOML, or a single value as plain
+    string). Exit 1 with message if <key> is absent.
+
+agentbundle pack-config set <pack> <key> <value>
+    Write <key> = <value> into ~/<root>/<pack>/config.toml (0o600).
+    Creates the file if absent. Preserves unrelated keys.
+    Value is always written as a TOML basic string — no type coercion
+    against [schema]. Pack scripts are responsible for parsing (e.g.
+    int(cfg["port"]), cfg["enabled"].lower() == "true"). This is
+    intentional: the CLI cannot safely infer type without a loaded schema,
+    and string-only is always lossless.
+
+agentbundle pack-config unset <pack> <key>
+    Remove <key> from the user override file. No-op if absent.
+
+agentbundle pack-config show <pack>
+    Print merged config annotated with the source of each value:
+      url = "https://jira.yourorg.com/"   # baked default
+      project-key = "MYPROJ"             # user override
+    "baked default" covers both pack-source defaults and catalogue
+    overrides — install-defaults.toml merges them at build time and
+    the runtime cannot distinguish which layer a baked value came from.
+```
+
+`pack-config set` uses the existing `_emit_basic_string` / `_toml_key`
+serialisation helpers in `config.py` and the same read-modify-write shape
+as `write_setting` in `user_config.py`.
+
+#### `agentbundle oplog`
+
+```
+agentbundle oplog show <pack> [--last N]
+    Print the last N entries (default 20) as human-readable lines.
+    Exits 0 with "no entries" if the log is absent.
+
+agentbundle oplog clear <pack> [--yes]
+    Truncate <pack>/ops.jsonl. Prompts for confirmation unless --yes.
+```
+
+The CLI write path (`agentbundle oplog write`) is omitted until a real
+non-Python caller exists.
 
 ---
 
-## Key design decisions
+### Pack-author reference
 
-**Resolution is stateless.** `resolve_default_source` never writes config and never reads the filesystem except via injected callables. This makes the precedence and validation logic unit-testable without touching real files or installed metadata.
+The canonical reference lives at `guides/_shared/reference/pack-config-api.md`.
+Other catalogues adopt the same `guides/_shared/` convention at the same
+path in their own repo — no projection, no external URL.
 
-**Fail-closed over silent fallback.** A misconfigured `enabled = true` block at Layer 3 raises rather than falling through. The invariant: if an operator configured Artifactory, a misconfiguration must surface immediately, not produce a confusing install from the wrong source.
+**What `packs/AGENTS.md` adds:**
 
-**`compile_defaults` is a pure function.** Given a `CatalogueConfig`, it returns a deterministic TOML string. No filesystem reads, no side effects. `write_defaults` wraps it with path-jail enforcement and an atomic write.
+```markdown
+## Per-pack config and ops log
 
-**Schema and business rules are separated.** The JSON schema handles structural constraints that are cheap to express declaratively. Business rules (`channel` required-when-enabled, segment character set, source URL validation) are code — they produce better error messages and are easier to evolve.
+Pack scripts read site-specific config via the `agentbundle` Python API.
+The catalogue operator pre-configures defaults in `catalogue.toml`; users
+override in `~/<root>/<pack>/config.toml`.
+
+**Reading config:**
+
+    from agentbundle.config import load_pack_config
+
+    cfg = load_pack_config("my-pack")
+    url = cfg.get("url", "https://fallback.example.com/")
+
+Returns the merged dict (baked defaults + user overrides). Never raises;
+returns `{}` on first run.
+
+**Writing an ops log entry:**
+
+    from agentbundle.oplog import write_entry
+
+    write_entry("my-pack", "archive", str(src), str(dst))
+
+**Declaring config keys** — create `packs/<pack>/config.toml`:
+
+    [defaults]
+    url = "https://example.com/"
+
+    [schema]
+    url = { type = "string", description = "Service base URL" }
+
+`catalogue lint` validates the declared schema.
+
+**User setup:**
+
+    agentbundle pack-config set my-pack url https://internal.example.com/
+    agentbundle pack-config show my-pack
+
+Full reference: `guides/_shared/reference/pack-config-api.md`
+```
+
+---
+
+### Files to create / modify
+
+All paths relative to `packages/agentbundle/` unless noted.
+
+| Path | Change |
+|------|--------|
+| `agentbundle/config.py` | Add `pack_dir()` and `load_pack_config()`; add `user_root` to `PackState` |
+| `agentbundle/oplog.py` | New module |
+| `agentbundle/safety.py` | Add `make_pack_dir(base, pack_name)` with symlink/TOCTOU guard |
+| `agentbundle/_data/catalogue.schema.json` | Add `catalogue.user-dir` (optional string); add top-level `pack-defaults` object |
+| `agentbundle/catalogue_tooling/config.py` | Add `user_dir` to `CatalogueConfig`; parse `[pack-defaults.*]` |
+| `agentbundle/catalogue_tooling/defaults.py` | Include `user_dir` and `[pack-defaults.*]` in `compile_defaults`; update `check_defaults` ordering |
+| `agentbundle/commands/pack_config_cmd.py` | New: `pack-config get/set/unset/show` |
+| `agentbundle/commands/oplog_cmd.py` | New: `oplog show/clear` |
+| `agentbundle/cli.py` | Register new subcommands |
+| `guides/_shared/reference/pack-config-api.md` *(repo root)* | New: pack-author reference guide |
+| `packs/AGENTS.md` *(repo root)* | Add pack-config + oplog section |
+| `tests/unit/test_pack_config.py` | New: root resolution, cascade merge, empty-dict on absent, env-var override |
+| `tests/unit/test_oplog.py` | New: creates dir, JSONL shape, extra= merge, truncation marker, concurrent appends, reserved-key rejection |
+| `tests/unit/test_pack_config_cmd.py` | New: CLI get/set/unset/show |
+
+---
+
+### Resolved design decisions
+
+**Root storage — `user-scope state.toml`, not a side index.** A separate
+index file is deletable and has no locking story. `state.toml` is the locked,
+authoritative per-pack record; adding `user_root` reuses `persist_state_locked`
+and prevents silent mislocation. Always the user-scope state.toml regardless
+of install scope — pack config/oplog is a user-home concern.
+
+**Slug collision across catalogues — `PackRootConflict` on disagreement.**
+`pack_dir` asserts all `(slug, *)` rows in user-scope state.toml agree on
+`user_root`. Catalogue operators must coordinate slugs across catalogues
+they intend to co-install. This is a known design limitation and the right
+failure mode (loud, not silent mislocation).
+
+**`catalogue.user-dir` jailed to `$HOME`.** `make_pack_dir` rejects a resolved
+base outside the user's home via `resolve_user_root()`. A catalogue cannot
+write to `/etc/` or arbitrary absolute paths.
+
+**`catalogue.user-dir` version-gated.** `catalogue lint` requires
+`minimum-agentbundle-version` ≥ the introducing release when `user-dir` is
+present. Older installs silently mislocate; the gate prevents that.
+
+**`catalogue.toml` key for pack-defaults — top-level `[pack-defaults.*]`.**
+Pack config is adapter-agnostic, so it does not belong under
+`[distribution.agentbundle]`.
+
+**Three-layer config cascade.** Pack-source defaults + catalogue overrides
+merged at build time into `install-defaults.toml`; user overrides applied
+at runtime. Two file reads at runtime; the full cascade is auditable via
+`pack-config show`.
+
+**`pack-config set` is string-only.** No type coercion against `[schema]`.
+Pack scripts parse as needed. The CLI cannot safely infer type without a
+loaded schema; string-only is always lossless.
+
+**Oplog — single `os.write()` on POSIX, capped at PIPE_BUF.** A retry loop
+would allow interleaving between calls; one syscall is atomic. Base-field
+oversize raises before I/O; extra-field oversize truncates (side-effect
+already committed). Windows uses `state_lock`.
+
+**`pack-config show` labels baked values as "baked default"** — not
+"catalogue default" or "pack default". `install-defaults.toml` merges both
+layers at build time; the runtime cannot distinguish them without added
+per-key provenance.
+
+**Pre-field state.toml rows default to `~/.agentbundle/`.** On next
+`upgrade`, the row is rewritten with the correct `user_root` from the
+catalogue source.
+
+**Self-hosted catalogue reference — `guides/_shared/reference/`, no PyPI
+link.** Other catalogues place their reference at the same path in their
+own repo.

--- a/packages/agentbundle/DESIGN.md
+++ b/packages/agentbundle/DESIGN.md
@@ -1,0 +1,104 @@
+# agentbundle — Design Document
+
+Living design reference for the `agentbundle` Python package. Records the architecture, module responsibilities, key invariants, and decisions so the reasoning survives beyond individual PRs.
+
+---
+
+## TL;DR
+
+`agentbundle` is a pack installer and catalogue manager. It resolves a catalogue source through a five-layer chain, validates it, fetches pack content, and projects it into the target repo (or user home) for the installed adapter. The resolution chain is stateless, first-match-wins, and fail-closed on malformed config — it never falls back silently.
+
+---
+
+## Module map
+
+| Module | Responsibility |
+|---|---|
+| `cli.py` / `commands/` | Entry points; thin argument parsing; delegates to handlers |
+| `catalogue.py` | Fetches and caches catalogue content; no source resolution |
+| `source_defaults.py` | Five-layer source resolution chain (see below) |
+| `catalogue_tooling/config.py` | Parses and validates `catalogue.toml` |
+| `catalogue_tooling/defaults.py` | Generates `install-defaults.toml` from `catalogue.toml` |
+| `catalogue_tooling/self_host.py` | Projects pack content into self-hosted adapter layouts |
+| `catalogue_tooling/lint.py` | Structural lint of catalogue layout |
+| `catalogue_tooling/verify.py` | Full 18-step pre-package verification |
+| `catalogue_tooling/package.py` | Builds gzip archive + channel descriptor for Artifactory |
+| `config.py` | User-scope pack config API (`pack_dir`, `load_pack_config`) |
+| `oplog.py` | Per-pack operation log (JSONL, append-only) |
+| `scope.py` | Adapter contract loading; shipped adapter names |
+| `safety.py` | Path-confinement guards used across write paths |
+| `_data/` | Bundled data files: schema, adapter contract, install-defaults |
+
+---
+
+## Source resolution chain
+
+`resolve_default_source` in `source_defaults.py` implements a five-layer, first-match-wins chain. Higher layers win; a matched layer returns immediately without consulting lower ones.
+
+```
+Layer 1  explicit positional arg          pass-through verbatim, no validation
+Layer 2  user [settings].source           validated; skipped if invalid (with stderr warning)
+Layer 3  org Artifactory bootstrap        reads install-defaults.toml; fail-closed on malformed
+Layer 4  editable-install detection       PEP 610 direct_url.json; stderr diagnostic on hit
+Layer 5  packaged default                 [defaults].source in install-defaults.toml; validated
+```
+
+**Fail-closed at Layer 3:** if `enabled = true` and any field is malformed, Layer 3 raises `CatalogueError` rather than falling through to Layer 4. This prevents a misconfigured org wheel from silently resolving the public catalogue.
+
+**AGENTBUNDLE_NO_REMOTE:** when this env var is set to any truthy value, Layers 3 and 4 are skipped entirely. Control falls directly to Layer 5 (packaged default) or the explicit argument. Used for offline and air-gapped deployments.
+
+---
+
+## Org bootstrap — how `install-defaults.toml` is generated
+
+`catalogue.toml` declares the org's Artifactory coordinates under `[distribution.agentbundle.artifactory]`:
+
+```toml
+enabled    = true
+base-url   = "https://artifactory.example.com"
+repository = "agentbundle-catalogues"
+bundle     = "engineering"
+channel    = "stable"
+```
+
+`agentbundle catalogue sync-defaults --write` calls `compile_defaults` (in `defaults.py`) which reads the validated `CatalogueConfig` and writes `install-defaults.toml`. That file is committed to the fork and baked into the wheel.
+
+**Invariant:** `load_catalogue_config` validates `channel` is present, non-empty, and matches `[A-Za-z0-9._-]+` when `enabled = true`. `compile_defaults` emits `art.channel or ""` — so the baked file always carries the real channel value, never an empty placeholder.
+
+The URL constructed at runtime is:
+
+```
+catalogue+<base-url>/<repository>/catalogues/<bundle>/channels/<channel>.json
+```
+
+---
+
+## `catalogue.toml` validation model
+
+`load_catalogue_config` (`config.py`) runs two passes:
+
+1. **JSON Schema** — structural validation via `agentbundle.build.validate`. Catches wrong types, unknown keys (`additionalProperties: false`), and missing required fields.
+2. **Business rules** — constraints the schema cannot express: credentials in URLs, path traversal, preferred-adapter against the live contract, channel required when enabled, etc.
+
+Both passes raise `CatalogueConfigError` (a subclass of `CatalogueError`). Schema errors list all violations; business rule errors name the specific field and suggest a correction.
+
+---
+
+## Security invariants
+
+- **No credentials in URLs.** `_check_no_credentials` rejects userinfo in netloc and credential-looking query params (`token`, `password`, `key`, `secret`, `api_key`, `apikey`) in any source or base-url field.
+- **Path confinement.** `_validate_path` and the `safety.py` guards reject absolute paths, `..` traversal, and symlink escapes outside the catalogue root. Applied to every path field in `catalogue.toml` and every write path in `defaults.py`.
+- **Error messages never contain raw credential values.** Errors that reference a base-url with embedded credentials name the field and config path; they do not echo the URL.
+- **Segment grammar.** `repository`, `bundle`, and `channel` in the org bootstrap are validated against `[A-Za-z0-9._-]+` and a `..` rejection before use in URL path construction.
+
+---
+
+## Key design decisions
+
+**Resolution is stateless.** `resolve_default_source` never writes config and never reads the filesystem except via injected callables. This makes the precedence and validation logic unit-testable without touching real files or installed metadata.
+
+**Fail-closed over silent fallback.** A misconfigured `enabled = true` block at Layer 3 raises rather than falling through. The invariant: if an operator configured Artifactory, a misconfiguration must surface immediately, not produce a confusing install from the wrong source.
+
+**`compile_defaults` is a pure function.** Given a `CatalogueConfig`, it returns a deterministic TOML string. No filesystem reads, no side effects. `write_defaults` wraps it with path-jail enforcement and an atomic write.
+
+**Schema and business rules are separated.** The JSON schema handles structural constraints that are cheap to express declaratively. Business rules (`channel` required-when-enabled, segment character set, source URL validation) are code — they produce better error messages and are easier to evolve.

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -153,6 +153,11 @@ Developers installing from your fork get the internal channel without a manual
 A malformed `enabled = true` config fails closed — no silent fallback to the public
 source.
 
+**Offline and air-gapped hosts:** set `AGENTBUNDLE_NO_REMOTE=1` to skip the org
+Artifactory bootstrap and editable-install detection entirely. `agentbundle` falls
+straight through to the packaged default, so hosts without network access to Artifactory
+still resolve a source without errors.
+
 See the full enterprise adoption guide at
 `docs/guides/_shared/how-to/use-an-artifactory-catalogue.md` for all six flows
 (org bootstrap, repo-scope CI upgrade, user-scope MDM, source-conflict remediation,

--- a/packages/agentbundle/agentbundle/_data/catalogue.schema.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue.schema.json
@@ -171,6 +171,10 @@
                 "bundle": {
                   "type": "string",
                   "description": "Catalogue bundle name (required when enabled)."
+                },
+                "channel": {
+                  "type": "string",
+                  "description": "Artifactory channel name (required when enabled = true)."
                 }
               }
             }

--- a/packages/agentbundle/agentbundle/catalogue_tooling/config.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/config.py
@@ -78,6 +78,7 @@ class ArtifactoryConfig:
     base_url: str | None = None
     repository: str | None = None
     bundle: str | None = None
+    channel: str | None = None
 
 
 @dataclass
@@ -446,9 +447,21 @@ def load_catalogue_config(root: Path) -> CatalogueConfig | None:
                     f"catalogue.toml: distribution.agentbundle.artifactory.{seg_name} "
                     f"must match [A-Za-z0-9._-]+, got {seg_val!r}"
                 )
+        channel = art_raw.get("channel")
+        if not channel or not isinstance(channel, str) or not channel.strip():
+            raise CatalogueConfigError(
+                "catalogue.toml: distribution.agentbundle.artifactory.channel "
+                "is required when enabled = true (e.g. channel = \"stable\")"
+            )
+        if not _SAFE_SEGMENT_RE.match(channel):
+            raise CatalogueConfigError(
+                f"catalogue.toml: distribution.agentbundle.artifactory.channel "
+                f"must match [A-Za-z0-9._-]+, got {channel!r}"
+            )
         art.base_url = base_url
         art.repository = repository
         art.bundle = bundle
+        art.channel = channel
 
     agentbundle_dist = AgentbundleDistribution(
         install_defaults_output=install_defaults_output,

--- a/packages/agentbundle/agentbundle/catalogue_tooling/defaults.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/defaults.py
@@ -84,8 +84,7 @@ def compile_defaults(config: CatalogueConfig) -> str:
         art_rows.append(("base-url", _emit_str(art.base_url or "")))
         art_rows.append(("repository", _emit_str(art.repository or "")))
         art_rows.append(("bundle", _emit_str(art.bundle or "")))
-        # channel is not in ArtifactoryConfig dataclass — emit empty when enabled
-        art_rows.append(("channel", _emit_str("")))
+        art_rows.append(("channel", _emit_str(art.channel or "")))
     parts.append(_emit_section("organization.artifactory", art_rows))
 
     # [defaults]

--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -20,6 +20,7 @@ consults a repo-committed source. See
 from __future__ import annotations
 
 import json
+import os
 import re
 import re as _re
 import sys
@@ -572,19 +573,20 @@ def resolve_default_source(
             file=stream,
         )
 
-    # Layer 3 — org Artifactory bootstrap (RFC-0072 D2).
-    if read_org is None:
-        read_org = read_org_bootstrap
-    org = read_org()  # None when disabled; raises CatalogueError on fail-closed
-    if org is not None:
-        return org
+    if not os.environ.get("AGENTBUNDLE_NO_REMOTE"):
+        # Layer 3 — org Artifactory bootstrap (RFC-0072 D2).
+        if read_org is None:
+            read_org = read_org_bootstrap
+        org = read_org()  # None when disabled; raises CatalogueError on fail-closed
+        if org is not None:
+            return org
 
-    # Layer 4 — editable detection.
-    if dist is _UNSET:
-        dist = _load_distribution()
-    editable = _detect_editable_source(dist, stream=stream)
-    if editable is not None:
-        return editable
+        # Layer 4 — editable detection.
+        if dist is _UNSET:
+            dist = _load_distribution()
+        editable = _detect_editable_source(dist, stream=stream)
+        if editable is not None:
+            return editable
 
     # Layer 5 — packaged default, validated.
     if read_packaged is None:

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.21.1"
+CLI_VERSION = "0.22.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.21.1"
+version = "0.22.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_defaults.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_defaults.py
@@ -47,6 +47,7 @@ def _make_config(
     art_base_url: str | None = None,
     art_repository: str | None = None,
     art_bundle: str | None = None,
+    art_channel: str | None = None,
 ) -> CatalogueConfig:
     """Construct a minimal CatalogueConfig for use in tests."""
     return CatalogueConfig(
@@ -79,6 +80,7 @@ def _make_config(
                     base_url=art_base_url,
                     repository=art_repository,
                     bundle=art_bundle,
+                    channel=art_channel,
                 ),
             )
         ),
@@ -129,6 +131,27 @@ def test_compile_with_artifactory():
     assert 'repository = "my-repo"' in output
     assert 'bundle = "my-bundle"' in output
     assert 'channel = ""' in output
+
+
+def test_compile_defaults_channel_emitted():
+    """compile_defaults emits channel = "stable" when ArtifactoryConfig.channel = "stable"."""
+    config = _make_config(
+        art_enabled=True,
+        art_base_url="https://art.example.com",
+        art_repository="my-repo",
+        art_bundle="my-bundle",
+        art_channel="stable",
+    )
+    output = compile_defaults(config)
+    assert 'channel = "stable"' in output
+
+
+def test_compile_defaults_artifactory_disabled_no_channel_required():
+    """compile_defaults with enabled = false succeeds; no channel line emitted."""
+    config = _make_config(art_enabled=False)
+    output = compile_defaults(config)
+    assert "enabled = false" in output
+    assert "channel" not in output
 
 
 def test_compile_with_defaults_source():

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -257,10 +257,12 @@ def test_config_valid_enterprise(tmp_path):
         "base-url = 'https://art.example.com'\n"
         "repository = 'my-repo'\n"
         "bundle = 'engineering'\n"
+        "channel = 'stable'\n"
     )
     _write_toml(tmp_path, content)
     result = load_catalogue_config(tmp_path)
     assert result is not None
+    assert result.distribution.agentbundle.artifactory.channel == "stable"
 
 
 def test_config_bad_schema_integer(tmp_path):
@@ -545,3 +547,62 @@ def test_cli_lint_packs_help():
     combined = stdout + stderr
     assert rc == 0, f"Expected zero exit for lint packs --help, got {rc}: {combined}"
     assert "--root" in combined, "--root not found in lint packs --help output"
+
+
+# ---------------------------------------------------------------------------
+# Artifactory channel field — load_catalogue_config validation
+# ---------------------------------------------------------------------------
+
+_ART_ENABLED_BASE = (
+    "schema = 1\n"
+    "[catalogue]\n"
+    "name = 'test'\ndisplay-name = 'T'\ndescription = 't'\n"
+    "minimum-agentbundle-version = '0.14.0'\n"
+    "[catalogue.paths]\n"
+    "packs = 'packs'\nprofiles = 'profiles'\ncontracts = 'contracts'\n"
+    "marketplace = '.claude-plugin/marketplace.json'\nbuild-output = 'dist'\n"
+    "[catalogue.build]\n"
+    "recipes = ['default']\nself-host = false\nclaude-plugin-branch = 'main'\n"
+    "marketplace-description = 't'\n"
+    "[catalogue.package]\n"
+    "include = ['packs/core']\nrequired = ['packs/core']\n"
+    "[distribution.agentbundle]\n"
+    "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+    "preferred-adapter = 'claude-code'\n"
+    "default-source = 'git+https://github.com/example/repo'\n"
+    "[distribution.agentbundle.artifactory]\n"
+    "enabled = true\n"
+    "base-url = 'https://art.example.com'\n"
+    "repository = 'my-repo'\n"
+    "bundle = 'engineering'\n"
+)
+
+
+def test_load_catalogue_config_art_enabled_with_channel(tmp_path):
+    """ArtifactoryConfig.channel is set when enabled = true and channel is present."""
+    from agentbundle.catalogue_tooling.config import load_catalogue_config
+
+    content = _ART_ENABLED_BASE + "channel = 'stable'\n"
+    _write_toml(tmp_path, content)
+    result = load_catalogue_config(tmp_path)
+    assert result is not None
+    assert result.distribution.agentbundle.artifactory.channel == "stable"
+
+
+def test_load_catalogue_config_art_enabled_no_channel_raises(tmp_path):
+    """enabled = true with no channel field raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    _write_toml(tmp_path, _ART_ENABLED_BASE)
+    with pytest.raises(CatalogueConfigError, match="channel"):
+        load_catalogue_config(tmp_path)
+
+
+def test_load_catalogue_config_art_enabled_empty_channel_raises(tmp_path):
+    """enabled = true with channel = '' raises CatalogueConfigError."""
+    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
+
+    content = _ART_ENABLED_BASE + "channel = ''\n"
+    _write_toml(tmp_path, content)
+    with pytest.raises(CatalogueConfigError, match="channel"):
+        load_catalogue_config(tmp_path)

--- a/packages/agentbundle/tests/unit/test_org_bootstrap.py
+++ b/packages/agentbundle/tests/unit/test_org_bootstrap.py
@@ -670,3 +670,77 @@ def test_resolve_layer1_beats_layer3():
     )
     assert out == "explicit-arg"
     assert called == [], "read_org must not have been called"
+
+
+# ---------------------------------------------------------------------------
+# test_source_from_org_bootstrap_with_channel — channel segment in URI
+# ---------------------------------------------------------------------------
+
+
+def test_source_from_org_bootstrap_with_channel():
+    """channel = "stable" in TOML produces a URI containing the channel segment."""
+    toml = """\
+[organization.artifactory]
+enabled = true
+base-url = "https://example.test/art"
+repository = "repo-local"
+bundle = "engineering"
+channel = "stable"
+"""
+    url = _source_from_org_bootstrap(toml, config_path="test-path")
+    assert url is not None
+    assert "channels/stable.json" in url
+    assert url == (
+        "catalogue+https://example.test/art"
+        "/repo-local/catalogues/engineering/channels/stable.json"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AGENTBUNDLE_NO_REMOTE — Layer 3 and 4 bypass
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_source_no_remote_skips_layers_3_and_4(monkeypatch):
+    """AGENTBUNDLE_NO_REMOTE=1 → Layer 3 (read_org) and Layer 4 (dist) are not called."""
+    monkeypatch.setenv("AGENTBUNDLE_NO_REMOTE", "1")
+
+    layer3_called: list[bool] = []
+    layer4_called: list[bool] = []
+
+    class _SpyDist:
+        def __getattr__(self, name: str):
+            layer4_called.append(True)
+            raise AssertionError(f"Layer 4 reached (attr: {name!r})")
+
+    def _read_org_spy() -> str | None:
+        layer3_called.append(True)
+        raise AssertionError("Layer 3 must not be called with AGENTBUNDLE_NO_REMOTE set")
+
+    with pytest.raises(CatalogueError):
+        # Layer 5 also absent → raises CatalogueError (all layers exhausted)
+        resolve_default_source(
+            None,
+            config_source=None,
+            dist=_SpyDist(),
+            read_org=_read_org_spy,
+            read_packaged=lambda: None,
+        )
+
+    assert layer3_called == [], "Layer 3 must not have been called"
+    assert layer4_called == [], "Layer 4 must not have been called"
+
+
+def test_resolve_default_source_no_remote_layer5_still_works(monkeypatch):
+    """AGENTBUNDLE_NO_REMOTE=1 → Layer 5 packaged default is still returned."""
+    monkeypatch.setenv("AGENTBUNDLE_NO_REMOTE", "1")
+
+    packaged = "git+https://example.test/packaged-default"
+    out = resolve_default_source(
+        None,
+        config_source=None,
+        dist=None,
+        read_org=lambda: (_ for _ in ()).throw(AssertionError("Layer 3 must not run")),
+        read_packaged=lambda: packaged,
+    )
+    assert out == packaged


### PR DESCRIPTION
## Summary

- **Schema**: add `channel` as an optional string to the `[distribution.agentbundle.artifactory]` block in both `contracts/catalogue.schema.json` and the bundled `_data/` copy. `additionalProperties: false` previously rejected the field entirely.
- **Config**: `ArtifactoryConfig` gains `channel: str | None = None`; `load_catalogue_config` validates it is present, non-empty, and safe-segment-clean when `enabled = true` (raises `CatalogueConfigError` with `channel = "stable"` as the example value).
- **Defaults**: `compile_defaults` now emits `art.channel or ""` instead of hardcoded `""` — fixes the root cause of every Artifactory-enabled `install-defaults.toml` shipping a broken empty channel value.
- **AGENTBUNDLE_NO_REMOTE**: `resolve_default_source` skips Layers 3 & 4 when this env var is set, falling through to Layer 5 (packaged default). Turns a phantom CI env var into a real documented escape hatch for offline/air-gapped deployments.
- **Docs**: corrected the archive output path and channel descriptor path in `enterprise-app-store.md`; added config example with `channel = "stable"` and an env var reference table.
- **New guide**: `guides/_shared/how-to/export-catalogue-org-fork.md` — adopter-facing walkthrough for configuring and exporting an org fork so developers get the right Artifactory source automatically.
- **AGENTS.local.md**: clarifies `docs/guides/` (maintainer-only, never projected) vs `guides/` (adopter-facing, projected).
- **README-pypi.md**: documents `AGENTBUNDLE_NO_REMOTE` in the Enterprise distribution section.
- **Version**: 0.21.1 → 0.22.0 (minor bump: schema change + new env var).

## Test plan

- [ ] `python -m pytest packages/agentbundle/tests/unit/test_org_bootstrap.py` — 57 passing, including 3 new tests for `test_source_from_org_bootstrap_with_channel`, `test_resolve_default_source_no_remote_skips_layers_3_and_4`, `test_resolve_default_source_no_remote_layer5_still_works`
- [ ] `python -m pytest packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py` — includes 3 new channel validation tests
- [ ] `python -m pytest packages/agentbundle/tests/unit/test_catalogue_tooling_defaults.py` — includes 2 new compile_defaults channel tests
- [ ] Full suite: `python -m pytest packages/agentbundle/tests/` — all pass (exit 0)
- [ ] `python -m ruff check` on all changed source files — clean

## Deferred

- `AGENTBUNDLE_CA_BUNDLE` (planned corporate TLS CA bundle override) — marked "upcoming" in the enterprise-app-store.md env var table; not implemented in this PR.