### PR TITLE
docs(reference): document five-layer source-resolution chain and env vars

### DIFF
--- a/docs/architecture/catalogue.md
+++ b/docs/architecture/catalogue.md
@@ -38,7 +38,7 @@ metadata into it from the pack's `.claude-plugin/plugin.json`. How a pack's
 
 Every source verb — `install`, `upgrade`, `list-packs`, `list-profiles`,
 `list-installed` — takes an optional trailing catalogue argument. When you
-omit it, the CLI resolves one through a four-layer, first-match-wins chain
+omit it, the CLI resolves one through a five-layer, first-match-wins chain
 (RFC-0046 / ADR-0036, in
 [`source_defaults.resolve_default_source`](../../packages/agentbundle/agentbundle/source_defaults.py)):
 
@@ -46,16 +46,19 @@ omit it, the CLI resolves one through a four-layer, first-match-wins chain
 | --- | --- | --- |
 | 1 | The explicit trailing argument | `agentbundle install core <catalogue>` — passed through verbatim |
 | 2 | User config `[settings].source` | `agentbundle config set source <catalogue>` |
-| 3 | Editable-install detection | `pip install -e <clone>` — auto-detected |
-| 4 | Packaged default | `_data/install-defaults.toml` — baked into the wheel |
+| 3 | Org Artifactory bootstrap | `[distribution.agentbundle.artifactory]` in `catalogue.toml`, baked into `_data/install-defaults.toml` |
+| 4 | Editable-install detection | `pip install -e <clone>` — auto-detected |
+| 5 | Packaged default | `_data/install-defaults.toml` — baked into the wheel |
 
-Layer 3 is the one that makes a local clone "just work": when `agentbundle`
+Layer 4 is the one that makes a local clone "just work": when `agentbundle`
 is installed editable, it reads its own PEP 610 `direct_url.json`, and walks
 up from the package directory — bounded by the enclosing `.git` root — to the
 first ancestor carrying both catalogue markers. So a developer working inside
 a clone gets that clone as their catalogue with no configuration.
 
-When no layer yields a source, the CLI refuses with a message naming all three
+Setting `AGENTBUNDLE_NO_REMOTE=1` skips Layers 3 and 4, falling through directly to Layer 5. See the [adopter reference](../guides/_shared/reference/agentbundle.md) for the full env var list.
+
+When no layer yields a source, the CLI refuses with a message naming the
 recovery paths rather than silently falling back to the current directory:
 
 ```
@@ -72,12 +75,12 @@ A catalogue source is either a **local path** (containing both markers) or a
 # Persist a default (layer 2) — survives across every verb, every repo.
 agentbundle config set source git+https://github.com/acme/agent-kit
 agentbundle config set source /abs/path/to/your/catalogue
-agentbundle config unset source          # clear it; fall back to layers 3–4
+agentbundle config unset source          # clear it; fall back to layers 3–5
 
 # One-off (layer 1) — a trailing argument beats the configured default.
 agentbundle install core git+https://github.com/acme/agent-kit
 
-# Bind to a working clone (layer 3) — no config needed.
+# Bind to a working clone (layer 4) — no config needed.
 pip install -e /abs/path/to/your/catalogue
 ```
 

--- a/docs/guides/reference/catalogue-toml.md
+++ b/docs/guides/reference/catalogue-toml.md
@@ -47,17 +47,45 @@ adapters = ["claude-code"]
 Run `agentbundle catalogue sync-defaults --root .` to sync these values into the self-hosted adapters'
 install manifests.
 
-### `[catalogue.packaging]`
+### `[catalogue.package]`
 
-Controls archive output paths for `agentbundle catalogue package`.
+Controls which packs are included in a packaged archive.
 
 ```toml
-[catalogue.packaging]
-output-root = "dist/artifactory"
-bundle      = "engineering"
-release     = "1.0.0"
-channel     = "stable"
+[catalogue.package]
+include  = []                              # default: all packs
+required = ["LICENSE-APACHE", "LICENSE-MIT"]
 ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `include` | array of strings | `[]` (all packs) | Pack paths to include in a packaged archive. An empty list includes all packs. |
+| `required` | array of strings | `["LICENSE-APACHE", "LICENSE-MIT"]` | Required root-level file paths. Overrides the default `LICENSE-APACHE` / `LICENSE-MIT` constraint when set. Absent or empty means use the default requirement. |
+
+### `[distribution.agentbundle.artifactory]`
+
+Configures the Artifactory org bootstrap. When present and `enabled = true`, `agentbundle catalogue sync-defaults --write` bakes these coordinates into `_data/install-defaults.toml` so that developers who install your wheel resolve the catalogue from Artifactory automatically — no per-developer `config set source` step.
+
+```toml
+[distribution.agentbundle.artifactory]
+enabled    = true
+base-url   = "https://artifactory.example.com"
+repository = "agentbundle-catalogues"
+bundle     = "engineering"
+channel    = "stable"
+```
+
+All five fields are required when `enabled = true`. No credentials go in this file — authenticate via [`AGENTBUNDLE_HTTP_BEARER_TOKEN`](../../guides/_shared/reference/agentbundle.md#environment-variables).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Whether the Artifactory bootstrap is active. Set `false` to revert to the public catalogue. |
+| `base-url` | string | Artifactory base URL (`https://` only; no embedded credentials). |
+| `repository` | string | Artifactory repository name. Must match `[A-Za-z0-9._-]+`. |
+| `bundle` | string | Catalogue bundle name. Must match `[A-Za-z0-9._-]+`. |
+| `channel` | string | Channel name (e.g. `stable`, `preview`). Must match `[A-Za-z0-9._-]+`. |
+
+See [Configure a catalogue for enterprise distribution](../../guides/_shared/how-to/configure-catalogue-enterprise-distribution.md) for the step-by-step setup guide.
 
 ## Valid values
 
@@ -71,6 +99,13 @@ channel     = "stable"
 | `maintainers[].name` | string | required when maintainer present |
 | `maintainers[].email` | string | optional |
 | `keywords` | array of strings | free text |
+| `catalogue.package.include` | array of strings | pack paths; empty = all packs |
+| `catalogue.package.required` | array of strings | root-level file paths; absent = `["LICENSE-APACHE", "LICENSE-MIT"]` |
+| `distribution.agentbundle.artifactory.enabled` | boolean | `true` or `false` |
+| `distribution.agentbundle.artifactory.base-url` | string | `https://` only, no credentials |
+| `distribution.agentbundle.artifactory.repository` | string | `[A-Za-z0-9._-]+` |
+| `distribution.agentbundle.artifactory.bundle` | string | `[A-Za-z0-9._-]+` |
+| `distribution.agentbundle.artifactory.channel` | string | `[A-Za-z0-9._-]+` |
 
 ## Example
 
@@ -90,4 +125,15 @@ stable  = "https://registry.acme.example/agentbundle/stable.json"
 [catalogue.install-defaults]
 packs    = ["core", "security-baseline"]
 adapters = ["claude-code", "cursor"]
+
+[catalogue.package]
+include  = []                              # empty = all packs
+required = ["LICENSE-APACHE", "LICENSE-MIT"]
+
+[distribution.agentbundle.artifactory]
+enabled    = false
+base-url   = "https://artifactory.example.com"
+repository = "agentbundle-catalogues"
+bundle     = "acme-platform"
+channel    = "stable"
 ```

--- a/guides/_shared/README.md
+++ b/guides/_shared/README.md
@@ -15,7 +15,7 @@ Guides about the catalogue itself — installing it, upgrading it, seeing what e
 
 ## Reference
 
-- [`agentbundle` reference](reference/agentbundle.md) — install the CLI, install a pack, configure the default adapter.
+- [`agentbundle` reference](reference/agentbundle.md) — install the CLI, install a pack, configure the default adapter, source-resolution chain, environment variables.
 - [Adapter support matrix](reference/adapter-support.md) — which primitives each agent tool receives, and where it degrades.
 - [Tracker vocabulary](reference/tracker-vocabulary.md) — how brief and spec levels map across GitHub, Linear, Jira, and Jira Align; skill routing table.
 - [Output rendering directives](reference/output-rendering.md) — the canonical directive catalog: which shape to declare in `## Output rendering` (Table, Status list, Severity list, Diagram, etc.) and when to omit.

--- a/guides/_shared/how-to/configure-catalogue-enterprise-distribution.md
+++ b/guides/_shared/how-to/configure-catalogue-enterprise-distribution.md
@@ -86,4 +86,4 @@ to the packaged default source.
 
 ## See also
 
-- [`agentbundle` reference](../reference/agentbundle.md) — full source-resolution chain and all env vars.
+- [`agentbundle` reference — source resolution and env vars](../reference/agentbundle.md#catalogue-source-resolution)

--- a/guides/_shared/reference/README.md
+++ b/guides/_shared/reference/README.md
@@ -4,7 +4,7 @@
 
 ## Pages
 
-- [`agentbundle.md`](agentbundle.md) — install the CLI, install a pack, configure the default adapter.
+- [`agentbundle.md`](agentbundle.md) — install the CLI, install a pack, configure the default adapter, source-resolution chain, environment variables.
 - [`agentskills-io-standard.md`](agentskills-io-standard.md) — the agentskills.io specification applied: frontmatter keys, description rules, directory layout, independent installation, and OWASP AST01–AST10 mapping.
 - [`adapter-support.md`](adapter-support.md) — the per-tool support matrix: which primitives each agent tool receives (skill / subagent / command / hook) and the runtime caveats, sourced from the adapter contract.
 - [`tracker-vocabulary.md`](tracker-vocabulary.md) — how brief and spec levels map to GitHub, Linear, Jira, and Jira Align objects; brief-intake skill routing table.

--- a/guides/_shared/reference/agentbundle.md
+++ b/guides/_shared/reference/agentbundle.md
@@ -143,6 +143,30 @@ Upgrades preserve their existing adapter regardless of user-config. If you insta
 - Re-running against the version you already have is a **re-apply**, not an upgrade: it reports `re-applied: <pack> @ <scope> <version> (already current)` — or names the count of locally edited files it kept as `.upstream` companions, when there were edits. Before it acts, it tells you up front how many of your edits will be preserved.
 - A pack installed for **more than one adapter** at a scope needs `--adapter` to disambiguate; the refusal lists each adapter with its installed version, e.g. `pass --adapter to pick one: claude-code (0.9.0), codex (0.9.0)`. The same applies to `diff` and `uninstall`.
 
+## Catalogue source resolution
+
+Every source verb — `install`, `upgrade`, `list-packs`, `list-profiles`, `list-installed` — takes an optional trailing catalogue argument. When you omit it, the CLI resolves one through a five-layer, first-match-wins chain:
+
+| Layer | Source | Set by |
+| ----- | ------ | ------ |
+| 1 | Explicit catalogue argument | `agentbundle install --pack <name> <catalogue>` — passed through verbatim, no validation |
+| 2 | User config `[settings].source` | `agentbundle config set source <catalogue>` |
+| 3 | Org Artifactory bootstrap | `[distribution.agentbundle.artifactory]` in `catalogue.toml`, baked into the wheel by `agentbundle catalogue sync-defaults --write` |
+| 4 | Editable-install detection | `pip install -e <clone>` — auto-detected via PEP 610 `direct_url.json`; walks up to the enclosing `.git` root |
+| 5 | Packaged default | `_data/install-defaults.toml` `[defaults].source` — baked into the wheel at publish time |
+
+Setting `AGENTBUNDLE_NO_REMOTE=1` skips Layers 3 and 4 (the org Artifactory bootstrap and editable-install detection), falling through directly to Layer 5. See [`AGENTBUNDLE_NO_REMOTE`](#environment-variables) below.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `AGENTBUNDLE_HTTP_BEARER_TOKEN` | unset | Bearer token sent as `Authorization: Bearer <token>` on `catalogue+https://` and `archive+https://` requests. **Secret — do not log or persist to version control.** Example: `AGENTBUNDLE_HTTP_BEARER_TOKEN=<token> agentbundle install --pack core` |
+| `AGENTBUNDLE_CA_BUNDLE` | unset | Absolute path to a PEM CA bundle for TLS verification of HTTPS catalogue sources. Set when your Artifactory instance uses a corporate or self-signed certificate. Raises `CatalogueError` if the path does not exist. Example: `AGENTBUNDLE_CA_BUNDLE=/etc/ssl/corp-ca.pem agentbundle install --pack core` |
+| `AGENTBUNDLE_NO_REMOTE` | unset | When set to any non-empty value, skips Layer 3 (org Artifactory bootstrap) and Layer 4 (editable-install detection), falling through to Layer 5. Use on hosts that cannot reach Artifactory, or in CI pipelines that resolve a local catalogue. Example: `AGENTBUNDLE_NO_REMOTE=1 agentbundle install --pack core /path/to/local-catalogue` |
+| `HTTPS_PROXY` | unset | Proxy URL for outbound HTTPS requests. Read automatically by Python's `urllib.request.ProxyHandler`; no `agentbundle`-specific wiring needed. Example: `HTTPS_PROXY=http://proxy.example.com:3128 agentbundle install --pack core` |
+| `NO_PROXY` | unset | Comma-separated list of hostnames that bypass the HTTPS proxy. Read automatically by Python's `urllib.request.ProxyHandler`. Example: `NO_PROXY=internal.example.com,localhost` |
+
 ## Other subcommands
 
 See `agentbundle --help` for the full set (`list-packs`, `list-profiles`, `list-targets`, `list-installed`, `validate`, `render`, `adapt`, `diff`, `upgrade`, `uninstall`, `reconcile`, etc.). Each has its own `--help` page documenting its flags.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -26,6 +26,14 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 - **Provenance exposed in `list-installed --format json`**: the three new fields appear on each
   row as `artifact_uri`, `archive_sha256`, and `source_revision` (null when absent).
   (`commands/list_installed.py`)
+- **Documentation: source-resolution chain and env vars** (`guides/_shared/reference/agentbundle.md`):
+  added "Catalogue source resolution" section (five-layer table derived from `source_defaults.py`)
+  and "Environment variables" section covering `AGENTBUNDLE_HTTP_BEARER_TOKEN`,
+  `AGENTBUNDLE_CA_BUNDLE`, `AGENTBUNDLE_NO_REMOTE`, `HTTPS_PROXY`, and `NO_PROXY`.
+  Updated `docs/architecture/catalogue.md` to document the five-layer chain with Layer 3
+  (Artifactory bootstrap); updated `docs/guides/reference/catalogue-toml.md` to replace the
+  stale `[catalogue.packaging]` section with `[catalogue.package]` and add the missing
+  `[distribution.agentbundle.artifactory]` section.
 
 ## [0.22.1] — 2026-07-28
 


### PR DESCRIPTION
## Summary

- **`guides/_shared/reference/agentbundle.md`**: added "Catalogue source resolution" section (five-layer table derived from `source_defaults.py`) and "Environment variables" section covering `AGENTBUNDLE_HTTP_BEARER_TOKEN`, `AGENTBUNDLE_CA_BUNDLE`, `AGENTBUNDLE_NO_REMOTE`, `HTTPS_PROXY`, and `NO_PROXY` — all verified implemented before documenting.
- **`docs/architecture/catalogue.md`**: updated from four-layer to five-layer chain; Artifactory org bootstrap is now Layer 3; old Layer 3 (editable detection) → Layer 4; old Layer 4 (packaged default) → Layer 5; all layer number references updated in prose and comments; `AGENTBUNDLE_NO_REMOTE=1` note added.
- **`docs/guides/reference/catalogue-toml.md`**: replaced stale `[catalogue.packaging]` section (which documented CLI flags as TOML fields) with correct `[catalogue.package]` (include/required per schema); added missing `[distribution.agentbundle.artifactory]` section with all five fields.
- **See also link** in `configure-catalogue-enterprise-distribution.md` tightened to the specific new anchor.
- **Both README index descriptions** extended to include "source-resolution chain, environment variables".

## Test plan

- [x] Lint passes (`python3 tools/lint-ruff.py`)
- [x] mypy clean (`python3 -m mypy packages/agentbundle/agentbundle/ --ignore-missing-imports`)
- [x] All agentbundle tests pass locally
- [x] Layer order in `agentbundle.md` and `catalogue.md` matches `source_defaults.resolve_default_source()` (Layer 3 = Artifactory bootstrap gated by `AGENTBUNDLE_NO_REMOTE`, Layer 4 = editable detection)
- [x] `[catalogue.packaging]` content gone from `catalogue-toml.md`; `[catalogue.package]` and `[distribution.agentbundle.artifactory]` present
- [x] No source code modified