### PR TITLE
fix(build): exclude __pycache__ from all adapter copytree and self-host drift gate

### DIFF
--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -109,15 +109,19 @@ def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def _ignore_absolute_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: drop symlinks with absolute targets.
+    """`shutil.copytree` ignore callback: drop symlinks with absolute targets
+    and Python bytecode cache directories.
 
     Relative symlinks (intra-skill cross-references) are preserved as
-    symlinks. Absolute symlinks always escape the tree and are a path-escape vector.
+    symlinks. Absolute symlinks always escape the tree and are a path-escape
+    vector. __pycache__ directories are excluded because .pyc files embed
+    absolute source paths and can never be byte-identical across machines.
     """
     base = Path(directory)
     return {
         name for name in names
-        if (base / name).is_symlink() and os.path.isabs(os.readlink(base / name))
+        if name == "__pycache__"
+        or ((base / name).is_symlink() and os.path.isabs(os.readlink(base / name)))
     }
 
 

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -159,15 +159,19 @@ def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> 
 
 
 def _ignore_absolute_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: drop symlinks with absolute targets.
+    """`shutil.copytree` ignore callback: drop symlinks with absolute targets
+    and Python bytecode cache directories.
 
     Relative symlinks (intra-skill cross-references) are preserved (AC5).
     Absolute symlinks always escape the tree and are a path-escape vector.
+    __pycache__ directories are excluded because .pyc files embed absolute
+    source paths and can never be byte-identical across machines.
     """
     base = Path(directory)
     return {
         name for name in names
-        if (base / name).is_symlink() and os.path.isabs(os.readlink(base / name))
+        if name == "__pycache__"
+        or ((base / name).is_symlink() and os.path.isabs(os.readlink(base / name)))
     }
 
 

--- a/packages/agentbundle/agentbundle/build/adapters/copilot.py
+++ b/packages/agentbundle/agentbundle/build/adapters/copilot.py
@@ -35,14 +35,16 @@ from agentbundle.build.projections.copilot_hooks_json import (
 
 
 def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member.
+    """`shutil.copytree` ignore callback: skip every symlink member and
+    Python bytecode cache directories.
 
     Drops nested symlinks so they are never reproduced in the output
     tree. The top-level `is_symlink()` skip in `_project_direct_directory`
-    covers the skill root; this covers the subtree.
+    covers the skill root; this covers the subtree. __pycache__ is excluded
+    because .pyc files embed absolute source paths and would cause drift.
     """
     base = Path(directory)
-    return {name for name in names if (base / name).is_symlink()}
+    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
 
 
 def _iter_primitives(contract: dict) -> Iterator[str]:

--- a/packages/agentbundle/agentbundle/build/adapters/cursor.py
+++ b/packages/agentbundle/agentbundle/build/adapters/cursor.py
@@ -134,7 +134,8 @@ def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member.
+    """`shutil.copytree` ignore callback: skip every symlink member and
+    Python bytecode cache directories.
 
     Drops **nested** symlinks during the copy so they are never reproduced in
     the output tree. Without this, a symlink inside a skill subdir would be
@@ -144,10 +145,11 @@ def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
     `is_symlink()` skip in `_project_direct_directory` only covers the skill
     root; this covers the subtree. (Build runs on trusted `packs/`; this is
     the install-from-untrusted-catalogue defense — mirrored in all five
-    direct-directory adapters.)
+    direct-directory adapters.) __pycache__ is excluded because .pyc files
+    embed absolute source paths and would cause drift on any other machine.
     """
     base = Path(directory)
-    return {name for name in names if (base / name).is_symlink()}
+    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
 
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:

--- a/packages/agentbundle/agentbundle/build/adapters/gemini.py
+++ b/packages/agentbundle/agentbundle/build/adapters/gemini.py
@@ -133,11 +133,13 @@ def _project_single(pack_path: Path, contract: dict, output_root: Path) -> None:
 
 
 def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member (drops nested
-    symlinks so the install walker can't read through them to embed out-of-tree
-    content). The cursor.py precedent."""
+    """`shutil.copytree` ignore callback: skip every symlink member and
+    Python bytecode cache directories (drops nested symlinks so the install
+    walker can't read through them to embed out-of-tree content; drops
+    __pycache__ because .pyc files embed absolute source paths and drift).
+    The cursor.py precedent."""
     base = Path(directory)
-    return {name for name in names if (base / name).is_symlink()}
+    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
 
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -370,14 +370,16 @@ def _project_hook_wiring_to_agent_json(
 
 
 def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member.
+    """`shutil.copytree` ignore callback: skip every symlink member and
+    Python bytecode cache directories.
 
     Drops nested symlinks so they are never reproduced in the output
     tree. The top-level `is_symlink()` skip in `_project_direct_directory`
-    covers the skill root; this covers the subtree.
+    covers the skill root; this covers the subtree. __pycache__ is excluded
+    because .pyc files embed absolute source paths and would cause drift.
     """
     base = Path(directory)
-    return {name for name in names if (base / name).is_symlink()}
+    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
 
 
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -393,6 +393,12 @@ EXCLUDED_PATTERNS: tuple[str, ...] = (
     "dist/**",
     ".worktrees/**",
     "*.upstream.*",  # adopter-local upstream stash sidecars
+    # Python bytecode cache — generated at import time, never part of the
+    # projection contract. Pyc files embed the absolute source path so they
+    # can never be byte-identical across machines; excluding them prevents
+    # false-positive drift failures when a skill script is imported or run
+    # before build-check executes. See docs/backlog.md § pycache-drift.
+    "**/__pycache__/**",
 )
 
 
@@ -496,6 +502,8 @@ def _project_seeds(packs_dir: Path, output_root: Path) -> dict[Path, Path]:
             continue
         for src in sorted(seeds_dir.rglob("*")):
             if not src.is_file():
+                continue
+            if "__pycache__" in src.parts:
                 continue
             # Underscore-prefixed files are *composition fragments*
             # (e.g. `_agents-footer.md`), not standalone projection

--- a/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
+++ b/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
@@ -285,12 +285,6 @@ def test_make_build_check_passes_post_migration(tmp_path):
         tmp_path / ".adapt-discovery.toml",
     )
 
-    # Remove any __pycache__ from the shadow copy — they would be flagged as
-    # unexpected projection artifacts by the self-host gate.
-    for pycache in packs_shadow.rglob("__pycache__"):
-        if pycache.is_dir():
-            shutil.rmtree(pycache, ignore_errors=True)
-
     # Populate the shadow working tree by running the real self-host
     # projection against it. --force bypasses the dirty-tree refusal
     # (tmp_path is not a git repo, so is_dirty_tree fails closed).

--- a/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
+++ b/packages/agentbundle/tests/integration/test_marketplace_manifest_regression.py
@@ -183,9 +183,6 @@ class TestRunAggregateMarketplaceName:
         """Run `agentbundle build` against the real packs and return marketplace.json."""
         packs_shadow = tmp_path / "packs"
         shutil.copytree(REPO_ROOT / "packs", packs_shadow, symlinks=True)
-        for pycache in packs_shadow.rglob("__pycache__"):
-            if pycache.is_dir():
-                shutil.rmtree(pycache, ignore_errors=True)
 
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary

- All six adapter `copytree` ignore callbacks (`claude_code`, `codex`, `copilot`, `cursor`, `gemini`, `kiro`) now also drop `__pycache__` directories, so bytecode cache dirs generated by pytest or skill imports are never projected into `.claude/`/`.codex/`/etc.
- Added `**/__pycache__/**` to `EXCLUDED_PATTERNS` in `self_host.py` as a drift-gate safety net for any `.pyc` files that reach the working tree from a pre-fix `build-self` run.
- Added `if "__pycache__" in src.parts: continue` in `_project_seeds()` to also guard the seed copy path.
- Removed the now-redundant manual `rglob("__pycache__")` cleanup workaround in `test_build_derivation_claude_plugins.py` and `test_marketplace_manifest_regression.py`.

## Root cause

`.pyc` files embed the absolute source path, so they can never be byte-identical between source and projection locations. Any `__pycache__` generated during a session (pytest run, skill import, work-loop state machine) caused the drift gate to report `(missing on disk)` or `(content differs)` on the next `make build-check`, even when no real projection change had occurred.

## Test plan

- [x] Unit tests: `test_catalogue_tooling_self_host.py`, `test_nested_symlink_hardening.py`, `test_safety_scan_per_pack_scoping.py` — all pass
- [x] Full unit suite (`packages/agentbundle/tests/unit/`) — all pass
- [x] Integration tests that previously needed the manual pycache cleanup — still pass without it