### PR TITLE
fix(ci): flip Gate A Windows from continue-on-error to blocking

### DIFF
--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -24,12 +24,8 @@ jobs:
   agentbundle-tests:
     name: "Gate A — agentbundle tests (${{ matrix.os }} / py${{ matrix.python }})"
     # Windows runs a curated portable subset (same paths as build-check-windows.yml)
-    # rather than the full suite. The full 2773-test run has 50+ pre-existing
-    # compat failures (CRLF, cp1252, symlinks, pwd module) that make the signal
-    # hard to read; the curated list covers path-sensitive and Windows-specific
-    # tests that are known to pass. continue-on-error is kept while the curated
-    # list is still being validated.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # rather than the full suite. The curated list is validated — gate is now
+    # blocking on all platforms.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Removes `continue-on-error: ${{ matrix.os == 'windows-latest' }}` from Gate A now that the curated portable subset (#782) is validated.

- The 50+ pre-wave5c failures were resolved by: PLW1514 encoding= enforcement (#761), PYTHONUTF8 env (#774), symlink guards (#775), newline= fixes (#780)
- #782 narrowed Windows to a curated portable subset and kept continue-on-error "while the curated list is being validated"
- The curated list is now confirmed clean — gate hardened to blocking