### PR TITLE
fix(tests): add newline="\n" to all write_text() fixture calls

### DIFF
--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_claude_code.py
@@ -20,27 +20,30 @@ def _seed_pack(root: Path) -> Path:
     (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
         "---\ndescription: foo skill\n---\n# foo\n",
         encoding="utf-8",
+        newline="\n",
     )
-    (pack / ".apm" / "skills" / "foo" / "extra.txt").write_text("nested\n", encoding="utf-8")
+    (pack / ".apm" / "skills" / "foo" / "extra.txt").write_text("nested\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "agents").mkdir(parents=True)
     (pack / ".apm" / "agents" / "bar.md").write_text(
         "---\nname: bar\n---\nagent body\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "hooks").mkdir(parents=True)
-    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
-    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8")
+    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8", newline="\n")
+    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
     (pack / ".apm" / "hook-wiring" / "baz.toml").write_text(
         '[hooks]\nbaz = "tools/hooks/baz.sh"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -82,6 +85,7 @@ class ClaudeCodeAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "reviewer.md").write_text(
                 "---\nname: reviewer\nmodel: opus\ntools: Read, Grep, Glob, Bash\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -115,6 +119,7 @@ class ClaudeCodeAdapterTests(unittest.TestCase):
             settings_path.write_text(
                 json.dumps({"otherKey": {"preserved": True}}),
                 encoding="utf-8",
+                newline="\n",
             )
             project(pack, self.contract, out)
             data = json.loads(settings_path.read_text(encoding="utf-8"))
@@ -149,7 +154,7 @@ def _seed_minimal_pack(root: Path, name: str, skill_name: str, body: str) -> Pat
     pack = root / name
     skill_dir = pack / ".apm" / "skills" / skill_name
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8", newline="\n")
     return pack
 
 
@@ -230,6 +235,7 @@ def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) 
         (skill_dir / "SKILL.md").write_text(
             f"# {skill_name}\nfrom {pack_name}\n",
             encoding="utf-8",
+            newline="\n",
         )
     return pack
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_codex.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_codex.py
@@ -28,25 +28,27 @@ def _seed_pack(root: Path, name: str = "pack", skill_prefix: str = "") -> Path:
     (pack / ".apm" / "skills" / f"{skill_prefix}foo" / "SKILL.md").write_text(
         f"---\ndescription: {skill_prefix}foo skill description\n---\n# foo\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".apm" / "skills" / f"{skill_prefix}alpha").mkdir(parents=True)
     (pack / ".apm" / "skills" / f"{skill_prefix}alpha" / "SKILL.md").write_text(
         f"---\ndescription: {skill_prefix}alpha skill description\n---\n# alpha\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "agents").mkdir(parents=True)
-    (pack / ".apm" / "agents" / "bar.md").write_text("agent body\n", encoding="utf-8")
+    (pack / ".apm" / "agents" / "bar.md").write_text("agent body\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hooks").mkdir(parents=True)
-    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
-    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8")
+    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8", newline="\n")
+    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-    (pack / ".apm" / "hook-wiring" / "baz.toml").write_text("[hooks]\n", encoding="utf-8")
+    (pack / ".apm" / "hook-wiring" / "baz.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -90,6 +92,7 @@ class CodexAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "bar.md").write_text(
                 "---\nname: bar\ndescription: a bar agent\n---\nAgent body.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -119,6 +122,7 @@ class CodexAdapterTests(unittest.TestCase):
                 "---\n"
                 "Body.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -147,6 +151,7 @@ class CodexAdapterTests(unittest.TestCase):
                 '[hooks]\n'
                 '"SessionStart" = [{matcher = "*", hooks = [{type = "command", command = "echo hi"}]}]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -165,7 +170,7 @@ class CodexAdapterTests(unittest.TestCase):
             pack = tmp_path / "pack"
             (pack / ".apm" / "commands").mkdir(parents=True)
             (pack / ".apm" / "commands" / "qux.md").write_text(
-                "# qux command\n", encoding="utf-8"
+                "# qux command\n", encoding="utf-8", newline="\n"
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -192,6 +197,7 @@ def _seed_two_skill_pack(root: Path, name: str = "two-skill") -> Path:
     (flat / "SKILL.md").write_text(
         "---\ndescription: flat skill\n---\n# flat\nbody\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     nested = pack / ".apm" / "skills" / "nested"
@@ -200,14 +206,17 @@ def _seed_two_skill_pack(root: Path, name: str = "two-skill") -> Path:
     (nested / "SKILL.md").write_text(
         "---\ndescription: nested skill\n---\n# nested\nbody\n",
         encoding="utf-8",
+        newline="\n",
     )
     (nested / "scripts" / "run.sh").write_text(
         "#!/bin/sh\necho run\n",
         encoding="utf-8",
+        newline="\n",
     )
     (nested / "references" / "notes.md").write_text(
         "# Notes\nReference content.\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -219,6 +228,7 @@ def _seed_symlinked_pack(root: Path, name: str = "symlinked") -> Path:
     (pack / ".apm" / "assets" / "shared.md").write_text(
         "# Shared\nContent.\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     linker = pack / ".apm" / "skills" / "linker"
@@ -226,6 +236,7 @@ def _seed_symlinked_pack(root: Path, name: str = "symlinked") -> Path:
     (linker / "SKILL.md").write_text(
         "---\ndescription: linker skill\n---\n# linker\n",
         encoding="utf-8",
+        newline="\n",
     )
     (linker / "references" / "shared.md").symlink_to(Path("../../../assets/shared.md"))
     return pack
@@ -235,7 +246,7 @@ def _seed_same_name_pack(root: Path, name: str, body: str) -> Path:
     pack = root / name
     skill_dir = pack / ".apm" / "skills" / "same-name"
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8", newline="\n")
     return pack
 
 
@@ -318,7 +329,7 @@ class TestDirectDirectoryProjection(unittest.TestCase):
             tmp_path = Path(tmp)
             external = tmp_path / "external-secrets"
             external.mkdir()
-            (external / "secret.txt").write_text("DO NOT LEAK\n", encoding="utf-8")
+            (external / "secret.txt").write_text("DO NOT LEAK\n", encoding="utf-8", newline="\n")
 
             pack = tmp_path / "pack"
             skills_dir = pack / ".apm" / "skills"
@@ -328,7 +339,7 @@ class TestDirectDirectoryProjection(unittest.TestCase):
             # And a legitimate skill — that one must still project.
             legit = skills_dir / "legit"
             legit.mkdir()
-            (legit / "SKILL.md").write_text("# legit\n", encoding="utf-8")
+            (legit / "SKILL.md").write_text("# legit\n", encoding="utf-8", newline="\n")
 
             out = tmp_path / "out"
 
@@ -357,7 +368,7 @@ class TestDirectDirectoryProjection(unittest.TestCase):
 
             external = tmp_path / "external"
             external.mkdir()
-            (external / "anchor").write_text("keep me\n", encoding="utf-8")
+            (external / "anchor").write_text("keep me\n", encoding="utf-8", newline="\n")
             (target / "flat").symlink_to(external, target_is_directory=True)
 
             project_packs([pack], self.contract, out)
@@ -398,6 +409,7 @@ def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) 
         (skill_dir / "SKILL.md").write_text(
             f"# {skill_name}\nfrom {pack_name}\n",
             encoding="utf-8",
+            newline="\n",
         )
     return pack
 
@@ -451,7 +463,7 @@ class TestCodexOrphanSweep(unittest.TestCase):
             pack = _seed_named_skills_pack(tmp_path, "pack", ["a"])
             external = tmp_path / "external"
             external.mkdir()
-            (external / "anchor").write_text("keep me\n", encoding="utf-8")
+            (external / "anchor").write_text("keep me\n", encoding="utf-8", newline="\n")
             out = tmp_path / "out"
             target = out / ".agents" / "skills"
             target.mkdir(parents=True)
@@ -508,7 +520,7 @@ class TestMigrationStripIntegrated(unittest.TestCase):
             pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
             out.mkdir()
-            (out / "AGENTS.md").write_text(populated, encoding="utf-8")
+            (out / "AGENTS.md").write_text(populated, encoding="utf-8", newline="\n")
 
             project_packs([pack], self.contract, out)
 
@@ -527,7 +539,7 @@ class TestMigrationStripIntegrated(unittest.TestCase):
             pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
             out.mkdir()
-            (out / "AGENTS.md").write_text(clean, encoding="utf-8")
+            (out / "AGENTS.md").write_text(clean, encoding="utf-8", newline="\n")
 
             project_packs([pack], self.contract, out)
 
@@ -543,7 +555,7 @@ class TestMigrationStripIntegrated(unittest.TestCase):
             pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
             out.mkdir()
-            (out / "AGENTS.md").write_text(self._populated(), encoding="utf-8")
+            (out / "AGENTS.md").write_text(self._populated(), encoding="utf-8", newline="\n")
 
             project_packs([pack], self.contract, out)
             first = (out / "AGENTS.md").read_bytes()
@@ -566,7 +578,7 @@ class TestMigrationStripIntegrated(unittest.TestCase):
             pack = _seed_two_skill_pack(tmp_path)
             out = tmp_path / "out"
             out.mkdir()
-            (out / "AGENTS.md").write_text(body, encoding="utf-8")
+            (out / "AGENTS.md").write_text(body, encoding="utf-8", newline="\n")
 
             project_packs([pack], self.contract, out)
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_copilot.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_copilot.py
@@ -19,20 +19,21 @@ def _seed_pack(root: Path) -> Path:
     (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
         "---\ndescription: foo skill\n---\nfoo body\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "agents").mkdir(parents=True)
-    (pack / ".apm" / "agents" / "bar.md").write_text("agent body\n", encoding="utf-8")
+    (pack / ".apm" / "agents" / "bar.md").write_text("agent body\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hooks").mkdir(parents=True)
-    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
-    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8")
+    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8", newline="\n")
+    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-    (pack / ".apm" / "hook-wiring" / "baz.toml").write_text("[hooks]\n", encoding="utf-8")
+    (pack / ".apm" / "hook-wiring" / "baz.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
     return pack
 
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_cursor.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_cursor.py
@@ -33,7 +33,7 @@ def _seed_agent(pack: Path, name: str, *, tools: str | None, model: str | None =
         lines.append(f"model: {model}")
     lines.append("---")
     lines.append("agent body")
-    (pack / ".apm" / "agents" / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (pack / ".apm" / "agents" / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
 
 
 def _seed_session_start_wiring(pack: Path) -> None:
@@ -42,6 +42,7 @@ def _seed_session_start_wiring(pack: Path) -> None:
         "[[hooks.SessionStart]]\n"
         'hooks = [\n  { type = "command", command = "python tools/hooks/session-start.py" },\n]\n',
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -140,11 +141,11 @@ class CursorProjectionTests(unittest.TestCase):
             tmp_path = Path(tmp)
             pack = tmp_path / "pack"
             (pack / ".apm" / "skills" / "my-skill").mkdir(parents=True)
-            (pack / ".apm" / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8")
+            (pack / ".apm" / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8", newline="\n")
             (pack / ".apm" / "commands").mkdir(parents=True)
-            (pack / ".apm" / "commands" / "do-thing.md").write_text("cmd", encoding="utf-8")
+            (pack / ".apm" / "commands" / "do-thing.md").write_text("cmd", encoding="utf-8", newline="\n")
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "on-start.py").write_text("#!py", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "on-start.py").write_text("#!py", encoding="utf-8", newline="\n")
             out = tmp_path / "out"
             cursor.project(pack, self.contract, out)
             self.assertTrue((out / ".agents" / "skills" / "my-skill" / "SKILL.md").exists())
@@ -217,6 +218,7 @@ class CursorProjectionTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "from-file.md").write_text(
                 "---\ndescription: no name field\ntools: Read, Grep\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             cursor.project(pack, self.contract, out)
@@ -258,6 +260,7 @@ class CursorProjectionTests(unittest.TestCase):
                     }
                 ),
                 encoding="utf-8",
+                newline="\n",
             )
             cursor.project(pack, self.contract, out)
             data = json.loads(target.read_text())
@@ -277,6 +280,7 @@ class CursorProjectionTests(unittest.TestCase):
                 "[[hooks.SessionStart]]\n"
                 'hooks = [ { type = "command", command = "echo y" } ]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             cursor.project(pack, self.contract, out)  # must not raise
@@ -297,6 +301,7 @@ class CursorProjectionTests(unittest.TestCase):
                 'hooks = [ { type = "command" }, '
                 '{ type = "command", command = "python tools/hooks/ok.py" } ]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             cursor.project(pack, self.contract, out)  # must not raise
@@ -326,9 +331,9 @@ class CursorProjectionTests(unittest.TestCase):
             pack = tmp_path / "pack"
             skill = pack / ".apm" / "skills" / "s"
             skill.mkdir(parents=True)
-            (skill / "SKILL.md").write_text("ok", encoding="utf-8")
+            (skill / "SKILL.md").write_text("ok", encoding="utf-8", newline="\n")
             secret = tmp_path / "secret.txt"
-            secret.write_text("SECRET", encoding="utf-8")
+            secret.write_text("SECRET", encoding="utf-8", newline="\n")
             os.symlink(secret, skill / "leak.txt")
             out = tmp_path / "out"
             cursor.project(pack, self.contract, out)
@@ -348,6 +353,7 @@ class CursorInstallDispatchTests(unittest.TestCase):
         (pack / ".apm" / "agents" / "foo.md").write_text(
             "---\nname: foo\ndescription: a foo agent\ntools: Read, Grep\n---\nBody.\n",
             encoding="utf-8",
+            newline="\n",
         )
         return pack
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_gemini.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_gemini.py
@@ -37,7 +37,7 @@ def _write_command(pack: Path, rel: str, *, description: str | None, body: str) 
     if description is not None:
         lines += ["---", f"description: {description}", "---"]
     lines.append(body)
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
 
 
 def _seed_agent(pack: Path, name: str, *, tools: str | None, model: str | None = None) -> None:
@@ -49,7 +49,7 @@ def _seed_agent(pack: Path, name: str, *, tools: str | None, model: str | None =
         lines.append(f"model: {model}")
     lines.append("---")
     lines.append("agent body")
-    (pack / ".apm" / "agents" / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (pack / ".apm" / "agents" / f"{name}.md").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
 
 
 def _seed_session_start_wiring(pack: Path) -> None:
@@ -58,6 +58,7 @@ def _seed_session_start_wiring(pack: Path) -> None:
         "[[hooks.SessionStart]]\n"
         'hooks = [\n  { type = "command", command = "python tools/hooks/session-start.py" },\n]\n',
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -131,7 +132,7 @@ class GeminiCommandTomlTests(unittest.TestCase):
             (pack / ".apm" / "commands").mkdir(parents=True)
             secret_dir = tmp / "outside"
             secret_dir.mkdir()
-            (secret_dir / "leak.md").write_text("---\ndescription: x\n---\nSECRET", encoding="utf-8")
+            (secret_dir / "leak.md").write_text("---\ndescription: x\n---\nSECRET", encoding="utf-8", newline="\n")
             os.symlink(secret_dir, pack / ".apm" / "commands" / "evil")
             _write_command(pack, "ok.md", description="d", body="ok")
             commands = self._project(tmp)
@@ -248,10 +249,10 @@ class GeminiProjectionTests(unittest.TestCase):
             tmp_path = Path(tmp)
             pack = tmp_path / "pack"
             (pack / ".apm" / "skills" / "my-skill").mkdir(parents=True)
-            (pack / ".apm" / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8")
+            (pack / ".apm" / "skills" / "my-skill" / "SKILL.md").write_text("x", encoding="utf-8", newline="\n")
             _write_command(pack, "do-thing.md", description="d", body="cmd")
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "on-start.py").write_text("#!py", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "on-start.py").write_text("#!py", encoding="utf-8", newline="\n")
             out = tmp_path / "out"
             gemini.project(pack, self.contract, out)
             self.assertTrue((out / ".agents" / "skills" / "my-skill" / "SKILL.md").exists())
@@ -332,7 +333,7 @@ class GeminiProjectionTests(unittest.TestCase):
             pack = tmp_path / "pack"
             (pack / ".apm" / "agents").mkdir(parents=True)
             (pack / ".apm" / "agents" / "from-file.md").write_text(
-                "---\ndescription: no name\ntools: Read, Grep\n---\nBody.\n", encoding="utf-8"
+                "---\ndescription: no name\ntools: Read, Grep\n---\nBody.\n", encoding="utf-8", newline="\n"
             )
             out = tmp_path / "out"
             gemini.project(pack, self.contract, out)
@@ -355,9 +356,9 @@ class GeminiProjectionTests(unittest.TestCase):
             pack = tmp_path / "pack"
             skill = pack / ".apm" / "skills" / "s"
             skill.mkdir(parents=True)
-            (skill / "SKILL.md").write_text("ok", encoding="utf-8")
+            (skill / "SKILL.md").write_text("ok", encoding="utf-8", newline="\n")
             secret = tmp_path / "secret.txt"
-            secret.write_text("SECRET", encoding="utf-8")
+            secret.write_text("SECRET", encoding="utf-8", newline="\n")
             os.symlink(secret, skill / "leak.txt")
             out = tmp_path / "out"
             gemini.project(pack, self.contract, out)
@@ -421,6 +422,7 @@ class GeminiSettingsMergeTests(unittest.TestCase):
                     for src in ("SessionStart", "SessionEnd", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop")
                 ),
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             gemini.project(pack, self.contract, out)
@@ -442,6 +444,7 @@ class GeminiSettingsMergeTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"theme": "keep-me", "hooks": {"AfterAgent": [{"hooks": []}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             gemini.project(pack, self.contract, out)
             data = self._settings(out)
@@ -458,6 +461,7 @@ class GeminiSettingsMergeTests(unittest.TestCase):
             (pack / ".apm" / "hook-wiring" / "w.toml").write_text(
                 '[[hooks.NoSuchEvent]]\nhooks = [ { type = "command", command = "echo x" } ]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             with self.assertRaises(ValueError):
@@ -473,6 +477,7 @@ class GeminiSettingsMergeTests(unittest.TestCase):
                 '[[hooks.PreToolUse]]\nmatcher = "Bash"\n'
                 'hooks = [ { type = "command", command = "echo x" } ]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             gemini.project(pack, self.contract, out)
@@ -492,6 +497,7 @@ class GeminiInstallDispatchTests(unittest.TestCase):
         (pack / ".apm" / "agents" / "foo.md").write_text(
             "---\nname: foo\ndescription: a foo agent\ntools: Read, Grep\n---\nBody.\n",
             encoding="utf-8",
+            newline="\n",
         )
         return pack
 
@@ -528,7 +534,7 @@ class GeminiInstallDispatchTests(unittest.TestCase):
             tmp_path = Path(tmp)
             pack = tmp_path / "pack"
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "session-start.py").write_text("#!py", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "session-start.py").write_text("#!py", encoding="utf-8", newline="\n")
             _seed_session_start_wiring(pack)
             projection = _render_for_user_scope(
                 pack, adapter="gemini", allowed_adapters=["gemini"],

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro.py
@@ -22,26 +22,29 @@ def _seed_pack(root: Path) -> Path:
     (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
         "# foo skill\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "agents").mkdir(parents=True)
     (pack / ".apm" / "agents" / "bar.md").write_text(
         "---\nname: bar\ntools: Read\n---\nagent body\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "hooks").mkdir(parents=True)
-    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
-    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8")
+    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\necho hi\n", encoding="utf-8", newline="\n")
+    (pack / ".apm" / "hooks" / "baz.py").write_text("print('hi')\n", encoding="utf-8", newline="\n")
 
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
     (pack / ".apm" / "hook-wiring" / "baz.toml").write_text(
         '[hooks]\nbaz = "tools/hooks/baz.sh"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -99,14 +102,17 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "opus-agent.md").write_text(
                 "---\nname: opus-agent\nmodel: opus\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             (pack / ".apm" / "agents" / "sonnet-agent.md").write_text(
                 "---\nname: sonnet-agent\nmodel: sonnet\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             (pack / ".apm" / "agents" / "haiku-agent.md").write_text(
                 "---\nname: haiku-agent\nmodel: haiku\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -131,6 +137,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "mystery.md").write_text(
                 "---\nname: mystery\nmodel: gpt-5-turbo\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             buf = io.StringIO()
@@ -153,6 +160,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "no-model.md").write_text(
                 "---\nname: no-model\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -172,6 +180,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "list-model.md").write_text(
                 "---\nname: list-model\nmodel: [opus]\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             buf = io.StringIO()
@@ -193,6 +202,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "multi.md").write_text(
                 "---\nname: multi\ntools: Read, Grep, Glob, Bash\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -209,6 +219,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "one.md").write_text(
                 "---\nname: one\ntools: Read\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -227,6 +238,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "bracketed.md").write_text(
                 "---\nname: bracketed\ntools: [Read, Grep]\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -244,6 +256,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "web.md").write_text(
                 "---\nname: web\ntools: Read, WebFetch, WebSearch\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -261,6 +274,7 @@ class KiroAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "nb.md").write_text(
                 "---\nname: nb\ntools: Read, NotebookEdit\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             stderr = io.StringIO()
@@ -323,7 +337,7 @@ def _seed_minimal_pack(root: Path, name: str, skill_name: str, body: str) -> Pat
     pack = root / name
     skill_dir = pack / ".apm" / "skills" / skill_name
     skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8", newline="\n")
     return pack
 
 
@@ -404,6 +418,7 @@ def _seed_named_skills_pack(root: Path, pack_name: str, skill_names: list[str]) 
         (skill_dir / "SKILL.md").write_text(
             f"# {skill_name}\nfrom {pack_name}\n",
             encoding="utf-8",
+            newline="\n",
         )
     return pack
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_alias.py
@@ -26,6 +26,7 @@ def _seed_pack(root: Path) -> Path:
     (pack / ".apm" / "agents" / "foo.md").write_text(
         "---\nname: foo\ntools: Read\n---\nbody\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_cli.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_cli.py
@@ -26,6 +26,7 @@ def _seed_agent_pack(root: Path, tools: str = "Read, Grep, Glob, Bash") -> Path:
     (pack / ".apm" / "agents" / "bar.md").write_text(
         f"---\nname: bar\ntools: {tools}\n---\nagent body\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -110,6 +111,7 @@ class KiroCliAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "bar.md").write_text(
                 "---\nname: bar\nresources: [file://README.md]\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_kiro_ide.py
@@ -26,6 +26,7 @@ def _seed_agent_pack(root: Path, tools: str = "Read, Grep", model: str | None = 
     (pack / ".apm" / "agents" / "bar.md").write_text(
         f"---\nname: bar\ntools: {tools}{model_line}\n---\nagent body\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -94,6 +95,7 @@ class KiroIdeAdapterTests(unittest.TestCase):
             (pack / ".apm" / "agents" / "bar.md").write_text(
                 "---\nname: bar\nresources: [file://README.md]\n---\nbody\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)
@@ -196,7 +198,7 @@ class KiroIdeAdapterTests(unittest.TestCase):
                 "then": {"type": "askAgent", "prompt": "Run lint."},
             }
             (hooks_dir / "on-save.kiro.hook").write_text(
-                json.dumps(hook_body), encoding="utf-8"
+                json.dumps(hook_body), encoding="utf-8", newline="\n"
             )
             out = tmp_path / "out"
             project(pack, self.contract, out)

--- a/packages/agentbundle/agentbundle/build/tests/test_adapter_root_bins_projection.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_adapter_root_bins_projection.py
@@ -37,6 +37,7 @@ def _make_fixture_pack(
         f'[pack.install]\ndefault-scope = "user"\n'
         f'allowed-scopes = ["user", "repo"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     if bins:
         bins_dir = pack / ".apm" / "adapter-root-bins"

--- a/packages/agentbundle/agentbundle/build/tests/test_build_ships_seeds.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_build_ships_seeds.py
@@ -28,20 +28,23 @@ def _make_seed_pack(packs_dir: Path) -> None:
     (skill / "SKILL.md").write_text(
         "---\nname: demo\ndescription: A demo skill for the seed-ship build test.\n---\n\nBody.\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / "pack.toml").write_text(
         '[pack]\nname = "seedpack"\nversion = "0.1.0"\ndescription = "seed-ship test pack."\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".claude-plugin").mkdir()
     (pack / ".claude-plugin" / "plugin.json").write_text(
         json.dumps({"name": "seedpack", "version": "0.1.0", "description": "seed-ship test pack."}) + "\n",
         encoding="utf-8",
+        newline="\n",
     )
     docs = pack / "seeds" / "docs"
     docs.mkdir(parents=True)
-    (pack / "seeds" / "AGENTS.md").write_text("# seedpack agents\n", encoding="utf-8")
-    (docs / "CHARTER.md").write_text("# seedpack charter\n", encoding="utf-8")
+    (pack / "seeds" / "AGENTS.md").write_text("# seedpack agents\n", encoding="utf-8", newline="\n")
+    (docs / "CHARTER.md").write_text("# seedpack charter\n", encoding="utf-8", newline="\n")
 
 
 class BuildShipsSeedsTests(unittest.TestCase):

--- a/packages/agentbundle/agentbundle/build/tests/test_direct_directory_cleanup.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_direct_directory_cleanup.py
@@ -36,7 +36,7 @@ def test_noop_on_missing_target(tmp_path: Path) -> None:
 def test_ignores_root_files(tmp_path: Path) -> None:
     (tmp_path / "a").mkdir()
     readme = tmp_path / "README.md"
-    readme.write_text("hello\n", encoding="utf-8")
+    readme.write_text("hello\n", encoding="utf-8", newline="\n")
 
     sweep_orphans(tmp_path, set())
 
@@ -48,7 +48,7 @@ def test_ignores_root_files(tmp_path: Path) -> None:
 def test_symlink_safe_sweep(tmp_path: Path) -> None:
     external = tmp_path / "outside"
     external.mkdir()
-    (external / "anchor").write_text("keep me\n", encoding="utf-8")
+    (external / "anchor").write_text("keep me\n", encoding="utf-8", newline="\n")
 
     target = tmp_path / "skills"
     target.mkdir()

--- a/packages/agentbundle/agentbundle/build/tests/test_end_to_end_build.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_end_to_end_build.py
@@ -130,7 +130,7 @@ class CheckCommandTests(unittest.TestCase):
             # fail-fast (spec AC14) doesn't reject the call. Canonical
             # v0.1 shape per adapt-to-project AC9.
             (working / ".adapt-discovery.toml").write_text(
-                'discovery-schema-version = "0.1"\n', encoding="utf-8"
+                'discovery-schema-version = "0.1"\n', encoding="utf-8", newline="\n"
             )
 
             from agentbundle.build.adapters import ADAPTERS
@@ -204,7 +204,7 @@ class ScaffoldCommandTests(unittest.TestCase):
             shutil.copytree(FIXTURES_PACKS, packs_clone)
             (packs_clone / "core" / "seeds").mkdir()
             (packs_clone / "core" / "seeds" / "AGENTS.md").write_text(
-                "# seeded\n", encoding="utf-8"
+                "# seeded\n", encoding="utf-8", newline="\n"
             )
             output_dir = workspace_path / "out"
 

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_diataxis_block.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_diataxis_block.py
@@ -34,7 +34,7 @@ _MISSING_SUBSTR = "is missing Diátaxis subdirectories"
 
 
 def _seed_common(root: Path) -> None:
-    (root / "AGENTS.md").write_text("# AGENTS.md\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# AGENTS.md\n", encoding="utf-8", newline="\n")
     (root / "CLAUDE.md").symlink_to("AGENTS.md")
     (root / "guides").mkdir(parents=True, exist_ok=True)
 
@@ -43,7 +43,7 @@ def _make_quadrants(base: Path) -> None:
     for q in QUADRANTS:
         d = base / q
         d.mkdir(parents=True, exist_ok=True)
-        (d / "README.md").write_text("# quadrant\n", encoding="utf-8")
+        (d / "README.md").write_text("# quadrant\n", encoding="utf-8", newline="\n")
 
 
 def _run_linter(cwd: Path) -> subprocess.CompletedProcess[str]:

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_legacy_block.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_legacy_block.py
@@ -56,9 +56,9 @@ def _seed_tree(
 ) -> None:
     contracts = root / "contracts"
     contracts.mkdir(parents=True)
-    (contracts / "adapter.toml").write_text(contract_body, encoding="utf-8")
+    (contracts / "adapter.toml").write_text(contract_body, encoding="utf-8", newline="\n")
 
-    (root / "AGENTS.md").write_text(agents_md_body, encoding="utf-8")
+    (root / "AGENTS.md").write_text(agents_md_body, encoding="utf-8", newline="\n")
     (root / "CLAUDE.md").symlink_to("AGENTS.md")
 
 

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_risk_block.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_agents_md_risk_block.py
@@ -43,10 +43,10 @@ def _seed(root: Path, canonical_block: str, agents_block: str) -> None:
     skill = root / ".claude" / "skills" / "work-loop"
     skill.mkdir(parents=True)
     (skill / "SKILL.md").write_text(
-        "# Skill: work-loop\n\n" + canonical_block, encoding="utf-8"
+        "# Skill: work-loop\n\n" + canonical_block, encoding="utf-8", newline="\n"
     )
     (root / "AGENTS.md").write_text(
-        "# AGENTS.md\n\n" + agents_block, encoding="utf-8"
+        "# AGENTS.md\n\n" + agents_block, encoding="utf-8", newline="\n"
     )
     (root / "CLAUDE.md").symlink_to("AGENTS.md")
 
@@ -98,6 +98,7 @@ class RiskBlockEqualityTests(unittest.TestCase):
                     "<!-- risk-triggers:end -->\n", ""
                 ),
                 encoding="utf-8",
+                newline="\n",
             )
             result = _run_linter(tmp_path)
             self.assertIn(_DRIFT_MARKER, result.stderr)
@@ -107,7 +108,7 @@ class RiskBlockEqualityTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             (tmp_path / "AGENTS.md").write_text(
-                "# AGENTS.md\n\nNo risk-trigger block here.\n", encoding="utf-8"
+                "# AGENTS.md\n\nNo risk-trigger block here.\n", encoding="utf-8", newline="\n"
             )
             (tmp_path / "CLAUDE.md").symlink_to("AGENTS.md")
             result = _run_linter(tmp_path)

--- a/packages/agentbundle/agentbundle/build/tests/test_lint_packs.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_lint_packs.py
@@ -58,6 +58,7 @@ def _write_minimal_pack(pack_dir: Path, name: str = "fixture-pack") -> None:
     (pack_dir / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "0.0.1"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
 # The repo-checked-in fixture lives under tests/fixtures/lint_packs/.
@@ -91,8 +92,9 @@ def _materialise_with_reserved_fixture(root: Path) -> Path:
         'default-scope = "repo"\n'
         'allowed-scopes = ["repo"]\n',
         encoding="utf-8",
+        newline="\n",
     )
-    (pack / "seeds" / "CON.md").write_text("reserved\n", encoding="utf-8")
+    (pack / "seeds" / "CON.md").write_text("reserved\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -124,8 +126,9 @@ class LintPackTests(unittest.TestCase):
             (pack / "pack.toml").write_text(
                 '[pack]\nname = "linky"\nversion = "0.0.1"\n',
                 encoding="utf-8",
+                newline="\n",
             )
-            (pack / "seeds" / "target.md").write_text("target\n", encoding="utf-8")
+            (pack / "seeds" / "target.md").write_text("target\n", encoding="utf-8", newline="\n")
             (pack / "seeds" / "alias.md").symlink_to("target.md")
             findings = lint_pack(pack)
             self.assertEqual(len(findings), 1, findings)
@@ -139,8 +142,9 @@ class LintPackTests(unittest.TestCase):
             (pack / "pack.toml").write_text(
                 '[pack]\nname = "linky-apm"\nversion = "0.0.1"\n',
                 encoding="utf-8",
+                newline="\n",
             )
-            (pack / ".apm" / "skills" / "real.md").write_text("x\n", encoding="utf-8")
+            (pack / ".apm" / "skills" / "real.md").write_text("x\n", encoding="utf-8", newline="\n")
             (pack / ".apm" / "skills" / "link.md").symlink_to("real.md")
             findings = lint_pack(pack)
             self.assertTrue(any("symlink" in f for f in findings))
@@ -160,8 +164,9 @@ class LintPackTests(unittest.TestCase):
             (clean / "pack.toml").write_text(
                 '[pack]\nname = "clean"\nversion = "0.0.1"\n',
                 encoding="utf-8",
+                newline="\n",
             )
-            (clean / "seeds" / "ok.md").write_text("ok\n", encoding="utf-8")
+            (clean / "seeds" / "ok.md").write_text("ok\n", encoding="utf-8", newline="\n")
             _materialise_with_reserved_fixture(packs_dir)
             results = lint_all_packs(packs_dir)
         self.assertIn("clean", results)
@@ -176,6 +181,7 @@ class LintPackTests(unittest.TestCase):
             (packs / "real-pack" / "pack.toml").write_text(
                 '[pack]\nname = "real-pack"\nversion = "0.0.1"\n',
                 encoding="utf-8",
+                newline="\n",
             )
             (packs / "not-a-pack").mkdir()  # no pack.toml
             results = lint_all_packs(packs)
@@ -210,14 +216,15 @@ class LintPackTests(unittest.TestCase):
             (pack / "pack.toml").write_text(
                 '[pack]\nname = "multi-violation"\nversion = "0.0.1"\n',
                 encoding="utf-8",
+                newline="\n",
             )
             # Three deliberate violations across two segments. The
             # sorted relpaths are: NUL.md, alpha/CON.md, beta/PRN.md.
-            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8", newline="\n")
             (pack / "seeds" / "alpha").mkdir()
-            (pack / "seeds" / "alpha" / "CON.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "alpha" / "CON.md").write_text("x\n", encoding="utf-8", newline="\n")
             (pack / "seeds" / "beta").mkdir()
-            (pack / "seeds" / "beta" / "PRN.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "beta" / "PRN.md").write_text("x\n", encoding="utf-8", newline="\n")
             findings = lint_pack(pack)
             self.assertEqual(len(findings), 3)
             relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
@@ -253,7 +260,7 @@ class LintPackVocabTests(unittest.TestCase):
             lines.append(f"description: {description}")
         lines.append("---")
         lines.append("Body.")
-        (skill_dir / "SKILL.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        (skill_dir / "SKILL.md").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
         return skill_dir / "SKILL.md"
 
     def _build_agent(
@@ -274,7 +281,7 @@ class LintPackVocabTests(unittest.TestCase):
         lines.append("---")
         lines.append("Body.")
         path = agents_dir / f"{stem}.md"
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
         return path
 
     # ------------------------------------------------------------------
@@ -345,6 +352,7 @@ class LintPackVocabTests(unittest.TestCase):
             (skill_dir / "SKILL.md").write_text(
                 "---\ndescription: >\n  folded\n  multi-line\nmodel: opus\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             findings = lint_pack(pack, constraints=constraints)
             ml_findings = [
@@ -397,6 +405,7 @@ class LintPackVocabTests(unittest.TestCase):
             (agents_dir / "valid-agent.md").write_text(
                 "---\ndescription: |\n  folded\nmodel: opus\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             findings = lint_pack(pack, constraints=constraints)
             ml_findings = [
@@ -434,7 +443,7 @@ class LintPackVocabTests(unittest.TestCase):
             pack = Path(tmp) / "mix-pack"
             _write_minimal_pack(pack, name="mix-pack")
             (pack / "seeds").mkdir(parents=True, exist_ok=True)
-            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8", newline="\n")
             self._build_skill(pack, "Bad_Name")
             findings = lint_pack(pack, constraints=constraints)
             relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
@@ -457,10 +466,10 @@ class LintPackVocabTests(unittest.TestCase):
             pack = Path(tmp) / "cross-subtree"
             _write_minimal_pack(pack, name="cross-subtree")
             (pack / "seeds").mkdir(parents=True, exist_ok=True)
-            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8", newline="\n")
             agents_dir = pack / ".apm" / "agents"
             agents_dir.mkdir(parents=True, exist_ok=True)
-            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8")
+            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8", newline="\n")
             findings = lint_pack(pack, constraints=constraints)
             relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
         # `.apm/agents/CON.md` sorts before `seeds/NUL.md` alphabetically.
@@ -520,6 +529,7 @@ class LintPackVocabTests(unittest.TestCase):
             (skill_dir / "SKILL.md").write_text(
                 "---\nname: >\n  Bad_Name\ndescription: short.\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             findings = lint_pack(pack, constraints=constraints)
             ml_findings = [
@@ -539,6 +549,7 @@ class LintPackVocabTests(unittest.TestCase):
             (agents_dir / "valid-agent.md").write_text(
                 "---\nname: |\n  Bad_Name\ndescription: short.\nmodel: opus\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             findings = lint_pack(pack, constraints=constraints)
             ml_findings = [
@@ -577,6 +588,7 @@ class LintPackVocabTests(unittest.TestCase):
             (skill_dir / "SKILL.md").write_text(
                 "﻿---\ndescription: " + long_desc + "\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             findings = lint_pack(pack, constraints=constraints)
             desc_findings = [
@@ -598,7 +610,7 @@ class LintPackVocabTests(unittest.TestCase):
             _write_minimal_pack(packs_dir / "p", name="p")
             vocab_dir = root / "contracts"
             vocab_dir.mkdir(parents=True)
-            (vocab_dir / "target-vocab.toml").write_text(body, encoding="utf-8")
+            (vocab_dir / "target-vocab.toml").write_text(body, encoding="utf-8", newline="\n")
             args = argparse.Namespace(packs_dir=str(packs_dir))
             buf = io.StringIO()
             with redirect_stderr(buf):
@@ -665,10 +677,10 @@ class LintPackVocabTests(unittest.TestCase):
             pack = Path(tmp) / "no-constraints-mix"
             _write_minimal_pack(pack, name="no-constraints-mix")
             (pack / "seeds").mkdir(parents=True, exist_ok=True)
-            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8")
+            (pack / "seeds" / "NUL.md").write_text("x\n", encoding="utf-8", newline="\n")
             agents_dir = pack / ".apm" / "agents"
             agents_dir.mkdir(parents=True, exist_ok=True)
-            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8")
+            (agents_dir / "CON.md").write_text("x\n", encoding="utf-8", newline="\n")
             findings = lint_pack(pack)
             relpaths = [f.rsplit(": ", 1)[-1] for f in findings]
         self.assertEqual(relpaths, sorted(relpaths))
@@ -690,6 +702,7 @@ class LintPackVocabTests(unittest.TestCase):
                 '[target.beta]\nname-pattern = "^[A-Z][A-Z0-9-]*$"\n'
                 'description-max-length = 1024\n',
                 encoding="utf-8",
+                newline="\n",
             )
             args = argparse.Namespace(packs_dir=str(packs_dir))
             buf = io.StringIO()

--- a/packages/agentbundle/agentbundle/build/tests/test_load_pack_hook_wiring_safely.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_load_pack_hook_wiring_safely.py
@@ -39,12 +39,12 @@ def _make_pack(
 
     for stem, body in (wiring or {}).items():
         (pack / ".apm" / "hook-wiring" / f"{stem}.toml").write_text(
-            body, encoding="utf-8"
+            body, encoding="utf-8", newline="\n"
         )
 
     for stem in agents or []:
         (pack / ".apm" / "agents" / f"{stem}.md").write_text(
-            f"# {stem}\n", encoding="utf-8"
+            f"# {stem}\n", encoding="utf-8", newline="\n"
         )
 
     # Create dangling symlinks to simulate the security-rail case.
@@ -163,7 +163,7 @@ class TestLoadPackHookWiringSafely(unittest.TestCase):
             pack = tmp / "no-wiring-pack"
             # Only create .apm/ with agents — no hook-wiring/ subdir.
             (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
-            (pack / ".apm" / "agents" / "work-loop.md").write_text("# work-loop\n", encoding="utf-8")
+            (pack / ".apm" / "agents" / "work-loop.md").write_text("# work-loop\n", encoding="utf-8", newline="\n")
             result = helper(pack, "no-wiring-pack")
             self.assertIsInstance(result, tuple)
             wiring_tomls, agent_basenames = result

--- a/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pack_schema_allowed_adapters.py
@@ -167,10 +167,10 @@ class TestKiroTargetAdaptersV06Gate(unittest.TestCase):
         apm.mkdir(parents=True)
         if with_agents:
             (apm / "agents").mkdir()
-            (apm / "agents" / "a.md").write_text("dummy", encoding="utf-8")
+            (apm / "agents" / "a.md").write_text("dummy", encoding="utf-8", newline="\n")
         if with_wiring:
             (apm / "hook-wiring").mkdir()
-            (apm / "hook-wiring" / "w.toml").write_text("event = 'PreToolUse'\n", encoding="utf-8")
+            (apm / "hook-wiring" / "w.toml").write_text("event = 'PreToolUse'\n", encoding="utf-8", newline="\n")
         return tmp_path
 
     def test_v06_pack_with_on_disk_shape_no_allowed_adapters_fires_rail(self) -> None:

--- a/packages/agentbundle/agentbundle/build/tests/test_pipeline.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_pipeline.py
@@ -33,17 +33,19 @@ def _seed_pack(root: Path, name: str = "demo") -> Path:
     (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
         "---\ndescription: foo\n---\n# foo\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".apm" / "agents").mkdir(parents=True)
-    (pack / ".apm" / "agents" / "bar.md").write_text("---\nname: bar\n---\n", encoding="utf-8")
+    (pack / ".apm" / "agents" / "bar.md").write_text("---\nname: bar\n---\n", encoding="utf-8", newline="\n")
     (pack / ".apm" / "hooks").mkdir(parents=True)
-    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (pack / ".apm" / "hooks" / "baz.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
 
     (pack / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "0.1.0"\ndescription = "demo pack"\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".claude-plugin").mkdir(parents=True)
     (pack / ".claude-plugin" / "plugin.json").write_text(
@@ -51,6 +53,7 @@ def _seed_pack(root: Path, name: str = "demo") -> Path:
             {"name": name, "version": "0.1.0", "description": "demo plugin"}, indent=2
         ),
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -138,7 +141,7 @@ class PackInternalCollisionTests(unittest.TestCase):
             tmp_path = Path(tmp)
             pack_path = _seed_pack(tmp_path / "packs", "core")
             (pack_path / ".apm" / "skills" / "foo").mkdir(exist_ok=True)
-            (pack_path / ".apm" / "skills" / "foo.md").write_text("dup\n", encoding="utf-8")
+            (pack_path / ".apm" / "skills" / "foo.md").write_text("dup\n", encoding="utf-8", newline="\n")
             with self.assertRaises(ValueError) as caught:
                 validate_pack_uniqueness(Pack(name="core", path=pack_path))
             self.assertIn("duplicate primitive", str(caught.exception))
@@ -219,9 +222,9 @@ class Rfc0002RecipeLoadTests(unittest.TestCase):
             pack_one = _seed_pack(packs_dir, "core")
             pack_two = _seed_pack(packs_dir, "extras")
             (pack_one / "seeds").mkdir()
-            (pack_one / "seeds" / "AGENTS.fragment.md").write_text("core fragment\n", encoding="utf-8")
+            (pack_one / "seeds" / "AGENTS.fragment.md").write_text("core fragment\n", encoding="utf-8", newline="\n")
             (pack_two / "seeds").mkdir()
-            (pack_two / "seeds" / "AGENTS.fragment.md").write_text("extras fragment\n", encoding="utf-8")
+            (pack_two / "seeds" / "AGENTS.fragment.md").write_text("extras fragment\n", encoding="utf-8", newline="\n")
             result = run_recipe(
                 recipe, discover_packs(packs_dir), tmp_path / "dist", self.contract
             )

--- a/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_projectable_subset.py
@@ -176,7 +176,7 @@ class ProjectPackReadmeTests(unittest.TestCase):
             root = Path(raw)
             pack = root / "pack"
             pack.mkdir()
-            (pack / "README.md").write_text("# demo\n", encoding="utf-8")
+            (pack / "README.md").write_text("# demo\n", encoding="utf-8", newline="\n")
             route = root / "route"
             route.mkdir()
             _project_pack_readme(pack, route)

--- a/packages/agentbundle/agentbundle/build/tests/test_projections_merge_json.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_projections_merge_json.py
@@ -43,7 +43,7 @@ class TestProjectMergeJson(unittest.TestCase):
 
     def test_empty_managed_key_writes_nothing(self) -> None:
         """TOML file present but managed-key payload is empty → no output."""
-        (self.source / "one.toml").write_text("[hooks]\n", encoding="utf-8")
+        (self.source / "one.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
         project_merge_json(self.source, self.output, self._rule())
         self.assertFalse((self.output / ".target" / "hooks.json").exists())
 
@@ -53,6 +53,7 @@ class TestProjectMergeJson(unittest.TestCase):
             '[hooks]\n'
             '"SessionStart" = [{ matcher = "*", hooks = [{ type = "command", command = "echo hi" }] }]\n',
             encoding="utf-8",
+            newline="\n",
         )
         project_merge_json(self.source, self.output, self._rule())
         target = self.output / ".target" / "hooks.json"
@@ -68,9 +69,10 @@ class TestProjectMergeJson(unittest.TestCase):
         target.write_text(
             json.dumps({"other-key": {"keep": "this"}, "hooks": {"X": ["old"]}}),
             encoding="utf-8",
+            newline="\n",
         )
         (self.source / "one.toml").write_text(
-            '[hooks]\n"Y" = ["new"]\n', encoding="utf-8"
+            '[hooks]\n"Y" = ["new"]\n', encoding="utf-8", newline="\n"
         )
         project_merge_json(self.source, self.output, self._rule())
         data = json.loads(target.read_text(encoding="utf-8"))
@@ -82,10 +84,10 @@ class TestProjectMergeJson(unittest.TestCase):
     def test_multiple_toml_files_merge_in_sorted_order(self) -> None:
         """Source files are iterated sorted; later overrides earlier."""
         (self.source / "a.toml").write_text(
-            '[hooks]\n"X" = ["from-a"]\n', encoding="utf-8"
+            '[hooks]\n"X" = ["from-a"]\n', encoding="utf-8", newline="\n"
         )
         (self.source / "b.toml").write_text(
-            '[hooks]\n"X" = ["from-b"]\n', encoding="utf-8"
+            '[hooks]\n"X" = ["from-b"]\n', encoding="utf-8", newline="\n"
         )
         project_merge_json(self.source, self.output, self._rule())
         target = self.output / ".target" / "hooks.json"
@@ -95,7 +97,7 @@ class TestProjectMergeJson(unittest.TestCase):
     def test_output_serialisation_shape(self) -> None:
         """Output uses indent=2, sort_keys=True, trailing newline (idempotency)."""
         (self.source / "one.toml").write_text(
-            '[hooks]\n"Y" = ["y"]\n"X" = ["x"]\n', encoding="utf-8"
+            '[hooks]\n"Y" = ["y"]\n"X" = ["x"]\n', encoding="utf-8", newline="\n"
         )
         project_merge_json(self.source, self.output, self._rule())
         target = self.output / ".target" / "hooks.json"
@@ -108,9 +110,9 @@ class TestProjectMergeJson(unittest.TestCase):
 
     def test_non_toml_files_ignored(self) -> None:
         """Files without .toml suffix are skipped."""
-        (self.source / "skip.md").write_text("ignored", encoding="utf-8")
+        (self.source / "skip.md").write_text("ignored", encoding="utf-8", newline="\n")
         (self.source / "one.toml").write_text(
-            '[hooks]\n"X" = ["x"]\n', encoding="utf-8"
+            '[hooks]\n"X" = ["x"]\n', encoding="utf-8", newline="\n"
         )
         project_merge_json(self.source, self.output, self._rule())
         target = self.output / ".target" / "hooks.json"
@@ -123,6 +125,7 @@ class TestProjectMergeJson(unittest.TestCase):
         (self.source / "one.toml").write_text(
             '[hooks]\n"SessionStart" = [{matcher="*", hooks=[{type="command", command="x"}]}]\n',
             encoding="utf-8",
+            newline="\n",
         )
         project_merge_json(
             self.source, self.output, self._rule(target_path=".codex/hooks.json")

--- a/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_scope_rails.py
@@ -49,7 +49,7 @@ allowed-scopes = ["repo"]
 def _write_pack(root: Path, name: str, toml_text: str) -> Path:
     pack = root / name
     pack.mkdir()
-    (pack / "pack.toml").write_text(toml_text, encoding="utf-8")
+    (pack / "pack.toml").write_text(toml_text, encoding="utf-8", newline="\n")
     return pack
 
 
@@ -62,7 +62,7 @@ class RailASeedsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / "seeds").mkdir()
-            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8")
+            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8", newline="\n")
 
             result = check_seeds(pack, ["user"])
             self.assertIsNotNone(result)
@@ -74,7 +74,7 @@ class RailASeedsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             (pack / "seeds").mkdir()
-            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8")
+            (pack / "seeds" / "AGENTS.md").write_text("hi", encoding="utf-8", newline="\n")
 
             self.assertIsNone(check_seeds(pack, ["repo"]))
 
@@ -96,7 +96,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
 
             result = check_hooks(pack, ["user"])
             self.assertIsNotNone(result)
@@ -108,7 +108,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-            (pack / ".apm" / "hook-wiring" / "pre-pr.toml").write_text("[hooks]\n", encoding="utf-8")
+            (pack / ".apm" / "hook-wiring" / "pre-pr.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
 
             result = check_hooks(pack, ["user"])
             self.assertIsNotNone(result)
@@ -120,7 +120,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
             self.assertIsNone(check_hooks(pack, ["repo"]))
 
     def test_rail_b_accepts_no_hooks(self) -> None:
@@ -139,7 +139,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
             self.assertIsNone(
                 check_hooks(pack, ["user"], user_scope_hooks=True),
                 "Rail B did not lift on user_scope_hooks=True",
@@ -153,7 +153,7 @@ class RailBHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
             # Default (no flag passed) — must refuse.
             self.assertIsNotNone(check_hooks(pack, ["user"]))
             # Explicit False — same refusal.
@@ -174,6 +174,7 @@ class RailCMarkersTests(unittest.TestCase):
             (skills_dir / "SKILL.md").write_text(
                 "# My skill\n\nDoes <adapt:PROJECT_NAME> things.\n",
                 encoding="utf-8",
+                newline="\n",
             )
 
             result = check_markers(pack, ["user"])
@@ -196,6 +197,7 @@ class RailCMarkersTests(unittest.TestCase):
             (skills_dir / "SKILL.md").write_text(
                 "# My skill\n\nDoes <adapt:project-name> things.\n",
                 encoding="utf-8",
+                newline="\n",
             )
 
             result = check_markers(pack, ["user"])
@@ -210,7 +212,7 @@ class RailCMarkersTests(unittest.TestCase):
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             agents_dir = pack / ".apm" / "agents"
             agents_dir.mkdir(parents=True)
-            (agents_dir / "reviewer.md").write_text("Owner: <adapt:owner>\n", encoding="utf-8")
+            (agents_dir / "reviewer.md").write_text("Owner: <adapt:owner>\n", encoding="utf-8", newline="\n")
 
             result = check_markers(pack, ["user"])
             self.assertIsNotNone(result)
@@ -230,11 +232,11 @@ class RailCMarkersTests(unittest.TestCase):
             skills_dir = pack / ".apm" / "skills" / "non-markers"
             skills_dir.mkdir(parents=True)
             # Wrong-cased prefix — must not match either grammar.
-            (skills_dir / "A.md").write_text("plays with <ADAPT:NAME>", encoding="utf-8")
+            (skills_dir / "A.md").write_text("plays with <ADAPT:NAME>", encoding="utf-8", newline="\n")
             # Mixed-case name — matches neither UPPER_SNAKE nor lowercase-hyphen.
-            (skills_dir / "B.md").write_text("plays with <adapt:MixedCase>", encoding="utf-8")
+            (skills_dir / "B.md").write_text("plays with <adapt:MixedCase>", encoding="utf-8", newline="\n")
             # Empty name — matches neither grammar.
-            (skills_dir / "C.md").write_text("plays with <adapt:>", encoding="utf-8")
+            (skills_dir / "C.md").write_text("plays with <adapt:>", encoding="utf-8", newline="\n")
             self.assertIsNone(check_markers(pack, ["user"]))
 
     def test_rail_c_does_not_inspect_repo_only_pack(self) -> None:
@@ -245,7 +247,7 @@ class RailCMarkersTests(unittest.TestCase):
             pack = _write_pack(Path(td), "p", PACK_TOML_REPO_ONLY)
             skills_dir = pack / ".apm" / "skills" / "doc-marker"
             skills_dir.mkdir(parents=True)
-            (skills_dir / "SKILL.md").write_text("documents <adapt:NAME>", encoding="utf-8")
+            (skills_dir / "SKILL.md").write_text("documents <adapt:NAME>", encoding="utf-8", newline="\n")
             self.assertIsNone(check_markers(pack, ["repo"]))
 
     def test_rail_c_skips_binary_files(self) -> None:
@@ -259,7 +261,7 @@ class RailCMarkersTests(unittest.TestCase):
             # Raw bytes that are not valid UTF-8 — should be skipped.
             (skills_dir / "icon.bin").write_bytes(b"\xff\xfe\x00<adapt:NAME>")
             # A clean text file in the same directory.
-            (skills_dir / "SKILL.md").write_text("# clean\n", encoding="utf-8")
+            (skills_dir / "SKILL.md").write_text("# clean\n", encoding="utf-8", newline="\n")
             self.assertIsNone(check_markers(pack, ["user"]))
 
     def test_rail_c_refuses_symlink_under_skills(self) -> None:
@@ -313,7 +315,7 @@ class RailCMarkersTests(unittest.TestCase):
             for sub in ("z-late", "a-early"):
                 d = pack / ".apm" / "skills" / sub
                 d.mkdir(parents=True)
-                (d / "SKILL.md").write_text("hi <adapt:NAME>", encoding="utf-8")
+                (d / "SKILL.md").write_text("hi <adapt:NAME>", encoding="utf-8", newline="\n")
             result = check_markers(pack, ["user"])
             self.assertIsNotNone(result)
             self.assertIn("a-early/SKILL.md", result)
@@ -346,6 +348,7 @@ default-scope = "user"
 allowed-scopes = ["repo"]
 """,
                 encoding="utf-8",
+                newline="\n",
             )
             args = argparse.Namespace(pack_path=str(pack), strict=False)
             buf = io.StringIO()
@@ -373,7 +376,7 @@ class CliValidateWiringTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             pack = _write_pack(Path(td), "p", PACK_TOML_USER_OK)
             (pack / ".apm" / "hooks").mkdir(parents=True)
-            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (pack / ".apm" / "hooks" / "pre-pr.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
 
             args = argparse.Namespace(pack_path=str(pack), strict=False)
             buf = io.StringIO()

--- a/packages/agentbundle/agentbundle/build/tests/test_security.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_security.py
@@ -62,7 +62,7 @@ class SymlinkProjectionTests(unittest.TestCase):
             pack = tmp_path / "pack"
             skill = pack / ".apm" / "skills" / "foo"
             skill.mkdir(parents=True)
-            (skill / "SKILL.md").write_text("ok\n", encoding="utf-8")
+            (skill / "SKILL.md").write_text("ok\n", encoding="utf-8", newline="\n")
             evil = skill / "leak.txt"
             os.symlink("/etc/passwd", evil)
 
@@ -81,6 +81,7 @@ class PluginManifestValidationTests(unittest.TestCase):
             path.write_text(
                 '{"name": "x", "version": "0.1.0", "description": "d"}',
                 encoding="utf-8",
+                newline="\n",
             )
             validate_plugin_manifest(path)  # no raise
 
@@ -90,6 +91,7 @@ class PluginManifestValidationTests(unittest.TestCase):
             path.write_text(
                 '{"version": "0.1.0", "description": "d"}',
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(ValueError) as caught:
                 validate_plugin_manifest(path)

--- a/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_self_host_check.py
@@ -47,10 +47,12 @@ def _seed_pack(root: Path, name: str = "core") -> Path:
     (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
         "---\ndescription: foo\n---\n# foo\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -61,10 +63,12 @@ def _seed_pack_with_skill(root: Path, name: str, skill: str, description: str) -
     (pack / ".apm" / "skills" / skill / "SKILL.md").write_text(
         f"---\ndescription: {description}\n---\n# {skill}\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -82,6 +86,7 @@ def _add_agent(pack: Path, name: str, body: str = "Do the work.\n") -> Path:
         "---\n"
         f"{body}",
         encoding="utf-8",
+        newline="\n",
     )
     return agent_path
 
@@ -93,7 +98,7 @@ def _seed_discovery(tree: Path) -> Path:
     table needed for the no-marker case.
     """
     path = tree / ".adapt-discovery.toml"
-    path.write_text('discovery-schema-version = "0.1"\n', encoding="utf-8")
+    path.write_text('discovery-schema-version = "0.1"\n', encoding="utf-8", newline="\n")
     return path
 
 
@@ -178,7 +183,7 @@ class DryRunCleanTreeTests(unittest.TestCase):
             _git_commit_all(working_tree, "seed")
 
             target = working_tree / ".claude" / "skills" / "foo" / "SKILL.md"
-            target.write_text("drift!\n", encoding="utf-8")
+            target.write_text("drift!\n", encoding="utf-8", newline="\n")
 
             buf = io.StringIO()
             with redirect_stderr(buf):
@@ -211,9 +216,9 @@ class DirtyTreeRefusalTests(unittest.TestCase):
             working_tree.mkdir()
             _git_init(working_tree)
             _seed_discovery(working_tree)
-            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "seed")
-            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8", newline="\n")
             self.assertTrue(is_dirty_tree(working_tree))
 
             exit_code = run_self_host(
@@ -235,9 +240,9 @@ class DirtyTreeRefusalTests(unittest.TestCase):
             working_tree.mkdir()
             _git_init(working_tree)
             _seed_discovery(working_tree)
-            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "seed")
-            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8", newline="\n")
 
             exit_code = run_self_host(
                 working_tree=working_tree,
@@ -264,6 +269,7 @@ class MarkerResolutionTests(unittest.TestCase):
             (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
                 "---\ndescription: <adapt:project-name>\n---\nHello <adapt:project-name>.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             working_tree = tmp_path / "tree"
             working_tree.mkdir()
@@ -272,6 +278,7 @@ class MarkerResolutionTests(unittest.TestCase):
             (working_tree / ".adapt-discovery.toml").write_text(
                 'discovery-schema-version = "0.1"\n[markers]\nproject-name = "demo"\n',
                 encoding="utf-8",
+                newline="\n",
             )
 
             exit_code = run_self_host(
@@ -297,6 +304,7 @@ class MarkerResolutionTests(unittest.TestCase):
             (tmp_path / "AGENTS.md").write_text(
                 "Hello <adapt:name>, also <adapt:unknown>!\n",
                 encoding="utf-8",
+                newline="\n",
             )
             count = resolve_markers(tmp_path, {"name": "World"})
             self.assertEqual(count, 1)
@@ -324,6 +332,7 @@ class WorkingTreeOnConflictTests(unittest.TestCase):
             (pack / ".apm" / "hook-wiring" / "baz.toml").write_text(
                 '[hooks]\nbaz = "tools/hooks/baz.sh"\n',
                 encoding="utf-8",
+                newline="\n",
             )
 
             working_tree = tmp_path / "tree"
@@ -335,6 +344,7 @@ class WorkingTreeOnConflictTests(unittest.TestCase):
             settings_path.write_text(
                 json.dumps({"otherKey": {"preserved": True}}),
                 encoding="utf-8",
+                newline="\n",
             )
 
             exit_code = run_self_host(
@@ -361,6 +371,7 @@ class WorkingTreeOnConflictTests(unittest.TestCase):
             (core / "seeds" / "AGENTS.md").write_text(
                 "# Custom AGENTS.md\n\nDo not lose me.\n",
                 encoding="utf-8",
+                newline="\n",
             )
 
             working_tree = tmp_path / "tree"
@@ -413,7 +424,7 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
             working_tree.mkdir()
             _git_init(working_tree)
             _seed_discovery(working_tree)
-            (working_tree / ".keep").write_text("", encoding="utf-8")
+            (working_tree / ".keep").write_text("", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "init")
 
             # Register a sentinel adapter into ADAPTERS, registry, and the
@@ -459,7 +470,7 @@ class SelfHostAdapterAllowListTests(unittest.TestCase):
             working_tree.mkdir()
             _git_init(working_tree)
             _seed_discovery(working_tree)
-            (working_tree / ".keep").write_text("", encoding="utf-8")
+            (working_tree / ".keep").write_text("", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "init")
 
             sentinel_module = MagicMock()
@@ -513,6 +524,7 @@ class SelfHostCodexProjectionTests(unittest.TestCase):
             (core / ".apm" / "hook-wiring" / "reviewer.toml").write_text(
                 '[hooks]\nreviewer = "tools/hooks/reviewer.sh"\n',
                 encoding="utf-8",
+                newline="\n",
             )
 
             working_tree = tmp_path / "tree"
@@ -564,10 +576,10 @@ class AgentsMdCompositionTests(unittest.TestCase):
             )
             (core / "seeds").mkdir()
             (core / "seeds" / "AGENTS.md").write_text(
-                "# Body\n\nBody source.\n", encoding="utf-8"
+                "# Body\n\nBody source.\n", encoding="utf-8", newline="\n"
             )
             (core / "seeds" / "_agents-footer.md").write_text(
-                "> Footer source.\n", encoding="utf-8"
+                "> Footer source.\n", encoding="utf-8", newline="\n"
             )
 
             working_tree = tmp_path / "tree"
@@ -619,16 +631,16 @@ class AgentsMdCompositionTests(unittest.TestCase):
             core = _seed_pack(packs_dir, "core")
             (core / "seeds").mkdir()
             (core / "seeds" / "AGENTS.md").write_text(
-                "# Seed body\n", encoding="utf-8"
+                "# Seed body\n", encoding="utf-8", newline="\n"
             )
             (core / "seeds" / "_agents-footer.md").write_text(
-                "> Seed footer.\n", encoding="utf-8"
+                "> Seed footer.\n", encoding="utf-8", newline="\n"
             )
 
             output = tmp_path / "out"
             output.mkdir()
             adopter_content = "# Adopter's filled-in AGENTS.md\n\nLive content.\n"
-            (output / "AGENTS.md").write_text(adopter_content, encoding="utf-8")
+            (output / "AGENTS.md").write_text(adopter_content, encoding="utf-8", newline="\n")
 
             result = _compose_agents_md(packs_dir, output, self.contract)
 
@@ -694,11 +706,12 @@ class SelfHostPackFilterTests(unittest.TestCase):
                 pack = packs_dir / name
                 (pack / "seeds" / "docs").mkdir(parents=True)
                 (pack / "seeds" / "docs" / f"{name}.md").write_text(
-                    f"# {name}\n", encoding="utf-8"
+                    f"# {name}\n", encoding="utf-8", newline="\n"
                 )
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output = tmp_path / "out"
             output.mkdir()
@@ -830,10 +843,10 @@ class SeedProjectionTests(unittest.TestCase):
             pack = packs_dir / "core"
             (pack / "seeds" / "docs").mkdir(parents=True)
             (pack / "seeds" / "docs" / "CHARTER.md").write_text(
-                "# Charter\n", encoding="utf-8"
+                "# Charter\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
-                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
             )
             output = tmp_path / "out"
             output.mkdir()
@@ -870,10 +883,10 @@ class SeedProjectionTests(unittest.TestCase):
             (pack / "seeds" / "docs" / "specs").mkdir(parents=True)
             # Placeholder seed (what ships to adopters).
             (pack / "seeds" / "docs" / "specs" / "README.md").write_text(
-                "# Specs\n\n<!-- no specs yet -->\n", encoding="utf-8"
+                "# Specs\n\n<!-- no specs yet -->\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
-                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
             )
             output = tmp_path / "out"
             (output / "docs" / "specs").mkdir(parents=True)
@@ -882,6 +895,7 @@ class SeedProjectionTests(unittest.TestCase):
             (output / "docs" / "specs" / "README.md").write_text(
                 "# Specs\n\n| Spec | Status |\n| --- | --- |\n| foo | Draft |\n",
                 encoding="utf-8",
+                newline="\n",
             )
 
             _project_seeds(packs_dir, output)
@@ -913,10 +927,10 @@ class SeedProjectionTests(unittest.TestCase):
             # Blank seed template (what ships to adopters on fresh install).
             (pack / "seeds").mkdir()
             (pack / "seeds" / "workspace.toml").write_text(
-                "[backlog]\nopen = []\n", encoding="utf-8"
+                "[backlog]\nopen = []\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
-                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
             )
             output = tmp_path / "out"
             output.mkdir()
@@ -925,7 +939,7 @@ class SeedProjectionTests(unittest.TestCase):
                 '[backlog]\nopen = [{slug = "my-deferred-item"}]\n\n'
                 '["ini-001"]\nname = "Platform Core"\n'
             )
-            (output / "workspace.toml").write_text(curated, encoding="utf-8")
+            (output / "workspace.toml").write_text(curated, encoding="utf-8", newline="\n")
 
             _project_seeds(packs_dir, output)
 
@@ -945,10 +959,10 @@ class SeedProjectionTests(unittest.TestCase):
             pack = packs_dir / "core"
             (pack / "seeds" / "docs" / "specs").mkdir(parents=True)
             (pack / "seeds" / "docs" / "specs" / "README.md").write_text(
-                "# Specs\n\n<!-- no specs yet -->\n", encoding="utf-8"
+                "# Specs\n\n<!-- no specs yet -->\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
-                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
             )
             output = tmp_path / "out"
             output.mkdir()  # No pre-existing docs/specs/README.md
@@ -979,11 +993,12 @@ class SeedProjectionTests(unittest.TestCase):
             pack = packs_dir / "user-guide-diataxis"
             (pack / "seeds" / "guides" / "tutorials").mkdir(parents=True)
             (pack / "seeds" / "guides" / "tutorials" / "README.md").write_text(
-                "# Tutorials\n", encoding="utf-8"
+                "# Tutorials\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
                 '[pack]\nname = "user-guide-diataxis"\nversion = "0.1.0"\n',
                 encoding="utf-8",
+                newline="\n",
             )
             output = tmp_path / "out"
             output.mkdir()  # No pre-existing guides tree
@@ -1006,11 +1021,12 @@ class SeedProjectionTests(unittest.TestCase):
                 pack = packs_dir / name
                 (pack / "seeds" / "docs" / "_templates").mkdir(parents=True)
                 (pack / "seeds" / "docs" / "_templates" / fname).write_text(
-                    f"# {fname}\n", encoding="utf-8"
+                    f"# {fname}\n", encoding="utf-8", newline="\n"
                 )
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output = tmp_path / "out"
             output.mkdir()
@@ -1030,10 +1046,11 @@ class SeedProjectionTests(unittest.TestCase):
             for name, content in [("core", "v1\n"), ("governance-extras", "v2\n")]:
                 pack = packs_dir / name
                 (pack / "seeds").mkdir(parents=True)
-                (pack / "seeds" / "AGENTS.md").write_text(content, encoding="utf-8")
+                (pack / "seeds" / "AGENTS.md").write_text(content, encoding="utf-8", newline="\n")
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output = tmp_path / "out"
             output.mkdir()
@@ -1071,11 +1088,12 @@ class SeedProjectionTests(unittest.TestCase):
                 pack = packs_dir / name
                 (pack / "seeds" / "docs" / "architecture").mkdir(parents=True)
                 (pack / "seeds" / "docs" / "architecture" / "reference.md").write_text(
-                    content, encoding="utf-8"
+                    content, encoding="utf-8", newline="\n"
                 )
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output = tmp_path / "out"
             output.mkdir()
@@ -1127,13 +1145,13 @@ class SeedProjectionTests(unittest.TestCase):
             pack = packs_dir / "core"
             (pack / "seeds").mkdir(parents=True)
             (pack / "seeds" / "_agents-footer.md").write_text(
-                "> footer\n", encoding="utf-8"
+                "> footer\n", encoding="utf-8", newline="\n"
             )
             (pack / "seeds" / "AGENTS.md").write_text(
-                "# AGENTS\n", encoding="utf-8"
+                "# AGENTS\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
-                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+                '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
             )
             output = tmp_path / "out"
             output.mkdir()
@@ -1160,10 +1178,12 @@ class MarketplaceAggregationTests(unittest.TestCase):
                 (pack / ".claude-plugin" / "plugin.json").write_text(
                     json.dumps({"name": name, "version": "0.1.0"}),
                     encoding="utf-8",
+                    newline="\n",
                 )
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output = tmp_path / "out"
             output.mkdir()
@@ -1190,10 +1210,12 @@ class MarketplaceAggregationTests(unittest.TestCase):
                 (pack / ".claude-plugin" / "plugin.json").write_text(
                     json.dumps({"name": name, "version": "0.1.0"}),
                     encoding="utf-8",
+                    newline="\n",
                 )
                 (pack / "pack.toml").write_text(
                     f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
                     encoding="utf-8",
+                    newline="\n",
                 )
             output_a = tmp_path / "out_a"
             output_a.mkdir()
@@ -1216,7 +1238,7 @@ class ClaudeSymlinkTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8", newline="\n")
             _recreate_claude_symlink(tree)
             link = tree / "CLAUDE.md"
             self.assertTrue(link.is_symlink())
@@ -1227,7 +1249,7 @@ class ClaudeSymlinkTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8", newline="\n")
             (tree / "CLAUDE.md").symlink_to("AGENTS.md")
             _recreate_claude_symlink(tree)  # should not raise
             self.assertEqual(os.readlink(tree / "CLAUDE.md"), "AGENTS.md")
@@ -1237,7 +1259,7 @@ class ClaudeSymlinkTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8", newline="\n")
             (tree / "CLAUDE.md").symlink_to("other.md")
             _recreate_claude_symlink(tree)
             self.assertEqual(os.readlink(tree / "CLAUDE.md"), "AGENTS.md")
@@ -1285,7 +1307,7 @@ class ClaudeSymlinkFallbackTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("# agents canonical\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("# agents canonical\n", encoding="utf-8", newline="\n")
             claude = _recreate_claude_symlink(tree, force_copy=True)
             self.assertFalse(claude.is_symlink())
             self.assertTrue(claude.is_file())
@@ -1298,7 +1320,7 @@ class ClaudeSymlinkFallbackTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("content\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("content\n", encoding="utf-8", newline="\n")
             (tree / "CLAUDE.md").symlink_to("AGENTS.md")
             _recreate_claude_symlink(tree, force_copy=True)
             claude = tree / "CLAUDE.md"
@@ -1318,7 +1340,7 @@ class ClaudeSymlinkFallbackTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("hello\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("hello\n", encoding="utf-8", newline="\n")
             buf = io.StringIO()
             with redirect_stderr(buf):
                 _recreate_claude_symlink(tree, force_copy=True)
@@ -1339,7 +1361,7 @@ class ClaudeSymlinkFallbackTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8", newline="\n")
             buf = io.StringIO()
             with patch("agentbundle.build.self_host.sys.platform", "win32"):
                 with redirect_stderr(buf):
@@ -1359,7 +1381,7 @@ class ClaudeSymlinkFallbackTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tree = Path(tmp)
-            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8")
+            (tree / "AGENTS.md").write_text("agents\n", encoding="utf-8", newline="\n")
             _recreate_claude_symlink(tree)
             link = tree / "CLAUDE.md"
             self.assertTrue(link.is_symlink())
@@ -1434,7 +1456,7 @@ class DriftSourceNamingTests(unittest.TestCase):
 
             # Introduce drift on a projected path.
             target = working_tree / ".claude" / "skills" / "foo" / "SKILL.md"
-            target.write_text("drift!\n", encoding="utf-8")
+            target.write_text("drift!\n", encoding="utf-8", newline="\n")
 
             buf = io.StringIO()
             with redirect_stderr(buf):
@@ -1486,7 +1508,7 @@ class InfoLineUnclassifiedTests(unittest.TestCase):
 
             # Introduce an unclassified path: not under any Excluded pattern,
             # not in Projected set.
-            (working_tree / "stray-note.md").write_text("note\n", encoding="utf-8")
+            (working_tree / "stray-note.md").write_text("note\n", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "seed + stray")
 
             buf = io.StringIO()
@@ -1520,6 +1542,7 @@ class ForwardFlowIntegrationTests(unittest.TestCase):
             (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
                 "---\ndescription: foo\n---\n# foo v1\n",
                 encoding="utf-8",
+                newline="\n",
             )
             working_tree = tmp_path / "tree"
             working_tree.mkdir()
@@ -1543,6 +1566,7 @@ class ForwardFlowIntegrationTests(unittest.TestCase):
             (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
                 "---\ndescription: foo\n---\n# foo v2\n",
                 encoding="utf-8",
+                newline="\n",
             )
 
             # Re-projection picks up the new content.
@@ -1586,9 +1610,9 @@ class DirtyTreeStderrMessageTests(unittest.TestCase):
             working_tree.mkdir()
             _git_init(working_tree)
             _seed_discovery(working_tree)
-            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("a\n", encoding="utf-8", newline="\n")
             _git_commit_all(working_tree, "seed")
-            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8")
+            (working_tree / "tracked.txt").write_text("b\n", encoding="utf-8", newline="\n")
 
             buf = io.StringIO()
             with redirect_stderr(buf):
@@ -1623,11 +1647,13 @@ class PlainBuildCopiesMarkerThroughTests(unittest.TestCase):
             (pack / ".apm" / "skills" / "foo" / "SKILL.md").write_text(
                 "---\ndescription: foo\n---\nHello <adapt:project-name>.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             (pack / ".claude-plugin").mkdir()
             (pack / ".claude-plugin" / "plugin.json").write_text(
                 json.dumps({"name": "core", "version": "0.1.0", "description": "x"}),
                 encoding="utf-8",
+                newline="\n",
             )
             output_dir = tmp_path / "dist"
             run_recipe(
@@ -1708,8 +1734,8 @@ class FileModeBitsTests(unittest.TestCase):
             tree = Path(tmp) / "tree"
             shadow.mkdir()
             tree.mkdir()
-            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
             os.chmod(shadow / "hook.sh", 0o755)
             os.chmod(tree / "hook.sh", 0o644)
 
@@ -1724,8 +1750,8 @@ class FileModeBitsTests(unittest.TestCase):
             tree = Path(tmp) / "tree"
             shadow.mkdir()
             tree.mkdir()
-            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
             os.chmod(shadow / "hook.sh", 0o755)
             os.chmod(tree / "hook.sh", 0o755)
 
@@ -1773,8 +1799,8 @@ class SymlinkTargetTests(unittest.TestCase):
             tree = Path(tmp) / "tree"
             shadow.mkdir()
             tree.mkdir()
-            (shadow / "AGENTS.md").write_text("body", encoding="utf-8")
-            (tree / "AGENTS.md").write_text("body", encoding="utf-8")
+            (shadow / "AGENTS.md").write_text("body", encoding="utf-8", newline="\n")
+            (tree / "AGENTS.md").write_text("body", encoding="utf-8", newline="\n")
             os.symlink("AGENTS.md", shadow / "alias.md")
             os.symlink("AGENTS.md", tree / "alias.md")
 
@@ -1793,11 +1819,11 @@ class SymlinkTargetTests(unittest.TestCase):
             shadow.mkdir()
             tree.mkdir()
             # Create a target so shadow's symlink "looks" valid in isolation.
-            (shadow / "target.md").write_text("body", encoding="utf-8")
+            (shadow / "target.md").write_text("body", encoding="utf-8", newline="\n")
             os.symlink("target.md", shadow / "alias.md")
             # On-disk: a regular file with identical content.
-            (tree / "target.md").write_text("body", encoding="utf-8")
-            (tree / "alias.md").write_text("body", encoding="utf-8")
+            (tree / "target.md").write_text("body", encoding="utf-8", newline="\n")
+            (tree / "alias.md").write_text("body", encoding="utf-8", newline="\n")
 
             drifts = diff_against_working_tree(shadow, tree)
             type_mismatch = [d for d in drifts if "alias.md" in d and "expected symlink" in d]
@@ -1847,8 +1873,8 @@ class StrengthenedDiffRegressionIntegrationTests(unittest.TestCase):
 
             # Rule (b) regression: an executable hook script whose
             # +x bit gets dropped on disk.
-            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
-            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            (shadow / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
+            (tree / "hook.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
             os.chmod(shadow / "hook.sh", 0o755)
             os.chmod(tree / "hook.sh", 0o644)
 
@@ -1857,10 +1883,10 @@ class StrengthenedDiffRegressionIntegrationTests(unittest.TestCase):
             # gate must not follow the symlinks — read_bytes would
             # accidentally compare AGENTS.md vs README.md content and
             # might have hidden the regression.
-            (shadow / "AGENTS.md").write_text("agents-body", encoding="utf-8")
-            (shadow / "README.md").write_text("readme-body", encoding="utf-8")
-            (tree / "AGENTS.md").write_text("agents-body", encoding="utf-8")
-            (tree / "README.md").write_text("readme-body", encoding="utf-8")
+            (shadow / "AGENTS.md").write_text("agents-body", encoding="utf-8", newline="\n")
+            (shadow / "README.md").write_text("readme-body", encoding="utf-8", newline="\n")
+            (tree / "AGENTS.md").write_text("agents-body", encoding="utf-8", newline="\n")
+            (tree / "README.md").write_text("readme-body", encoding="utf-8", newline="\n")
             os.symlink("AGENTS.md", shadow / "CLAUDE.md")
             os.symlink("README.md", tree / "CLAUDE.md")
 
@@ -1894,7 +1920,7 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
         symlink to AGENTS.md (the POSIX shadow shape)."""
         shadow = tree / "shadow"
         shadow.mkdir()
-        (shadow / "AGENTS.md").write_text("body\n", encoding="utf-8")
+        (shadow / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
         (shadow / "CLAUDE.md").symlink_to("AGENTS.md")
         return shadow
 
@@ -1903,8 +1929,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
         regular-file copy of AGENTS.md (the Windows shadow shape)."""
         shadow = tree / "shadow"
         shadow.mkdir()
-        (shadow / "AGENTS.md").write_text("body\n", encoding="utf-8")
-        (shadow / "CLAUDE.md").write_text("body\n", encoding="utf-8")
+        (shadow / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+        (shadow / "CLAUDE.md").write_text("body\n", encoding="utf-8", newline="\n")
         return shadow
 
     def test_symlink_shadow_against_symlink_disk_no_drift(self) -> None:
@@ -1913,7 +1939,7 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
             (disk / "CLAUDE.md").symlink_to("AGENTS.md")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
@@ -1925,8 +1951,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("body\n", encoding="utf-8", newline="\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
     def test_symlink_shadow_against_materialised_disk_no_drift(self) -> None:
@@ -1937,8 +1963,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("AGENTS.md", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("AGENTS.md", encoding="utf-8", newline="\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
     def test_copy_shadow_against_symlink_disk_no_drift(self) -> None:
@@ -1950,7 +1976,7 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_copy_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
             (disk / "CLAUDE.md").symlink_to("AGENTS.md")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
@@ -1964,8 +1990,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_copy_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("body\n", encoding="utf-8", newline="\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
     def test_copy_shadow_against_materialised_disk_no_drift(self) -> None:
@@ -1978,8 +2004,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_copy_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("AGENTS.md", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("AGENTS.md", encoding="utf-8", newline="\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
     def test_clause_b_routes_through_lf_normalisation(self) -> None:
@@ -1999,12 +2025,12 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             # CRLF difference on disk is non-trivial (a one-line file
             # ending in \n vs \r\n is indistinguishable after strip).
             (shadow / "AGENTS.md").write_text(
-                "line one\nline two\n", encoding="utf-8"
+                "line one\nline two\n", encoding="utf-8", newline="\n"
             )
             disk = tree / "disk"
             disk.mkdir()
             (disk / "AGENTS.md").write_text(
-                "line one\nline two\n", encoding="utf-8"
+                "line one\nline two\n", encoding="utf-8", newline="\n"
             )
             (disk / "CLAUDE.md").write_bytes(b"line one\r\nline two\r\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
@@ -2019,7 +2045,7 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
             (disk / "CLAUDE.md").write_bytes(b"AGENTS.md\r\n")
             self.assertEqual(diff_against_working_tree(shadow, disk), [])
 
@@ -2034,9 +2060,9 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
             (disk / "CLAUDE.md").write_text(
-                "AGENTS.md\nmore words\n", encoding="utf-8"
+                "AGENTS.md\nmore words\n", encoding="utf-8", newline="\n"
             )
             drifts = diff_against_working_tree(shadow, disk)
             claude_drifts = [d for d in drifts if "CLAUDE.md" in d]
@@ -2054,8 +2080,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("tampered\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("tampered\n", encoding="utf-8", newline="\n")
             drifts = diff_against_working_tree(shadow, disk)
             claude_drifts = [d for d in drifts if "CLAUDE.md" in d]
             self.assertEqual(len(claude_drifts), 1, drifts)
@@ -2073,8 +2099,8 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
-            (disk / "CLAUDE.md").write_text("evil\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
+            (disk / "CLAUDE.md").write_text("evil\n", encoding="utf-8", newline="\n")
             drifts = diff_against_working_tree(shadow, disk)
             claude_drifts = [d for d in drifts if "CLAUDE.md" in d]
             self.assertEqual(len(claude_drifts), 1, drifts)
@@ -2086,7 +2112,7 @@ class ClaudeMdEquivalenceTests(unittest.TestCase):
             shadow = self._shadow_with_symlink_claude(tree)
             disk = tree / "disk"
             disk.mkdir()
-            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8")
+            (disk / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
             drifts = diff_against_working_tree(shadow, disk)
             claude_drifts = [d for d in drifts if "CLAUDE.md" in d]
             self.assertEqual(len(claude_drifts), 1, drifts)
@@ -2104,7 +2130,7 @@ class RecreateClaudeBridgeInvariantTests(unittest.TestCase):
     "The shadow side is trusted by construction ...")."""
 
     def _seed(self, tmp: Path, force_copy: bool) -> Path:
-        (tmp / "AGENTS.md").write_text("body\n", encoding="utf-8")
+        (tmp / "AGENTS.md").write_text("body\n", encoding="utf-8", newline="\n")
         _recreate_claude_symlink(tmp, force_copy=force_copy)
         return tmp
 
@@ -2158,6 +2184,7 @@ class SelfHostAdapterRoutingTests(unittest.TestCase):
                 'default-scope = "repo"\n'
                 'allowed-scopes = ["repo"]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             (packs_dir / "core" / ".apm").mkdir()
             out = tmp_path / "out"

--- a/packages/agentbundle/agentbundle/build/tests/test_shared_libs_projection.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_shared_libs_projection.py
@@ -59,12 +59,13 @@ def _write_pack(
     (pack / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "0.1.0"\n',
         encoding="utf-8",
+        newline="\n",
     )
     if shared_libs_files:
         sl = pack / ".apm" / "shared-libs"
         sl.mkdir(parents=True)
         for fname, text in shared_libs_files.items():
-            (sl / fname).write_text(text, encoding="utf-8")
+            (sl / fname).write_text(text, encoding="utf-8", newline="\n")
     return pack
 
 

--- a/packages/agentbundle/agentbundle/build/tests/test_writers_emit_lf.py
+++ b/packages/agentbundle/agentbundle/build/tests/test_writers_emit_lf.py
@@ -13,6 +13,9 @@ Scope: the walk covers the inner `agentbundle/` package only. The sibling
 canonical copy `packages/agentbundle/templates/install-marker.py` is outside
 it — that copy writes via `os.write(fd, bytes)` (byte-safe), so it carries no
 text writer to guard today; a text writer added there would not be caught here.
+Test helpers (files under ``tests/``) are also excluded by design: they write
+fixture data whose exact bytes are under test control and are never projected
+onto a user's filesystem.
 
 See `docs/specs/lf-line-endings/spec.md`.
 """

--- a/packages/agentbundle/tests/integration/test_adapt_cmd.py
+++ b/packages/agentbundle/tests/integration/test_adapt_cmd.py
@@ -70,7 +70,7 @@ def _setup_projected(tmp_path: Path, files: dict[str, str]) -> None:
         adapter="claude-code",
     )
     (tmp_path / ".agentbundle-state.toml").write_text(
-        dump_state(state), encoding="utf-8"
+        dump_state(state), encoding="utf-8", newline="\n"
     )
 
 
@@ -133,10 +133,10 @@ def test_adapt_pending_md_lists_companions(tmp_path):
 
     # Place two .upstream companions.
     (tmp_path / "AGENTS.upstream.md").write_text(
-        "# AGENTS UPSTREAM\nExtra line.\n", encoding="utf-8"
+        "# AGENTS UPSTREAM\nExtra line.\n", encoding="utf-8", newline="\n"
     )
     (tmp_path / "docs" / "CHARTER.upstream.md").write_text(
-        "# CHARTER UPSTREAM\n", encoding="utf-8"
+        "# CHARTER UPSTREAM\n", encoding="utf-8", newline="\n"
     )
 
     rc = _run(root=str(tmp_path))
@@ -153,7 +153,7 @@ def test_adapt_pending_md_includes_diff_summary(tmp_path):
     upstream_content = "line1\nline2\nline3\n"
 
     _setup_projected(tmp_path, {"AGENTS.md": original_content})
-    (tmp_path / "AGENTS.upstream.md").write_text(upstream_content, encoding="utf-8")
+    (tmp_path / "AGENTS.upstream.md").write_text(upstream_content, encoding="utf-8", newline="\n")
 
     rc = _run(root=str(tmp_path))
     assert rc == 0
@@ -229,7 +229,7 @@ def test_adapt_discovery_accepted_entries_applied(tmp_path):
 
 def test_ci_with_companions_exits_nonzero(tmp_path, capsys):
     """``adapt --ci`` exits 1 when any .upstream.* companion is on disk."""
-    (tmp_path / "AGENTS.upstream.md").write_text("upstream", encoding="utf-8")
+    (tmp_path / "AGENTS.upstream.md").write_text("upstream", encoding="utf-8", newline="\n")
 
     rc = _run(root=str(tmp_path), ci=True)
     assert rc == 1, "--ci should exit 1 when companions present"
@@ -240,10 +240,10 @@ def test_ci_with_companions_exits_nonzero(tmp_path, capsys):
 
 def test_ci_with_companions_lists_all_on_stderr(tmp_path, capsys):
     """``adapt --ci`` lists every pending companion on stderr."""
-    (tmp_path / "AGENTS.upstream.md").write_text("upstream1", encoding="utf-8")
+    (tmp_path / "AGENTS.upstream.md").write_text("upstream1", encoding="utf-8", newline="\n")
     docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / "CHARTER.upstream.md").write_text("upstream2", encoding="utf-8")
+    (docs / "CHARTER.upstream.md").write_text("upstream2", encoding="utf-8", newline="\n")
 
     rc = _run(root=str(tmp_path), ci=True)
     assert rc == 1
@@ -260,7 +260,7 @@ def test_ci_with_companions_lists_all_on_stderr(tmp_path, capsys):
 def test_ci_clean_exits_zero(tmp_path):
     """``adapt --ci`` exits 0 when no .upstream.* companions exist."""
     # No companions; only a normal file.
-    (tmp_path / "AGENTS.md").write_text("# normal file", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# normal file", encoding="utf-8", newline="\n")
 
     rc = _run(root=str(tmp_path), ci=True)
     assert rc == 0, "--ci should exit 0 with no companions"
@@ -269,7 +269,7 @@ def test_ci_clean_exits_zero(tmp_path):
 def test_ci_clean_after_companions_removed_exits_zero(tmp_path):
     """``adapt --ci`` exits 0 when a previously present companion has been removed."""
     companion = tmp_path / "AGENTS.upstream.md"
-    companion.write_text("upstream", encoding="utf-8")
+    companion.write_text("upstream", encoding="utf-8", newline="\n")
     companion.unlink()  # simulate human having resolved it
 
     rc = _run(root=str(tmp_path), ci=True)
@@ -295,7 +295,7 @@ def test_binary_file_skipped_without_error(tmp_path):
         files={"data.bin": {"sha": sha256_bytes(binary_content), "from-pack-version": "0.1.0"}},
         adapter="claude-code",
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
     (tmp_path / "data.bin").write_bytes(binary_content)
 
     values_path = ADAPT_FIXTURES / "values.toml"

--- a/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_adapt_dual_scope.py
@@ -51,7 +51,7 @@ def _write_state(path: Path, files: dict[str, str], scope: str = "repo") -> None
         adapter="claude-code",
     )
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(dump_state(state), encoding="utf-8")
+    path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 def _stage_companion(root: Path, relpath: str, content: bytes, companion_content: bytes) -> None:
@@ -210,25 +210,27 @@ def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch
     target_rel = ".claude/skills/foo/SKILL.md"
     target = fake_home / target_rel
     target.parent.mkdir(parents=True)
-    target.write_text("project=<adapt:project-name>", encoding="utf-8")
+    target.write_text("project=<adapt:project-name>", encoding="utf-8", newline="\n")
     _write_state(user_dir / "state.toml", {target_rel: "00"}, scope="user")
 
     # User-scope discovery: canonical v0.1 shape, no [markers] (markers
     # are repo-only per RFC-0004). Plus a repo-scope discovery carrying
     # the marker value the substitution needs.
     (user_dir / ".adapt-discovery.toml").write_text(
-        'discovery-schema-version = "0.1"\n', encoding="utf-8"
+        'discovery-schema-version = "0.1"\n', encoding="utf-8", newline="\n"
     )
     (repo_root / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n'
         '[markers]\nproject-name = "demo"\n',
         encoding="utf-8",
+        newline="\n",
     )
     # Counter-fixture at the BARE user path (must be ignored).
     (fake_home / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n'
         '[markers]\nproject-name = "WRONG"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     _write_state(repo_root / ".agentbundle-state.toml", {})
@@ -237,7 +239,7 @@ def test_adapt_reads_user_scope_discovery_in_dot_directory(tmp_path, monkeypatch
     # when no --values-from is passed; we want to confirm the discovery
     # values are consulted alongside).
     values_file = tmp_path / "values.toml"
-    values_file.write_text('[values]\n# only sets unrelated keys\n', encoding="utf-8")
+    values_file.write_text('[values]\n# only sets unrelated keys\n', encoding="utf-8", newline="\n")
 
     args = argparse.Namespace(
         values_from=str(values_file), ci=False, root=str(repo_root)

--- a/packages/agentbundle/tests/integration/test_adapt_preflight_detection.py
+++ b/packages/agentbundle/tests/integration/test_adapt_preflight_detection.py
@@ -119,6 +119,7 @@ def test_repo_scope_dirty_state_porcelain_detects_uncommitted_edit(tmp_path: Pat
     target.write_text(
         target.read_text(encoding="utf-8") + "\n# adopter-edited\n",
         encoding="utf-8",
+        newline="\n",
     )
     dirty = _porcelain(work)
     assert dirty != "", (
@@ -152,7 +153,7 @@ def test_repo_scope_dirty_state_porcelain_lists_untracked_seed(tmp_path: Path):
     (work / "EXPECTED_TREE.md").unlink()
     _init_git_repo(work)
 
-    (work / "NOTES.md").write_text("scratch\n", encoding="utf-8")
+    (work / "NOTES.md").write_text("scratch\n", encoding="utf-8", newline="\n")
     dirty = _porcelain(work)
     assert "NOTES.md" in dirty, (
         f"porcelain must surface untracked files by path; got: {dirty!r}"

--- a/packages/agentbundle/tests/integration/test_adapt_schema_migration.py
+++ b/packages/agentbundle/tests/integration/test_adapt_schema_migration.py
@@ -35,7 +35,7 @@ def _seed_repo(root: Path, files: dict[str, str]) -> None:
     state.packs[("core", "claude-code")] = PackState(
         installed_version="0.1.0", files=file_entries, adapter="claude-code"
     )
-    (root / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+    (root / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 def _ns(root: Path, values_from: Path | None = None) -> argparse.Namespace:
@@ -52,6 +52,7 @@ def test_markers_table_substitutes(tmp_path):
     (tmp_path / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n[markers]\nowner = "octocat"\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc = adapt.run(_ns(tmp_path, values_from=tmp_path / ".adapt-discovery.toml"))
     assert rc == 0
@@ -62,7 +63,7 @@ def test_legacy_accepted_refused_with_prefix(tmp_path, capsys):
     """Legacy top-level ``[accepted]`` refused with stderr ``adapt: `` prefix."""
     _seed_repo(tmp_path, {"AGENTS.md": "x\n"})
     (tmp_path / ".adapt-discovery.toml").write_text(
-        '[accepted]\nowner = "octocat"\n', encoding="utf-8"
+        '[accepted]\nowner = "octocat"\n', encoding="utf-8", newline="\n"
     )
     rc = adapt.run(_ns(tmp_path))
     assert rc == 1
@@ -81,6 +82,7 @@ def test_unknown_schema_version_refused_with_prefix(tmp_path, capsys):
     (tmp_path / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "9.9"\n[markers]\nowner = "x"\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc = adapt.run(_ns(tmp_path))
     assert rc == 1
@@ -93,7 +95,7 @@ def test_lowercase_hyphen_markers_match(tmp_path):
     """``<adapt:project-name>`` substitutes (canonical form, AC14)."""
     _seed_repo(tmp_path, {"AGENTS.md": "project=<adapt:project-name>\n"})
     values = tmp_path / "values.toml"
-    values.write_text('[markers]\nproject-name = "demo"\n', encoding="utf-8")
+    values.write_text('[markers]\nproject-name = "demo"\n', encoding="utf-8", newline="\n")
     rc = adapt.run(_ns(tmp_path, values_from=values))
     assert rc == 0
     assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == "project=demo\n"
@@ -108,6 +110,7 @@ def test_upper_snake_markers_no_longer_substituted(tmp_path, capsys):
     values.write_text(
         '[markers]\nPROJECT_NAME = "WRONG"\nproject-name = "demo"\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc = adapt.run(_ns(tmp_path, values_from=values))
     assert rc == 0

--- a/packages/agentbundle/tests/integration/test_apm_install_route.py
+++ b/packages/agentbundle/tests/integration/test_apm_install_route.py
@@ -82,7 +82,7 @@ def _write_pack_toml(
         default-scope = {json.dumps(allowed_scopes[0])}
         allowed-scopes = {json.dumps(allowed_scopes)}
     """).lstrip()
-    (pack_root / "pack.toml").write_text(content, encoding="utf-8")
+    (pack_root / "pack.toml").write_text(content, encoding="utf-8", newline="\n")
 
 
 def _run_writer(
@@ -169,7 +169,7 @@ def test_install_route_flag_claude_plugins_records_claude_plugins(tmp_path):
     settings_dir = project_dir / ".claude"
     settings_dir.mkdir()
     (settings_dir / "settings.local.json").write_text(
-        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8"
+        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8", newline="\n"
     )
     plugin_data = tmp_path / "data"
     plugin_data.mkdir()
@@ -536,7 +536,7 @@ def test_route_flag_dispatches_claude_plugins_scope_detection(tmp_path):
     settings_dir = home / ".claude"
     settings_dir.mkdir()
     (settings_dir / "settings.json").write_text(
-        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8"
+        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8", newline="\n"
     )
     plugin_data = tmp_path / "data"
     plugin_data.mkdir()
@@ -576,7 +576,7 @@ def test_route_flag_dispatches_apm_scope_detection(tmp_path):
     settings_dir = home / ".claude"
     settings_dir.mkdir()
     (settings_dir / "settings.json").write_text(
-        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8"
+        json.dumps({"enabledPlugins": ["core"]}), encoding="utf-8", newline="\n"
     )
 
     env = _base_env({"PLUGIN_ROOT": pack_root, "HOME": home})
@@ -716,7 +716,7 @@ def test_lockfile_replay_replaces_entry(tmp_path):
         "installed-at = 2026-05-20T10:00:00Z\n"
         'install-route = "apm"\n'
     )
-    (cwd / ".adapt-install-marker.toml").write_text(pre_seeded, encoding="utf-8")
+    (cwd / ".adapt-install-marker.toml").write_text(pre_seeded, encoding="utf-8", newline="\n")
 
     env = _base_env({"PLUGIN_ROOT": pack_root, "HOME": home})
     result = _run_writer(projected, env=env, cwd=cwd)

--- a/packages/agentbundle/tests/integration/test_brownfield_adapt_end_to_end.py
+++ b/packages/agentbundle/tests/integration/test_brownfield_adapt_end_to_end.py
@@ -46,7 +46,7 @@ def _setup_brownfield(tmp_path: Path) -> Path:
         installed_version="0.1.0", files=files, adapter="claude-code"
     )
     (work / ".agentbundle-state.toml").write_text(
-        dump_state(state), encoding="utf-8"
+        dump_state(state), encoding="utf-8", newline="\n"
     )
     # Hand-write the canonical discovery file with [markers].
     (work / ".adapt-discovery.toml").write_text(
@@ -56,6 +56,7 @@ def _setup_brownfield(tmp_path: Path) -> Path:
         'owner = "octocat"\n'
         'repo-url = "https://example.com/myproject"\n',
         encoding="utf-8",
+        newline="\n",
     )
     return work
 
@@ -152,11 +153,11 @@ def test_pending_report_byte_identical_with_multiple_companions(tmp_path):
     }
     files: dict = {}
     for rel, body in bodies.items():
-        (work / rel).write_text(body, encoding="utf-8")
+        (work / rel).write_text(body, encoding="utf-8", newline="\n")
         comp_rel = companion_path(Path(rel)).as_posix()
         (work / comp_rel).parent.mkdir(parents=True, exist_ok=True)
         (work / comp_rel).write_text(
-            f"upstream variant of {rel}\n", encoding="utf-8"
+            f"upstream variant of {rel}\n", encoding="utf-8", newline="\n"
         )
         files[rel] = {
             "sha": sha256_bytes(body.encode("utf-8")),
@@ -168,10 +169,10 @@ def test_pending_report_byte_identical_with_multiple_companions(tmp_path):
         installed_version="0.1.0", files=files, adapter="claude-code"
     )
     (work / ".agentbundle-state.toml").write_text(
-        dump_state(state), encoding="utf-8"
+        dump_state(state), encoding="utf-8", newline="\n"
     )
     (work / ".adapt-discovery.toml").write_text(
-        'discovery-schema-version = "0.1"\n[markers]\n', encoding="utf-8"
+        'discovery-schema-version = "0.1"\n[markers]\n', encoding="utf-8", newline="\n"
     )
 
     assert adapt.run(_ns(work)) == 0

--- a/packages/agentbundle/tests/integration/test_build_check_drift_gates.py
+++ b/packages/agentbundle/tests/integration/test_build_check_drift_gates.py
@@ -84,6 +84,7 @@ def _make_minimal_pack(packs_dir: Path, pack_name: str = "alpha") -> Path:
         f'description = "Drift-gate test pack."\n'
         f'[pack.install]\nallowed-scopes = ["repo"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     plugin_dir = pack_dir / ".claude-plugin"
     plugin_dir.mkdir(parents=True, exist_ok=True)
@@ -92,6 +93,7 @@ def _make_minimal_pack(packs_dir: Path, pack_name: str = "alpha") -> Path:
             {"name": pack_name, "version": "0.1.0", "description": "Drift-gate test."}
         ),
         encoding="utf-8",
+        newline="\n",
     )
     return pack_dir
 
@@ -214,7 +216,7 @@ def test_make_build_check_catches_emit_basic_string_drift(tmp_path, monkeypatch)
     )
 
     mutated_path = tmp_path / "install-marker-mutated.py"
-    mutated_path.write_text(mutated_text, encoding="utf-8")
+    mutated_path.write_text(mutated_text, encoding="utf-8", newline="\n")
 
     monkeypatch.setattr(
         self_host_mod,
@@ -281,7 +283,7 @@ def test_make_build_check_fails_on_source_hooks_block(tmp_path):
     plugin_json_path = pack_dir / ".claude-plugin" / "plugin.json"
     manifest = json.loads(plugin_json_path.read_text(encoding="utf-8"))
     manifest["hooks"] = {}
-    plugin_json_path.write_text(json.dumps(manifest), encoding="utf-8")
+    plugin_json_path.write_text(json.dumps(manifest), encoding="utf-8", newline="\n")
 
     output_dir = tmp_path / "workspace"
     output_dir.mkdir()

--- a/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
+++ b/packages/agentbundle/tests/integration/test_build_derivation_claude_plugins.py
@@ -266,7 +266,7 @@ def test_derivation_recovers_from_phantom_files(tmp_path):
     phantom_dir = tmp_path / "claude-plugins" / pack_name / ".claude-plugin"
     phantom_dir.mkdir(parents=True, exist_ok=True)
     phantom_file = phantom_dir / "stale.json"
-    phantom_file.write_text('{"phantom": true}', encoding="utf-8")
+    phantom_file.write_text('{"phantom": true}', encoding="utf-8", newline="\n")
 
     assert phantom_file.exists(), "pre-condition: phantom file must exist before build"
 
@@ -442,7 +442,7 @@ def test_build_rejects_source_plugin_json_with_hooks_block(tmp_path):
     mutated_manifest = mutated_packs / pack_name / ".claude-plugin" / "plugin.json"
     original = json.loads(mutated_manifest.read_text(encoding="utf-8"))
     original["hooks"] = {"SessionStart": [{"command": "echo evil"}]}
-    mutated_manifest.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+    mutated_manifest.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8", newline="\n")
 
     result = _run_build(mutated_packs, tmp_path / "out")
 

--- a/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
+++ b/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
@@ -119,7 +119,7 @@ def pack_root_factory(tmp_path):
             default-scope = {json.dumps(allowed_scopes[0])}
             allowed-scopes = {json.dumps(allowed_scopes)}
         """).lstrip()
-        (plugin_root / "pack.toml").write_text(pack_toml_content, encoding="utf-8")
+        (plugin_root / "pack.toml").write_text(pack_toml_content, encoding="utf-8", newline="\n")
 
         # Write settings files based on opt_in_at
         for scope in opt_in_at:
@@ -130,6 +130,7 @@ def pack_root_factory(tmp_path):
                 settings_file.write_text(
                     json.dumps({"enabledPlugins": [name]}),
                     encoding="utf-8",
+                    newline="\n",
                 )
             elif scope == "project":
                 settings_dir = project_dir / ".claude"
@@ -138,6 +139,7 @@ def pack_root_factory(tmp_path):
                 settings_file.write_text(
                     json.dumps({"enabledPlugins": [name]}),
                     encoding="utf-8",
+                    newline="\n",
                 )
             elif scope == "user":
                 settings_dir = home / ".claude"
@@ -146,6 +148,7 @@ def pack_root_factory(tmp_path):
                 settings_file.write_text(
                     json.dumps({"enabledPlugins": [name]}),
                     encoding="utf-8",
+                    newline="\n",
                 )
 
         return plugin_root, plugin_data, home, project_dir
@@ -346,7 +349,7 @@ def test_scope_malformed_local_json_falls_through_to_project(pack_root_factory):
     )
     # Overwrite local settings with garbage.
     local_settings = project_dir / ".claude" / "settings.local.json"
-    local_settings.write_text("{not valid json", encoding="utf-8")
+    local_settings.write_text("{not valid json", encoding="utf-8", newline="\n")
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -508,7 +511,7 @@ def test_atomic_rename_uses_os_replace_and_recovers_on_crash(tmp_path, pack_root
     # We need to add "local" opt-in for pack-b in the project_dir settings.
     local_settings = project_dir / ".claude" / "settings.local.json"
     # Update to include both packs.
-    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8")  # noqa: E501
+    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n")  # noqa: E501
 
     # Set up the sitecustomize.py that crashes os.replace on first call.
     sitecustomize_dir = tmp_path / "sitecustomize_crash"
@@ -528,6 +531,7 @@ def test_atomic_rename_uses_os_replace_and_recovers_on_crash(tmp_path, pack_root
             _os.replace = _crashing_replace
         """),
         encoding="utf-8",
+        newline="\n",
     )
 
     env_b_crash = _make_env(
@@ -602,6 +606,7 @@ def test_hash_file_not_written_when_marker_write_fails(tmp_path, pack_root_facto
             _os.replace = _perm_replace
         """),
         encoding="utf-8",
+        newline="\n",
     )
 
     env_fail = _make_env(
@@ -671,7 +676,7 @@ def test_detection_keep_data_reinstall_writes(pack_root_factory):
     # Pre-seed the hash file with the correct hash.
     import hashlib
     current_hash = hashlib.sha256((plugin_root / "pack.toml").read_bytes()).hexdigest()
-    (plugin_data / "pack-manifest-hash").write_text(current_hash + "\n", encoding="utf-8")
+    (plugin_data / "pack-manifest-hash").write_text(current_hash + "\n", encoding="utf-8", newline="\n")
 
     # Marker file is absent (simulates --keep-data reinstall).
     env = _make_env(
@@ -740,7 +745,7 @@ def test_two_writers_sequential_both_entries_present(pack_root_factory):
     # Make pack-a settings visible in the shared project_dir.
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8")  # noqa: E501
+    local_settings.write_text(json.dumps({"enabledPlugins": ["pack-a", "pack-b"]}), encoding="utf-8", newline="\n")  # noqa: E501
 
     env_a = _make_env(
         plugin_root=plugin_root_a, plugin_data=plugin_data_a, home=home, project_dir=project_dir
@@ -817,7 +822,7 @@ def test_cli_to_claude_plugins_handoff_preserves_datetime(tmp_path, pack_root_fa
     # Make the project dir settings include plugins-pack.
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8")
+    local_settings.write_text(json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8", newline="\n")
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -887,7 +892,7 @@ def test_cli_to_claude_plugins_handoff_preserves_install_route(tmp_path, pack_ro
     )
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["governance-extras"]}), encoding="utf-8")  # noqa: E501
+    local_settings.write_text(json.dumps({"enabledPlugins": ["governance-extras"]}), encoding="utf-8", newline="\n")  # noqa: E501
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -942,7 +947,7 @@ def test_plugin_upgrade_replaces_entry_not_stacks(pack_root_factory):
         installed-at = {old_ts.strftime("%Y-%m-%dT%H:%M:%SZ")}
         install-route = "claude-plugins"
     """).lstrip()
-    marker_path.write_text(old_content, encoding="utf-8")
+    marker_path.write_text(old_content, encoding="utf-8", newline="\n")
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -1093,7 +1098,7 @@ def test_cli_seed_unresolved_markers_and_new_companions_survive_rewrite(
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
     local_settings.write_text(
-        json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8"
+        json.dumps({"enabledPlugins": ["plugins-pack"]}), encoding="utf-8", newline="\n"
     )
 
     env = _make_env(
@@ -1192,6 +1197,7 @@ def test_writer_drops_entries_with_malformed_name_or_version(tmp_path, pack_root
         f"installed-at = {ts}\n"
         'install-route = "cli"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     plugin_root, plugin_data, _, _ = pack_root_factory(
@@ -1202,7 +1208,7 @@ def test_writer_drops_entries_with_malformed_name_or_version(tmp_path, pack_root
     )
     local_settings = project_dir / ".claude" / "settings.local.json"
     local_settings.parent.mkdir(parents=True, exist_ok=True)
-    local_settings.write_text(json.dumps({"enabledPlugins": ["third-pack"]}), encoding="utf-8")
+    local_settings.write_text(json.dumps({"enabledPlugins": ["third-pack"]}), encoding="utf-8", newline="\n")
 
     env = _make_env(
         plugin_root=plugin_root, plugin_data=plugin_data, home=home, project_dir=project_dir
@@ -1309,13 +1315,13 @@ def test_writer_refuses_pack_name_with_control_chars(tmp_path):
         'default-scope = "repo"\n'
         'allowed-scopes = ["repo"]\n'
     )
-    (plugin_root / "pack.toml").write_text(pack_toml_content, encoding="utf-8")
+    (plugin_root / "pack.toml").write_text(pack_toml_content, encoding="utf-8", newline="\n")
 
     # Opt in at local scope.
     settings_dir = project_dir / ".claude"
     settings_dir.mkdir(parents=True, exist_ok=True)
     (settings_dir / "settings.local.json").write_text(
-        _json.dumps({"enabledPlugins": [bad_name]}), encoding="utf-8"
+        _json.dumps({"enabledPlugins": [bad_name]}), encoding="utf-8", newline="\n"
     )
 
     env = _make_env(
@@ -1389,7 +1395,7 @@ def test_malformed_pack_toml_exits_nonzero_with_stderr(tmp_path):
     """Concern-18: garbage pack.toml → exit 1 with stderr mentioning 'pack.toml'."""
     plugin_root = tmp_path / "plugin_root"
     plugin_root.mkdir()
-    (plugin_root / "pack.toml").write_text("not valid toml {{{{", encoding="utf-8")
+    (plugin_root / "pack.toml").write_text("not valid toml {{{{", encoding="utf-8", newline="\n")
 
     plugin_data = tmp_path / "plugin_data"
     plugin_data.mkdir()
@@ -1443,6 +1449,7 @@ def test_hash_file_write_failure_self_heals(tmp_path, pack_root_factory):
             _os.replace = _selective_replace
         """),
         encoding="utf-8",
+        newline="\n",
     )
 
     env_fail = _make_env(

--- a/packages/agentbundle/tests/integration/test_config_cascade.py
+++ b/packages/agentbundle/tests/integration/test_config_cascade.py
@@ -82,7 +82,7 @@ def test_subprocess_fail_soft_against_malformed_config() -> None:
 
     cfg_path = _user_config_path()
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    cfg_path.write_text('[settings]\nadapter = "unterminated\n')
+    cfg_path.write_text('[settings]\nadapter = "unterminated\n', encoding="utf-8", newline="\n")
 
     # `config path` works — main() unconditionally loads the config
     # before dispatch, but the loader is fail-soft (returns
@@ -113,7 +113,7 @@ def test_in_process_resolver_honors_user_config(tmp_path: Path) -> None:
     # Write a real config file under the sandbox.
     cfg_path = _user_config_path()
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    cfg_path.write_text('[settings]\nadapter = "codex"\n')
+    cfg_path.write_text('[settings]\nadapter = "codex"\n', encoding="utf-8", newline="\n")
 
     loaded = load_user_config()
     assert loaded.adapter == "codex"

--- a/packages/agentbundle/tests/integration/test_credbroker_floor_precedence.py
+++ b/packages/agentbundle/tests/integration/test_credbroker_floor_precedence.py
@@ -121,7 +121,7 @@ def _plant_credbroker(parent: pathlib.Path) -> pathlib.Path:
     pkg = parent / "credbroker"
     pkg.mkdir(parents=True)
     init = pkg / "__init__.py"
-    init.write_text(_FAKE_CREDBROKER, encoding="utf-8")
+    init.write_text(_FAKE_CREDBROKER, encoding="utf-8", newline="\n")
     return init
 
 

--- a/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_credential_brokers_pack_install.py
@@ -215,7 +215,7 @@ class SeedsRefusalRailTests(_BaseInstall):
         # Inject a seeds/ directory with one file post-copy.
         seeds = self.cat / "packs" / "credential-brokers" / "seeds"
         seeds.mkdir()
-        (seeds / "README.md").write_text("# injected fixture\n", encoding="utf-8")
+        (seeds / "README.md").write_text("# injected fixture\n", encoding="utf-8", newline="\n")
 
     def test_install_refuses_with_pinned_message(self) -> None:
         args = argparse.Namespace(
@@ -407,7 +407,7 @@ class UserScopeFloorDeliveryTests(_BaseInstall):
             self.skipTest(f"{entry} not present in this checkout")
         stub = self.tmp / "httpxstub"
         stub.mkdir()
-        (stub / "httpx.py").write_text("# stub: import-only\n", encoding="utf-8")
+        (stub / "httpx.py").write_text("# stub: import-only\n", encoding="utf-8", newline="\n")
 
         # Make the floor the *only* credbroker. `-S` (no site-packages) does
         # that — but only apply it when a credbroker is actually installed in

--- a/packages/agentbundle/tests/integration/test_discovery_schema_cross_consumer.py
+++ b/packages/agentbundle/tests/integration/test_discovery_schema_cross_consumer.py
@@ -28,7 +28,7 @@ from agentbundle.safety import sha256_bytes
 def _seed_repo(root: Path) -> None:
     state = State()
     p = root / "AGENTS.md"
-    p.write_text("x\n", encoding="utf-8")
+    p.write_text("x\n", encoding="utf-8", newline="\n")
     state.packs[("core", "claude-code")] = PackState(
         installed_version="0.1.0",
         files={
@@ -40,7 +40,7 @@ def _seed_repo(root: Path) -> None:
         adapter="claude-code",
     )
     (root / ".agentbundle-state.toml").write_text(
-        dump_state(state), encoding="utf-8"
+        dump_state(state), encoding="utf-8", newline="\n"
     )
 
 
@@ -84,7 +84,7 @@ def test_consumer_refuses_legacy_shape(
     """Each consumer refuses its respective legacy shape with the
     spec-mandated prefixed first stderr line."""
     _seed_repo(tmp_path)
-    (tmp_path / ".adapt-discovery.toml").write_text(body, encoding="utf-8")
+    (tmp_path / ".adapt-discovery.toml").write_text(body, encoding="utf-8", newline="\n")
 
     rc = _run_cli(tmp_path) if consumer == "cli" else _run_self_host(tmp_path)
     assert rc != 0
@@ -104,6 +104,7 @@ def test_consumer_accepts_canonical_markers_shape(consumer: str, tmp_path, capsy
     (tmp_path / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n[markers]\nowner = "x"\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc = _run_cli(tmp_path) if consumer == "cli" else _run_self_host(tmp_path)
     # No legacy-prefix line on stderr.

--- a/packages/agentbundle/tests/integration/test_install_adapt_chain.py
+++ b/packages/agentbundle/tests/integration/test_install_adapt_chain.py
@@ -40,7 +40,7 @@ allowed-scopes = ["repo"]
 def _stage_pack(catalogue_root: Path, name: str, body: str) -> Path:
     pack = catalogue_root / "packs" / name
     pack.mkdir(parents=True)
-    (pack / "pack.toml").write_text(body, encoding="utf-8")
+    (pack / "pack.toml").write_text(body, encoding="utf-8", newline="\n")
     (pack / ".apm").mkdir()
     return pack
 
@@ -61,10 +61,11 @@ def _stage_pack_with_skill(catalogue_root: Path, name: str, body: str) -> Path:
     Tier-2 collision in install.py:_classify_for_install)."""
     pack = catalogue_root / "packs" / name
     (pack / ".apm" / "skills" / name).mkdir(parents=True)
-    (pack / "pack.toml").write_text(body, encoding="utf-8")
+    (pack / "pack.toml").write_text(body, encoding="utf-8", newline="\n")
     (pack / ".apm" / "skills" / name / "SKILL.md").write_text(
         f"---\nname: {name}\ndescription: x\n---\nbody-from-bundle\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -86,7 +87,7 @@ def test_install_marker_records_new_companions(tmp_path):
     collision_relpath = "claude-plugins/demo/.claude/skills/demo/SKILL.md"
     collision_full = target / collision_relpath
     collision_full.parent.mkdir(parents=True)
-    collision_full.write_text("adopter-edited\n", encoding="utf-8")
+    collision_full.write_text("adopter-edited\n", encoding="utf-8", newline="\n")
 
     rc, _, _ = _install(
         {"pack": "demo", "catalogue": str(cat), "output": str(target), "scope": None, "force": False}  # noqa: E501
@@ -206,7 +207,7 @@ def test_install_chained_adapt_failure_returns_nonzero_preserves_marker(tmp_path
     target.mkdir()
     # Pre-seed a malformed discovery file (legacy [accepted] table).
     (target / ".adapt-discovery.toml").write_text(
-        '[accepted]\nowner = "x"\n', encoding="utf-8"
+        '[accepted]\nowner = "x"\n', encoding="utf-8", newline="\n"
     )
 
     rc, _, err = _install(
@@ -238,6 +239,7 @@ def test_install_chains_adapt_in_process_no_subprocess(tmp_path, monkeypatch):
     (pack / ".apm" / "skills" / "demo" / "SKILL.md").write_text(
         "---\nname: demo\ndescription: x\n---\nowner=<adapt:owner>\n",
         encoding="utf-8",
+        newline="\n",
     )
     target = tmp_path / "repo"
     target.mkdir()
@@ -245,6 +247,7 @@ def test_install_chains_adapt_in_process_no_subprocess(tmp_path, monkeypatch):
     (target / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n[markers]\nowner = "octocat"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     # Trap any subprocess invocation. If the chain shells out, this raises.
@@ -367,6 +370,7 @@ def test_user_scope_only_install_chains_adapt_against_args_output(tmp_path, monk
     (target / ".adapt-discovery.toml").write_text(
         'discovery-schema-version = "0.1"\n[markers]\nowner = "octocat"\n',
         encoding="utf-8",
+        newline="\n",
     )
     fake_home = tmp_path / "home"
     fake_home.mkdir()

--- a/packages/agentbundle/tests/integration/test_install_cmd.py
+++ b/packages/agentbundle/tests/integration/test_install_cmd.py
@@ -157,7 +157,7 @@ def test_state_file_merge_preserves_existing_pack(tmp_path):
         files={"some/file.md": {"sha": "abc", "from-pack-version": "1.0.0"}},
     )
     state_path = tmp_path / ".agentbundle-state.toml"
-    state_path.write_text(dump_state(state), encoding="utf-8")
+    state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
     rc = _run_install("alpha", str(FIXTURE_CATALOGUE), str(tmp_path))
     assert rc == 0

--- a/packages/agentbundle/tests/integration/test_install_copilot_full_parity.py
+++ b/packages/agentbundle/tests/integration/test_install_copilot_full_parity.py
@@ -212,12 +212,13 @@ class CopilotUserScopeSyntheticHookPackTests(unittest.TestCase):
         (pack / ".apm" / "hooks").mkdir(parents=True)
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack / ".apm" / "hooks" / "on-start.py").write_text(
-            "print('hi')\n", encoding="utf-8"
+            "print('hi')\n", encoding="utf-8", newline="\n"
         )
         (pack / ".apm" / "hook-wiring" / "on-start.toml").write_text(
             "[[hooks.SessionStart]]\n"
             'hooks = [ { type = "command", command = "python tools/on-start.py" } ]\n',
             encoding="utf-8",
+            newline="\n",
         )
         pack.joinpath("pack.toml").write_text(
             '[pack]\n'
@@ -236,6 +237,7 @@ class CopilotUserScopeSyntheticHookPackTests(unittest.TestCase):
             # rewritten), so this only lifts the consent rail — no merge.
             "user-scope-hooks = true\n",
             encoding="utf-8",
+            newline="\n",
         )
 
     def test_synthetic_hook_pack_lands_copilot_user_hooks(self) -> None:

--- a/packages/agentbundle/tests/integration/test_install_default_source.py
+++ b/packages/agentbundle/tests/integration/test_install_default_source.py
@@ -33,7 +33,7 @@ def _local_catalogue(tmp_path: Path) -> Path:
     shutil.copytree(REAL_CORE, cat / "packs" / "core", symlinks=False)
     cp = cat / ".claude-plugin"
     cp.mkdir()
-    (cp / "marketplace.json").write_text("{}", encoding="utf-8")
+    (cp / "marketplace.json").write_text("{}", encoding="utf-8", newline="\n")
     return cat
 
 
@@ -172,6 +172,7 @@ def test_bare_list_profiles_resolves_default_source(tmp_path):
     (profiles_dir / "sample.toml").write_text(
         'scope = "repo"\ndescription = "a sample profile"\n\n[[packs]]\npack = "core"\n',
         encoding="utf-8",
+        newline="\n",
     )
     args = argparse.Namespace(catalogue=None, _user_config=UserConfig(source=str(cat)))
     out, err = io.StringIO(), io.StringIO()

--- a/packages/agentbundle/tests/integration/test_install_dependencies_gate.py
+++ b/packages/agentbundle/tests/integration/test_install_dependencies_gate.py
@@ -32,7 +32,7 @@ def _stage_pack(catalogue_root: Path, pack_name: str, toml_text: str) -> Path:
     """Create a minimal pack under catalogue_root/packs/<pack_name>/."""
     pack = catalogue_root / "packs" / pack_name
     pack.mkdir(parents=True)
-    (pack / "pack.toml").write_text(toml_text, encoding="utf-8")
+    (pack / "pack.toml").write_text(toml_text, encoding="utf-8", newline="\n")
     (pack / ".apm").mkdir()  # empty projection
     return pack
 
@@ -66,13 +66,13 @@ def _pre_install_core(
 
     if scope == "repo":
         state_path = target / ".agentbundle-state.toml"
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
     else:
         assert fake_home is not None, "fake_home required for user-scope pre-seed"
         user_dir = fake_home / ".agentbundle"
         user_dir.mkdir(parents=True, exist_ok=True)
         state_path = user_dir / "state.toml"
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/integration/test_install_dropped_primitives_warning.py
+++ b/packages/agentbundle/tests/integration/test_install_dropped_primitives_warning.py
@@ -285,12 +285,12 @@ allowed-adapters = ["claude-code", "kiro", "codex"]
     def _stage_pack(self, root: Path) -> Path:
         pack = root / "packs" / "dual-warn"
         pack.mkdir(parents=True)
-        (pack / "pack.toml").write_text(self.PACK_TOML, encoding="utf-8")
+        (pack / "pack.toml").write_text(self.PACK_TOML, encoding="utf-8", newline="\n")
         (pack / ".apm" / "commands").mkdir(parents=True)
         # Ship a command — codex drops this; the warning must name it
         # at BOTH scopes when the dual-scope path fires.
         (pack / ".apm" / "commands" / "do-thing.md").write_text(
-            "# do-thing\n", encoding="utf-8"
+            "# do-thing\n", encoding="utf-8", newline="\n"
         )
         return pack
 

--- a/packages/agentbundle/tests/integration/test_install_dual_scope.py
+++ b/packages/agentbundle/tests/integration/test_install_dual_scope.py
@@ -56,7 +56,7 @@ allowed-scopes = ["repo", "user"]
 def _stage_pack(catalogue_root: Path, pack_name: str, toml_text: str) -> Path:
     pack = catalogue_root / "packs" / pack_name
     pack.mkdir(parents=True)
-    (pack / "pack.toml").write_text(toml_text, encoding="utf-8")
+    (pack / "pack.toml").write_text(toml_text, encoding="utf-8", newline="\n")
     (pack / ".apm").mkdir()  # empty apm → empty projection
     return pack
 

--- a/packages/agentbundle/tests/integration/test_install_pack_metadata_shape.py
+++ b/packages/agentbundle/tests/integration/test_install_pack_metadata_shape.py
@@ -58,6 +58,7 @@ def _write_pack(
         f"name = {_emit_basic_string(manifest_name)}\n"
         f"version = {_emit_basic_string(manifest_version)}\n",
         encoding="utf-8",
+        newline="\n",
     )
 
 

--- a/packages/agentbundle/tests/integration/test_install_profile.py
+++ b/packages/agentbundle/tests/integration/test_install_profile.py
@@ -68,10 +68,11 @@ def _stage_pack(cat, name, *, version="0.1.0", scope="repo", deps=None,
             f'pack = "{dep_name}"',
             f'version = "{dep_range}"',
         ]
-    (pdir / "pack.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (pdir / "pack.toml").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
     (skill / "SKILL.md").write_text(
         f"---\ndescription: fixture skill for {name}.\n---\n\n# {name}\n",
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -81,7 +82,7 @@ def _stage_profile(cat, name, scope, packs):
     body = [f'scope = "{scope}"', 'description = "fixture profile"']
     for p in packs:
         body += ["[[packs]]", f'pack = "{p}"']
-    (pdir / f"{name}.toml").write_text("\n".join(body) + "\n", encoding="utf-8")
+    (pdir / f"{name}.toml").write_text("\n".join(body) + "\n", encoding="utf-8", newline="\n")
 
 
 def _three_pack_repo_catalogue(cat):
@@ -177,7 +178,7 @@ def test_profile_skips_already_installed(tmp_path):
     state.packs[("pf-core", "claude-code")] = PackState(
         installed_version="0.4.9", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
 
     rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
     assert rc == 0, f"profile install failed: {err}"
@@ -307,7 +308,7 @@ def test_profile_refuses_when_dep_preinstalled_at_unsatisfying_version(tmp_path)
     state.packs[("pf-core", "claude-code")] = PackState(
         installed_version="0.0.1", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+    (target / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
 
     rc, out, err = _run_install(["--profile", "test-bundle", str(cat), "--output", str(target)])
     assert rc != 0
@@ -364,12 +365,13 @@ def test_profile_refuses_pack_installed_at_opposite_scope(tmp_path, monkeypatch)
         '[pack.adapter-contract]\nversion = "0.6"\n'
         '[pack.install]\ndefault-scope = "user"\nallowed-scopes = ["user", "repo"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     (cat / "packs" / "pf-tool" / ".apm" / "skills" / "pf-tool-skill").mkdir(
         parents=True, exist_ok=True
     )
     (cat / "packs" / "pf-tool" / ".apm" / "skills" / "pf-tool-skill" / "SKILL.md").write_text(
-        "---\ndescription: fixture.\n---\n\n# pf-tool\n", encoding="utf-8"
+        "---\ndescription: fixture.\n---\n\n# pf-tool\n", encoding="utf-8", newline="\n"
     )
     _stage_profile(cat, "userset", "user", ["pf-tool"])
 
@@ -378,7 +380,7 @@ def test_profile_refuses_pack_installed_at_opposite_scope(tmp_path, monkeypatch)
     repo_state.packs[("pf-tool", "claude-code")] = PackState(
         installed_version="0.1.0", scope="repo", adapter="claude-code"
     )
-    (target / ".agentbundle-state.toml").write_text(dump_state(repo_state), encoding="utf-8")
+    (target / ".agentbundle-state.toml").write_text(dump_state(repo_state), encoding="utf-8", newline="\n")
 
     rc, out, err = _run_install(["--profile", "userset", str(cat), "--output", str(target)])
     assert rc == 1

--- a/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
+++ b/packages/agentbundle/tests/integration/test_install_repo_scope_per_adapter.py
@@ -304,6 +304,7 @@ def _plant_state_row(
             {adapter_line}"""
         ),
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -374,6 +375,7 @@ class RepoScopeUpgradeWithStateHintTests(unittest.TestCase):
             (claude_dir / "SKILL.md").write_text(
                 "---\nname: marker\ndescription: claude-state\n---\nBody.",
                 encoding="utf-8",
+                newline="\n",
             )
 
             # Step 3: upgrade.
@@ -643,11 +645,11 @@ class RepoScopeMigrationTriggerBTests(unittest.TestCase):
             # now irrelevant because the v0.3 state file itself refuses.
             (adopter / "claude-plugins" / "core").mkdir(parents=True)
             (adopter / "claude-plugins" / "core" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
             (adopter / "apm" / "core").mkdir(parents=True)
             (adopter / "apm" / "core" / "pack.toml").write_text(
-                "", encoding="utf-8"
+                "", encoding="utf-8", newline="\n"
             )
 
             rc, stdout, stderr = _run_install(

--- a/packages/agentbundle/tests/integration/test_install_session_start_wiring.py
+++ b/packages/agentbundle/tests/integration/test_install_session_start_wiring.py
@@ -58,14 +58,14 @@ def _stage_synthetic_pack(catalogue_root: Path) -> None:
     """
     pack = catalogue_root / "packs" / "test-core"
     pack.mkdir(parents=True)
-    (pack / "pack.toml").write_text(PACK_TOML, encoding="utf-8")
+    (pack / "pack.toml").write_text(PACK_TOML, encoding="utf-8", newline="\n")
     apm = pack / ".apm"
     (apm / "hooks").mkdir(parents=True)
     # Empty stub: hook-body projection is direct-file; content doesn't
     # matter for the wiring-shape assertion.
-    (apm / "hooks" / "session-start.py").write_text("", encoding="utf-8")
+    (apm / "hooks" / "session-start.py").write_text("", encoding="utf-8", newline="\n")
     (apm / "hook-wiring").mkdir()
-    (apm / "hook-wiring" / "session-start.toml").write_text(WIRING_TOML, encoding="utf-8")
+    (apm / "hook-wiring" / "session-start.toml").write_text(WIRING_TOML, encoding="utf-8", newline="\n")
 
 
 def _install(args_dict) -> tuple[int, str, str]:

--- a/packages/agentbundle/tests/integration/test_install_snapshot.py
+++ b/packages/agentbundle/tests/integration/test_install_snapshot.py
@@ -147,7 +147,7 @@ def _compare_or_update_paths_golden(pack_name: str, actual_paths: list[str]) -> 
 
     if os.environ.get("UPDATE_GOLDEN") == "1":
         golden.parent.mkdir(parents=True, exist_ok=True)
-        golden.write_text(actual_text, encoding="utf-8")
+        golden.write_text(actual_text, encoding="utf-8", newline="\n")
         return
 
     assert golden.exists(), (

--- a/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
+++ b/packages/agentbundle/tests/integration/test_install_upgrade_offer.py
@@ -195,7 +195,7 @@ def test_install_run_forwards_resolved_adapter_when_multi_adapter_and_no_cli_ada
         }
     )
     (agentbundle_dir / "state.toml").write_text(
-        dump_state(two_adapter_state), encoding="utf-8"
+        dump_state(two_adapter_state), encoding="utf-8", newline="\n"
     )
     shutil.copytree(converters_src, cat / "packs" / "converters")
     (tmp_path / "repo").mkdir()

--- a/packages/agentbundle/tests/integration/test_install_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_install_user_hooks.py
@@ -223,7 +223,7 @@ class ForceMergeFlagBindingTests(unittest.TestCase):
             pack = tmp / "catalogue" / "packs" / "repo-default"
             (pack / ".apm" / "skills" / "x").mkdir(parents=True)
             (pack / ".apm" / "skills" / "x" / "SKILL.md").write_text(
-                "# x\n", encoding="utf-8"
+                "# x\n", encoding="utf-8", newline="\n"
             )
             (pack / "pack.toml").write_text(
                 '[pack]\nname = "repo-default"\nversion = "0.1.0"\n\n'
@@ -231,6 +231,7 @@ class ForceMergeFlagBindingTests(unittest.TestCase):
                 '[pack.install]\ndefault-scope = "repo"\n'
                 'allowed-scopes = ["repo"]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             (tmp / "repo").mkdir()
             args = _install_args(
@@ -260,11 +261,11 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
         # a merge target there; the refusal lives on the merge path
         # (kiro-cli), guarded by the pre-flight rail + in-merge grammar.
         (pack / ".apm" / "agents" / "evil.md").write_text(
-            "---\nname: evil\n---\nbody\n", encoding="utf-8"
+            "---\nname: evil\n---\nbody\n", encoding="utf-8", newline="\n"
         )
         (pack / ".apm" / "hooks").mkdir(parents=True)
         (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
-            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+            "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
         )
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
@@ -272,6 +273,7 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
             'attach-to-agent = "../../../tmp/escape"\n\n'
             '[[hooks.agentSpawn]]\ncommand = "x"\n',
             encoding="utf-8",
+            newline="\n",
         )
         (pack / "pack.toml").write_text(
             '[pack]\nname = "evil-pack"\nversion = "0.1.0"\n\n'
@@ -280,6 +282,7 @@ class AttachToAgentPathTraversalRefusedTests(_UserScopeInstallBase):
             'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
             'allowed-adapters = ["kiro-cli"]\n',
             encoding="utf-8",
+            newline="\n",
         )
         for entry in pack.rglob("*.sh"):
             entry.chmod(0o755)
@@ -315,17 +318,18 @@ class KiroAliasRefusesUserScopeHooksLikeKiroIdeTests(_UserScopeInstallBase):
         pack = self.cat / "packs" / name
         (pack / ".apm" / "agents").mkdir(parents=True)
         (pack / ".apm" / "agents" / "reviewer.md").write_text(
-            "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+            "---\nname: reviewer\n---\nbody\n", encoding="utf-8", newline="\n"
         )
         (pack / ".apm" / "hooks").mkdir(parents=True)
         (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
-            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+            "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
         )
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
             'attach-to-agent = "reviewer"\n\n'
             '[[hooks.agentSpawn]]\ncommand = "x"\n',
             encoding="utf-8",
+            newline="\n",
         )
         (pack / "pack.toml").write_text(
             f'[pack]\nname = "{name}"\nversion = "0.1.0"\n\n'
@@ -334,6 +338,7 @@ class KiroAliasRefusesUserScopeHooksLikeKiroIdeTests(_UserScopeInstallBase):
             'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
             f'allowed-adapters = ["{adapter}"]\n',
             encoding="utf-8",
+            newline="\n",
         )
         for entry in pack.rglob("*.sh"):
             entry.chmod(0o755)
@@ -378,12 +383,13 @@ class RailBStillRefusesPacksWithoutOptInTests(_UserScopeInstallBase):
         # Synthesise a pack that ships hooks but lacks the opt-in flag.
         pack_dir = self.cat / "packs" / "no-opt-in"
         (pack_dir / ".apm" / "hooks").mkdir(parents=True)
-        (pack_dir / ".apm" / "hooks" / "x.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        (pack_dir / ".apm" / "hooks" / "x.sh").write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
         (pack_dir / "pack.toml").write_text(
             "[pack]\nname = \"no-opt-in\"\nversion = \"0.1.0\"\n"
             "[pack.adapter-contract]\nversion = \"0.3\"\n"
             "[pack.install]\ndefault-scope = \"user\"\nallowed-scopes = [\"user\"]\n",
             encoding="utf-8",
+            newline="\n",
         )
         args = _install_args(
             pack="no-opt-in",

--- a/packages/agentbundle/tests/integration/test_kiro_ide_hook_e2e.py
+++ b/packages/agentbundle/tests/integration/test_kiro_ide_hook_e2e.py
@@ -50,7 +50,7 @@ def _make_fixture_pack(root: Path, pack_name: str = "kiro-ide-hooks-basic") -> P
     # hook-body — the placeholder target.
     (pack / ".apm" / "hooks").mkdir(parents=True)
     (pack / ".apm" / "hooks" / "lint.py").write_text(
-        "#!/usr/bin/env python3\nprint('lint')\n", encoding="utf-8"
+        "#!/usr/bin/env python3\nprint('lint')\n", encoding="utf-8", newline="\n"
     )
     # askAgent hook (byte-copy path).
     (pack / ".apm" / "kiro-ide-hooks").mkdir(parents=True)
@@ -63,6 +63,7 @@ def _make_fixture_pack(root: Path, pack_name: str = "kiro-ide-hooks-basic") -> P
             "then": {"type": "askAgent", "prompt": "Lint the saved file."},
         }, indent=2) + "\n",
         encoding="utf-8",
+        newline="\n",
     )
     # runCommand hook (parse, expand, emit path).
     (pack / ".apm" / "kiro-ide-hooks" / "lint-command.kiro.hook").write_text(
@@ -77,6 +78,7 @@ def _make_fixture_pack(root: Path, pack_name: str = "kiro-ide-hooks-basic") -> P
             },
         }, indent=2) + "\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 
@@ -148,7 +150,7 @@ class ValidateCommandRailFires(unittest.TestCase):
             pack = _make_fixture_pack(root)
             # Drop a required field to trigger refusal path 1.
             broken = pack / ".apm" / "kiro-ide-hooks" / "broken.kiro.hook"
-            broken.write_text(json.dumps({"description": "no name no version"}), encoding="utf-8")
+            broken.write_text(json.dumps({"description": "no name no version"}), encoding="utf-8", newline="\n")
 
             # pack.toml is needed for validate.run.
             (pack / "pack.toml").write_text(
@@ -156,6 +158,7 @@ class ValidateCommandRailFires(unittest.TestCase):
                 '[pack.adapter-contract]\nversion = "0.3"\n'
                 '[pack.install]\ndefault-scope = "repo"\nallowed-scopes = ["repo"]\n',
                 encoding="utf-8",
+                newline="\n",
             )
 
             import argparse

--- a/packages/agentbundle/tests/integration/test_kiro_repo_hooks_fixture.py
+++ b/packages/agentbundle/tests/integration/test_kiro_repo_hooks_fixture.py
@@ -52,6 +52,7 @@ class KiroRepoHooksFixtureTests(unittest.TestCase):
                 indent=2,
             ) + "\n",
             encoding="utf-8",
+            newline="\n",
         )
 
     def test_fixture_round_trip_install_uninstall(self) -> None:

--- a/packages/agentbundle/tests/integration/test_kiro_user_hooks_fixture.py
+++ b/packages/agentbundle/tests/integration/test_kiro_user_hooks_fixture.py
@@ -63,6 +63,7 @@ class KiroUserHooksFixtureTests(unittest.TestCase):
                 indent=2,
             ) + "\n",
             encoding="utf-8",
+            newline="\n",
         )
 
     def test_user_scope_round_trip(self) -> None:
@@ -110,7 +111,7 @@ class KiroUserHooksFixtureTests(unittest.TestCase):
 
         # Create a concrete hook body the substituted command will dispatch.
         hook_body = self.tmp / "stub.sh"
-        hook_body.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        hook_body.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
         hook_body.chmod(0o755)
 
         # Simulate T8b's resolver: substitute the placeholder in the

--- a/packages/agentbundle/tests/integration/test_multi_pack_install.py
+++ b/packages/agentbundle/tests/integration/test_multi_pack_install.py
@@ -285,7 +285,7 @@ def _drop_pack_from_state(adopter: Path, pack_name: str) -> None:
     keys_to_drop = [(n, a) for (n, a) in state.packs if n == pack_name]
     for key in keys_to_drop:
         del state.packs[key]
-    state_path.write_text(dump_state(state), encoding="utf-8")
+    state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/integration/test_orphan_cleanup_respects_foreign_state.py
+++ b/packages/agentbundle/tests/integration/test_orphan_cleanup_respects_foreign_state.py
@@ -95,6 +95,7 @@ def _stage_pack(
             """
         ),
         encoding="utf-8",
+        newline="\n",
     )
     apm = pack_dir / ".apm"
     apm.mkdir()
@@ -104,6 +105,7 @@ def _stage_pack(
         (sd / "SKILL.md").write_text(
             f"---\nname: {skill}\ndescription: from-{name}\n---\nBody from {name}.",
             encoding="utf-8",
+            newline="\n",
         )
     return pack_dir
 

--- a/packages/agentbundle/tests/integration/test_recommends_cross_scope.py
+++ b/packages/agentbundle/tests/integration/test_recommends_cross_scope.py
@@ -93,7 +93,7 @@ allowed-scopes = ["user"]
 def _stage_pack(catalogue_root: Path, name: str, toml: str) -> Path:
     pack = catalogue_root / "packs" / name
     pack.mkdir(parents=True)
-    (pack / "pack.toml").write_text(toml, encoding="utf-8")
+    (pack / "pack.toml").write_text(toml, encoding="utf-8", newline="\n")
     (pack / ".apm").mkdir()
     return pack
 

--- a/packages/agentbundle/tests/integration/test_reconcile.py
+++ b/packages/agentbundle/tests/integration/test_reconcile.py
@@ -115,7 +115,7 @@ class OrphanInFileTests(_ReconcileBase):
             {"id": "ghost-pack:session", "command": "echo hi"}
         )
         settings.write_text(
-            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+            json.dumps(data, indent=2) + "\n", encoding="utf-8", newline="\n"
         )
 
         rc, stdout, _err = _run_reconcile()
@@ -142,7 +142,7 @@ class OrphanInStateTests(_ReconcileBase):
         data = json.loads(settings.read_text(encoding="utf-8"))
         data["hooks"]["UserPromptSubmit"] = []
         settings.write_text(
-            json.dumps(data, indent=2) + "\n", encoding="utf-8"
+            json.dumps(data, indent=2) + "\n", encoding="utf-8", newline="\n"
         )
 
         rc, stdout, _err = _run_reconcile()
@@ -173,7 +173,7 @@ class GroupedByAdapterTests(_ReconcileBase):
         data["hooks"].setdefault("Other", []).append(
             {"id": "ghost-cc:x", "command": "x"}
         )
-        settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        settings.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8", newline="\n")
 
         agent_json = self.home / ".kiro" / "agents" / "reviewer.json"
         agent = json.loads(agent_json.read_text(encoding="utf-8"))
@@ -181,7 +181,7 @@ class GroupedByAdapterTests(_ReconcileBase):
             {"id": "ghost-kiro:y", "command": "y"}
         )
         agent_json.write_text(
-            json.dumps(agent, indent=2) + "\n", encoding="utf-8"
+            json.dumps(agent, indent=2) + "\n", encoding="utf-8", newline="\n"
         )
 
         rc, stdout, _err = _run_reconcile()

--- a/packages/agentbundle/tests/integration/test_self_host_schema_migration.py
+++ b/packages/agentbundle/tests/integration/test_self_host_schema_migration.py
@@ -31,7 +31,7 @@ def _minimal_contract() -> dict:
 def _seed(working_tree: Path, discovery_body: str) -> None:
     """Write the discovery file and a stub packs dir for the run."""
     (working_tree / ".adapt-discovery.toml").write_text(
-        discovery_body, encoding="utf-8"
+        discovery_body, encoding="utf-8", newline="\n"
     )
 
 
@@ -115,7 +115,7 @@ def test_canonical_markers_table_loads(tmp_path, capsys):
 def test_lowercase_hyphen_marker_substitutes(tmp_path):
     """``resolve_markers`` substitutes ``<adapt:project-name>`` (AC14)."""
     target = tmp_path / "AGENTS.md"
-    target.write_text("name: <adapt:project-name>\n", encoding="utf-8")
+    target.write_text("name: <adapt:project-name>\n", encoding="utf-8", newline="\n")
     modified = self_host.resolve_markers(
         tmp_path, {"project-name": "demo"}, extra_paths=[Path("AGENTS.md")]
     )
@@ -126,7 +126,7 @@ def test_lowercase_hyphen_marker_substitutes(tmp_path):
 def test_upper_snake_marker_left_in_place_with_warning(tmp_path, capsys):
     """Legacy ``<adapt:PROJECT_NAME>`` is left in place; warning emitted."""
     target = tmp_path / "AGENTS.md"
-    target.write_text("name: <adapt:PROJECT_NAME>\n", encoding="utf-8")
+    target.write_text("name: <adapt:PROJECT_NAME>\n", encoding="utf-8", newline="\n")
     modified = self_host.resolve_markers(
         tmp_path,
         {"PROJECT_NAME": "WRONG", "project-name": "demo"},

--- a/packages/agentbundle/tests/integration/test_show_cmd.py
+++ b/packages/agentbundle/tests/integration/test_show_cmd.py
@@ -53,13 +53,13 @@ def _make_catalogue(root: Path, *, name: str = "demo",
     if meta:
         toml += 'version = "1.2.3"\ndescription = "Demo fixture pack"\n'
     (pack).mkdir(parents=True)
-    (pack / "pack.toml").write_text(toml, encoding="utf-8")
+    (pack / "pack.toml").write_text(toml, encoding="utf-8", newline="\n")
     for s in skills:
         (pack / ".apm" / "skills" / s).mkdir(parents=True)
-        (pack / ".apm" / "skills" / s / "SKILL.md").write_text("# s\n", encoding="utf-8")
+        (pack / ".apm" / "skills" / s / "SKILL.md").write_text("# s\n", encoding="utf-8", newline="\n")
     for a in agents:
         (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
-        (pack / ".apm" / "agents" / f"{a}.md").write_text("# a\n", encoding="utf-8")
+        (pack / ".apm" / "agents" / f"{a}.md").write_text("# a\n", encoding="utf-8", newline="\n")
     return root
 
 
@@ -88,7 +88,7 @@ def test_primary_via_default_source_chain(tmp_path, capsys):
     # .claude-plugin/marketplace.json (layer-1 overrides skip this check).
     marker = cat / ".claude-plugin" / "marketplace.json"
     marker.parent.mkdir(parents=True)
-    marker.write_text("{}\n", encoding="utf-8")
+    marker.write_text("{}\n", encoding="utf-8", newline="\n")
     args = SimpleNamespace(
         pack="demo", catalogue=None, format="json", root=".",
         _user_config=SimpleNamespace(source=str(cat)),
@@ -266,7 +266,7 @@ def test_degrade_legacy_state_scope_warned_not_fatal(
     names the skipped scope — mirroring `list-installed`."""
     # Repo scope: a legacy-schema state file that `load_state` refuses.
     (tmp_path / ".agentbundle-state.toml").write_text(
-        'schema-version = "0.3"\n', encoding="utf-8"
+        'schema-version = "0.3"\n', encoding="utf-8", newline="\n"
     )
     # User scope: a valid state carrying the installed pack.
     _write_state(

--- a/packages/agentbundle/tests/integration/test_uninstall_cmd.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_cmd.py
@@ -61,7 +61,7 @@ def _seed_state(tmp_path: Path, pack_name: str, files: dict[str, str]) -> None:
             for relpath, sha in files.items()
         },
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8")
+    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +185,7 @@ def test_multi_pack_uninstall_a_preserves_b(tmp_path):
         installed_version="1.0.0",
         files={"docs/beta_readme.md": {"sha": beta_sha, "from-pack-version": "1.0.0"}},
     )
-    state_path.write_text(dump_state(state), encoding="utf-8")
+    state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
     # Uninstall alpha.
     rc = _run_uninstall("alpha", str(tmp_path))
@@ -215,7 +215,7 @@ def test_missing_pack_exits_nonzero(tmp_path, capsys):
     from agentbundle.config import State, dump_state
 
     state_path = tmp_path / ".agentbundle-state.toml"
-    state_path.write_text(dump_state(State()), encoding="utf-8")
+    state_path.write_text(dump_state(State()), encoding="utf-8", newline="\n")
 
     rc = _run_uninstall("nonexistent", str(tmp_path))
     assert rc != 0, "uninstall of missing pack must exit non-zero"

--- a/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_uninstall_user_hooks.py
@@ -140,12 +140,13 @@ class MultiPackUninstallPrecisionTests(_UninstallBase):
         pack_b_dir = self.cat / "packs" / "pack-b"
         (pack_b_dir / ".apm" / "hooks").mkdir(parents=True)
         (pack_b_dir / ".apm" / "hooks" / "on-prompt-b.sh").write_text(
-            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+            "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
         )
         (pack_b_dir / ".apm" / "hook-wiring").mkdir(parents=True)
         (pack_b_dir / ".apm" / "hook-wiring" / "on-prompt-b.toml").write_text(
             '[[hooks.UserPromptSubmit]]\ncommand = "do-b"\nmatcher = ""\n',
             encoding="utf-8",
+            newline="\n",
         )
         (pack_b_dir / "pack.toml").write_text(
             '[pack]\nname = "pack-b"\nversion = "0.1.0"\n\n'
@@ -153,6 +154,7 @@ class MultiPackUninstallPrecisionTests(_UninstallBase):
             '[pack.install]\ndefault-scope = "user"\n'
             'allowed-scopes = ["user"]\nuser-scope-hooks = true\n',
             encoding="utf-8",
+            newline="\n",
         )
         for entry in pack_b_dir.rglob("*.sh"):
             entry.chmod(0o755)
@@ -255,6 +257,7 @@ class KiroUserHooksUninstallTests(_UninstallBase):
         data["notes"] = "adopter-added"
         agent_json.write_text(
             json.dumps(data, indent=2) + "\n", encoding="utf-8",
+            newline="\n",
         )
 
         rc, err = _run_uninstall(_uninstall_args(
@@ -306,7 +309,7 @@ class LegacyKiroJsonUninstallMigrationTests(_UninstallBase):
         old_row = state.packs.pop(("kiro-user-hooks", "kiro-cli"))
         old_row.adapter = "kiro"
         state.packs[("kiro-user-hooks", "kiro")] = old_row
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
         rc, err = _run_uninstall(_uninstall_args(
             pack="kiro-user-hooks",

--- a/packages/agentbundle/tests/integration/test_upgrade_attach_to_agent.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_attach_to_agent.py
@@ -94,6 +94,7 @@ class AttachToAgentRenameTests(unittest.TestCase):
             'attach-to-agent = "code-reviewer"\n\n'
             '[[hooks.agentSpawn]]\ncommand = "$HOOK_BODY_PATH"\nmatcher = ""\n',
             encoding="utf-8",
+            newline="\n",
         )
 
         rc, err = _run_upgrade(argparse.Namespace(

--- a/packages/agentbundle/tests/integration/test_upgrade_cmd.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_cmd.py
@@ -801,7 +801,7 @@ def test_upgrade_prefix_violation_writes_nothing(tmp_path, capsys):
             outside_rel: {"sha": installed_sha, "from-pack-version": "0.1.0"},
         },
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(s), encoding="utf-8")
+    (tmp_path / ".agentbundle-state.toml").write_text(dump_state(s), encoding="utf-8", newline="\n")
     # On-disk: user has edited the outside-prefix file (different from installed sha)
     (tmp_path / "outside-prefix").mkdir()
     (tmp_path / outside_rel).write_bytes(b"user edited\n")
@@ -978,7 +978,7 @@ def test_missing_pack_version_errors(tmp_path, capsys, pack_toml_body):
     cat = tmp_path / "noversion_cat"
     pack_dir = cat / "packs" / "core"
     pack_dir.mkdir(parents=True)
-    (pack_dir / "pack.toml").write_text(pack_toml_body, encoding="utf-8")
+    (pack_dir / "pack.toml").write_text(pack_toml_body, encoding="utf-8", newline="\n")
     rc = _run_upgrade(pack="core", catalogue=str(cat), root=str(tmp_path))
     assert rc != 0
     assert "declares no [pack] version" in capsys.readouterr().err
@@ -1035,7 +1035,7 @@ def test_reapply_with_local_edit_notice_and_companion_recap(tmp_path, capsys):
     state = load_state(tmp_path / ".agentbundle-state.toml")
     ps = state.row("core", "claude-code")
     edited_relpath = sorted(ps.files)[0]
-    (tmp_path / edited_relpath).write_text("# local edit\n", encoding="utf-8")
+    (tmp_path / edited_relpath).write_text("# local edit\n", encoding="utf-8", newline="\n")
 
     rc = _run_upgrade(pack="core", catalogue=str(CAT_V2), root=str(tmp_path), yes=True)
     assert rc == 0
@@ -1059,7 +1059,7 @@ def test_per_primitive_upgrade_suppresses_whole_pack_drift_notice(tmp_path, caps
     # Edit an installed file so a whole-pack run *would* notice drift.
     state = load_state(tmp_path / ".agentbundle-state.toml")
     ps = state.row("core", "claude-code")
-    (tmp_path / sorted(ps.files)[0]).write_text("# local edit\n", encoding="utf-8")
+    (tmp_path / sorted(ps.files)[0]).write_text("# local edit\n", encoding="utf-8", newline="\n")
     capsys.readouterr()
 
     rc = _run_upgrade(

--- a/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
+++ b/packages/agentbundle/tests/integration/test_upgrade_user_hooks.py
@@ -144,10 +144,10 @@ class UpgradeAddsHookEntryTests(_UpgradeBase):
         # Mutate the catalogue: add a second wiring TOML to the pack.
         pack_in_cat = self.cat / "packs" / "cc-user-hooks"
         (pack_in_cat / ".apm" / "hook-wiring" / "on-session.toml").write_text(
-            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8"
+            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8", newline="\n"
         )
         (pack_in_cat / ".apm" / "hooks" / "on-session.sh").write_text(
-            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+            "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
         )
         (pack_in_cat / ".apm" / "hooks" / "on-session.sh").chmod(0o755)
 
@@ -183,10 +183,10 @@ class UpgradeRemovesHookEntryTests(_UpgradeBase):
         pack_in_cat = self.cat / "packs" / "cc-user-hooks"
         # Add an extra wiring TOML before install so we can drop it on upgrade.
         (pack_in_cat / ".apm" / "hook-wiring" / "on-session.toml").write_text(
-            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8"
+            '[[hooks.SessionStart]]\ncommand = "session-cmd"\n', encoding="utf-8", newline="\n"
         )
         (pack_in_cat / ".apm" / "hooks" / "on-session.sh").write_text(
-            "#!/bin/sh\nexit 0\n", encoding="utf-8"
+            "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
         )
         (pack_in_cat / ".apm" / "hooks" / "on-session.sh").chmod(0o755)
         self.assertEqual(_run_install(_install_args(
@@ -243,10 +243,10 @@ class LegacyKiroJsonUpgradeMigrationTests(_UpgradeBase):
         old_row = state.packs.pop(("kiro-user-hooks", "kiro-cli"))
         old_row.adapter = "kiro"
         state.packs[("kiro-user-hooks", "kiro")] = old_row
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
         pt = (pack_dst / "pack.toml").read_text(encoding="utf-8")
         (pack_dst / "pack.toml").write_text(
-            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8"
+            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8", newline="\n"
         )
 
         rc, err = _run_upgrade(_upgrade_args(
@@ -290,10 +290,10 @@ class LegacyKiroJsonUpgradeMigrationTests(_UpgradeBase):
         old_row = state.packs.pop(("kiro-user-hooks", "kiro-cli"))
         old_row.adapter = "kiro"
         state.packs[("kiro-user-hooks", "kiro")] = old_row
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
         pt = (pack_dst / "pack.toml").read_text(encoding="utf-8")
         (pack_dst / "pack.toml").write_text(
-            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8"
+            pt.replace('["kiro-cli"]', '["kiro"]'), encoding="utf-8", newline="\n"
         )
 
         rc, err = _run_upgrade(_upgrade_args(

--- a/packages/agentbundle/tests/integration/test_version_gate_matrix.py
+++ b/packages/agentbundle/tests/integration/test_version_gate_matrix.py
@@ -37,6 +37,7 @@ version = "0.1.0"
 version = "99.0"
 """,
         encoding="utf-8",
+        newline="\n",
     )
     (FIXTURE_PACK.parent / "packs").mkdir(parents=True, exist_ok=True)
     # Symlink into a packs/<name>/ layout for subcommands that take

--- a/packages/agentbundle/tests/unit/test_adapt_discovery_schema.py
+++ b/packages/agentbundle/tests/unit/test_adapt_discovery_schema.py
@@ -108,7 +108,7 @@ accepted-at      = 2026-05-22T10:00:00Z
 
 def _write_toml(tmp_path: Path, content: str) -> Path:
     p = tmp_path / ".adapt-discovery.toml"
-    p.write_text(content, encoding="utf-8")
+    p.write_text(content, encoding="utf-8", newline="\n")
     return p
 
 
@@ -244,7 +244,7 @@ def test_findings_round_trip_preserves_fields(tmp_path):
 
     toml_text = adapt_discovery_to_toml(original)
     p = tmp_path / ".adapt-discovery.toml"
-    p.write_text(toml_text, encoding="utf-8")
+    p.write_text(toml_text, encoding="utf-8", newline="\n")
 
     reparsed = load_adapt_discovery_typed(p, scope="repo")
     assert reparsed.schema_version == original.schema_version
@@ -276,6 +276,7 @@ def test_marker_key_must_follow_lowercase_hyphen_grammar(tmp_path):
         'discovery-schema-version = "0.1"\n'
         '[markers]\nProjectName = "x"\n',  # UPPER prefix violates ^[a-z]...
         encoding="utf-8",
+        newline="\n",
     )
     with pytest.raises(ConfigError, match="lowercase-hyphen grammar"):
         load_adapt_discovery_typed(bad, scope="repo")
@@ -286,6 +287,7 @@ def test_marker_key_must_follow_lowercase_hyphen_grammar(tmp_path):
         'discovery-schema-version = "0.1"\n'
         '[markers]\nproject_name = "x"\n',
         encoding="utf-8",
+        newline="\n",
     )
     with pytest.raises(ConfigError, match="lowercase-hyphen grammar"):
         load_adapt_discovery_typed(bad2, scope="repo")

--- a/packages/agentbundle/tests/unit/test_append_layout_section.py
+++ b/packages/agentbundle/tests/unit/test_append_layout_section.py
@@ -47,7 +47,7 @@ def test_never_overwrite_leaves_existing_section_byte_identical(tmp_path):
         '[research]\n'
         'parent = "~/my-research"  # custom\n'
     )
-    layout.write_text(original, encoding="utf-8")
+    layout.write_text(original, encoding="utf-8", newline="\n")
     _append_layout_section(
         tmp_path,
         "repo",
@@ -62,7 +62,7 @@ def test_appends_missing_section_when_file_exists(tmp_path):
     """A pre-existing file missing `[research]` gains it (the other section
     survives)."""
     layout = tmp_path / "agentbundle-layout.toml"
-    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
     _append_layout_section(
         tmp_path,
         "repo",
@@ -89,7 +89,7 @@ def test_scope_keyed_selection_repo_vs_user(tmp_path):
     }
     # Repo scope.
     repo_layout = tmp_path / "agentbundle-layout.toml"
-    repo_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    repo_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
     _append_layout_section(
         tmp_path, "repo", pack_name="research", pack_layout=pack_layout,
         allowed_prefixes=None,
@@ -100,7 +100,7 @@ def test_scope_keyed_selection_repo_vs_user(tmp_path):
     home = tmp_path / "home"
     (home / ".agentbundle").mkdir(parents=True)
     user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
-    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
     _append_layout_section(
         home, "user", pack_name="research", pack_layout=pack_layout,
         allowed_prefixes=[".agentbundle/"],
@@ -115,7 +115,7 @@ def test_omit_user_subtable_is_user_scope_no_op(tmp_path):
     (home / ".agentbundle").mkdir(parents=True)
     user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
     original = '[architect]\nparent = "docs/design"\n'
-    user_layout.write_text(original, encoding="utf-8")
+    user_layout.write_text(original, encoding="utf-8", newline="\n")
     _append_layout_section(
         home,
         "user",
@@ -131,7 +131,7 @@ def test_no_layout_table_is_no_op(tmp_path):
     every pack)."""
     layout = tmp_path / "agentbundle-layout.toml"
     original = '[architect]\nparent = "docs/design"\n'
-    layout.write_text(original, encoding="utf-8")
+    layout.write_text(original, encoding="utf-8", newline="\n")
     _append_layout_section(
         tmp_path, "repo", pack_name="core", pack_layout={}, allowed_prefixes=None,
     )
@@ -147,7 +147,7 @@ def test_injection_safe_roundtrip_of_default_parent(tmp_path):
     """A `[pack.layout]` default containing `"`, `]`, newline, and `../`
     round-trips intact and well-formed; no smuggled sibling table materialises."""
     layout = tmp_path / "agentbundle-layout.toml"
-    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
     hostile = 'a"b]c\n[evil]\nx = "../../etc"'
     _append_layout_section(
         tmp_path, "repo", pack_name="research",
@@ -167,6 +167,7 @@ def test_reemit_drops_tampered_existing_parent(tmp_path):
     layout.write_text(
         '[architect]\nparent = 42\n\n[oldpack]\nparent = ["x"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     _append_layout_section(
         tmp_path, "repo", pack_name="research",
@@ -184,7 +185,7 @@ def test_malformed_file_left_untouched(tmp_path):
     never corrupted by an append."""
     layout = tmp_path / "agentbundle-layout.toml"
     original = "this is not = valid toml ] [\n"
-    layout.write_text(original, encoding="utf-8")
+    layout.write_text(original, encoding="utf-8", newline="\n")
     _append_layout_section(
         tmp_path, "repo", pack_name="research",
         pack_layout={"repo": {"parent": ".context/research"}},
@@ -204,7 +205,7 @@ def test_user_scope_write_succeeds_against_real_prefix_list(tmp_path):
     home = tmp_path / "home"
     (home / ".agentbundle").mkdir(parents=True)
     user_layout = home / ".agentbundle" / "agentbundle-layout.toml"
-    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    user_layout.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
     _append_layout_section(
         home,
         "user",
@@ -223,7 +224,7 @@ def test_symlink_layout_file_fails_closed(tmp_path):
     outside = tmp_path / "outside"
     outside.mkdir()
     real_target = outside / "agentbundle-layout.toml"
-    real_target.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8")
+    real_target.write_text('[architect]\nparent = "docs/design"\n', encoding="utf-8", newline="\n")
 
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/packages/agentbundle/tests/unit/test_catalogue_pack_defaults.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_pack_defaults.py
@@ -247,7 +247,7 @@ default-source = "git+https://github.com/example/catalogue"
 [distribution.agentbundle.artifactory]
 enabled = false
 """
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
 
@@ -292,7 +292,7 @@ default-source = "git+https://github.com/example/catalogue"
 [distribution.agentbundle.artifactory]
 enabled = false
 """
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
 
@@ -338,7 +338,7 @@ enabled = false
 [pack-defaults.bin]
 something = "value"
 """
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
 
@@ -515,7 +515,7 @@ def test_load_catalogue_config_rejects_traversal_user_dir(tmp_path):
         "[catalogue.paths]",
         'user-dir = "~/../../etc"\n\n[catalogue.paths]',
     )
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
 
@@ -529,7 +529,7 @@ def test_load_catalogue_config_pack_defaults_parsed(tmp_path):
         _FIXTURE_TOML_BASE
         + "\n[pack-defaults.atlassian]\nurl = \"https://jira.example.com/\"\n"
     )
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
 
@@ -553,7 +553,7 @@ def test_check_defaults_pack_defaults_drift(tmp_path, monkeypatch):
     # Write a baked file with a hand-edited extra key — drifted from compile_defaults output.
     correct = compile_defaults(config)
     drifted = correct + "\nextra-key = \"injected\"\n"
-    (tmp_path / "install-defaults.toml").write_text(drifted, encoding="utf-8")
+    (tmp_path / "install-defaults.toml").write_text(drifted, encoding="utf-8", newline="\n")
 
     result = check_defaults(tmp_path)
     assert result.ok is False
@@ -575,7 +575,7 @@ def test_install_user_root_plumbing(tmp_path):
         "[catalogue.paths]",
         'user-dir = "~/custom-install"\n\n[catalogue.paths]',
     )
-    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8")
+    (tmp_path / "catalogue.toml").write_text(toml_content, encoding="utf-8", newline="\n")
 
     from agentbundle.catalogue_tooling.config import load_catalogue_config
     from agentbundle.config import PackState, State, dump_state

--- a/packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py
@@ -52,7 +52,7 @@ def _assert_none_in(label: str, text: str, unexpected: Iterable[str]) -> None:
 
 def _write(path: Path, body: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(body, encoding="utf-8")
+    path.write_text(body, encoding="utf-8", newline="\n")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_archive.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_archive.py
@@ -205,7 +205,7 @@ def test_archive_sidecar_mismatch_early_exit(tmp_path):
     """Sidecar .sha256 file with wrong hash → CAT-V-ARC-001, early return."""
     archive_path = _make_valid_archive(tmp_path)
     sidecar = tmp_path / "test.tar.gz.sha256"
-    sidecar.write_text("0000000000000000000000000000000000000000000000000000000000000000  test.tar.gz\n")  # noqa: E501
+    sidecar.write_text("0000000000000000000000000000000000000000000000000000000000000000  test.tar.gz\n", encoding="utf-8", newline="\n")  # noqa: E501
 
     result = verify_archive(archive_path, sha256_file=sidecar)
     assert not result.ok

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_defaults.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_defaults.py
@@ -198,6 +198,7 @@ def test_check_drift(tmp_path, monkeypatch):
     (tmp_path / "install-defaults.toml").write_text(
         "# stale content\n[organization]\npreferred_adapter = \"old-adapter\"\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = check_defaults(tmp_path)
     assert result.ok is False
@@ -211,7 +212,7 @@ def test_check_ok(tmp_path, monkeypatch):
         _defaults_module, "load_catalogue_config", lambda root: config
     )
     expected = compile_defaults(config)
-    (tmp_path / "install-defaults.toml").write_text(expected, encoding="utf-8")
+    (tmp_path / "install-defaults.toml").write_text(expected, encoding="utf-8", newline="\n")
     result = check_defaults(tmp_path)
     assert result.ok is True
     assert result.diagnostics == []

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py
@@ -193,7 +193,7 @@ def _dict_to_toml(d: dict, prefix: str = "") -> str:
 
 def _write_toml(tmp_path: Path, content: str) -> Path:
     f = tmp_path / "catalogue.toml"
-    f.write_text(content, encoding="utf-8")
+    f.write_text(content, encoding="utf-8", newline="\n")
     return tmp_path
 
 

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
@@ -39,7 +39,7 @@ def _setup_markers(root: Path) -> None:
     (root / "packs").mkdir(parents=True, exist_ok=True)
     (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
     (root / ".claude-plugin" / "marketplace.json").write_text(
-        "{}", encoding="utf-8"
+        "{}", encoding="utf-8", newline="\n"
     )
 
 
@@ -54,9 +54,9 @@ def _add_pack(
     pack_dir = root / "packs" / dir_name
     pack_dir.mkdir(parents=True, exist_ok=True)
     if pack_toml is not None:
-        (pack_dir / "pack.toml").write_text(pack_toml, encoding="utf-8")
+        (pack_dir / "pack.toml").write_text(pack_toml, encoding="utf-8", newline="\n")
     if plugin_json is not None:
-        (pack_dir / "plugin.json").write_text(plugin_json, encoding="utf-8")
+        (pack_dir / "plugin.json").write_text(plugin_json, encoding="utf-8", newline="\n")
     return pack_dir
 
 
@@ -281,6 +281,7 @@ def test_cat_l011_skill_missing_frontmatter_key(tmp_path, monkeypatch):
     (skill_dir / "SKILL.md").write_text(
         "---\ndescription: Does something useful\n---\n\nBody.\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = lint_catalogue(tmp_path)
     codes = [d.code for d in result.diagnostics]
@@ -390,7 +391,7 @@ def _setup_profile(root: Path, name: str, content: str) -> Path:
     """Write a profile TOML file under root/profiles/."""
     (root / "profiles").mkdir(parents=True, exist_ok=True)
     p = root / "profiles" / f"{name}.toml"
-    p.write_text(content, encoding="utf-8")
+    p.write_text(content, encoding="utf-8", newline="\n")
     return p
 
 
@@ -420,6 +421,7 @@ def _add_pack_full(
         f'[pack]\nname = "{name}"\nversion = "{version}"\n'
         f'{install_section}{deps_section}\n',
         encoding="utf-8",
+        newline="\n",
     )
     return pack_dir
 
@@ -593,12 +595,13 @@ def _add_pack_with_seeds(
     (pack_dir / "pack.toml").write_text(
         f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\nlint-seeds = {flag}\n',
         encoding="utf-8",
+        newline="\n",
     )
     if seeds:
         for rel, content in seeds.items():
             seed_path = pack_dir / "seeds" / rel
             seed_path.parent.mkdir(parents=True, exist_ok=True)
-            seed_path.write_text(content, encoding="utf-8")
+            seed_path.write_text(content, encoding="utf-8", newline="\n")
     return pack_dir
 
 
@@ -706,11 +709,12 @@ def test_check_seeds_patterns_jsonl_nonempty(tmp_path, monkeypatch):
     (pack_dir / "pack.toml").write_text(
         '[pack]\nname = "pack-a"\nversion = "0.1.0"\nlint-seeds = true\n',
         encoding="utf-8",
+        newline="\n",
     )
     for rel, content in seeds.items():
         p = pack_dir / "seeds" / rel
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content, encoding="utf-8")
+        p.write_text(content, encoding="utf-8", newline="\n")
     result = lint_catalogue(tmp_path)
     l029 = [d for d in result.diagnostics if d.code == "CAT-L029"]
     assert l029, "expected CAT-L029 for non-empty patterns.jsonl"
@@ -749,7 +753,7 @@ def test_check_seeds_symlinked_dir_skipped(tmp_path, monkeypatch):
     link = pack_dir / "seeds" / "evil-link"
     target = tmp_path / "outside"
     target.mkdir()
-    (target / "passwd").write_text("root:x:0:0\n", encoding="utf-8")
+    (target / "passwd").write_text("root:x:0:0\n", encoding="utf-8", newline="\n")
     try:
         link.symlink_to(target, target_is_directory=True)
     except (OSError, NotImplementedError):
@@ -773,7 +777,7 @@ def test_check_seeds_symlinked_file_skipped(tmp_path, monkeypatch):
     pack_dir = _add_pack_with_seeds(tmp_path, "pack-a", lint_seeds=True,
                                     seeds={"AGENTS.md": "<project-name>"})
     outside = tmp_path / "outside.md"
-    outside.write_text("<project-name>", encoding="utf-8")
+    outside.write_text("<project-name>", encoding="utf-8", newline="\n")
     link = pack_dir / "seeds" / "AGENTS.md"
     link.unlink()
     try:
@@ -810,6 +814,7 @@ def _add_pack_fv(root: Path, name: str, *, pack_toml_extra: str = "") -> Path:
         f'[pack.install]\nallowed-adapters = ["claude"]\n'
         f'{pack_toml_extra}\n',
         encoding="utf-8",
+        newline="\n",
     )
     return pack_dir
 
@@ -943,11 +948,11 @@ def _add_credentialed_skill(
     """Add a credentialed skill to pack_dir/.apm/skills/<skill_name>/."""
     skill_dir = pack_dir / ".apm" / "skills" / skill_name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(skill_md_content, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(skill_md_content, encoding="utf-8", newline="\n")
     if script_content is not None:
         scripts_dir = skill_dir / "scripts"
         scripts_dir.mkdir(parents=True, exist_ok=True)
-        (scripts_dir / "run.py").write_text(script_content, encoding="utf-8")
+        (scripts_dir / "run.py").write_text(script_content, encoding="utf-8", newline="\n")
 
 
 _CLEAN_SKILL_MD = """\

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -43,29 +43,29 @@ def _make_catalogue(
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
-    (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8", newline="\n")
 
     # Profile
     profiles_dir = root / "profiles"
     profiles_dir.mkdir()
-    (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8")
+    (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8", newline="\n")
 
     if with_agents_md:
-        (root / "AGENTS.md").write_text("# Catalogue Agent Context\n", encoding="utf-8")
+        (root / "AGENTS.md").write_text("# Catalogue Agent Context\n", encoding="utf-8", newline="\n")
 
-    (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8")
+    (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8", newline="\n")
 
     if with_license_apache:
-        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
+        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8", newline="\n")
     if with_license_mit:
-        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8", newline="\n")
 
     if with_marketplace:
         cp_dir = root / ".claude-plugin"
         cp_dir.mkdir()
-        (cp_dir / "marketplace.json").write_text('{"packs": ["core"]}\n', encoding="utf-8")
+        (cp_dir / "marketplace.json").write_text('{"packs": ["core"]}\n', encoding="utf-8", newline="\n")
 
     return root
 
@@ -449,7 +449,7 @@ def test_denied_dirs_not_in_archive(tmp_path: Path) -> None:
     for denied in [".git", "tools", "packages", "dist", "__pycache__"]:
         d = root / denied
         d.mkdir()
-        (d / "stub.txt").write_text("should be excluded\n", encoding="utf-8")
+        (d / "stub.txt").write_text("should be excluded\n", encoding="utf-8", newline="\n")
 
     output = tmp_path / "out"
     with mock.patch.dict(os.environ, {"SOURCE_DATE_EPOCH": "1700000000"}):
@@ -533,13 +533,13 @@ def _make_two_pack_catalogue(tmp_path: Path) -> Path:
         pack_dir = root / "packs" / pack_name
         pack_dir.mkdir(parents=True)
         (pack_dir / "pack.toml").write_text(
-            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8"
+            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
         )
-    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
-    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8", newline="\n")
+    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8", newline="\n")
     cp_dir = root / ".claude-plugin"
     cp_dir.mkdir()
-    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8", newline="\n")
     return root
 
 
@@ -565,15 +565,15 @@ def test_scan_content_nonpack_dirs_always_included(tmp_path: Path) -> None:
     pack_dir = root / "packs" / "pack-alpha"
     pack_dir.mkdir(parents=True)
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "pack-alpha"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "pack-alpha"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
     (root / "profiles").mkdir()
     (root / "profiles" / "default.toml").write_text(
-        '[profile]\nname = "default"\n', encoding="utf-8"
+        '[profile]\nname = "default"\n', encoding="utf-8", newline="\n"
     )
     (root / "contracts").mkdir()
     (root / "contracts" / "adapter.toml").write_text(
-        '[contract]\nversion = "1"\n', encoding="utf-8"
+        '[contract]\nversion = "1"\n', encoding="utf-8", newline="\n"
     )
     paths = _scan_content(root, pack_include=["packs/pack-alpha"])
     posix = [p.relative_to(root).as_posix() for p in paths]
@@ -602,7 +602,7 @@ def test_check_required_custom_license(tmp_path: Path) -> None:
     root = tmp_path / "catalogue"
     root.mkdir()
     (root / "packs").mkdir()
-    (root / "LICENSE").write_text("Custom license\n", encoding="utf-8")
+    (root / "LICENSE").write_text("Custom license\n", encoding="utf-8", newline="\n")
     paths = [root / "LICENSE"]
     err = _check_required_files(root, paths, required_override=["LICENSE"])
     assert err is None
@@ -651,14 +651,14 @@ def test_package_honours_include_config(tmp_path: Path) -> None:
         pack_dir = root / "packs" / pack_name
         pack_dir.mkdir(parents=True)
         (pack_dir / "pack.toml").write_text(
-            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8"
+            f'[pack]\nname = "{pack_name}"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
         )
-    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8")
-    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
-    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8", newline="\n")
+    (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8", newline="\n")
+    (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8", newline="\n")
     cp_dir = root / ".claude-plugin"
     cp_dir.mkdir()
-    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8", newline="\n")
     output = tmp_path / "out"
 
     with (
@@ -690,13 +690,13 @@ def test_package_custom_required_no_apache_license(tmp_path: Path) -> None:
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
-    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8")
-    (root / "LICENSE").write_text("Proprietary license\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8", newline="\n")
+    (root / "LICENSE").write_text("Proprietary license\n", encoding="utf-8", newline="\n")
     cp_dir = root / ".claude-plugin"
     cp_dir.mkdir()
-    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8")
+    (cp_dir / "marketplace.json").write_text('{"packs": []}\n', encoding="utf-8", newline="\n")
     output = tmp_path / "out"
 
     with (

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
@@ -74,7 +74,7 @@ def test_verify_empty_dir_passes(tmp_path):
 def test_verify_no_tools_dir_needed(tmp_path):
     """External catalogue portability (T5): no Makefile or tools/ dir required → ok=True."""
     # A minimal directory that has no build tooling at all.
-    (tmp_path / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("# Catalogue\n", encoding="utf-8", newline="\n")
     result = verify_catalogue(tmp_path)
     assert result.ok, [d.message for d in result.diagnostics]
 
@@ -245,7 +245,7 @@ def test_step_agent_artifacts_skill_missing_name(tmp_path):
     skill_dir = tmp_path / ".claude" / "skills" / "my-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\ndescription: A skill\n---\nBody text.\n", encoding="utf-8"
+        "---\ndescription: A skill\n---\nBody text.\n", encoding="utf-8", newline="\n"
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert any(
@@ -262,6 +262,7 @@ def test_step_agent_artifacts_agent_missing_model(tmp_path):
     (agents_dir / "my-agent.md").write_text(
         "---\nname: my-agent\ndescription: An agent\n---\nAgent body.\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-011" for d in result)
@@ -275,6 +276,7 @@ def test_step_agent_artifacts_credentialed_skill_bad_auth(tmp_path):
     (skill_dir / "SKILL.md").write_text(
         "---\nname: cred-skill\ndescription: A skill\nmetadata:\n  auth: bad-broker\n---\nBody.\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-011" for d in result)
@@ -288,6 +290,7 @@ def test_step_agent_artifacts_unknown_skill_key(tmp_path):
     (skill_dir / "SKILL.md").write_text(
         "---\nname: my-skill\ndescription: A skill\nunknown-key: value\n---\nBody.\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-011" for d in result)
@@ -301,6 +304,7 @@ def test_step_agent_artifacts_broken_link(tmp_path):
     (skill_dir / "SKILL.md").write_text(
         "---\nname: my-skill\ndescription: A skill\n---\nSee [this](missing.md).\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-011" for d in result)
@@ -359,6 +363,7 @@ def test_step_agent_artifacts_clean(tmp_path):
     (skill_dir / "SKILL.md").write_text(
         "---\nname: my-skill\ndescription: A clean skill\n---\nBody.\n",
         encoding="utf-8",
+        newline="\n",
     )
     result = _step_agent_artifacts(tmp_path, None, None, tmp_path)
     assert result == []
@@ -381,7 +386,7 @@ def test_step_plugin_manifests_invalid_manifest(tmp_path):
     from agentbundle.catalogue_tooling.verify import _step_plugin_manifests
     plugin_dir = tmp_path / "dist" / "claude-plugins" / "my-pack.claude-plugin"
     plugin_dir.mkdir(parents=True)
-    (plugin_dir / "plugin.json").write_text(json.dumps({}), encoding="utf-8")
+    (plugin_dir / "plugin.json").write_text(json.dumps({}), encoding="utf-8", newline="\n")
     result = _step_plugin_manifests(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-013" for d in result)
 
@@ -392,7 +397,7 @@ def test_step_plugin_manifests_marketplace_with_hooks(tmp_path):
     dist_dir = tmp_path / "dist" / "claude-plugins"
     dist_dir.mkdir(parents=True)
     marketplace = {"plugins": [{"name": "my-pack", "hooks": {"PostInstall": []}}]}
-    (dist_dir / "marketplace.json").write_text(json.dumps(marketplace), encoding="utf-8")
+    (dist_dir / "marketplace.json").write_text(json.dumps(marketplace), encoding="utf-8", newline="\n")
     result = _step_plugin_manifests(tmp_path, None, None, tmp_path)
     assert any(d.code == "CAT-V-013" for d in result)
 

--- a/packages/agentbundle/tests/unit/test_cli_profile_surface.py
+++ b/packages/agentbundle/tests/unit/test_cli_profile_surface.py
@@ -36,11 +36,13 @@ def _catalogue(tmp_path):
         'scope = "user"\ndescription = "Architect toolkit"\n'
         '[[packs]]\npack = "architect"\n[[packs]]\npack = "research"\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pdir / "full-ceremony.toml").write_text(
         'scope = "repo"\ndescription = "Full governance bundle"\n'
         '[[packs]]\npack = "core"\n',
         encoding="utf-8",
+        newline="\n",
     )
     return tmp_path
 

--- a/packages/agentbundle/tests/unit/test_codex_agent_toml.py
+++ b/packages/agentbundle/tests/unit/test_codex_agent_toml.py
@@ -92,7 +92,7 @@ class TestCodexAgentTomlSerialiser(unittest.TestCase):
         return target.read_text(encoding="utf-8")
 
     def _write(self, body: str) -> None:
-        (self.source / "agent.md").write_text(body, encoding="utf-8")
+        (self.source / "agent.md").write_text(body, encoding="utf-8", newline="\n")
 
     def test_trivial_round_trip(self) -> None:
         self._write(
@@ -241,6 +241,7 @@ class TestCodexAgentTomlSerialiser(unittest.TestCase):
         (self.source / "agent.md").write_text(
             "---\nname: foo\nsummary: it's a summary\n---\nBody.\n",
             encoding="utf-8",
+            newline="\n",
         )
         project_codex_agent_toml(self.source, self.output, RULE, custom_mapping)
         target = self.output / ".codex" / "agents" / "agent.toml"
@@ -277,10 +278,10 @@ class TestCodexAgentTomlSerialiser(unittest.TestCase):
     def test_multiple_files_sorted(self) -> None:
         """Multiple agent.md files each project independently."""
         (self.source / "b.md").write_text(
-            "---\nname: b\ndescription: B\n---\nB body.\n", encoding="utf-8"
+            "---\nname: b\ndescription: B\n---\nB body.\n", encoding="utf-8", newline="\n"
         )
         (self.source / "a.md").write_text(
-            "---\nname: a\ndescription: A\n---\nA body.\n", encoding="utf-8"
+            "---\nname: a\ndescription: A\n---\nA body.\n", encoding="utf-8", newline="\n"
         )
         project_codex_agent_toml(
             self.source, self.output, RULE, CODEX_AGENT_FRONTMATTER_V08
@@ -291,7 +292,7 @@ class TestCodexAgentTomlSerialiser(unittest.TestCase):
 
     def test_non_md_files_ignored(self) -> None:
         """Files without ``.md`` suffix are skipped."""
-        (self.source / "skip.txt").write_text("ignored", encoding="utf-8")
+        (self.source / "skip.txt").write_text("ignored", encoding="utf-8", newline="\n")
         self._write("---\nname: foo\n---\nBody.\n")
         self._run()
         # If `skip.txt` had been processed we'd get .codex/agents/skip.toml;

--- a/packages/agentbundle/tests/unit/test_codex_projection_modes.py
+++ b/packages/agentbundle/tests/unit/test_codex_projection_modes.py
@@ -179,6 +179,7 @@ class TestCodexProjectRoutesAgentToBuildPipeline(unittest.TestCase):
             (pack / ".apm" / "agents" / "foo.md").write_text(
                 "---\nname: foo\ndescription: a foo agent\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             out = tmp_path / "out"
             codex.project(pack, contract, out)

--- a/packages/agentbundle/tests/unit/test_config.py
+++ b/packages/agentbundle/tests/unit/test_config.py
@@ -20,6 +20,7 @@ version = "0.1.0"
 version = "0.1"
 """,
         encoding="utf-8",
+        newline="\n",
     )
     parsed = config.load_pack_toml(pack_toml)
     assert parsed["pack"]["name"] == "core"
@@ -28,7 +29,7 @@ version = "0.1"
 
 def test_load_pack_toml_raises_typed_error_on_malformed(tmp_path):
     pack_toml = tmp_path / "pack.toml"
-    pack_toml.write_text("this = is = not toml", encoding="utf-8")
+    pack_toml.write_text("this = is = not toml", encoding="utf-8", newline="\n")
     with pytest.raises(config.ConfigError, match="not valid TOML"):
         config.load_pack_toml(pack_toml)
 
@@ -62,6 +63,7 @@ primitives = ["skill", "agent", "hook-body", "hook-wiring", "command"]
 "docs/CHARTER.md" = { sha = "def456", from-pack-version = "0.2.0" }
 """,
         encoding="utf-8",
+        newline="\n",
     )
 
     state = config.load_state(state_toml)
@@ -101,6 +103,7 @@ primitives = ["skill"]
 version = "0.3.0"
 """,
         encoding="utf-8",
+        newline="\n",
     )
     state = config.load_state(state_toml)
     assert state.row("core", "claude-code").primitive_versions == {
@@ -115,7 +118,7 @@ version = "0.3.0"
 
 def test_load_state_raises_on_malformed_toml(tmp_path):
     p = tmp_path / "state.toml"
-    p.write_text("not = = toml", encoding="utf-8")
+    p.write_text("not = = toml", encoding="utf-8", newline="\n")
     with pytest.raises(config.ConfigError, match="not valid TOML"):
         config.load_state(p)
 
@@ -129,6 +132,7 @@ PROJECT_NAME = "demo"
 OWNER = "octocat"
 """,
         encoding="utf-8",
+        newline="\n",
     )
     values = config.load_values_from(p)
     assert values == {"PROJECT_NAME": "demo", "OWNER": "octocat"}
@@ -142,13 +146,14 @@ def test_load_values_from_rejects_non_string(tmp_path):
 COUNT = 3
 """,
         encoding="utf-8",
+        newline="\n",
     )
     with pytest.raises(config.ConfigError, match="must be a string"):
         config.load_values_from(p)
 
 
 def _write(path: Path, content: str) -> Path:
-    path.write_text(content, encoding="utf-8")
+    path.write_text(content, encoding="utf-8", newline="\n")
     return path
 
 
@@ -159,7 +164,7 @@ def _write(path: Path, content: str) -> Path:
 
 def test_load_state_rejects_non_string_schema_version(tmp_path):
     p = tmp_path / "state.toml"
-    p.write_text("schema-version = 42\n", encoding="utf-8")
+    p.write_text("schema-version = 42\n", encoding="utf-8", newline="\n")
     with pytest.raises(config.ConfigError, match="schema-version"):
         config.load_state(p)
 
@@ -169,12 +174,14 @@ def test_load_state_rejects_pack_not_a_table(tmp_path):
     p.write_text(
         'schema-version = "0.1"\n[pack]\nlooks-like-a-table-but-isnt = "nope"\n[pack.x]\ninstalled-version = ""\n',  # noqa: E501
         encoding="utf-8",
+        newline="\n",
     )
     # The above IS a valid TOML structure; for an actually-broken case:
     p.write_text(
         'schema-version = "0.4"\n[pack.x.adapters.claude-code]\n'
         'installed-version = ""\nfiles = "not-a-table"\n',
         encoding="utf-8",
+        newline="\n",
     )
     with pytest.raises(config.ConfigError, match="files"):
         config.load_state(p)

--- a/packages/agentbundle/tests/unit/test_config_cmd.py
+++ b/packages/agentbundle/tests/unit/test_config_cmd.py
@@ -125,7 +125,7 @@ def test_unset_missing_key_is_noop(capsys) -> None:
 def test_unset_preserves_other_settings(capsys) -> None:
     cfg_path = _user_config_path()
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n')
+    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n")
     exit_code = run(_args("unset", "adapter"))
     assert exit_code == 0
     assert cfg_path.exists()

--- a/packages/agentbundle/tests/unit/test_copilot_agent_md.py
+++ b/packages/agentbundle/tests/unit/test_copilot_agent_md.py
@@ -69,7 +69,7 @@ class TestCopilotAgentMdSerialiser(unittest.TestCase):
         self._tmpdir.cleanup()
 
     def _write(self, body: str, name: str = "agent.md") -> None:
-        (self.source / name).write_text(body, encoding="utf-8")
+        (self.source / name).write_text(body, encoding="utf-8", newline="\n")
 
     def _run(self, stem: str = "agent") -> str:
         project_copilot_agent_md(

--- a/packages/agentbundle/tests/unit/test_copilot_hooks_json.py
+++ b/packages/agentbundle/tests/unit/test_copilot_hooks_json.py
@@ -37,7 +37,7 @@ class TestCopilotHooksJsonSerialiser(unittest.TestCase):
         self._tmpdir.cleanup()
 
     def _write(self, name: str, body: str) -> None:
-        (self.source / name).write_text(body, encoding="utf-8")
+        (self.source / name).write_text(body, encoding="utf-8", newline="\n")
 
     def _run(self) -> None:
         project_copilot_hooks_json(self.source, self.output, RULE)

--- a/packages/agentbundle/tests/unit/test_copilot_user_scope_wiring.py
+++ b/packages/agentbundle/tests/unit/test_copilot_user_scope_wiring.py
@@ -135,6 +135,7 @@ class TestRenderForUserScopeDispatchesCopilot(unittest.TestCase):
             (pack / ".apm" / "agents" / "foo.md").write_text(
                 "---\nname: foo\ndescription: a foo agent\n---\nBody.\n",
                 encoding="utf-8",
+                newline="\n",
             )
             projection = _render_for_user_scope(
                 pack,

--- a/packages/agentbundle/tests/unit/test_credential_setup_skill.py
+++ b/packages/agentbundle/tests/unit/test_credential_setup_skill.py
@@ -56,10 +56,10 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
     # relative import (`from .credentials_shim ...`) resolves.
     skill_dir = tmp_path / "credential-setup"
     skill_dir.mkdir()
-    (skill_dir / "__init__.py").write_text("")
+    (skill_dir / "__init__.py").write_text("", encoding="utf-8", newline="\n")
     scripts_dir = skill_dir / "scripts"
     scripts_dir.mkdir()
-    (scripts_dir / "__init__.py").write_text("")
+    (scripts_dir / "__init__.py").write_text("", encoding="utf-8", newline="\n")
     shutil.copy(SETUP_PY, scripts_dir / "setup.py")
     for shim_file in SHIM_SOURCE.iterdir():
         if shim_file.is_file() and shim_file.suffix == ".py":
@@ -79,7 +79,7 @@ def test_ac19_reserved_sso_namespace_refused(tmp_path):
         # We need a Python package layout — use underscored name.
         skill_dir2 = tmp_path / "credential_setup"
         skill_dir2.mkdir()
-        (skill_dir2 / "__init__.py").write_text("")
+        (skill_dir2 / "__init__.py").write_text("", encoding="utf-8", newline="\n")
         shutil.copy(SETUP_PY, skill_dir2 / "setup.py")
         for shim_file in SHIM_SOURCE.iterdir():
             if shim_file.is_file() and shim_file.suffix == ".py":
@@ -102,7 +102,7 @@ def test_ac18_argv_ban_refused(tmp_path):
         pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
-    (skill_dir / "__init__.py").write_text("")
+    (skill_dir / "__init__.py").write_text("", encoding="utf-8", newline="\n")
     shutil.copy(SETUP_PY, skill_dir / "setup.py")
     for shim_file in SHIM_SOURCE.iterdir():
         if shim_file.is_file() and shim_file.suffix == ".py":
@@ -126,7 +126,7 @@ def test_ac18_no_token_in_stdout(tmp_path, monkeypatch):
         pytest.skip("credbroker not installed")
     skill_dir = tmp_path / "credential_setup"
     skill_dir.mkdir()
-    (skill_dir / "__init__.py").write_text("")
+    (skill_dir / "__init__.py").write_text("", encoding="utf-8", newline="\n")
     shutil.copy(SETUP_PY, skill_dir / "setup.py")
     for shim_file in SHIM_SOURCE.iterdir():
         if shim_file.is_file() and shim_file.suffix == ".py":
@@ -138,6 +138,7 @@ def test_ac18_no_token_in_stdout(tmp_path, monkeypatch):
         '[namespace]\nname = "ns_test"\n\n'
         '[[namespace.keys]]\nname = "API_TOKEN"\nlabel = "API token"\nsecret = true\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     # Force HOME to a tmp dir so any Tier-2 backend write is sandboxed.

--- a/packages/agentbundle/tests/unit/test_credentials_shim_load_credentials.py
+++ b/packages/agentbundle/tests/unit/test_credentials_shim_load_credentials.py
@@ -48,7 +48,7 @@ class _ShimImportBase(unittest.TestCase):
         self.addCleanup(self._env.stop)
         pkg = self.tmp / "fixture_pkg"
         pkg.mkdir()
-        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "__init__.py").write_text("", encoding="utf-8", newline="\n")
         for fname in (
             "credentials_shim.py",
             "_keychain_macos.py",
@@ -125,6 +125,7 @@ class ShimTier3Tests(_ShimImportBase):
         dotfile.write_text(
             "SHIMNS_API_TOKEN=tier3-value\n",
             encoding="utf-8",
+            newline="\n",
         )
         if os.name == "posix":
             dotfile.chmod(0o600)
@@ -138,6 +139,7 @@ class ShimTier3Tests(_ShimImportBase):
         dotfile.write_text(
             'SHIMNS_API_TOKEN="value with spaces"\n',
             encoding="utf-8",
+            newline="\n",
         )
         creds = self.shim.load_credentials("shimns", required_keys=["API_TOKEN"])
         self.assertEqual(creds.API_TOKEN, "value with spaces")
@@ -148,13 +150,13 @@ class ShimEnvParseSurfaceTests(_ShimImportBase):
 
     def test_basic_parse(self) -> None:
         tmp = self.tmp / "fixture.env"
-        tmp.write_text("KEY=value\n# comment\nOTHER=other\n", encoding="utf-8")
+        tmp.write_text("KEY=value\n# comment\nOTHER=other\n", encoding="utf-8", newline="\n")
         out = self.shim.parse_env_file(tmp)
         self.assertEqual(out, {"KEY": "value", "OTHER": "other"})
 
     def test_refuses_export_prefix(self) -> None:
         tmp = self.tmp / "fixture.env"
-        tmp.write_text("export KEY=value\n", encoding="utf-8")
+        tmp.write_text("export KEY=value\n", encoding="utf-8", newline="\n")
         with self.assertRaises(self.shim.EnvParseError):
             self.shim.parse_env_file(tmp)
 

--- a/packages/agentbundle/tests/unit/test_credentials_shim_stdlib.py
+++ b/packages/agentbundle/tests/unit/test_credentials_shim_stdlib.py
@@ -41,7 +41,7 @@ class ShimStdlibOnlySubprocessTests(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         pkg = self.tmp / "fixture_skill"
         pkg.mkdir()
-        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "__init__.py").write_text("", encoding="utf-8", newline="\n")
         for fname in (
             "credentials_shim.py",
             "_keychain_macos.py",

--- a/packages/agentbundle/tests/unit/test_flow_metrics_upstream_probe.py
+++ b/packages/agentbundle/tests/unit/test_flow_metrics_upstream_probe.py
@@ -63,7 +63,7 @@ def test_user_scope_probe_across_three_adapters(upstream, adapter_dir, monkeypat
         home_path = Path(home)
         script = home_path / adapter_dir / "skills" / "jira" / "scripts" / "jira.py"
         script.parent.mkdir(parents=True)
-        script.write_text("# stub\n")
+        script.write_text("# stub\n", encoding="utf-8", newline="\n")
 
         monkeypatch.setenv("HOME", str(home_path))
         if sys.platform == "win32":
@@ -82,7 +82,7 @@ def test_project_scope_probe_across_three_adapters(upstream, adapter_dir, monkey
         proj_path = Path(proj)
         script = proj_path / adapter_dir / "skills" / "jira" / "scripts" / "jira.py"
         script.parent.mkdir(parents=True)
-        script.write_text("# stub\n")
+        script.write_text("# stub\n", encoding="utf-8", newline="\n")
 
         # Empty HOME so user-scope candidates don't accidentally match.
         monkeypatch.setenv("HOME", str(Path(home)))
@@ -103,11 +103,11 @@ def test_env_override_wins_over_user_scope(upstream, monkeypatch):
         # were the env override absent.
         decoy = home_path / ".claude" / "skills" / "jira" / "scripts" / "jira.py"
         decoy.parent.mkdir(parents=True)
-        decoy.write_text("# decoy\n")
+        decoy.write_text("# decoy\n", encoding="utf-8", newline="\n")
 
         # The override target.
         override_path = Path(override) / "jira.py"
-        override_path.write_text("# override\n")
+        override_path.write_text("# override\n", encoding="utf-8", newline="\n")
 
         monkeypatch.setenv("HOME", str(home_path))
         monkeypatch.setenv("FLOW_METRICS_JIRA_SCRIPT", str(override_path))

--- a/packages/agentbundle/tests/unit/test_init_state_cmd.py
+++ b/packages/agentbundle/tests/unit/test_init_state_cmd.py
@@ -94,7 +94,7 @@ def test_init_state_merge_preserves_other_pack(tmp_path):
         files={"some/path.md": {"sha": "deadbeef", "from-pack-version": "1.0.0"}},
     )
     (tmp_path / ".agentbundle-state.toml").write_text(
-        config.dump_state(pre_state), encoding="utf-8"
+        config.dump_state(pre_state), encoding="utf-8", newline="\n"
     )
 
     _project_pack_into(CORE_PACK, tmp_path)
@@ -171,6 +171,7 @@ def test_init_state_refuses_pack_without_version(tmp_path):
     (pack_dir / "pack.toml").write_text(
         '[pack]\nname = "anon"\n',  # no version
         encoding="utf-8",
+        newline="\n",
     )
 
     args = _make_args(pack="anon", root=str(tmp_path))

--- a/packages/agentbundle/tests/unit/test_install_argparse_emit_install_routes.py
+++ b/packages/agentbundle/tests/unit/test_install_argparse_emit_install_routes.py
@@ -104,7 +104,7 @@ def _make_minimal_pack(root: Path, name: str = "demo", default_scope: str = "rep
         allowed-adapters = ["claude-code", "kiro"]
         """
     )
-    (pack_dir / "pack.toml").write_text(pack_toml, encoding="utf-8")
+    (pack_dir / "pack.toml").write_text(pack_toml, encoding="utf-8", newline="\n")
     return pack_dir
 
 

--- a/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
+++ b/packages/agentbundle/tests/unit/test_install_dropped_primitives_warning.py
@@ -50,31 +50,31 @@ def _seed_pack(
         for name in skills:
             (pack / ".apm" / "skills" / name).mkdir(parents=True)
             (pack / ".apm" / "skills" / name / "SKILL.md").write_text(
-                f"# {name}\n", encoding="utf-8"
+                f"# {name}\n", encoding="utf-8", newline="\n"
             )
     if agents:
         (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
         for name in agents:
             (pack / ".apm" / "agents" / f"{name}.md").write_text(
-                f"# {name}\n", encoding="utf-8"
+                f"# {name}\n", encoding="utf-8", newline="\n"
             )
     if hook_bodies:
         (pack / ".apm" / "hooks").mkdir(parents=True, exist_ok=True)
         for name in hook_bodies:
             (pack / ".apm" / "hooks" / f"{name}.sh").write_text(
-                f"# {name}\n", encoding="utf-8"
+                f"# {name}\n", encoding="utf-8", newline="\n"
             )
     if hook_wirings:
         (pack / ".apm" / "hook-wiring").mkdir(parents=True, exist_ok=True)
         for name in hook_wirings:
             (pack / ".apm" / "hook-wiring" / f"{name}.toml").write_text(
-                "[hooks]\n", encoding="utf-8"
+                "[hooks]\n", encoding="utf-8", newline="\n"
             )
     if commands:
         (pack / ".apm" / "commands").mkdir(parents=True, exist_ok=True)
         for name in commands:
             (pack / ".apm" / "commands" / f"{name}.md").write_text(
-                f"# {name}\n", encoding="utf-8"
+                f"# {name}\n", encoding="utf-8", newline="\n"
             )
     return pack
 
@@ -159,9 +159,9 @@ class TestEnumerateDroppedPrimitives(unittest.TestCase):
         pack = self.tmp_path / "pack"
         (pack / ".apm" / "commands").mkdir(parents=True)
         # One real command (.md), plus junk files.
-        (pack / ".apm" / "commands" / "real.md").write_text("# real\n", encoding="utf-8")
-        (pack / ".apm" / "commands" / ".DS_Store").write_text("junk", encoding="utf-8")
-        (pack / ".apm" / "commands" / "README.txt").write_text("not a command", encoding="utf-8")
+        (pack / ".apm" / "commands" / "real.md").write_text("# real\n", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "commands" / ".DS_Store").write_text("junk", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "commands" / "README.txt").write_text("not a command", encoding="utf-8", newline="\n")
         # Stray subdirectory — shouldn't count toward .md commands.
         (pack / ".apm" / "commands" / "subdir").mkdir()
         result = _enumerate_dropped_primitives(pack, "codex")
@@ -174,8 +174,8 @@ class TestEnumerateDroppedPrimitives(unittest.TestCase):
         # so the dropped-count is absent regardless of suffix. Name preserved.
         pack = self.tmp_path / "pack"
         (pack / ".apm" / "hook-wiring").mkdir(parents=True)
-        (pack / ".apm" / "hook-wiring" / "real.toml").write_text("[hooks]\n", encoding="utf-8")
-        (pack / ".apm" / "hook-wiring" / "stray.md").write_text("not a wiring", encoding="utf-8")
+        (pack / ".apm" / "hook-wiring" / "real.toml").write_text("[hooks]\n", encoding="utf-8", newline="\n")
+        (pack / ".apm" / "hook-wiring" / "stray.md").write_text("not a wiring", encoding="utf-8", newline="\n")
         result = _enumerate_dropped_primitives(pack, "copilot")
         self.assertNotIn("hook-wiring", result)
 
@@ -590,6 +590,7 @@ class TestMaybeEmitEventDrops(unittest.TestCase):
         (hw_dir / "session-start.toml").write_text(
             '[[hooks.SessionStart]]\nhooks = [{type = "command", command = "x"}]\n',
             encoding="utf-8",
+            newline="\n",
         )
 
         captured = StringIO()

--- a/packages/agentbundle/tests/unit/test_install_event_dropped_wirings.py
+++ b/packages/agentbundle/tests/unit/test_install_event_dropped_wirings.py
@@ -47,7 +47,7 @@ def _seed_wiring(root: Path, name: str, content: str) -> Path:
     hw_dir = root / ".apm" / "hook-wiring"
     hw_dir.mkdir(parents=True, exist_ok=True)
     p = hw_dir / f"{name}.toml"
-    p.write_text(content, encoding="utf-8")
+    p.write_text(content, encoding="utf-8", newline="\n")
     return p
 
 

--- a/packages/agentbundle/tests/unit/test_install_first_value_handoff.py
+++ b/packages/agentbundle/tests/unit/test_install_first_value_handoff.py
@@ -213,6 +213,7 @@ class InstallFirstValueHandoffIntegrationTests(unittest.TestCase):
             f'default-scope = "repo"\n'
             f'allowed-scopes = ["repo"]\n',
             encoding="utf-8",
+            newline="\n",
         )
         # A minimal skill so the projection is non-empty.
         skill_dir = pack_dir / ".apm" / "skills" / "dummy"
@@ -220,6 +221,7 @@ class InstallFirstValueHandoffIntegrationTests(unittest.TestCase):
         (skill_dir / "SKILL.md").write_text(
             "---\ndescription: Scratch skill.\n---\nScratch skill body.\n",
             encoding="utf-8",
+            newline="\n",
         )
         return pack_dir
 

--- a/packages/agentbundle/tests/unit/test_install_inband_detection.py
+++ b/packages/agentbundle/tests/unit/test_install_inband_detection.py
@@ -67,12 +67,14 @@ def _make_pack(
             {aa_line}"""
         ),
         encoding="utf-8",
+        newline="\n",
     )
     skill_dir = pack_dir / ".apm" / "skills" / f"{name}-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {name}-skill\ndescription: {name}\n---\nBody.",
         encoding="utf-8",
+        newline="\n",
     )
     return pack_dir
 
@@ -111,6 +113,7 @@ def _plant_state(
             """
         ),
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -152,11 +155,11 @@ class TriggerBShapeMismatchTests(unittest.TestCase):
             # Plant dist-tree files (pre-RFC-0012 shape).
             (adopter / "claude-plugins" / "demo").mkdir(parents=True)
             (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
             (adopter / "apm" / "demo").mkdir(parents=True)
             (adopter / "apm" / "demo" / "pack.toml").write_text(
-                "", encoding="utf-8"
+                "", encoding="utf-8", newline="\n"
             )
 
             rc, stderr = _run_install(
@@ -189,7 +192,7 @@ class TriggerBShapeMismatchTests(unittest.TestCase):
             _plant_state(adopter, pack_name="demo", source=str(packs_dir))
             (adopter / "claude-plugins" / "demo").mkdir(parents=True)
             (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
 
             # `--yes` so the new force-cleanup confirm (CLI-hygiene AC7) does
@@ -299,7 +302,7 @@ class CrossAdapterCoexistenceTests(unittest.TestCase):
             _plant_state(adopter, pack_name="demo", adapter="claude-code", source=str(packs_dir))
             (adopter / "claude-plugins" / "demo").mkdir(parents=True)
             (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
 
             # Same adapter (claude-code) install → (b) fires on the legacy shape.
@@ -341,7 +344,7 @@ class PrecedenceAndSessionShortCircuitTests(unittest.TestCase):
             _plant_state(adopter, pack_name="apack", source=str(packs_dir))
             (adopter / "claude-plugins" / "apack").mkdir(parents=True)
             (adopter / "claude-plugins" / "apack" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
             # Pack B: no state row but a GENUINE non-projection orphan under
             # its skill dir → (c) should fire when installing B. Issue #190 —
@@ -350,7 +353,7 @@ class PrecedenceAndSessionShortCircuitTests(unittest.TestCase):
             # not a projected relpath, so it stays an orphan.
             orphan = adopter / ".claude" / "skills" / "bpack-skill" / "STALE.md"
             orphan.parent.mkdir(parents=True)
-            orphan.write_text("stale", encoding="utf-8")
+            orphan.write_text("stale", encoding="utf-8", newline="\n")
 
             # Install pack A first — (b) fires.
             rc_a, stderr_a = _run_install(
@@ -401,7 +404,7 @@ class PrecedenceAndSessionShortCircuitTests(unittest.TestCase):
                 adopter / ".claude" / "skills" / "apack-skill" / "SKILL.md"
             )
             a_orphan.parent.mkdir(parents=True)
-            a_orphan.write_text("stale apack content", encoding="utf-8")
+            a_orphan.write_text("stale apack content", encoding="utf-8", newline="\n")
 
             # Install pack B. (c) must NOT fire on pack A's leftovers.
             rc, stderr = _run_install(
@@ -436,7 +439,7 @@ class PrecedenceAndSessionShortCircuitTests(unittest.TestCase):
             _plant_state(adopter, pack_name="demo", source=str(packs_dir))
             (adopter / "claude-plugins" / "demo").mkdir(parents=True)
             (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
 
             rc1, stderr1 = _run_install(
@@ -473,7 +476,7 @@ class EmitInstallRoutesBypassesDetectionTests(unittest.TestCase):
             _plant_state(adopter, pack_name="demo", source=str(packs_dir))
             (adopter / "claude-plugins" / "demo").mkdir(parents=True)
             (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-                "{}", encoding="utf-8"
+                "{}", encoding="utf-8", newline="\n"
             )
 
             rc, stderr = _run_install(
@@ -508,7 +511,7 @@ class ForceCleanupConfirmTests(unittest.TestCase):
         _plant_state(adopter, pack_name="demo", source=str(packs_dir))
         (adopter / "claude-plugins" / "demo").mkdir(parents=True)
         (adopter / "claude-plugins" / "demo" / "plugin.json").write_text(
-            "{}", encoding="utf-8"
+            "{}", encoding="utf-8", newline="\n"
         )
         return packs_dir, adopter
 

--- a/packages/agentbundle/tests/unit/test_install_messages_repo_scope.py
+++ b/packages/agentbundle/tests/unit/test_install_messages_repo_scope.py
@@ -81,6 +81,7 @@ class OrphanRefusalTests(unittest.TestCase):
                 """
             ),
             encoding="utf-8",
+            newline="\n",
         )
         # Minimal skill so the projection lands something.
         skill_dir = pack_dir / ".apm" / "skills" / "demo-skill"
@@ -88,6 +89,7 @@ class OrphanRefusalTests(unittest.TestCase):
         (skill_dir / "SKILL.md").write_text(
             "---\nname: demo-skill\ndescription: demo\n---\nBody.",
             encoding="utf-8",
+            newline="\n",
         )
         return pack_dir
 
@@ -114,7 +116,7 @@ class OrphanRefusalTests(unittest.TestCase):
             # projected relpath, so the issue-#190 filter keeps it an orphan.
             orphan = adopter / ".claude" / "skills" / "demo-skill" / "STALE.md"
             orphan.parent.mkdir(parents=True)
-            orphan.write_text("stale", encoding="utf-8")
+            orphan.write_text("stale", encoding="utf-8", newline="\n")
             # No state row recorded.
 
             parser = _build_parser()
@@ -157,7 +159,7 @@ class OrphanRefusalTests(unittest.TestCase):
             # Genuine non-projection orphan (see the without-force test).
             orphan = adopter / ".claude" / "skills" / "demo-skill" / "STALE.md"
             orphan.parent.mkdir(parents=True)
-            orphan.write_text("stale", encoding="utf-8")
+            orphan.write_text("stale", encoding="utf-8", newline="\n")
 
             parser = _build_parser()
             args = parser.parse_args(
@@ -196,7 +198,7 @@ class OrphanRefusalTests(unittest.TestCase):
         adopter.mkdir()
         orphan = adopter / ".claude" / "skills" / "demo-skill" / "STALE.md"
         orphan.parent.mkdir(parents=True)
-        orphan.write_text("stale", encoding="utf-8")
+        orphan.write_text("stale", encoding="utf-8", newline="\n")
         return packs_dir, adopter, orphan
 
     def _argv(self, adopter: Path, packs_dir: Path, *, yes: bool = False) -> list[str]:

--- a/packages/agentbundle/tests/unit/test_install_refusal_ordering.py
+++ b/packages/agentbundle/tests/unit/test_install_refusal_ordering.py
@@ -85,12 +85,14 @@ def _make_pack(
             """
         ),
         encoding="utf-8",
+        newline="\n",
     )
     skill_dir = pack_dir / ".apm" / "skills" / f"{name}-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {name}-skill\ndescription: {name}\n---\nBody.",
         encoding="utf-8",
+        newline="\n",
     )
     return pack_dir
 

--- a/packages/agentbundle/tests/unit/test_install_state_provenance.py
+++ b/packages/agentbundle/tests/unit/test_install_state_provenance.py
@@ -196,7 +196,7 @@ class StateReadWithoutProvenanceFieldsTests(unittest.TestCase):
         tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
         state_path = tmp / ".agentbundle-state.toml"
-        state_path.write_text(state_toml, encoding="utf-8")
+        state_path.write_text(state_toml, encoding="utf-8", newline="\n")
 
         state = load_state(state_path)
         ps = state.row("converters", "claude-code")

--- a/packages/agentbundle/tests/unit/test_kiro_ide_hook_projection.py
+++ b/packages/agentbundle/tests/unit/test_kiro_ide_hook_projection.py
@@ -38,13 +38,13 @@ def _make_pack(
         kiro_dir.mkdir(parents=True)
         for filename, body in kiro_ide_hooks.items():
             (kiro_dir / filename).write_text(
-                json.dumps(body, indent=2) + "\n", encoding="utf-8"
+                json.dumps(body, indent=2) + "\n", encoding="utf-8", newline="\n"
             )
     if hook_bodies is not None:
         body_dir = pack / ".apm" / "hooks"
         body_dir.mkdir(parents=True)
         for filename, content in hook_bodies.items():
-            (body_dir / filename).write_text(content, encoding="utf-8")
+            (body_dir / filename).write_text(content, encoding="utf-8", newline="\n")
     return pack
 
 
@@ -353,6 +353,7 @@ class EmptyBareNameRefuses(unittest.TestCase):
                     "then": {"type": "askAgent", "prompt": "x"},
                 }) + "\n",
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(kiro_ide_hook.KiroIdeHookRefusal) as cm:
                 kiro_ide_hook.project(

--- a/packages/agentbundle/tests/unit/test_kiro_ide_hook_rail.py
+++ b/packages/agentbundle/tests/unit/test_kiro_ide_hook_rail.py
@@ -72,12 +72,12 @@ def _make_pack(root: Path, pack_name: str = "test-pack",
     hooks_dir = pack / ".apm" / "kiro-ide-hooks"
     hooks_dir.mkdir(parents=True)
     for filename, body in (hooks or {}).items():
-        (hooks_dir / filename).write_text(json.dumps(body), encoding="utf-8")
+        (hooks_dir / filename).write_text(json.dumps(body), encoding="utf-8", newline="\n")
     if hook_bodies:
         body_dir = pack / ".apm" / "hooks"
         body_dir.mkdir(parents=True)
         for filename in hook_bodies:
-            (body_dir / filename).write_text("#!/bin/sh\n", encoding="utf-8")
+            (body_dir / filename).write_text("#!/bin/sh\n", encoding="utf-8", newline="\n")
     return pack
 
 

--- a/packages/agentbundle/tests/unit/test_lint_agent_artifacts_metadata_auth.py
+++ b/packages/agentbundle/tests/unit/test_lint_agent_artifacts_metadata_auth.py
@@ -29,7 +29,7 @@ ALL_BROKERS = ("env", "cli", "creds", "sso-cookie")
 def _write_skill(root: Path, name: str, body_frontmatter: str) -> None:
     skill_dir = root / ".claude" / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(body_frontmatter, encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(body_frontmatter, encoding="utf-8", newline="\n")
 
 
 def _run_lint(root: Path) -> list:

--- a/packages/agentbundle/tests/unit/test_lint_spec_status_deferred.py
+++ b/packages/agentbundle/tests/unit/test_lint_spec_status_deferred.py
@@ -30,7 +30,7 @@ def test_workspace_only_slug_passes_check(tmp_path: Path) -> None:
     lint = _load_lint_module()
 
     workspace = tmp_path / "workspace.toml"
-    workspace.write_text('[backlog]\nopen = [{slug = "my-ws-only-slug"}]\n', encoding="utf-8")
+    workspace.write_text('[backlog]\nopen = [{slug = "my-ws-only-slug"}]\n', encoding="utf-8", newline="\n")
 
     specs = tmp_path / "docs" / "specs" / "my-spec"
     specs.mkdir(parents=True)
@@ -38,6 +38,7 @@ def test_workspace_only_slug_passes_check(tmp_path: Path) -> None:
         "- **Status:** Approved\n\n## Acceptance Criteria\n\n"
         "- [ ] do thing (deferred: my-ws-only-slug)\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     hard, _warn = lint.check(tmp_path, base_ref=None)
@@ -57,8 +58,9 @@ def test_slug_absent_from_workspace_is_hard_violation(tmp_path: Path) -> None:
         "- **Status:** Approved\n\n## Acceptance Criteria\n\n"
         "- [ ] do thing (deferred: nonexistent-slug)\n",
         encoding="utf-8",
+        newline="\n",
     )
-    (tmp_path / "workspace.toml").write_text("[backlog]\nopen = []\n", encoding="utf-8")
+    (tmp_path / "workspace.toml").write_text("[backlog]\nopen = []\n", encoding="utf-8", newline="\n")
 
     hard, _warn = lint.check(tmp_path, base_ref=None)
     assert any("nonexistent-slug" in v for v in hard)
@@ -80,6 +82,7 @@ def test_malformed_toml_falls_back_via_backlog_open_slugs(tmp_path: Path) -> Non
     workspace.write_text(
         '[backlog]\nopen = [\n  {slug = "alpha"},\n  invalid syntax here\n]\n',
         encoding="utf-8",
+        newline="\n",
     )
     slugs = lint.backlog_open_slugs(workspace)
     assert "alpha" in slugs

--- a/packages/agentbundle/tests/unit/test_list_installed_cmd.py
+++ b/packages/agentbundle/tests/unit/test_list_installed_cmd.py
@@ -134,7 +134,7 @@ def _make_args(**kw) -> SimpleNamespace:
 
 def _write_state(path: Path, state: State) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(dump_state(state), encoding="utf-8")
+    path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 def _write_catalogue(root: Path, versions: dict[str, str]) -> Path:
@@ -143,7 +143,7 @@ def _write_catalogue(root: Path, versions: dict[str, str]) -> Path:
         pd = root / "packs" / name
         pd.mkdir(parents=True, exist_ok=True)
         (pd / "pack.toml").write_text(
-            f'[pack]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8"
+            f'[pack]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8", newline="\n"
         )
     return root
 
@@ -229,7 +229,7 @@ def test_legacy_state_in_one_scope_is_skipped_not_fatal(tmp_path, capsys):
     # An incompatible (legacy-schema) repo state file is warned-and-skipped,
     # not a hard abort -- list-installed still exits 0.
     (tmp_path / ".agentbundle-state.toml").write_text(
-        'schema-version = "0.1"\n', encoding="utf-8"
+        'schema-version = "0.1"\n', encoding="utf-8", newline="\n"
     )
     args = _make_args(root=str(tmp_path), scope="repo", no_check=True)
     rc = li.run(args)
@@ -317,7 +317,7 @@ def test_cli_populated_table_and_check_drift_via_subprocess(tmp_path):
     # A clean install: file on disk matches the recorded SHA.
     rel = ".claude/skills/x/SKILL.md"
     (tmp_path / ".claude/skills/x").mkdir(parents=True)
-    (tmp_path / rel).write_text("orig\n", encoding="utf-8")
+    (tmp_path / rel).write_text("orig\n", encoding="utf-8", newline="\n")
     sha = sha256_bytes(b"orig\n")
     _write_state(
         tmp_path / ".agentbundle-state.toml",
@@ -330,7 +330,7 @@ def test_cli_populated_table_and_check_drift_via_subprocess(tmp_path):
         ),
     )
     # Edit the file so it drifts.
-    (tmp_path / rel).write_text("edited\n", encoding="utf-8")
+    (tmp_path / rel).write_text("edited\n", encoding="utf-8", newline="\n")
 
     proc = subprocess.run(
         [sys.executable, "-m", "agentbundle", "list-installed",

--- a/packages/agentbundle/tests/unit/test_list_installed_status.py
+++ b/packages/agentbundle/tests/unit/test_list_installed_status.py
@@ -40,7 +40,7 @@ def _make_args(**kw) -> SimpleNamespace:
 
 def _write_state(path: Path, state: State) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(dump_state(state), encoding="utf-8")
+    path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 def _write_catalogue(root: Path, versions: dict[str, str]) -> Path:
@@ -49,7 +49,7 @@ def _write_catalogue(root: Path, versions: dict[str, str]) -> Path:
         pd = root / "packs" / name
         pd.mkdir(parents=True, exist_ok=True)
         (pd / "pack.toml").write_text(
-            f'[pack]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8"
+            f'[pack]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8", newline="\n"
         )
     return root
 
@@ -230,7 +230,7 @@ def test_resolve_per_source_pack_absent_version(tmp_path):
     """pack.toml present but no 'version' → unparseable-catalogue-version, not pack-not-found."""
     pd = tmp_path / "cat" / "packs" / "core"
     pd.mkdir(parents=True)
-    (pd / "pack.toml").write_text('[pack]\nname = "core"\n', encoding="utf-8")
+    (pd / "pack.toml").write_text('[pack]\nname = "core"\n', encoding="utf-8", newline="\n")
     rows = [
         {"scope": "repo", "pack": "core", "adapter": "claude-code",
          "_pack_state": PackState(installed_version="1.0.0", source=str(tmp_path / "cat"))},
@@ -243,7 +243,7 @@ def test_resolve_per_source_malformed_catalogue(tmp_path):
     """ConfigError on load_pack_toml → malformed-catalogue."""
     pd = tmp_path / "cat" / "packs" / "core"
     pd.mkdir(parents=True)
-    (pd / "pack.toml").write_text("NOT VALID TOML {{{}}} \x00\x01", encoding="utf-8")
+    (pd / "pack.toml").write_text("NOT VALID TOML {{{}}} \x00\x01", encoding="utf-8", newline="\n")
     rows = [
         {"scope": "repo", "pack": "core", "adapter": "claude-code",
          "_pack_state": PackState(installed_version="1.0.0", source=str(tmp_path / "cat"))},
@@ -260,6 +260,7 @@ def test_resolve_per_source_incompatible_contract(tmp_path):
         '[pack]\nname = "core"\nversion = "1.0.0"\n'
         '[pack.adapter-contract]\nversion = "99.0"\n',
         encoding="utf-8",
+        newline="\n",
     )
     rows = [
         {"scope": "repo", "pack": "core", "adapter": "claude-code",
@@ -277,6 +278,7 @@ def test_resolve_per_source_adapter_not_supported(tmp_path):
         '[pack]\nname = "core"\nversion = "1.0.0"\n'
         '[pack.install]\nallowed-adapters = ["some-other-adapter"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     rows = [
         {"scope": "repo", "pack": "core", "adapter": "claude-code",
@@ -291,7 +293,7 @@ def test_resolve_per_source_no_adapter_contract_is_compatible(tmp_path):
     pd = tmp_path / "cat" / "packs" / "core"
     pd.mkdir(parents=True)
     (pd / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "1.0.0"\n', encoding="utf-8"
+        '[pack]\nname = "core"\nversion = "1.0.0"\n', encoding="utf-8", newline="\n"
     )
     rows = [
         {"scope": "repo", "pack": "core", "adapter": "claude-code",
@@ -711,7 +713,7 @@ def test_json_drift_count_integer_with_flag(tmp_path, capsys):
 
     rel = ".claude/skills/x/SKILL.md"
     (tmp_path / ".claude/skills/x").mkdir(parents=True)
-    (tmp_path / rel).write_text("orig\n", encoding="utf-8")
+    (tmp_path / rel).write_text("orig\n", encoding="utf-8", newline="\n")
     sha = sha256_bytes(b"orig\n")
     _write_state(
         tmp_path / ".agentbundle-state.toml",
@@ -722,7 +724,7 @@ def test_json_drift_count_integer_with_flag(tmp_path, capsys):
         }),
     )
     # Edit the file to cause drift
-    (tmp_path / rel).write_text("edited\n", encoding="utf-8")
+    (tmp_path / rel).write_text("edited\n", encoding="utf-8", newline="\n")
 
     args = _make_args(root=str(tmp_path), no_check=True, format="json", check_drift=True)
     li.run(args)
@@ -1023,7 +1025,7 @@ def test_table_drift_column_rendered_with_flag(tmp_path, capsys):
 
     rel = ".claude/skills/x/SKILL.md"
     (tmp_path / ".claude/skills/x").mkdir(parents=True)
-    (tmp_path / rel).write_text("orig\n", encoding="utf-8")
+    (tmp_path / rel).write_text("orig\n", encoding="utf-8", newline="\n")
     sha = sha256_bytes(b"orig\n")
     _write_state(
         tmp_path / ".agentbundle-state.toml",
@@ -1033,7 +1035,7 @@ def test_table_drift_column_rendered_with_flag(tmp_path, capsys):
             )
         }),
     )
-    (tmp_path / rel).write_text("edited\n", encoding="utf-8")
+    (tmp_path / rel).write_text("edited\n", encoding="utf-8", newline="\n")
     args = _make_args(root=str(tmp_path), no_check=True, check_drift=True, scope="repo")
     li.run(args)
     out = capsys.readouterr().out
@@ -1065,7 +1067,7 @@ installed-version = "0.5.0"
 
 def _write_golden_state(tmp_path: Path) -> None:
     state_path = tmp_path / ".agentbundle-state.toml"
-    state_path.write_text(_GOLDEN_STATE_TOML, encoding="utf-8")
+    state_path.write_text(_GOLDEN_STATE_TOML, encoding="utf-8", newline="\n")
 
 
 def test_table_golden_80col(tmp_path, capsys):
@@ -1139,7 +1141,7 @@ def test_table_long_pack_name_no_broken_structure(tmp_path, capsys):
         f'[pack."{long_name}".adapters.codex]\n'
         f'installed-version = "1.0.0"\n'
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(state_toml, encoding="utf-8")
+    (tmp_path / ".agentbundle-state.toml").write_text(state_toml, encoding="utf-8", newline="\n")
     args = _make_args(root=str(tmp_path), scope="repo", no_check=True)
     li.run(args)
     out = capsys.readouterr().out
@@ -1160,7 +1162,7 @@ def test_subprocess_exit_0_on_catalogue_failure(tmp_path):
         'installed-version = "1.0.0"\n'
         'source = "git+ssh://example.test/repo"\n'
     )
-    (tmp_path / ".agentbundle-state.toml").write_text(state_toml, encoding="utf-8")
+    (tmp_path / ".agentbundle-state.toml").write_text(state_toml, encoding="utf-8", newline="\n")
     proc = subprocess.run(
         [sys.executable, "-m", "agentbundle", "list-installed",
          "--scope", "repo", "--format", "json", "--root", str(tmp_path)],

--- a/packages/agentbundle/tests/unit/test_loop_cohort_schedule.py
+++ b/packages/agentbundle/tests/unit/test_loop_cohort_schedule.py
@@ -195,7 +195,7 @@ import sys  # noqa: E402
 
 def _schedule(tmp_path, plan_text):
     plan = tmp_path / "plan.md"
-    plan.write_text(plan_text)
+    plan.write_text(plan_text, encoding="utf-8", newline="\n")
     return subprocess.run(
         [sys.executable, str(LC_PATH), "schedule", str(tmp_path), "--plan", str(plan)],
         capture_output=True, text=True,
@@ -391,7 +391,7 @@ def _mk_repo(tmp_path):
     _git(repo, "init", "-q", "-b", "main")
     _git(repo, "config", "user.email", "a@x")
     _git(repo, "config", "user.name", "a")
-    (repo / "base.py").write_text("BASE = 1\n")
+    (repo / "base.py").write_text("BASE = 1\n", encoding="utf-8", newline="\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "-m", "base")
     return repo
@@ -401,7 +401,7 @@ def _branch(repo, name, relpath, content="X = 1\n", *, modify=False):
     _git(repo, "checkout", "-q", "-b", name, "main")
     f = repo / relpath
     f.parent.mkdir(parents=True, exist_ok=True)
-    f.write_text(content)
+    f.write_text(content, encoding="utf-8", newline="\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "-m", name)
     _git(repo, "checkout", "-q", "main")
@@ -446,7 +446,7 @@ def test_verb_auto_unresolvable_base_fails_closed(tmp_path):
     repo = _mk_repo(tmp_path)
     _branch(repo, "p", "feat_p/p.py")
     _git(repo, "checkout", "-q", "--orphan", "orphan")  # no common ancestor
-    (repo / "o.py").write_text("O = 1\n")
+    (repo / "o.py").write_text("O = 1\n", encoding="utf-8", newline="\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-q", "-m", "orphan")
     _git(repo, "checkout", "-q", "main")

--- a/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
+++ b/packages/agentbundle/tests/unit/test_merge_into_agent_json.py
@@ -41,7 +41,7 @@ def _seed_agent_json(target: Path, extra: dict | None = None) -> None:
     if extra:
         body.update(extra)
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+    target.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8", newline="\n")
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +210,7 @@ class FailureModeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "reviewer.json"
-            target.write_text("{not valid", encoding="utf-8")
+            target.write_text("{not valid", encoding="utf-8", newline="\n")
             before = target.read_bytes()
             with self.assertRaises(AgentJsonRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
@@ -226,7 +226,7 @@ class FailureModeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "reviewer.json"
-            target.write_text(json.dumps({"name": "x", "hooks": ["wrong"]}), encoding="utf-8")
+            target.write_text(json.dumps({"name": "x", "hooks": ["wrong"]}), encoding="utf-8", newline="\n")
             with self.assertRaises(AgentJsonRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             self.assertIn("hooks has unexpected shape", str(ctx.exception))
@@ -242,6 +242,7 @@ class FailureModeTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"name": "x", "hooks": {"E": "wrong"}}),
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(AgentJsonRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})

--- a/packages/agentbundle/tests/unit/test_multi_adapter_disambiguator.py
+++ b/packages/agentbundle/tests/unit/test_multi_adapter_disambiguator.py
@@ -35,7 +35,7 @@ def _two_adapter_state() -> State:
 
 def _write_repo_state(root: Path) -> None:
     (root / ".agentbundle-state.toml").write_text(
-        dump_state(_two_adapter_state()), encoding="utf-8"
+        dump_state(_two_adapter_state()), encoding="utf-8", newline="\n"
     )
 
 
@@ -71,7 +71,7 @@ def test_diff_disambiguator_includes_versions(tmp_path, capsys):
     pack_dir = tmp_path / "pack"
     pack_dir.mkdir()
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "foo"\nversion = "0.9.0"\n', encoding="utf-8"
+        '[pack]\nname = "foo"\nversion = "0.9.0"\n', encoding="utf-8", newline="\n"
     )
     args = SimpleNamespace(
         pack_path=str(pack_dir), root=str(tmp_path), scope="repo", adapter=None,

--- a/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
+++ b/packages/agentbundle/tests/unit/test_nested_symlink_hardening.py
@@ -28,7 +28,7 @@ def _make_skill_source(tmp: Path) -> tuple[Path, Path]:
     source_dir = tmp / "source"
     source_skill = source_dir / "my-skill"
     source_skill.mkdir(parents=True)
-    (source_skill / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
+    (source_skill / "SKILL.md").write_text("# My Skill\n", encoding="utf-8", newline="\n")
     (source_skill / "secret-link").symlink_to("/etc/passwd")
 
     target_dir = tmp / "target"
@@ -105,7 +105,7 @@ class TestCodexNestedSymlinkDropped(unittest.TestCase):
             pack = tmp / "pack"
             skill_dir = pack / ".apm" / "skills" / "my-skill"
             skill_dir.mkdir(parents=True)
-            (skill_dir / "SKILL.md").write_text("# My Skill\n", encoding="utf-8")
+            (skill_dir / "SKILL.md").write_text("# My Skill\n", encoding="utf-8", newline="\n")
             (skill_dir / "secret-link").symlink_to("/etc/passwd")
 
             output = tmp / "output"

--- a/packages/agentbundle/tests/unit/test_pack_config_api.py
+++ b/packages/agentbundle/tests/unit/test_pack_config_api.py
@@ -221,7 +221,7 @@ def test_load_pack_config_user_override(tmp_path):
     from agentbundle.config import load_pack_config, pack_dir
 
     d = pack_dir("atlassian", home=tmp_path)
-    (d / "config.toml").write_text('url = "https://custom.example.com/"', encoding="utf-8")
+    (d / "config.toml").write_text('url = "https://custom.example.com/"', encoding="utf-8", newline="\n")
     result = load_pack_config("atlassian", home=tmp_path)
 
     assert result.get("url") == "https://custom.example.com/"
@@ -231,7 +231,7 @@ def test_load_pack_config_malformed_user_toml(tmp_path):
     from agentbundle.config import load_pack_config, pack_dir
 
     d = pack_dir("atlassian", home=tmp_path)
-    (d / "config.toml").write_text("not valid toml ][", encoding="utf-8")
+    (d / "config.toml").write_text("not valid toml ][", encoding="utf-8", newline="\n")
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         result = load_pack_config("atlassian", home=tmp_path)
@@ -244,7 +244,7 @@ def test_load_pack_config_path_override(tmp_path):
     from agentbundle.config import load_pack_config
 
     custom_config = tmp_path / "myconfig.toml"
-    custom_config.write_text('key = "value"', encoding="utf-8")
+    custom_config.write_text('key = "value"', encoding="utf-8", newline="\n")
 
     result = load_pack_config("atlassian", path=custom_config, home=tmp_path)
 

--- a/packages/agentbundle/tests/unit/test_pack_inventory.py
+++ b/packages/agentbundle/tests/unit/test_pack_inventory.py
@@ -19,15 +19,15 @@ def _make_pack(root: Path) -> Path:
     # Two well-formed skills (out of alphabetical order on disk).
     for name in ("zeta", "alpha"):
         (skills / name).mkdir(parents=True)
-        (skills / name / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+        (skills / name / "SKILL.md").write_text("# skill\n", encoding="utf-8", newline="\n")
     # A directory with no SKILL.md — not a skill (AC2).
     (skills / "not-a-skill").mkdir(parents=True)
-    (skills / "not-a-skill" / "README.md").write_text("x\n", encoding="utf-8")
+    (skills / "not-a-skill" / "README.md").write_text("x\n", encoding="utf-8", newline="\n")
     # Agents: two .md files, plus a non-.md file and a subdir to ignore.
     agents.mkdir(parents=True)
-    (agents / "beta.md").write_text("# agent\n", encoding="utf-8")
-    (agents / "aardvark.md").write_text("# agent\n", encoding="utf-8")
-    (agents / "notes.txt").write_text("ignore me\n", encoding="utf-8")
+    (agents / "beta.md").write_text("# agent\n", encoding="utf-8", newline="\n")
+    (agents / "aardvark.md").write_text("# agent\n", encoding="utf-8", newline="\n")
+    (agents / "notes.txt").write_text("ignore me\n", encoding="utf-8", newline="\n")
     (agents / "nested").mkdir()
     return pack
 

--- a/packages/agentbundle/tests/unit/test_package_catalogue.py
+++ b/packages/agentbundle/tests/unit/test_package_catalogue.py
@@ -63,40 +63,40 @@ def _make_fixture_catalogue(
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
-    (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8", newline="\n")
 
     if with_profiles:
         profiles_dir = root / "profiles"
         profiles_dir.mkdir()
-        (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8")  # noqa: E501
+        (profiles_dir / "default.toml").write_text('[profile]\nname = "default"\n', encoding="utf-8", newline="\n")  # noqa: E501
 
     if with_contracts:
         contracts_dir = root / "contracts"
         contracts_dir.mkdir(parents=True)
-        (contracts_dir / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8")  # noqa: E501
+        (contracts_dir / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8", newline="\n")  # noqa: E501
 
-    (root / "AGENTS.md").write_text("# Test Catalogue Agent Context\n", encoding="utf-8")
+    (root / "AGENTS.md").write_text("# Test Catalogue Agent Context\n", encoding="utf-8", newline="\n")
 
     if with_readme:
-        (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8")
+        (root / "README.md").write_text("# Test Catalogue\n", encoding="utf-8", newline="\n")
 
     if with_license:
-        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8")
-        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8")
+        (root / "LICENSE-APACHE").write_text("Apache-2.0\n", encoding="utf-8", newline="\n")
+        (root / "LICENSE-MIT").write_text("MIT\n", encoding="utf-8", newline="\n")
 
     if with_marketplace:
         claude_plugin_dir = root / ".claude-plugin"
         claude_plugin_dir.mkdir()
         (claude_plugin_dir / "marketplace.json").write_text(
-            '{"packs": ["core"]}\n', encoding="utf-8"
+            '{"packs": ["core"]}\n', encoding="utf-8", newline="\n"
         )
 
     for extra in extra_dirs or []:
         extra_dir = root / extra
         extra_dir.mkdir(parents=True, exist_ok=True)
-        (extra_dir / "file.txt").write_text("excluded\n", encoding="utf-8")
+        (extra_dir / "file.txt").write_text("excluded\n", encoding="utf-8", newline="\n")
 
     return root
 
@@ -162,7 +162,7 @@ def test_scan_content_excludes_symlinks(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(tmp_path)
     # Create a symlink inside packs/core/
     target = root / "packs" / "core" / "real.md"
-    target.write_text("real\n", encoding="utf-8")
+    target.write_text("real\n", encoding="utf-8", newline="\n")
     symlink = root / "packs" / "core" / "link.md"
     symlink.symlink_to(target)
 
@@ -207,7 +207,7 @@ def test_validate_content_valid_catalogue_returns_none(tmp_path: Path) -> None:
 def test_validate_content_missing_packs_dir_rejected(tmp_path: Path) -> None:
     root = tmp_path / "no_packs"
     root.mkdir()
-    (root / "README.md").write_text("hi\n", encoding="utf-8")
+    (root / "README.md").write_text("hi\n", encoding="utf-8", newline="\n")
     err = _validate_content(root, [])
     assert err is not None
     assert "packs" in err
@@ -216,7 +216,7 @@ def test_validate_content_missing_packs_dir_rejected(tmp_path: Path) -> None:
 def test_validate_content_symlink_file_rejected(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(tmp_path)
     target = root / "packs" / "core" / "real.md"
-    target.write_text("real\n", encoding="utf-8")
+    target.write_text("real\n", encoding="utf-8", newline="\n")
     symlink = root / "packs" / "core" / "link.md"
     symlink.symlink_to(target)
     # _scan_content skips symlinks, but _validate_content must still catch them
@@ -230,7 +230,7 @@ def test_validate_content_symlink_dir_rejected(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(tmp_path)
     real_dir = tmp_path / "real_subdir"
     real_dir.mkdir()
-    (real_dir / "file.md").write_text("content\n", encoding="utf-8")
+    (real_dir / "file.md").write_text("content\n", encoding="utf-8", newline="\n")
     symlink_dir = root / "packs" / "core" / "subdir"
     symlink_dir.symlink_to(real_dir)
     paths = _scan_content(root)
@@ -244,7 +244,7 @@ def test_validate_content_top_level_dir_symlink_rejected(tmp_path: Path) -> None
     real_packs.mkdir()
     pack_dir = real_packs / "core"
     pack_dir.mkdir()
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8")  # noqa: E501
+    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
 
     root = tmp_path / "cat"
     root.mkdir()
@@ -261,14 +261,14 @@ def test_validate_content_intermediate_dir_symlink_rejected(tmp_path: Path) -> N
     real_docs = tmp_path / "real_docs"
     contracts = real_docs / "contracts"
     contracts.mkdir(parents=True)
-    (contracts / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8")
+    (contracts / "adapter.toml").write_text('[contract]\nversion = "1"\n', encoding="utf-8", newline="\n")
 
     root = tmp_path / "cat"
     root.mkdir()
     # packs/ must exist for packs-dir check not to fire first
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8")  # noqa: E501
+    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
 
     symlink_docs = root / "docs"
     symlink_docs.symlink_to(real_docs)
@@ -282,7 +282,7 @@ def test_validate_content_root_file_symlink_rejected(tmp_path: Path) -> None:
     """README.md that is a symlink at root is rejected."""
     root = _make_fixture_catalogue(tmp_path, with_readme=False)
     real_readme = tmp_path / "real_readme.md"
-    real_readme.write_text("# real\n", encoding="utf-8")
+    real_readme.write_text("# real\n", encoding="utf-8", newline="\n")
     (root / "README.md").symlink_to(real_readme)
     paths = _scan_content(root)
     err = _validate_content(root, paths)
@@ -309,10 +309,10 @@ def test_validate_content_traversal_rejected(tmp_path: Path) -> None:
     (root / "packs").mkdir()
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir()
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8")  # noqa: E501
+    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n")  # noqa: E501
 
     outside = tmp_path / "outside.txt"
-    outside.write_text("evil\n", encoding="utf-8")
+    outside.write_text("evil\n", encoding="utf-8", newline="\n")
 
     # Patch .resolve() on a path to return a location outside root
     fake_path = mock.MagicMock(spec=Path)
@@ -329,7 +329,7 @@ def test_validate_content_invalid_pack_toml_rejected(tmp_path: Path) -> None:
     root.mkdir()
     bad_pack = root / "packs" / "bad"
     bad_pack.mkdir(parents=True)
-    (bad_pack / "pack.toml").write_text("not valid toml ][", encoding="utf-8")
+    (bad_pack / "pack.toml").write_text("not valid toml ][", encoding="utf-8", newline="\n")
     err = _validate_content(root, [])
     assert err is not None
     assert "bad" in err or "pack.toml" in err
@@ -340,7 +340,7 @@ def test_validate_content_pack_toml_missing_version_rejected(tmp_path: Path) -> 
     root.mkdir()
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
-    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\n', encoding="utf-8")
+    (pack_dir / "pack.toml").write_text('[pack]\nname = "core"\n', encoding="utf-8", newline="\n")
     err = _validate_content(root, [])
     assert err is not None
     assert "version" in err
@@ -350,7 +350,7 @@ def test_validate_content_invalid_profile_toml_rejected(tmp_path: Path) -> None:
     root = _make_fixture_catalogue(tmp_path, with_profiles=False)
     profiles_dir = root / "profiles"
     profiles_dir.mkdir()
-    (profiles_dir / "bad.toml").write_text("not valid toml ][", encoding="utf-8")
+    (profiles_dir / "bad.toml").write_text("not valid toml ][", encoding="utf-8", newline="\n")
     paths = _scan_content(root)
     err = _validate_content(root, paths)
     assert err is not None

--- a/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
+++ b/packages/agentbundle/tests/unit/test_pipeline_phase_order.py
@@ -31,25 +31,27 @@ def _multi_primitive_pack(root: Path) -> Path:
     pack = root / "pack"
     (pack / ".apm" / "skills" / "demo").mkdir(parents=True)
     (pack / ".apm" / "skills" / "demo" / "SKILL.md").write_text(
-        "# demo\n", encoding="utf-8"
+        "# demo\n", encoding="utf-8", newline="\n"
     )
     (pack / ".apm" / "agents").mkdir(parents=True)
     (pack / ".apm" / "agents" / "reviewer.md").write_text(
         "---\nname: reviewer\ndescription: Demo agent.\ntools: Read\n---\nbody\n",
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".apm" / "hooks").mkdir(parents=True)
     (pack / ".apm" / "hooks" / "on-spawn.sh").write_text(
-        "#!/bin/sh\nexit 0\n", encoding="utf-8"
+        "#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n"
     )
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
     (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
         'attach-to-agent = "reviewer"\n\n'
         '[[hooks.agentSpawn]]\ncommand = "$HOOK_BODY_PATH"\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pack / ".apm" / "commands").mkdir(parents=True)
-    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8")
+    (pack / ".apm" / "commands" / "qux.md").write_text("# qux\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -134,6 +136,7 @@ class PhaseOrderExecutionTests(unittest.TestCase):
                 "[[hooks.SessionStart]]\n"
                 'hooks = [ { type = "command", command = "echo hi" } ]\n',
                 encoding="utf-8",
+                newline="\n",
             )
             order = self._run_with_recorder(copilot, pack, Path(tmp) / "out")
             self._assert_phase_order(order, "copilot")
@@ -224,13 +227,13 @@ class CrossAdapterIndependenceTests(unittest.TestCase):
             pack_kiro = tmp_path / "pack-kiro"
             (pack_kiro / ".apm" / "agents").mkdir(parents=True)
             (pack_kiro / ".apm" / "agents" / "reviewer.md").write_text(
-                "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+                "---\nname: reviewer\n---\nbody\n", encoding="utf-8", newline="\n"
             )
 
             pack_cc = tmp_path / "pack-cc"
             (pack_cc / ".apm" / "hook-wiring").mkdir(parents=True)
             (pack_cc / ".apm" / "hook-wiring" / "on-prompt.toml").write_text(
-                '[hooks]\nUserPromptSubmit = ["do-thing"]\n', encoding="utf-8"
+                '[hooks]\nUserPromptSubmit = ["do-thing"]\n', encoding="utf-8", newline="\n"
             )
 
             out = tmp_path / "out"

--- a/packages/agentbundle/tests/unit/test_profile_reader.py
+++ b/packages/agentbundle/tests/unit/test_profile_reader.py
@@ -23,7 +23,7 @@ def _write(catalogue: Path, name: str, body: str) -> Path:
     pdir = catalogue / "profiles"
     pdir.mkdir(parents=True, exist_ok=True)
     path = pdir / name
-    path.write_text(body, encoding="utf-8")
+    path.write_text(body, encoding="utf-8", newline="\n")
     return path
 
 

--- a/packages/agentbundle/tests/unit/test_resolve_user_scope_target_adapter.py
+++ b/packages/agentbundle/tests/unit/test_resolve_user_scope_target_adapter.py
@@ -55,7 +55,7 @@ def _make_pack(tmp_path: Path, name: str = "demo", with_agents: bool = False) ->
     if with_agents:
         agents = pack / ".apm" / "agents"
         agents.mkdir()
-        (agents / "alpha.md").write_text("dummy", encoding="utf-8")
+        (agents / "alpha.md").write_text("dummy", encoding="utf-8", newline="\n")
     return pack
 
 

--- a/packages/agentbundle/tests/unit/test_safety.py
+++ b/packages/agentbundle/tests/unit/test_safety.py
@@ -218,7 +218,7 @@ def test_copy_jailed_refuses_reserved_name(tmp_path):
     guard runs on it too, so an install-time `cp` of pack content
     cannot land a `CON.md` on a Windows adopter."""
     source = tmp_path / "src.md"
-    source.write_text("x\n", encoding="utf-8")
+    source.write_text("x\n", encoding="utf-8", newline="\n")
     with pytest.raises(safety.PathJailError, match="reserved"):
         safety.copy_jailed(tmp_path, source, "CON.md")
 

--- a/packages/agentbundle/tests/unit/test_safety_repo_scope_prefixes.py
+++ b/packages/agentbundle/tests/unit/test_safety_repo_scope_prefixes.py
@@ -158,9 +158,9 @@ class ScanForPackArtifactsTests(unittest.TestCase):
         with TemporaryDirectory() as raw:
             root = Path(raw)
             (root / ".claude" / "skills" / "demo").mkdir(parents=True)
-            (root / ".claude" / "skills" / "demo" / "SKILL.md").write_text("x")
+            (root / ".claude" / "skills" / "demo" / "SKILL.md").write_text("x", encoding="utf-8", newline="\n")
             (root / ".claude" / "agents").mkdir(parents=True)
-            (root / ".claude" / "agents" / "a.md").write_text("y")
+            (root / ".claude" / "agents" / "a.md").write_text("y", encoding="utf-8", newline="\n")
             found = safety.scan_for_pack_artifacts(root, [".claude/"])
             relpaths = sorted(p.relative_to(root).as_posix() for p in found)
             self.assertEqual(
@@ -174,9 +174,9 @@ class ScanForPackArtifactsTests(unittest.TestCase):
         with TemporaryDirectory() as raw:
             root = Path(raw)
             (root / ".claude" / "skills").mkdir(parents=True)
-            (root / ".claude" / "skills" / "x.md").write_text("x")
+            (root / ".claude" / "skills" / "x.md").write_text("x", encoding="utf-8", newline="\n")
             (root / ".agentbundle").mkdir(parents=True)
-            (root / ".agentbundle" / "state.toml").write_text("y")
+            (root / ".agentbundle" / "state.toml").write_text("y", encoding="utf-8", newline="\n")
             found = safety.scan_for_pack_artifacts(
                 root, [".claude/", ".agentbundle/"]
             )
@@ -188,7 +188,7 @@ class ScanForPackArtifactsTests(unittest.TestCase):
         with TemporaryDirectory() as raw:
             root = Path(raw)
             (root / ".claude" / "skills").mkdir(parents=True)
-            (root / ".claude" / "skills" / "x.md").write_text("x")
+            (root / ".claude" / "skills" / "x.md").write_text("x", encoding="utf-8", newline="\n")
             # .kiro/ doesn't exist — skipped, not an error.
             found = safety.scan_for_pack_artifacts(
                 root, [".claude/", ".kiro/"]
@@ -202,7 +202,7 @@ class ScanForPackArtifactsTests(unittest.TestCase):
         with TemporaryDirectory() as raw:
             root = Path(raw)
             (root / ".claude" / "skills").mkdir(parents=True)
-            (root / ".claude" / "skills" / "x.md").write_text("x")
+            (root / ".claude" / "skills" / "x.md").write_text("x", encoding="utf-8", newline="\n")
             before = sorted(p.relative_to(root).as_posix() for p in root.rglob("*"))
             safety.scan_for_pack_artifacts(root, [".claude/"])
             after = sorted(p.relative_to(root).as_posix() for p in root.rglob("*"))

--- a/packages/agentbundle/tests/unit/test_safety_scan_per_pack_scoping.py
+++ b/packages/agentbundle/tests/unit/test_safety_scan_per_pack_scoping.py
@@ -50,6 +50,7 @@ def _make_pack_source(
             """
         ),
         encoding="utf-8",
+        newline="\n",
     )
     apm = pack_dir / ".apm"
     apm.mkdir()
@@ -59,12 +60,13 @@ def _make_pack_source(
         (skill_dir / "SKILL.md").write_text(
             f"---\nname: {skill_name}\ndescription: x\n---\nBody.",
             encoding="utf-8",
+            newline="\n",
         )
     for agent_name in (agents or []):
         agents_dir = apm / "agents"
         agents_dir.mkdir(exist_ok=True)
         (agents_dir / f"{agent_name}.md").write_text(
-            "agent body", encoding="utf-8"
+            "agent body", encoding="utf-8", newline="\n"
         )
     return pack_dir
 
@@ -73,7 +75,7 @@ def _plant(root: Path, relpath: str, content: str = "x") -> Path:
     """Plant a file at ``root/<relpath>``; create parent dirs as needed."""
     target = root / relpath
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(content, encoding="utf-8")
+    target.write_text(content, encoding="utf-8", newline="\n")
     return target
 
 
@@ -257,6 +259,7 @@ class PerPackScopingTests(unittest.TestCase):
             (pack_dir / "pack.toml").write_text(
                 '[pack]\nname = "bpack"\nversion = "0.1.0"\n',
                 encoding="utf-8",
+                newline="\n",
             )
             adopter = tmp / "adopter"
             adopter.mkdir()
@@ -387,7 +390,7 @@ class CollectPackOwnedNamesTests(unittest.TestCase):
             _make_pack_source(packs, name="bpack", skills=["bpack-skill"])
             # Plant noise under .apm/skills/.
             (packs / "bpack" / ".apm" / "skills" / "__pycache__").mkdir()
-            (packs / "bpack" / ".apm" / "skills" / ".DS_Store").write_text("")
+            (packs / "bpack" / ".apm" / "skills" / ".DS_Store").write_text("", encoding="utf-8", newline="\n")
 
             primitives, _ = _collect_pack_owned_names(
                 packs / "bpack", "bpack"
@@ -409,9 +412,9 @@ class CollectPackOwnedNamesTests(unittest.TestCase):
             pack_dir = tmp / "broker"
             apm = pack_dir / ".apm"
             (apm / "shared-libs").mkdir(parents=True)
-            (apm / "shared-libs" / "credentials_shim.py").write_text("x")
+            (apm / "shared-libs" / "credentials_shim.py").write_text("x", encoding="utf-8", newline="\n")
             (apm / "adapter-root-bins").mkdir(parents=True)
-            (apm / "adapter-root-bins" / "sso-broker.py").write_text("x")
+            (apm / "adapter-root-bins" / "sso-broker.py").write_text("x", encoding="utf-8", newline="\n")
 
             primitives, _ = _collect_pack_owned_names(pack_dir, "broker")
             self.assertIn(

--- a/packages/agentbundle/tests/unit/test_scaffold_cmd.py
+++ b/packages/agentbundle/tests/unit/test_scaffold_cmd.py
@@ -175,12 +175,12 @@ def test_symlinked_seed_file_is_not_delivered(tmp_path):
     """Defence-in-depth: a pack-shipped symlinked seed must not be read through
     and delivered (it could point at a host secret)."""
     secret = tmp_path / "secret.txt"
-    secret.write_text("TOP SECRET HOST FILE\n", encoding="utf-8")
+    secret.write_text("TOP SECRET HOST FILE\n", encoding="utf-8", newline="\n")
 
     packs_dir = tmp_path / "packs"
     seeds = packs_dir / "evil" / "seeds"
     seeds.mkdir(parents=True)
-    (seeds / "AGENTS.md").write_text("# ok\n", encoding="utf-8")
+    (seeds / "AGENTS.md").write_text("# ok\n", encoding="utf-8", newline="\n")
     _symlink_or_skip(secret, seeds / "leak.md")
 
     output = tmp_path / "out"
@@ -195,12 +195,12 @@ def test_symlinked_seed_directory_is_not_traversed(tmp_path):
     Python 3.11/3.12 rglob-recurses-into-symlinks gap (os.walk followlinks=False)."""
     external = tmp_path / "external"
     external.mkdir()
-    (external / "secret.txt").write_text("HOST SECRET\n", encoding="utf-8")
+    (external / "secret.txt").write_text("HOST SECRET\n", encoding="utf-8", newline="\n")
 
     packs_dir = tmp_path / "packs"
     seeds = packs_dir / "evil" / "seeds"
     seeds.mkdir(parents=True)
-    (seeds / "AGENTS.md").write_text("# ok\n", encoding="utf-8")
+    (seeds / "AGENTS.md").write_text("# ok\n", encoding="utf-8", newline="\n")
     _symlink_or_skip(external, seeds / "evildir")
 
     output = tmp_path / "out"
@@ -285,7 +285,7 @@ def test_init_state_refuses_path_jail_escape(tmp_path, monkeypatch):
     packs_dir = tmp_path / "packs"
     pack = packs_dir / "core"
     (pack).mkdir(parents=True)
-    (pack / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1"\n', encoding="utf-8")
+    (pack / "pack.toml").write_text('[pack]\nname = "core"\nversion = "0.1"\n', encoding="utf-8", newline="\n")
 
     def _refuse(root, relpath, content):
         raise safety.PathJailError("refusing to write outside repo root: /etc")

--- a/packages/agentbundle/tests/unit/test_source_conflict_guard.py
+++ b/packages/agentbundle/tests/unit/test_source_conflict_guard.py
@@ -75,12 +75,14 @@ def _stage_pack(
             {aa_line}"""
         ),
         encoding="utf-8",
+        newline="\n",
     )
     skill_dir = pack_dir / ".apm" / "skills" / f"{pack_name}-skill"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {pack_name}-skill\ndescription: {pack_name}\n---\nBody.",
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -413,7 +415,7 @@ class SourceConflictInstallIntegrationTests(unittest.TestCase):
         # Seed legacy state manually.
         state = _state_with_row("demo", "claude-code", "agent-ready-repo")
         state_path = self.repo / ".agentbundle-state.toml"
-        state_path.write_text(dump_state(state), encoding="utf-8")
+        state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
         rc, _, err = self._install(catalogue=self.cat_a, adapter="kiro")
         self.assertNotEqual(rc, 0)
@@ -439,7 +441,7 @@ class SourceConflictInstallIntegrationTests(unittest.TestCase):
         # Plant dist-tree files.
         dist_tree_file = self.repo / "claude-plugins" / "demo" / "plugin.json"
         dist_tree_file.parent.mkdir(parents=True)
-        dist_tree_file.write_text("{}", encoding="utf-8")
+        dist_tree_file.write_text("{}", encoding="utf-8", newline="\n")
 
         rc2, _, err2 = self._install(
             catalogue=self.cat_b, adapter="claude-code", force=True, yes=True
@@ -574,6 +576,7 @@ def _stage_pack_both_scopes(catalogue_root: Path, pack_name: str) -> None:
             """
         ),
         encoding="utf-8",
+        newline="\n",
     )
     (pack_dir / ".apm").mkdir(exist_ok=True)
 

--- a/packages/agentbundle/tests/unit/test_source_defaults.py
+++ b/packages/agentbundle/tests/unit/test_source_defaults.py
@@ -60,12 +60,12 @@ def _make_markers(root: Path) -> None:
     (root / "packs").mkdir(parents=True, exist_ok=True)
     cp = root / ".claude-plugin"
     cp.mkdir(parents=True, exist_ok=True)
-    (cp / "marketplace.json").write_text("{}", encoding="utf-8")
+    (cp / "marketplace.json").write_text("{}", encoding="utf-8", newline="\n")
 
 
 def _make_git(root: Path, *, as_file: bool = False) -> None:
     if as_file:
-        (root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8")
+        (root / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8", newline="\n")
     else:
         (root / ".git").mkdir(parents=True, exist_ok=True)
 

--- a/packages/agentbundle/tests/unit/test_state_v01_refuse_write.py
+++ b/packages/agentbundle/tests/unit/test_state_v01_refuse_write.py
@@ -38,7 +38,7 @@ primitives = ["skill"]
 
 def _v01(tmp_path: Path) -> Path:
     p = tmp_path / ".agentbundle-state.toml"
-    p.write_text(V01_STATE, encoding="utf-8")
+    p.write_text(V01_STATE, encoding="utf-8", newline="\n")
     return p
 
 
@@ -65,7 +65,7 @@ def test_install_refuses_v01_state(tmp_path):
     pack = tmp_path / "catalogue" / "demo"
     pack.mkdir(parents=True)
     (pack / "pack.toml").write_text(
-        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
     (pack / ".apm").mkdir()  # empty apm so render is a no-op
 
@@ -96,7 +96,7 @@ def test_upgrade_refuses_v01_state(tmp_path):
     pack = tmp_path / "catalogue" / "core"
     pack.mkdir(parents=True)
     (pack / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "0.2.0"\n', encoding="utf-8"
+        '[pack]\nname = "core"\nversion = "0.2.0"\n', encoding="utf-8", newline="\n"
     )
     (pack / ".apm").mkdir()
     args = argparse.Namespace(
@@ -122,7 +122,7 @@ def test_init_state_without_migrate_refuses_v01(tmp_path):
     pack = tmp_path / "packs" / "demo"
     pack.mkdir(parents=True)
     (pack / "pack.toml").write_text(
-        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
     args = argparse.Namespace(
         pack="demo",
@@ -162,7 +162,7 @@ def test_diff_refuses_legacy_state_gracefully(tmp_path):
     pack = tmp_path / "packs" / "demo"
     pack.mkdir(parents=True)
     (pack / "pack.toml").write_text(
-        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
     args = argparse.Namespace(
         pack_path=str(pack), root=str(tmp_path), scope=None, adapter=None

--- a/packages/agentbundle/tests/unit/test_state_v02.py
+++ b/packages/agentbundle/tests/unit/test_state_v02.py
@@ -34,7 +34,7 @@ primitives = ["skill"]
 
 
 def _write(p: Path, text: str) -> Path:
-    p.write_text(text, encoding="utf-8")
+    p.write_text(text, encoding="utf-8", newline="\n")
     return p
 
 
@@ -51,7 +51,7 @@ def test_init_state_refuses_legacy_state_file(tmp_path):
     pack = packs_dir / "demo"
     pack.mkdir(parents=True)
     (pack / "pack.toml").write_text(
-        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8"
+        '[pack]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
     )
     args = argparse.Namespace(
         pack="demo", packs_dir=str(packs_dir), root=str(tmp_path), migrate=False,

--- a/packages/agentbundle/tests/unit/test_state_v0_4_schema.py
+++ b/packages/agentbundle/tests/unit/test_state_v0_4_schema.py
@@ -22,7 +22,7 @@ def _write_tmp(test: unittest.TestCase, text: str) -> Path:
     fd_dir = tempfile.mkdtemp()
     test.addCleanup(__import__("shutil").rmtree, fd_dir, ignore_errors=True)
     path = Path(fd_dir) / ".agentbundle-state.toml"
-    path.write_text(text, encoding="utf-8")
+    path.write_text(text, encoding="utf-8", newline="\n")
     return path
 
 

--- a/packages/agentbundle/tests/unit/test_statelock.py
+++ b/packages/agentbundle/tests/unit/test_statelock.py
@@ -45,7 +45,7 @@ def test_mutual_exclusion(tmp_path: Path) -> None:
 def test_stale_lock_reclaimed(tmp_path: Path) -> None:
     state_path = tmp_path / "state.toml"
     lock_path = state_path.with_name(state_path.name + ".lock")
-    lock_path.write_text("99999", encoding="utf-8")
+    lock_path.write_text("99999", encoding="utf-8", newline="\n")
     # Backdate the lockfile beyond the stale threshold.
     import os
     old = time.time() - 120
@@ -96,7 +96,7 @@ def test_persist_state_locked_merges_concurrent_rows(tmp_path: Path) -> None:
         installed_version="1.0.0", adapter="claude-code", scope="repo",
         files={".claude/skills/x/SKILL.md": {"sha": "1"}},
     )
-    state_path.write_text(config.dump_state(seed), encoding="utf-8")
+    state_path.write_text(config.dump_state(seed), encoding="utf-8", newline="\n")
 
     def add_codex(state: config.State) -> None:
         state.packs[("research", "codex")] = config.PackState(

--- a/packages/agentbundle/tests/unit/test_toml_emitters.py
+++ b/packages/agentbundle/tests/unit/test_toml_emitters.py
@@ -216,6 +216,7 @@ def test_install_marker_resists_prior_installed_at_string_injection(
         "unresolved-markers = []\n"
         "new-companions = []\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     _append_install_marker(
@@ -293,6 +294,7 @@ def test_cli_install_preserves_existing_install_route(tmp_path) -> None:
         f"installed-at = {ts}\n"
         'install-route = "claude-plugins"\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     # CLI installs a different pack.
@@ -383,6 +385,7 @@ def test_cli_install_coerces_malformed_unresolved_markers_field(tmp_path) -> Non
         'unresolved-markers = "bad-string-not-a-list"\n'
         "new-companions = []\n",
         encoding="utf-8",
+        newline="\n",
     )
 
     # Should not raise; CLI install for a different pack must succeed.

--- a/packages/agentbundle/tests/unit/test_upgrade_bulk_all.py
+++ b/packages/agentbundle/tests/unit/test_upgrade_bulk_all.py
@@ -984,7 +984,7 @@ def test_table_unicode_identifier(tmp_path):
     state = _make_state([("núcleo", "claude-code", "agent-ready-repo", "0.1.0")])
     # Create an empty state file so _run_all doesn't fail with FileNotFoundError
     state_path = tmp_path / ".agentbundle-state.toml"
-    state_path.write_text('schema-version = "0.4"\n', encoding="utf-8")
+    state_path.write_text('schema-version = "0.4"\n', encoding="utf-8", newline="\n")
     with (
         patch("agentbundle.commands.upgrade.load_state", return_value=state),
         patch(
@@ -1096,7 +1096,7 @@ def _write_state_toml(root: Path, state: State) -> None:
     from agentbundle.config import dump_state
     state_path = resolve_state_path("repo", root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(dump_state(state), encoding="utf-8")
+    state_path.write_text(dump_state(state), encoding="utf-8", newline="\n")
 
 
 from contextlib import contextmanager  # noqa: E402

--- a/packages/agentbundle/tests/unit/test_user_config_io.py
+++ b/packages/agentbundle/tests/unit/test_user_config_io.py
@@ -32,7 +32,7 @@ def test_read_missing_file_returns_empty(tmp_path: Path, capsys) -> None:
 
 def test_read_valid_adapter(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "codex"\n')
+    cfg_path.write_text('[settings]\nadapter = "codex"\n', encoding="utf-8", newline="\n")
     assert read_user_config(cfg_path) == UserConfig(adapter="codex")
 
 
@@ -40,7 +40,7 @@ def test_read_malformed_toml_warns_and_returns_empty(
     tmp_path: Path, capsys
 ) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "unterminated\n')  # missing close quote
+    cfg_path.write_text('[settings]\nadapter = "unterminated\n', encoding="utf-8", newline="\n")  # missing close quote
     result = read_user_config(cfg_path)
     assert result == UserConfig(adapter=None)
     captured = capsys.readouterr()
@@ -52,7 +52,7 @@ def test_read_invalid_adapter_warns_and_nullifies(
     tmp_path: Path, capsys
 ) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "obsolete-name"\n')
+    cfg_path.write_text('[settings]\nadapter = "obsolete-name"\n', encoding="utf-8", newline="\n")
     result = read_user_config(cfg_path)
     assert result == UserConfig(adapter=None)
     captured = capsys.readouterr()
@@ -101,7 +101,7 @@ def test_write_refuses_unknown_key(tmp_path: Path) -> None:
 
 def test_write_refuses_non_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[future]\nx = 1\n')
+    cfg_path.write_text('[future]\nx = 1\n', encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         write_setting(cfg_path, "adapter", "codex")
@@ -111,7 +111,7 @@ def test_write_refuses_non_settings_table(tmp_path: Path) -> None:
 
 def test_write_refuses_non_string_settings_value(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\ntags = ["a", "b"]\n')
+    cfg_path.write_text('[settings]\ntags = ["a", "b"]\n', encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         write_setting(cfg_path, "adapter", "codex")
@@ -121,7 +121,7 @@ def test_write_refuses_non_string_settings_value(tmp_path: Path) -> None:
 
 def test_write_refuses_nested_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings.future]\nx = 1\n')
+    cfg_path.write_text('[settings.future]\nx = 1\n', encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         write_setting(cfg_path, "adapter", "codex")
@@ -144,7 +144,7 @@ def test_unset_only_adapter_deletes_file(tmp_path: Path) -> None:
 
 def test_unset_preserves_unknown_settings_keys(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n')
+    cfg_path.write_text('[settings]\nadapter = "codex"\nfuture_str = "x"\n', encoding="utf-8", newline="\n")
     unset_setting(cfg_path, "adapter")
     # File still exists; future_str preserved.
     assert cfg_path.exists()
@@ -174,7 +174,7 @@ def test_unset_refuses_unknown_key(tmp_path: Path) -> None:
 
 def test_unset_refuses_non_settings_table(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[future]\nx = 1\n')
+    cfg_path.write_text('[future]\nx = 1\n', encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         unset_setting(cfg_path, "adapter")
@@ -184,7 +184,7 @@ def test_unset_refuses_non_settings_table(tmp_path: Path) -> None:
 
 def test_unset_refuses_non_string_settings_value(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\ntags = ["a", "b"]\nadapter = "codex"\n')
+    cfg_path.write_text('[settings]\ntags = ["a", "b"]\nadapter = "codex"\n', encoding="utf-8", newline="\n")
     original = cfg_path.read_bytes()
     with pytest.raises(ValueError) as excinfo:
         unset_setting(cfg_path, "adapter")
@@ -195,6 +195,6 @@ def test_unset_refuses_non_string_settings_value(tmp_path: Path) -> None:
 def test_unset_empty_settings_after_remove_deletes_file(tmp_path: Path) -> None:
     # File starts with only [settings] adapter; unset → empty → deleted.
     cfg_path = tmp_path / "config.toml"
-    cfg_path.write_text('[settings]\nadapter = "codex"\n')
+    cfg_path.write_text('[settings]\nadapter = "codex"\n', encoding="utf-8", newline="\n")
     unset_setting(cfg_path, "adapter")
     assert not cfg_path.exists()

--- a/packages/agentbundle/tests/unit/test_user_config_source.py
+++ b/packages/agentbundle/tests/unit/test_user_config_source.py
@@ -68,7 +68,7 @@ def test_source_and_adapter_are_independent_failsoft(tmp_path):
     # A non-string `source` is dropped (warned) without dropping a valid adapter.
     adapter = sorted(shipped_adapters_from_contract())[0]
     p = tmp_path / "config.toml"
-    p.write_text(f'[settings]\nadapter = "{adapter}"\nsource = 42\n', encoding="utf-8")
+    p.write_text(f'[settings]\nadapter = "{adapter}"\nsource = 42\n', encoding="utf-8", newline="\n")
     cfg = read_user_config(p)
     assert cfg.adapter == adapter
     assert cfg.source is None

--- a/packages/agentbundle/tests/unit/test_user_merge_json.py
+++ b/packages/agentbundle/tests/unit/test_user_merge_json.py
@@ -35,7 +35,7 @@ class EmptyFileTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             owned = project(
                 target_path=target,
                 pack_name="personal-reviewers",
@@ -83,6 +83,7 @@ class EmptyFileTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"theme": "dark", "model": "opus", "env": {"K": "V"}}),
                 encoding="utf-8",
+                newline="\n",
             )
             project(
                 target_path=target,
@@ -107,7 +108,7 @@ class IdempotencyTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             wiring = {"on-prompt": {"hooks": {"UserPromptSubmit": [{"command": "x"}]}}}
             project(target, "p", wiring)
             first = target.read_bytes()
@@ -121,7 +122,7 @@ class IdempotencyTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             project(target, "a", {"x": {"hooks": {"E": [{"command": "1"}]}}})
             project(target, "b", {"y": {"hooks": {"E": [{"command": "2"}]}}})
             project(target, "a", {"x": {"hooks": {"E": [{"command": "1"}]}}})  # reinstall a
@@ -142,7 +143,7 @@ class TwoPacksOverlappingEventTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             project(target, "alpha", {"hk": {"hooks": {"E": [{"command": "a"}]}}})
             project(target, "beta", {"hk": {"hooks": {"E": [{"command": "b"}]}}})
             data = json.loads(target.read_text(encoding="utf-8"))
@@ -163,7 +164,7 @@ class UninstallTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             project(target, "alpha", {"hk": {"hooks": {"E": [{"command": "a"}]}}})
             project(target, "beta", {"hk": {"hooks": {"E": [{"command": "b"}]}}})
             unproject(target, [("E", "alpha:hk")])
@@ -176,7 +177,7 @@ class UninstallTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             project(target, "a", {"h": {"hooks": {"E": [{"command": "1"}]}}})
             project(target, "b", {"h": {"hooks": {"E": [{"command": "2"}]}}})
             project(target, "c", {"h": {"hooks": {"E": [{"command": "3"}]}}})
@@ -191,7 +192,7 @@ class UninstallTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{}", encoding="utf-8")
+            target.write_text("{}", encoding="utf-8", newline="\n")
             project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             unproject(target, [("E", "p:h")])
             data = json.loads(target.read_text(encoding="utf-8"))
@@ -226,6 +227,7 @@ class AdopterCollisionTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"UserPromptSubmit": [{"command": "do-x"}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(UserMergeRefusal) as ctx:
                 project(
@@ -251,6 +253,7 @@ class AdopterCollisionTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"E": [{"command": "  do-x   "}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(UserMergeRefusal):
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "do-x"}]}}})
@@ -265,6 +268,7 @@ class AdopterCollisionTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"E": [{"command": "do-x"}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             project(
                 target,
@@ -287,6 +291,7 @@ class AdopterCollisionTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"E": [{"command": "manual-thing"}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             project(target, "p", {"h": {"hooks": {"E": [{"command": "pack-thing"}]}}})
             data = json.loads(target.read_text(encoding="utf-8"))
@@ -307,7 +312,7 @@ class UnparseableJsonTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text("{not valid json", encoding="utf-8")
+            target.write_text("{not valid json", encoding="utf-8", newline="\n")
             before = target.read_bytes()
             with self.assertRaises(UserMergeRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
@@ -332,7 +337,7 @@ class WrongShapeTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text(json.dumps({"hooks": ["wrong"]}), encoding="utf-8")
+            target.write_text(json.dumps({"hooks": ["wrong"]}), encoding="utf-8", newline="\n")
             with self.assertRaises(UserMergeRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             self.assertIn("hooks has unexpected shape", str(ctx.exception))
@@ -348,6 +353,7 @@ class WrongShapeTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"E": "wrong-shape"}}),
                 encoding="utf-8",
+                newline="\n",
             )
             with self.assertRaises(UserMergeRefusal) as ctx:
                 project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
@@ -365,7 +371,7 @@ class AutoInitTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             target = Path(td) / "settings.json"
-            target.write_text(json.dumps({"theme": "dark"}), encoding="utf-8")
+            target.write_text(json.dumps({"theme": "dark"}), encoding="utf-8", newline="\n")
             project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             data = json.loads(target.read_text(encoding="utf-8"))
             self.assertIn("hooks", data)
@@ -379,6 +385,7 @@ class AutoInitTests(unittest.TestCase):
             target.write_text(
                 json.dumps({"hooks": {"Other": [{"command": "y"}]}}),
                 encoding="utf-8",
+                newline="\n",
             )
             project(target, "p", {"h": {"hooks": {"E": [{"command": "x"}]}}})
             data = json.loads(target.read_text(encoding="utf-8"))

--- a/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
+++ b/packages/agentbundle/tests/unit/test_validate_attach_to_agent.py
@@ -188,13 +188,13 @@ class FilesystemWrapperTests(unittest.TestCase):
         (pack / ".apm" / "hook-wiring").mkdir(parents=True, exist_ok=True)
         for name, body in wiring.items():
             (pack / ".apm" / "hook-wiring" / f"{name}.toml").write_text(
-                body, encoding="utf-8"
+                body, encoding="utf-8", newline="\n"
             )
         if agents:
             (pack / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
             for name in agents:
                 (pack / ".apm" / "agents" / f"{name}.md").write_text(
-                    f"# {name}\n", encoding="utf-8"
+                    f"# {name}\n", encoding="utf-8", newline="\n"
                 )
         return pack
 

--- a/packages/agentbundle/tests/unit/test_validate_categories.py
+++ b/packages/agentbundle/tests/unit/test_validate_categories.py
@@ -25,6 +25,7 @@ def _write_pack(tmp_path: Path, categories_line: str) -> Path:
         'description = "Demo pack."\n'
         f"{categories_line}\n",
         encoding="utf-8",
+        newline="\n",
     )
     return pack
 

--- a/packages/agentbundle/tests/unit/test_validate_cmd.py
+++ b/packages/agentbundle/tests/unit/test_validate_cmd.py
@@ -93,7 +93,7 @@ def test_schema_invalid_pack_exits_1(tmp_path, capsys):
     from agentbundle.commands import validate as validate_mod
 
     (tmp_path / "pack.toml").write_text(
-        '[not_the_right_key]\nfoo = "bar"\n', encoding="utf-8"
+        '[not_the_right_key]\nfoo = "bar"\n', encoding="utf-8", newline="\n"
     )
     rc = validate_mod.run(_args(tmp_path))
     captured = capsys.readouterr()
@@ -123,6 +123,7 @@ def test_known_recipe_passes(tmp_path):
     (tmp_path / "pack.toml").write_text(
         '[pack]\nname = "r"\nversion = "0.1"\nrecipes = ["per-pack-claude-plugin"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc, stderr = _run(tmp_path)
     assert rc == 0, f"Expected 0, got {rc}. stderr: {stderr!r}"
@@ -138,7 +139,7 @@ def test_strict_without_fixtures_warns_and_exits_0(tmp_path, capsys):
     from agentbundle.commands import validate as validate_mod
 
     (tmp_path / "pack.toml").write_text(
-        '[pack]\nname = "s"\nversion = "0.1"\n', encoding="utf-8"
+        '[pack]\nname = "s"\nversion = "0.1"\n', encoding="utf-8", newline="\n"
     )
 
     # Patch _conformance_fixtures_dir to return a non-existent path.
@@ -272,12 +273,13 @@ def test_kiro_cli_pack_with_unknown_attach_to_agent_exits_1(tmp_path):
     pack = tmp_path / "cli-hooks"
     (pack / ".apm" / "agents").mkdir(parents=True)
     (pack / ".apm" / "agents" / "reviewer.md").write_text(
-        "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+        "---\nname: reviewer\n---\nbody\n", encoding="utf-8", newline="\n"
     )
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
     (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
         'attach-to-agent = "no-such-agent"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pack / "pack.toml").write_text(
         '[pack]\nname = "cli-hooks"\nversion = "0.1.0"\n\n'
@@ -286,6 +288,7 @@ def test_kiro_cli_pack_with_unknown_attach_to_agent_exits_1(tmp_path):
         'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
         'allowed-adapters = ["kiro-cli"]\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     rc, stderr = _run(pack)
@@ -303,12 +306,13 @@ def test_kiro_legacy_alias_pack_validate_stays_strict(tmp_path):
     pack = tmp_path / "legacy-kiro-hooks"
     (pack / ".apm" / "agents").mkdir(parents=True)
     (pack / ".apm" / "agents" / "reviewer.md").write_text(
-        "---\nname: reviewer\n---\nbody\n", encoding="utf-8"
+        "---\nname: reviewer\n---\nbody\n", encoding="utf-8", newline="\n"
     )
     (pack / ".apm" / "hook-wiring").mkdir(parents=True)
     (pack / ".apm" / "hook-wiring" / "on-spawn.toml").write_text(
         'attach-to-agent = "no-such-agent"\n\n[[hooks.agentSpawn]]\ncommand = "x"\n',
         encoding="utf-8",
+        newline="\n",
     )
     (pack / "pack.toml").write_text(
         '[pack]\nname = "legacy-kiro-hooks"\nversion = "0.1.0"\n\n'
@@ -317,6 +321,7 @@ def test_kiro_legacy_alias_pack_validate_stays_strict(tmp_path):
         'allowed-scopes = ["user"]\nuser-scope-hooks = true\n'
         'allowed-adapters = ["kiro"]\n',
         encoding="utf-8",
+        newline="\n",
     )
 
     rc, stderr = _run(pack)

--- a/packages/agentbundle/tests/unit/test_validate_hook_wiring_per_file_compatibility.py
+++ b/packages/agentbundle/tests/unit/test_validate_hook_wiring_per_file_compatibility.py
@@ -81,16 +81,16 @@ def _make_hook_wiring_pack(
     pack = root / name
     pack.mkdir(parents=True, exist_ok=True)
     (pack / "pack.toml").write_text(
-        _PACK_TOML_V08_REPO.format(name=name), encoding="utf-8"
+        _PACK_TOML_V08_REPO.format(name=name), encoding="utf-8", newline="\n"
     )
     wiring_dir = pack / ".apm" / "hook-wiring"
     wiring_dir.mkdir(parents=True, exist_ok=True)
     for fname, content in wiring_files.items():
-        (wiring_dir / fname).write_text(content, encoding="utf-8")
+        (wiring_dir / fname).write_text(content, encoding="utf-8", newline="\n")
     agents_dir = pack / ".apm" / "agents"
     agents_dir.mkdir(parents=True, exist_ok=True)
     for stem in (agent_files or []):
-        (agents_dir / f"{stem}.md").write_text(f"# {stem}\n", encoding="utf-8")
+        (agents_dir / f"{stem}.md").write_text(f"# {stem}\n", encoding="utf-8", newline="\n")
     return pack
 
 
@@ -212,7 +212,7 @@ def test_validate_still_refuses_on_hook_wiring_symlink(tmp_path, capsys):
     # Create a symlink instead of a regular file in hook-wiring/
     wiring_dir = pack / ".apm" / "hook-wiring"
     target = tmp_path / "real_file.toml"
-    target.write_text("[[hooks.agentSpawn]]\ncommand = \"x\"\n", encoding="utf-8")
+    target.write_text("[[hooks.agentSpawn]]\ncommand = \"x\"\n", encoding="utf-8", newline="\n")
     (wiring_dir / "sym.toml").symlink_to(target)
 
     rc = _run(pack)
@@ -302,6 +302,7 @@ def test_validate_still_refuses_on_allowed_adapters_violation(tmp_path, capsys):
         'allowed-scopes = ["repo"]\n'
         'allowed-adapters = ["totally-unknown-adapter-xyz"]\n',
         encoding="utf-8",
+        newline="\n",
     )
     rc = _run(pack)
     captured = capsys.readouterr()

--- a/packages/agentbundle/tests/unit/test_values_from_shapes.py
+++ b/packages/agentbundle/tests/unit/test_values_from_shapes.py
@@ -12,7 +12,7 @@ from agentbundle.config import ConfigError, load_values_from
 
 def _write(tmp_path, body: str):
     p = tmp_path / "values.toml"
-    p.write_text(body, encoding="utf-8")
+    p.write_text(body, encoding="utf-8", newline="\n")
     return p
 
 


### PR DESCRIPTION
## Summary

- 790 write_text() calls across 135 test files were missing `newline="\n"`, which causes CRLF output on Windows text-mode writes and breaks byte-comparison tests.
- Applied mechanically via an AST-driven one-off script (not committed). Production code is already covered by `test_writers_emit_lf.py`; test helpers are excluded from that guard by design.
- Extended `test_writers_emit_lf.py`'s docstring to document the intentional exclusion.

## Why

On Windows, `Path.write_text(...)` without `newline="\n"` writes `\r\n`. Any test that compares file bytes or expects LF-only output silently fails on Windows. This is the test-fixture counterpart to the production-code fix already shipped.

## Test plan

- [ ] `python3 -m pytest agentbundle/build/tests/ tests/unit/ -q` from `packages/agentbundle/` — all green (confirmed locally)
- [ ] AST scan confirms 0 remaining violations in test directories

## What was not changed

Production code and the `test_writers_emit_lf.py` guard itself were not touched. The guard's walk already excludes test paths by design; this PR fixes the sites the guard intentionally skips.

Spec: docs/specs/lf-line-endings/spec.md
Engine-Change-RFC: fix/test-write-text-newline (test-only, no engine behaviour change)