### PR TITLE
fix(work-loop): explicit spec status-transition instructions (core 0.15.6)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -323,6 +323,8 @@ Don't keep it in your head — your context will turn over and you'll lose it.
 
 ### 2. EXECUTE — make the change
 
+**Spec status — bump to `Implementing` now.** If the active spec's `**Status:**` field is `Draft` or `Approved`, set it to `Implementing` before writing any code. Do not leave the spec in `Draft` while implementation is in progress.
+
 Match the discipline to the verification mode you picked during PLAN:
 
 - **TDD-mode tasks** — red-green-refactor:
@@ -774,8 +776,11 @@ mode below, then evaluate the terminal-state bullet last.
   - `git status` shows no uncommitted or untracked files (except
     gitignored scratch).
   - **Doc-drift invariants hold** (the four the `adversarial-reviewer`'s
-    "Spec drift" check names, against `CONVENTIONS.md` § 4): the touched spec's
-    status reflects the change; every Acceptance Criterion is `[x]` or carries
+    "Spec drift" check names, against `CONVENTIONS.md` § 4): **set the spec's
+    `**Status:**` field to `Shipped`** — use spec vocabulary only:
+    `Draft | Approved | Implementing | Shipped | Archived`; the plan vocabulary
+    (`Drafting`, `Executing`, `Done`) is invalid here and will fail
+    `lint-spec-status.py`; every Acceptance Criterion is `[x]` or carries
     `(deferred: <slug>)`; each deferral resolves in `workspace.toml
     [backlog].open`; intra-repo references the change touches resolve. Where you have
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.15.5"
+      "version": "0.15.6"
     },
     {
       "author": {

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -323,6 +323,8 @@ Don't keep it in your head — your context will turn over and you'll lose it.
 
 ### 2. EXECUTE — make the change
 
+**Spec status — bump to `Implementing` now.** If the active spec's `**Status:**` field is `Draft` or `Approved`, set it to `Implementing` before writing any code. Do not leave the spec in `Draft` while implementation is in progress.
+
 Match the discipline to the verification mode you picked during PLAN:
 
 - **TDD-mode tasks** — red-green-refactor:
@@ -774,8 +776,11 @@ mode below, then evaluate the terminal-state bullet last.
   - `git status` shows no uncommitted or untracked files (except
     gitignored scratch).
   - **Doc-drift invariants hold** (the four the `adversarial-reviewer`'s
-    "Spec drift" check names, against `CONVENTIONS.md` § 4): the touched spec's
-    status reflects the change; every Acceptance Criterion is `[x]` or carries
+    "Spec drift" check names, against `CONVENTIONS.md` § 4): **set the spec's
+    `**Status:**` field to `Shipped`** — use spec vocabulary only:
+    `Draft | Approved | Implementing | Shipped | Archived`; the plan vocabulary
+    (`Drafting`, `Executing`, `Done`) is invalid here and will fail
+    `lint-spec-status.py`; every Acceptance Criterion is `[x]` or carries
     `(deferred: <slug>)`; each deferral resolves in `workspace.toml
     [backlog].open`; intra-repo references the change touches resolve. Where you have
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -323,6 +323,8 @@ Don't keep it in your head — your context will turn over and you'll lose it.
 
 ### 2. EXECUTE — make the change
 
+**Spec status — bump to `Implementing` now.** If the active spec's `**Status:**` field is `Draft` or `Approved`, set it to `Implementing` before writing any code. Do not leave the spec in `Draft` while implementation is in progress.
+
 Match the discipline to the verification mode you picked during PLAN:
 
 - **TDD-mode tasks** — red-green-refactor:
@@ -774,8 +776,11 @@ mode below, then evaluate the terminal-state bullet last.
   - `git status` shows no uncommitted or untracked files (except
     gitignored scratch).
   - **Doc-drift invariants hold** (the four the `adversarial-reviewer`'s
-    "Spec drift" check names, against `CONVENTIONS.md` § 4): the touched spec's
-    status reflects the change; every Acceptance Criterion is `[x]` or carries
+    "Spec drift" check names, against `CONVENTIONS.md` § 4): **set the spec's
+    `**Status:**` field to `Shipped`** — use spec vocabulary only:
+    `Draft | Approved | Implementing | Shipped | Archived`; the plan vocabulary
+    (`Drafting`, `Executing`, `Done`) is invalid here and will fail
+    `lint-spec-status.py`; every Acceptance Criterion is `[x]` or carries
     `(deferred: <slug>)`; each deferral resolves in `workspace.toml
     [backlog].open`; intra-repo references the change touches resolve. Where you have
     Python, run `scripts/lint-spec-status.py` (this skill's sibling to

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.5"
+version = "0.15.6"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"


### PR DESCRIPTION
## Summary

- **EXECUTE preamble**: agents now set spec `**Status:**` to `Implementing` before writing any code (instead of leaving it in `Draft` throughout)
- **DECIDE checklist**: replaces vague "status reflects the change" with an explicit `→ Shipped` instruction and an inline vocabulary guard that names the plan vocab (`Drafting`, `Executing`, `Done`) as invalid — the specific values that fail `lint-spec-status.py`
- Bumps core pack to 0.15.6 (`pack.toml` + `plugin.json`)

**Root cause**: the prior phrasing was inferential — capable models (Sonnet/Opus) read it correctly, but literal-instruction models (Fable) skip the inference step entirely, leaving specs in `Draft` or substituting the plan vocabulary.

## Test plan

- [ ] Invoke `work-loop` on a spec in `Draft` state — confirm it bumps to `Implementing` at EXECUTE start
- [ ] Complete the loop — confirm it sets to `Shipped` at finish-time checklist
- [ ] `lint-spec-status.py` exits 0 on the resulting spec