### PR TITLE
ci(catalogue): add Artifactory archive publication workflow

### DIFF
--- a/.github/workflows/publish-catalogue.yml
+++ b/.github/workflows/publish-catalogue.yml
@@ -1,0 +1,215 @@
+name: publish-catalogue
+
+# Prerequisites (platform administrator):
+# - Artifactory Generic repository provisioned and named in ARTIFACTORY_REPOSITORY var
+# - ARTIFACTORY_TOKEN org secret set with deploy permissions to that repository
+# - Repository overwrite policy: immutable for releases/, overwrite-allowed for channels/
+# - Retention policy: configured per your org's archive retention requirements
+# - Replication: configured independently if multi-region is required
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundle:
+        description: 'Catalogue bundle name (e.g. "engineering")'
+        required: true
+        type: string
+      release:
+        description: 'Release identifier (e.g. "1.0.0")'
+        required: true
+        type: string
+      channel:
+        description: 'Channel to update (e.g. "stable")'
+        required: true
+        type: string
+      dry_run:
+        description: 'Skip the upload step'
+        required: false
+        type: boolean
+        default: true
+
+  workflow_call:
+    inputs:
+      bundle:
+        required: true
+        type: string
+      release:
+        required: true
+        type: string
+      channel:
+        required: true
+        type: string
+      dry_run:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      ARTIFACTORY_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-catalogue-${{ inputs.bundle }}-${{ inputs.release }}-${{ inputs.channel }}
+  cancel-in-progress: false
+
+jobs:
+
+  # ── Job 1: package-and-validate ───────────────────────────────────────────
+  # Always runs. No secrets required. This is the CI contract: every invocation
+  # must produce a verifiable archive regardless of whether upload is requested.
+  package-and-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install agentbundle
+        run: pip install -e packages/agentbundle
+
+      - name: Verify catalogue (source)
+        run: agentbundle catalogue verify --root .
+
+      - name: Package catalogue
+        run: |
+          agentbundle catalogue package \
+            --root . \
+            --bundle "${{ inputs.bundle }}" \
+            --release "${{ inputs.release }}" \
+            --channel "${{ inputs.channel }}" \
+            --output /tmp/catalogue-dist
+
+      - name: Assert archive, sidecar, and descriptor exist
+        run: |
+          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          SIDECAR="${ARCHIVE}.sha256"
+          DESCRIPTOR="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"
+          ls "$ARCHIVE"
+          ls "$SIDECAR"
+          ls "$DESCRIPTOR"
+
+      - name: Verify archive integrity
+        run: |
+          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          SIDECAR="${ARCHIVE}.sha256"
+          agentbundle catalogue verify \
+            --archive "$ARCHIVE" \
+            --sha256-file "$SIDECAR"
+
+      - name: Validate channel descriptor
+        env:
+          DESCRIPTOR: /tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json
+          EXPECTED_BUNDLE: ${{ inputs.bundle }}
+          EXPECTED_RELEASE: ${{ inputs.release }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          with open(os.environ["DESCRIPTOR"]) as f:
+              d = json.load(f)
+          required = {"kind", "bundle", "release", "artifact", "sha256"}
+          missing = required - set(d.keys())
+          if missing:
+              print(f"FAIL: descriptor missing fields: {missing}"); sys.exit(1)
+          if d.get("bundle") != os.environ["EXPECTED_BUNDLE"]:
+              print("FAIL: bundle mismatch"); sys.exit(1)
+          if d.get("release") != os.environ["EXPECTED_RELEASE"]:
+              print("FAIL: release mismatch"); sys.exit(1)
+          print("Descriptor validation: PASS")
+          PY
+
+      - name: Scan archive for credential patterns
+        env:
+          ARCHIVE: /tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz
+        run: |
+          python3 - <<'PY'
+          import os, re, sys, tarfile
+          from pathlib import Path
+          BANNED = re.compile(
+              r'(?i)(bearer|AGENTBUNDLE_HTTP_BEARER_TOKEN)\s*[=:]\s*[A-Za-z0-9+/]{20,}'
+          )
+          arc = Path(os.environ["ARCHIVE"])
+          with tarfile.open(arc, "r:gz") as tf:
+              for m in tf.getmembers():
+                  f = tf.extractfile(m)
+                  if f and BANNED.search(f.read().decode(errors="replace")):
+                      print(f"FAIL: credential pattern in {m.name}"); sys.exit(1)
+          print("Credential scan: PASS")
+          PY
+
+      - name: Upload catalogue-dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: catalogue-dist
+          path: /tmp/catalogue-dist/
+          if-no-files-found: error
+
+  # ── Job 2: upload-to-artifactory ─────────────────────────────────────────
+  # Skipped when dry_run is true or ARTIFACTORY_TOKEN is unset.
+  # The channel descriptor upload (final step) runs only after archive and
+  # sidecar are verified remotely — making the release visible to consumers
+  # last.
+  upload-to-artifactory:
+    needs: [package-and-validate]
+    if: ${{ !inputs.dry_run && secrets.ARTIFACTORY_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+      ARTIFACTORY_BASE_URL: ${{ vars.ARTIFACTORY_BASE_URL }}
+      ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download catalogue-dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: catalogue-dist
+          path: /tmp/catalogue-dist
+
+      - name: Install JFrog CLI
+        run: curl -fL https://install-cli.jfrog.io | sh
+
+      - name: Configure JFrog CLI
+        run: |
+          jf config add artifactory \
+            --url "$ARTIFACTORY_BASE_URL" \
+            --access-token "$ARTIFACTORY_TOKEN" \
+            --interactive=false
+
+      - name: Set path variables
+        run: |
+          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+          echo "SIDECAR=${ARCHIVE}.sha256" >> "$GITHUB_ENV"
+          echo "DESCRIPTOR=/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json" >> "$GITHUB_ENV"
+
+      - name: Upload archive to Artifactory
+        run: |
+          jf rt upload \
+            "$ARCHIVE" \
+            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz" \
+            --fail-no-op
+
+      - name: Upload sidecar to Artifactory
+        run: |
+          jf rt upload \
+            "$SIDECAR" \
+            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256"
+
+      - name: Remote verify — download sidecar and compare
+        run: |
+          jf rt dl \
+            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256" \
+            /tmp/remote-sidecar.sha256
+          diff "$SIDECAR" /tmp/remote-sidecar.sha256
+
+      - name: Upload channel descriptor to Artifactory
+        run: |
+          jf rt upload \
+            "$DESCRIPTOR" \
+            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"

--- a/.github/workflows/publish-catalogue.yml
+++ b/.github/workflows/publish-catalogue.yml
@@ -149,66 +149,91 @@ jobs:
           if-no-files-found: error
 
   # ── Job 2: upload-to-artifactory ─────────────────────────────────────────
-  # Skipped when dry_run is true or ARTIFACTORY_TOKEN is unset.
-  # The channel descriptor upload (final step) runs only after archive and
-  # sidecar are verified remotely — making the release visible to consumers
-  # last.
+  # Runs when dry_run is false. A guard step at the top checks ARTIFACTORY_TOKEN
+  # and skips all upload steps when the secret is absent (secrets context is not
+  # available in job-level if: expressions per actionlint SC-context-availability).
+  # The channel descriptor upload (final step) runs only after archive and sidecar
+  # are verified remotely — making the release visible to consumers last.
   upload-to-artifactory:
     needs: [package-and-validate]
-    if: ${{ !inputs.dry_run && secrets.ARTIFACTORY_TOKEN != '' }}
+    if: ${{ !inputs.dry_run }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
       ARTIFACTORY_BASE_URL: ${{ vars.ARTIFACTORY_BASE_URL }}
       ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY }}
     steps:
-      - uses: actions/checkout@v4
+      - id: guard
+        name: Check Artifactory token presence
+        env:
+          ART_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+        run: |
+          if [ -n "$ART_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ARTIFACTORY_TOKEN is not set; skipping Artifactory upload."
+          fi
 
-      - name: Download catalogue-dist artifact
+      - if: steps.guard.outputs.configured == 'true'
+        uses: actions/checkout@v4
+
+      - if: steps.guard.outputs.configured == 'true'
+        name: Download catalogue-dist artifact
         uses: actions/download-artifact@v4
         with:
           name: catalogue-dist
           path: /tmp/catalogue-dist
 
-      - name: Install JFrog CLI
+      - if: steps.guard.outputs.configured == 'true'
+        name: Install JFrog CLI
         run: curl -fL https://install-cli.jfrog.io | sh
 
-      - name: Configure JFrog CLI
+      - if: steps.guard.outputs.configured == 'true'
+        name: Configure JFrog CLI
+        env:
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
         run: |
           jf config add artifactory \
             --url "$ARTIFACTORY_BASE_URL" \
             --access-token "$ARTIFACTORY_TOKEN" \
             --interactive=false
 
-      - name: Set path variables
+      - if: steps.guard.outputs.configured == 'true'
+        name: Set path variables
         run: |
           ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
-          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
-          echo "SIDECAR=${ARCHIVE}.sha256" >> "$GITHUB_ENV"
-          echo "DESCRIPTOR=/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json" >> "$GITHUB_ENV"
+          {
+            echo "ARCHIVE=$ARCHIVE"
+            echo "SIDECAR=${ARCHIVE}.sha256"
+            echo "DESCRIPTOR=/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"
+          } >> "$GITHUB_ENV"
 
-      - name: Upload archive to Artifactory
+      - if: steps.guard.outputs.configured == 'true'
+        name: Upload archive to Artifactory
         run: |
           jf rt upload \
             "$ARCHIVE" \
             "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz" \
             --fail-no-op
 
-      - name: Upload sidecar to Artifactory
+      - if: steps.guard.outputs.configured == 'true'
+        name: Upload sidecar to Artifactory
         run: |
           jf rt upload \
             "$SIDECAR" \
             "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256"
 
-      - name: Remote verify — download sidecar and compare
+      - if: steps.guard.outputs.configured == 'true'
+        name: Remote verify — download sidecar and compare
         run: |
           jf rt dl \
             "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256" \
             /tmp/remote-sidecar.sha256
           diff "$SIDECAR" /tmp/remote-sidecar.sha256
 
-      - name: Upload channel descriptor to Artifactory
+      - if: steps.guard.outputs.configured == 'true'
+        name: Upload channel descriptor to Artifactory
         run: |
           jf rt upload \
             "$DESCRIPTOR" \

--- a/.github/workflows/publish-catalogue.yml
+++ b/.github/workflows/publish-catalogue.yml
@@ -62,6 +62,10 @@ jobs:
   package-and-validate:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      BUNDLE: ${{ inputs.bundle }}
+      RELEASE: ${{ inputs.release }}
+      CHANNEL: ${{ inputs.channel }}
     steps:
       - uses: actions/checkout@v4
 
@@ -79,23 +83,23 @@ jobs:
         run: |
           agentbundle catalogue package \
             --root . \
-            --bundle "${{ inputs.bundle }}" \
-            --release "${{ inputs.release }}" \
-            --channel "${{ inputs.channel }}" \
+            --bundle "$BUNDLE" \
+            --release "$RELEASE" \
+            --channel "$CHANNEL" \
             --output /tmp/catalogue-dist
 
       - name: Assert archive, sidecar, and descriptor exist
         run: |
-          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          ARCHIVE="/tmp/catalogue-dist/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz"
           SIDECAR="${ARCHIVE}.sha256"
-          DESCRIPTOR="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"
+          DESCRIPTOR="/tmp/catalogue-dist/catalogues/$BUNDLE/channels/$CHANNEL.json"
           ls "$ARCHIVE"
           ls "$SIDECAR"
           ls "$DESCRIPTOR"
 
       - name: Verify archive integrity
         run: |
-          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          ARCHIVE="/tmp/catalogue-dist/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz"
           SIDECAR="${ARCHIVE}.sha256"
           agentbundle catalogue verify \
             --archive "$ARCHIVE" \
@@ -160,6 +164,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
+      BUNDLE: ${{ inputs.bundle }}
+      RELEASE: ${{ inputs.release }}
+      CHANNEL: ${{ inputs.channel }}
       ARTIFACTORY_BASE_URL: ${{ vars.ARTIFACTORY_BASE_URL }}
       ARTIFACTORY_REPOSITORY: ${{ vars.ARTIFACTORY_REPOSITORY }}
     steps:
@@ -202,11 +209,11 @@ jobs:
       - if: steps.guard.outputs.configured == 'true'
         name: Set path variables
         run: |
-          ARCHIVE="/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz"
+          ARCHIVE="/tmp/catalogue-dist/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz"
           {
             echo "ARCHIVE=$ARCHIVE"
             echo "SIDECAR=${ARCHIVE}.sha256"
-            echo "DESCRIPTOR=/tmp/catalogue-dist/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"
+            echo "DESCRIPTOR=/tmp/catalogue-dist/catalogues/$BUNDLE/channels/$CHANNEL.json"
           } >> "$GITHUB_ENV"
 
       - if: steps.guard.outputs.configured == 'true'
@@ -214,7 +221,7 @@ jobs:
         run: |
           jf rt upload \
             "$ARCHIVE" \
-            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz" \
+            "$ARTIFACTORY_REPOSITORY/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz" \
             --fail-no-op
 
       - if: steps.guard.outputs.configured == 'true'
@@ -222,13 +229,13 @@ jobs:
         run: |
           jf rt upload \
             "$SIDECAR" \
-            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256"
+            "$ARTIFACTORY_REPOSITORY/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz.sha256"
 
       - if: steps.guard.outputs.configured == 'true'
         name: Remote verify — download sidecar and compare
         run: |
           jf rt dl \
-            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/releases/${{ inputs.release }}/catalogue-${{ inputs.release }}.tar.gz.sha256" \
+            "$ARTIFACTORY_REPOSITORY/catalogues/$BUNDLE/releases/$RELEASE/catalogue-$RELEASE.tar.gz.sha256" \
             /tmp/remote-sidecar.sha256
           diff "$SIDECAR" /tmp/remote-sidecar.sha256
 
@@ -237,4 +244,4 @@ jobs:
         run: |
           jf rt upload \
             "$DESCRIPTOR" \
-            "$ARTIFACTORY_REPOSITORY/catalogues/${{ inputs.bundle }}/channels/${{ inputs.channel }}.json"
+            "$ARTIFACTORY_REPOSITORY/catalogues/$BUNDLE/channels/$CHANNEL.json"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -24,6 +24,7 @@ rules:
       - iac-staleness.yml
       - pack-evals.yml
       - pages.yml
+      - publish-catalogue.yml
       - publish-claude-plugins.yml
       - release-agentbundle.yml
       - release-credbroker.yml


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-catalogue.yml` with `workflow_dispatch` and `workflow_call` triggers
- **Job 1 (`package-and-validate`)**: always runs without secrets — verifies source catalogue, packages the archive, asserts output paths, verifies archive integrity, validates the channel descriptor schema (`artifact` field, confirmed from `_write_channel_descriptor` in `package.py`), scans for credential patterns (matching Gate C), and uploads a `catalogue-dist` workflow artifact
- **Job 2 (`upload-to-artifactory`)**: skipped when `dry_run=true` or `ARTIFACTORY_TOKEN` is unset; uploads archive (with `--fail-no-op`), sidecar, remotely verifies sidecar, then uploads channel descriptor last — ensuring the release is only visible to consumers after the archive is confirmed present in Artifactory

## Test plan

- [ ] Trigger via `workflow_dispatch` with `dry_run=true`; confirm `package-and-validate` passes and artifact is uploaded; confirm `upload-to-artifactory` is skipped
- [ ] Confirm `upload-to-artifactory` is skipped when `ARTIFACTORY_TOKEN` secret is absent
- [ ] Confirm channel descriptor upload step follows the remote verify step (ordering per AC 3)
- [ ] Confirm no credentials appear in non-secret workflow fields