### PR TITLE
perf(ci): reduce Windows gate wall-clock — drop platform-independent ruff/mypy, add scoped pip cache

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -81,6 +81,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: |
+            tools/requirements.txt
+            packages/agentbundle/pyproject.toml
+            packages/credbroker/pyproject.toml
 
       - name: Install agentbundle (editable) + pytest
         # Installed first so `python -m agentbundle.build` resolves on
@@ -90,15 +95,6 @@ jobs:
         # Windows, and `pip install -e` is needed for the pytest steps
         # below anyway).
         run: pip install -e packages/agentbundle/ pytest -r tools/requirements.txt
-
-      - name: Install ruff + mypy
-        run: pip install ruff mypy
-
-      - name: ruff lint
-        run: python tools/lint-ruff.py
-
-      - name: mypy type-check (typed packages only)
-        run: python tools/lint-mypy.py
 
       - name: Run bundler build (populates dist/ for build-check drift gates)
         # The drift gates added by docs/specs/claude-plugins-install-route/

--- a/docs/specs/optimize-windows-ci-gates/spec.md
+++ b/docs/specs/optimize-windows-ci-gates/spec.md
@@ -1,0 +1,22 @@
+# Spec: optimize-windows-ci-gates
+
+**Mode:** light (no risk trigger fired)
+**Status:** Shipped
+
+## Objective
+
+Reduce `build-check-windows.yml` wall-clock time by removing platform-independent static-analysis steps (ruff/mypy) that duplicate the authoritative Linux job, and adding scoped pip caching. The T4 test step (`test_credential_brokers_pack_install.py`) is retained: adversarial review confirmed that only 3 of ~15 assertions self-skip on Windows; the path-sensitive integration assertions (user-scope install, consumer import resolution) run on Windows and represent the sole Windows CI coverage for that contract.
+
+## Acceptance Criteria
+
+- [x] AC1 — `Install ruff + mypy`, `ruff lint`, and `mypy type-check` steps are absent from `build-check-windows.yml`
+- [x] AC2 — `actions/setup-python@v5` in `build-check-windows.yml` includes `cache: 'pip'` with `cache-dependency-path` scoped to `tools/requirements.txt`, `packages/agentbundle/pyproject.toml`, and `packages/credbroker/pyproject.toml`
+- [x] AC3 — The workflow YAML is syntactically valid (passes `yaml.safe_load`)
+- [x] AC4 — No implementation or config files other than `build-check-windows.yml` are modified (spec dir excepted)
+- [x] AC5 — The T4 pytest step (`pytest user-scope floor delivery / test_credential_brokers_pack_install.py`) is present and unchanged
+
+## Tasks
+
+1. Edit `.github/workflows/build-check-windows.yml`: remove three ruff/mypy steps, add `cache: 'pip'` with scoped `cache-dependency-path`
+2. Validate YAML syntax
+3. Commit and open PR


### PR DESCRIPTION
## Summary

- Removes `Install ruff + mypy`, `ruff lint`, and `mypy type-check` steps from `build-check-windows.yml` — these produce identical results on Windows and Linux; `build-check.yml` (Linux) is the authoritative run
- Adds `cache: 'pip'` with `cache-dependency-path` scoped to the three files the job installs from (`tools/requirements.txt`, `packages/agentbundle/pyproject.toml`, `packages/credbroker/pyproject.toml`) — avoids full-monorepo cache-key invalidation on unrelated `pyproject.toml` changes

## What was NOT changed

The `pytest user-scope floor delivery (credbroker-user-scope T4)` step was initially considered for removal (its inline comment notes that POSIX mode-bit tests self-skip on Windows). Adversarial review confirmed this was wrong: only 3 of ~15 assertions self-skip; the path-sensitive integration assertions (user-scope install, consumer import resolution via `~/.agentbundle/lib`) run on Windows and have no other Windows CI coverage. Step retained unchanged.

## Estimated saving

~1–2 min wall-clock on `build-check-windows` (ruff + mypy install + execution). Caching saves additional time on cache hits.

## Test plan

- [ ] `build-check-windows` CI job passes on this PR
- [ ] YAML validates: `python -c "import yaml; yaml.safe_load(open('.github/workflows/build-check-windows.yml'))"`
- [ ] No other workflow jobs changed