### PR TITLE
perf(ci): path-filter pages workflow to only build on site-relevant changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,26 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'web/**'
+      - 'docs-site/**'
+      - 'guides/**'
+      - 'docs/product/changelog.md'
+      - 'CONTRIBUTING.md'
+      - 'packs/**/README.md'
+      - 'tools/build-site.py'
+      - '.github/workflows/pages.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'web/**'
+      - 'docs-site/**'
+      - 'guides/**'
+      - 'docs/product/changelog.md'
+      - 'CONTRIBUTING.md'
+      - 'packs/**/README.md'
+      - 'tools/build-site.py'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Adds `paths` filters to both `push` and `pull_request` triggers on `.github/workflows/pages.yml`
- The Pages build (Astro marketing site + Starlight docs) now only runs when site-relevant files change
- `workflow_dispatch` is left unfiltered so manual runs always work

**Paths covered:**
- `web/**` — marketing site source + shared `tokens.css`
- `docs-site/**` — Starlight docs source
- `guides/**` — aggregated into docs site by `build-site.py`
- `docs/product/changelog.md` — aggregated into docs site
- `CONTRIBUTING.md` — aggregated into docs site
- `packs/**/README.md` — pack pages aggregated into docs site
- `tools/build-site.py` — aggregator script itself
- `.github/workflows/pages.yml` — workflow file changes

## Test plan

- [ ] Verify a PR touching only non-site files (e.g. `packages/`) skips this workflow
- [ ] Verify a PR touching `web/` or `docs-site/` triggers the workflow as expected
- [ ] Confirm `workflow_dispatch` still runs without path restriction