### PR TITLE
fix(packaging): honour include/required config in catalogue package command

### DIFF
--- a/contracts/catalogue.schema.json
+++ b/contracts/catalogue.schema.json
@@ -108,17 +108,17 @@
         "package": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["include", "required"],
+          "required": ["include"],
           "properties": {
             "include": {
               "type": "array",
               "items": { "type": "string" },
-              "description": "Pack paths to include in a packaged archive."
+              "description": "Pack paths to include in a packaged archive. Empty list means include all packs."
             },
             "required": {
               "type": "array",
               "items": { "type": "string" },
-              "description": "Pack paths that must be present (subset of include)."
+              "description": "Required root-level file paths. Overrides the default LICENSE-APACHE / LICENSE-MIT constraint when set. Absent or empty means use the default requirement."
             }
           }
         }

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
-## [Unreleased]
+## [0.22.1] — 2026-07-28
 
 ### Added
 
@@ -29,6 +29,18 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 - `compile_defaults` no longer emits `channel = ""` when Artifactory is enabled. The
   previous hardcoded empty value made every Artifactory-enabled install-defaults.toml
   unusable at runtime.
+
+### Changed
+
+- **`agentbundle catalogue package`** now honours `catalogue.package.include`
+  and `catalogue.package.required` from `catalogue.toml`. When `include` is
+  non-empty, only those pack directories are archived (non-pack dirs such as
+  `profiles/`, `contracts/`, and `.claude-plugin/` are always included). When
+  `required` is set, it replaces the default `LICENSE-APACHE` / `LICENSE-MIT`
+  constraint; absent or empty `required` preserves existing behavior.
+  Path-traversal entries in `include` are rejected before any filesystem access.
+  (`catalogue_tooling/package.py`, `catalogue_tooling/config.py`,
+  `_data/catalogue.schema.json`, `contracts/catalogue.schema.json`)
 
 ### Documentation
 

--- a/packages/agentbundle/DESIGN.md
+++ b/packages/agentbundle/DESIGN.md
@@ -1028,3 +1028,78 @@ catalogue source.
 **Self-hosted catalogue reference — `guides/_shared/reference/`, no PyPI
 link.** Other catalogues place their reference at the same path in their
 own repo.
+
+---
+
+## Catalogue packaging engine (`catalogue_tooling/package.py`)
+
+### Content allowlist
+
+Every packaged archive is built from an explicit allowlist — nothing outside it is ever included. The allowlist has three layers:
+
+| Layer | What | Controlled by |
+| ----- | ---- | ------------- |
+| Pack directories | `packs/<name>/` | `_DEFAULT_INCLUDE_DIRS` + `config.package.include` |
+| Non-pack directories | `profiles/`, `contracts/`, `.claude-plugin/` | `_DEFAULT_INCLUDE_DIRS` (always included) |
+| Root files | `AGENTS.md`, `README.md`, `LICENSE-*` | `_DEFAULT_INCLUDE_ROOT_FILES` (always included) |
+
+**Non-pack directories and root files are always included regardless of `config.package.include`.**
+
+### `config.package.include` semantics (D-3)
+
+When `catalogue.package.include` is non-empty in `catalogue.toml`, it is an explicit pack allowlist:
+
+- Each entry must be a relative path starting with `packs/` (e.g., `"packs/core"`).
+- Entries containing `..` components are rejected before any filesystem access.
+- Entries pointing to non-existent directories raise a clear error.
+- An empty `include = []` means include all packs — the default behavior.
+
+This lets operators ship partial catalogues: a `[catalogue.package] include = ["packs/core"]` archive contains only `packs/core/` plus the always-included non-pack dirs and root files.
+
+### `config.package.required` semantics (D-2)
+
+The default `_REQUIRED_PATHS` constant requires `LICENSE-APACHE` and `LICENSE-MIT` (in addition to `packs/` and `.claude-plugin/marketplace.json`). Enterprise operators with proprietary or single-file licenses can override this:
+
+- When `catalogue.package.required` is explicitly set and non-empty, it **replaces** `_REQUIRED_PATHS` entirely.
+- When `required` is absent or empty (the common case), `_REQUIRED_PATHS` applies unchanged.
+- This is a full replacement, not a merge — the operator owns the complete required-files contract when they override it.
+
+### 8-step staging + atomic placement sequence
+
+`package_catalogue()` never writes partial output. It uses a staged-then-renamed sequence:
+
+1. Pre-package `verify_catalogue` (full source-checkout pipeline)
+2. Load `catalogue.toml` config (include/required overrides, manifest metadata)
+3. Scan + validate content (allowlist, symlink/hardlink/traversal guards, pack.toml validity)
+4. Build archive bytes in memory
+5. Write staged `.tmp` archive + sidecar
+6. Self-verify the staged archive (`verify_archive`)
+7. Atomic rename archive and sidecar into place
+8. Write channel descriptor **last** (only after archive is verified and placed)
+
+Step 6 ensures the archive is structurally sound before it becomes visible. Step 8 ensures the channel descriptor never points to a partially-written or missing archive.
+
+### Config loading order
+
+`catalogue.toml` is loaded exactly once, immediately after `verify_catalogue` returns ok. Both the packaging behavior (include/required) and the manifest metadata (name, display-name, min-version) come from this single load. If config loading fails, all fields default to their safe fallbacks and the archive is built from defaults.
+
+---
+
+## Schema contract (`_data/catalogue.schema.json`, `contracts/catalogue.schema.json`)
+
+The `[catalogue.package]` section:
+
+- `include` — required, array of strings. Empty array = include all packs.
+- `required` — optional, array of strings. When present and non-empty, overrides `_REQUIRED_PATHS`; when absent or empty, `_REQUIRED_PATHS` applies.
+
+Both schema copies (`_data/` and `contracts/`) must stay identical. The `_data/` copy is bundled into the wheel; `contracts/` is the source-of-truth in the repo.
+
+---
+
+## Invariants
+
+- **Symlinks are always rejected.** No symlink — file, directory, or hardlink — enters the archive. This is checked at scan time (excluded) and validate time (error).
+- **Path traversal in `include` is rejected before any I/O.** The `..` check happens before any `os.walk` call.
+- **Archives are deterministic under `SOURCE_DATE_EPOCH`.** All timestamps, sort orders, and member metadata are fixed; identical inputs produce byte-identical archives.
+- **`catalogue.toml` is never included in the archive.** It is stripped from `file_bytes` before archiving even if `_scan_content` somehow collected it.
+- **Channel descriptor is written last.** A descriptor that exists always points to a valid, verified archive.

--- a/packages/agentbundle/agentbundle/_data/catalogue.schema.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue.schema.json
@@ -108,17 +108,17 @@
         "package": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["include", "required"],
+          "required": ["include"],
           "properties": {
             "include": {
               "type": "array",
               "items": { "type": "string" },
-              "description": "Pack paths to include in a packaged archive."
+              "description": "Pack paths to include in a packaged archive. Empty list means include all packs."
             },
             "required": {
               "type": "array",
               "items": { "type": "string" },
-              "description": "Pack paths that must be present (subset of include)."
+              "description": "Required root-level file paths. Overrides the default LICENSE-APACHE / LICENSE-MIT constraint when set. Absent or empty means use the default requirement."
             }
           }
         }

--- a/packages/agentbundle/agentbundle/catalogue_tooling/config.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/config.py
@@ -373,15 +373,6 @@ def load_catalogue_config(root: Path) -> CatalogueConfig | None:
     include = pkg_raw.get("include", [])
     required = pkg_raw.get("required", [])
 
-    include_set = set(include)
-    required_set = set(required)
-    not_in_include = required_set - include_set
-    if not_in_include:
-        raise CatalogueConfigError(
-            f"catalogue.toml: package.required entries not in package.include: "
-            f"{sorted(not_in_include)}"
-        )
-
     package = CataloguePackage(include=include, required=required)
 
     # --- [distribution.agentbundle] ---

--- a/packages/agentbundle/agentbundle/catalogue_tooling/package.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/package.py
@@ -92,26 +92,60 @@ def _validate_flag_value(flag: str, value: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _scan_content(root: Path) -> list[Path]:
+def _scan_content(root: Path, pack_include: list[str] | None = None) -> list[Path]:
     """Return sorted list of regular (non-symlink) files from the content allowlist.
 
-    Uses _DEFAULT_INCLUDE_DIRS and _DEFAULT_INCLUDE_ROOT_FILES; applies
-    _IMPLICIT_DENY_DIRS to skip denied top-level directories even if they appear
-    inside an allowed dir (unlikely but defensive).
+    When pack_include is non-empty, only the listed pack directories are walked;
+    non-pack dirs (profiles/, contracts/, .claude-plugin/) are always included.
+    An empty or absent pack_include includes all packs (default behavior).
     """
     collected: list[Path] = []
 
-    for dir_parts in _DEFAULT_INCLUDE_DIRS:
-        d = root.joinpath(*dir_parts)
-        if not d.is_dir() or d.is_symlink():
-            continue
-        for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
-            dp = Path(dirpath)
-            for fname in filenames:
-                p = dp / fname
-                if p.is_file() and not p.is_symlink():
-                    collected.append(p)
-            dirnames[:] = [dn for dn in dirnames if not (dp / dn).is_symlink()]
+    if pack_include:
+        for entry in pack_include:
+            parts = Path(entry).parts
+            if not entry.startswith("packs/") or ".." in parts:
+                raise ValueError(
+                    f"pack_include entry {entry!r} must start with 'packs/' and must not "
+                    f"contain path traversal components"
+                )
+            d = root / entry
+            if not d.is_dir():
+                raise ValueError(
+                    f"pack_include entry {entry!r} does not exist on disk at {d}"
+                )
+            for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
+                dp = Path(dirpath)
+                for fname in filenames:
+                    p = dp / fname
+                    if p.is_file() and not p.is_symlink():
+                        collected.append(p)
+                dirnames[:] = [dn for dn in dirnames if not (dp / dn).is_symlink()]
+        for dir_parts in _DEFAULT_INCLUDE_DIRS:
+            if dir_parts[0] == "packs":
+                continue
+            d = root.joinpath(*dir_parts)
+            if not d.is_dir() or d.is_symlink():
+                continue
+            for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
+                dp = Path(dirpath)
+                for fname in filenames:
+                    p = dp / fname
+                    if p.is_file() and not p.is_symlink():
+                        collected.append(p)
+                dirnames[:] = [dn for dn in dirnames if not (dp / dn).is_symlink()]
+    else:
+        for dir_parts in _DEFAULT_INCLUDE_DIRS:
+            d = root.joinpath(*dir_parts)
+            if not d.is_dir() or d.is_symlink():
+                continue
+            for dirpath, dirnames, filenames in os.walk(str(d), followlinks=False):
+                dp = Path(dirpath)
+                for fname in filenames:
+                    p = dp / fname
+                    if p.is_file() and not p.is_symlink():
+                        collected.append(p)
+                dirnames[:] = [dn for dn in dirnames if not (dp / dn).is_symlink()]
 
     for fname in _DEFAULT_INCLUDE_ROOT_FILES:
         p = root / fname
@@ -121,10 +155,18 @@ def _scan_content(root: Path) -> list[Path]:
     return sorted(collected, key=lambda p: p.relative_to(root).as_posix())
 
 
-def _check_required_files(root: Path, content_paths: list[Path]) -> str | None:
-    """Return error string if any required path is missing, else None."""
+def _check_required_files(
+    root: Path,
+    content_paths: list[Path],
+    required_override: list[str] | None = None,
+) -> str | None:
+    """Return error string if any required path is missing, else None.
+
+    When required_override is not None, checks those paths instead of _REQUIRED_PATHS.
+    """
+    required = required_override if required_override is not None else _REQUIRED_PATHS
     posix_set = {p.relative_to(root).as_posix() for p in content_paths}
-    for req in _REQUIRED_PATHS:
+    for req in required:
         if req.endswith("/"):
             # Directory check
             if not (root / req.rstrip("/")).is_dir():
@@ -479,10 +521,30 @@ def package_catalogue(
         )
         return _err(f"pre-package verify failed: {msgs}")
 
-    # --- Scan and validate content ---
-    content_paths = _scan_content(root)
+    # --- Load catalogue.toml for package config ---
+    pack_include: list[str] = []
+    required_override: list[str] | None = None
+    catalogue_name: str | None = None
+    catalogue_display_name: str | None = None
+    min_version_manifest = minimum_agentbundle_version
+    try:
+        from agentbundle.catalogue_tooling.config import load_catalogue_config
+        config = load_catalogue_config(root)
+        if config is not None:
+            catalogue_name = config.name
+            catalogue_display_name = config.display_name
+            if min_version_manifest is None:
+                min_version_manifest = config.minimum_agentbundle_version
+            pack_include = config.package.include or []
+            if config.package.required:
+                required_override = config.package.required
+    except Exception:
+        pass
 
-    req_err = _check_required_files(root, content_paths)
+    # --- Scan and validate content ---
+    content_paths = _scan_content(root, pack_include=pack_include)
+
+    req_err = _check_required_files(root, content_paths, required_override=required_override)
     if req_err is not None:
         return _err(req_err)
 
@@ -533,21 +595,6 @@ def package_catalogue(
 
     if published_at is None:
         published_at = datetime.now(UTC).replace(microsecond=0).isoformat()
-
-    # --- Read catalogue.toml metadata for manifest ---
-    catalogue_name: str | None = None
-    catalogue_display_name: str | None = None
-    min_version_manifest = minimum_agentbundle_version
-    try:
-        from agentbundle.catalogue_tooling.config import load_catalogue_config
-        config = load_catalogue_config(root)
-        if config is not None:
-            catalogue_name = config.name
-            catalogue_display_name = config.display_name
-            if min_version_manifest is None:
-                min_version_manifest = config.minimum_agentbundle_version
-    except Exception:
-        pass
 
     # --- Compute marketplace_digest ---
     marketplace_digest: str | None = None

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.22.0"
+CLI_VERSION = "0.22.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.22.0"
+version = "0.22.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -380,19 +380,6 @@ def test_config_symlink_escape(tmp_path):
         load_catalogue_config(tmp_path)
 
 
-def test_config_required_not_in_include(tmp_path):
-    """AC6: required ⊄ include raises CatalogueConfigError."""
-    from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config
-
-    content = _VALID_BASE.replace(
-        "include = ['packs/core']\nrequired = ['packs/core']",
-        "include = ['packs/core']\nrequired = ['packs/enterprise']",
-    )
-    _write_toml(tmp_path, content)
-    with pytest.raises(CatalogueConfigError, match="required|include"):
-        load_catalogue_config(tmp_path)
-
-
 def test_config_unknown_recipe(tmp_path):
     """AC6: unknown recipe raises CatalogueConfigError."""
     from agentbundle.catalogue_tooling.config import CatalogueConfigError, load_catalogue_config

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -519,3 +519,212 @@ def test_check_required_files_fails_on_missing_license(tmp_path: Path) -> None:
     err = _check_required_files(root, paths)
     assert err is not None
     assert "LICENSE-APACHE" in err
+
+
+# ---------------------------------------------------------------------------
+# pack_include and required_override
+# ---------------------------------------------------------------------------
+
+
+def _make_two_pack_catalogue(tmp_path: Path) -> Path:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    for pack_name in ("pack-alpha", "pack-beta"):
+        pack_dir = root / "packs" / pack_name
+        pack_dir.mkdir(parents=True)
+        (pack_dir / "pack.toml").write_text(
+            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
+    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+    cp_dir = root / ".claude-plugin"
+    cp_dir.mkdir()
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    return root
+
+
+def test_scan_content_include_one_pack(tmp_path: Path) -> None:
+    root = _make_two_pack_catalogue(tmp_path)
+    paths = _scan_content(root, pack_include=["packs/pack-alpha"])
+    posix = [p.relative_to(root).as_posix() for p in paths]
+    assert any(p.startswith("packs/pack-alpha/") for p in posix)
+    assert not any(p.startswith("packs/pack-beta/") for p in posix)
+
+
+def test_scan_content_include_empty_includes_all(tmp_path: Path) -> None:
+    root = _make_two_pack_catalogue(tmp_path)
+    paths = _scan_content(root, pack_include=[])
+    posix = [p.relative_to(root).as_posix() for p in paths]
+    assert any(p.startswith("packs/pack-alpha/") for p in posix)
+    assert any(p.startswith("packs/pack-beta/") for p in posix)
+
+
+def test_scan_content_nonpack_dirs_always_included(tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    pack_dir = root / "packs" / "pack-alpha"
+    pack_dir.mkdir(parents=True)
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "pack-alpha"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (root / "profiles").mkdir()
+    (root / "profiles" / "default.toml").write_text(
+        '[profile]\nname = "default"\n', encoding="utf-8"
+    )
+    (root / "contracts").mkdir()
+    (root / "contracts" / "adapter.toml").write_text(
+        '[contract]\nversion = "1"\n', encoding="utf-8"
+    )
+    paths = _scan_content(root, pack_include=["packs/pack-alpha"])
+    posix = [p.relative_to(root).as_posix() for p in paths]
+    assert any(p.startswith("packs/pack-alpha/") for p in posix)
+    assert any(p.startswith("profiles/") for p in posix)
+    assert any(p.startswith("contracts/") for p in posix)
+
+
+def test_scan_content_include_nonexistent_raises(tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    (root / "packs").mkdir()
+    with pytest.raises(ValueError, match="does not exist"):
+        _scan_content(root, pack_include=["packs/nonexistent-pack"])
+
+
+@pytest.mark.parametrize("bad_entry", ["../outside", "packs/../../escape"])
+def test_scan_content_include_path_traversal_raises(bad_entry: str, tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        _scan_content(root, pack_include=[bad_entry])
+
+
+def test_check_required_custom_license(tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    (root / "packs").mkdir()
+    (root / "LICENSE").write_text("Custom license\n", encoding="utf-8")
+    paths = [root / "LICENSE"]
+    err = _check_required_files(root, paths, required_override=["LICENSE"])
+    assert err is None
+
+
+def test_check_required_none_uses_defaults(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path, with_license_apache=False)
+    paths = _scan_content(root)
+    err = _check_required_files(root, paths, required_override=None)
+    assert err is not None
+    assert "LICENSE-APACHE" in err
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: package_catalogue honours include / required config
+# ---------------------------------------------------------------------------
+
+
+def _ok_verify_result():
+    from agentbundle.catalogue_tooling.results import VerifyResult
+    return VerifyResult(
+        ok=True,
+        diagnostics=[],
+        schema_version=1,
+        command="catalogue verify",
+        operation="source-checkout",
+        agentbundle_version="0.0.0",
+        catalogue_schema_version=1,
+    )
+
+
+def _mock_package_config(include: list, required: list):
+    config = mock.MagicMock()
+    config.name = "test"
+    config.display_name = "Test"
+    config.minimum_agentbundle_version = "0.1.0"
+    config.package.include = include
+    config.package.required = required
+    return config
+
+
+def test_package_honours_include_config(tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    for pack_name in ("pack-a", "pack-b"):
+        pack_dir = root / "packs" / pack_name
+        pack_dir.mkdir(parents=True)
+        (pack_dir / "pack.toml").write_text(
+            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8"
+        )
+    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8")
+    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
+    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+    cp_dir = root / ".claude-plugin"
+    cp_dir.mkdir()
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    output = tmp_path / "out"
+
+    with (
+        mock.patch(
+            "agentbundle.catalogue_tooling.verify.verify_catalogue",
+            return_value=_ok_verify_result(),
+        ),
+        mock.patch(
+            "agentbundle.catalogue_tooling.config.load_catalogue_config",
+            return_value=_mock_package_config(include=["packs/pack-a"], required=[]),
+        ),
+        mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}),
+    ):
+        result = package_catalogue(
+            root=root, bundle="b", release="0.1.0", channel="c", output=output
+        )
+
+    assert result.ok, [d.message for d in result.diagnostics]
+    archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
+        names = tf.getnames()
+    assert any(n.startswith("packs/pack-a/") for n in names)
+    assert not any(n.startswith("packs/pack-b/") for n in names)
+
+
+def test_package_custom_required_no_apache_license(tmp_path: Path) -> None:
+    root = tmp_path / "catalogue"
+    root.mkdir()
+    pack_dir = root / "packs" / "core"
+    pack_dir.mkdir(parents=True)
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8")
+    (root / "LICENSE").write_text("Proprietary license\n", encoding="utf-8")
+    cp_dir = root / ".claude-plugin"
+    cp_dir.mkdir()
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    output = tmp_path / "out"
+
+    with (
+        mock.patch(
+            "agentbundle.catalogue_tooling.verify.verify_catalogue",
+            return_value=_ok_verify_result(),
+        ),
+        mock.patch(
+            "agentbundle.catalogue_tooling.config.load_catalogue_config",
+            return_value=_mock_package_config(include=[], required=["LICENSE"]),
+        ),
+        mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}),
+    ):
+        result = package_catalogue(
+            root=root, bundle="b", release="0.1.0", channel="c", output=output
+        )
+
+    assert result.ok, [d.message for d in result.diagnostics]
+
+
+def test_package_default_required_still_enforced(tmp_path: Path) -> None:
+    root = _make_catalogue(tmp_path, with_license_apache=False)
+    output = tmp_path / "out"
+
+    with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
+        result = package_catalogue(
+            root=root, bundle="b", release="0.1.0", channel="c", output=output
+        )
+
+    assert not result.ok
+    assert any("LICENSE-APACHE" in d.message for d in result.diagnostics)


### PR DESCRIPTION
## Summary

- **Defect 1 fixed**: `_scan_content` now accepts `pack_include` (from `catalogue.package.include`) and only walks the specified pack directories when the list is non-empty. Non-pack directories (`profiles/`, `contracts/`, `.claude-plugin/`) are always included. Path-traversal entries are rejected before any filesystem access.
- **Defect 2 fixed**: `package_catalogue` now reads `config.package.include` and `config.package.required` from `catalogue.toml` and passes them to `_scan_content` and `_check_required_files`. Config is loaded once, immediately after `verify_catalogue` returns ok, so both packaging behavior and manifest metadata come from the same load.
- **Defect 3 fixed**: `_check_required_files` now accepts `required_override` so operators with proprietary or single-file licenses can replace the default `LICENSE-APACHE`/`LICENSE-MIT` requirement. Absent or empty `required` preserves existing default behavior.

Schema change: `catalogue.package.required` is now optional in `catalogue.schema.json` (removed from the `required` array). The existing subset-of-include validation in `config.py` is removed since `required` now has file-path semantics, not pack-path semantics.

Adds 11 new tests (8 unit + 3 integration) and `packages/agentbundle/DESIGN.md` documenting the packaging engine invariants.

Minor version bump to 0.22.0 (behavior change to a public command).

## Test plan

- [x] `test_scan_content_include_one_pack` — only listed pack in result
- [x] `test_scan_content_include_empty_includes_all` — empty list = all packs
- [x] `test_scan_content_nonpack_dirs_always_included` — profiles/contracts present despite include filter
- [x] `test_scan_content_include_nonexistent_raises` — clear error on missing pack
- [x] `test_scan_content_include_path_traversal_raises` — traversal rejected before I/O
- [x] `test_check_required_custom_license` — override replaces default requirement
- [x] `test_check_required_none_uses_defaults` — None uses `_REQUIRED_PATHS`
- [x] `test_package_honours_include_config` — end-to-end: only pack-a in archive
- [x] `test_package_custom_required_no_apache_license` — packaging succeeds with `required = ["LICENSE"]`
- [x] `test_package_default_required_still_enforced` — no config = default still requires Apache/MIT
- [x] Full suite: 1837 passed, 5 skipped

## Deferred

- `catalogue.toml` in this repo still has `required = ["packs/core"]` (old pack-path semantics). Under the new semantics this means "require packs/core to exist" — which is always true — so it has no visible effect. Updating it to reflect file-path semantics is a follow-up.

Engine-Change-RFC: ADR-0056