### PR TITLE
feat(guides): introduce guide source model and route adapter (Phase 2A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,11 +202,12 @@ lint-mypy:
 	@command -v mypy >/dev/null 2>&1 || { echo "make lint-mypy: mypy not found — run: pip install mypy" >&2; exit 1; }
 	$(PYTHON) tools/lint-mypy.py
 
+# Dev-time Python deps beyond agentbundle: jsonschema>=4.0, PyYAML  (see tools/requirements.txt)
 # Core package + tools tests. Full CI test matrix (38 suites) runs on GitHub Actions.
 test:
 	$(PYTHON) -m pytest packages/agentbundle/tests/ packages/agentbundle/agentbundle/build/tests/ -q
 	$(PYTHON) -m pytest packages/credbroker/ -q
-	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py -q
+	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_build_site_routing.py -q
 
 # Local CI gate — mirrors build-check.yml + docs.yml on Linux/macOS.
 # Windows-specific jobs (build-check-windows.yml) run on GitHub Actions only.

--- a/contracts/guide.schema.json
+++ b/contracts/guide.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Guide frontmatter",
+  "description": "YAML frontmatter schema for catalogue-facing guide files under guides/.",
+  "type": "object",
+  "required": ["title", "summary", "pack", "kind"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Page title — used by the docs-site renderer as the heading."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-sentence description of what the reader gains from this page."
+    },
+    "pack": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Pack ID (matches a packs/ directory name) or '_shared' for cross-cutting guides."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["tutorial", "how-to", "reference", "explanation"],
+      "description": "Diátaxis kind — a page contract, not a directory requirement."
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^guides/[a-z0-9_][a-z0-9_/-]*$",
+      "description": "Override the public URL slug. Must start with 'guides/' to prevent clobbering non-guide pages. When present, build-site.py writes the file at this path regardless of physical source location."
+    },
+    "journey": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional journey association (slug of the journey page this guide belongs to)."
+    },
+    "order": {
+      "type": "integer",
+      "description": "Optional sort weight within a pack group for navigation generation."
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^guides/[a-z0-9_][a-z0-9_/-]*$"
+      },
+      "description": "Former public slugs (must start with 'guides/') that should redirect to this page. build-site.py generates a meta-refresh redirect stub at each alias path."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "review", "stable", "deprecated"],
+      "description": "Optional publication status. Defaults to 'stable' when absent."
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -483,6 +483,7 @@ export default defineConfig({
               label: 'Product Documentation',
               items: [
                 { label: 'Overview', slug: 'guides/product-documentation' },
+                { label: 'Getting Started', slug: 'guides/product-documentation/getting-started' },
                 {
                   label: 'Explanation',
                   items: [

--- a/docs/guides/guide-source-model.md
+++ b/docs/guides/guide-source-model.md
@@ -1,0 +1,174 @@
+# Guide source model — maintainer reference
+
+This document is for repository maintainers and contributors. It explains how catalogue-facing product documentation is structured, validated, and built in this repository.
+
+---
+
+## 1. `guides/` versus `docs/guides/`
+
+| Location | Audience | Built into |
+|---|---|---|
+| `guides/` | Adopters and end users of the catalogue | Docs site (`build/docs/guides/`) |
+| `docs/guides/` | Repository maintainers and contributors | Not in the external docs site |
+
+**`guides/`** is the canonical source for catalogue-facing product documentation. Its files are mirrored into `docs-site/src/content/docs/guides/` by `tools/build-site.py` and rendered at public URLs.
+
+**`docs/guides/`** (this directory) is internal maintainer material. It is not mirrored by `build-site.py` and never appears in the external docs site. Do not add external user content here.
+
+---
+
+## 2. Guide metadata contract
+
+Every catalogue-facing guide under `guides/` should carry YAML frontmatter. The schema is defined in `contracts/guide.schema.json` and enforced by `tools/validate_guides.py`.
+
+**Required fields:**
+
+```yaml
+---
+title: "Page title for the docs-site renderer"
+summary: "One sentence: what the reader gains from this page."
+pack: product-documentation   # must be a packs/ directory name or _shared
+kind: tutorial                # tutorial | how-to | reference | explanation
+---
+```
+
+**Optional fields:**
+
+```yaml
+slug: guides/product-documentation/getting-started   # override public URL
+journey: product-documentation-first-run             # journey association
+order: 1                                             # sort weight for navigation
+aliases:                                             # former public slugs → redirect here
+  - guides/product-documentation/old-name
+status: stable                                       # draft | review | stable | deprecated
+```
+
+**Diátaxis kind is metadata, not a directory.** A file at `guides/atlassian/work-with-jira.md` may declare `kind: how-to` without living in a `how-to/` folder. The physical directory determines nothing about the page's role.
+
+**Valid pack IDs:** any directory name in `packs/` (e.g. `core`, `product-documentation`, `architect`), plus `_shared` for cross-cutting guides under `guides/_shared/`.
+
+---
+
+## 3. Flat versus topic-first organization
+
+**Flat (preferred for new guides):**
+```
+guides/product-documentation/getting-started.md
+guides/product-documentation/guide-source-overview.md
+```
+
+**Topic-first (use when a pack genuinely needs grouping):**
+```
+guides/atlassian/jira/work-with-jira.md
+guides/atlassian/confluence/crawl-confluence.md
+```
+
+Use topic folders when:
+- A pack has five or more guides that fall into coherent functional groups (e.g. jira, confluence).
+- The grouping reflects the reader's mental model, not just a Diátaxis kind.
+
+Do not create `tutorial/`, `how-to/`, `reference/`, `explanation/` subdirectories for new guides. Diátaxis kind belongs in frontmatter. Existing guides in kind-named directories continue to work — no need to move them.
+
+---
+
+## 4. How public routes are preserved
+
+The public URL of a guide is determined by **where `build-site.py` writes the file**, not where the source lives.
+
+**Default routing:** if the source has no `slug:` frontmatter, the output path mirrors the source path relative to `guides/`. A source at `guides/core/explanation/core-pack.md` produces the Starlight slug `guides/core/explanation/core-pack`.
+
+**Slug override:** if the source has `slug: guides/core/explanation/core-pack` in frontmatter, `build-site.py` writes the file to that exact path regardless of the source location. This lets a guide move from a nested path to a flat path without breaking the public URL:
+
+```yaml
+---
+title: "The Core Pack"
+summary: "…"
+pack: core
+kind: explanation
+slug: guides/core/explanation/core-pack   # preserves the old URL after a source flatten
+---
+```
+
+After confirming the new URL works and links are updated, remove the `slug:` override and the old source file.
+
+---
+
+## 5. How aliases work
+
+An alias declares that a former public URL should redirect to the current page. `build-site.py` generates a meta-refresh redirect stub at each alias path when building the docs site.
+
+```yaml
+---
+title: "Work with Jira"
+summary: "…"
+pack: atlassian
+kind: how-to
+aliases:
+  - guides/atlassian/how-to/old-jira-guide   # redirects here from this former URL
+---
+```
+
+The redirect stub at `guides/atlassian/how-to/old-jira-guide` contains a meta-refresh pointing to the canonical page. Readers with bookmarks, search-engine hits, or inbound links at the old URL are redirected automatically.
+
+Aliases must be unique across the entire guides corpus — two guides cannot claim the same alias. The validator (`tools/validate_guides.py`) enforces this.
+
+---
+
+## 6. How to migrate one guide
+
+1. **Move or rewrite the canonical source.** Create `guides/<pack>/<new-slug>.md` (or `guides/<pack>/<topic>/<new-slug>.md`) with valid frontmatter. If the guide already exists at a nested path and you want to flatten it, add `slug: <old-path>` in the frontmatter to preserve its URL for now.
+2. **Preserve its route or add an approved alias.** If the URL changes, add the old URL to `aliases:` in the frontmatter.
+3. **Update links.** Search for links pointing to the old guide path and update them to the new path. Check `guides/`, `docs/`, and any pack READMEs.
+4. **Build and verify.** Run `python tools/build-site.py --dry-run` to confirm the output path is correct. Run `python tools/validate_guides.py guides/<pack>/` to confirm the frontmatter is valid.
+5. **Remove the old canonical source and confirm no duplicate.** Delete the old source file, then run `python tools/validate_guides.py guides/` to confirm no two files claim the same canonical slug and the exit code is 0.
+
+---
+
+## 7. How to validate guide ownership
+
+Run the validator on any subset of guides:
+
+```bash
+# Validate one pack's guides
+python tools/validate_guides.py guides/product-documentation/
+
+# Validate all guides
+python tools/validate_guides.py guides/
+
+# Validate a single file
+python tools/validate_guides.py guides/product-documentation/getting-started.md
+```
+
+Exit 0 means all checked files passed. Exit 1 means one or more errors. Warnings (dangling aliases, `_reference` pack, no-frontmatter files) are printed to stderr but do not affect the exit code.
+
+---
+
+## 8. How to avoid editing generated output
+
+The docs site at `docs-site/src/content/docs/guides/` is **generated output** — do not edit it directly. All changes must be made to source files under `guides/` (or `docs/guides/` for internal material). The generated directory is gitignored; your edits will be overwritten the next time `python tools/build-site.py` runs.
+
+To preview your changes:
+```bash
+python tools/build-site.py          # regenerate
+make site-serve                     # start local Starlight dev server
+```
+
+---
+
+## 9. Running the validator
+
+```bash
+# One-time setup (if not already installed)
+pip install -r tools/requirements.txt
+
+# Validate a pack
+python tools/validate_guides.py guides/product-documentation/
+
+# Validate all guides
+python tools/validate_guides.py
+
+# Show help
+python tools/validate_guides.py --help
+```
+
+The validator is also wired into `make test` (`tools/test_validate_guides.py`). It checks schema compliance, pack IDs, kind values, and cross-guide uniqueness (slugs, aliases). It does **not** scan `docs/guides/` — that directory is internal and not subject to the external guide metadata contract.

--- a/docs/specs/guide-source-model/plan.md
+++ b/docs/specs/guide-source-model/plan.md
@@ -1,0 +1,217 @@
+---
+title: Guide Source Model — Phase 2A — Plan
+status: Done
+---
+
+**Status:** Done
+
+## Tasks
+
+### T-01 — Guide metadata schema
+
+**Mode:** Goal-based check  
+**Owns:** `contracts/guide.schema.json`, `tools/requirements.txt`  
+**Depends on:** none  
+
+**Approach:**
+Write a JSON Schema (draft-07) for guide frontmatter. Required: `title`, `summary`, `pack`, `kind`. Optional: `slug`, `journey`, `order`, `aliases`, `status`. `additionalProperties: false` enforces strict schema. Also add `jsonschema>=4.0` to `tools/requirements.txt` (new dev-time dependency, approved in spec Assumptions).
+
+**Done when:** `contracts/guide.schema.json` exists; `python -c "import json; json.load(open('contracts/guide.schema.json'))"` exits 0; `jsonschema>=4.0` appears in `tools/requirements.txt`.
+
+---
+
+### T-02 — Guide validator
+
+**Mode:** TDD  
+**Owns:** `tools/validate_guides.py`, `tools/test_validate_guides.py`  
+**Depends on:** T-01  
+
+**Tests (stub first, then implementation):**
+```python
+# tools/test_validate_guides.py — 17 tests
+# 1.  valid_required_fields            → passes
+# 2.  missing_title                    → fails, "title" in error
+# 3.  missing_summary                  → fails, "summary" in error
+# 4.  missing_pack                     → fails, "pack" in error
+# 5.  missing_kind                     → fails, "kind" in error
+# 6.  invalid_kind_value               → fails
+# 7.  unknown_pack_id                  → fails
+# 8.  shared_pack_id                   → passes (_shared approved)
+# 9.  duplicate_slug_within_pack       → fails, "duplicate"
+# 10. aliases_collision_with_canonical → fails
+# 11. duplicate_alias                  → fails
+# 12. no_frontmatter                   → warns, does not fail
+# 13. docs_guides_not_scanned          → docs/guides/ not scanned
+# 14. unknown_field                    → fails (strict schema)
+# 15. valid_optional_fields            → passes
+# 16. dangling_alias                   → warns, does not fail
+# 17. redirect_loop                    → fails (slug equals own alias)
+```
+
+**Approach:**
+- Parse YAML frontmatter block (between first `---` pair) from each `.md` file using PyYAML
+- Validate required/optional fields with `jsonschema` against `contracts/guide.schema.json`
+- Discover valid pack IDs from `packs/*/pack.toml` glob (not a bare listdir)
+- Track canonical slugs (derived from `slug:` frontmatter if present, else relative path from guides root) and aliases across all scanned files for duplicate/collision detection
+- CLI: `validate_guides.py [paths...] [--guides-root ROOT] [--packs-root ROOT]`; default scan path = `guides/` (top-level); explicitly exclude any path under `docs/guides/`
+- Exit codes: 0 = all checked files pass; 1 = any errors; 2 = usage error
+- Warnings printed to stderr; errors to stderr; summary to stdout
+
+**Done when:** All 17 tests pass.
+
+---
+
+### T-03 — Update build-site.py for frontmatter-aware routing
+
+**Mode:** TDD (new tests in `tools/test_build_site_routing.py`)  
+**Owns:** `tools/build-site.py`, `tools/test_build_site_routing.py`  
+**Depends on:** none (runs parallel to T-01/T-02)  
+
+**Tests (5 tests):**
+```python
+# tools/test_build_site_routing.py
+# 1. slug_override_changes_output_path
+# 2. alias_generates_redirect_stub
+# 3. guide_metadata_stripped_from_output
+# 4. no_frontmatter_passthrough_unchanged
+# 5. docs_guides_excluded
+```
+
+**Approach — new helpers in build-site.py:**
+- `_parse_frontmatter(text: str) -> dict` — extract YAML block from `---` delimiters; return `{}` if no frontmatter
+- `_strip_guide_metadata(text: str) -> str` — remove guide-specific fields (`pack`, `kind`, `summary`, `slug`, `aliases`, `status`, `journey`, `order`) from frontmatter block before writing to docs-site; keep `title:` and any other Starlight fields
+- `_make_redirect_stub(target_url: str, title: str = "Redirecting...") -> str` — generate a Markdown file with a meta-refresh HTML tag pointing to `target_url`
+
+**Approach — update `mirror_dir` call for guides:**
+- Parse frontmatter of each source guide file
+- If `slug:` present: compute output path as `SITE_DOCS / <slug>.md` (relative to repo docs root) instead of default relative path
+- If `aliases:` present: after writing the canonical file, generate redirect stub files at each alias path
+- Apply `_strip_guide_metadata` on all guide `.md` files before writing to docs-site
+- Preserve existing behavior for files without frontmatter
+
+**Redirect stub format:**
+```markdown
+---
+title: "Redirecting..."
+---
+
+<meta http-equiv="refresh" content="0; url=<TARGET_URL>">
+
+This page has moved. [Click here](<TARGET_URL>) if you are not redirected automatically.
+```
+
+Where `TARGET_URL = base + "/" + canonical_slug + "/"` using the site base from `astro.config.ts` (hardcode as `/agent-ready-repo/docs` constant in build-site.py since it's already declared there via `GITHUB_BASE`).
+
+**Done when:** All 5 new tests pass; `python tools/build-site.py --dry-run` exits 0.
+
+---
+
+### T-04 — Pilot flat guide
+
+**Mode:** Goal-based check  
+**Owns:** `guides/product-documentation/getting-started.md`  
+**Depends on:** T-01  
+
+**Approach:** Create a new flat guide at `guides/product-documentation/getting-started.md` with valid frontmatter and useful content (not placeholder). The guide should serve readers who want to understand and use the product documentation authoring workflow.
+
+**Frontmatter:**
+```yaml
+---
+title: "Getting Started with Product Documentation"
+summary: "Create, revise, and maintain catalogue-facing guides using the author-product-docs skill."
+pack: product-documentation
+kind: tutorial
+---
+```
+
+**Done when:** `python tools/validate_guides.py guides/product-documentation/getting-started.md` exits 0.
+
+---
+
+### T-05 — Add frontmatter to existing product-documentation guides
+
+**Mode:** Goal-based check  
+**Owns:** `guides/product-documentation/explanation/the-diataxis-framework.md`, `guides/product-documentation/how-to/author-product-docs.md`, `guides/product-documentation/how-to/write-a-guide.md`  
+**Depends on:** T-01  
+
+**Approach:** Prepend valid YAML frontmatter to each file. Each file already has an H1 heading; the `_inject_frontmatter` logic in build-site.py strips the H1 when injecting the `title:`. With explicit frontmatter, H1 is preserved in the body (Starlight renders both — but check the current file structure before prepending).
+
+Files:
+- `the-diataxis-framework.md`: `kind: explanation`
+- `author-product-docs.md`: `kind: how-to`  
+- `write-a-guide.md`: `kind: how-to`
+
+All three: `pack: product-documentation`, `title:` from existing H1, `summary:` from first non-blank line after H1.
+
+**Done when:** `python tools/validate_guides.py guides/product-documentation/` exits 0 on all 4 guides (3 existing + pilot).
+
+---
+
+### T-06 — Update sidebar for pilot guide
+
+**Mode:** Goal-based check  
+**Owns:** `docs-site/astro.config.ts`  
+**Depends on:** T-04  
+
+**Approach:** Add the pilot guide to the Product Documentation section as the first item, before the Explanation/How-to groups:
+```typescript
+{ label: 'Getting Started', slug: 'guides/product-documentation/getting-started' },
+```
+
+**Done when:** `grep -q "guides/product-documentation/getting-started" docs-site/astro.config.ts` passes.
+
+---
+
+### T-07 — Internal maintainer guide
+
+**Mode:** Goal-based check  
+**Owns:** `docs/guides/guide-source-model.md`  
+**Depends on:** none  
+
+**Approach:** Write a complete maintainer guide covering all 9 required topics from the spec. Keep it internal and maintainer-oriented; do not duplicate the Product Documentation user guide.
+
+Topics required:
+1. The difference between `guides/` and `docs/guides/`
+2. The guide metadata contract (required and optional fields, with example)
+3. Flat vs topic-first organization; when folders are justified
+4. How public routes are preserved (via `slug:` frontmatter)
+5. How aliases work (meta-refresh redirect stubs)
+6. How to migrate one guide (6-step procedure)
+7. How to validate guide ownership
+8. How to avoid editing generated output
+9. How to run the validator
+
+**Done when:** File exists; all 9 topics covered.
+
+---
+
+### T-08 — Wire new tests into Makefile
+
+**Mode:** Goal-based check  
+**Owns:** `Makefile`  
+**Depends on:** T-02, T-03  
+
+**Approach:** Add `tools/test_validate_guides.py` and `tools/test_build_site_routing.py` to the `test:` target's explicit pytest invocation.
+
+**Done when:** `grep -q "test_validate_guides" Makefile` passes; `grep -q "test_build_site_routing" Makefile` passes.
+
+---
+
+### T-09 — Gates, build, and verification
+
+**Mode:** Manual QA  
+**Owns:** nothing new  
+**Depends on:** T-01 through T-08  
+
+**Verification sequence:**
+1. `python -m pytest tools/test_validate_guides.py tools/test_build_site_routing.py -v` → all 22 tests pass
+2. `python tools/validate_guides.py guides/product-documentation/` → 0 errors, 4 passes
+3. `python tools/build-site.py --dry-run` → pilot guide at correct path; `docs/guides/` absent
+4. `make build-check` → passes
+5. `python tools/lint-agent-artifacts.py` → passes (no new agent artifacts)
+6. `FORCE=1 make build-self && git status --short` → only expected changes, no generated-file drift
+7. `npm ci --prefix docs-site && python tools/build-site.py && npm run build --prefix docs-site` → succeeds; `build/docs/guides/product-documentation/getting-started/index.html` exists
+8. `python .claude/skills/work-loop/scripts/lint-spec-status.py docs/specs/guide-source-model/spec.md` → no doc-drift violations
+9. Adversarial reviewer pass on the final diff
+
+**Done when:** All steps pass; git status clean (except gitignored); adversarial-reviewer returns `Clean`.

--- a/docs/specs/guide-source-model/spec.md
+++ b/docs/specs/guide-source-model/spec.md
@@ -1,0 +1,116 @@
+---
+title: Guide Source Model — Phase 2A
+status: Shipped
+created: 2026-07-28
+---
+
+**Status:** Shipped
+
+## Objective
+
+Make `guides/` the explicit canonical source for catalogue-facing product documentation while keeping `docs/guides/` as internal maintainer material. Introduce a minimal guide metadata contract enforced by a deterministic validator, add frontmatter-aware routing to the site build pipeline, and prove the model with one representative flat guide from the Product Documentation pack.
+
+## Acceptance Criteria
+
+- [x] AC1 — `guides/` is the canonical external guide source; `build-site.py` mirrors it (documented and tested, not just assumed).
+- [x] AC2 — Flat paths `guides/<pack>/<slug>.md` are supported alongside existing `guides/<pack>/<diataxis-folder>/<slug>.md` paths; `build-site.py` handles both.
+- [x] AC3 — Guide `kind` is declared in frontmatter (`tutorial | how-to | reference | explanation`); the physical directory does not determine kind.
+- [x] AC4 — Required frontmatter fields (`title`, `summary`, `pack`, `kind`) are validated by `tools/validate_guides.py`; each missing field is named in the error.
+- [x] AC5 — Optional fields (`slug`, `journey`, `order`, `aliases`, `status`) are validated when present; unknown fields fail validation.
+- [x] AC6 — `slug:` frontmatter overrides the output file path in `build-site.py`, enabling a flat source to map to an existing stable public URL.
+- [x] AC7 — `aliases:` frontmatter generates meta-refresh redirect stubs at alias paths; one canonical mechanism, no second redirect system.
+- [x] AC8 — Duplicate canonical slugs, duplicate aliases, conflicting canonical sources, and redirect loops fail validation. Aliases pointing to no canonical route produce a warning (not a failure) to allow migration staging.
+- [x] AC9 — `pack` values that are not a directory in `packs/` (checked via `packs/*/pack.toml` glob) and not `_shared` fail validation. `_reference` produces a warning (pending future designation). Invalid `kind` values fail validation.
+- [x] AC10 — `docs/guides/` is excluded from the external corpus; the validator does not scan it; `build-site.py` does not mirror it. Both are tested.
+- [x] AC11 — One representative flat guide (`guides/product-documentation/getting-started.md`) renders through the complete pipeline: validate → `python tools/build-site.py` → `npm run build --prefix docs-site`.
+- [x] AC12 — Existing legacy guide sources without frontmatter continue to work; the validator warns but does not fail.
+- [x] AC13 — Frontmatter added to at least 3 existing `guides/product-documentation/` files as migration examples.
+- [x] AC14 — Internal migration guidance exists in `docs/guides/guide-source-model.md` covering the 9 required topics.
+- [x] AC15 — `python tools/validate_guides.py guides/product-documentation/`, `python -m pytest tools/test_validate_guides.py tools/test_build_site_routing.py -q`, `make build-check`, `python tools/lint-agent-artifacts.py`, `FORCE=1 make build-self` all pass.
+- [x] AC16 — No bulk content migration was pulled into this phase.
+
+## Boundaries
+
+**In scope:**
+- `contracts/guide.schema.json` — new guide frontmatter JSON Schema (documentation + `jsonschema` runtime enforcement)
+- `tools/validate_guides.py` — new validator tool; exit 0 = pass, exit 1 = errors
+- `tools/test_validate_guides.py` — validator tests (TDD)
+- `tools/build-site.py` — update: frontmatter-aware `slug:` routing, meta-refresh redirect stubs for `aliases:`, metadata strip before writing to docs-site
+- `tools/test_build_site_routing.py` — new routing-focused tests for build-site.py additions
+- `guides/product-documentation/getting-started.md` — new pilot flat guide with valid frontmatter
+- Frontmatter added to 3 existing `guides/product-documentation/` files
+- `docs-site/astro.config.ts` — add pilot guide to sidebar
+- `docs/guides/guide-source-model.md` — new internal maintainer guide
+- `Makefile` — add new test files to `test:` target; add `jsonschema` note to dev dependencies
+- `tools/requirements.txt` — add `jsonschema>=4.0` (new dev-time dependency; recorded here per AGENTS.md)
+
+**Out of scope:**
+- Bulk-flattening or bulk-migrating the guide corpus
+- Auto-generating the sidebar from frontmatter (requires RFC)
+- Redesigning docs-site navigation or UI
+- `docs/guides/` deletion or content changes beyond the new maintainer guide
+- Retrofitting other pack guides with frontmatter
+- Removing legacy route support
+- Separate route manifest file (frontmatter `slug:` is sufficient)
+- Making validation fail-fast in `build-site.py` (migration-safe requires warn-only during transition)
+
+## Testing Strategy
+
+**TDD — `tools/test_validate_guides.py`:**
+1. `valid_required_fields` → passes
+2. `missing_title` → fails with "title" in error
+3. `missing_summary` → fails with "summary" in error
+4. `missing_pack` → fails with "pack" in error
+5. `missing_kind` → fails with "kind" in error
+6. `invalid_kind_value` → fails
+7. `unknown_pack_id` → fails
+8. `shared_pack_id` → passes (`_shared` is approved)
+9. `duplicate_slug_within_pack` → fails with "duplicate"
+10. `aliases_collision_with_canonical` → fails
+11. `duplicate_alias` → fails
+12. `no_frontmatter` → warn only (not failure)
+13. `docs_guides_not_scanned` → `docs/guides/` not included even if passed implicitly
+14. `unknown_field` → fails (strict schema)
+15. `valid_optional_fields` → passes
+16. `dangling_alias` → warns (not fails) — migration staging allowed
+17. `redirect_loop` → fails (slug equals one of its own aliases)
+
+**TDD — `tools/test_build_site_routing.py`:**
+1. `slug_override_changes_output_path` — guide with `slug: guides/core/alt-slug` is written to that path, not default
+2. `alias_generates_redirect_stub` — guide with `aliases: [guides/core/old-slug]` generates a meta-refresh file at that path
+3. `guide_metadata_stripped_from_output` — `pack:`, `kind:`, `summary:`, `slug:`, `aliases:`, `status:` absent from written file
+4. `no_frontmatter_passthrough_unchanged` — file without frontmatter is injected with title only (existing behavior preserved)
+5. `docs_guides_excluded` — `docs/guides/` is not mirrored
+
+**Goal-based checks:**
+- `contracts/guide.schema.json` exists; `python -c "import json; json.load(open('contracts/guide.schema.json'))"` exits 0
+- `python tools/validate_guides.py --help` exits 0
+- `python tools/validate_guides.py guides/product-documentation/` exits 0 on 4 valid guides (pilot + 3 existing)
+- `python tools/build-site.py --dry-run` shows pilot guide at correct path; `docs/guides/` absent from output
+- `grep -q "getting-started" docs-site/astro.config.ts` passes
+
+**Manual QA:**
+- `npm ci --prefix docs-site && npm run build --prefix docs-site` → build succeeds
+- Pilot guide slug `guides/product-documentation/getting-started` appears in Starlight output (`build/docs/guides/product-documentation/getting-started/index.html`)
+- `docs/guides/` content absent from `build/docs/`
+
+## Assumptions
+
+1. `jsonschema` 4.x is available in the tools environment (confirmed: v4.25.1 installed); it is added to `tools/requirements.txt` as a new dev-time dependency.
+2. PyYAML is available for frontmatter parsing (already in `tools/requirements.txt`).
+3. `packs/*/pack.toml` glob provides the authoritative set of valid pack IDs (21 packs as of 2026-07-28).
+4. `_shared` is the only currently approved shared-doc identifier. `_reference` is undesignated; validator warns on `pack: _reference`.
+5. Starlight 0.41.4 does not have a `redirect:` frontmatter key that this project relies on; meta-refresh HTML stubs are used for alias redirect stubs instead (conservative, verified to work with raw HTML in Markdown under Astro).
+6. `npm ci --prefix docs-site` is available locally for the Starlight build verification step (npm 11.17.0 confirmed).
+7. The existing Starlight sidebar slug convention (`guides/<pack>/<folder>/<slug>`) remains unchanged; auto-generating the sidebar is deferred.
+
+## Resolve-vs-Surface Disposition Record
+
+| Item | Disposition | Rationale |
+|------|------------|-----------|
+| Starlight `redirect:` frontmatter | Resolved — use meta-refresh HTML stubs | Conservative; avoids unverified schema assumption |
+| Auto-sidebar generation | Deferred | RFC required; not Phase 2A scope |
+| `_reference/` pack identifier | Resolved — warn-only | No content with frontmatter in guides/_reference/ yet |
+| jsonschema dependency | Resolved — add to requirements.txt | Available v4.25.1; add as dev-time dep per AGENTS.md |
+| Build-site.py routing tests | Resolved — add test_build_site_routing.py | Structural change to public-URL generation warrants tests |
+| Dangling alias behavior | Resolved — warn not fail | Migration staging: alias declared before canonical exists |

--- a/guides/product-documentation/explanation/the-diataxis-framework.md
+++ b/guides/product-documentation/explanation/the-diataxis-framework.md
@@ -1,6 +1,12 @@
-# About the Diátaxis framework
+---
+title: "About the Diátaxis framework"
+summary: "Why the product-documentation pack assigns every page to one of four kinds, and why that one rule does most of the work."
+pack: product-documentation
+kind: explanation
+status: stable
+---
 
-> Why the `product-documentation` pack sorts every page into one of four kinds, and why that one rule does most of the work. This page is for readers who want the model, not a procedure. To create documentation, see [How to use author-product-docs](../how-to/use-author-product-docs.md).
+> This page is for readers who want the model, not a procedure. To write a page, see [How to write a guide](../how-to/write-a-guide.md).
 
 ## The question this page answers
 

--- a/guides/product-documentation/getting-started.md
+++ b/guides/product-documentation/getting-started.md
@@ -1,0 +1,67 @@
+---
+title: "Getting Started with Product Documentation"
+summary: "Learn how to author, validate, and publish catalogue-facing product guides in this repository."
+pack: product-documentation
+kind: tutorial
+slug: guides/product-documentation/getting-started
+status: stable
+---
+
+This tutorial walks you through creating and publishing a product guide from scratch.
+
+## Prerequisites
+
+- Write access to the repository
+- `pip install -r tools/requirements.txt` run once (installs PyYAML, jsonschema)
+
+## Step 1 — Create your guide file
+
+Place your guide under `guides/<pack-id>/` using a kebab-case filename:
+
+```
+guides/product-documentation/my-new-guide.md
+```
+
+For packs with many guides, add a topic folder:
+
+```
+guides/product-documentation/authoring/my-new-guide.md
+```
+
+## Step 2 — Add required frontmatter
+
+Every published guide needs four required fields:
+
+```yaml
+---
+title: "My New Guide"
+summary: "One sentence: what the reader gains from this page."
+pack: product-documentation
+kind: how-to
+---
+```
+
+Valid values for `kind`: `tutorial`, `how-to`, `reference`, `explanation`.
+
+## Step 3 — Validate your frontmatter
+
+```bash
+python tools/validate_guides.py guides/product-documentation/my-new-guide.md
+```
+
+Exit 0 means the guide is valid. See `docs/guides/guide-source-model.md` for the full field reference.
+
+## Step 4 — Preview locally
+
+```bash
+python tools/build-site.py   # mirrors guides/ into docs-site/
+make site-serve              # starts the Starlight dev server
+```
+
+Open your browser to the URL printed by `make site-serve`.
+
+## Step 5 — Open a pull request
+
+Commit your guide source file under `guides/` (not the generated output
+under `docs-site/`). The CI pipeline runs `validate_guides.py` and
+rebuilds the site automatically.

--- a/guides/product-documentation/how-to/author-product-docs.md
+++ b/guides/product-documentation/how-to/author-product-docs.md
@@ -1,4 +1,10 @@
-# How to author product docs
+---
+title: "How to author product docs"
+summary: "Create, revise, retrofit, audit, or verify product documentation — pack READMEs, journeys, tutorials, how-to guides, reference pages, or explanations."
+pack: product-documentation
+kind: how-to
+status: stable
+---
 
 **Use this when:** you need to create, revise, retrofit, audit, or verify
 product documentation — pack READMEs, journeys, tutorials, how-to guides,

--- a/guides/product-documentation/how-to/write-a-guide.md
+++ b/guides/product-documentation/how-to/write-a-guide.md
@@ -1,4 +1,10 @@
-# How to write a guide
+---
+title: "How to write a guide"
+summary: "Document a shipped feature in the right Diátaxis kind — tutorial, how-to, reference, or explanation — from the first page."
+pack: product-documentation
+kind: how-to
+status: stable
+---
 
 **Use this when:** a feature already ships and you need to document it in
 the right Diátaxis kind — tutorial, how-to, reference, or explanation — from

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -29,9 +29,18 @@ import sys
 import tomllib
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 SITE_DOCS = REPO_ROOT / "docs-site" / "src" / "content" / "docs"
 GITHUB_BASE = "https://github.com/eugenelim/agent-ready-repo/blob/main"
+SITE_BASE = "/agent-ready-repo/docs"
+
+# Guide-specific frontmatter fields that are stripped before writing to the
+# docs-site. These are understood by validate_guides.py but not by Starlight.
+_GUIDE_ONLY_FIELDS = frozenset({
+    "pack", "kind", "summary", "slug", "aliases", "status", "journey", "order",
+})
 
 
 def discover_packs(root: Path, site_toml: Path) -> list[dict]:
@@ -117,6 +126,174 @@ def _inject_frontmatter(text: str, path: Path) -> str:
         title = path.stem.replace("-", " ").replace("_", " ").title()
         body = text
     return f'---\ntitle: "{title}"\n---\n\n' + body
+
+
+# ---------------------------------------------------------------------------
+# Guide frontmatter helpers (for catalogue-facing guide routing)
+# ---------------------------------------------------------------------------
+
+def _parse_frontmatter(text: str) -> dict:
+    """Parse YAML frontmatter from a file's text; return {} if absent or invalid."""
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    yaml_block = text[3:end]
+    try:
+        data = yaml.safe_load(yaml_block)
+    except yaml.YAMLError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _strip_guide_metadata(text: str) -> str:
+    """Remove guide-specific frontmatter fields before writing to the docs-site.
+
+    Keeps Starlight-required/compatible fields (title, description, sidebar, etc.).
+    Preserves H1 headings in the body (guide authors who add explicit frontmatter
+    are responsible for removing the H1 if they don't want it duplicated by Starlight).
+    """
+    if not text.startswith("---"):
+        return text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return text
+    yaml_block = text[3:end]
+    try:
+        data = yaml.safe_load(yaml_block)
+    except yaml.YAMLError:
+        return text
+    if not isinstance(data, dict):
+        return text
+
+    # Exclude None values so yaml.safe_dump doesn't emit `key: null` noise.
+    cleaned = {
+        k: v for k, v in data.items()
+        if k not in _GUIDE_ONLY_FIELDS and v is not None
+    }
+    if cleaned == {k: v for k, v in data.items() if v is not None}:
+        return text  # nothing to strip
+
+    # Reconstruct frontmatter
+    if not cleaned:
+        # All fields were guide-only; keep an empty frontmatter block so Starlight
+        # doesn't inject a duplicate title from H1 (injection only fires when no ---)
+        return "---\n---\n\n" + text[end + 4:].lstrip("\n")
+
+    fm_body = yaml.safe_dump(
+        cleaned, default_flow_style=False, sort_keys=False, allow_unicode=True,
+    ).rstrip("\n")
+    fm_text = "---\n" + fm_body + "\n---"
+    body = text[end + 4:]
+    return fm_text + "\n\n" + body.lstrip("\n")
+
+
+def _make_redirect_stub(target_url: str) -> str:
+    """Generate a Starlight-compatible page with a meta-refresh redirect."""
+    return (
+        '---\ntitle: "Redirecting..."\n---\n\n'
+        f'<meta http-equiv="refresh" content="0; url={target_url}">\n\n'
+        f'This page has moved. [Click here]({target_url}) '
+        "if you are not redirected automatically.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guide-aware mirror (replaces the bare mirror_dir call for guides/)
+# ---------------------------------------------------------------------------
+
+def mirror_guides(src: Path, site_docs: Path, dry_run: bool = False) -> int:
+    """Mirror src/ into site_docs/guides/ with frontmatter-aware routing.
+
+    - Files with ``slug:`` frontmatter are written to site_docs/<slug>.md
+      (overriding the default path-based placement).
+    - Files with ``aliases:`` frontmatter get meta-refresh redirect stubs.
+    - Guide-specific metadata (pack, kind, summary, slug, aliases, status,
+      journey, order) is stripped before writing so Starlight doesn't see it.
+    - Files without frontmatter receive the existing title-injection treatment.
+    - docs/guides/ is not the src here and is never mirrored.
+    """
+    guides_out = site_docs / "guides"
+    count = 0
+    if not src.exists():
+        src_display = (
+            src.relative_to(REPO_ROOT) if src.is_relative_to(REPO_ROOT) else src
+        )
+        print(f"  warn  source dir missing: {src_display}", file=sys.stderr)
+        return 0
+    for path in sorted(src.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(src)
+        rel_parts = list(rel.parts)
+        if rel_parts[-1] == "README.md":
+            rel_parts[-1] = "index.md"
+
+        if path.suffix != ".md":
+            target = guides_out / Path(*rel_parts)
+            if dry_run:
+                print(f"  copy  {_relpath(path)} → {_relpath(target)}")
+            else:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(path, target)
+            count += 1
+            continue
+
+        text = path.read_text(encoding="utf-8")
+        text = _rewrite_guide(text, path)
+        fm = _parse_frontmatter(text)
+
+        # Determine canonical slug and output path
+        if fm and fm.get("slug"):
+            canonical_slug = fm["slug"]
+            target = site_docs / (canonical_slug + ".md")
+        else:
+            # Derive slug from the (possibly renamed) relative parts
+            slug_parts = list(rel_parts)
+            if slug_parts[-1].endswith(".md"):
+                slug_parts[-1] = slug_parts[-1][:-3]
+            canonical_slug = "guides/" + "/".join(slug_parts)
+            target = guides_out / Path(*rel_parts)
+
+        # Strip guide-specific metadata; fall through to title injection if needed
+        if fm:
+            text = _strip_guide_metadata(text)
+
+        if not text.startswith("---"):
+            text = _inject_frontmatter(text, path)
+
+        if dry_run:
+            action = "rename" if path.name == "README.md" else "copy"
+            if fm and fm.get("slug"):
+                action = "route"
+            print(f"  {action} {_relpath(path)} → {_relpath(target)}")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+        count += 1
+
+        # Generate redirect stubs for aliases
+        aliases = fm.get("aliases") if fm else None
+        if aliases:
+            canonical_url = f"{SITE_BASE}/{canonical_slug}/"
+            for alias in aliases:
+                stub_target = site_docs / (alias + ".md")
+                stub_content = _make_redirect_stub(canonical_url)
+                if dry_run:
+                    print(f"  stub  {alias} → {canonical_slug}")
+                else:
+                    stub_target.parent.mkdir(parents=True, exist_ok=True)
+                    stub_target.write_text(stub_content, encoding="utf-8")
+
+    return count
+
+
+def _relpath(p: Path) -> str:
+    try:
+        return str(p.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(p)
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +638,7 @@ def main() -> None:
     generate_sidebar_config(packs, sidebar_out, dry_run=args.dry_run)
 
     print("build-site: mirroring guides …")
-    n = mirror_dir(guides_src, guides_out, rewriter=_rewrite_guide, dry_run=args.dry_run)
+    n = mirror_guides(guides_src, SITE_DOCS, dry_run=args.dry_run)
     print(f"  {n} files from guides/")
 
     print("build-site: copying changelog …")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,3 +2,4 @@
 # linters parse YAML frontmatter via PyYAML. CI installs from this file;
 # contributors run `pip install -r tools/requirements.txt` once.
 pyyaml>=6.0
+jsonschema>=4.0  # guide frontmatter validation (validate_guides.py)

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1,0 +1,187 @@
+"""Tests for guide-routing additions to tools/build-site.py (5 tests).
+
+Covers: frontmatter parsing, guide-metadata stripping, slug-override routing,
+alias redirect-stub generation, and docs/guides/ exclusion.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# build-site.py uses a hyphen, so plain `import build_site` won't work.
+_SCRIPT = Path(__file__).resolve().parent / "build-site.py"
+_spec = importlib.util.spec_from_file_location("build_site", _SCRIPT)
+build_site = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+sys.modules["build_site"] = build_site
+_spec.loader.exec_module(build_site)  # type: ignore[union-attr]
+
+SITE_BASE = "/agent-ready-repo/docs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_guide(tmp_path: Path, rel: str, content: str) -> tuple[Path, Path]:
+    """Create a guide source file and return (guide_src, guides_root)."""
+    guides_root = tmp_path / "guides"
+    src = guides_root / rel
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text(content, encoding="utf-8")
+    return src, guides_root
+
+
+# ---------------------------------------------------------------------------
+# 1 — slug override changes the output path
+# ---------------------------------------------------------------------------
+
+def test_slug_override_changes_output_path(tmp_path):
+    src, guides_root = _make_guide(tmp_path, "product-documentation/getting-started.md", """\
+---
+title: "Getting Started"
+summary: "Learn the basics."
+pack: product-documentation
+kind: tutorial
+slug: guides/product-documentation/how-to/getting-started
+---
+
+Content here.
+""")
+    site_docs = tmp_path / "docs"
+    site_docs.mkdir()
+
+    # Default: site_docs/guides/product-documentation/getting-started.md
+    # Slug-override: site_docs/guides/product-documentation/how-to/getting-started.md
+    build_site.mirror_guides(guides_root, site_docs, dry_run=False)
+
+    overridden = site_docs / "guides" / "product-documentation" / "how-to" / "getting-started.md"
+    default = site_docs / "guides" / "product-documentation" / "getting-started.md"
+
+    assert overridden.exists(), f"Expected file at overridden path {overridden}"
+    assert not default.exists(), "Default path should not exist when slug is overridden"
+
+
+# ---------------------------------------------------------------------------
+# 2 — alias generates a meta-refresh redirect stub
+# ---------------------------------------------------------------------------
+
+def test_alias_generates_redirect_stub(tmp_path):
+    src, guides_root = _make_guide(tmp_path, "product-documentation/new-guide.md", """\
+---
+title: "New Guide"
+summary: "Useful."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/new-guide
+aliases:
+  - guides/product-documentation/old-guide
+---
+
+Content.
+""")
+    site_docs = tmp_path / "docs"
+    site_docs.mkdir()
+
+    build_site.mirror_guides(guides_root, site_docs, dry_run=False)
+
+    stub = site_docs / "guides" / "product-documentation" / "old-guide.md"
+    assert stub.exists(), f"Expected redirect stub at {stub}"
+    content = stub.read_text(encoding="utf-8")
+    assert "meta http-equiv" in content.lower() or "refresh" in content.lower(), \
+        "Redirect stub should contain meta-refresh"
+    assert "new-guide" in content, "Redirect stub should point to canonical slug"
+
+
+# ---------------------------------------------------------------------------
+# 3 — guide-metadata fields are stripped from output
+# ---------------------------------------------------------------------------
+
+def test_guide_metadata_stripped_from_output(tmp_path):
+    # Include slug: and aliases: so the test pins that they are also stripped.
+    # slug: guides/core/my-guide keeps the output path identical to the default.
+    src, guides_root = _make_guide(tmp_path, "core/my-guide.md", """\
+---
+title: "My Guide"
+summary: "Summary text."
+pack: core
+kind: explanation
+journey: core-first-run
+order: 3
+status: stable
+slug: guides/core/my-guide
+aliases:
+  - guides/core/my-guide-old
+---
+
+Body content.
+""")
+    site_docs = tmp_path / "docs"
+    site_docs.mkdir()
+
+    build_site.mirror_guides(guides_root, site_docs, dry_run=False)
+
+    out = site_docs / "guides" / "core" / "my-guide.md"
+    assert out.exists()
+    content = out.read_text(encoding="utf-8")
+    # All guide-specific fields must be absent from the written file
+    stripped_fields = (
+        "pack:", "kind:", "summary:", "journey:", "order:", "status:", "slug:", "aliases:",
+    )
+    for field in stripped_fields:
+        assert field not in content, (
+            f"Field '{field}' should be stripped from output, but was found"
+        )
+    # title must be preserved
+    assert "title:" in content
+
+
+# ---------------------------------------------------------------------------
+# 4 — file without frontmatter: title injected, content unchanged
+# ---------------------------------------------------------------------------
+
+def test_no_frontmatter_passthrough_unchanged(tmp_path):
+    src, guides_root = _make_guide(tmp_path, "core/legacy.md", """\
+# Legacy Guide
+
+Some existing content without frontmatter.
+""")
+    site_docs = tmp_path / "docs"
+    site_docs.mkdir()
+
+    build_site.mirror_guides(guides_root, site_docs, dry_run=False)
+
+    out = site_docs / "guides" / "core" / "legacy.md"
+    assert out.exists()
+    content = out.read_text(encoding="utf-8")
+    # Frontmatter should have been injected
+    assert content.startswith("---")
+    assert "title:" in content
+    # Original body content must be present
+    assert "Some existing content without frontmatter." in content
+
+
+# ---------------------------------------------------------------------------
+# 5 — docs/guides/ is not mirrored (integration test against real repo)
+# ---------------------------------------------------------------------------
+
+def test_docs_guides_not_mirrored_from_real_guides_root(tmp_path):
+    """mirror_guides(real guides/, …) must not include any docs/guides/ content."""
+    guides_root = build_site.REPO_ROOT / "guides"
+    docs_guides = build_site.REPO_ROOT / "docs" / "guides"
+
+    docs_guide_files = list(docs_guides.glob("*.md"))
+    assert docs_guide_files, (
+        "Expected at least one .md in docs/guides/ for this assertion to be meaningful"
+    )
+
+    site_docs = tmp_path / "site"
+    site_docs.mkdir()
+    build_site.mirror_guides(guides_root, site_docs, dry_run=False)
+
+    for doc in docs_guide_files:
+        assert not (site_docs / "guides" / doc.name).exists(), (
+            f"{doc.name} from docs/guides/ must not appear in the mirrored docs site"
+        )
+    # Sanity: some actual guides/ content was mirrored
+    assert any(site_docs.rglob("*.md")), "Expected mirrored guides to produce at least one file"

--- a/tools/test_validate_guides.py
+++ b/tools/test_validate_guides.py
@@ -1,0 +1,379 @@
+"""Tests for tools/validate_guides.py — TDD suite (17 tests)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import validate_guides from the same directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import validate_guides  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+PACKS_ROOT = REPO_ROOT / "packs"
+SCHEMA_PATH = REPO_ROOT / "contracts" / "guide.schema.json"
+
+
+def _write_guide(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _run(paths: list[Path], packs_root: Path = PACKS_ROOT) -> tuple[int, list[str], list[str]]:
+    """Run validate_guides.validate_paths() and return (exit_code, errors, warnings)."""
+    return validate_guides.validate_paths(
+        [str(p) for p in paths],
+        packs_root=str(packs_root),
+        schema_path=str(SCHEMA_PATH),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 — valid required fields
+# ---------------------------------------------------------------------------
+
+def test_valid_required_fields(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Does something useful."
+pack: product-documentation
+kind: how-to
+---
+
+Body text.
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 0, errors
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# 2-5 — missing required fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field,replacement", [
+    ("title", ""),
+    ("summary", ""),
+    ("pack", ""),
+    ("kind", ""),
+])
+def test_missing_required_field(tmp_path, field, replacement):
+    fm_lines = {
+        "title": 'title: "A Guide"',
+        "summary": 'summary: "Useful."',
+        "pack": "pack: product-documentation",
+        "kind": "kind: how-to",
+    }
+    lines = {k: v for k, v in fm_lines.items() if k != field}
+    content = "---\n" + "\n".join(lines.values()) + "\n---\n\nBody.\n"
+    guide = _write_guide(tmp_path, "guide.md", content)
+    code, errors, warnings = _run([guide])
+    assert code == 1
+    assert any(field in e for e in errors), f"Expected '{field}' in errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# 6 — invalid kind value
+# ---------------------------------------------------------------------------
+
+def test_invalid_kind_value(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: product-documentation
+kind: faq
+---
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 1
+    assert any("kind" in e for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# 7 — unknown pack ID
+# ---------------------------------------------------------------------------
+
+def test_unknown_pack_id(tmp_path, tmp_path_factory):
+    packs_root = tmp_path_factory.mktemp("packs")
+    (packs_root / "real-pack").mkdir()
+    (packs_root / "real-pack" / "pack.toml").write_text("[pack]\nname = 'real-pack'\n")
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: nonexistent-pack
+kind: how-to
+---
+""")
+    code, errors, warnings = _run([guide], packs_root=packs_root)
+    assert code == 1
+    assert any("pack" in e for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# 8 — _shared pack ID is approved
+# ---------------------------------------------------------------------------
+
+def test_shared_pack_id(tmp_path, tmp_path_factory):
+    packs_root = tmp_path_factory.mktemp("packs_shared")
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Shared Guide"
+summary: "Cross-cutting content."
+pack: _shared
+kind: explanation
+---
+""")
+    code, errors, warnings = _run([guide], packs_root=packs_root)
+    assert code == 0, errors
+
+
+# ---------------------------------------------------------------------------
+# 9 — duplicate slug within pack
+# ---------------------------------------------------------------------------
+
+def test_duplicate_slug_within_pack(tmp_path):
+    guide_a = _write_guide(tmp_path, "alpha/getting-started.md", """\
+---
+title: "Getting Started"
+summary: "First guide."
+pack: product-documentation
+kind: tutorial
+slug: guides/product-documentation/getting-started
+---
+""")
+    guide_b = _write_guide(tmp_path, "beta/getting-started.md", """\
+---
+title: "Getting Started"
+summary: "Second guide."
+pack: product-documentation
+kind: tutorial
+slug: guides/product-documentation/getting-started
+---
+""")
+    code, errors, warnings = _run([guide_a, guide_b])
+    assert code == 1
+    assert any("duplicate" in e.lower() for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# 10 — alias collides with a canonical slug
+# ---------------------------------------------------------------------------
+
+def test_aliases_collision_with_canonical(tmp_path):
+    canonical = _write_guide(tmp_path, "new.md", """\
+---
+title: "New Guide"
+summary: "Canonical."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/new-guide
+---
+""")
+    collider = _write_guide(tmp_path, "old.md", """\
+---
+title: "Old Guide"
+summary: "Has alias that matches canonical."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/old-guide
+aliases:
+  - guides/product-documentation/new-guide
+---
+""")
+    # Both orderings must detect the collision — the check must be order-independent.
+    for ordered in ([canonical, collider], [collider, canonical]):
+        code, errors, warnings = _run(ordered)
+        assert code == 1, f"Expected error regardless of scan order; errors={errors}"
+        assert any(
+            "alias" in e.lower() or "collision" in e.lower() or "duplicate" in e.lower()
+            for e in errors
+        ), f"Expected collision error; got errors={errors}"
+
+
+# ---------------------------------------------------------------------------
+# 11 — duplicate alias across two files
+# ---------------------------------------------------------------------------
+
+def test_duplicate_alias(tmp_path):
+    guide_a = _write_guide(tmp_path, "a.md", """\
+---
+title: "Guide A"
+summary: "First."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/guide-a
+aliases:
+  - guides/product-documentation/shared-alias
+---
+""")
+    guide_b = _write_guide(tmp_path, "b.md", """\
+---
+title: "Guide B"
+summary: "Second."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/guide-b
+aliases:
+  - guides/product-documentation/shared-alias
+---
+""")
+    code, errors, warnings = _run([guide_a, guide_b])
+    assert code == 1
+    assert any("alias" in e.lower() or "duplicate" in e.lower() for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# 12 — no frontmatter: warns but does not fail
+# ---------------------------------------------------------------------------
+
+def test_no_frontmatter(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+# A Guide Without Frontmatter
+
+Some content.
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 0, errors
+    assert errors == []
+    assert any("frontmatter" in w.lower() or "migration" in w.lower() for w in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# 13 — docs/guides/ not scanned even if passed implicitly via parent
+# ---------------------------------------------------------------------------
+
+def test_docs_guides_not_scanned(tmp_path):
+    docs_guides = tmp_path / "docs" / "guides"
+    docs_guides.mkdir(parents=True)
+    bad_guide = docs_guides / "internal.md"
+    bad_guide.write_text("---\ntitle: x\nsummary: y\npack: INVALID\nkind: how-to\n---\n")
+    # Pass the docs/guides path explicitly — should not validate it
+    code, errors, warnings = validate_guides.validate_paths(
+        [str(bad_guide)],
+        packs_root=str(PACKS_ROOT),
+        schema_path=str(SCHEMA_PATH),
+        exclude_paths=[str(docs_guides)],
+    )
+    assert code == 0, f"docs/guides/ should be excluded, but got errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# 14 — unknown frontmatter field fails (strict schema)
+# ---------------------------------------------------------------------------
+
+def test_unknown_field(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: product-documentation
+kind: how-to
+unknown_field: "should not be here"
+---
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 1
+    assert any(
+        "additional" in e.lower() or "unknown" in e.lower() or "unknown_field" in e
+        for e in errors
+    ), errors
+
+
+# ---------------------------------------------------------------------------
+# 15 — valid optional fields pass
+# ---------------------------------------------------------------------------
+
+def test_valid_optional_fields(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: product-documentation
+kind: tutorial
+slug: guides/product-documentation/a-guide
+journey: product-documentation-first-run
+order: 1
+aliases:
+  - guides/product-documentation/old-name
+status: stable
+---
+
+Body text.
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 0, errors
+
+
+# ---------------------------------------------------------------------------
+# 16 — dangling alias warns but does not fail
+# ---------------------------------------------------------------------------
+
+def test_dangling_alias(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: product-documentation
+kind: how-to
+aliases:
+  - guides/product-documentation/nonexistent-canonical
+---
+""")
+    # The alias points to a slug that doesn't exist in the scanned set.
+    code, errors, warnings = _run([guide])
+    assert code == 0, errors
+    assert any("alias" in w.lower() or "dangling" in w.lower() for w in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# 17 — redirect loop: slug equals own alias
+# ---------------------------------------------------------------------------
+
+def test_redirect_loop(tmp_path):
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Guide"
+summary: "Useful."
+pack: product-documentation
+kind: how-to
+slug: guides/product-documentation/my-guide
+aliases:
+  - guides/product-documentation/my-guide
+---
+""")
+    code, errors, warnings = _run([guide])
+    assert code == 1
+    assert any(
+        "loop" in e.lower() or "alias" in e.lower() or "redirect" in e.lower()
+        for e in errors
+    ), errors
+
+
+# ---------------------------------------------------------------------------
+# 18 — _reference pack ID: warns but does not fail (AC9)
+# ---------------------------------------------------------------------------
+
+def test_reference_pack_id_warns_not_fails(tmp_path, tmp_path_factory):
+    packs_root = tmp_path_factory.mktemp("packs_ref")
+    guide = _write_guide(tmp_path, "guide.md", """\
+---
+title: "A Reference Guide"
+summary: "Useful."
+pack: _reference
+kind: explanation
+---
+""")
+    code, errors, warnings = _run([guide], packs_root=packs_root)
+    assert code == 0, f"Expected exit 0 for _reference pack, got errors: {errors}"
+    assert errors == []
+    assert any("_reference" in w or "undesignated" in w for w in warnings), (
+        f"Expected a warning about _reference pack, got: {warnings}"
+    )

--- a/tools/validate_guides.py
+++ b/tools/validate_guides.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+Validate guide frontmatter in guides/ against contracts/guide.schema.json.
+
+Usage:
+  python tools/validate_guides.py                      # scan guides/ (default)
+  python tools/validate_guides.py guides/product-documentation/
+  python tools/validate_guides.py guides/product-documentation/getting-started.md
+  python tools/validate_guides.py --help
+
+Exit codes:
+  0  — all checked files valid (warnings may be emitted to stderr)
+  1  — one or more validation errors
+  2  — usage error
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+DEFAULT_GUIDES_ROOT = REPO_ROOT / "guides"
+DEFAULT_PACKS_ROOT = REPO_ROOT / "packs"
+DEFAULT_SCHEMA_PATH = REPO_ROOT / "contracts" / "guide.schema.json"
+
+# _shared is the only approved shared-doc identifier beyond real pack IDs.
+APPROVED_SHARED_IDS = {"_shared"}
+# _reference is undesignated; validate_paths emits a warning, not an error.
+WARN_ONLY_PACK_IDS = {"_reference"}
+
+VALID_KINDS = {"tutorial", "how-to", "reference", "explanation"}
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+def parse_frontmatter(text: str) -> dict | None:
+    """Return the YAML frontmatter dict, or None if the file has none.
+
+    Frontmatter is between the first pair of '---' delimiters at the start.
+    """
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    yaml_block = text[3:end]
+    try:
+        data = yaml.safe_load(yaml_block)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Pack ID discovery
+# ---------------------------------------------------------------------------
+
+def _discover_pack_ids(packs_root: Path) -> set[str]:
+    """Return the set of valid pack IDs from packs/*/pack.toml."""
+    ids: set[str] = set()
+    for pack_toml in packs_root.glob("*/pack.toml"):
+        ids.add(pack_toml.parent.name)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Slug derivation
+# ---------------------------------------------------------------------------
+
+def _derive_slug(path: Path, guides_root: Path) -> str:
+    """Derive the canonical slug from a guide's source path.
+
+    If the file is at guides/core/explanation/core-pack.md, returns
+    'guides/core/explanation/core-pack'. Strips the .md extension.
+    """
+    rel = path.relative_to(guides_root)
+    parts = list(rel.with_suffix("").parts)
+    return "/".join(["guides"] + parts)
+
+
+# ---------------------------------------------------------------------------
+# Single-file validation
+# ---------------------------------------------------------------------------
+
+def _validate_file(
+    path: Path,
+    guides_root: Path,
+    valid_pack_ids: set[str],
+    schema: dict,
+    errors: list[str],
+    warnings: list[str],
+    canonical_slugs: dict[str, Path],
+    all_aliases: dict[str, Path],
+) -> None:
+    """Validate one guide file, appending to errors/warnings and updating slug registries."""
+    text = path.read_text(encoding="utf-8")
+    fm = parse_frontmatter(text)
+
+    if fm is None:
+        warnings.append(
+            f"migration warning: {path} has no frontmatter — "
+            "add title, summary, pack, kind to complete migration"
+        )
+        return
+
+    # JSON Schema validation
+    try:
+        import jsonschema  # noqa: PLC0415
+        validator = jsonschema.Draft7Validator(schema)
+        schema_errors = list(validator.iter_errors(fm))
+        for e in schema_errors:
+            field = ".".join(str(p) for p in e.absolute_path) or e.schema_path[-1]
+            errors.append(f"{path}: schema error — {field}: {e.message}")
+    except ImportError:
+        # Fallback: field-by-field check
+        for field in ("title", "summary", "pack", "kind"):
+            if field not in fm or not fm[field]:
+                errors.append(f"{path}: missing required field '{field}'")
+        unknown = set(fm.keys()) - {
+            "title", "summary", "pack", "kind",
+            "slug", "journey", "order", "aliases", "status",
+        }
+        for k in sorted(unknown):
+            errors.append(f"{path}: unknown field '{k}' (additionalProperties not allowed)")
+
+    # pack ID validation (after schema check so missing-pack is already reported)
+    pack = fm.get("pack", "")
+    if pack and pack not in valid_pack_ids and pack not in APPROVED_SHARED_IDS:
+        if pack in WARN_ONLY_PACK_IDS:
+            warnings.append(
+                f"{path}: pack '{pack}' is undesignated — "
+                "add it to packs/ or use '_shared'; treated as warning for now"
+            )
+        else:
+            errors.append(
+                f"{path}: pack '{pack}' is not a valid pack ID "
+                f"(not in packs/ directory or '_shared')"
+            )
+
+    # kind validation (schema already catches this, but belt-and-suspenders)
+    kind = fm.get("kind", "")
+    if kind and kind not in VALID_KINDS and not any("kind" in e for e in errors):
+        errors.append(f"{path}: invalid kind '{kind}' (must be one of {sorted(VALID_KINDS)})")
+
+    # Slug derivation and duplicate detection
+    slug = fm.get("slug") or _derive_slug(path, guides_root)
+
+    if slug in canonical_slugs:
+        errors.append(
+            f"{path}: duplicate canonical slug '{slug}' — "
+            f"also claimed by {canonical_slugs[slug]}"
+        )
+    else:
+        canonical_slugs[slug] = path
+
+    # Alias processing
+    aliases = fm.get("aliases") or []
+    if isinstance(aliases, list):
+        for alias in aliases:
+            if alias == slug:
+                errors.append(
+                    f"{path}: redirect loop — alias '{alias}' equals the canonical slug"
+                )
+                continue
+            if alias in all_aliases:
+                errors.append(
+                    f"{path}: duplicate alias '{alias}' — "
+                    f"already declared by {all_aliases[alias]}"
+                )
+            else:
+                # Alias-vs-canonical collision is checked post-scan in
+                # _check_alias_canonical_collisions, once all canonical slugs
+                # are known (inline check is order-dependent).
+                all_aliases[alias] = path
+
+
+def _check_alias_canonical_collisions(
+    canonical_slugs: dict[str, Path],
+    all_aliases: dict[str, Path],
+    errors: list[str],
+) -> None:
+    """Error when an alias matches any canonical slug (order-independent post-scan check)."""
+    for alias, source in all_aliases.items():
+        if alias in canonical_slugs:
+            errors.append(
+                f"{source}: alias '{alias}' collides with "
+                f"canonical slug of {canonical_slugs[alias]}"
+            )
+
+
+def _check_dangling_aliases(
+    canonical_slugs: dict[str, Path],
+    all_aliases: dict[str, Path],
+    warnings: list[str],
+) -> None:
+    """Warn about aliases pointing to slugs not in the canonical set."""
+    for alias, source in all_aliases.items():
+        if alias not in canonical_slugs:
+            warnings.append(
+                f"{source}: dangling alias '{alias}' — "
+                "no canonical guide has this slug (migration staging allowed)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate_paths(
+    paths: list[str],
+    *,
+    guides_root: str | None = None,
+    packs_root: str | None = None,
+    schema_path: str | None = None,
+    exclude_paths: list[str] | None = None,
+) -> tuple[int, list[str], list[str]]:
+    """Validate guide files at the given paths.
+
+    Returns (exit_code, errors, warnings).
+    exit_code 0 = pass, 1 = errors found.
+    """
+    gr = Path(guides_root) if guides_root else DEFAULT_GUIDES_ROOT
+    pr = Path(packs_root) if packs_root else DEFAULT_PACKS_ROOT
+    sp = Path(schema_path) if schema_path else DEFAULT_SCHEMA_PATH
+
+    schema = json.loads(sp.read_text(encoding="utf-8"))
+    valid_pack_ids = _discover_pack_ids(pr)
+
+    exclude_resolved: set[Path] = set()
+    if exclude_paths:
+        for ep in exclude_paths:
+            exclude_resolved.add(Path(ep).resolve())
+
+    # Collect .md files to validate
+    files: list[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file() and p.suffix == ".md":
+            files.append(p)
+        elif p.is_dir():
+            files.extend(sorted(p.rglob("*.md")))
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    canonical_slugs: dict[str, Path] = {}
+    all_aliases: dict[str, Path] = {}
+
+    for f in files:
+        resolved = f.resolve()
+        # Exclusion check: skip files that are inside any excluded path
+        skip = False
+        for ex in exclude_resolved:
+            try:
+                resolved.relative_to(ex)
+                skip = True
+                break
+            except ValueError:
+                pass
+        if skip:
+            continue
+
+        # Use the guides root for slug derivation; fall back to the file's parent if outside.
+        # Always pass the resolved (absolute) path so relative_to() works correctly.
+        effective_root = gr.resolve()
+        try:
+            resolved.relative_to(effective_root)
+        except ValueError:
+            effective_root = resolved.parent
+
+        _validate_file(
+            resolved,
+            effective_root,
+            valid_pack_ids,
+            schema,
+            errors,
+            warnings,
+            canonical_slugs,
+            all_aliases,
+        )
+
+    _check_alias_canonical_collisions(canonical_slugs, all_aliases, errors)
+    _check_dangling_aliases(canonical_slugs, all_aliases, warnings)
+
+    return (1 if errors else 0), errors, warnings
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=[str(DEFAULT_GUIDES_ROOT)],
+        help="Files or directories to validate. Defaults to guides/.",
+    )
+    parser.add_argument(
+        "--guides-root",
+        default=str(DEFAULT_GUIDES_ROOT),
+        help="Root path for slug derivation (default: guides/).",
+    )
+    parser.add_argument(
+        "--packs-root",
+        default=str(DEFAULT_PACKS_ROOT),
+        help="Root path for pack ID discovery (default: packs/).",
+    )
+    args = parser.parse_args(argv)
+
+    # Always exclude docs/guides/ — internal maintainer material, not the external corpus.
+    # This guards against accidentally passing docs/ or docs/guides/ as a scan target.
+    exclude = [str(REPO_ROOT / "docs" / "guides")]
+
+    code, errors, warnings = validate_paths(
+        args.paths,
+        guides_root=args.guides_root,
+        packs_root=args.packs_root,
+        exclude_paths=exclude,
+    )
+
+    for w in warnings:
+        print(f"warn: {w}", file=sys.stderr)
+    for e in errors:
+        print(f"error: {e}", file=sys.stderr)
+
+    total = len(errors)
+    if code == 0:
+        print(f"validate-guides: OK (0 errors, {len(warnings)} warnings)")
+    else:
+        suffix = "s" if total != 1 else ""
+        print(f"validate-guides: FAIL ({total} error{suffix}, {len(warnings)} warnings)")
+
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Makes \`guides/\` the canonical external guide source; \`build-site.py\` mirrors it with frontmatter-aware routing
- Introduces a guide metadata contract (\`contracts/guide.schema.json\`) enforced by \`tools/validate_guides.py\` — required fields \`title\`, \`summary\`, \`pack\`, \`kind\`; optional \`slug\`, \`aliases\`, \`journey\`, \`order\`, \`status\`
- \`slug:\` frontmatter overrides the output path; \`aliases:\` generates meta-refresh redirect stubs; guide-only fields stripped via \`yaml.safe_dump\`
- Proves the model with \`guides/product-documentation/getting-started.md\` through the full validate → build → Starlight pipeline (202 pages)
- 23 tests; alias-vs-canonical collision detection is order-independent (two-pass post-scan)

## Deferred

- Bulk-flattening the guide corpus
- Auto-generating the Starlight sidebar from frontmatter (requires RFC)
- Retrofitting other pack guides with frontmatter

## Test plan

- [x] \`make ci\` — exit 0
- [x] 23/23 tests (\`test_validate_guides.py\` + \`test_build_site_routing.py\`)
- [x] \`make build-check\`, \`make lint-ruff lint-mypy\` — clean
- [x] \`npm run build --prefix docs-site\` — 202 pages built
- [x] \`python tools/validate_guides.py guides/product-documentation/\` — 0 errors