### PR TITLE
feat(https): AGENTBUNDLE_CA_BUNDLE support for custom CA in HTTPS catalogue

### DIFF
--- a/docs/guides/how-to/enterprise-app-store.md
+++ b/docs/guides/how-to/enterprise-app-store.md
@@ -122,4 +122,4 @@ secrets or a credentials broker.
 |---|---|
 | `AGENTBUNDLE_HTTP_BEARER_TOKEN` | Bearer token for authenticated HTTPS catalogue sources. Never forwarded across origins; not logged. |
 | `AGENTBUNDLE_NO_REMOTE` | When set to `1`, skips the Artifactory org bootstrap (Layer 3) and editable-install detection (Layer 4). Useful for offline and air-gapped deployments. |
-| `AGENTBUNDLE_CA_BUNDLE` | Path to a PEM CA bundle for corporate TLS. (Upcoming — not yet implemented.) |
+| `AGENTBUNDLE_CA_BUNDLE` | Path to a PEM file containing one or more CA certificates. Use when your Artifactory instance uses a private or self-signed CA. Example: `export AGENTBUNDLE_CA_BUNDLE=/etc/ssl/corp-ca.pem` |

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [Unreleased]
+
+### Added
+
+- **`AGENTBUNDLE_CA_BUNDLE` environment variable** (`https_catalogue.py`): when set to a path,
+  `_build_opener` loads a custom PEM CA bundle into an `ssl.SSLContext` and passes it to
+  `HTTPSHandler`. Raises `CatalogueError` with a clear message if the path does not exist.
+  When the variable is absent, behavior is unchanged. Enables HTTPS catalogue sources behind
+  a corporate or self-signed CA without modifying the system trust store.
+
 ## [0.22.1] — 2026-07-28
 
 ### Added

--- a/packages/agentbundle/agentbundle/https_catalogue.py
+++ b/packages/agentbundle/agentbundle/https_catalogue.py
@@ -27,6 +27,7 @@ import json
 import os
 import re
 import shutil
+import ssl
 import sys
 import tarfile
 import tempfile
@@ -101,7 +102,12 @@ class _OriginLockingRedirectHandler(urllib.request.HTTPRedirectHandler):
 # ---------------------------------------------------------------------------
 
 
-def _build_opener(token: str | None, original_url: str) -> urllib.request.OpenerDirector:
+def _build_opener(
+    token: str | None,
+    original_url: str,
+    *,
+    env: dict | None = None,
+) -> urllib.request.OpenerDirector:
     """Build a custom opener with proxy support, redirect enforcement, HTTPS only.
 
     - ``ProxyHandler()`` (no args) reads HTTPS_PROXY / NO_PROXY from
@@ -110,10 +116,22 @@ def _build_opener(token: str | None, original_url: str) -> urllib.request.Opener
     - ``_OriginLockingRedirectHandler`` rejects cross-origin redirects before
       they are followed; same-origin redirects forward ``Authorization`` intact.
     - Bearer token is added as ``Authorization: Bearer <token>`` when present.
+    - ``env`` defaults to ``os.environ``; injectable for testing.
     """
     redirect_handler = _OriginLockingRedirectHandler(original_url)
     proxy_handler = urllib.request.ProxyHandler()
-    https_handler = urllib.request.HTTPSHandler()
+
+    ca_bundle = (env if env is not None else os.environ).get("AGENTBUNDLE_CA_BUNDLE")
+    if ca_bundle:
+        if not Path(ca_bundle).exists():
+            raise CatalogueError(
+                f"AGENTBUNDLE_CA_BUNDLE path does not exist: {ca_bundle!r}"
+            )
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.load_verify_locations(cafile=ca_bundle)
+        https_handler = urllib.request.HTTPSHandler(context=ctx)
+    else:
+        https_handler = urllib.request.HTTPSHandler()
 
     opener = urllib.request.OpenerDirector()
     opener.addheaders = []  # prevent default User-Agent from leaking in some paths
@@ -456,7 +474,7 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
     if source_uri.startswith("catalogue+https://"):
         # Strip the "catalogue+" prefix to get the actual HTTPS URL
         channel_url = source_uri[len("catalogue+"):]
-        opener = _build_opener(token, channel_url)
+        opener = _build_opener(token, channel_url, env=env)
 
         dest = None
         archive_path = None
@@ -491,7 +509,7 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
         expected_sha256 = fragment[len("sha256="):]
         # Remove fragment from URL for actual request
         archive_url = urlunsplit(parsed._replace(fragment=""))
-        opener = _build_opener(token, archive_url)
+        opener = _build_opener(token, archive_url, env=env)
 
         dest = None
         archive_path = None

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.22.1"
+CLI_VERSION = "0.23.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.22.1"
+version = "0.23.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_https_catalogue.py
+++ b/packages/agentbundle/tests/unit/test_https_catalogue.py
@@ -18,6 +18,7 @@ import io
 import json
 import os
 import re
+import ssl
 import subprocess
 import sys
 import tarfile
@@ -874,7 +875,7 @@ def test_bearer_token_passed_to_opener():
 
     captured_env = {}
 
-    def fake_build_opener(token, original_url):
+    def fake_build_opener(token, original_url, **kwargs):
         captured_env["token"] = token
         return _MockOpener(b"", token=token)
 
@@ -1030,3 +1031,49 @@ def test_resolve_catalogue_http_error_is_https_only_message():
     msg = str(exc.value)
     assert "https" in msg.lower()
     assert "catalogue+https://" in msg or "archive+https://" in msg
+
+
+# ---------------------------------------------------------------------------
+# T2 — AGENTBUNDLE_CA_BUNDLE support in _build_opener
+# ---------------------------------------------------------------------------
+
+
+def test_build_opener_custom_ca_bundle(tmp_path: Path):
+    """AGENTBUNDLE_CA_BUNDLE: custom CA path is passed to ssl.SSLContext.load_verify_locations."""
+    ca_file = tmp_path / "corp-ca.pem"
+    ca_file.write_bytes(b"")
+
+    mock_ctx = mock.MagicMock()
+    with mock.patch("ssl.SSLContext", return_value=mock_ctx) as mock_ssl_ctx:
+        opener = _build_opener(
+            None,
+            "https://example.test/stable.json",
+            env={"AGENTBUNDLE_CA_BUNDLE": str(ca_file)},
+        )
+
+    mock_ssl_ctx.assert_called_once_with(ssl.PROTOCOL_TLS_CLIENT)
+    mock_ctx.load_verify_locations.assert_called_once_with(cafile=str(ca_file))
+    https_handlers = [h for h in opener.handlers if isinstance(h, urllib.request.HTTPSHandler)]
+    assert len(https_handlers) == 1
+
+
+def test_build_opener_missing_ca_file_raises():
+    """AGENTBUNDLE_CA_BUNDLE with non-existent path raises CatalogueError naming the file."""
+    missing = "/nonexistent/corp-ca.pem"
+    with pytest.raises(CatalogueError) as exc:
+        _build_opener(
+            None,
+            "https://example.test/stable.json",
+            env={"AGENTBUNDLE_CA_BUNDLE": missing},
+        )
+    assert missing in str(exc.value)
+
+
+def test_build_opener_no_ca_bundle_uses_default():
+    """Without AGENTBUNDLE_CA_BUNDLE, HTTPSHandler is built without a custom context."""
+    real_handler = urllib.request.HTTPSHandler
+    with mock.patch.object(urllib.request, "HTTPSHandler", wraps=real_handler) as mock_handler:
+        _build_opener(None, "https://example.test/stable.json", env={})
+
+    # Our code path must call HTTPSHandler() with no arguments (default SSL context)
+    mock_handler.assert_called_once_with()


### PR DESCRIPTION
## Summary

- Adds `AGENTBUNDLE_CA_BUNDLE` env var support to `_build_opener` in `https_catalogue.py`: when set, loads a PEM CA bundle into an `ssl.SSLContext` passed to `HTTPSHandler`; raises `CatalogueError` with the missing path named if the file doesn't exist; no-op when absent
- Updates `docs/guides/how-to/enterprise-app-store.md` to document the env var (removes the "upcoming" caveat)
- Adds three unit tests covering the custom CA path, missing file error, and unchanged default behavior
- Bumps version `0.22.1` → `0.23.0` (new documented env var, minor bump)

## Test plan

- [ ] `python -m pytest packages/agentbundle/tests/unit/test_https_catalogue.py` — 97 passed
- [ ] `python -m ruff check` — clean on changed files