### PR TITLE
fix(tests): guard symlink_to() calls in Windows-hostile test files

### DIFF
--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -372,7 +372,10 @@ def test_config_symlink_escape(tmp_path):
     target = tmp_path.parent / "outside_dir"
     target.mkdir(exist_ok=True)
     link = tmp_path / "escape_link"
-    link.symlink_to(target)
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("symlink creation requires elevated privileges on Windows")
 
     content = _VALID_BASE.replace("packs = 'packs'", "packs = 'escape_link'")
     _write_toml(tmp_path, content)

--- a/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
+++ b/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
@@ -16,6 +16,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 
 def _make_skill_source(tmp: Path) -> tuple[Path, Path]:
     """Return (source_dir, target_dir) with a nested symlink fixture.
@@ -29,7 +31,10 @@ def _make_skill_source(tmp: Path) -> tuple[Path, Path]:
     source_skill = source_dir / "my-skill"
     source_skill.mkdir(parents=True)
     (source_skill / "SKILL.md").write_text("# My Skill\n", encoding="utf-8", newline="\n")
-    (source_skill / "secret-link").symlink_to("/etc/passwd")
+    try:
+        (source_skill / "secret-link").symlink_to("/etc/passwd")
+    except OSError:
+        pytest.skip("symlink creation requires elevated privileges on Windows")
 
     target_dir = tmp / "target"
     target_dir.mkdir()
@@ -106,7 +111,10 @@ class TestCodexNestedSymlinkDropped(unittest.TestCase):
             skill_dir = pack / ".apm" / "skills" / "my-skill"
             skill_dir.mkdir(parents=True)
             (skill_dir / "SKILL.md").write_text("# My Skill\n", encoding="utf-8", newline="\n")
-            (skill_dir / "secret-link").symlink_to("/etc/passwd")
+            try:
+                (skill_dir / "secret-link").symlink_to("/etc/passwd")
+            except OSError:
+                pytest.skip("symlink creation requires elevated privileges on Windows")
 
             output = tmp / "output"
             output.mkdir()


### PR DESCRIPTION
## Summary

- Wrap the three unguarded `symlink_to()` call sites in `test_nested_symlink_hardening.py` (×2) and `test_catalogue_tooling_foundation.py` (×1) with `try/except OSError` + `pytest.skip(...)`.
- Tests that verify symlink-rejection logic are vacuously unverifiable when symlink creation itself fails on Windows — skipping is the correct response.
- All other tests in these files are unaffected; no module-level `skipif` added.
- Pattern matches the existing guard at `test_catalogue_tooling_lint.py:753–756`.

## Test plan

- [x] `python3 -m pytest tests/unit/test_nested_symlink_hardening.py tests/unit/test_catalogue_tooling_foundation.py -q` — 30/30 passed on macOS.