### PR TITLE
fix(oplog): honour HOME env var on Windows in oplog clear

### DIFF
--- a/packages/agentbundle/agentbundle/commands/oplog_cmd.py
+++ b/packages/agentbundle/agentbundle/commands/oplog_cmd.py
@@ -33,11 +33,18 @@ def run(args: argparse.Namespace) -> int:
 
 
 def _ops_path(pack_name: str, args: argparse.Namespace, *, create: bool = True) -> Path:
+    import os
+
     from agentbundle import safety
     from agentbundle.config import load_state
     from agentbundle.config import pack_dir as _pack_dir
 
     home_arg = getattr(args, "home", None)
+    if not home_arg:
+        # On Windows, Path.home() reads USERPROFILE, not HOME.  Honour HOME
+        # explicitly so tests and container environments that set it redirect
+        # the storage root as expected on all platforms.
+        home_arg = os.environ.get("HOME")
     home = Path(home_arg) if home_arg else None
 
     state = None


### PR DESCRIPTION
## Summary

- `_ops_path` in `oplog_cmd.py` fell back to `Path.home()` when `--home` was not supplied; on Windows, `ntpath.expanduser` reads `USERPROFILE` not `HOME`, so the `HOME` env var set by test helpers was silently ignored
- The clear subcommand resolved `ops.jsonl` to the real user profile (where the file doesn't exist), the `exists()` guard short-circuited, and the truncation never happened — leaving the test file untouched
- Fix: check `os.environ.get("HOME")` explicitly before handing off to `Path.home()`, consistent with POSIX behaviour

Fixes `test_cli_oplog_clear_with_yes` on `windows-latest` / `py3.11` (Gate A).

## Test plan

- [x] `test_cli_oplog_clear_with_yes` passes locally
- [x] Full `test_pack_config_api.py` suite (36 tests) passes — no regressions
- [ ] Gate A CI (`windows-latest` / `py3.11`) green