### PR TITLE
fix(ci): add PYTHONUTF8=1 env to Gate A Windows test step

### DIFF
--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -52,6 +52,9 @@ jobs:
         run: pip install 'pyyaml>=6.0'
       - name: Run full agentbundle test suite
         working-directory: packages/agentbundle
+        env:
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: "utf-8"
         run: python -m pytest tests/ agentbundle/build/tests/ -q
 
   # ── Gate B: external catalogue portability ────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `PYTHONUTF8: "1"` and `PYTHONIOENCODING: "utf-8"` to the **Run full agentbundle test suite** step in `catalogue-tooling-ci-gates.yml`
- `build-check-windows.yml` already sets these vars for its curated Windows subset; this aligns Gate A to match
- Fixes `UnicodeDecodeError` crashes on cp1252-default Windows runners when subprocess output contains non-ASCII chars (✓, ✖, box-drawing)

## Test plan

- [ ] Watch the Windows matrix in Gate A — failure count should drop vs. the "50+ pre-existing compat failures" baseline
- [ ] `continue-on-error: true` stays in place until all compat PRs land (separate follow-up)