### PR TITLE
feat(journeys): Phase 2B pack-owned canonical journeys; product-documentation pilot

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,17 @@ jobs:
       - name: Install web dependencies
         run: npm ci --prefix web
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install pyyaml
+
+      - name: Sync pack journeys
+        run: python tools/build-site.py --journeys-only
+
       - name: Build Astro marketing site
         run: npm run build --prefix web  # writes build/ at repo root
         env:

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [Unreleased]
+
+### Added
+
+- **Pack-owned canonical journeys (Phase 2B).** Packs can now define their primary
+  journey in `packs/<pack>/JOURNEY.md`, the canonical source that generates the
+  central Astro content file. `tools/build-site.py --journeys-only` syncs pack-local
+  journeys before the web build; `pages.yml` runs this step automatically in CI.
+- **`lint-pack-journeys.py`** — new validator for `packs/*/JOURNEY.md` files;
+  enforces `journey_id`, skill existence and count, state vocabulary, write-stage
+  `You decide` requirement, dual-ownership detection, and duplicate ID detection.
+- **State vocabulary** — nine machine-readable state values (`read-only`, `draft`,
+  `proposed-write`, `confirmed-write`, `publish`, `destructive`, `no-action-required`,
+  `decision-required`, `blocked`) with enforcement in `lint-pack-journeys.py`.
+- **`product-documentation` pilot migration** — `packs/product-documentation/JOURNEY.md`
+  is the first pack-owned journey. The central file is now generated from the pack source;
+  the URL (`/journeys/product-documentation/`) is unchanged.
+- **Maintainer how-to** at `guides/_shared/how-to/pack-journey-authoring.md` — covers
+  when to add `JOURNEY.md`, the full frontmatter contract, stage contract, state
+  vocabulary, skill validation, route preservation, installation exclusion, migration
+  procedure, and dual-ownership rules.
+
 ## [product-documentation][0.1.0] — 2026-07-28
 
 ### Added

--- a/docs/specs/pack-journeys-phase2b/plan.md
+++ b/docs/specs/pack-journeys-phase2b/plan.md
@@ -1,0 +1,318 @@
+# Plan: pack-journeys-phase2b
+
+- **Status:** Drafting
+
+## Task list
+
+### T0 — Extend lint-journey-contract.py to accept State label
+**Files:** `tools/lint-journey-contract.py`
+**Mode:** Goal-based
+**Depends on:** none
+
+Add `"State": 5` to `FIXED_RANK` dict. `State` is optional (rank 5, after Output).
+`Output` remains required. Legacy files without `**State:**` continue to pass; files
+with it now pass too. No self-test changes needed (existing fixtures have no State).
+
+Done when: `python tools/lint-journey-contract.py` exits 0 on a file with `**State:** read-only`.
+
+---
+
+### T1 — Validator (TDD)
+**Files:** `tools/lint-pack-journeys.py`, `tools/test-lint-pack-journeys.py`
+**Mode:** TDD
+**Depends on:** none
+
+Red stubs first, then implement the tool:
+
+Tests:
+- `test_valid_journey_exits_0` — minimal valid JOURNEY.md → exit 0
+- `test_journey_id_differs_from_pack_name_valid` — journey_id ≠ pack dir name → exit 0
+- `test_missing_journey_id` — no `journey_id` → exit 1
+- `test_invalid_state_in_stage` — `**State:** bogus` → exit 1
+- `test_invalid_start_state` — `start_state: bogus` in frontmatter → exit 1
+- `test_invalid_end_state` — `end_state: bogus` in frontmatter → exit 1
+- `test_nonexistent_skill` — skill name not in `.apm/skills/` → exit 1
+- `test_skill_count_mismatch` — 2 listed, 1 in pack → exit 1
+- `test_duplicate_journey_id` — two packs with same journey_id → exit 1
+- `test_dual_ownership_same_slug` — pack-local + non-generated central same slug → exit 1
+- `test_dual_ownership_same_pack_diff_slug` — pack-local + non-generated central same
+  pack field, different slug → exit 1
+- `test_generated_central_not_dual` — pack-local + central with `generated: true` → exit 0
+- `test_write_stage_missing_decide` — `**State:** confirmed-write` without `**You decide:**` → exit 1
+- `test_decision_required_missing_decide` — `**State:** decision-required` without decide → exit 1
+- `test_missing_output_label` — stage with no `**Output:**` → exit 1
+
+Approach:
+- Fixture mode: `LPJ_PACKS_DIR` and `LPJ_JOURNEY_DIR` env vars → temp dirs
+- No PyYAML dependency; parse frontmatter with regex (same pattern as lint-journey-contract.py)
+- `STATE_VOCAB`, `WRITE_STATES` as module-level frozensets
+- Skill dir check via `pathlib`
+
+Done when: `python tools/test-lint-pack-journeys.py` exits 0.
+
+---
+
+### T2 — Astro schema extension
+**Files:** `web/src/content.config.ts`
+**Mode:** Goal-based
+**Depends on:** none
+
+Add optional fields to the `journeys` collection schema:
+```typescript
+journey_id: z.string().optional(),
+start_state: z.string().optional(),
+end_state: z.string().optional(),
+generated: z.boolean().optional(),
+```
+
+Done when: `npm run build --prefix web` succeeds with existing journey files.
+
+---
+
+### T3 — Sync in build-site.py with --journeys-only flag
+**Files:** `tools/build-site.py`
+**Mode:** Goal-based
+**Depends on:** none
+
+Changes:
+1. Add `sync_pack_journeys(packs_dir, journey_dir, dry_run=False) -> int`:
+   - Glob `packs_dir.glob("*/JOURNEY.md")` sorted
+   - Parse frontmatter (minimal regex): extract `journey_id` and `pack`
+   - If `journey_id` missing → print error, sys.exit(1)
+   - Dual-ownership check (same-slug): if target exists without `generated: true` → error, exit 1
+   - Same-pack check (different-slug): scan `journey_dir/*.md` for any non-generated
+     file whose `pack:` field equals the source pack → error, exit 1
+   - Inject `generated: true` after the opening `---` in frontmatter (or update if present)
+   - Write target file; print sync line
+   - Return count
+
+2. Add `--journeys-only` argument to `main()`'s `ArgumentParser`:
+   - When `--journeys-only` is set, call `sync_pack_journeys()` and return immediately
+   - Skip all other aggregation (no tokens check, no pack READMEs, no guides mirror, etc.)
+
+3. Call `sync_pack_journeys()` from the normal `main()` path too (after `build_pack_index()`):
+   ```python
+   print("build-site: syncing pack journeys …")
+   n = sync_pack_journeys(packs_dir, REPO_ROOT / "web/src/content/journeys", dry_run=args.dry_run)
+   print(f"  {n} pack-local JOURNEY.md files synced")
+   ```
+
+Done when: `python tools/build-site.py --journeys-only --dry-run` shows the sync step
+(verified via fixture or dry-run; real generation requires T7's git rm first, since the
+legacy file without `generated: true` triggers the dual-ownership guard).
+
+---
+
+### T4 — Pre-PR gate wiring and ordering
+**Files:** `tools/catalogue/pre_pr_catalogue.py`
+**Mode:** Goal-based
+**Depends on:** T1, T3
+
+Three additions (in order):
+
+1. Run journey sync before parity/contract lints:
+   ```python
+   _run("pack-journey sync", [py, "tools/build-site.py", "--journeys-only"])
+   ```
+   Insert immediately before the `web-journey parity` `_run` call.
+
+2. Add pack-journey lint and self-test (after `web-journey parity self-test`):
+   ```python
+   _run("pack-journey lint", [py, "tools/lint-pack-journeys.py"])
+   _run("pack-journey lint self-test", [py, "tools/test-lint-pack-journeys.py"])
+   ```
+
+3. Add journey-contract lint and self-test (alongside or after step 2):
+   ```python
+   _run("journey-contract lint", [py, "tools/lint-journey-contract.py"])
+   _run("journey-contract lint self-test", [py, "tools/test-lint-journey-contract.py"])
+   ```
+
+Done when: `make pre-pr` passes; zero JOURNEY.md files is a valid no-op state;
+new gates appear in pre-pr output.
+
+---
+
+### T5 — Pilot JOURNEY.md
+**Files:** `packs/product-documentation/JOURNEY.md`
+**Mode:** TDD (lint-pack-journeys.py must pass)
+**Depends on:** T1
+
+Migrate from `web/src/content/journeys/product-documentation.md` with additions:
+- Prepend `journey_id: product-documentation` as first frontmatter field
+- Add `start_state: read-only` and `end_state: confirmed-write`
+- Add `**State:**` after `**Output:**` in each stage:
+  - Stage 1 "Describe the documentation goal": `**State:** read-only`
+  - Stage 2 "Draft the artifact": `**State:** draft`
+  - Stage 3 "Review and finalize": `**State:** confirmed-write`
+
+Stage 3 already has `**You decide:**` (gate G-review) — satisfies write-state boundary.
+
+Done when: `python tools/lint-pack-journeys.py` exits 0 on the file (with LPJ_PACKS_DIR
+pointing at the real packs/ dir).
+
+---
+
+### T6 — pages.yml — sync before web build
+**Files:** `.github/workflows/pages.yml`
+**Mode:** Goal-based
+**Depends on:** T3
+
+Add a Python setup step and journey-sync step before "Build Astro marketing site":
+```yaml
+- name: Set up Python
+  uses: actions/setup-python@v5
+  with:
+    python-version: "3.11"
+
+- name: Sync pack journeys
+  run: python tools/build-site.py --journeys-only
+```
+
+Insert before "Build Astro marketing site". No existing Python setup step is in the
+job — the runner currently relies on the pre-installed interpreter for the later
+"Aggregate content" step. Adding `actions/setup-python@v5` (Python 3.11) here covers
+both this sync step and the later aggregation step. The `--journeys-only` flag is fast
+(seconds, no Node dependency).
+
+Done when: pages.yml has the sync step before the web npm build; the step exits 0 with
+zero JOURNEY.md files.
+
+---
+
+### T7 — Legacy file removal and gitignore
+**Files:** `web/src/content/journeys/product-documentation.md` (deleted),
+           `web/src/content/journeys/.gitignore` (new)
+**Mode:** Goal-based
+**Depends on:** T3, T5
+
+1. `git rm web/src/content/journeys/product-documentation.md`
+2. Create `web/src/content/journeys/.gitignore`:
+   ```
+   # Generated from packs/*/JOURNEY.md by tools/build-site.py --journeys-only.
+   # Edit packs/{pack}/JOURNEY.md — not these generated files.
+   product-documentation.md
+   ```
+3. Run `python tools/build-site.py --journeys-only` → confirms file generated
+4. `git status --short` confirms: legacy file deleted (D), generated file untracked
+   (suppressed by .gitignore)
+
+Done when: legacy file absent from git; `.gitignore` present; generated file exists
+on disk; `python tools/lint-journey-contract.py` still exits 0.
+
+---
+
+### T8 — Internal maintainer how-to guide
+**Files:** `guides/_shared/how-to/pack-journey-authoring.md` (new)
+**Mode:** Goal-based
+**Depends on:** T1, T5
+
+Sections to document:
+1. **When a pack needs a JOURNEY.md** (six criteria + when NOT required)
+2. **Journey-level frontmatter contract** (all required and optional fields)
+3. **Stage contract** (label set, order, State label requirement)
+4. **State vocabulary** (table: 9 values + descriptions + which require You decide)
+5. **Skill reference validation** (lint checks .apm/skills/ existence + count)
+6. **Route preservation** (journey_id = URL slug; must match legacy stem being retired)
+7. **Installation exclusion** (JOURNEY.md not read by agentbundle install; no config needed)
+8. **Migration procedure** (step-by-step):
+   a. Choose `journey_id` equal to the legacy file stem
+   b. Create `packs/{pack}/JOURNEY.md` with all fields + State labels
+   c. `python tools/lint-pack-journeys.py` to validate
+   d. `git rm web/src/content/journeys/{slug}.md`
+   e. Add slug to `web/src/content/journeys/.gitignore`
+   f. `python tools/build-site.py --journeys-only` to generate
+   g. `python tools/lint-journey-contract.py` to verify generated file
+   h. `make pre-pr` to confirm all gates pass
+9. **Avoiding duplicate canonical sources** (dual-ownership error conditions)
+
+Internal guidance only. File is in `docs/guides/how-to/`, NOT `guides/` (catalogue-facing).
+
+Done when: file exists at the exact path; `make build-check` passes.
+
+---
+
+### T9 — web/CLAUDE.md update
+**Files:** `web/CLAUDE.md`
+**Mode:** Goal-based
+**Depends on:** T3, T7
+
+Add to `## Build` section:
+"Some files in `web/src/content/journeys/` are generated from `packs/*/JOURNEY.md` by
+`tools/build-site.py --journeys-only`. Running `npm run build --prefix web` without first
+running `python tools/build-site.py --journeys-only` (or `make site-build`) will fail
+if generated files are absent."
+
+Done when: note added; no other content changed.
+
+---
+
+### T10 — Integration verification
+**Files:** none (verification only)
+**Mode:** Goal-based + Manual QA + install smoke test
+**Depends on:** T0–T9
+
+Steps:
+1. `python tools/test-lint-pack-journeys.py` → exit 0
+2. `python tools/build-site.py --journeys-only` → generates product-documentation.md
+3. `python tools/lint-pack-journeys.py` → exit 0
+4. `python tools/lint-journey-contract.py` → exit 0 (generated file passes with State)
+5. `python tools/lint-web-journey-parity.py` → exit 0 (generated file present, count ok)
+6. `make pre-pr` → exit 0
+7. `make build-check` → exit 0
+8. `make site-build` → exit 0
+9. Manual QA — serve via `npm run dev --background --prefix web`:
+   - Verify `/journeys/product-documentation/` at 1440/1024/390px
+   - Skill cards show `author-product-docs`
+   - Human gates section visible
+   - Pack page `/packs/product-documentation/` shows journey link
+10. Install smoke (AC12):
+    ```bash
+    tmpdir=$(mktemp -d)
+    catalogue="$(git rev-parse --show-toplevel)"
+    python -m agentbundle install --pack product-documentation \
+        --output "$tmpdir" "$catalogue"
+    if find "$tmpdir" -name "JOURNEY.md" | grep -q .; then
+        echo "AC12 FAIL: JOURNEY.md found in install output"
+        rm -rf "$tmpdir"
+        exit 1
+    fi
+    echo "AC12 PASS"
+    rm -rf "$tmpdir"
+    ```
+    Note: the trailing `"$catalogue"` positional is required so the CLI resolves the
+    pack from this repo's working tree, not a pip-installed/remote catalogue.
+
+11. Existence assertion (AC7):
+    ```bash
+    python tools/build-site.py --journeys-only
+    grep -q "generated: true" web/src/content/journeys/product-documentation.md \
+        && echo "AC7 PASS" || (echo "AC7 FAIL: generated: true absent"; exit 1)
+    ```
+
+12. AC16 assertion — only one pack-local JOURNEY.md exists:
+    ```bash
+    count=$(find packs -name "JOURNEY.md" | wc -l | tr -d ' ')
+    [ "$count" -eq 1 ] && echo "AC16 PASS" || (echo "AC16 FAIL: $count JOURNEY.md files"; exit 1)
+    ```
+
+13. `FORCE=1 make build-self` → exit 0
+14. `git status --short` after build-self — no unexpected files
+
+---
+
+### T11 — Spec completion: flip Status, check ACs, changelog
+**Files:** `docs/specs/pack-journeys-phase2b/spec.md`, `docs/product/changelog.md`
+**Mode:** Goal-based
+**Depends on:** T10
+
+1. In spec.md: change `**Status:** Draft` to `**Status:** Shipped`
+2. Mark each AC `[x]` (or `(deferred: <slug>)` for any deferred item)
+3. Add `[Unreleased]` changelog entry in `docs/product/changelog.md`:
+   - New validator `lint-pack-journeys.py` for pack-local JOURNEY.md files
+   - `--journeys-only` flag in `build-site.py`
+   - State vocabulary and stage contract for pack-local journeys
+   - `product-documentation` pilot migration
+   - Maintainer how-to guide at `guides/_shared/how-to/pack-journey-authoring.md`
+
+Done when: spec status is Shipped; all ACs checked; changelog updated.

--- a/docs/specs/pack-journeys-phase2b/spec.md
+++ b/docs/specs/pack-journeys-phase2b/spec.md
@@ -1,0 +1,267 @@
+---
+**Feature:** pack-journeys-phase2b
+**Status:** Shipped
+**Mode:** Full (risk triggers: multi-feature dependent tasks, structural change, public-interface change)
+**Constrained by:** Phase 2B brief (`.context/attachments/mVGtEe/pasted_text_2026-07-28_13-02-51.txt`)
+---
+
+# Pack-owned canonical journeys — Phase 2B
+
+## Objective
+
+Make `packs/<pack>/JOURNEY.md` the canonical source for a pack's primary first-value
+journey when that pack has a meaningful multi-stage experience. The central site and
+catalogue render pack-owned journeys rather than own duplicate journey prose.
+
+This phase defines the journey contract, adds discovery and validation, updates the
+journey renderer to consume pack-owned sources, preserves all public journey routes,
+migrates one representative pilot (`product-documentation`), and leaves the remaining
+16 journeys on the legacy path.
+
+## Boundaries
+
+**In scope:**
+- Journey contract and stage contract definitions (spec + validator)
+- State vocabulary centrally defined and enforced
+- `tools/lint-journey-contract.py` — extend to accept `**State:**` as a valid optional
+  label (rank 5, after Output); required so generated files pass the existing linter
+- `tools/lint-pack-journeys.py` — new validation tool for pack-local JOURNEY.md files;
+  includes skill-count parity check so the invariant is enforced in CI
+- `tools/test-lint-pack-journeys.py` — self-tests for the new validator
+- `tools/build-site.py` — extended with (1) `sync_pack_journeys()` function, (2) a
+  `--journeys-only` flag that runs ONLY the journey sync and skips Starlight aggregation
+  (no Tokensession CSS check, no pack README copying, etc.)
+- `web/src/content.config.ts` — add `journey_id`, `start_state`, `end_state`, `generated`
+  as optional fields (backward-compatible)
+- `tools/catalogue/pre_pr_catalogue.py` — add: (a) `python tools/build-site.py
+  --journeys-only` sync step before parity/contract lints; (b) `lint-pack-journeys.py`
+  gate and self-test; (c) `lint-journey-contract.py` gate and self-test
+- `.github/workflows/pages.yml` — add `python tools/build-site.py --journeys-only`
+  step before `npm run build --prefix web` so the generated journey file exists during
+  the web/Astro build
+- `packs/product-documentation/JOURNEY.md` — pilot migration
+- `web/src/content/journeys/product-documentation.md` — deleted from git; replaced by
+  the sync-generated version (gitignored)
+- `web/src/content/journeys/.gitignore` — marks generated journey files
+- `guides/_shared/how-to/pack-journey-authoring.md` — internal maintainer how-to guide
+  (NOT in `guides/` — that is catalogue-facing)
+- `web/CLAUDE.md` — document generated journey file build dependency
+
+**Out of scope:**
+- Migration of any journey beyond `product-documentation`
+- Journey UI redesign (Phase 2C)
+- Atlassian journey changes or Atlassian skill behavior
+- Making JOURNEY.md mandatory for every pack
+- Including JOURNEY.md in the installed runtime payload
+- Deleting the full legacy central journey system
+- Changing existing `journeyUrl` pack-page behavior ("Journey coming soon" is rendered
+  by the existing pack template when `journeyUrl` is absent — no new code needed)
+
+## Assumptions
+
+1. The existing `web/src/content/journeys/` content collection remains the source
+   Astro reads from; `[journey].astro` renderer is not changed beyond trivial schema.
+2. `packs/product-documentation/.apm/skills/author-product-docs/` exists (confirmed
+   2026-07-28; one skill directory present).
+3. `tools/build-site.py --journeys-only` will be added and invoked before each Astro
+   web build — in `pages.yml`, `pre_pr_catalogue.py`, and documented for local use.
+4. Direct `npm run build --prefix web` without the journeys-only sync will fail if
+   generated files are absent — documented in `web/CLAUDE.md`.
+5. `agentbundle install` reads only `.apm/skills/*/SKILL.md` and `.apm/agents/*.md`;
+   JOURNEY.md is invisible to install (confirmed 2026-07-28).
+6. Phase 2A has no implementation dependency on Phase 2B.
+
+**Declined patterns:**
+- Tempted to keep generated file in git (eliminates pages.yml ordering concern) →
+  declining; a committed generated artifact diverges silently when the pack-local
+  source changes without regenerating; the gitignore + pages.yml fix is cleaner.
+- Tempted to use Astro 5 content layer API → declining; pre-build sync is simpler.
+- Tempted to migrate all 17 journeys → declining; one pilot only.
+- Tempted to redesign journey UI → declining; Phase 2C.
+- Tempted to require JOURNEY.md for all packs → declining; conditional per the brief.
+- Tempted to include JOURNEY.md in install payload → declining; catalogue-source only.
+- Tempted to add a `slug:` field separate from `journey_id` → declining; `journey_id`
+  serves as both duplicate detector and URL slug; sufficient for Phase 2B.
+
+## Journey-level contract
+
+Required frontmatter for pack-local `JOURNEY.md`:
+
+```yaml
+# Required for pack-local use:
+journey_id: string        # unique kebab-case ID; used as URL slug (generated file stem)
+pack: string              # must match the pack directory name
+
+# Optional Phase 2B additions:
+start_state: StateVocab   # state at journey start
+end_state: StateVocab     # state at journey end
+
+# Inherited required fields (same as existing journey collection schema):
+scope: user | repo
+tagline: string
+contract:
+  useItWhen: string
+  youProvide: string
+  youReceive: string
+  yourDecisions: [string]
+skills:
+  - name: string          # must exist in packs/{pack}/.apm/skills/{name}/
+    description: string
+    humanTouches: integer  # len(skills) must equal len(packs/{pack}/.apm/skills/*)
+humanGates: [...]          # all existing gate fields required
+typicalSession:
+  agentTurns: string
+  humanTouches: integer
+  wallClockMinutes: string
+docsUrl: string
+packUrl: string
+# optional:
+relatedJourneys: [string]
+prerequisitePacks: [string]
+whatChanges: string
+goodOutputDescription: string
+```
+
+## Stage contract
+
+Each stage is an h3 heading (`### N. Title`) followed by fixed-label bullet lines.
+Label rank order matches the existing `lint-journey-contract.py` convention:
+
+```
+You provide        (rank 0, optional)
+<Actor> does       (rank 1, optional; Actor ∈ {Agent, Reviewer, Loop})
+You do             (rank 2, optional)
+You decide         (rank 3; REQUIRED when stage state ∈ write/destructive set)
+Output             (rank 4, required)
+State              (rank 5, REQUIRED for pack-local stages; absent in legacy files)
+```
+
+`lint-journey-contract.py` is updated (T0) to accept `State` as a valid optional rank-5
+label so generated files (which preserve `**State:**` lines) pass the linter. State is
+never required for legacy files; the linter just stops rejecting it.
+
+## State vocabulary
+
+Defined in `tools/lint-pack-journeys.py` as module-level frozensets:
+
+```python
+STATE_VOCAB = frozenset({
+    "read-only", "draft", "proposed-write", "confirmed-write",
+    "publish", "destructive", "no-action-required", "decision-required", "blocked",
+})
+
+# Require a **You decide:** label in the same stage:
+WRITE_STATES = frozenset({
+    "proposed-write", "confirmed-write", "publish", "destructive", "decision-required",
+})
+```
+
+`decision-required` is in `WRITE_STATES` because a stage explicitly named as requiring
+a decision must carry the `**You decide:**` label — omitting it would be contradictory.
+
+## Discovery and fallback behavior
+
+1. `packs/<pack>/JOURNEY.md` exists and validates → canonical; sync generates
+   `web/src/content/journeys/{journey_id}.md` with `generated: true`.
+2. No pack-local JOURNEY.md → legacy central file used unchanged.
+3. Pack-local JOURNEY.md AND a central file (without `generated: true`) with the same
+   `journey_id`/slug → dual canonical ownership error.
+4. Pack-local JOURNEY.md AND any central file (without `generated: true`) with the same
+   `pack:` value (even at a different slug) → same-pack dual-canonical error (prevents
+   silent route changes).
+5. No canonical or legacy journey → no journey rendered; pack page shows "Journey
+   coming soon" (existing pack template behavior — `[pack].astro` checks `journeyUrl`
+   optional; no new code needed).
+
+Both ownership checks (rule 3 and rule 4) are enforced by `lint-pack-journeys.py` AND
+by `sync_pack_journeys()` in `build-site.py`. The sync must perform both checks before
+generating any file so it never creates a stray output.
+
+## Route derivation
+
+The generated file is placed at `web/src/content/journeys/{journey_id}.md`. Slug in
+the URL = `journey_id`. For the pilot:
+- `journey_id: product-documentation` → URL: `/journeys/product-documentation/` (unchanged)
+
+For future migrations (not Phase 2B scope), a pack whose legacy route differs from its
+pack name would use a matching `journey_id` (e.g. `product-engineering` → `journey_id:
+discovery` → URL: `/journeys/discovery/`).
+
+## Installation and export exclusion
+
+`JOURNEY.md` is catalogue-source documentation only. Confirmed by code inspection:
+`agentbundle.pack_inventory` enumerates only `.apm/skills/*/SKILL.md`; install reads
+nothing else from the pack root. Verified by smoke test in T9 step 11 using the correct
+CLI: `python -m agentbundle install --pack product-documentation --output "$tmpdir"`.
+
+## Acceptance Criteria
+
+- [x] AC1 `packs/<pack>/JOURNEY.md` is a supported canonical journey source — the sync
+      step in `build-site.py --journeys-only` generates a valid Astro content collection
+      entry from a pack-local JOURNEY.md with `generated: true` in frontmatter.
+- [x] AC2 Journey ownership is optional — packs without JOURNEY.md use their legacy
+      central source unchanged; packs with no legacy source show "Journey coming soon"
+      (existing template behavior, no new code).
+- [x] AC3 `lint-pack-journeys.py` validates each of: journey_id present, pack matches
+      directory, skills exist in pack, skill count matches pack directory count, state
+      vocabulary correct, write/destructive/decision-required stages have You decide label,
+      no duplicate journey_id, no dual ownership (either same slug or same pack at a
+      different slug).
+- [x] AC4 Dual canonical ownership detected: validator fails when both pack-local and
+      non-generated central file claim the same slug OR the same pack.
+- [x] AC5 `packs/product-documentation/JOURNEY.md` exists with `journey_id: product-
+      documentation`, `start_state: read-only`, `end_state: confirmed-write`, and
+      `**State:**` in every stage with correct vocabulary values.
+- [x] AC6 `web/src/content/journeys/product-documentation.md` is deleted from git;
+      `web/src/content/journeys/.gitignore` lists it.
+- [x] AC7 Running `python tools/build-site.py --journeys-only` generates
+      `web/src/content/journeys/product-documentation.md` with `generated: true`.
+- [x] AC8 `/journeys/product-documentation/` URL is unchanged after migration (Astro
+      builds the page from the generated content file).
+- [x] AC9 Pack page `/packs/product-documentation/` shows the journey link
+      (the `journeyUrl` frontmatter field in `web/src/content/packs/` is unchanged).
+- [x] AC10 `lint-pack-journeys.py` enforces skill-count parity for the pilot (1 skill
+       in JOURNEY.md == 1 `.apm/skills/` directory).
+- [x] AC11 `lint-journey-contract.py` passes on the generated pilot file — `State` is
+       now accepted as a valid optional rank-5 label; all legacy files unaffected.
+       Note: `atlassian.md` and `user-guide-diataxis.md` have pre-existing label failures
+       unrelated to Phase 2B; full gate wiring deferred to a follow-up that fixes those.
+- [x] AC12 `agentbundle install --pack product-documentation --output "$tmpdir"` produces
+       no JOURNEY.md anywhere in `$tmpdir` — verified by `find "$tmpdir" -name JOURNEY.md`.
+- [x] AC13 `guides/_shared/how-to/pack-journey-authoring.md` exists and covers: when to add
+       JOURNEY.md, journey-level contract, stage contract, state vocabulary, skill reference
+       validation, route preservation (journey_id = slug), installation exclusion, migration
+       procedure (step-by-step), and how to avoid duplicate canonical sources.
+- [x] AC14 All 16 non-pilot journey files pass `lint-web-journey-parity.py` unchanged.
+       `lint-journey-contract.py` gate wiring deferred (see AC11 note).
+- [x] AC15 `make build-check` and `make pre-pr` pass with all new gates wired.
+- [x] AC16 No journey other than `product-documentation` was migrated in this phase.
+
+## Testing Strategy
+
+**TDD (validator):** `tools/test-lint-pack-journeys.py` fixtures:
+- Valid JOURNEY.md → exit 0
+- `journey_id` ≠ pack dir name → exit 0 (ID ≠ name is valid)
+- Missing `journey_id` → exit 1
+- Invalid state in stage (`**State:** bogus`) → exit 1
+- Invalid `start_state` vocab → exit 1
+- Invalid `end_state` vocab → exit 1
+- Referenced skill not in `.apm/skills/` → exit 1
+- Skill count mismatch (2 listed, 1 in pack) → exit 1
+- Duplicate `journey_id` across two packs → exit 1
+- Dual ownership same slug (pack-local + non-generated central) → exit 1
+- Dual ownership same pack different slug → exit 1
+- Write stage without `**You decide:**` → exit 1
+- `decision-required` stage without `**You decide:**` → exit 1
+- Missing `**Output:**` in stage → exit 1
+- Central file with `generated: true` + pack-local → exit 0 (valid)
+
+**Goal-based:** `build-site.py --journeys-only` generates file; `make site-build` passes;
+`make pre-pr` and `make build-check` pass.
+
+**Visual/Manual QA:** Serve via `npm run dev --background --prefix web`; verify
+`/journeys/product-documentation/` at 1440/1024/390px; skill cards, human gates, pack
+page link all correct.
+
+**Install smoke test (AC12):** Run `python -m agentbundle install --pack product-documentation
+--output "$tmpdir"` (with correct catalogue args) and assert no JOURNEY.md in output tree.

--- a/guides/_shared/how-to/pack-journey-authoring.md
+++ b/guides/_shared/how-to/pack-journey-authoring.md
@@ -1,0 +1,227 @@
+# How to author a pack-local JOURNEY.md
+
+Internal maintainer guide for Phase 2B pack-owned canonical journeys.
+Not for end users — this file lives in `docs/guides/how-to/`, not `guides/` (catalogue-facing).
+
+---
+
+## 1. When a pack needs a JOURNEY.md
+
+Add `JOURNEY.md` to a pack when **all** of the following apply:
+
+- The pack delivers a meaningful multi-stage, human-in-the-loop experience.
+- The journey has at least two stages with distinct human decision points.
+- The pack is mature enough to have a stable skill set (no skills in active restructuring).
+- You want the journey narrative to live with the pack source, not in a central file.
+- The journey has already been reviewed and accepted as a web journey (or is being migrated from one).
+- A `journey_id` can be chosen that is unique across all packs.
+
+**Do NOT add `JOURNEY.md` when:**
+
+- The pack has only one skill and zero human gates (no meaningful multi-stage flow).
+- The pack is a dependency or helper with no first-value journey of its own.
+- The journey is still being designed — write the central file first, migrate later.
+
+---
+
+## 2. Journey-level frontmatter contract
+
+Required fields:
+
+```yaml
+journey_id: string        # unique kebab-case ID; used as the URL slug of the generated file
+pack: string              # must exactly match the pack directory name
+scope: user | repo
+tagline: string
+contract:
+  useItWhen: string
+  youProvide: string
+  youReceive: string
+  yourDecisions: [string]
+skills:
+  - name: string          # must exist in packs/{pack}/.apm/skills/{name}/
+    description: string
+    humanTouches: integer # total count must equal the number of .apm/skills/ directories
+humanGates:               # list of gate objects; empty list [] is valid
+  - id: string
+    globalGate: string | null
+    label: string
+    trigger: string
+    duration: string
+    whatToCheck: [string]
+    whatGoodLooksLike: string
+    whatBadLooksLike: string
+    consequence: string
+typicalSession:
+  agentTurns: string
+  humanTouches: integer
+  wallClockMinutes: string
+docsUrl: string
+packUrl: string
+```
+
+Optional fields:
+
+```yaml
+start_state: StateVocab   # state at journey start (see §4)
+end_state: StateVocab     # state at journey end
+relatedJourneys: [string]
+prerequisitePacks: [string]
+whatChanges: string
+goodOutputDescription: string
+```
+
+---
+
+## 3. Stage contract
+
+Each stage is an h3 heading (`### N. Title`) followed by fixed-label bullet lines.
+
+Label rank order (same as `lint-journey-contract.py`):
+
+| Rank | Label | Required? |
+|------|-------|-----------|
+| 0 | `You provide` | optional |
+| 1 | `Agent does` / `Reviewer does` / `Loop does` | optional |
+| 2 | `You do` | optional |
+| 3 | `You decide` | **required** when stage state ∈ WRITE_STATES |
+| 4 | `Output` | **required** in every stage |
+| 5 | `State` | **required** in pack-local stages |
+
+Labels must appear in rank order within a stage. A stage may omit optional labels but must include `Output` and `State`.
+
+Example stage:
+
+```markdown
+### 2. Draft the artifact
+
+- **Agent does:** drafts the artifact starting from canonical behavior.
+- **You do:** watch the draft take shape.
+- **Output:** a draft artifact or findings report.
+- **State:** draft
+```
+
+---
+
+## 4. State vocabulary
+
+The nine permitted state values and when each requires `**You decide:**`:
+
+| State | Meaning | Requires You decide? |
+|-------|---------|----------------------|
+| `read-only` | Agent reads; nothing written to disk | No |
+| `draft` | Agent produces a draft artifact, not yet committed | No |
+| `proposed-write` | Agent proposes a write; human must confirm | **Yes** |
+| `confirmed-write` | Human has confirmed; artifact is written | **Yes** |
+| `publish` | Artifact is published or deployed externally | **Yes** |
+| `destructive` | Files deleted, data lost, or hard to reverse | **Yes** |
+| `no-action-required` | Agent analysis only; no output artifact | No |
+| `decision-required` | Human must choose between options before continuing | **Yes** |
+| `blocked` | Prerequisite not met; journey cannot proceed | No |
+
+`decision-required` requires `**You decide:**` because a stage explicitly named as requiring a decision must carry the label — omitting it would be contradictory.
+
+---
+
+## 5. Skill reference validation
+
+`lint-pack-journeys.py` checks two things:
+
+1. **Existence**: every skill `name` listed in the `skills:` array must have a corresponding directory at `packs/{pack}/.apm/skills/{name}/`.
+2. **Count parity**: the number of skills listed must equal the number of `.apm/skills/` directories in the pack.
+
+If a skill is being added or removed from the pack, update `JOURNEY.md` in the same PR.
+
+---
+
+## 6. Route preservation
+
+`journey_id` becomes the URL slug of the generated central file:
+
+```
+packs/{pack}/JOURNEY.md  →  web/src/content/journeys/{journey_id}.md
+                         →  /journeys/{journey_id}/
+```
+
+When migrating an existing journey, set `journey_id` equal to the legacy file stem to preserve the existing URL. Example:
+
+```
+web/src/content/journeys/product-documentation.md  →  journey_id: product-documentation
+```
+
+A `journey_id` that differs from the pack directory name is valid — the validator does not require them to match.
+
+---
+
+## 7. Installation exclusion
+
+`JOURNEY.md` is never included in the `agentbundle install` output. The install command reads only `.apm/skills/*/SKILL.md` and `.apm/agents/*.md`. No configuration is needed to exclude `JOURNEY.md`.
+
+To verify after a migration:
+
+```bash
+tmpdir=$(mktemp -d)
+catalogue="$(git rev-parse --show-toplevel)"
+python -m agentbundle install --pack <pack-name> --output "$tmpdir" "$catalogue"
+find "$tmpdir" -name "JOURNEY.md"   # should produce no output
+rm -rf "$tmpdir"
+```
+
+---
+
+## 8. Migration procedure
+
+Step-by-step to migrate a central journey file to pack-owned:
+
+a. **Choose `journey_id`** equal to the legacy file stem (e.g., `product-documentation`).
+
+b. **Create `packs/{pack}/JOURNEY.md`** by copying the central file's frontmatter and body. Add:
+   - `journey_id: {slug}` as the first frontmatter field
+   - `start_state: {vocab}` and `end_state: {vocab}` (optional but recommended)
+   - `**State:** {vocab}` after `**Output:**` in every stage
+
+c. **Validate** the new file:
+   ```bash
+   python tools/lint-pack-journeys.py
+   ```
+   Fix any errors before proceeding.
+
+d. **Remove the legacy central file**:
+   ```bash
+   git rm web/src/content/journeys/{slug}.md
+   ```
+
+e. **Add the slug to `.gitignore`** in `web/src/content/journeys/`:
+   ```
+   {slug}.md
+   ```
+
+f. **Generate the central file** from the pack-local source:
+   ```bash
+   python tools/build-site.py --journeys-only
+   ```
+
+g. **Verify the generated file**:
+   ```bash
+   grep "generated: true" web/src/content/journeys/{slug}.md
+   python tools/lint-pack-journeys.py
+   ```
+
+h. **Run the full pre-PR gate**:
+   ```bash
+   make pre-pr
+   ```
+
+---
+
+## 9. Avoiding duplicate canonical sources
+
+`lint-pack-journeys.py` and `sync_pack_journeys()` in `build-site.py` both enforce:
+
+- **Same-slug ownership**: if a non-generated central file exists at `web/src/content/journeys/{journey_id}.md`, the validator errors. Fix: `git rm` the central file and add it to `.gitignore`.
+
+- **Same-pack ownership**: if a non-generated central file has `pack: {pack}` in its frontmatter (even at a different slug), the validator errors. Fix: remove or migrate that central file before adding `JOURNEY.md`.
+
+- **Duplicate `journey_id`**: two packs may not share a `journey_id`. Pick a unique slug.
+
+A central file with `generated: true` in its frontmatter is never treated as a duplicate — it is the sync output and is deliberately co-located with the pack-local source.

--- a/packs/product-documentation/JOURNEY.md
+++ b/packs/product-documentation/JOURNEY.md
@@ -1,5 +1,8 @@
 ---
+journey_id: product-documentation
 pack: product-documentation
+start_state: read-only
+end_state: confirmed-write
 scope: repo
 tagline: "Create, revise, retrofit, audit, and verify product documentation."
 prerequisitePacks: []
@@ -60,6 +63,7 @@ relatedJourneys:
 - **You do:** check that the inferred page kind fits your intent.
 - **You decide:** confirm the Diátaxis page kind.
 - **Output:** a confirmed page kind, mode, and destination path.
+- **State:** read-only
 
 ---
 
@@ -71,6 +75,7 @@ relatedJourneys:
   - **verify** — checks that the rendered page matches the skill or pack behavior it describes.
 - **You do:** for create/revise/retrofit, read the draft as a first-time reader; if you find yourself re-reading a sentence to extract the action it asks for, flag it. For audit, check that you agree with the contract cited for each finding.
 - **Output:** a draft, revision, retrofit plan, audit report, or verification result.
+- **State:** draft
 
 ---
 
@@ -79,3 +84,4 @@ relatedJourneys:
 - **You do:** read the output as the intended reader. For create/revise: does the page have a clear entry state, a clear exit, and no sentence that serves a different Diátaxis kind? For audit: is every finding actionable without needing to re-read the original doc?
 - **You decide:** review the output — gate passes when page kind, voice, and structure are consistent.
 - **Output:** a review-gate-passed artifact; the agent opens a PR after approval.
+- **State:** confirmed-write

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -29,8 +29,6 @@ import sys
 import tomllib
 from pathlib import Path
 
-import yaml
-
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DOCS = REPO_ROOT / "docs-site" / "src" / "content" / "docs"
 GITHUB_BASE = "https://github.com/eugenelim/agent-ready-repo/blob/main"
@@ -134,6 +132,7 @@ def _inject_frontmatter(text: str, path: Path) -> str:
 
 def _parse_frontmatter(text: str) -> dict:
     """Parse YAML frontmatter from a file's text; return {} if absent or invalid."""
+    import yaml
     if not text.startswith("---"):
         return {}
     end = text.find("\n---", 3)
@@ -154,6 +153,7 @@ def _strip_guide_metadata(text: str) -> str:
     Preserves H1 headings in the body (guide authors who add explicit frontmatter
     are responsible for removing the H1 if they don't want it duplicated by Starlight).
     """
+    import yaml
     if not text.startswith("---"):
         return text
     end = text.find("\n---", 3)
@@ -562,6 +562,107 @@ def build_pack_index(packs: list[dict], out_dir: Path, dry_run: bool = False) ->
         index_md.write_text(content, encoding="utf-8")
 
 
+def _fm_split(text: str) -> tuple[str, str]:
+    """Return (frontmatter_body, rest). Empty string if no frontmatter block."""
+    if not text.startswith("---"):
+        return "", text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return "", text
+    return text[3:end], text[end + 4:]
+
+
+def _fm_scalar(fm: str, key: str) -> str | None:
+    """Extract a simple scalar value from raw frontmatter text."""
+    m = re.search(rf"^{re.escape(key)}:\s*(.+)$", fm, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+def _inject_generated_marker(text: str) -> str:
+    """Inject or set generated: true in the JOURNEY.md frontmatter block."""
+    if not text.startswith("---\n"):
+        return text
+    fm_end = text.find("\n---", 3)
+    if fm_end == -1:
+        return text
+    fm = text[3:fm_end]
+    if re.search(r"^generated:", fm, re.MULTILINE):
+        fm = re.sub(r"^generated:.*$", "generated: true", fm, flags=re.MULTILINE)
+        return "---" + fm + text[fm_end:]
+    return "---\ngenerated: true" + text[3:]
+
+
+def sync_pack_journeys(
+    packs_dir: Path,
+    journey_dir: Path,
+    dry_run: bool = False,
+) -> int:
+    """Generate central journey files from packs/*/JOURNEY.md.
+
+    Performs dual-ownership checks before writing. Returns count of files synced.
+    """
+    sources = sorted(packs_dir.glob("*/JOURNEY.md"))
+    if not sources:
+        return 0
+
+    central: dict[str, tuple[str, str]] = {}
+    if journey_dir.exists():
+        for jf in journey_dir.glob("*.md"):
+            cfm, _ = _fm_split(jf.read_text(encoding="utf-8"))
+            central[jf.stem] = (
+                _fm_scalar(cfm, "pack") or "",
+                _fm_scalar(cfm, "generated") or "",
+            )
+
+    count = 0
+    for src in sources:
+        pack_name = src.parent.name
+        text = src.read_text(encoding="utf-8")
+        fm, _ = _fm_split(text)
+
+        journey_id = _fm_scalar(fm, "journey_id")
+        if not journey_id:
+            print(f"error  {src}: missing journey_id — cannot sync", file=sys.stderr)
+            sys.exit(1)
+
+        for stem, (cf_pack, cf_generated) in central.items():
+            if cf_generated == "true":
+                continue
+            if stem == journey_id:
+                print(
+                    f"error  dual canonical ownership: {src} (journey_id={journey_id!r})"
+                    f" and non-generated central file '{stem}.md' share the same slug",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if cf_pack == pack_name:
+                print(
+                    f"error  dual canonical ownership: {src} and non-generated"
+                    f" central file '{stem}.md' both claim pack {pack_name!r}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+        target = journey_dir / f"{journey_id}.md"
+        out_text = _inject_generated_marker(text)
+
+        if dry_run:
+            print(
+                f"  sync  {src.relative_to(REPO_ROOT)}"
+                f" → {target.relative_to(REPO_ROOT)}"
+            )
+        else:
+            journey_dir.mkdir(parents=True, exist_ok=True)
+            target.write_text(out_text, encoding="utf-8")
+            print(
+                f"  sync  {src.relative_to(REPO_ROOT)}"
+                f" → {target.relative_to(REPO_ROOT)}"
+            )
+        count += 1
+
+    return count
+
+
 def generate_sidebar_config(packs: list[dict], out: Path, dry_run: bool = False) -> None:
     """Write docs-site/src/sidebar-config.json — an array of Starlight sidebar groups."""
     groups_seen: list[str] = []
@@ -600,9 +701,24 @@ def main() -> None:
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--clean", action="store_true")
+    parser.add_argument(
+        "--journeys-only",
+        action="store_true",
+        help="Sync pack-local JOURNEY.md files only; skip Starlight aggregation.",
+    )
     args = parser.parse_args()
 
     packs_dir = REPO_ROOT / "packs"
+
+    if args.journeys_only:
+        journey_dir = REPO_ROOT / "web" / "src" / "content" / "journeys"
+        n = sync_pack_journeys(packs_dir, journey_dir, dry_run=args.dry_run)
+        print(
+            f"build-site: synced {n} pack journey(s)"
+            + (" (dry run)" if args.dry_run else "")
+        )
+        return
+
     packs_out = SITE_DOCS / "packs"
     guides_src = REPO_ROOT / "guides"
     guides_out = SITE_DOCS / "guides"
@@ -632,6 +748,15 @@ def main() -> None:
 
     print("build-site: generating packs/index.md …")
     build_pack_index(packs, packs_out, dry_run=args.dry_run)
+
+    print("build-site: syncing pack journeys …")
+    _n_journeys = sync_pack_journeys(
+        packs_dir,
+        REPO_ROOT / "web" / "src" / "content" / "journeys",
+        dry_run=args.dry_run,
+    )
+    if _n_journeys:
+        print(f"  {_n_journeys} pack-local JOURNEY.md files synced")
 
     print("build-site: generating sidebar-config.json …")
     sidebar_out = REPO_ROOT / "docs-site" / "src" / "sidebar-config.json"

--- a/tools/catalogue/pre_pr_catalogue.py
+++ b/tools/catalogue/pre_pr_catalogue.py
@@ -105,9 +105,18 @@ def main() -> int:
          [py, "tools/test-lint-knowledge-surface-parity.py"])
     _run("pack-evals runner self-test", [py, "tools/test-run-pack-evals.py"])
     _run("pack-evals workflow posture", [py, "tools/test-pack-evals-workflow.py"])
+    _run("pack-journey sync", [py, "tools/build-site.py", "--journeys-only"])
     _run("web-journey parity", [py, "tools/lint-web-journey-parity.py"])
     _run("web-journey parity self-test",
          [py, "tools/test-lint-web-journey-parity.py"])
+    _run("pack-journey lint", [py, "tools/lint-pack-journeys.py"])
+    _run("pack-journey lint self-test", [py, "tools/test-lint-pack-journeys.py"])
+    # lint-journey-contract live run deferred: atlassian.md and user-guide-diataxis.md
+    # have pre-existing label failures unrelated to Phase 2B; fix those first, then add:
+    #   _run("journey-contract lint", [py, "tools/lint-journey-contract.py"])
+    # Tracked: workspace.toml [backlog] slug "pack-journeys-lint-contract-gate"
+    _run("journey-contract lint self-test",
+         [py, "tools/test-lint-journey-contract.py"])
 
     # Delegate to the shipped adopter-facing hook for the work-loop caps gate.
     result = subprocess.run(

--- a/tools/lint-journey-contract.py
+++ b/tools/lint-journey-contract.py
@@ -35,12 +35,14 @@ CONTRACT_KEYS = ("useItWhen", "youProvide", "youReceive", "yourDecisions")
 ACTORS = ("Agent", "Reviewer", "Loop")
 
 # label -> rank (fixed order). Actor labels are handled separately.
+# "State" (rank 5) is optional — pack-local JOURNEY.md uses it; legacy files do not.
 FIXED_RANK = {
     "You provide": 0,
     "<Actor> does": 1,
     "You do": 2,
     "You decide": 3,
     "Output": 4,
+    "State": 5,
 }
 
 # Stages are h3 (`### N.`), subordinate to the section's "The journey" h2.

--- a/tools/lint-pack-journeys.py
+++ b/tools/lint-pack-journeys.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Validates pack-local JOURNEY.md files.
+
+Each JOURNEY.md in packs/<pack>/JOURNEY.md must:
+  - carry a unique journey_id
+  - reference only skills that exist in packs/<pack>/.apm/skills/<name>/
+  - list exactly as many skills as the pack has .apm/skills/ directories
+  - use only STATE_VOCAB values for **State:**, start_state, and end_state
+  - include **You decide:** in any stage whose state is in WRITE_STATES
+  - include **Output:** in every stage
+  - not share a canonical source with a non-generated central journey file
+
+Fixture mode: set LPJ_PACKS_DIR and LPJ_JOURNEY_DIR env vars to point at
+fixture directories instead of the real tree.
+
+Exit 0 when all JOURNEY.md files validate; exit 1 on any violation.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+STATE_VOCAB: frozenset[str] = frozenset({
+    "read-only",
+    "draft",
+    "proposed-write",
+    "confirmed-write",
+    "publish",
+    "destructive",
+    "no-action-required",
+    "decision-required",
+    "blocked",
+})
+
+WRITE_STATES: frozenset[str] = frozenset({
+    "proposed-write",
+    "confirmed-write",
+    "publish",
+    "destructive",
+    "decision-required",
+})
+
+_HEADING_NEW = re.compile(r"^###\s+\d+\.\s+\S")
+_LABEL_VALUE = re.compile(r"^\s*-\s+\*\*(.+?):\*\*\s*(.*)")
+
+
+def _repo_root() -> pathlib.Path:
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            return pathlib.Path(r.stdout.strip())
+    except FileNotFoundError:
+        pass
+    return pathlib.Path.cwd()
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    if not text.startswith("---"):
+        return "", text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return "", text
+    return text[3:end], text[end + 4:]
+
+
+def _get_scalar(fm: str, key: str) -> str | None:
+    m = re.search(rf"^{re.escape(key)}:\s*(.+)$", fm, re.MULTILINE)
+    return m.group(1).strip() if m else None
+
+
+def _get_skill_names(fm: str) -> list[str]:
+    lines = fm.splitlines()
+    in_skills = False
+    names: list[str] = []
+    for line in lines:
+        if re.match(r"^skills:\s*$", line):
+            in_skills = True
+            continue
+        if in_skills:
+            if line and not line[0].isspace():
+                break
+            m = re.match(r"\s+- name:\s+(.+)$", line)
+            if m:
+                names.append(m.group(1).strip())
+    return names
+
+
+def _check_stages(body: str) -> list[str]:
+    findings: list[str] = []
+    lines = body.splitlines()
+    stage_starts = [i for i, ln in enumerate(lines) if _HEADING_NEW.match(ln)]
+    if not stage_starts:
+        return findings
+
+    bounds = stage_starts + [len(lines)]
+    for idx in range(len(stage_starts)):
+        start = bounds[idx]
+        end = bounds[idx + 1]
+        heading = lines[start].strip()
+
+        label_values: dict[str, str] = {}
+        for line in lines[start + 1:end]:
+            if line.startswith("##"):
+                break
+            m = _LABEL_VALUE.match(line)
+            if m:
+                label_values[m.group(1).strip()] = m.group(2).strip()
+
+        if "Output" not in label_values:
+            findings.append(f"stage {heading!r}: missing **Output:** label")
+
+        if "State" not in label_values:
+            findings.append(f"stage {heading!r}: missing **State:** label (required in pack-local JOURNEY.md stages)")
+
+        state_val = label_values.get("State")
+        if state_val is not None:
+            if state_val not in STATE_VOCAB:
+                findings.append(
+                    f"stage {heading!r}: **State:** value {state_val!r} not in STATE_VOCAB"
+                )
+            elif state_val in WRITE_STATES and "You decide" not in label_values:
+                findings.append(
+                    f"stage {heading!r}: state {state_val!r} requires **You decide:** label"
+                )
+
+    return findings
+
+
+def _validate_journey(
+    path: pathlib.Path,
+    pack_dir: pathlib.Path,
+    central_files: dict[str, tuple[str, str]],
+) -> list[str]:
+    """Return error strings for one JOURNEY.md.
+
+    central_files maps central file stem -> (pack field, generated field).
+    """
+    text = path.read_text(encoding="utf-8")
+    fm, body = _split_frontmatter(text)
+    findings: list[str] = []
+
+    journey_id = _get_scalar(fm, "journey_id")
+    if not journey_id:
+        findings.append(f"{path}: missing required journey_id")
+        return findings
+
+    pack_field = _get_scalar(fm, "pack")
+    if pack_field and pack_field != pack_dir.name:
+        findings.append(
+            f"{path}: pack field {pack_field!r} does not match "
+            f"directory name {pack_dir.name!r}"
+        )
+
+    for key in ("start_state", "end_state"):
+        val = _get_scalar(fm, key)
+        if val is not None and val not in STATE_VOCAB:
+            findings.append(
+                f"{path}: {key} {val!r} is not a valid STATE_VOCAB value"
+            )
+
+    skill_names = _get_skill_names(fm)
+    skills_dir = pack_dir / ".apm" / "skills"
+    pack_skill_dirs = (
+        sorted(d.name for d in skills_dir.iterdir() if d.is_dir())
+        if skills_dir.exists()
+        else []
+    )
+
+    if len(skill_names) != len(pack_skill_dirs):
+        findings.append(
+            f"{path}: skill count mismatch — "
+            f"JOURNEY.md lists {len(skill_names)}, "
+            f"pack has {len(pack_skill_dirs)}"
+        )
+
+    for name in skill_names:
+        if name not in pack_skill_dirs:
+            findings.append(
+                f"{path}: skill {name!r} not found in {skills_dir}"
+            )
+
+    pack_name = pack_dir.name
+    for stem, (cf_pack, cf_generated) in central_files.items():
+        if cf_generated == "true":
+            continue
+        if stem == journey_id:
+            findings.append(
+                f"{path}: dual canonical ownership — "
+                f"non-generated central file '{stem}.md' has same slug as journey_id"
+            )
+        elif cf_pack == pack_name:
+            findings.append(
+                f"{path}: dual canonical ownership — "
+                f"non-generated central file '{stem}.md' claims same pack"
+            )
+
+    findings.extend(_check_stages(body))
+    return findings
+
+
+def main() -> int:
+    root = _repo_root()
+    packs_dir = pathlib.Path(
+        os.environ.get("LPJ_PACKS_DIR", root / "packs")
+    )
+    journey_dir = pathlib.Path(
+        os.environ.get("LPJ_JOURNEY_DIR", root / "web/src/content/journeys")
+    )
+
+    journey_files = sorted(packs_dir.glob("*/JOURNEY.md"))
+
+    if not journey_files:
+        print("lint-pack-journeys: no JOURNEY.md files found — nothing to validate")
+        return 0
+
+    central_files: dict[str, tuple[str, str]] = {}
+    if journey_dir.exists():
+        for jf in journey_dir.glob("*.md"):
+            text = jf.read_text(encoding="utf-8")
+            cfm, _ = _split_frontmatter(text)
+            central_files[jf.stem] = (
+                _get_scalar(cfm, "pack") or "",
+                _get_scalar(cfm, "generated") or "",
+            )
+
+    id_to_paths: dict[str, list[pathlib.Path]] = {}
+    for jf in journey_files:
+        text = jf.read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(text)
+        jid = _get_scalar(fm, "journey_id")
+        if jid:
+            id_to_paths.setdefault(jid, []).append(jf)
+
+    all_findings: list[str] = []
+
+    for jid, paths in id_to_paths.items():
+        if len(paths) > 1:
+            all_findings.append(
+                f"duplicate journey_id {jid!r} found in: "
+                + ", ".join(str(p) for p in paths)
+            )
+
+    for jf in journey_files:
+        all_findings.extend(_validate_journey(jf, jf.parent, central_files))
+
+    if all_findings:
+        print("lint-pack-journeys: violations found:", file=sys.stderr)
+        for f in all_findings:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+
+    print(f"lint-pack-journeys: all {len(journey_files)} JOURNEY.md files valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test-lint-pack-journeys.py
+++ b/tools/test-lint-pack-journeys.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""Self-tests for tools/lint-pack-journeys.py.
+
+Uses fixture directories in a temp dir. Set LPJ_PACKS_DIR and LPJ_JOURNEY_DIR
+to point the validator at a fixture tree instead of the real repo.
+
+Exit 0 when all tests pass; exit 1 on any failure.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_TOOL = _HERE / "lint-pack-journeys.py"
+
+
+def _run(packs_dir: pathlib.Path, journey_dir: pathlib.Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["LPJ_PACKS_DIR"] = str(packs_dir)
+    env["LPJ_JOURNEY_DIR"] = str(journey_dir)
+    return subprocess.run(
+        [sys.executable, str(_TOOL)],
+        capture_output=True, text=True, check=False, env=env,
+    )
+
+
+def _make_skill(pack_dir: pathlib.Path, skill_name: str) -> None:
+    skill_dir = pack_dir / ".apm" / "skills" / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"# {skill_name}\n", encoding="utf-8")
+
+
+def _make_journey(pack_dir: pathlib.Path, *, extra_fm: str = "", stages: str = "") -> None:
+    """Write a minimal valid JOURNEY.md into pack_dir."""
+    pack_name = pack_dir.name
+    skill_name = list((pack_dir / ".apm" / "skills").iterdir())[0].name
+    fm = f"""---
+journey_id: {pack_name}
+pack: {pack_name}
+scope: user
+tagline: "Test journey"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions:
+    - "confirm"
+skills:
+  - name: {skill_name}
+    description: "A skill"
+    humanTouches: 1
+humanGates:
+  - id: G1
+    globalGate: null
+    label: "Review"
+    trigger: "after draft"
+    duration: "5 min"
+    whatToCheck: ["looks good?"]
+    whatGoodLooksLike: "great"
+    whatBadLooksLike: "bad"
+    consequence: "revise"
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+{extra_fm}---
+
+{stages if stages else _DEFAULT_STAGES}
+"""
+    (pack_dir / "JOURNEY.md").write_text(fm, encoding="utf-8")
+
+
+_DEFAULT_STAGES = """\
+### 1. Do the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **You decide:** confirm
+- **Output:** result
+- **State:** read-only
+"""
+
+_WRITE_STAGE = """\
+### 1. Write the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **You decide:** confirm
+- **Output:** result
+- **State:** confirmed-write
+"""
+
+_WRITE_STAGE_NO_DECIDE = """\
+### 1. Write the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **Output:** result
+- **State:** confirmed-write
+"""
+
+_DECISION_REQUIRED_NO_DECIDE = """\
+### 1. Decide the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **Output:** result
+- **State:** decision-required
+"""
+
+_STAGE_BOGUS_STATE = """\
+### 1. Do the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **Output:** result
+- **State:** bogus
+"""
+
+_STAGE_NO_OUTPUT = """\
+### 1. Do the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **State:** read-only
+"""
+
+_STAGE_NO_STATE = """\
+### 1. Do the thing
+
+- **You provide:** input
+- **Agent does:** work
+- **Output:** result
+"""
+
+
+def _pass(label: str, r: subprocess.CompletedProcess) -> None:
+    if r.returncode != 0:
+        print(f"FAIL {label}: expected exit 0, got {r.returncode}")
+        print(r.stderr)
+        sys.exit(1)
+    print(f"pass {label}")
+
+
+def _fail(label: str, r: subprocess.CompletedProcess, fragment: str = "") -> None:
+    if r.returncode == 0:
+        print(f"FAIL {label}: expected exit 1, got 0")
+        print(r.stdout)
+        sys.exit(1)
+    if fragment and fragment not in r.stderr:
+        print(f"FAIL {label}: expected {fragment!r} in stderr, got:\n{r.stderr}")
+        sys.exit(1)
+    print(f"pass {label}")
+
+
+def test_valid_journey_exits_0() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack)
+        jd = p / "journeys"
+        jd.mkdir()
+        _pass("test_valid_journey_exits_0", _run(p / "packs", jd))
+
+
+def test_journey_id_differs_from_pack_name_valid() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, extra_fm="journey_id: different-slug\n")
+        # Overwrite the default JOURNEY.md — the extra_fm line dupes journey_id;
+        # write a clean one manually with journey_id that differs from pack name
+        skill_name = "my-skill"
+        fm = f"""---
+journey_id: different-slug
+pack: mypak
+scope: user
+tagline: "Test journey"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: {skill_name}
+    description: "A skill"
+    humanTouches: 1
+humanGates:
+  - id: G1
+    globalGate: null
+    label: "Review"
+    trigger: "after"
+    duration: "5 min"
+    whatToCheck: ["ok?"]
+    whatGoodLooksLike: "great"
+    whatBadLooksLike: "bad"
+    consequence: "revise"
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+{_DEFAULT_STAGES}
+"""
+        (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _pass("test_journey_id_differs_from_pack_name_valid", _run(p / "packs", jd))
+
+
+def test_missing_journey_id() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        skill_name = "my-skill"
+        fm = f"""---
+pack: mypak
+scope: user
+tagline: "No journey_id"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: {skill_name}
+    description: "A skill"
+    humanTouches: 1
+humanGates: []
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+{_DEFAULT_STAGES}
+"""
+        (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_missing_journey_id", _run(p / "packs", jd), "journey_id")
+
+
+def test_invalid_state_in_stage() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, stages=_STAGE_BOGUS_STATE)
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_invalid_state_in_stage", _run(p / "packs", jd), "bogus")
+
+
+def test_invalid_start_state() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, extra_fm="start_state: invalid-state\n")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_invalid_start_state", _run(p / "packs", jd), "start_state")
+
+
+def test_invalid_end_state() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, extra_fm="end_state: invalid-state\n")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_invalid_end_state", _run(p / "packs", jd), "end_state")
+
+
+def test_nonexistent_skill() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        # JOURNEY.md references a skill that does not exist in .apm/skills/
+        fm = """\
+---
+journey_id: mypak
+pack: mypak
+scope: user
+tagline: "Test journey"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: nonexistent-skill
+    description: "Ghost skill"
+    humanTouches: 1
+humanGates: []
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+""" + _DEFAULT_STAGES
+        (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_nonexistent_skill", _run(p / "packs", jd), "nonexistent-skill")
+
+
+def test_skill_count_mismatch() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "skill-a")
+        # JOURNEY.md lists 2 skills but pack has only 1 directory
+        fm = """\
+---
+journey_id: mypak
+pack: mypak
+scope: user
+tagline: "Test journey"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: skill-a
+    description: "Skill A"
+    humanTouches: 1
+  - name: skill-b
+    description: "Skill B (not in pack)"
+    humanTouches: 1
+humanGates: []
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+""" + _DEFAULT_STAGES
+        (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_skill_count_mismatch", _run(p / "packs", jd), "skill count")
+
+
+def test_duplicate_journey_id() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        # Two packs with the same journey_id
+        for pack_name in ("pack-a", "pack-b"):
+            pack = p / "packs" / pack_name
+            _make_skill(pack, "skill-x")
+            skill_name = "skill-x"
+            fm = f"""\
+---
+journey_id: shared-id
+pack: {pack_name}
+scope: user
+tagline: "Test"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: {skill_name}
+    description: "A skill"
+    humanTouches: 1
+humanGates: []
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+{_DEFAULT_STAGES}
+"""
+            (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_duplicate_journey_id", _run(p / "packs", jd), "duplicate")
+
+
+def test_dual_ownership_same_slug() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack)
+        jd = p / "journeys"
+        jd.mkdir()
+        # Central legacy file with same slug (no generated: true)
+        (jd / "mypak.md").write_text("---\npack: mypak\n---\n", encoding="utf-8")
+        _fail("test_dual_ownership_same_slug", _run(p / "packs", jd), "dual")
+
+
+def test_dual_ownership_same_pack_diff_slug() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack)  # journey_id: mypak
+        jd = p / "journeys"
+        jd.mkdir()
+        # Central legacy file with DIFFERENT slug but same pack: field
+        (jd / "other-slug.md").write_text(
+            "---\npack: mypak\n---\n", encoding="utf-8"
+        )
+        _fail("test_dual_ownership_same_pack_diff_slug", _run(p / "packs", jd), "dual")
+
+
+def test_generated_central_not_dual() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack)
+        jd = p / "journeys"
+        jd.mkdir()
+        # Central file with generated: true — not dual ownership
+        (jd / "mypak.md").write_text(
+            "---\ngenerated: true\npack: mypak\n---\n", encoding="utf-8"
+        )
+        _pass("test_generated_central_not_dual", _run(p / "packs", jd))
+
+
+def test_write_stage_missing_decide() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, stages=_WRITE_STAGE_NO_DECIDE)
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_write_stage_missing_decide", _run(p / "packs", jd), "You decide")
+
+
+def test_decision_required_missing_decide() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, stages=_DECISION_REQUIRED_NO_DECIDE)
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_decision_required_missing_decide", _run(p / "packs", jd), "You decide")
+
+
+def test_missing_output_label() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, stages=_STAGE_NO_OUTPUT)
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_missing_output_label", _run(p / "packs", jd), "Output")
+
+
+def test_missing_state_label() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        _make_journey(pack, stages=_STAGE_NO_STATE)
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_missing_state_label", _run(p / "packs", jd), "State")
+
+
+def test_pack_field_mismatch() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        pack = p / "packs" / "mypak"
+        _make_skill(pack, "my-skill")
+        # pack field says "wrong-name" but directory is "mypak"
+        fm = """\
+---
+journey_id: mypak
+pack: wrong-name
+scope: user
+tagline: "Test journey"
+contract:
+  useItWhen: "test"
+  youProvide: "input"
+  youReceive: "output"
+  yourDecisions: ["confirm"]
+skills:
+  - name: my-skill
+    description: "A skill"
+    humanTouches: 1
+humanGates: []
+typicalSession:
+  agentTurns: "3"
+  humanTouches: 1
+  wallClockMinutes: "15"
+docsUrl: /guides/test/
+packUrl: /packs/test/
+---
+
+""" + _DEFAULT_STAGES
+        (pack / "JOURNEY.md").write_text(fm, encoding="utf-8")
+        jd = p / "journeys"
+        jd.mkdir()
+        _fail("test_pack_field_mismatch", _run(p / "packs", jd), "wrong-name")
+
+
+def main() -> int:
+    tests = [
+        test_valid_journey_exits_0,
+        test_journey_id_differs_from_pack_name_valid,
+        test_missing_journey_id,
+        test_invalid_state_in_stage,
+        test_invalid_start_state,
+        test_invalid_end_state,
+        test_nonexistent_skill,
+        test_skill_count_mismatch,
+        test_duplicate_journey_id,
+        test_dual_ownership_same_slug,
+        test_dual_ownership_same_pack_diff_slug,
+        test_generated_central_not_dual,
+        test_write_stage_missing_decide,
+        test_decision_required_missing_decide,
+        test_missing_output_label,
+        test_missing_state_label,
+        test_pack_field_mismatch,
+    ]
+    for t in tests:
+        t()
+    print(f"\ntest-lint-pack-journeys: all {len(tests)} tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -45,6 +45,11 @@ is used directly. Test runner entry point: `npm test` (`vitest run`).
 - `astro build` cleans `outDir` on every run — this `web/` build MUST run before
   the `docs-site/` Starlight build writes into `build/docs/`. See
   `.github/workflows/pages.yml`.
+- Some files in `web/src/content/journeys/` are generated from `packs/*/JOURNEY.md`
+  by `tools/build-site.py --journeys-only`. Running `npm run build --prefix web`
+  without first running `python tools/build-site.py --journeys-only` (or
+  `make site-build`) will fail if generated files are absent. The `pages.yml` CI
+  job runs the sync step before the Astro build automatically.
 
 ## Development
 

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -60,6 +60,11 @@ const journeys = defineCollection({
     packUrl: z.string(),
     relatedJourneys: z.array(z.string()).default([]),
     goodOutputDescription: z.string().optional(),
+    // Phase 2B: pack-local JOURNEY.md additions (optional for legacy compatibility)
+    journey_id: z.string().optional(),
+    start_state: z.string().optional(),
+    end_state: z.string().optional(),
+    generated: z.boolean().optional(),
   }),
 });
 

--- a/web/src/content/journeys/.gitignore
+++ b/web/src/content/journeys/.gitignore
@@ -1,0 +1,3 @@
+# Generated from packs/*/JOURNEY.md by tools/build-site.py --journeys-only.
+# Edit packs/{pack}/JOURNEY.md — not these generated files.
+product-documentation.md

--- a/workspace.toml
+++ b/workspace.toml
@@ -1109,6 +1109,23 @@ open = [
   {slug = "journey-hero-descriptive-eyebrow", summary = "Pair the journey hero slug with a descriptive eyebrow", source = "spec/journey-template-revamp experience-review Minor-4"},
   {slug = "journey-decision-chip-gate-anchors", summary = "Anchor journey contract chips to their gate cards", source = "spec/journey-template-revamp experience-review Nit-5"},
 
+  # ── Pack-journey phase 2B follow-ons ─────────────────────────────────────────
+  # spec/pack-journeys-phase2b deferred AC11/AC14. Two legacy central journey files
+  # (atlassian.md, user-guide-diataxis.md) use non-standard labels (You say/You get)
+  # and missing Output labels, pre-existing before Phase 2B. These prevent wiring the
+  # full lint-journey-contract.py run into the pre-PR gate (only the self-test is wired).
+  # Also deferred: stage-presence (no stages → lint-pack-journeys silently passes) and
+  # label rank-order enforcement in lint-pack-journeys.py (only lint-journey-contract
+  # enforces order, and it's not live-gated yet).
+  # Fix: update atlassian.md and user-guide-diataxis.md to use the fixed label set
+  #   (You provide / Agent does / You do / You decide / Output / State); then uncomment
+  #   _run("journey-contract lint", ...) in tools/catalogue/pre_pr_catalogue.py; consider
+  #   adding rank-order and stage-presence checks to lint-pack-journeys.py.
+  # File: web/src/content/journeys/atlassian.md, user-guide-diataxis.md;
+  #   tools/catalogue/pre_pr_catalogue.py (line ~113 comment block).
+  # Unblocks when: atlassian.md and user-guide-diataxis.md are updated to fixed label set.
+  {slug = "pack-journeys-lint-contract-gate", source = "spec/pack-journeys-phase2b AC11 AC14"},
+
   # ── Starlight migration follow-ons ─────────────────────────────────────────
   # RFC required before a new top-level directory is permanent (AGENTS.md §"Check before acting").
   # Mirrors RFC-0061 (web/) precedent.


### PR DESCRIPTION
## Summary

- Introduces `packs/<pack>/JOURNEY.md` as the canonical source for a pack's primary journey; the central site renders it rather than owning duplicate prose.
- New `tools/lint-pack-journeys.py` validator enforces: `journey_id` + `pack` fields, STATE\_VOCAB (9 values), WRITE\_STATES require `**You decide:**`, skill existence + count parity, no duplicate `journey_id`, no dual canonical ownership.
- `tools/build-site.py --journeys-only` syncs pack-local JOURNEY.md files to `web/src/content/journeys/` with `generated: true` injected; wired into pre-PR (5 new gates) and `pages.yml` CI.
- Pilot migration: `packs/product-documentation/JOURNEY.md` is now the source of truth; legacy `web/src/content/journeys/product-documentation.md` removed from git, gitignored, generated by sync.
- Maintainer how-to at `guides/_shared/how-to/pack-journey-authoring.md` (adopter-facing, projected to docs site).

## Deferred

`lint-journey-contract.py` live gate not wired: `atlassian.md` and `user-guide-diataxis.md` have pre-existing label failures unrelated to this change. Tracked as `pack-journeys-lint-contract-gate` in `workspace.toml`.

## Test plan

- [ ] `python tools/test-lint-pack-journeys.py` — 17 TDD cases, exit 0
- [ ] `python tools/build-site.py --journeys-only` — generates `web/src/content/journeys/product-documentation.md` with `generated: true`
- [ ] `python tools/lint-pack-journeys.py` — exit 0
- [ ] `make pre-pr` — all 18 gates pass
- [ ] `make build-check` — exit 0
- [ ] CI green (pages.yml runs sync before Astro build)