### PR TITLE
feat(state): record exact archive provenance on PackState

### DIFF
--- a/docs/guides/how-to/enterprise-app-store.md
+++ b/docs/guides/how-to/enterprise-app-store.md
@@ -116,6 +116,24 @@ For automated packaging in CI:
 Never embed production Artifactory URLs, credentials, or bearer tokens in workflow YAML. Use
 secrets or a credentials broker.
 
+## Installed provenance
+
+After installation from an Artifactory source, each pack row in
+`.agentbundle-state.toml` includes three provenance fields:
+
+| Field | Description |
+|---|---|
+| `artifact-uri` | The exact archive URL resolved at install time |
+| `archive-sha256` | Hex SHA-256 of the fetched archive, verified before extraction |
+| `source-revision` | Source revision recorded in the channel descriptor, if the publisher included it (e.g. the Git SHA passed via `--source-revision` in CI) |
+
+These fields are also exposed in `agentbundle list-installed --format json` under
+`artifact_uri`, `archive_sha256`, and `source_revision` on each row.
+
+Operators can correlate any installed pack to a specific archive artifact in
+Artifactory for audit or incident response. Packs installed from a local directory
+source omit all three fields.
+
 ## Environment variables
 
 | Variable | Description |

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -15,6 +15,17 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
   `HTTPSHandler`. Raises `CatalogueError` with a clear message if the path does not exist.
   When the variable is absent, behavior is unchanged. Enables HTTPS catalogue sources behind
   a corporate or self-signed CA without modifying the system trust store.
+- **Exact provenance fields on `PackState`** (`artifact_uri`, `archive_sha256`, `source_revision`):
+  after `agentbundle install` or `agentbundle upgrade` from a `catalogue+https://` or
+  `archive+https://` source, `.agentbundle-state.toml` now records the resolved archive URL,
+  the verified SHA-256 digest, and the optional `source_revision` from the channel descriptor.
+  Operators can correlate any installed pack row to a specific archive artifact for audit or
+  incident response. Local-directory installs leave all three fields absent. Existing state
+  files that predate this change are read without error; the missing fields default to `None`.
+  (`config.py`, `https_catalogue.py`, `commands/install.py`, `commands/upgrade.py`)
+- **Provenance exposed in `list-installed --format json`**: the three new fields appear on each
+  row as `artifact_uri`, `archive_sha256`, and `source_revision` (null when absent).
+  (`commands/list_installed.py`)
 
 ## [0.22.1] — 2026-07-28
 

--- a/packages/agentbundle/agentbundle/build/tests/fixtures/packs/product-documentation/.claude-plugin/plugin.json
+++ b/packages/agentbundle/agentbundle/build/tests/fixtures/packs/product-documentation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "user-guide-diataxis",
+  "name": "product-documentation",
   "version": "0.1.0",
-  "description": "Diátaxis user-guide pack."
+  "description": "Product documentation authoring pack."
 }

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     import argparse
 
     from agentbundle.config import State
+    from agentbundle.https_catalogue import CatalogueArchiveResult
     from agentbundle.safety import Tier
     from agentbundle.user_config import UserConfig
 
@@ -271,11 +272,26 @@ def run(args: argparse.Namespace) -> int:
         return 1
 
     # ── Step 1: Resolve catalogue + locate + spec gate ────────────────────────
-    try:
-        catalogue_dir = resolve_catalogue(catalogue_uri)
-    except CatalogueError as exc:
-        print(f"install: {exc}", file=sys.stderr)
-        return 1
+    # For catalogue+https:// and archive+https:// sources, call the provenance-
+    # aware fetcher directly so artifact_uri / archive_sha256 / source_revision
+    # can be recorded in PackState. For all other source types, fall through to
+    # resolve_catalogue (which returns only a Path).
+    _https_provenance: CatalogueArchiveResult | None = None
+    if catalogue_uri.startswith(("catalogue+https://", "archive+https://")):
+        from agentbundle.https_catalogue import fetch_catalogue_archive_with_provenance
+        try:
+            _archive_result = fetch_catalogue_archive_with_provenance(catalogue_uri)
+            catalogue_dir = _archive_result.path
+            _https_provenance = _archive_result
+        except CatalogueError as exc:
+            print(f"install: {exc}", file=sys.stderr)
+            return 1
+    else:
+        try:
+            catalogue_dir = resolve_catalogue(catalogue_uri)
+        except CatalogueError as exc:
+            print(f"install: {exc}", file=sys.stderr)
+            return 1
 
     # Load catalogue.toml for operator-declared user-dir (RFC-0074 / ADR-0058).
     # Absent catalogue.toml → user_dir stays at the default "~/.agentbundle".
@@ -1135,6 +1151,13 @@ def run(args: argparse.Namespace) -> int:
             # RFC-0074 / ADR-0058: write user-root from catalogue.user-dir so
             # pack_dir() can resolve the correct user-scope directory at runtime.
             user_root=_catalogue_user_dir,
+            artifact_uri=_https_provenance.artifact_uri if _https_provenance is not None else None,
+            archive_sha256=(
+                _https_provenance.archive_sha256 if _https_provenance is not None else None
+            ),
+            source_revision=(
+                _https_provenance.source_revision if _https_provenance is not None else None
+            ),
         )
 
         for relpath, content in sorted(projection.items()):

--- a/packages/agentbundle/agentbundle/commands/list_installed.py
+++ b/packages/agentbundle/agentbundle/commands/list_installed.py
@@ -313,6 +313,7 @@ def _render_json(
     # Build per-row JSON dicts with exactly nine contract keys
     json_rows = []
     for row in display_rows:
+        ps = row.get("_pack_state")
         json_rows.append({
             "pack": row["pack"],
             "adapter": row["adapter"],
@@ -323,6 +324,9 @@ def _render_json(
             "status": row.get("status"),
             "status_reason": row.get("status_reason"),
             "drift_count": row.get("drift"),  # None when --check-drift not active
+            "artifact_uri": ps.artifact_uri if ps is not None else None,
+            "archive_sha256": ps.archive_sha256 if ps is not None else None,
+            "source_revision": ps.source_revision if ps is not None else None,
         })
 
     result = {

--- a/packages/agentbundle/agentbundle/commands/upgrade.py
+++ b/packages/agentbundle/agentbundle/commands/upgrade.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import argparse
 
+    from agentbundle.https_catalogue import CatalogueArchiveResult
     from agentbundle.user_config import UserConfig
 
 from agentbundle import safety
@@ -108,6 +109,11 @@ class _BulkRow:
     _projection: dict | None = None      # dict[str, bytes] | None
     allowed_prefixes: list | None = None  # list[str] | None
     resolved_adapter: str | None = None  # repo scope only
+
+    # provenance captured from catalogue+https:// / archive+https:// fetches
+    artifact_uri: str | None = None
+    archive_sha256: str | None = None
+    source_revision: str | None = None
 
     # set during apply
     outcome: str = "planned"
@@ -232,15 +238,29 @@ def _run_source_version_preflight(
             continue
 
         if cs not in source_resolution_map:
-            try:
-                cat_dir = resolve_catalogue(cs)
-                source_resolution_map[cs] = (cat_dir, None, None)
-            except CatalogueError as exc:
-                source_resolution_map[cs] = (
-                    None, "catalogue-error", _redact_credentials(str(exc))
-                )
+            if cs.startswith(("catalogue+https://", "archive+https://")):
+                from agentbundle.https_catalogue import fetch_catalogue_archive_with_provenance
+                try:
+                    _ar = fetch_catalogue_archive_with_provenance(cs)
+                    source_resolution_map[cs] = (
+                        _ar.path, None, None,
+                        _ar.artifact_uri, _ar.archive_sha256, _ar.source_revision,
+                    )
+                except CatalogueError as exc:
+                    source_resolution_map[cs] = (
+                        None, "catalogue-error", _redact_credentials(str(exc)),
+                        None, None, None,
+                    )
+            else:
+                try:
+                    cat_dir = resolve_catalogue(cs)
+                    source_resolution_map[cs] = (cat_dir, None, None, None, None, None)
+                except CatalogueError as exc:
+                    source_resolution_map[cs] = (
+                        None, "catalogue-error", _redact_credentials(str(exc)), None, None, None
+                    )
 
-        cat_dir, _err_code, _err_msg = source_resolution_map[cs]
+        cat_dir, _err_code, _err_msg, _art_uri, _arc_sha, _src_rev = source_resolution_map[cs]
         if cat_dir is None:
             row.status = "unknown"
             row.status_reason = "source-unavailable"
@@ -253,6 +273,9 @@ def _run_source_version_preflight(
             continue
         row.pack_dir = pack_dir
         row.catalogue_dir = cat_dir
+        row.artifact_uri = _art_uri
+        row.archive_sha256 = _arc_sha
+        row.source_revision = _src_rev
 
         try:
             pack_toml = load_pack_toml(pack_dir / "pack.toml")
@@ -568,6 +591,9 @@ def _apply_single_row(
         pack_state.installed_version = to_version  # type: ignore[attr-defined]
         if row.canonical_source is not None:
             pack_state.source = row.canonical_source  # type: ignore[attr-defined]
+        pack_state.artifact_uri = row.artifact_uri  # type: ignore[attr-defined]
+        pack_state.archive_sha256 = row.archive_sha256  # type: ignore[attr-defined]
+        pack_state.source_revision = row.source_revision  # type: ignore[attr-defined]
 
     state_toml_content = dump_state(state)  # type: ignore[arg-type]
     state_relpath = state_path.relative_to(root).as_posix()
@@ -622,7 +648,8 @@ def _build_json_doc(
         if cs is None:
             continue
         if cs not in sources_seen:
-            cat_dir, error_code, error_message = source_resolution_map.get(cs, (None, None, None))
+            _default = (None, None, None, None, None, None)
+            cat_dir, error_code, error_message = source_resolution_map.get(cs, _default)[:3]
             sources_seen[cs] = {
                 "source": cs,
                 "resolved": cat_dir is not None,
@@ -1027,11 +1054,22 @@ def run(args: argparse.Namespace) -> int:
     is_per_primitive = prim_flag is not None
 
     # ── Resolve catalogue ─────────────────────────────────────────────────────
-    try:
-        catalogue_dir = resolve_catalogue(catalogue_uri)
-    except CatalogueError as exc:
-        print(f"upgrade: {exc}", file=sys.stderr)
-        return 1
+    _https_provenance: CatalogueArchiveResult | None = None
+    if catalogue_uri.startswith(("catalogue+https://", "archive+https://")):
+        from agentbundle.https_catalogue import fetch_catalogue_archive_with_provenance
+        try:
+            _archive_result = fetch_catalogue_archive_with_provenance(catalogue_uri)
+            catalogue_dir = _archive_result.path
+            _https_provenance = _archive_result
+        except CatalogueError as exc:
+            print(f"upgrade: {exc}", file=sys.stderr)
+            return 1
+    else:
+        try:
+            catalogue_dir = resolve_catalogue(catalogue_uri)
+        except CatalogueError as exc:
+            print(f"upgrade: {exc}", file=sys.stderr)
+            return 1
 
     # ── Locate pack dir ───────────────────────────────────────────────────────
     pack_dir = _locate_pack(catalogue_dir, pack_name)
@@ -1385,6 +1423,13 @@ def run(args: argparse.Namespace) -> int:
         available_version=to_version,
         _projection=work_projection,
         allowed_prefixes=allowed_prefixes,
+        artifact_uri=_https_provenance.artifact_uri if _https_provenance is not None else None,
+        archive_sha256=(
+            _https_provenance.archive_sha256 if _https_provenance is not None else None
+        ),
+        source_revision=(
+            _https_provenance.source_revision if _https_provenance is not None else None
+        ),
     )
     _success, companions = _apply_single_row(_single_row, state, state_path, root, args)
     if not _success:

--- a/packages/agentbundle/agentbundle/config.py
+++ b/packages/agentbundle/agentbundle/config.py
@@ -148,6 +148,12 @@ class PackState:
     # Absent rows default to "~/.agentbundle" on read. Written at install time
     # from catalogue.user-dir.
     user_root: str = "~/.agentbundle"
+    # Exact provenance of the archive that produced this install. All three are
+    # None for local-directory sources; populated for catalogue+https:// and
+    # archive+https:// sources. Absent fields in existing state files read as None.
+    artifact_uri: str | None = None
+    archive_sha256: str | None = None
+    source_revision: str | None = None
 
     def file_sha(self, relpath: str) -> str | None:
         entry = self.files.get(relpath)
@@ -548,6 +554,10 @@ def _parse_adapter_row(
         raw_user_root if isinstance(raw_user_root, str) else "~/.agentbundle"
     )
 
+    raw_artifact_uri = body.get("artifact-uri")
+    raw_archive_sha256 = body.get("archive-sha256")
+    raw_source_revision = body.get("source-revision")
+
     return PackState(
         installed_version=body.get("installed-version", ""),
         source=body.get("source"),
@@ -560,6 +570,9 @@ def _parse_adapter_row(
         target_file=target_file,
         hook_wiring_owned=hook_wiring_owned,
         user_root=user_root,
+        artifact_uri=raw_artifact_uri if isinstance(raw_artifact_uri, str) else None,
+        archive_sha256=raw_archive_sha256 if isinstance(raw_archive_sha256, str) else None,
+        source_revision=raw_source_revision if isinstance(raw_source_revision, str) else None,
     )
 
 
@@ -664,6 +677,12 @@ def dump_state(state: State) -> str:
         lines.append(f"installed-version = {_emit_basic_string(ps.installed_version)}")
         if ps.source is not None:
             lines.append(f"source = {_emit_basic_string(ps.source)}")
+        if ps.artifact_uri is not None:
+            lines.append(f"artifact-uri = {_emit_basic_string(ps.artifact_uri)}")
+        if ps.archive_sha256 is not None:
+            lines.append(f"archive-sha256 = {_emit_basic_string(ps.archive_sha256)}")
+        if ps.source_revision is not None:
+            lines.append(f"source-revision = {_emit_basic_string(ps.source_revision)}")
         lines.append(f"install-route = {_emit_basic_string(ps.install_route)}")
         lines.append(f"scope = {_emit_basic_string(ps.scope)}")
         # user-root: always emit so round-trip is byte-stable. Default value

--- a/packages/agentbundle/agentbundle/https_catalogue.py
+++ b/packages/agentbundle/agentbundle/https_catalogue.py
@@ -33,10 +33,22 @@ import tarfile
 import tempfile
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
 from agentbundle.catalogue import CatalogueError
+
+
+@dataclass
+class CatalogueArchiveResult:
+    """Provenance metadata returned alongside the extracted archive path."""
+
+    path: Path
+    artifact_uri: str | None = None
+    archive_sha256: str | None = None
+    source_revision: str | None = None
+
 
 # ---------------------------------------------------------------------------
 # Named safety limits (RFC-0072; all enforced regardless of Content-Length)
@@ -455,13 +467,17 @@ def _safe_extract(archive_path: Path, dest: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path:
-    """Fetch and extract a catalogue archive from a ``catalogue+https://`` or
-    ``archive+https://`` source URI.
+def fetch_catalogue_archive_with_provenance(
+    source_uri: str, *, env: dict | None = None
+) -> CatalogueArchiveResult:
+    """Fetch and extract a catalogue archive, returning path and provenance.
 
-    Returns the path to the extracted temp directory. The caller is responsible
-    for cleanup on success. On any failure, temp directories are cleaned up
-    before the ``CatalogueError`` is re-raised.
+    Returns a :class:`CatalogueArchiveResult` whose ``path`` is the extracted
+    temp directory and whose remaining fields record the resolved artifact URL,
+    the verified SHA-256, and the optional ``source_revision`` from the channel
+    descriptor. The caller is responsible for cleanup of ``result.path`` on
+    success. On any failure, temp directories are cleaned up before the
+    ``CatalogueError`` is re-raised.
 
     ``env`` defaults to ``os.environ``; injectable for testing (bearer token
     lookup). Note: proxy settings are always read from ``os.environ`` by
@@ -472,7 +488,6 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
     token = env.get("AGENTBUNDLE_HTTP_BEARER_TOKEN")
 
     if source_uri.startswith("catalogue+https://"):
-        # Strip the "catalogue+" prefix to get the actual HTTPS URL
         channel_url = source_uri[len("catalogue+"):]
         opener = _build_opener(token, channel_url, env=env)
 
@@ -488,7 +503,13 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
             )
             dest = Path(tempfile.mkdtemp(prefix="agentbundle-"))
             _safe_extract(archive_path, dest)
-            return dest
+            _raw_rev = descriptor.get("source_revision")
+            return CatalogueArchiveResult(
+                path=dest,
+                artifact_uri=artifact_url,
+                archive_sha256=descriptor["sha256"],
+                source_revision=_raw_rev if isinstance(_raw_rev, str) else None,
+            )
         except Exception:
             if dest is not None:
                 shutil.rmtree(str(dest), ignore_errors=True)
@@ -498,7 +519,6 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
             raise
 
     elif source_uri.startswith("archive+https://"):
-        # Strip "archive+" prefix, extract sha256 from fragment
         archive_url_with_fragment = source_uri[len("archive+"):]
         parsed = urlsplit(archive_url_with_fragment)
         fragment = parsed.fragment
@@ -507,7 +527,6 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
                 "archive+https:// URL must have #sha256=<64hex> fragment"
             )
         expected_sha256 = fragment[len("sha256="):]
-        # Remove fragment from URL for actual request
         archive_url = urlunsplit(parsed._replace(fragment=""))
         opener = _build_opener(token, archive_url, env=env)
 
@@ -517,7 +536,12 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
             archive_path = _stream_and_verify(archive_url, expected_sha256, opener, _HTTP_TIMEOUT)
             dest = Path(tempfile.mkdtemp(prefix="agentbundle-"))
             _safe_extract(archive_path, dest)
-            return dest
+            return CatalogueArchiveResult(
+                path=dest,
+                artifact_uri=archive_url,
+                archive_sha256=expected_sha256,
+                source_revision=None,
+            )
         except Exception:
             if dest is not None:
                 shutil.rmtree(str(dest), ignore_errors=True)
@@ -530,3 +554,12 @@ def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path
         raise CatalogueError(
             f"https_catalogue: unsupported scheme in {source_uri!r}"
         )
+
+
+def fetch_catalogue_archive(source_uri: str, *, env: dict | None = None) -> Path:
+    """Backward-compatible wrapper; returns only the extracted archive path.
+
+    Prefer :func:`fetch_catalogue_archive_with_provenance` when provenance
+    metadata (artifact URI, SHA-256, source revision) is needed.
+    """
+    return fetch_catalogue_archive_with_provenance(source_uri, env=env).path

--- a/packages/agentbundle/tests/skills/test_product_documentation_pack.py
+++ b/packages/agentbundle/tests/skills/test_product_documentation_pack.py
@@ -127,8 +127,14 @@ def test_skill_names_are_distinct():
     """
     compat_skill_dir = COMPAT_PACK / ".apm" / "skills"
     product_skill_dir = PRODUCT_DOC_PACK / ".apm" / "skills"
-    compat_names = {p.name for p in compat_skill_dir.iterdir() if p.is_dir()} if compat_skill_dir.exists() else set()
-    product_names = {p.name for p in product_skill_dir.iterdir() if p.is_dir()} if product_skill_dir.exists() else set()
+    compat_names = (
+        {p.name for p in compat_skill_dir.iterdir() if p.is_dir()}
+        if compat_skill_dir.exists() else set()
+    )
+    product_names = (
+        {p.name for p in product_skill_dir.iterdir() if p.is_dir()}
+        if product_skill_dir.exists() else set()
+    )
     collision = compat_names & product_names
     assert not collision, (
         f"user-guide-diataxis and product-documentation share skill dir name(s): "

--- a/packages/agentbundle/tests/unit/test_install_state_provenance.py
+++ b/packages/agentbundle/tests/unit/test_install_state_provenance.py
@@ -1,0 +1,206 @@
+"""Tests for PackState provenance fields (artifact_uri, archive_sha256, source_revision).
+
+Covers:
+  - HTTPS install writes provenance into PackState
+  - Local install leaves provenance as None
+  - HTTPS upgrade updates provenance on the existing row
+  - State files without provenance fields are read as None (backward compat)
+
+Parametrization opt-out: these tests target state-accumulation logic, not the
+per-adapter projection layout, so they are not parametrized over adapters.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import shutil
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONVERTERS_PACK_SRC = REPO_ROOT / "packs" / "converters"
+
+
+def _run_install(args: argparse.Namespace) -> tuple[int, str, str]:
+    from agentbundle.commands import install
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        rc = install.run(args)
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+def _run_upgrade(args: argparse.Namespace) -> tuple[int, str, str]:
+    from agentbundle.commands import upgrade
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        rc = upgrade.run(args)
+    return rc, stdout.getvalue(), stderr.getvalue()
+
+
+def _install_args(cat: Path, repo: Path, *, scope: str = "repo") -> argparse.Namespace:
+    return argparse.Namespace(
+        pack="converters",
+        catalogue=str(cat),
+        output=str(repo),
+        scope=scope,
+        force=False,
+        force_merge=False,
+        adapter=None,
+    )
+
+
+def _upgrade_args(catalogue: str, repo: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        pack="converters",
+        catalogue=catalogue,
+        root=str(repo),
+        scope="repo",
+        yes=True,
+        skill=None,
+        agent=None,
+        hook=None,
+        seed=None,
+        command=None,
+    )
+
+
+class InstallHTTPSProvenanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir()
+        self.cat = self.tmp / "catalogue"
+        (self.cat / "packs").mkdir(parents=True)
+        shutil.copytree(CONVERTERS_PACK_SRC, self.cat / "packs" / "converters")
+
+    def _read_pack_state(self) -> object:
+        from agentbundle.config import load_state
+
+        state_path = self.repo / ".agentbundle-state.toml"
+        state = load_state(state_path)
+        rows = state.rows_for_pack("converters")
+        self.assertEqual(len(rows), 1, f"expected 1 adapter row, got: {list(rows)}")
+        return next(iter(rows.values()))
+
+    def test_install_from_https_sets_provenance(self) -> None:
+        from agentbundle.https_catalogue import CatalogueArchiveResult
+
+        fake_uri = "https://example.com/releases/1.0.0/converters.tar.gz"
+        fake_sha = "a" * 64
+        fake_rev = "abc123def456"
+        fake_result = CatalogueArchiveResult(
+            path=self.cat,
+            artifact_uri=fake_uri,
+            archive_sha256=fake_sha,
+            source_revision=fake_rev,
+        )
+
+        with patch(
+            "agentbundle.https_catalogue.fetch_catalogue_archive_with_provenance",
+            return_value=fake_result,
+        ):
+            args = argparse.Namespace(
+                pack="converters",
+                catalogue="catalogue+https://example.com/channel.json",
+                output=str(self.repo),
+                scope="repo",
+                force=False,
+                force_merge=False,
+                adapter=None,
+            )
+            rc, _stdout, _stderr = _run_install(args)
+
+        self.assertEqual(rc, 0, _stderr)
+        ps = self._read_pack_state()
+        self.assertEqual(ps.artifact_uri, fake_uri)
+        self.assertEqual(ps.archive_sha256, fake_sha)
+        self.assertEqual(ps.source_revision, fake_rev)
+
+    def test_install_from_local_leaves_provenance_null(self) -> None:
+        rc, _stdout, _stderr = _run_install(_install_args(self.cat, self.repo))
+
+        self.assertEqual(rc, 0, _stderr)
+        ps = self._read_pack_state()
+        self.assertIsNone(ps.artifact_uri)
+        self.assertIsNone(ps.archive_sha256)
+        self.assertIsNone(ps.source_revision)
+
+    def test_upgrade_from_https_updates_provenance(self) -> None:
+        from agentbundle.https_catalogue import CatalogueArchiveResult
+
+        # First install from local (provenance = None)
+        rc, _stdout, _stderr = _run_install(_install_args(self.cat, self.repo))
+        self.assertEqual(rc, 0, f"initial install failed: {_stderr}")
+
+        ps_before = self._read_pack_state()
+        self.assertIsNone(ps_before.artifact_uri)
+
+        # Upgrade from HTTPS (mocked)
+        fake_uri = "https://example.com/releases/1.0.0/converters-v2.tar.gz"
+        fake_sha = "b" * 64
+        fake_rev = "def456abc123"
+        fake_result = CatalogueArchiveResult(
+            path=self.cat,
+            artifact_uri=fake_uri,
+            archive_sha256=fake_sha,
+            source_revision=fake_rev,
+        )
+
+        with patch(
+            "agentbundle.https_catalogue.fetch_catalogue_archive_with_provenance",
+            return_value=fake_result,
+        ):
+            rc, _stdout, _stderr = _run_upgrade(
+                _upgrade_args("catalogue+https://example.com/channel.json", self.repo)
+            )
+
+        self.assertEqual(rc, 0, _stderr)
+        ps = self._read_pack_state()
+        self.assertEqual(ps.artifact_uri, fake_uri)
+        self.assertEqual(ps.archive_sha256, fake_sha)
+        self.assertEqual(ps.source_revision, fake_rev)
+
+
+class StateReadWithoutProvenanceFieldsTests(unittest.TestCase):
+    def test_state_read_without_provenance_fields_is_valid(self) -> None:
+        import tempfile
+
+        from agentbundle.config import STATE_SCHEMA_VERSION, load_state
+
+        state_toml = textwrap.dedent(f"""\
+            schema-version = "{STATE_SCHEMA_VERSION}"
+
+            [pack.converters.adapters.claude-code]
+            installed-version = "1.0.0"
+            install-route = "cli"
+            scope = "repo"
+            user-root = "~/.agentbundle"
+            primitives = []
+
+            [pack.converters.adapters.claude-code.files]
+        """)
+
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        state_path = tmp / ".agentbundle-state.toml"
+        state_path.write_text(state_toml, encoding="utf-8")
+
+        state = load_state(state_path)
+        ps = state.row("converters", "claude-code")
+        self.assertIsNotNone(ps)
+        self.assertIsNone(ps.artifact_uri)
+        self.assertIsNone(ps.archive_sha256)
+        self.assertIsNone(ps.source_revision)

--- a/packages/agentbundle/tests/unit/test_list_installed_status.py
+++ b/packages/agentbundle/tests/unit/test_list_installed_status.py
@@ -539,13 +539,14 @@ def test_json_row_all_fields_present():
 
 
 def test_json_row_exact_key_set():
-    """Each row has exactly nine contract keys; no internal keys."""
+    """Each row has the expected contract keys; no internal keys."""
     row = _make_row(status="up-to-date", available_version="1.0.0")
     out = li._render_json([row], [], scope_val="all", updates_only=False, check=True)
     result = json.loads(out)
     expected_keys = {
         "pack", "adapter", "scope", "source", "installed_version",
         "available_version", "status", "status_reason", "drift_count",
+        "artifact_uri", "archive_sha256", "source_revision",
     }
     for r in result["rows"]:
         assert set(r.keys()) == expected_keys


### PR DESCRIPTION
## Summary

- Adds `artifact_uri`, `archive_sha256`, and `source_revision` fields to `PackState`; persisted in `.agentbundle-state.toml` as kebab-case TOML keys
- Populates provenance during `catalogue+https://` and `archive+https://` installs and upgrades via a new `fetch_catalogue_archive_with_provenance()` function (original `fetch_catalogue_archive()` kept as backward-compat wrapper)
- Exposes the three fields in `list-installed --format json`; existing state files without the fields read as `None` without error

## What changed

| File | Change |
|------|--------|
| `agentbundle/config.py` | 3 optional fields on `PackState`; `_parse_adapter_row` reads them; `dump_state` emits them when non-None |
| `agentbundle/https_catalogue.py` | `CatalogueArchiveResult` dataclass + `fetch_catalogue_archive_with_provenance()` |
| `agentbundle/commands/install.py` | HTTPS-scheme branch at Step 1 captures provenance; passed to `PackState` constructor |
| `agentbundle/commands/upgrade.py` | `_BulkRow` gains 3 fields; single-pack and bulk paths both populate provenance; `_apply_single_row` writes them back to state |
| `agentbundle/commands/list_installed.py` | `_render_json` includes provenance keys in each row |
| `docs/guides/how-to/enterprise-app-store.md` | "Installed provenance" section |
| `CHANGELOG.md` | `[Unreleased]` entry |
| `version.py`, `pyproject.toml` | `0.22.1` → `0.23.0` (minor bump: new optional fields + JSON output shape) |
| `tests/unit/test_install_state_provenance.py` | 4 new tests (HTTPS install sets provenance, local install leaves null, upgrade updates provenance, state round-trip without fields) |
| `tests/unit/test_list_installed_status.py` | Updated exact JSON key-set expectation (9 → 12 keys) |

## Test plan

- [x] `test_install_state_provenance.py` — 4 new tests pass
- [x] `test_list_installed_status.py` — 91 tests pass (including updated key-set assertion)
- [x] Full unit suite — all pass, 3 skips
- [x] Integration tests — pass
- [x] `ruff check` — clean