### PR TITLE
fix(ci): trim Gate A Windows to curated portable test subset

### DIFF
--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -1,7 +1,7 @@
 name: catalogue-tooling-ci-gates
 
 # Nine gates introduced by ini-005 Wave 5c:
-#   A: agentbundle-tests             — full pytest matrix (Ubuntu 3.11/3.12, Windows 3.11)
+#   A: agentbundle-tests             — full pytest on Ubuntu 3.11/3.12; curated portable subset on Windows 3.11
 #   B: external-catalogue-smoke      — portable engine outside this repo
 #   C: enterprise-agentbundle-distribution — enterprise distribution + credential scan
 #   D: catalogue-artifact-smoke      — real catalogue packaging round-trip
@@ -23,9 +23,12 @@ jobs:
   # ── Gate A: complete agentbundle test discovery ───────────────────────────
   agentbundle-tests:
     name: "Gate A — agentbundle tests (${{ matrix.os }} / py${{ matrix.python }})"
-    # Windows has 50+ pre-existing compat failures (CRLF, cp1252, symlinks, pwd
-    # module) that pre-date wave5c. Keep the run so regressions surface, but
-    # don't let it block the PR until the Windows-compat follow-up lands.
+    # Windows runs a curated portable subset (same paths as build-check-windows.yml)
+    # rather than the full suite. The full 2773-test run has 50+ pre-existing
+    # compat failures (CRLF, cp1252, symlinks, pwd module) that make the signal
+    # hard to read; the curated list covers path-sensitive and Windows-specific
+    # tests that are known to pass. continue-on-error is kept while the curated
+    # list is still being validated.
     continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
@@ -50,12 +53,28 @@ jobs:
         run: pip install -e packages/credbroker
       - name: Install pyyaml for agent-artifact lint and credentialed-skill tests
         run: pip install 'pyyaml>=6.0'
-      - name: Run full agentbundle test suite
+      - name: Run full agentbundle test suite (Linux)
+        if: matrix.os != 'windows-latest'
         working-directory: packages/agentbundle
         env:
           PYTHONUTF8: "1"
           PYTHONIOENCODING: "utf-8"
         run: python -m pytest tests/ agentbundle/build/tests/ -q
+      - name: Run agentbundle test suite (Windows — curated portable subset)
+        if: matrix.os == 'windows-latest'
+        working-directory: packages/agentbundle
+        env:
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: "utf-8"
+        run: |
+          python -m pytest tests/integration/test_install_converters_user_scope.py
+          python -m pytest agentbundle/build/tests/test_shared_libs_projection.py
+          python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
+          python -m pytest agentbundle/build/tests/test_self_host_fixture_guard.py
+          python -m pytest agentbundle/build/tests/test_user_libs_projection.py
+          python -m pytest tests/integration/test_credential_brokers_pack_install.py
+          python -m pytest tests/hooks/
+          python -m pytest tests/unit/test_packstate_source_provenance.py
 
   # ── Gate B: external catalogue portability ────────────────────────────────
   external-catalogue-smoke:


### PR DESCRIPTION
## Summary

- Gate A (`catalogue-tooling-ci-gates.yml`) was running all ~2773 agentbundle tests on Windows, which was slow and noisy due to 50+ pre-existing compat failures (CRLF, cp1252, symlinks, `pwd` module)
- Windows now runs the same curated 8-path subset already validated by `build-check-windows.yml`, plus `tests/unit/test_packstate_source_provenance.py` (the only file with Windows-specific test methods using `skipif(sys.platform != "win32")`)
- Linux continues to run the full suite unchanged

## Test plan

- [ ] Gate A Linux (Ubuntu 3.11 + 3.12): full suite still runs — no change
- [ ] Gate A Windows (Windows 3.11): curated subset runs and passes
- [ ] `build-check-windows.yml`: unchanged, still runs its own curated list

## Follow-on

Option B (add `pytest.mark.posix_only` / `pytest.mark.windows` markers) would let `continue-on-error` be removed from Gate A Windows, making it a blocking check. Not in scope here.