### PR TITLE
fix(ci): flip Gate A Windows from continue-on-error to blocking

### DIFF
--- a/packages/agentbundle/tests/integration/test_adapt_cmd.py
+++ b/packages/agentbundle/tests/integration/test_adapt_cmd.py
@@ -23,6 +23,7 @@ ADAPT_FIXTURES = Path(__file__).parent.parent / "fixtures" / "adapt"
 # Helper: build an argparse.Namespace the same way the CLI would
 # ---------------------------------------------------------------------------
 
+
 def _args(
     *,
     root: str,
@@ -39,12 +40,14 @@ def _run(
     ci: bool = False,
 ) -> int:
     from agentbundle.commands.adapt import run
+
     return run(_args(root=root, values_from=values_from, ci=ci))
 
 
 # ---------------------------------------------------------------------------
 # Helper: set up a tmp_path with a state file + projected files
 # ---------------------------------------------------------------------------
+
 
 def _setup_projected(tmp_path: Path, files: dict[str, str]) -> None:
     """Write files and seed a .agentbundle-state.toml recording them."""
@@ -77,6 +80,7 @@ def _setup_projected(tmp_path: Path, files: dict[str, str]) -> None:
 # ---------------------------------------------------------------------------
 # 1. Marker substitution: <adapt:project-name> replaced by values.toml
 # ---------------------------------------------------------------------------
+
 
 def test_marker_substitution_replaces_markers(tmp_path):
     """``adapt --values-from values.toml`` substitutes every <adapt:NAME> marker."""
@@ -117,6 +121,7 @@ def test_marker_substitution_sha_matches_substituted_form(tmp_path):
 # ---------------------------------------------------------------------------
 # 2. .adapt-pending.md lists .upstream.* companions with diff summaries
 # ---------------------------------------------------------------------------
+
 
 def test_adapt_pending_md_lists_companions(tmp_path):
     """Two .upstream.md companions should both appear in .adapt-pending.md.
@@ -178,6 +183,7 @@ def test_adapt_pending_md_no_companions_says_none_pending(tmp_path):
 # 3. .adapt-discovery.toml never written: byte-identical before and after
 # ---------------------------------------------------------------------------
 
+
 def test_adapt_discovery_toml_never_written(tmp_path):
     """``adapt`` reads .adapt-discovery.toml but must not modify it."""
     import shutil
@@ -227,6 +233,7 @@ def test_adapt_discovery_accepted_entries_applied(tmp_path):
 # 4. --ci with companions: exit non-zero, stderr lists companions
 # ---------------------------------------------------------------------------
 
+
 def test_ci_with_companions_exits_nonzero(tmp_path, capsys):
     """``adapt --ci`` exits 1 when any .upstream.* companion is on disk."""
     (tmp_path / "AGENTS.upstream.md").write_text("upstream", encoding="utf-8", newline="\n")
@@ -257,6 +264,7 @@ def test_ci_with_companions_lists_all_on_stderr(tmp_path, capsys):
 # 5. --ci clean: exit zero when no companions on disk
 # ---------------------------------------------------------------------------
 
+
 def test_ci_clean_exits_zero(tmp_path):
     """``adapt --ci`` exits 0 when no .upstream.* companions exist."""
     # No companions; only a normal file.
@@ -280,6 +288,7 @@ def test_ci_clean_after_companions_removed_exits_zero(tmp_path):
 # 6. Binary file skipped gracefully
 # ---------------------------------------------------------------------------
 
+
 def test_binary_file_skipped_without_error(tmp_path):
     """Projected files that cannot be decoded as UTF-8 are skipped with a warning."""
     binary_content = bytes(range(256))
@@ -295,7 +304,9 @@ def test_binary_file_skipped_without_error(tmp_path):
         files={"data.bin": {"sha": sha256_bytes(binary_content), "from-pack-version": "0.1.0"}},
         adapter="claude-code",
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        dump_state(state), encoding="utf-8", newline="\n"
+    )
     (tmp_path / "data.bin").write_bytes(binary_content)
 
     values_path = ADAPT_FIXTURES / "values.toml"

--- a/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
@@ -113,9 +113,7 @@ def test_adapt_writes_per_scope_pending_reports(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "case", ["repo_only", "user_only", "both"]
-)
+@pytest.mark.parametrize("case", ["repo_only", "user_only", "both"])
 def test_adapt_ci_or_across_scopes(tmp_path, monkeypatch, case):
     fake_home = tmp_path / "home"
     user_dir = fake_home / ".agentbundle"
@@ -220,15 +218,13 @@ def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch
         'discovery-schema-version = "0.1"\n', encoding="utf-8", newline="\n"
     )
     (repo_root / ".adapt-discovery.toml").write_text(
-        'discovery-schema-version = "0.1"\n'
-        '[markers]\nproject-name = "demo"\n',
+        'discovery-schema-version = "0.1"\n[markers]\nproject-name = "demo"\n',
         encoding="utf-8",
         newline="\n",
     )
     # Counter-fixture at the BARE user path (must be ignored).
     (fake_home / ".adapt-discovery.toml").write_text(
-        'discovery-schema-version = "0.1"\n'
-        '[markers]\nproject-name = "WRONG"\n',
+        'discovery-schema-version = "0.1"\n[markers]\nproject-name = "WRONG"\n',
         encoding="utf-8",
         newline="\n",
     )
@@ -239,11 +235,11 @@ def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch
     # when no --values-from is passed; we want to confirm the discovery
     # values are consulted alongside).
     values_file = tmp_path / "values.toml"
-    values_file.write_text('[values]\n# only sets unrelated keys\n', encoding="utf-8", newline="\n")
-
-    args = argparse.Namespace(
-        values_from=str(values_file), ci=False, root=str(repo_root)
+    values_file.write_text(
+        "[values]\n# only sets unrelated keys\n", encoding="utf-8", newline="\n"
     )
+
+    args = argparse.Namespace(values_from=str(values_file), ci=False, root=str(repo_root))
     rc = adapt.run(args)
     assert rc == 0
     # The marker should have been resolved to "demo" (namespaced discovery).

--- a/packages/agentbundle/tests/integration/test_adapt_schema_migration.py
+++ b/packages/agentbundle/tests/integration/test_adapt_schema_migration.py
@@ -35,7 +35,9 @@ def _seed_repo(root: Path, files: dict[str, str]) -> None:
     state.packs[("core", "claude-code")] = PackState(
         installed_version="0.1.0", files=file_entries, adapter="claude-code"
     )
-    (root / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
+    (root / ".agentbundle-state.toml").write_text(
+        dump_state(state), encoding="utf-8", newline="\n"
+    )
 
 
 def _ns(root: Path, values_from: Path | None = None) -> argparse.Namespace:

--- a/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
+++ b/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
@@ -38,26 +38,19 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[4]
 # packages/agentbundle/tests/integration/ → parents[2] = packages/agentbundle/
 FIXTURES_PACKS = (
-    Path(__file__).resolve().parents[2]
-    / "agentbundle"
-    / "build"
-    / "tests"
-    / "fixtures"
-    / "packs"
+    Path(__file__).resolve().parents[2] / "agentbundle" / "build" / "tests" / "fixtures" / "packs"
 )
 TEMPLATE_PATH = REPO_ROOT / "packages" / "agentbundle" / "templates" / "install-marker.py"
 
 # Expected canonical command in the derived plugin.json.
 EXPECTED_COMMAND = (
     'python3 "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/scripts/install-marker.py"'
-    ' --install-route claude-plugins'
+    " --install-route claude-plugins"
 )
 
 # All fixture packs — parametrisation covers multi-pack derivation (Concern-5).
 FIXTURE_PACK_NAMES = [
-    p.name
-    for p in sorted(FIXTURES_PACKS.iterdir())
-    if p.is_dir() and (p / "pack.toml").exists()
+    p.name for p in sorted(FIXTURES_PACKS.iterdir()) if p.is_dir() and (p / "pack.toml").exists()
 ]
 
 
@@ -130,9 +123,7 @@ def test_derivation_synthesises_hooks_block(tmp_path, pack_name):
     result = _run_build(FIXTURES_PACKS, tmp_path)
     assert result.returncode == 0, result.stderr
 
-    derived_json = (
-        tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
-    )
+    derived_json = tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
     assert derived_json.exists(), f"[{pack_name}] derived plugin.json missing"
 
     manifest = json.loads(derived_json.read_text(encoding="utf-8"))
@@ -149,7 +140,9 @@ def test_derivation_synthesises_hooks_block(tmp_path, pack_name):
         f"(Claude Code 2.1.209+ contract); got keys: {list(entry.keys())}"
     )
     inner = entry["hooks"]
-    assert isinstance(inner, list) and len(inner) == 1, f"[{pack_name}] inner hooks must be 1-element list"  # noqa: E501
+    assert isinstance(inner, list) and len(inner) == 1, (
+        f"[{pack_name}] inner hooks must be 1-element list"
+    )  # noqa: E501
     assert inner[0]["type"] == "command", f"[{pack_name}] inner hook type must be 'command'"
     assert inner[0]["command"] == EXPECTED_COMMAND, (
         f"[{pack_name}] SessionStart command mismatch:\n"
@@ -165,9 +158,7 @@ def test_derivation_preserves_source_fields(tmp_path, pack_name):
     assert result.returncode == 0, result.stderr
 
     source_json = FIXTURES_PACKS / pack_name / ".claude-plugin" / "plugin.json"
-    derived_json = (
-        tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
-    )
+    derived_json = tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
 
     source = json.loads(source_json.read_text(encoding="utf-8"))
     derived = json.loads(derived_json.read_text(encoding="utf-8"))
@@ -193,11 +184,7 @@ def test_derivation_idempotent(tmp_path):
     derived_root = tmp_path / "claude-plugins"
 
     def _snapshot(base: Path) -> dict[str, bytes]:
-        return {
-            str(p.relative_to(base)): p.read_bytes()
-            for p in base.rglob("*")
-            if p.is_file()
-        }
+        return {str(p.relative_to(base)): p.read_bytes() for p in base.rglob("*") if p.is_file()}
 
     snap1 = _snapshot(derived_root)
 
@@ -225,11 +212,7 @@ def test_derivation_cold_rebuild_byte_identical(tmp_path):
     derived_root = tmp_path / "claude-plugins"
 
     def _snapshot(base: Path) -> dict[str, bytes]:
-        return {
-            str(p.relative_to(base)): p.read_bytes()
-            for p in base.rglob("*")
-            if p.is_file()
-        }
+        return {str(p.relative_to(base)): p.read_bytes() for p in base.rglob("*") if p.is_file()}
 
     snap1 = _snapshot(derived_root)
 
@@ -390,9 +373,7 @@ def test_shell_exec_quoting_survives_space_in_root(tmp_path):
     assert result.returncode == 0, result.stderr
 
     pack_name = FIXTURE_PACK_NAMES[0]
-    derived_json = (
-        tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
-    )
+    derived_json = tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
     manifest = json.loads(derived_json.read_text(encoding="utf-8"))
     # Command is now nested: hooks.SessionStart[0].hooks[0].command
     command = manifest["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -442,7 +423,9 @@ def test_build_rejects_source_plugin_json_with_hooks_block(tmp_path):
     mutated_manifest = mutated_packs / pack_name / ".claude-plugin" / "plugin.json"
     original = json.loads(mutated_manifest.read_text(encoding="utf-8"))
     original["hooks"] = {"SessionStart": [{"command": "echo evil"}]}
-    mutated_manifest.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8", newline="\n")
+    mutated_manifest.write_text(
+        json.dumps(original, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
 
     result = _run_build(mutated_packs, tmp_path / "out")
 
@@ -475,9 +458,7 @@ def test_claude_plugins_hook_command_now_passes_flag(tmp_path):
     assert result.returncode == 0, result.stderr
 
     pack_name = FIXTURE_PACK_NAMES[0]
-    derived_json = (
-        tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
-    )
+    derived_json = tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
     manifest = json.loads(derived_json.read_text(encoding="utf-8"))
     # Command is now nested: hooks.SessionStart[0].hooks[0].command
     command = manifest["hooks"]["SessionStart"][0]["hooks"][0]["command"]
@@ -533,9 +514,7 @@ def test_derived_plugin_json_has_no_marketplace_only_fields(tmp_path, pack_name)
     result = _run_build(FIXTURES_PACKS, tmp_path)
     assert result.returncode == 0, result.stderr
 
-    derived_json = (
-        tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
-    )
+    derived_json = tmp_path / "claude-plugins" / pack_name / ".claude-plugin" / "plugin.json"
     manifest = json.loads(derived_json.read_text(encoding="utf-8"))
     for field in ("source", "category"):
         assert field not in manifest, (

--- a/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
+++ b/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
@@ -42,7 +42,9 @@ assert WRITER.exists(), f"Writer not found at {WRITER}"
 # ---------------------------------------------------------------------------
 
 
-def _run_writer(env: dict, *, install_route: str = "claude-plugins") -> subprocess.CompletedProcess:  # noqa: E501
+def _run_writer(
+    env: dict, *, install_route: str = "claude-plugins"
+) -> subprocess.CompletedProcess:  # noqa: E501
     """Invoke the writer in subprocess.
 
     Pass ``--install-route claude-plugins`` by default — the apm-install-route-parity
@@ -50,6 +52,7 @@ def _run_writer(env: dict, *, install_route: str = "claude-plugins") -> subproce
     exercise the claude-plugins branch unless they explicitly opt into ``"apm"``.
     """
     import subprocess
+
     return subprocess.run(
         [sys.executable, str(WRITER), "--install-route", install_route],
         env=env,
@@ -167,6 +170,7 @@ def _make_env(
 ) -> dict:
     """Build a clean os.environ dict for subprocess runs."""
     import os
+
     env = {
         "PATH": os.environ.get("PATH", ""),
         "CLAUDE_PLUGIN_ROOT": str(plugin_root),
@@ -203,14 +207,24 @@ ALLOWED_MODULES = frozenset({
     # `argparse` admitted by apm-install-route-parity AC1 (one-entry growth in
     # the import allow-list) for the `--install-route` flag.
     # `contextlib` admitted for the atomic-marker-write pattern.
-    "argparse", "contextlib",
-    "datetime", "hashlib", "json", "os", "pathlib", "re", "sys", "tempfile", "tomllib",
+    "argparse",
+    "contextlib",
+    "datetime",
+    "hashlib",
+    "json",
+    "os",
+    "pathlib",
+    "re",
+    "sys",
+    "tempfile",
+    "tomllib",
 })
 
 
 def test_writer_is_stdlib_only():
     """AC1: the writer imports only modules from the allow-list."""
     import re
+
     content = WRITER.read_text(encoding="utf-8")
     pattern = re.compile(r"^(?:import|from)\s+(\S+)", re.MULTILINE)
     imported = {m.group(1).split(".")[0] for m in pattern.finditer(content)}
@@ -219,9 +233,7 @@ def test_writer_is_stdlib_only():
     # typing module members used via "from typing import" are stdlib.
     imported.discard("typing")
     forbidden = imported - ALLOWED_MODULES
-    assert not forbidden, (
-        f"Writer imports modules outside the allow-list: {sorted(forbidden)}"
-    )
+    assert not forbidden, f"Writer imports modules outside the allow-list: {sorted(forbidden)}"
 
 
 def test_writer_docstring_names_spec():
@@ -413,7 +425,7 @@ def test_refuse_repo_only_pack_at_user_scope(pack_root_factory):
         name="core",
         version="0.1.0",
         allowed_scopes=["repo"],  # repo only
-        opt_in_at=["user"],       # but opted in at user scope
+        opt_in_at=["user"],  # but opted in at user scope
     )
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -435,8 +447,8 @@ def test_refuse_user_only_pack_at_project_scope(pack_root_factory):
     plugin_root, plugin_data, home, project_dir = pack_root_factory(
         name="converters",
         version="0.1.0",
-        allowed_scopes=["user"],   # user only
-        opt_in_at=["project"],     # but opted in at project scope
+        allowed_scopes=["user"],  # user only
+        opt_in_at=["project"],  # but opted in at project scope
     )
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -458,7 +470,7 @@ def test_refuse_user_only_pack_at_local_scope(pack_root_factory):
         name="converters",
         version="0.1.0",
         allowed_scopes=["user"],  # user only
-        opt_in_at=["local"],      # opted in at local scope
+        opt_in_at=["local"],  # opted in at local scope
     )
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -511,7 +523,9 @@ def test_atomic_rename_uses_os_replace_and_recovers_on_crash(tmp_path, pack_root
     # We need to add "local" opt-in for pack-b in the project_dir settings.
     local_settings = project_dir / ".claude" / "settings.local.json"
     # Update to include both packs.
-    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n")  # noqa: E501
+    local_settings.write_text(
+        json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     # Set up the sitecustomize.py that crashes os.replace on first call.
     sitecustomize_dir = tmp_path / "sitecustomize_crash"
@@ -675,8 +689,11 @@ def test_detection_keep_data_reinstall_writes(pack_root_factory):
 
     # Pre-seed the hash file with the correct hash.
     import hashlib
+
     current_hash = hashlib.sha256((plugin_root / "pack.toml").read_bytes()).hexdigest()
-    (plugin_data / "pack-manifest-hash").write_text(current_hash + "\n", encoding="utf-8", newline="\n")
+    (plugin_data / "pack-manifest-hash").write_text(
+        current_hash + "\n", encoding="utf-8", newline="\n"
+    )
 
     # Marker file is absent (simulates --keep-data reinstall).
     env = _make_env(
@@ -745,7 +762,9 @@ def test_two_writers_sequential_both_entries_present(pack_root_factory):
     # Make pack-a settings visible in the shared project_dir.
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n")  # noqa: E501
+    local_settings.write_text(
+        json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     env_a = _make_env(
         plugin_root=plugin_root_a, plugin_data=plugin_data_a, home=home, project_dir=project_dir
@@ -808,6 +827,7 @@ def test_cli_to_claude_plugins_handoff_preserves_datetime(tmp_path, pack_root_fa
     cli_entries = [e for e in data.get("packs-installed", []) if e.get("name") == "cli-pack"]
     assert len(cli_entries) == 1
     import datetime as dt
+
     assert isinstance(cli_entries[0]["installed-at"], dt.datetime), (
         "CLI entry installed-at did not round-trip as datetime.datetime"
     )
@@ -822,7 +842,9 @@ def test_cli_to_claude_plugins_handoff_preserves_datetime(tmp_path, pack_root_fa
     # Make the project dir settings include plugins-pack.
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8", newline="\n")
+    local_settings.write_text(
+        json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8", newline="\n"
+    )
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -892,7 +914,9 @@ def test_cli_to_claude_plugins_handoff_preserves_install_route(tmp_path, pack_ro
     )
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["governance-extras"]}), encoding="utf-8", newline="\n")  # noqa: E501
+    local_settings.write_text(
+        json.dumps({"enabledPlugins": ["governance-extras"]}), encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -937,6 +961,7 @@ def test_plugin_upgrade_replaces_entry_not_stacks(pack_root_factory):
     # Pre-seed marker with the old version.
     marker_path = project_dir / ".adapt-install-marker.toml"
     import datetime as dt
+
     old_ts = dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     old_content = textwrap.dedent(f"""
         marker-schema-version = "0.1"
@@ -957,9 +982,7 @@ def test_plugin_upgrade_replaces_entry_not_stacks(pack_root_factory):
 
     data = _read_marker(marker_path)
     core_entries = [e for e in data.get("packs-installed", []) if e.get("name") == "core"]
-    assert len(core_entries) == 1, (
-        f"Expected exactly 1 entry for 'core', got {len(core_entries)}"
-    )
+    assert len(core_entries) == 1, f"Expected exactly 1 entry for 'core', got {len(core_entries)}"
     assert core_entries[0]["version"] == "0.2.0"
 
 
@@ -991,11 +1014,13 @@ def test_marker_write_refuses_path_outside_jail(tmp_path, pack_root_factory):
     # Resolve the jail so _assert_under receives a pre-resolved path
     # (matching the contract _marker_path guarantees).
     import pathlib
+
     resolved_jail = pathlib.Path(os.path.realpath(jail_dir))
 
     outside_path = foreign_dir / ".adapt-install-marker.toml"
 
     import datetime as dt
+
     new_entry = {
         "name": "core",
         "version": "0.1.0",
@@ -1007,9 +1032,7 @@ def test_marker_write_refuses_path_outside_jail(tmp_path, pack_root_factory):
         mod._write_marker(outside_path, new_entry, resolved_jail)
 
     # The foreign marker file must not have been created.
-    assert not outside_path.exists(), (
-        "Writer wrote to a path outside the jail — jail check failed"
-    )
+    assert not outside_path.exists(), "Writer wrote to a path outside the jail — jail check failed"
 
 
 # ---------------------------------------------------------------------------
@@ -1141,8 +1164,18 @@ def test_emit_basic_string_parity_with_source():
     vendored_fn = mod._emit_basic_string
 
     corpus = [
-        " ", "", "hello", 'a"b', "a\\b", "\n", "\x00", "\x01", "\x1f", "\x7f",
-        "café", "🚀",
+        " ",
+        "",
+        "hello",
+        'a"b',
+        "a\\b",
+        "\n",
+        "\x00",
+        "\x01",
+        "\x1f",
+        "\x7f",
+        "café",
+        "🚀",
     ]
     for value in corpus:
         source_out = source_fn(value)
@@ -1208,7 +1241,9 @@ def test_writer_drops_entries_with_malformed_name_or_version(tmp_path, pack_root
     )
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["third-pack"]}), encoding="utf-8", newline="\n")
+    local_settings.write_text(
+        json.dumps({"enabledPlugins": ["third-pack"]}), encoding="utf-8", newline="\n"
+    )
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -1307,7 +1342,7 @@ def test_writer_refuses_pack_name_with_control_chars(tmp_path):
     bad_name = "core\nevil"
     pack_toml_content = (
         "[pack]\n"
-        f'name = {_json.dumps(bad_name)}\n'
+        f"name = {_json.dumps(bad_name)}\n"
         'version = "0.1.0"\n'
         'description = "Adversarial pack."\n'
         "\n"
@@ -1330,7 +1365,9 @@ def test_writer_refuses_pack_name_with_control_chars(tmp_path):
     result = _run_writer(env)
 
     # (a) exit 0.
-    assert result.returncode == 0, f"Expected exit 0; got {result.returncode}. stderr: {result.stderr!r}"  # noqa: E501
+    assert result.returncode == 0, (
+        f"Expected exit 0; got {result.returncode}. stderr: {result.stderr!r}"
+    )  # noqa: E501
     # (b) no marker file.
     assert not (project_dir / ".adapt-install-marker.toml").exists(), (
         "Writer wrote a marker for a pack with an invalid name"
@@ -1484,6 +1521,4 @@ def test_hash_file_write_failure_self_heals(tmp_path, pack_root_factory):
     # Final marker: exactly one entry for the pack (upgrade-replace, no duplication).
     data = tomllib.loads(marker_path.read_text(encoding="utf-8"))
     core_entries = [e for e in data.get("packs-installed", []) if e["name"] == "core"]
-    assert len(core_entries) == 1, (
-        f"Expected exactly 1 entry for 'core', got {len(core_entries)}"
-    )
+    assert len(core_entries) == 1, f"Expected exactly 1 entry for 'core', got {len(core_entries)}"

--- a/packages/agentbundle/tests/integration/test_install_profile.py
+++ b/packages/agentbundle/tests/integration/test_install_profile.py
@@ -41,8 +41,7 @@ def _isolate_home_and_caches(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _stage_pack(cat, name, *, version="0.1.0", scope="repo", deps=None,
-                allowed_adapters=None):
+def _stage_pack(cat, name, *, version="0.1.0", scope="repo", deps=None, allowed_adapters=None):
     pdir = cat / "packs" / name
     skill = pdir / ".apm" / "skills" / f"{name}-skill"
     skill.mkdir(parents=True)
@@ -58,9 +57,7 @@ def _stage_pack(cat, name, *, version="0.1.0", scope="repo", deps=None,
         f'allowed-scopes = ["{scope}"]',
     ]
     if allowed_adapters is not None:
-        lines.append(
-            "allowed-adapters = [" + ", ".join(f'"{a}"' for a in allowed_adapters) + "]"
-        )
+        lines.append("allowed-adapters = [" + ", ".join(f'"{a}"' for a in allowed_adapters) + "]")
     for dep_name, dep_range in deps or []:
         lines += [
             "[[pack.dependencies.required]]",
@@ -178,7 +175,9 @@ def test_profile_skips_already_installed(tmp_path):
     state.packs[("pf-core", "claude-code")] = PackState(
         installed_version="0.4.9", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
+    (target / ".agentbundle-state.toml").write_text(
+        dump_state(state), encoding="utf-8", newline="\n"
+    )
 
     rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
     assert rc == 0, f"profile install failed: {err}"
@@ -201,8 +200,9 @@ def test_profile_refuses_when_a_pack_disallows_the_pinned_adapter(tmp_path):
     target.mkdir()
     # pf-core legacy (→ claude-code default); pf-addon-b only allows codex.
     _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
-    _stage_pack(cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")],
-                allowed_adapters=["codex"])
+    _stage_pack(
+        cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")], allowed_adapters=["codex"]
+    )
     _stage_profile(cat, "split", "repo", ["pf-core", "pf-addon-b"])
 
     rc, out, err = _run_install(["--profile", "split", str(cat), "--output", str(target)])
@@ -308,7 +308,9 @@ def test_profile_refuses_when_dep_preinstalled_at_unsatisfying_version(tmp_path)
     state.packs[("pf-core", "claude-code")] = PackState(
         installed_version="0.0.1", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
+    (target / ".agentbundle-state.toml").write_text(
+        dump_state(state), encoding="utf-8", newline="\n"
+    )
 
     rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
     assert rc != 0
@@ -380,7 +382,9 @@ def test_profile_refuses_pack_installed_at_opposite_scope(tmp_path, monkeypatch)
     repo_state.packs[("pf-tool", "claude-code")] = PackState(
         installed_version="0.1.0", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(repo_state), encoding="utf-8", newline="\n")
+    (target / ".agentbundle-state.toml").write_text(
+        dump_state(repo_state), encoding="utf-8", newline="\n"
+    )
 
     rc, out, err = _run_install(["--profile", "userset", str(cat), "--output", str(target)])
     assert rc == 1

--- a/packages/agentbundle/tests/integration/test_install_session_start_wiring.py
+++ b/packages/agentbundle/tests/integration/test_install_session_start_wiring.py
@@ -65,7 +65,9 @@ def _stage_synthetic_pack(catalogue_root: Path) -> None:
     # matter for the wiring-shape assertion.
     (apm / "hooks" / "session-start.py").write_text("", encoding="utf-8", newline="\n")
     (apm / "hook-wiring").mkdir()
-    (apm / "hook-wiring" / "session-start.toml").write_text(WIRING_TOML, encoding="utf-8", newline="\n")
+    (apm / "hook-wiring" / "session-start.toml").write_text(
+        WIRING_TOML, encoding="utf-8", newline="\n"
+    )
 
 
 def _install(args_dict) -> tuple[int, str, str]:
@@ -82,15 +84,13 @@ def test_install_writes_nested_session_start_binding(tmp_path):
     target = tmp_path / "repo"
     target.mkdir()
 
-    rc, _stdout, stderr = _install(
-        {
-            "pack": "test-core",
-            "catalogue": str(cat),
-            "output": str(target),
-            "scope": None,
-            "force": False,
-        }
-    )
+    rc, _stdout, stderr = _install({
+        "pack": "test-core",
+        "catalogue": str(cat),
+        "output": str(target),
+        "scope": None,
+        "force": False,
+    })
     assert rc == 0, f"install failed: {stderr}"
 
     # Repo-scope install produces the dist-tree Claude-plugin layout:
@@ -120,9 +120,7 @@ def test_install_writes_nested_session_start_binding(tmp_path):
     # literal command string Claude Code expects.
     inner = outer.get("hooks", [])
     assert len(inner) == 1, f"expected 1 inner hook, got {inner!r}"
-    assert inner[0]["type"] == "command", (
-        f"inner hook type must be 'command'; got {inner[0]!r}"
-    )
+    assert inner[0]["type"] == "command", f"inner hook type must be 'command'; got {inner[0]!r}"
     assert inner[0]["command"] == "python tools/hooks/session-start.py", (
         f"inner hook command mismatch; got {inner[0]!r}"
     )

--- a/packages/agentbundle/tests/integration/test_install_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_install_user_hooks.py
@@ -168,11 +168,11 @@ class KiroUserHooksInstallTests(_UserScopeInstallBase):
 
 class ForceMergeFlagBindingTests(unittest.TestCase):
     """AC12 binding rails for ``--force-merge``:
-       - Bound to ``install`` verb (other verbs refuse with
-         ``unknown flag for <verb>: --force-merge``).
-       - Bound to ``--scope user``.
-       - Claude-Code-only at install time (refused on Kiro-targeted
-         packs since agent JSON is pack-owned)."""
+    - Bound to ``install`` verb (other verbs refuse with
+      ``unknown flag for <verb>: --force-merge``).
+    - Bound to ``--scope user``.
+    - Claude-Code-only at install time (refused on Kiro-targeted
+      packs since agent JSON is pack-owned)."""
 
     def test_force_merge_on_uninstall_refuses_with_unknown_flag(self) -> None:
         import subprocess
@@ -270,8 +270,7 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
             # Path-traversal payload.
-            'attach-to-agent = "../../../tmp/escape"\n\n'
-            '[[hooks.agentSpawn]]\ncommand = "x"\n',
+            'attach-to-agent = "../../../tmp/escape"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
             encoding="utf-8",
             newline="\n",
         )
@@ -301,7 +300,8 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
         # `escape` artifact lands anywhere under the sandbox (in particular
         # outside the user-scope home jail).
         self.assertEqual(
-            list(self.tmp.rglob("*escape*")), [],
+            list(self.tmp.rglob("*escape*")),
+            [],
             "path-traversal attach-to-agent created a file outside the jail",
         )
 
@@ -326,8 +326,7 @@ class KiroAliasRefusesUserScopeHooksLikeKiroIdeTests(_UserScopeInstallBase):
         )
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
-            'attach-to-agent = "reviewer"\n\n'
-            '[[hooks.agentSpawn]]\ncommand = "x"\n',
+            'attach-to-agent = "reviewer"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
             encoding="utf-8",
             newline="\n",
         )
@@ -347,20 +346,24 @@ class KiroAliasRefusesUserScopeHooksLikeKiroIdeTests(_UserScopeInstallBase):
         self._make_hooks_pack("kiro-alias-hooks", "kiro")
         self._make_hooks_pack("kiro-ide-hooks", "kiro-ide")
 
-        rc_alias, _out, err_alias = _run_install(_install_args(
-            pack="kiro-alias-hooks",
-            catalogue=str(self.cat),
-            output=str(self.repo),
-            scope="user",
-            adapter="kiro",
-        ))
-        rc_ide, _out2, err_ide = _run_install(_install_args(
-            pack="kiro-ide-hooks",
-            catalogue=str(self.cat),
-            output=str(self.repo),
-            scope="user",
-            adapter="kiro-ide",
-        ))
+        rc_alias, _out, err_alias = _run_install(
+            _install_args(
+                pack="kiro-alias-hooks",
+                catalogue=str(self.cat),
+                output=str(self.repo),
+                scope="user",
+                adapter="kiro",
+            )
+        )
+        rc_ide, _out2, err_ide = _run_install(
+            _install_args(
+                pack="kiro-ide-hooks",
+                catalogue=str(self.cat),
+                output=str(self.repo),
+                scope="user",
+                adapter="kiro-ide",
+            )
+        )
 
         # Both refuse — the alias is a true alias for kiro-ide.
         self.assertEqual(rc_alias, 1, f"kiro alias should refuse like kiro-ide: {err_alias}")
@@ -383,11 +386,13 @@ class RailBStillRefusesPacksWithoutOptInTests(_UserScopeInstallBase):
         # Synthesise a pack that ships hooks but lacks the opt-in flag.
         pack_dir = self.cat / "packs" / "no-opt-in"
         (pack_dir / ".apm" / "hooks").mkdir(parents=True)
-        (pack_dir / ".apm" / "hooks" / "x.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+        (pack_dir / ".apm" / "hooks" / "x.sh").write_text(
+            "#!/bin/sh\n", encoding="utf-8", newline="\n"
+        )
         (pack_dir / "pack.toml").write_text(
-            "[pack]\nname = \"no-opt-in\"\nversion = \"0.1.0\"\n"
-            "[pack.adapter-contract]\nversion = \"0.3\"\n"
-            "[pack.install]\ndefault-scope = \"user\"\nallowed-scopes = [\"user\"]\n",
+            '[pack]\nname = "no-opt-in"\nversion = "0.1.0"\n'
+            '[pack.adapter-contract]\nversion = "0.3"\n'
+            '[pack.install]\ndefault-scope = "user"\nallowed-scopes = ["user"]\n',
             encoding="utf-8",
             newline="\n",
         )

--- a/packages/agentbundle/tests/integration/test_kiro_ide_hook_e2e.py
+++ b/packages/agentbundle/tests/integration/test_kiro_ide_hook_e2e.py
@@ -36,9 +36,17 @@ def _synthesised_v0_4_contract() -> dict:
         "target": {"repo": ".kiro/hooks/<pack>/<name>.kiro.hook"},
         "on-conflict": "prompt-then-preserve",
         "ide-event-vocabulary": [
-            "fileCreated", "fileEdit", "fileSave", "fileDeleted",
-            "promptSubmit", "agentStop", "preToolUse", "postToolUse",
-            "preTaskExecution", "postTaskExecution", "manualTrigger",
+            "fileCreated",
+            "fileEdit",
+            "fileSave",
+            "fileDeleted",
+            "promptSubmit",
+            "agentStop",
+            "preToolUse",
+            "postToolUse",
+            "preTaskExecution",
+            "postTaskExecution",
+            "manualTrigger",
         ],
         "ide-action-vocabulary": ["askAgent", "runCommand"],
     }
@@ -55,28 +63,36 @@ def _make_fixture_pack(root: Path, pack_name: str = "kiro-ide-hooks-basic") -> P
     # askAgent hook (byte-copy path).
     (pack / ".apm" / "kiro-ide-hooks").mkdir(parents=True)
     (pack / ".apm" / "kiro-ide-hooks" / "lint-prompt.kiro.hook").write_text(
-        json.dumps({
-            "name": "Lint on save",
-            "description": "Ask the agent to lint.",
-            "version": "1",
-            "when": {"type": "fileSave", "patterns": ["**/*.py"]},
-            "then": {"type": "askAgent", "prompt": "Lint the saved file."},
-        }, indent=2) + "\n",
+        json.dumps(
+            {
+                "name": "Lint on save",
+                "description": "Ask the agent to lint.",
+                "version": "1",
+                "when": {"type": "fileSave", "patterns": ["**/*.py"]},
+                "then": {"type": "askAgent", "prompt": "Lint the saved file."},
+            },
+            indent=2,
+        )
+        + "\n",
         encoding="utf-8",
         newline="\n",
     )
     # runCommand hook (parse, expand, emit path).
     (pack / ".apm" / "kiro-ide-hooks" / "lint-command.kiro.hook").write_text(
-        json.dumps({
-            "name": "Lint via command",
-            "description": "Invoke the lint hook-body directly.",
-            "version": "1",
-            "when": {"type": "fileSave", "patterns": ["**/*.py"]},
-            "then": {
-                "type": "runCommand",
-                "command": "${hook-body:lint}",
+        json.dumps(
+            {
+                "name": "Lint via command",
+                "description": "Invoke the lint hook-body directly.",
+                "version": "1",
+                "when": {"type": "fileSave", "patterns": ["**/*.py"]},
+                "then": {
+                    "type": "runCommand",
+                    "command": "${hook-body:lint}",
+                },
             },
-        }, indent=2) + "\n",
+            indent=2,
+        )
+        + "\n",
         encoding="utf-8",
         newline="\n",
     )
@@ -99,7 +115,9 @@ class KiroAdapterDispatchesKiroIdeHook(unittest.TestCase):
             kiro_adapter.project(pack, contract, output)
 
             # askAgent — byte-copy preserves source exactly.
-            ask_path = output / ".kiro" / "hooks" / "kiro-ide-hooks-basic" / "lint-prompt.kiro.hook"  # noqa: E501
+            ask_path = (
+                output / ".kiro" / "hooks" / "kiro-ide-hooks-basic" / "lint-prompt.kiro.hook"
+            )  # noqa: E501
             self.assertTrue(ask_path.exists())
             ask_body = json.loads(ask_path.read_text(encoding="utf-8"))
             self.assertEqual(ask_body["then"]["type"], "askAgent")
@@ -107,7 +125,9 @@ class KiroAdapterDispatchesKiroIdeHook(unittest.TestCase):
 
             # runCommand — placeholder expanded to ./tools/hooks/lint.py
             # (Kiro adapter's legacy hook-body target is tools/hooks/).
-            cmd_path = output / ".kiro" / "hooks" / "kiro-ide-hooks-basic" / "lint-command.kiro.hook"  # noqa: E501
+            cmd_path = (
+                output / ".kiro" / "hooks" / "kiro-ide-hooks-basic" / "lint-command.kiro.hook"
+            )  # noqa: E501
             self.assertTrue(cmd_path.exists())
             cmd_body = json.loads(cmd_path.read_text(encoding="utf-8"))
             self.assertEqual(cmd_body["then"]["command"], "./tools/hooks/lint.py")
@@ -150,7 +170,9 @@ class ValidateCommandRailFires(unittest.TestCase):
             pack = _make_fixture_pack(root)
             # Drop a required field to trigger refusal path 1.
             broken = pack / ".apm" / "kiro-ide-hooks" / "broken.kiro.hook"
-            broken.write_text(json.dumps({"description": "no name no version"}), encoding="utf-8", newline="\n")
+            broken.write_text(
+                json.dumps({"description": "no name no version"}), encoding="utf-8", newline="\n"
+            )
 
             # pack.toml is needed for validate.run.
             (pack / "pack.toml").write_text(
@@ -164,6 +186,7 @@ class ValidateCommandRailFires(unittest.TestCase):
             import argparse
 
             from agentbundle.commands.validate import run as validate_run
+
             ns = argparse.Namespace(pack_path=str(pack), strict=False)
 
             buf = io.StringIO()

--- a/packages/agentbundle/tests/integration/test_show_cmd.py
+++ b/packages/agentbundle/tests/integration/test_show_cmd.py
@@ -36,17 +36,22 @@ UNRESOLVABLE = "git+ssh://example.com/owner/repo"
 # ---------------------------------------------------------------------------
 
 
-def _args(pack: str, *, catalogue: str | None = None, fmt: str = "table",
-          root: str = ".") -> SimpleNamespace:
+def _args(
+    pack: str, *, catalogue: str | None = None, fmt: str = "table", root: str = "."
+) -> SimpleNamespace:
     return SimpleNamespace(
         pack=pack, catalogue=catalogue, format=fmt, root=root, _user_config=None
     )
 
 
-def _make_catalogue(root: Path, *, name: str = "demo",
-                    skills: tuple[str, ...] = ("zeta", "alpha"),
-                    agents: tuple[str, ...] = ("beta", "aardvark"),
-                    meta: bool = True) -> Path:
+def _make_catalogue(
+    root: Path,
+    *,
+    name: str = "demo",
+    skills: tuple[str, ...] = ("zeta", "alpha"),
+    agents: tuple[str, ...] = ("beta", "aardvark"),
+    meta: bool = True,
+) -> Path:
     """Build ``<root>/packs/<name>/`` with pack.toml + .apm tree; return root."""
     pack = root / "packs" / name
     toml = f'[pack]\nname = "{name}"\n'
@@ -56,7 +61,9 @@ def _make_catalogue(root: Path, *, name: str = "demo",
     (pack / "pack.toml").write_text(toml, encoding="utf-8", newline="\n")
     for s in skills:
         (pack / ".apm" / "skills" / s).mkdir(parents=True)
-        (pack / ".apm" / "skills" / s / "SKILL.md").write_text("# s\n", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "skills" / s / "SKILL.md").write_text(
+            "# s\n", encoding="utf-8", newline="\n"
+        )
     for a in agents:
         (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
         (pack / ".apm" / "agents" / f"{a}.md").write_text("# a\n", encoding="utf-8", newline="\n")
@@ -90,7 +97,10 @@ def test_primary_via_default_source_chain(tmp_path, capsys):
     marker.parent.mkdir(parents=True)
     marker.write_text("{}\n", encoding="utf-8", newline="\n")
     args = SimpleNamespace(
-        pack="demo", catalogue=None, format="json", root=".",
+        pack="demo",
+        catalogue=None,
+        format="json",
+        root=".",
         _user_config=SimpleNamespace(source=str(cat)),
     )
     rc = show.run(args)
@@ -182,16 +192,18 @@ def test_unknown_pack_json_still_empty_stdout(tmp_path, capsys):
 def test_degrade_installed_repo_scope(tmp_path, capsys):
     _write_state(
         tmp_path / ".agentbundle-state.toml",
-        State(packs={
-            ("demo", "claude-code"): PackState(
-                installed_version="0.9.0",
-                files={
-                    ".claude/skills/zeta/SKILL.md": {"sha": "a"},
-                    ".claude/skills/alpha/SKILL.md": {"sha": "b"},
-                    ".claude/agents/beta.md": {"sha": "c"},
-                },
-            )
-        }),
+        State(
+            packs={
+                ("demo", "claude-code"): PackState(
+                    installed_version="0.9.0",
+                    files={
+                        ".claude/skills/zeta/SKILL.md": {"sha": "a"},
+                        ".claude/skills/alpha/SKILL.md": {"sha": "b"},
+                        ".claude/agents/beta.md": {"sha": "c"},
+                    },
+                )
+            }
+        ),
     )
     rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
     out = capsys.readouterr().out
@@ -207,12 +219,14 @@ def test_degrade_installed_repo_scope(tmp_path, capsys):
 def test_degrade_table_omits_version_prints_source_line(tmp_path, capsys):
     _write_state(
         tmp_path / ".agentbundle-state.toml",
-        State(packs={
-            ("demo", "claude-code"): PackState(
-                installed_version="0.9.0",
-                files={".claude/skills/alpha/SKILL.md": {"sha": "b"}},
-            )
-        }),
+        State(
+            packs={
+                ("demo", "claude-code"): PackState(
+                    installed_version="0.9.0",
+                    files={".claude/skills/alpha/SKILL.md": {"sha": "b"}},
+                )
+            }
+        ),
     )
     rc = show.run(_args("demo", catalogue=UNRESOLVABLE, root=str(tmp_path)))
     out = capsys.readouterr().out
@@ -226,30 +240,32 @@ def test_degrade_multi_adapter_dedupes_across_extensions(tmp_path, capsys):
     collapse to one entry per logical skill/agent (extension-agnostic recovery)."""
     _write_state(
         tmp_path / ".agentbundle-state.toml",
-        State(packs={
-            ("demo", "claude-code"): PackState(
-                installed_version="0.9.0",
-                files={
-                    ".claude/skills/alpha/SKILL.md": {"sha": "1"},
-                    ".claude/agents/bot.md": {"sha": "2"},
-                },
-            ),
-            ("demo", "codex"): PackState(
-                installed_version="0.9.0",
-                files={
-                    ".agents/skills/alpha/SKILL.md": {"sha": "3"},
-                    ".codex/agents/bot.toml": {"sha": "4"},
-                },
-            ),
-            ("demo", "kiro"): PackState(
-                installed_version="0.9.0",
-                files={".kiro/agents/bot.json": {"sha": "5"}},
-            ),
-            ("demo", "copilot"): PackState(
-                installed_version="0.9.0",
-                files={".github/agents/bot.agent.md": {"sha": "6"}},
-            ),
-        }),
+        State(
+            packs={
+                ("demo", "claude-code"): PackState(
+                    installed_version="0.9.0",
+                    files={
+                        ".claude/skills/alpha/SKILL.md": {"sha": "1"},
+                        ".claude/agents/bot.md": {"sha": "2"},
+                    },
+                ),
+                ("demo", "codex"): PackState(
+                    installed_version="0.9.0",
+                    files={
+                        ".agents/skills/alpha/SKILL.md": {"sha": "3"},
+                        ".codex/agents/bot.toml": {"sha": "4"},
+                    },
+                ),
+                ("demo", "kiro"): PackState(
+                    installed_version="0.9.0",
+                    files={".kiro/agents/bot.json": {"sha": "5"}},
+                ),
+                ("demo", "copilot"): PackState(
+                    installed_version="0.9.0",
+                    files={".github/agents/bot.agent.md": {"sha": "6"}},
+                ),
+            }
+        ),
     )
     rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
     obj = json.loads(capsys.readouterr().out)
@@ -258,9 +274,7 @@ def test_degrade_multi_adapter_dedupes_across_extensions(tmp_path, capsys):
     assert obj["agents"] == ["bot"]  # never "bot.agent" / "bot.json"
 
 
-def test_degrade_legacy_state_scope_warned_not_fatal(
-    tmp_path, capsys, _isolate_user_config_dir
-):
+def test_degrade_legacy_state_scope_warned_not_fatal(tmp_path, capsys, _isolate_user_config_dir):
     """A legacy/incompatible state file in one scope is warned-and-skipped (not
     fatal): recovery still succeeds from the other scope, and a stderr warning
     names the skipped scope — mirroring `list-installed`."""
@@ -271,12 +285,14 @@ def test_degrade_legacy_state_scope_warned_not_fatal(
     # User scope: a valid state carrying the installed pack.
     _write_state(
         _isolate_user_config_dir / ".agentbundle" / "state.toml",
-        State(packs={
-            ("demo", "claude-code"): PackState(
-                installed_version="0.9.0",
-                files={".claude/skills/recovered/SKILL.md": {"sha": "x"}},
-            )
-        }),
+        State(
+            packs={
+                ("demo", "claude-code"): PackState(
+                    installed_version="0.9.0",
+                    files={".claude/skills/recovered/SKILL.md": {"sha": "x"}},
+                )
+            }
+        ),
     )
     rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
     captured = capsys.readouterr()
@@ -291,12 +307,14 @@ def test_degrade_installed_user_scope_only(tmp_path, capsys, _isolate_user_confi
     user_state = _isolate_user_config_dir / ".agentbundle" / "state.toml"
     _write_state(
         user_state,
-        State(packs={
-            ("demo", "claude-code"): PackState(
-                installed_version="0.9.0",
-                files={".claude/skills/solo/SKILL.md": {"sha": "x"}},
-            )
-        }),
+        State(
+            packs={
+                ("demo", "claude-code"): PackState(
+                    installed_version="0.9.0",
+                    files={".claude/skills/solo/SKILL.md": {"sha": "x"}},
+                )
+            }
+        ),
     )
     # repo root (tmp_path) has no state → recovery must come from user scope.
     rc = show.run(_args("demo", catalogue=UNRESOLVABLE, fmt="json", root=str(tmp_path)))
@@ -354,8 +372,7 @@ def test_agent_from_relpath_extension_agnostic():
 def test_show_run_writes_no_files(tmp_path, capsys):
     _make_catalogue(tmp_path / "cat")
     before = set((tmp_path / "cat").rglob("*"))
-    rc = show.run(_args("demo", catalogue=str(tmp_path / "cat"), fmt="json",
-                        root=str(tmp_path)))
+    rc = show.run(_args("demo", catalogue=str(tmp_path / "cat"), fmt="json", root=str(tmp_path)))
     capsys.readouterr()
     after = set((tmp_path / "cat").rglob("*"))
     assert rc == 0
@@ -372,7 +389,8 @@ def test_show_run_writes_no_files(tmp_path, capsys):
 def test_show_help_documents_format():
     proc = subprocess.run(
         [sys.executable, "-m", "agentbundle", "show", "--help"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert proc.returncode == 0
     assert "--format" in proc.stdout

--- a/packages/agentbundle/tests/integration/test_uninstall_cmd.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_cmd.py
@@ -14,9 +14,7 @@ import types
 from pathlib import Path
 
 # Fixture catalogue reused from the install tests.
-FIXTURE_CATALOGUE = (
-    Path(__file__).parent.parent / "fixtures" / "install" / "catalogue"
-)
+FIXTURE_CATALOGUE = Path(__file__).parent.parent / "fixtures" / "install" / "catalogue"
 ALPHA_PACK_DIR = FIXTURE_CATALOGUE / "packs" / "alpha"
 
 
@@ -27,26 +25,35 @@ ALPHA_PACK_DIR = FIXTURE_CATALOGUE / "packs" / "alpha"
 
 def _run_install(pack: str, catalogue: str, output: str) -> int:
     from agentbundle.commands.install import run
+
     # Test fixtures predate RFC-0012's per-IDE projection at repo scope;
     # pass `emit_install_routes=True` to keep the dist-tree shape these
     # tests assert against. The per-IDE projection path is covered by
     # the new `test_install_repo_scope_per_adapter.py` integration suite.
-    return run(types.SimpleNamespace(
-        pack=pack, catalogue=catalogue, output=output,
-        emit_install_routes=True,
-    ))
+    return run(
+        types.SimpleNamespace(
+            pack=pack,
+            catalogue=catalogue,
+            output=output,
+            emit_install_routes=True,
+        )
+    )
 
 
-def _run_uninstall(
-    pack: str, root: str, *, yes: bool = True, dry_run: bool = False
-) -> int:
+def _run_uninstall(pack: str, root: str, *, yes: bool = True, dry_run: bool = False) -> int:
     from agentbundle.commands.uninstall import run
+
     # `yes=True` by default so the pre-existing non-prompt tests don't block on
     # input(); the confirmation-flow tests pass yes=False and monkeypatch
     # input/isatty (mirrors test_upgrade_cmd.py's `_run_upgrade`).
-    return run(types.SimpleNamespace(
-        pack=pack, root=root, yes=yes, dry_run=dry_run,
-    ))
+    return run(
+        types.SimpleNamespace(
+            pack=pack,
+            root=root,
+            yes=yes,
+            dry_run=dry_run,
+        )
+    )
 
 
 def _seed_state(tmp_path: Path, pack_name: str, files: dict[str, str]) -> None:
@@ -57,11 +64,12 @@ def _seed_state(tmp_path: Path, pack_name: str, files: dict[str, str]) -> None:
     state.packs[(pack_name, "claude-code")] = PackState(
         installed_version="0.1.0",
         files={
-            relpath: {"sha": sha, "from-pack-version": "0.1.0"}
-            for relpath, sha in files.items()
+            relpath: {"sha": sha, "from-pack-version": "0.1.0"} for relpath, sha in files.items()
         },
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        dump_state(state), encoding="utf-8", newline="\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -221,9 +229,7 @@ def test_missing_pack_exits_nonzero(tmp_path, capsys):
     assert rc != 0, "uninstall of missing pack must exit non-zero"
 
     captured = capsys.readouterr()
-    assert "nonexistent" in captured.err, (
-        "stderr must mention the missing pack name"
-    )
+    assert "nonexistent" in captured.err, "stderr must mention the missing pack name"
 
 
 # ---------------------------------------------------------------------------
@@ -234,9 +240,7 @@ def test_missing_pack_exits_nonzero(tmp_path, capsys):
 def _snapshot_tree(root: Path) -> dict[str, bytes]:
     """Map every file under `root` to its bytes (for write-nothing assertions)."""
     return {
-        str(p.relative_to(root)): p.read_bytes()
-        for p in sorted(root.rglob("*"))
-        if p.is_file()
+        str(p.relative_to(root)): p.read_bytes() for p in sorted(root.rglob("*")) if p.is_file()
     }
 
 

--- a/packages/agentbundle/tests/integration/test_upgrade_cmd.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_cmd.py
@@ -63,18 +63,22 @@ def _args_upgrade(
 def _args_install(pack: str, catalogue: str, output: str) -> types.SimpleNamespace:
     # RFC-0012: dist-tree fixtures need `emit_install_routes=True`.
     return types.SimpleNamespace(
-        pack=pack, catalogue=catalogue, output=output,
+        pack=pack,
+        catalogue=catalogue,
+        output=output,
         emit_install_routes=True,
     )
 
 
 def _run_upgrade(**kwargs) -> int:
     from agentbundle.commands.upgrade import run
+
     return run(_args_upgrade(**kwargs))
 
 
 def _run_install(pack: str, catalogue: str, output: str) -> int:
     from agentbundle.commands.install import run
+
     return run(_args_install(pack, catalogue, output))
 
 
@@ -129,7 +133,7 @@ def test_whole_pack_upgrade_updates_version_and_content(tmp_path):
         ("skill", "work-loop", "skill", "skills"),
         ("agent", "reviewer", "agent", "agents"),
         ("hook", "pre-commit", "hook-body", "hooks"),
-        ("seed", None, "seed", "seeds"),   # skip; no seeds in fixture
+        ("seed", None, "seed", "seeds"),  # skip; no seeds in fixture
         ("command", "deploy", "command", "commands"),
     ],
 )
@@ -153,16 +157,12 @@ def test_per_primitive_upgrade_moves_only_matching_files(
     prim_paths = set(_filter_for_primitive(v2_projection, prim_name, src_dir).keys())
     # --hook co-moves the matching hook-wiring of the same name (spec AC #10).
     if flag_attr == "hook":
-        prim_paths |= set(
-            _filter_for_primitive(v2_projection, prim_name, "hook-wiring").keys()
-        )
+        prim_paths |= set(_filter_for_primitive(v2_projection, prim_name, "hook-wiring").keys())
     non_prim_paths = set(v1_projection.keys()) - prim_paths
 
     # Capture v1 content for non-matching paths before upgrade.
     non_prim_before = {
-        rp: (tmp_path / rp).read_bytes()
-        for rp in non_prim_paths
-        if (tmp_path / rp).exists()
+        rp: (tmp_path / rp).read_bytes() for rp in non_prim_paths if (tmp_path / rp).exists()
     }
 
     kwargs: dict = {"pack": "core", "catalogue": str(CAT_V2), "root": str(tmp_path)}
@@ -233,9 +233,7 @@ def test_mixed_version_warning_on_whole_pack_after_per_primitive(tmp_path, capsy
     assert "mixed-version" in captured.err, (
         "stderr must contain 'mixed-version' when pack has per-primitive overrides"
     )
-    assert "work-loop" in captured.err, (
-        "stderr must name the mixed-version primitive"
-    )
+    assert "work-loop" in captured.err, "stderr must name the mixed-version primitive"
 
 
 # ---------------------------------------------------------------------------
@@ -384,13 +382,9 @@ def test_whole_pack_upgrade_prints_success_recap(tmp_path, capsys):
     assert rc == 0
 
     captured = capsys.readouterr()
-    assert captured.out.strip(), (
-        "whole-pack upgrade must print a non-empty recap to stdout"
-    )
+    assert captured.out.strip(), "whole-pack upgrade must print a non-empty recap to stdout"
     last = captured.out.strip().splitlines()[-1]
-    assert last.startswith("upgraded:"), (
-        f"recap must start with 'upgraded:'; got: {last!r}"
-    )
+    assert last.startswith("upgraded:"), f"recap must start with 'upgraded:'; got: {last!r}"
     assert "core" in last and "0.2.0" in last, (
         f"recap must name pack and target version; got: {last!r}"
     )
@@ -412,13 +406,9 @@ def test_per_primitive_upgrade_prints_success_recap(tmp_path, capsys):
     assert rc == 0
 
     captured = capsys.readouterr()
-    assert captured.out.strip(), (
-        "per-primitive upgrade must print a non-empty recap to stdout"
-    )
+    assert captured.out.strip(), "per-primitive upgrade must print a non-empty recap to stdout"
     last = captured.out.strip().splitlines()[-1]
-    assert last.startswith("upgraded:"), (
-        f"recap must start with 'upgraded:'; got: {last!r}"
-    )
+    assert last.startswith("upgraded:"), f"recap must start with 'upgraded:'; got: {last!r}"
     assert "core" in last and "work-loop" in last and "0.2.0" in last, (
         f"recap must name pack, primitive, and target version; got: {last!r}"
     )
@@ -436,6 +426,7 @@ def test_filter_for_primitive_refuses_ambiguous_name():
         "apm/core/.apm/skills/foo.md": b"file form",
     }
     import pytest
+
     with pytest.raises(ValueError, match="ambiguous"):
         _filter_for_primitive(projection, "foo", "skills")
 
@@ -480,9 +471,7 @@ def test_upgrade_tier2_collision_surfaces_companion_path(tmp_path, capsys):
     adopter_bytes = b"# adopter edits -- do not clobber\n"
     (tmp_path / target_rel).write_bytes(adopter_bytes)  # forces Tier-2
 
-    rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path)
-    )
+    rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path))
     assert rc == 0, "upgrade over a Tier-2 collision must still succeed"
 
     # Never clobbered: the adopter's edit survives at the original path.
@@ -516,9 +505,7 @@ def test_upgrade_without_collision_emits_no_companion_notice(tmp_path, capsys):
     assert rc == 0
     capsys.readouterr()  # drop install output
 
-    rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path)
-    )
+    rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path))
     assert rc == 0
 
     err = capsys.readouterr().err
@@ -544,9 +531,7 @@ def test_upgrade_multiple_tier2_collisions_counts_and_lists_all(tmp_path, capsys
     for rp in targets:
         (tmp_path / rp).write_bytes(f"# adopter edit of {rp}\n".encode())
 
-    rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path)
-    )
+    rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path))
     assert rc == 0
 
     err = capsys.readouterr().err
@@ -582,8 +567,10 @@ def test_per_primitive_upgrade_surfaces_tier2_companion(tmp_path, capsys):
     (tmp_path / target_rel).write_bytes(b"# adopter-edited skill body\n")
 
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2),
-        root=str(tmp_path), skill="work-loop",
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        skill="work-loop",
     )
     assert rc == 0
 
@@ -610,9 +597,7 @@ def _snapshot_tree(root: Path) -> dict[str, bytes]:
     }
 
 
-def test_dry_run_upgrade_tier2_collision_previews_companion_writes_nothing(
-    tmp_path, capsys
-):
+def test_dry_run_upgrade_tier2_collision_previews_companion_writes_nothing(tmp_path, capsys):
     """AC1/AC4/AC6: a dry-run upgrade over an adopter-edited file previews the
     `companion`/tier-2 line (with the `-> *.upstream` target), exits 0, and
     leaves the tree + state byte-identical with no companion on disk."""
@@ -636,8 +621,10 @@ def test_dry_run_upgrade_tier2_collision_previews_companion_writes_nothing(
     before = _snapshot_tree(tmp_path)
 
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2),
-        root=str(tmp_path), dry_run=True,
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        dry_run=True,
     )
     assert rc == 0, "dry-run upgrade must exit 0 even with a Tier-2 collision"
 
@@ -652,9 +639,7 @@ def test_dry_run_upgrade_tier2_collision_previews_companion_writes_nothing(
 
     # No-write invariant: tree + state byte-identical, no companion on disk.
     assert _snapshot_tree(tmp_path) == before, "dry-run upgrade must write nothing"
-    assert not (tmp_path / companion_rel).exists(), (
-        "dry-run must not drop the .upstream companion"
-    )
+    assert not (tmp_path / companion_rel).exists(), "dry-run must not drop the .upstream companion"
 
 
 def test_dry_run_upgrade_no_edits_previews_overwrite_writes_nothing(tmp_path, capsys):
@@ -667,8 +652,10 @@ def test_dry_run_upgrade_no_edits_previews_overwrite_writes_nothing(tmp_path, ca
     before = _snapshot_tree(tmp_path)
 
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2),
-        root=str(tmp_path), dry_run=True,
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        dry_run=True,
     )
     assert rc == 0
 
@@ -698,8 +685,11 @@ def test_dry_run_upgrade_per_primitive_scopes_to_that_primitive(tmp_path, capsys
     before = _snapshot_tree(tmp_path)
 
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2),
-        root=str(tmp_path), skill="work-loop", dry_run=True,
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        skill="work-loop",
+        dry_run=True,
     )
     assert rc == 0
     out = capsys.readouterr().out
@@ -717,8 +707,11 @@ def test_dry_run_upgrade_per_primitive_scopes_to_that_primitive(tmp_path, capsys
 
     # Primitive-not-found passes through as a non-zero pre-render refusal.
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2),
-        root=str(tmp_path), skill="bogus", dry_run=True,
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        skill="bogus",
+        dry_run=True,
     )
     assert rc != 0, "a --dry-run for a missing primitive must still exit non-zero"
     assert _snapshot_tree(tmp_path) == before
@@ -768,8 +761,10 @@ def test_dry_run_upgrade_preflight_path_jail_passthrough(tmp_path):
     malicious = {"../../evil_dry_run.txt": b"evil"}
     with mock.patch("agentbundle.render.render_pack", return_value=malicious):
         rc = _run_upgrade(
-            pack="core", catalogue=str(CAT_V2),
-            root=str(tmp_path), dry_run=True,
+            pack="core",
+            catalogue=str(CAT_V2),
+            root=str(tmp_path),
+            dry_run=True,
         )
     assert rc != 0, "dry-run must surface the path-jail pre-flight failure"
     assert not (tmp_path / ".." / ".." / "evil_dry_run.txt").resolve().exists(), (
@@ -801,7 +796,9 @@ def test_upgrade_prefix_violation_writes_nothing(tmp_path, capsys):
             outside_rel: {"sha": installed_sha, "from-pack-version": "0.1.0"},
         },
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(s), encoding="utf-8", newline="\n")
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        dump_state(s), encoding="utf-8", newline="\n"
+    )
     # On-disk: user has edited the outside-prefix file (different from installed sha)
     (tmp_path / "outside-prefix").mkdir()
     (tmp_path / outside_rel).write_bytes(b"user edited\n")
@@ -850,9 +847,7 @@ def test_per_primitive_recap_shows_from_to(tmp_path, capsys):
     assert _install_v1(tmp_path) == 0
     capsys.readouterr()
 
-    rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop"
-    )
+    rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop")
     assert rc == 0
     recap = capsys.readouterr().out.strip().splitlines()[-1]
     assert recap == "upgraded: core skill/work-loop @ repo 0.1.0 -> 0.2.0", recap
@@ -952,8 +947,11 @@ def test_dry_run_no_prompt_no_write(tmp_path, capsys, monkeypatch):
 
     monkeypatch.setattr("builtins.input", _boom)
     rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path),
-        dry_run=True, yes=False,
+        pack="core",
+        catalogue=str(CAT_V2),
+        root=str(tmp_path),
+        dry_run=True,
+        yes=False,
     )
     assert rc == 0
     assert _snapshot_tree(tmp_path) == before
@@ -963,8 +961,8 @@ def test_dry_run_no_prompt_no_write(tmp_path, capsys, monkeypatch):
     "pack_toml_body",
     [
         '[pack]\nname = "core"\ndescription = "no version"\nseeds = []\n',  # missing key
-        '[pack]\nname = "core"\nversion = 2\nseeds = []\n',                  # non-string
-        '[other]\nx = 1\n',                                                  # no [pack] table
+        '[pack]\nname = "core"\nversion = 2\nseeds = []\n',  # non-string
+        "[other]\nx = 1\n",  # no [pack] table
     ],
     ids=["missing-key", "non-string", "no-pack-table"],
 )
@@ -989,14 +987,16 @@ def test_per_primitive_from_uses_recorded_override(tmp_path, capsys):
     override (0.2.0), not installed_version (0.1.0)."""
     assert _install_v1(tmp_path) == 0
     # First per-primitive upgrade → records skill/work-loop @ 0.2.0.
-    assert _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop"
-    ) == 0
+    assert (
+        _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop")
+        == 0
+    )
     capsys.readouterr()
     # Second per-primitive upgrade → from is the recorded override 0.2.0.
-    assert _run_upgrade(
-        pack="core", catalogue=str(CAT_V3), root=str(tmp_path), skill="work-loop"
-    ) == 0
+    assert (
+        _run_upgrade(pack="core", catalogue=str(CAT_V3), root=str(tmp_path), skill="work-loop")
+        == 0
+    )
     recap = capsys.readouterr().out.strip().splitlines()[-1]
     assert recap == "upgraded: core skill/work-loop @ repo 0.2.0 -> 0.3.0", recap
 
@@ -1062,9 +1062,7 @@ def test_per_primitive_upgrade_suppresses_whole_pack_drift_notice(tmp_path, caps
     (tmp_path / sorted(ps.files)[0]).write_text("# local edit\n", encoding="utf-8", newline="\n")
     capsys.readouterr()
 
-    rc = _run_upgrade(
-        pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop"
-    )
+    rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path), skill="work-loop")
     assert rc == 0
     assert "have local edits" not in capsys.readouterr().err
 

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -50,10 +50,14 @@ def _make_catalogue(
     # Profile
     profiles_dir = root / "profiles"
     profiles_dir.mkdir()
-    (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8", newline="\n")
+    (profiles_dir / "default.toml").write_text(
+        '[profile]\nname = "default"\n', encoding="utf-8", newline="\n"
+    )
 
     if with_agents_md:
-        (root / "AGENTS.md").write_text("# Catalogue Agent Context\n", encoding="utf-8", newline="\n")
+        (root / "AGENTS.md").write_text(
+            "# Catalogue Agent Context\n", encoding="utf-8", newline="\n"
+        )
 
     (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8", newline="\n")
 
@@ -65,7 +69,9 @@ def _make_catalogue(
     if with_marketplace:
         cp_dir = root / ".claude-plugin"
         cp_dir.mkdir()
-        (cp_dir / "marketplace.json").write_text('{"packs": ["core"]}\n', encoding="utf-8", newline="\n")
+        (cp_dir / "marketplace.json").write_text(
+            '{"packs": ["core"]}\n', encoding="utf-8", newline="\n"
+        )
 
     return root
 
@@ -209,6 +215,7 @@ def test_channel_descriptor_written_last(tmp_path: Path) -> None:
     def _spy_verify(archive_path, *, sha256_file=None):
         write_order.append("verify_archive")
         from agentbundle.catalogue_tooling.archive import verify_archive
+
         return verify_archive(archive_path, sha256_file=sha256_file)
 
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
@@ -247,6 +254,7 @@ def test_deterministic_under_source_date_epoch(tmp_path: Path) -> None:
     def _arc(out):
         path = out / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
         return path.read_bytes()
+
     assert hashlib.sha256(_arc(out1)).digest() == hashlib.sha256(_arc(out2)).digest()
 
 
@@ -278,14 +286,26 @@ def test_staged_cleanup_on_verify_failure(tmp_path: Path) -> None:
 
     def _failing_verify(archive_path, *, sha256_file=None):
         from agentbundle.catalogue_tooling.results import Diagnostic, Severity, VerifyResult
+
         return VerifyResult(
             ok=False,
-            diagnostics=[Diagnostic(
-                code="TEST", severity=Severity.ERROR, pack=None, path=None,
-                line=None, col=None, message="injected failure", remediation=None,
-            )],
-            schema_version=1, command="test", operation="test",
-            agentbundle_version="0.0.0", catalogue_schema_version=1,
+            diagnostics=[
+                Diagnostic(
+                    code="TEST",
+                    severity=Severity.ERROR,
+                    pack=None,
+                    path=None,
+                    line=None,
+                    col=None,
+                    message="injected failure",
+                    remediation=None,
+                )
+            ],
+            schema_version=1,
+            command="test",
+            operation="test",
+            agentbundle_version="0.0.0",
+            catalogue_schema_version=1,
         )
 
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
@@ -356,6 +376,7 @@ def test_compat_alias_deprecation_warning(tmp_path: Path) -> None:
     import types as _types
 
     from agentbundle.commands.package_catalogue import run
+
     args = _types.SimpleNamespace(
         root=str(root),
         bundle="b",
@@ -409,6 +430,7 @@ def test_extracted_archive_valid_local_catalogue(tmp_path: Path) -> None:
                     dest.write_bytes(fobj.read())
 
     from agentbundle.catalogue_tooling.verify import verify_catalogue
+
     verify_result = verify_catalogue(extract_dir)
     assert verify_result.ok, [d.message for d in verify_result.diagnostics]
 
@@ -482,8 +504,15 @@ def test_cli_catalogue_package_help() -> None:
         cli.main(["catalogue", "package", "--help"])
     assert exc_info.value.code == 0
     help_text = stdout_buf.getvalue()
-    for flag in ["--root", "--bundle", "--release", "--channel", "--output",
-                 "--source-revision", "--minimum-agentbundle-version"]:
+    for flag in [
+        "--root",
+        "--bundle",
+        "--release",
+        "--channel",
+        "--output",
+        "--source-revision",
+        "--minimum-agentbundle-version",
+    ]:
         assert flag in help_text, f"missing flag {flag!r} in help text"
 
 
@@ -623,6 +652,7 @@ def test_check_required_none_uses_defaults(tmp_path: Path) -> None:
 
 def _ok_verify_result():
     from agentbundle.catalogue_tooling.results import VerifyResult
+
     return VerifyResult(
         ok=True,
         diagnostics=[],

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
@@ -162,7 +162,12 @@ def test_render_json_contains_all_fields():
     result = _make_result(ok=False, diagnostics=[_make_error_diag()])
     doc = json.loads(render_json(result))
     for key in (
-        "schema_version", "command", "operation", "agentbundle_version", "ok", "diagnostics"
+        "schema_version",
+        "command",
+        "operation",
+        "agentbundle_version",
+        "ok",
+        "diagnostics",
     ):
         assert key in doc, f"missing key {key!r} in render_json output"
 
@@ -235,6 +240,7 @@ def test_cli_verify_format_json(tmp_path):
 def test_step_agent_artifacts_no_claude_dir(tmp_path):
     """No .claude/ dir → empty list (graceful skip)."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert result == []
 
@@ -242,6 +248,7 @@ def test_step_agent_artifacts_no_claude_dir(tmp_path):
 def test_step_agent_artifacts_skill_missing_name(tmp_path):
     """Skill with no name key → CAT-V-011, 'frontmatter missing required key: name'."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -257,6 +264,7 @@ def test_step_agent_artifacts_skill_missing_name(tmp_path):
 def test_step_agent_artifacts_agent_missing_model(tmp_path):
     """Agent without model → CAT-V-011."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     agents_dir = tmp_path / ".claude" / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "my-agent.md").write_text(
@@ -271,6 +279,7 @@ def test_step_agent_artifacts_agent_missing_model(tmp_path):
 def test_step_agent_artifacts_credentialed_skill_bad_auth(tmp_path):
     """Skill with invalid auth value → CAT-V-011."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     skill_dir = tmp_path / ".claude" / "skills" / "cred-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -285,6 +294,7 @@ def test_step_agent_artifacts_credentialed_skill_bad_auth(tmp_path):
 def test_step_agent_artifacts_unknown_skill_key(tmp_path):
     """Skill with unknown frontmatter key → CAT-V-011."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -299,6 +309,7 @@ def test_step_agent_artifacts_unknown_skill_key(tmp_path):
 def test_step_agent_artifacts_broken_link(tmp_path):
     """Skill with broken relative link → CAT-V-011."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -327,6 +338,7 @@ def test_step_agent_artifacts_pyyaml_absent(tmp_path, monkeypatch):
     monkeypatch.setattr(builtins, "__import__", _mock_import)
 
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
 
     assert len(result) == 1
@@ -338,6 +350,7 @@ def test_step_agent_artifacts_pyyaml_absent(tmp_path, monkeypatch):
 def test_step_agent_artifacts_no_module_scope_yaml():
     """verify.py must not import yaml at module scope."""
     import agentbundle.catalogue_tooling.verify as verify_mod
+
     assert not hasattr(verify_mod, "yaml")
 
 
@@ -358,6 +371,7 @@ def test_step_agent_artifacts_pipeline_integration(tmp_path):
 def test_step_agent_artifacts_clean(tmp_path):
     """A clean skill → empty list."""
     from agentbundle.catalogue_tooling.verify import _step_agent_artifacts
+
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -377,6 +391,7 @@ def test_step_agent_artifacts_clean(tmp_path):
 def test_step_plugin_manifests_no_dist_dir(tmp_path):
     """No dist/claude-plugins dir → empty list (graceful skip)."""
     from agentbundle.catalogue_tooling.verify import _step_plugin_manifests
+
     result = _step_plugin_manifests(tmp_path, None, None, tmp_path)
     assert result == []
 
@@ -384,6 +399,7 @@ def test_step_plugin_manifests_no_dist_dir(tmp_path):
 def test_step_plugin_manifests_invalid_manifest(tmp_path):
     """plugin.json failing schema → CAT-V-013."""
     from agentbundle.catalogue_tooling.verify import _step_plugin_manifests
+
     plugin_dir = tmp_path / "dist" / "claude-plugins" / "my-pack.claude-plugin"
     plugin_dir.mkdir(parents=True)
     (plugin_dir / "plugin.json").write_text(json.dumps({}), encoding="utf-8", newline="\n")
@@ -394,10 +410,13 @@ def test_step_plugin_manifests_invalid_manifest(tmp_path):
 def test_step_plugin_manifests_marketplace_with_hooks(tmp_path):
     """marketplace.json with hooks in plugin entry → CAT-V-013."""
     from agentbundle.catalogue_tooling.verify import _step_plugin_manifests
+
     dist_dir = tmp_path / "dist" / "claude-plugins"
     dist_dir.mkdir(parents=True)
     marketplace = {"plugins": [{"name": "my-pack", "hooks": {"PostInstall": []}}]}
-    (dist_dir / "marketplace.json").write_text(json.dumps(marketplace), encoding="utf-8", newline="\n")
+    (dist_dir / "marketplace.json").write_text(
+        json.dumps(marketplace), encoding="utf-8", newline="\n"
+    )
     result = _step_plugin_manifests(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-013" for d in result)
 
@@ -405,6 +424,7 @@ def test_step_plugin_manifests_marketplace_with_hooks(tmp_path):
 def test_step_plugin_manifests_clean(tmp_path):
     """Empty dist/claude-plugins dir (no manifests, no marketplace.json) → empty list."""
     from agentbundle.catalogue_tooling.verify import _step_plugin_manifests
+
     (tmp_path / "dist" / "claude-plugins").mkdir(parents=True)
     result = _step_plugin_manifests(tmp_path, None, None, tmp_path)
     assert result == []

--- a/packages/agentbundle/tests/unit/test_config_cmd.py
+++ b/packages/agentbundle/tests/unit/test_config_cmd.py
@@ -125,7 +125,9 @@ def test_unset_missing_key_is_noop(capsys) -> None:
 def test_unset_preserves_other_settings(capsys) -> None:
     cfg_path = _user_config_path()
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text(
+        '[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n"
+    )
     exit_code = run(_args("unset", "adapter"))
     assert exit_code == 0
     assert cfg_path.exists()

--- a/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
+++ b/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
@@ -125,7 +125,9 @@ class TestEnumerateDroppedPrimitives(unittest.TestCase):
         """Claude-code has no `dropped` modes."""
         pack = _seed_pack(
             self.tmp_path / "pack",
-            agents=["a"], commands=["c1"], hook_wirings=["w1"],
+            agents=["a"],
+            commands=["c1"],
+            hook_wirings=["w1"],
         )
         result = _enumerate_dropped_primitives(pack, "claude-code")
         self.assertEqual(result, {})
@@ -159,9 +161,15 @@ class TestEnumerateDroppedPrimitives(unittest.TestCase):
         pack = self.tmp_path / "pack"
         (pack / ".apm" / "commands").mkdir(parents=True)
         # One real command (.md), plus junk files.
-        (pack / ".apm" / "commands" / "real.md").write_text("# real\n", encoding="utf-8", newline="\n")
-        (pack / ".apm" / "commands" / ".DS_Store").write_text("junk", encoding="utf-8", newline="\n")
-        (pack / ".apm" / "commands" / "README.txt").write_text("not a command", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "commands" / "real.md").write_text(
+            "# real\n", encoding="utf-8", newline="\n"
+        )
+        (pack / ".apm" / "commands" / ".DS_Store").write_text(
+            "junk", encoding="utf-8", newline="\n"
+        )
+        (pack / ".apm" / "commands" / "README.txt").write_text(
+            "not a command", encoding="utf-8", newline="\n"
+        )
         # Stray subdirectory — shouldn't count toward .md commands.
         (pack / ".apm" / "commands" / "subdir").mkdir()
         result = _enumerate_dropped_primitives(pack, "codex")
@@ -174,8 +182,12 @@ class TestEnumerateDroppedPrimitives(unittest.TestCase):
         # so the dropped-count is absent regardless of suffix. Name preserved.
         pack = self.tmp_path / "pack"
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-        (pack / ".apm" / "hook-wiring" / "real.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
-        (pack / ".apm" / "hook-wiring" / "stray.md").write_text("not a wiring", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "hook-wiring" / "real.toml").write_text(
+            "[hooks]\n", encoding="utf-8", newline="\n"
+        )
+        (pack / ".apm" / "hook-wiring" / "stray.md").write_text(
+            "not a wiring", encoding="utf-8", newline="\n"
+        )
         result = _enumerate_dropped_primitives(pack, "copilot")
         self.assertNotIn("hook-wiring", result)
 
@@ -208,8 +220,11 @@ class TestEnumerateCompatiblePrimitives(unittest.TestCase):
         hook-body + hook-wiring; only `command` drops."""
         pack = _seed_pack(
             self.tmp_path / "pack",
-            skills=["s1"], agents=["a1"], hook_bodies=["h1"],
-            hook_wirings=["w1"], commands=["c1"],
+            skills=["s1"],
+            agents=["a1"],
+            hook_bodies=["h1"],
+            hook_wirings=["w1"],
+            commands=["c1"],
         )
         result = _enumerate_compatible_primitives(pack, "copilot")
         self.assertEqual(set(result), {"skill", "agent", "hook-body", "hook-wiring"})
@@ -234,7 +249,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
 
     def test_one_type_plural(self) -> None:
         msg = _format_dropped_warning(
-            "core", "codex",
+            "core",
+            "codex",
             dropped_counts={"command": 3},
             compatible_types=["skill"],
         )
@@ -242,7 +258,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
 
     def test_two_type(self) -> None:
         msg = _format_dropped_warning(
-            "core", "copilot",
+            "core",
+            "copilot",
             dropped_counts={"agent": 2, "command": 3},
             compatible_types=["skill"],
         )
@@ -251,7 +268,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
 
     def test_three_type_serial_comma(self) -> None:
         msg = _format_dropped_warning(
-            "core", "copilot",
+            "core",
+            "copilot",
             dropped_counts={"agent": 2, "command": 3, "hook-wiring": 1},
             compatible_types=["skill", "hook-body"],
         )
@@ -261,7 +279,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
     def test_zero_count_elision(self) -> None:
         """Counts with a zero entry render as if the zero weren't there."""
         msg = _format_dropped_warning(
-            "core", "codex",
+            "core",
+            "codex",
             dropped_counts={"agent": 0, "command": 3, "hook-wiring": 0},
             compatible_types=["skill"],
         )
@@ -274,7 +293,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
 
     def test_compatible_list_in_message(self) -> None:
         msg = _format_dropped_warning(
-            "core", "codex",
+            "core",
+            "codex",
             dropped_counts={"command": 1},
             compatible_types=["skill", "agent", "hook-body", "hook-wiring"],
         )
@@ -287,7 +307,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
     def test_pinned_wording_exact_template_plural(self) -> None:
         """Spec AC10 pinned wording — exact string match for N>1 case."""
         msg = _format_dropped_warning(
-            "core", "codex",
+            "core",
+            "codex",
             dropped_counts={"command": 3},
             compatible_types=["skill", "agent", "hook-body", "hook-wiring"],
         )
@@ -302,7 +323,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
     def test_pinned_wording_exact_template_singular(self) -> None:
         """Spec AC10 pinned wording — exact string match for N=1 case."""
         msg = _format_dropped_warning(
-            "core", "codex",
+            "core",
+            "codex",
             dropped_counts={"command": 1},
             compatible_types=["skill", "agent"],
         )
@@ -316,7 +338,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
     def test_pinned_wording_exact_template_three_type(self) -> None:
         """Spec AC10 pinned wording — exact string match for serial-comma case."""
         msg = _format_dropped_warning(
-            "core", "copilot",
+            "core",
+            "copilot",
             dropped_counts={"agent": 2, "command": 3, "hook-wiring": 1},
             compatible_types=["skill", "hook-body"],
         )
@@ -334,7 +357,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
         a malformed 'ships  that ...' string."""
         with self.assertRaises(ValueError):
             _format_dropped_warning(
-                "core", "codex",
+                "core",
+                "codex",
                 dropped_counts={"agent": 0, "command": 0},
                 compatible_types=["skill"],
             )
@@ -343,7 +367,8 @@ class TestFormatDroppedWarning(unittest.TestCase):
         """Empty dict raises the same way as all-zero."""
         with self.assertRaises(ValueError):
             _format_dropped_warning(
-                "core", "codex",
+                "core",
+                "codex",
                 dropped_counts={},
                 compatible_types=["skill"],
             )
@@ -364,7 +389,8 @@ class TestShortCircuitSeenSet(unittest.TestCase):
         is silent."""
         pack = _seed_pack(
             self.tmp_path / "pack",
-            agents=["a"], commands=["c"],
+            agents=["a"],
+            commands=["c"],
         )
         import sys
         from io import StringIO
@@ -405,7 +431,8 @@ class TestShortCircuitSeenSet(unittest.TestCase):
         """
         pack = _seed_pack(
             self.tmp_path / "pack",
-            agents=["a"], commands=["c"],
+            agents=["a"],
+            commands=["c"],
         )
         import sys
         from io import StringIO
@@ -416,8 +443,11 @@ class TestShortCircuitSeenSet(unittest.TestCase):
         sys.stderr = captured
         try:
             _maybe_emit_dropped_warning(
-                root=self.tmp_path, pack_dir=pack, pack_name="pack",
-                adapter="copilot", scope="repo",
+                root=self.tmp_path,
+                pack_dir=pack,
+                pack_name="pack",
+                adapter="copilot",
+                scope="repo",
             )
             self.assertIn("warning:", captured.getvalue())
 
@@ -425,8 +455,11 @@ class TestShortCircuitSeenSet(unittest.TestCase):
             captured.seek(0)
             captured.truncate()
             _maybe_emit_dropped_warning(
-                root=self.tmp_path, pack_dir=pack, pack_name="pack",
-                adapter="copilot", scope="repo",
+                root=self.tmp_path,
+                pack_dir=pack,
+                pack_name="pack",
+                adapter="copilot",
+                scope="repo",
             )
             self.assertEqual(captured.getvalue(), "")
 
@@ -434,11 +467,15 @@ class TestShortCircuitSeenSet(unittest.TestCase):
             captured.seek(0)
             captured.truncate()
             _maybe_emit_dropped_warning(
-                root=self.tmp_path, pack_dir=pack, pack_name="pack",
-                adapter="copilot", scope="user",
+                root=self.tmp_path,
+                pack_dir=pack,
+                pack_name="pack",
+                adapter="copilot",
+                scope="user",
             )
             self.assertIn(
-                "warning:", captured.getvalue(),
+                "warning:",
+                captured.getvalue(),
                 "user-scope warning should fire fresh despite repo "
                 "being silenced — that's the independence AC11 pins",
             )
@@ -447,8 +484,11 @@ class TestShortCircuitSeenSet(unittest.TestCase):
             captured.seek(0)
             captured.truncate()
             _maybe_emit_dropped_warning(
-                root=self.tmp_path, pack_dir=pack, pack_name="pack",
-                adapter="copilot", scope="user",
+                root=self.tmp_path,
+                pack_dir=pack,
+                pack_name="pack",
+                adapter="copilot",
+                scope="user",
             )
             self.assertEqual(captured.getvalue(), "")
 
@@ -463,7 +503,9 @@ class TestShortCircuitSeenSet(unittest.TestCase):
         """Claude-code has no dropped modes; warning stays silent."""
         pack = _seed_pack(
             self.tmp_path / "pack",
-            agents=["a"], commands=["c"], hook_wirings=["w"],
+            agents=["a"],
+            commands=["c"],
+            hook_wirings=["w"],
         )
         import sys
         from io import StringIO

--- a/packages/agentbundle/tests/unit/test_lint_spec_status_deferred.py
+++ b/packages/agentbundle/tests/unit/test_lint_spec_status_deferred.py
@@ -7,6 +7,7 @@ Tests:
   (e) malformed TOML drives through backlog_open_slugs (not just _regex helper)
   (f) _regex_backlog_slugs directly resolves slugs from [backlog].open
 """
+
 from __future__ import annotations
 
 import importlib.util
@@ -30,7 +31,9 @@ def test_workspace_only_slug_passes_check(tmp_path: Path) -> None:
     lint = _load_lint_module()
 
     workspace = tmp_path / "workspace.toml"
-    workspace.write_text('[backlog]\nopen = [{slug = "my-ws-only-slug"}]\n', encoding="utf-8", newline="\n")
+    workspace.write_text(
+        '[backlog]\nopen = [{slug = "my-ws-only-slug"}]\n', encoding="utf-8", newline="\n"
+    )
 
     specs = tmp_path / "docs" / "specs" / "my-spec"
     specs.mkdir(parents=True)
@@ -60,7 +63,9 @@ def test_slug_absent_from_workspace_is_hard_violation(tmp_path: Path) -> None:
         encoding="utf-8",
         newline="\n",
     )
-    (tmp_path / "workspace.toml").write_text("[backlog]\nopen = []\n", encoding="utf-8", newline="\n")
+    (tmp_path / "workspace.toml").write_text(
+        "[backlog]\nopen = []\n", encoding="utf-8", newline="\n"
+    )
 
     hard, _warn = lint.check(tmp_path, base_ref=None)
     assert any("nonexistent-slug" in v for v in hard)

--- a/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
+++ b/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
@@ -62,9 +62,7 @@ class MergeIntoAgentJsonTests(unittest.TestCase):
                 wiring_tomls={
                     "on-prompt": {
                         "attach-to-agent": "reviewer",
-                        "hooks": {
-                            "userPromptSubmit": [{"command": "x", "matcher": ""}]
-                        },
+                        "hooks": {"userPromptSubmit": [{"command": "x", "matcher": ""}]},
                     }
                 },
             )
@@ -73,7 +71,9 @@ class MergeIntoAgentJsonTests(unittest.TestCase):
             self.assertEqual(data["name"], "reviewer")
             self.assertEqual(data["description"], "Reviews pending work.")
             # Hooks merged.
-            self.assertEqual(data["hooks"]["userPromptSubmit"][0]["id"], "clipboard-summary:on-prompt")  # noqa: E501
+            self.assertEqual(
+                data["hooks"]["userPromptSubmit"][0]["id"], "clipboard-summary:on-prompt"
+            )  # noqa: E501
             self.assertEqual(data["hooks"]["userPromptSubmit"][0]["command"], "x")
             self.assertEqual(owned, [("userPromptSubmit", "clipboard-summary:on-prompt")])
 
@@ -226,7 +226,9 @@ class FailureModeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "reviewer.json"
-            target.write_text(json.dumps({"name": "x", "hooks": ["wrong"]}), encoding="utf-8", newline="\n")
+            target.write_text(
+                json.dumps({"name": "x", "hooks": ["wrong"]}), encoding="utf-8", newline="\n"
+            )
             with self.assertRaises(AgentJsonRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             self.assertIn("hooks has unexpected shape", str(ctx.exception))
@@ -264,9 +266,7 @@ class EventVocabularyRailTests(unittest.TestCase):
 
         refusal = check_kiro_event_vocabulary(
             pack_name="demo",
-            wiring_tomls={
-                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
-            },
+            wiring_tomls={"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}},
             vocabulary=["agentSpawn", "userPromptSubmit", "preToolUse"],
             target_adapters={"kiro"},
             adapter_name="kiro",
@@ -280,9 +280,7 @@ class EventVocabularyRailTests(unittest.TestCase):
 
         refusal = check_kiro_event_vocabulary(
             pack_name="demo",
-            wiring_tomls={
-                "on-prompt": {"hooks": {"userPromptSubmit": [{"command": "x"}]}}
-            },
+            wiring_tomls={"on-prompt": {"hooks": {"userPromptSubmit": [{"command": "x"}]}}},
             vocabulary=["agentSpawn", "userPromptSubmit", "preToolUse"],
             target_adapters={"kiro"},
             adapter_name="kiro",
@@ -298,9 +296,7 @@ class EventVocabularyRailTests(unittest.TestCase):
 
         refusal = check_kiro_event_vocabulary(
             pack_name="demo",
-            wiring_tomls={
-                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
-            },
+            wiring_tomls={"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}},
             vocabulary=None,  # adapter doesn't declare it
             target_adapters={"claude-code"},
             adapter_name="claude-code",
@@ -314,9 +310,7 @@ class EventVocabularyRailTests(unittest.TestCase):
 
         refusal = check_kiro_event_vocabulary(
             pack_name="demo",
-            wiring_tomls={
-                "on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}
-            },
+            wiring_tomls={"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}},
             vocabulary=["agentSpawn"],
             target_adapters={"claude-code"},
             adapter_name="kiro",
@@ -334,7 +328,9 @@ class EventVocabularyRailTests(unittest.TestCase):
         refusal = check_kiro_event_vocabulary(
             pack_name="demo",
             wiring_tomls={
-                "first": {"hooks": {"GoodEvent": [{"command": "x"}], "BadOne": [{"command": "y"}]}},  # noqa: E501
+                "first": {
+                    "hooks": {"GoodEvent": [{"command": "x"}], "BadOne": [{"command": "y"}]}
+                },  # noqa: E501
                 "second": {"hooks": {"AlsoBad": [{"command": "z"}]}},
             },
             vocabulary=["GoodEvent"],

--- a/packages/agentbundle/tests/unit/test_pack_config_api.py
+++ b/packages/agentbundle/tests/unit/test_pack_config_api.py
@@ -150,9 +150,7 @@ def test_pack_dir_state_rows_disagree(tmp_path):
     state.packs[("atlassian", "claude-code")] = PackState(
         installed_version="1.0.0", user_root="~/.agentbundle"
     )
-    state.packs[("atlassian", "kiro")] = PackState(
-        installed_version="1.0.0", user_root="~/other"
-    )
+    state.packs[("atlassian", "kiro")] = PackState(installed_version="1.0.0", user_root="~/other")
 
     with pytest.raises(PackRootConflict) as exc_info:
         pack_dir("atlassian", state=state, home=tmp_path)
@@ -221,7 +219,9 @@ def test_load_pack_config_user_override(tmp_path):
     from agentbundle.config import load_pack_config, pack_dir
 
     d = pack_dir("atlassian", home=tmp_path)
-    (d / "config.toml").write_text('url = "https://custom.example.com/"', encoding="utf-8", newline="\n")
+    (d / "config.toml").write_text(
+        'url = "https://custom.example.com/"', encoding="utf-8", newline="\n"
+    )
     result = load_pack_config("atlassian", home=tmp_path)
 
     assert result.get("url") == "https://custom.example.com/"
@@ -308,10 +308,7 @@ def test_write_entry_reserved_key_raises(tmp_path):
     from agentbundle.oplog import write_entry
 
     with pytest.raises(ValueError, match="reserved"):
-        write_entry(
-            "atlassian", "install", src="s",
-            extra={"ts": "2026-01-01"}, home=tmp_path
-        )
+        write_entry("atlassian", "install", src="s", extra={"ts": "2026-01-01"}, home=tmp_path)
     # No I/O should have happened
     ops_file = tmp_path / ".agentbundle" / "atlassian" / "ops.jsonl"
     assert not ops_file.exists()
@@ -330,10 +327,7 @@ def test_write_entry_too_large_raises(tmp_path):
 def test_write_entry_extra_truncated(tmp_path):
     from agentbundle.oplog import write_entry
 
-    write_entry(
-        "atlassian", "install", src="s",
-        extra={"k": "v" * 5000}, home=tmp_path
-    )
+    write_entry("atlassian", "install", src="s", extra={"k": "v" * 5000}, home=tmp_path)
 
     ops_file = tmp_path / ".agentbundle" / "atlassian" / "ops.jsonl"
     entry = json.loads(ops_file.read_text(encoding="utf-8").strip())

--- a/packages/agentbundle/tests/unit/test_package_catalogue.py
+++ b/packages/agentbundle/tests/unit/test_package_catalogue.py
@@ -70,14 +70,20 @@ def _make_fixture_catalogue(
     if with_profiles:
         profiles_dir = root / "profiles"
         profiles_dir.mkdir()
-        (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8", newline="\n")  # noqa: E501
+        (profiles_dir / "default.toml").write_text(
+            '[profile]\nname = "default"\n', encoding="utf-8", newline="\n"
+        )  # noqa: E501
 
     if with_contracts:
         contracts_dir = root / "contracts"
         contracts_dir.mkdir(parents=True)
-        (contracts_dir / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8", newline="\n")  # noqa: E501
+        (contracts_dir / "adapter.toml").write_text(
+            '[contract]\nversion = "1"\n', encoding="utf-8", newline="\n"
+        )  # noqa: E501
 
-    (root / "AGENTS.md").write_text("# Test Catalogue Agent Context\n", encoding="utf-8", newline="\n")
+    (root / "AGENTS.md").write_text(
+        "# Test Catalogue Agent Context\n", encoding="utf-8", newline="\n"
+    )
 
     if with_readme:
         (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8", newline="\n")
@@ -134,9 +140,7 @@ def _make_args(
 
 
 def test_scan_content_includes_allowlisted_files(tmp_path: Path) -> None:
-    root = _make_fixture_catalogue(
-        tmp_path, extra_dirs=["build", "tests", ".git"]
-    )
+    root = _make_fixture_catalogue(tmp_path, extra_dirs=["build", "tests", ".git"])
     paths = _scan_content(root)
     posix = [p.relative_to(root).as_posix() for p in paths]
     # Allowlisted entries present (Wave 4 allowlist)
@@ -181,8 +185,12 @@ def test_scan_content_returns_sorted_paths(tmp_path: Path) -> None:
 
 def test_scan_content_absent_optional_dir(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(
-        tmp_path, with_profiles=False, with_contracts=False, with_readme=False,
-        with_license=False, with_marketplace=False,
+        tmp_path,
+        with_profiles=False,
+        with_contracts=False,
+        with_readme=False,
+        with_license=False,
+        with_marketplace=False,
     )
     paths = _scan_content(root)
     posix = [p.relative_to(root).as_posix() for p in paths]
@@ -244,7 +252,9 @@ def test_validate_content_top_level_dir_symlink_rejected(tmp_path: Path) -> None
     real_packs.mkdir()
     pack_dir = real_packs / "core"
     pack_dir.mkdir()
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     root = tmp_path / "cat"
     root.mkdir()
@@ -261,14 +271,18 @@ def test_validate_content_intermediate_dir_symlink_rejected(tmp_path: Path) -> N
     real_docs = tmp_path / "real_docs"
     contracts = real_docs / "contracts"
     contracts.mkdir(parents=True)
-    (contracts / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8", newline="\n")
+    (contracts / "adapter.toml").write_text(
+        '[contract]\nversion = "1"\n', encoding="utf-8", newline="\n"
+    )
 
     root = tmp_path / "cat"
     root.mkdir()
     # packs/ must exist for packs-dir check not to fire first
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     symlink_docs = root / "docs"
     symlink_docs.symlink_to(real_docs)
@@ -309,7 +323,9 @@ def test_validate_content_traversal_rejected(tmp_path: Path) -> None:
     (root / "packs").mkdir()
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir()
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
+    (pack_dir / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
+    )  # noqa: E501
 
     outside = tmp_path / "outside.txt"
     outside.write_text("evil\n", encoding="utf-8", newline="\n")
@@ -416,18 +432,24 @@ def test_generate_manifest_required_fields() -> None:
 
 def test_generate_manifest_source_revision_null() -> None:
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision=None,
+        bundle="b",
+        release="r",
+        source_revision=None,
         generated_at="2023-11-14T22:13:20+00:00",
-        file_digests={}, packs_metadata=[],
+        file_digests={},
+        packs_metadata=[],
     )
     assert json.loads(manifest_bytes)["source_revision"] is None
 
 
 def test_generate_manifest_source_revision_string() -> None:
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision="abc123",
+        bundle="b",
+        release="r",
+        source_revision="abc123",
         generated_at="2023-11-14T22:13:20+00:00",
-        file_digests={}, packs_metadata=[],
+        file_digests={},
+        packs_metadata=[],
     )
     assert json.loads(manifest_bytes)["source_revision"] == "abc123"
 
@@ -435,9 +457,12 @@ def test_generate_manifest_source_revision_string() -> None:
 def test_generate_manifest_files_sorted() -> None:
     digests = {"z/file.txt": "a" * 64, "a/file.txt": "b" * 64}
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision=None,
+        bundle="b",
+        release="r",
+        source_revision=None,
         generated_at="2023-11-14T22:13:20+00:00",
-        file_digests=digests, packs_metadata=[],
+        file_digests=digests,
+        packs_metadata=[],
     )
     files = json.loads(manifest_bytes)["files"]
     paths = [f["path"] for f in files]
@@ -447,9 +472,12 @@ def test_generate_manifest_files_sorted() -> None:
 def test_generate_manifest_packs_sorted() -> None:
     packs = [{"name": "zzz", "version": "1.0.0"}, {"name": "aaa", "version": "2.0.0"}]
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision=None,
+        bundle="b",
+        release="r",
+        source_revision=None,
         generated_at="2023-11-14T22:13:20+00:00",
-        file_digests={}, packs_metadata=packs,
+        file_digests={},
+        packs_metadata=packs,
     )
     pack_names = [p["name"] for p in json.loads(manifest_bytes)["packs"]]
     assert pack_names == sorted(pack_names)
@@ -457,9 +485,12 @@ def test_generate_manifest_packs_sorted() -> None:
 
 def test_generate_manifest_no_self_reference() -> None:
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision=None,
+        bundle="b",
+        release="r",
+        source_revision=None,
         generated_at="2023-11-14T22:13:20+00:00",
-        file_digests={"packs/core/pack.toml": "a" * 64}, packs_metadata=[],
+        file_digests={"packs/core/pack.toml": "a" * 64},
+        packs_metadata=[],
     )
     paths = [f["path"] for f in json.loads(manifest_bytes)["files"]]
     assert "catalogue-manifest.json" not in paths
@@ -468,9 +499,12 @@ def test_generate_manifest_no_self_reference() -> None:
 def test_generate_manifest_accepts_fixed_generated_at() -> None:
     ts = "2023-11-14T22:13:20+00:00"
     manifest_bytes = _generate_manifest(
-        bundle="b", release="r", source_revision=None,
+        bundle="b",
+        release="r",
+        source_revision=None,
         generated_at=ts,
-        file_digests={}, packs_metadata=[],
+        file_digests={},
+        packs_metadata=[],
     )
     assert json.loads(manifest_bytes)["generated_at"] == ts
 
@@ -668,8 +702,17 @@ def test_package_catalogue_end_to_end(tmp_path: Path) -> None:
     assert result == 0
 
     # AC3: exactly three output files
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
-    sidecar_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz.sha256"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
+    sidecar_path = (
+        output
+        / "catalogues"
+        / "engineering"
+        / "releases"
+        / "0.1.0"
+        / "catalogue-0.1.0.tar.gz.sha256"
+    )  # noqa: E501
     descriptor_path = output / "catalogues" / "engineering" / "channels" / "stable.json"
 
     assert archive_path.exists()
@@ -728,7 +771,9 @@ def test_package_catalogue_refuse_overwrite(tmp_path: Path) -> None:
     args = _make_args(root, output=output)
 
     # Pre-create the archive path with known content
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     archive_path.write_bytes(b"existing_content")
 
@@ -756,8 +801,12 @@ def test_package_catalogue_archive_reproducible(tmp_path: Path) -> None:
     assert r1 == 0
     assert r2 == 0
 
-    a1 = (output1 / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz").read_bytes()  # noqa: E501
-    a2 = (output2 / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz").read_bytes()  # noqa: E501
+    a1 = (
+        output1 / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    ).read_bytes()  # noqa: E501
+    a2 = (
+        output2 / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    ).read_bytes()  # noqa: E501
     assert hashlib.sha256(a1).digest() == hashlib.sha256(a2).digest()
 
 
@@ -769,7 +818,9 @@ def test_package_catalogue_sidecar_format(tmp_path: Path) -> None:
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     sidecar_path = archive_path.parent / "catalogue-0.1.0.tar.gz.sha256"
 
     archive_bytes = archive_path.read_bytes()
@@ -786,7 +837,9 @@ def test_package_catalogue_source_date_epoch_in_manifest(tmp_path: Path) -> None
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     with tarfile.open(fileobj=io.BytesIO(archive_path.read_bytes()), mode="r:gz") as tf:
         mf = tf.extractfile("catalogue-manifest.json")
         assert mf is not None
@@ -804,7 +857,9 @@ def test_package_catalogue_generated_at_no_microseconds(tmp_path: Path) -> None:
     with mock.patch.dict(os.environ, env, clear=True):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     with tarfile.open(fileobj=io.BytesIO(archive_path.read_bytes()), mode="r:gz") as tf:
         mf = tf.extractfile("catalogue-manifest.json")
         assert mf is not None
@@ -868,12 +923,18 @@ def test_package_catalogue_install_flags_rejected(extra_flags: list[str], tmp_pa
         cli.main(
             [
                 "package-catalogue",
-                "--root", ".",
-                "--bundle", "b",
-                "--release", "r",
-                "--channel", "c",
-                "--output", ".",
-            ] + extra_flags
+                "--root",
+                ".",
+                "--bundle",
+                "b",
+                "--release",
+                "r",
+                "--channel",
+                "c",
+                "--output",
+                ".",
+            ]
+            + extra_flags
         )
     assert exc_info.value.code != 0
 
@@ -886,7 +947,9 @@ def test_package_catalogue_sha256_in_descriptor_matches_sidecar(tmp_path: Path) 
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     sidecar_path = archive_path.parent / "catalogue-0.1.0.tar.gz.sha256"
     descriptor_path = output / "catalogues" / "engineering" / "channels" / "stable.json"
 
@@ -941,6 +1004,7 @@ def test_package_catalogue_published_at_default(tmp_path: Path) -> None:
     assert "." not in descriptor["published_at"]
     # Must be parseable as an ISO-8601 datetime
     from datetime import datetime
+
     dt = datetime.fromisoformat(descriptor["published_at"])
     assert dt is not None
 
@@ -953,7 +1017,9 @@ def test_package_catalogue_manifest_digest_matches_archived_bytes(tmp_path: Path
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     archive_bytes = archive_path.read_bytes()
 
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
@@ -983,7 +1049,9 @@ def test_package_catalogue_packs_version_matches_archived_pack_toml(tmp_path: Pa
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
         run(_make_args(root, output=output))
 
-    archive_path = output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"  # noqa: E501
+    archive_path = (
+        output / "catalogues" / "engineering" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
+    )  # noqa: E501
     archive_bytes = archive_path.read_bytes()
 
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
@@ -1049,6 +1117,7 @@ def test_package_catalogue_flag_traversal_rejected(flag: str, value: str, tmp_pa
 def test_no_git_shell_out_in_package_catalogue() -> None:
     """AC23: no subprocess/git shell-out in package_catalogue.py."""
     import re
+
     source_path = Path(package_catalogue.__file__)
     content = source_path.read_text(encoding="utf-8")
     patterns = [
@@ -1061,19 +1130,44 @@ def test_no_git_shell_out_in_package_catalogue() -> None:
         r'\["git"',
     ]
     for pat in patterns:
-        assert not re.search(pat, content), f"Found disallowed pattern {pat!r} in package_catalogue.py"  # noqa: E501
+        assert not re.search(pat, content), (
+            f"Found disallowed pattern {pat!r} in package_catalogue.py"
+        )  # noqa: E501
 
 
 def test_no_new_runtime_dependency() -> None:
     """AC27: package_catalogue.py imports only stdlib and agentbundle."""
     import ast
+
     source_path = Path(package_catalogue.__file__)
     tree = ast.parse(source_path.read_text(encoding="utf-8"))
     stdlib_modules = {
-        "gzip", "hashlib", "io", "json", "os", "re", "sys", "tarfile", "tomllib",
-        "datetime", "pathlib", "typing", "contextlib", "collections", "__future__",
-        "abc", "argparse", "functools", "itertools", "math", "shutil", "string",
-        "time", "types", "warnings", "copy",
+        "gzip",
+        "hashlib",
+        "io",
+        "json",
+        "os",
+        "re",
+        "sys",
+        "tarfile",
+        "tomllib",
+        "datetime",
+        "pathlib",
+        "typing",
+        "contextlib",
+        "collections",
+        "__future__",
+        "abc",
+        "argparse",
+        "functools",
+        "itertools",
+        "math",
+        "shutil",
+        "string",
+        "time",
+        "types",
+        "warnings",
+        "copy",
     }
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/packages/agentbundle/tests/unit/test_safety_repo_scope_prefixes.py
+++ b/packages/agentbundle/tests/unit/test_safety_repo_scope_prefixes.py
@@ -158,7 +158,9 @@ class ScanForPackArtifactsTests(unittest.TestCase):
         with TemporaryDirectory() as raw:
             root = Path(raw)
             (root / ".claude" / "skills" / "demo").mkdir(parents=True)
-            (root / ".claude" / "skills" / "demo" / "SKILL.md").write_text("x", encoding="utf-8", newline="\n")
+            (root / ".claude" / "skills" / "demo" / "SKILL.md").write_text(
+                "x", encoding="utf-8", newline="\n"
+            )
             (root / ".claude" / "agents").mkdir(parents=True)
             (root / ".claude" / "agents" / "a.md").write_text("y", encoding="utf-8", newline="\n")
             found = safety.scan_for_pack_artifacts(root, [".claude/"])
@@ -177,9 +179,7 @@ class ScanForPackArtifactsTests(unittest.TestCase):
             (root / ".claude" / "skills" / "x.md").write_text("x", encoding="utf-8", newline="\n")
             (root / ".agentbundle").mkdir(parents=True)
             (root / ".agentbundle" / "state.toml").write_text("y", encoding="utf-8", newline="\n")
-            found = safety.scan_for_pack_artifacts(
-                root, [".claude/", ".agentbundle/"]
-            )
+            found = safety.scan_for_pack_artifacts(root, [".claude/", ".agentbundle/"])
             self.assertEqual(len(found), 2)
 
     def test_missing_prefix_dirs_silently_skipped(self) -> None:
@@ -190,9 +190,7 @@ class ScanForPackArtifactsTests(unittest.TestCase):
             (root / ".claude" / "skills").mkdir(parents=True)
             (root / ".claude" / "skills" / "x.md").write_text("x", encoding="utf-8", newline="\n")
             # .kiro/ doesn't exist — skipped, not an error.
-            found = safety.scan_for_pack_artifacts(
-                root, [".claude/", ".kiro/"]
-            )
+            found = safety.scan_for_pack_artifacts(root, [".claude/", ".kiro/"])
             self.assertEqual(len(found), 1)
 
     def test_read_only_no_state_mutation(self) -> None:

--- a/packages/agentbundle/tests/unit/test_safety_scan_per_pack_scoping.py
+++ b/packages/agentbundle/tests/unit/test_safety_scan_per_pack_scoping.py
@@ -54,7 +54,7 @@ def _make_pack_source(
     )
     apm = pack_dir / ".apm"
     apm.mkdir()
-    for skill_name in (skills or []):
+    for skill_name in skills or []:
         skill_dir = apm / "skills" / skill_name
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
@@ -62,12 +62,10 @@ def _make_pack_source(
             encoding="utf-8",
             newline="\n",
         )
-    for agent_name in (agents or []):
+    for agent_name in agents or []:
         agents_dir = apm / "agents"
         agents_dir.mkdir(exist_ok=True)
-        (agents_dir / f"{agent_name}.md").write_text(
-            "agent body", encoding="utf-8", newline="\n"
-        )
+        (agents_dir / f"{agent_name}.md").write_text("agent body", encoding="utf-8", newline="\n")
     return pack_dir
 
 
@@ -121,12 +119,15 @@ class PerPackScopingTests(unittest.TestCase):
             _plant(adopter, ".claude/skills/bpack-skill/SKILL.md")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             rels = sorted(p.relative_to(adopter).as_posix() for p in result)
             self.assertEqual(
-                rels, [".claude/skills/bpack-skill/SKILL.md"],
+                rels,
+                [".claude/skills/bpack-skill/SKILL.md"],
                 f"pack-A's orphan leaked into pack-B's scan: {rels!r}",
             )
 
@@ -148,11 +149,14 @@ class PerPackScopingTests(unittest.TestCase):
             _plant(adopter, ".claude/agents/some-other-agent.md")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             self.assertEqual(
-                result, [],
+                result,
+                [],
                 f"cross-pack false positive: {[str(p) for p in result]!r}",
             )
 
@@ -175,12 +179,15 @@ class PerPackScopingTests(unittest.TestCase):
             _plant(adopter, ".github/instructions/apack.md")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".github/instructions/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".github/instructions/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             rels = sorted(p.relative_to(adopter).as_posix() for p in result)
             self.assertEqual(
-                rels, [".github/instructions/bpack.md"],
+                rels,
+                [".github/instructions/bpack.md"],
                 f"copilot stem match failed: {rels!r}",
             )
 
@@ -203,12 +210,15 @@ class PerPackScopingTests(unittest.TestCase):
             _plant(adopter, ".agents/skills/apack-skill/SKILL.md")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".agents/skills/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".agents/skills/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             rels = sorted(p.relative_to(adopter).as_posix() for p in result)
             self.assertEqual(
-                rels, [".agents/skills/bpack-skill/SKILL.md"],
+                rels,
+                [".agents/skills/bpack-skill/SKILL.md"],
                 f"codex primitive-segment match failed: {rels!r}",
             )
 
@@ -222,7 +232,8 @@ class PerPackScopingTests(unittest.TestCase):
             packs = tmp / "packs"
             packs.mkdir()
             _make_pack_source(
-                packs, name="bpack",
+                packs,
+                name="bpack",
                 skills=["bpack-skill"],
                 agents=["bpack-agent"],
             )
@@ -233,14 +244,15 @@ class PerPackScopingTests(unittest.TestCase):
             _plant(adopter, ".claude/skills/foreign-skill/SKILL.md")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             rels = sorted(p.relative_to(adopter).as_posix() for p in result)
             self.assertEqual(
                 rels,
-                [".claude/agents/bpack-agent.md",
-                 ".claude/skills/bpack-skill/SKILL.md"],
+                [".claude/agents/bpack-agent.md", ".claude/skills/bpack-skill/SKILL.md"],
             )
 
     def test_pack_with_no_apm_directory_only_matches_pack_name(self) -> None:
@@ -268,8 +280,10 @@ class PerPackScopingTests(unittest.TestCase):
 
             # Copilot shape: matches.
             copilot = safety.scan_for_pack_artifacts(
-                adopter, [".github/instructions/"],
-                pack_dir=pack_dir, pack_name="bpack",
+                adopter,
+                [".github/instructions/"],
+                pack_dir=pack_dir,
+                pack_name="bpack",
             )
             self.assertEqual(
                 [p.relative_to(adopter).as_posix() for p in copilot],
@@ -278,8 +292,10 @@ class PerPackScopingTests(unittest.TestCase):
             # Claude-shape: no match (no primitive directories to match
             # against, and "bpack" doesn't appear in the foreign path).
             claude = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=pack_dir, pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=pack_dir,
+                pack_name="bpack",
             )
             self.assertEqual(claude, [])
 
@@ -311,11 +327,14 @@ class CrossPackNameCollisionTests(unittest.TestCase):
             _plant(adopter, ".claude/hooks/bpack.py", content="foreign-hook")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             self.assertEqual(
-                result, [],
+                result,
+                [],
                 "cross-pack name collision matched pack B's scan; "
                 "the depth-restricted stem rule isn't holding",
             )
@@ -339,11 +358,14 @@ class CrossPackNameCollisionTests(unittest.TestCase):
             _plant(adopter, ".claude/skills/bpack/SKILL.md", content="foreign")
 
             result = safety.scan_for_pack_artifacts(
-                adopter, [".claude/"],
-                pack_dir=packs / "bpack", pack_name="bpack",
+                adopter,
+                [".claude/"],
+                pack_dir=packs / "bpack",
+                pack_name="bpack",
             )
             self.assertEqual(
-                result, [],
+                result,
+                [],
                 "cross-pack segment-named-after-pack-name matched; "
                 "primitive_names should not include pack_name itself",
             )
@@ -363,17 +385,17 @@ class CollectPackOwnedNamesTests(unittest.TestCase):
             packs = tmp / "packs"
             packs.mkdir()
             _make_pack_source(
-                packs, name="bpack",
+                packs,
+                name="bpack",
                 skills=["bpack-skill"],
                 agents=["bpack-agent"],
             )
-            primitives, stem = _collect_pack_owned_names(
-                packs / "bpack", "bpack"
-            )
+            primitives, stem = _collect_pack_owned_names(packs / "bpack", "bpack")
             self.assertEqual(primitives, {"bpack-skill", "bpack-agent"})
             self.assertEqual(stem, "bpack")
             self.assertNotIn(
-                "bpack", primitives,
+                "bpack",
+                primitives,
                 "primitive_names must not include pack_name — that's "
                 "what enabled the cross-pack collision regression",
             )
@@ -390,11 +412,11 @@ class CollectPackOwnedNamesTests(unittest.TestCase):
             _make_pack_source(packs, name="bpack", skills=["bpack-skill"])
             # Plant noise under .apm/skills/.
             (packs / "bpack" / ".apm" / "skills" / "__pycache__").mkdir()
-            (packs / "bpack" / ".apm" / "skills" / ".DS_Store").write_text("", encoding="utf-8", newline="\n")
-
-            primitives, _ = _collect_pack_owned_names(
-                packs / "bpack", "bpack"
+            (packs / "bpack" / ".apm" / "skills" / ".DS_Store").write_text(
+                "", encoding="utf-8", newline="\n"
             )
+
+            primitives, _ = _collect_pack_owned_names(packs / "bpack", "bpack")
             self.assertEqual(primitives, {"bpack-skill"})
 
     def test_rfc_0013_primitive_types_are_collected(self) -> None:
@@ -412,18 +434,24 @@ class CollectPackOwnedNamesTests(unittest.TestCase):
             pack_dir = tmp / "broker"
             apm = pack_dir / ".apm"
             (apm / "shared-libs").mkdir(parents=True)
-            (apm / "shared-libs" / "credentials_shim.py").write_text("x", encoding="utf-8", newline="\n")
+            (apm / "shared-libs" / "credentials_shim.py").write_text(
+                "x", encoding="utf-8", newline="\n"
+            )
             (apm / "adapter-root-bins").mkdir(parents=True)
-            (apm / "adapter-root-bins" / "sso-broker.py").write_text("x", encoding="utf-8", newline="\n")
+            (apm / "adapter-root-bins" / "sso-broker.py").write_text(
+                "x", encoding="utf-8", newline="\n"
+            )
 
             primitives, _ = _collect_pack_owned_names(pack_dir, "broker")
             self.assertIn(
-                "credentials_shim", primitives,
+                "credentials_shim",
+                primitives,
                 "shared-libs primitive not collected; RFC-0013 type "
                 "missing from _PACK_PRIMITIVE_TYPES",
             )
             self.assertIn(
-                "sso-broker", primitives,
+                "sso-broker",
+                primitives,
                 "adapter-root-bins primitive not collected; RFC-0013 "
                 "type missing from _PACK_PRIMITIVE_TYPES",
             )

--- a/packages/agentbundle/tests/unit/test_scaffold_cmd.py
+++ b/packages/agentbundle/tests/unit/test_scaffold_cmd.py
@@ -270,6 +270,7 @@ def test_scaffold_refuses_path_jail_escape(tmp_path, monkeypatch):
     # resolved outside the root.
     def _refuse(root, relpath, content):
         raise safety.PathJailError("refusing to write outside repo root: /etc")
+
     monkeypatch.setattr(safety, "write_jailed", _refuse)
 
     args = argparse.Namespace(pack="evil", packs_dir=str(packs_dir), output=str(output))
@@ -285,10 +286,13 @@ def test_init_state_refuses_path_jail_escape(tmp_path, monkeypatch):
     packs_dir = tmp_path / "packs"
     pack = packs_dir / "core"
     (pack).mkdir(parents=True)
-    (pack / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1"\n', encoding="utf-8", newline="\n")
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "core"\nversion = "0.1"\n', encoding="utf-8", newline="\n"
+    )
 
     def _refuse(root, relpath, content):
         raise safety.PathJailError("refusing to write outside repo root: /etc")
+
     monkeypatch.setattr(safety, "write_jailed", _refuse)
 
     args = argparse.Namespace(pack="core", packs_dir=str(packs_dir), root=str(tmp_path))

--- a/packages/agentbundle/tests/unit/test_source_defaults.py
+++ b/packages/agentbundle/tests/unit/test_source_defaults.py
@@ -65,7 +65,9 @@ def _make_markers(root: Path) -> None:
 
 def _make_git(root: Path, *, as_file: bool = False) -> None:
     if as_file:
-        (root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8", newline="\n")
+        (root / ".git").write_text(
+            "gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8", newline="\n"
+        )
     else:
         (root / ".git").mkdir(parents=True, exist_ok=True)
 
@@ -345,9 +347,7 @@ def test_invalid_packaged_default_skipped():
 
 def test_all_layers_empty_raises_with_recovery_paths():
     with pytest.raises(CatalogueError) as exc:
-        resolve_default_source(
-            None, config_source=None, dist=None, read_packaged=lambda: None
-        )
+        resolve_default_source(None, config_source=None, dist=None, read_packaged=lambda: None)
     msg = str(exc.value)
     assert (
         "no catalogue source: pass a catalogue argument, run 'agentbundle config "
@@ -362,9 +362,7 @@ def test_no_implicit_cwd_fallback(tmp_path, monkeypatch):
     _make_markers(tmp_path)
     monkeypatch.chdir(tmp_path)
     with pytest.raises(CatalogueError):
-        resolve_default_source(
-            None, config_source=None, dist=None, read_packaged=lambda: None
-        )
+        resolve_default_source(None, config_source=None, dist=None, read_packaged=lambda: None)
 
 
 def test_editable_detected_but_no_root_falls_through_to_layer4(tmp_path, capsys):
@@ -399,18 +397,23 @@ def test_resolution_writes_nothing(tmp_path, monkeypatch):
 
     clone, pkg = _clone(tmp_path)
     # layer 2 hit
-    resolve_default_source(None, config_source="git+https://github.com/x/y", dist=None,
-                           read_packaged=lambda: None)
+    resolve_default_source(
+        None, config_source="git+https://github.com/x/y", dist=None, read_packaged=lambda: None
+    )
     # layer 3 hit
-    resolve_default_source(None, config_source=None, dist=_FakeDist(_direct_url(pkg)),
-                           read_packaged=lambda: None)
+    resolve_default_source(
+        None, config_source=None, dist=_FakeDist(_direct_url(pkg)), read_packaged=lambda: None
+    )
     # editable-deferred + layer 4
-    resolve_default_source(None, config_source="http://bad", dist=None,
-                           read_packaged=lambda: "git+https://github.com/a/b")
+    resolve_default_source(
+        None,
+        config_source="http://bad",
+        dist=None,
+        read_packaged=lambda: "git+https://github.com/a/b",
+    )
     # all-layers-empty error path
     with pytest.raises(CatalogueError):
-        resolve_default_source(None, config_source=None, dist=None,
-                               read_packaged=lambda: None)
+        resolve_default_source(None, config_source=None, dist=None, read_packaged=lambda: None)
     assert cfg.read_bytes() == before
 
 
@@ -495,7 +498,10 @@ def test_read_packaged_preferred_adapter_valid_returns_value(monkeypatch):
         lambda _t: "cursor",
     )
     from agentbundle import scope as _scope
-    monkeypatch.setattr(_scope, "shipped_adapters_from_contract", lambda: ("cursor", "claude-code"))  # noqa: E501
+
+    monkeypatch.setattr(
+        _scope, "shipped_adapters_from_contract", lambda: ("cursor", "claude-code")
+    )  # noqa: E501
     result = read_packaged_preferred_adapter()
     assert result == "cursor"
 
@@ -508,7 +514,10 @@ def test_read_packaged_preferred_adapter_invalid_raises(monkeypatch):
         lambda _t: "not-an-adapter",
     )
     from agentbundle import scope as _scope
-    monkeypatch.setattr(_scope, "shipped_adapters_from_contract", lambda: ("cursor", "claude-code"))  # noqa: E501
+
+    monkeypatch.setattr(
+        _scope, "shipped_adapters_from_contract", lambda: ("cursor", "claude-code")
+    )  # noqa: E501
     with pytest.raises(CatalogueError, match="not-an-adapter"):
         read_packaged_preferred_adapter()
 
@@ -557,6 +566,7 @@ def test_load_distribution_prefers_record_bearing_dist(monkeypatch):
     other = _D("requests", None)
 
     import importlib.metadata as md
+
     # egg-info first in iteration order — the record-bearing dist must still win.
     monkeypatch.setattr(md, "distributions", lambda: iter([other, egg, distinfo]))
     assert _load_distribution() is distinfo

--- a/packages/agentbundle/tests/unit/test_user_config_io.py
+++ b/packages/agentbundle/tests/unit/test_user_config_io.py
@@ -36,11 +36,11 @@ def test_read_valid_adapter(tmp_path: Path) -> None:
     assert read_user_config(cfg_path) == UserConfig(adapter="codex")
 
 
-def test_read_malformed_toml_warns_and_returns_empty(
-    tmp_path: Path, capsys
-) -> None:
+def test_read_malformed_toml_warns_and_returns_empty(tmp_path: Path, capsys) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "unterminated\n', encoding="utf-8", newline="\n")  # missing close quote
+    cfg_path.write_text(
+        '[settings]\nadapter = "unterminated\n', encoding="utf-8", newline="\n"
+    )  # missing close quote
     result = read_user_config(cfg_path)
     assert result == UserConfig(adapter=None)
     captured = capsys.readouterr()
@@ -48,9 +48,7 @@ def test_read_malformed_toml_warns_and_returns_empty(
     assert "agentbundle" in captured.err.lower()
 
 
-def test_read_invalid_adapter_warns_and_nullifies(
-    tmp_path: Path, capsys
-) -> None:
+def test_read_invalid_adapter_warns_and_nullifies(tmp_path: Path, capsys) -> None:
     cfg_path = tmp_path / "config.toml"
     cfg_path.write_text('[settings]\nadapter = "obsolete-name"\n', encoding="utf-8", newline="\n")
     result = read_user_config(cfg_path)
@@ -101,7 +99,7 @@ def test_write_refuses_unknown_key(tmp_path: Path) -> None:
 
 def test_write_refuses_non_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[future]\nx = 1\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text("[future]\nx = 1\n", encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         write_setting(cfg_path, "adapter", "codex")
@@ -121,7 +119,7 @@ def test_write_refuses_non_string_settings_value(tmp_path: Path) -> None:
 
 def test_write_refuses_nested_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings.future]\nx = 1\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text("[settings.future]\nx = 1\n", encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         write_setting(cfg_path, "adapter", "codex")
@@ -144,7 +142,9 @@ def test_unset_only_adapter_deletes_file(tmp_path: Path) -> None:
 
 def test_unset_preserves_unknown_settings_keys(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text(
+        '[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n"
+    )
     unset_setting(cfg_path, "adapter")
     # File still exists; future_str preserved.
     assert cfg_path.exists()
@@ -174,7 +174,7 @@ def test_unset_refuses_unknown_key(tmp_path: Path) -> None:
 
 def test_unset_refuses_non_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[future]\nx = 1\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text("[future]\nx = 1\n", encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         unset_setting(cfg_path, "adapter")
@@ -184,7 +184,9 @@ def test_unset_refuses_non_settings_table(tmp_path: Path) -> None:
 
 def test_unset_refuses_non_string_settings_value(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\ntags = ["a", "b"]\nadapter = "codex"\n', encoding="utf-8", newline="\n")
+    cfg_path.write_text(
+        '[settings]\ntags = ["a", "b"]\nadapter = "codex"\n', encoding="utf-8", newline="\n"
+    )
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         unset_setting(cfg_path, "adapter")

--- a/packages/agentbundle/tests/unit/test_user_config_source.py
+++ b/packages/agentbundle/tests/unit/test_user_config_source.py
@@ -68,7 +68,9 @@ def test_source_and_adapter_are_independent_failsoft(tmp_path):
     # A non-string `source` is dropped (warned) without dropping a valid adapter.
     adapter = sorted(shipped_adapters_from_contract())[0]
     p = tmp_path / "config.toml"
-    p.write_text(f'[settings]\nadapter = "{adapter}"\nsource = 42\n', encoding="utf-8", newline="\n")
+    p.write_text(
+        f'[settings]\nadapter = "{adapter}"\nsource = 42\n', encoding="utf-8", newline="\n"
+    )
     cfg = read_user_config(p)
     assert cfg.adapter == adapter
     assert cfg.source is None


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: ${{ matrix.os == 'windows-latest' }}` from Gate A
- Updates the comment to document why the gate is now safe to harden

## Why now

The 50+ pre-wave5c Windows failures were tracked in the CI comment. Investigation confirmed three factors already resolved them:

1. **#761** — `PLW1514` (ruff `unspecified-encoding` rule) enforced explicit `encoding=` on every `open()`/`read_text()`/`write_text()` call across the codebase, eliminating the cp1252-vs-UTF-8 class of failures
2. **#774** — Added `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` env to the Gate A Windows test step
3. **Existing guards** — `hasattr(os, 'O_NOFOLLOW')`, `@pytest.mark.skipif(sys.platform == "win32")`, and `os.name != "posix"` checks already handled the POSIX-API and symlink cases

The pre-W1 run (#773) already showed an all-clean Windows matrix (all dots, no `F` markers in pytest output) before this PR. Run #774 (the `PYTHONUTF8` commit) is confirmed clean too.

## What's not changing

- The Windows+3.12 exclude stays — that's a CI capacity question, not a compat question
- `fail-fast: false` stays so a Windows failure doesn't cancel the Linux run mid-stream