### PR TITLE
perf(packaging): stream archive directly to disk, eliminate in-memory BytesIO buffer

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,15 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Changed
+
+- **`_build_archive` → `_write_archive`** (`catalogue_tooling/package.py`): the archive builder
+  now streams the compressed output directly to the staged file on disk instead of
+  materialising the full content in an `io.BytesIO` buffer first. The SHA-256 is then computed
+  over the smaller compressed file. All determinism guarantees are preserved (sorted members,
+  normalised metadata, zeroed gzip mtime, `GNU_FORMAT`). No change to archive contents, sidecar,
+  or channel descriptor.
+
 ### Added
 
 - **`AGENTBUNDLE_CA_BUNDLE` environment variable** (`https_catalogue.py`): when set to a path,

--- a/packages/agentbundle/agentbundle/catalogue_tooling/package.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/package.py
@@ -344,10 +344,9 @@ def _generate_manifest(
 # ---------------------------------------------------------------------------
 
 
-def _build_archive(file_bytes: dict[str, bytes], manifest_bytes: bytes) -> bytes:
-    """Build a deterministic .tar.gz archive in memory.
+def _write_archive(file_bytes: dict[str, bytes], manifest_bytes: bytes, dest: Path) -> None:
+    """Write a deterministic .tar.gz archive directly to *dest*.
 
-    Returns the complete compressed bytes.
     - All members sorted lexicographically by name.
     - All members: uid=0, gid=0, mtime=0, mode=0o644.
     - gzip header mtime field (bytes 4-7) is zeroed.
@@ -357,31 +356,33 @@ def _build_archive(file_bytes: dict[str, bytes], manifest_bytes: bytes) -> bytes
     members.append(("catalogue-manifest.json", manifest_bytes))
     members.sort(key=lambda x: x[0])
 
-    buf = io.BytesIO()
-    gz = gzip.GzipFile(fileobj=buf, mode="wb", mtime=0)
-    tar = tarfile.TarFile(fileobj=gz, mode="w", format=tarfile.GNU_FORMAT)  # type: ignore[arg-type]
+    with dest.open("wb") as f:
+        # filename="" keeps the gzip FNAME header field empty for byte-identical output
+        # regardless of the dest path — same determinism guarantee as the old BytesIO path.
+        gz = gzip.GzipFile(fileobj=f, mode="wb", mtime=0, filename="")
+        tar = tarfile.TarFile(fileobj=gz, mode="w", format=tarfile.GNU_FORMAT)  # type: ignore[arg-type]
+        try:
+            for member_name, data in members:
+                if member_name.startswith("/"):
+                    raise ValueError(f"unsafe archive member name: {member_name!r}")
+                parts = member_name.split("/")
+                if ".." in parts:
+                    raise ValueError(f"unsafe archive member name: {member_name!r}")
+                if len(member_name) >= 2 and member_name[1] == ":":
+                    raise ValueError(f"unsafe archive member name: {member_name!r}")
 
-    for member_name, data in members:
-        if member_name.startswith("/"):
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-        parts = member_name.split("/")
-        if ".." in parts:
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-        if len(member_name) >= 2 and member_name[1] == ":":
-            raise ValueError(f"unsafe archive member name: {member_name!r}")
-
-        info = tarfile.TarInfo(name=member_name)
-        info.type = tarfile.REGTYPE
-        info.size = len(data)
-        info.uid = 0
-        info.gid = 0
-        info.mtime = 0
-        info.mode = 0o644
-        tar.addfile(info, io.BytesIO(data))
-
-    tar.close()
-    gz.close()
-    return buf.getvalue()
+                info = tarfile.TarInfo(name=member_name)
+                info.type = tarfile.REGTYPE
+                info.size = len(data)
+                info.uid = 0
+                info.gid = 0
+                info.mtime = 0
+                info.mode = 0o644
+                tar.addfile(info, io.BytesIO(data))
+        finally:
+            # Close tar then gz while f is still open so GC sees no closed-file state.
+            tar.close()
+            gz.close()
 
 
 # ---------------------------------------------------------------------------
@@ -461,15 +462,14 @@ def package_catalogue(
 ) -> PackageResult:
     """Package a catalogue at *root* into an Artifactory artifact layout.
 
-    Implements the 8-step staging + atomic placement sequence:
+    Implements the 7-step staging + atomic placement sequence:
       1. Pre-package verify_catalogue
-      2. Build archive bytes in memory
-      3. Write staged archive
-      4. Compute + write staged sidecar
-      5. Self-verify staged archive + sidecar
-      6. Atomic place archive
-      7. Atomic place sidecar
-      8. Write channel descriptor LAST
+      2. Build and stream archive directly to the staged path
+      3. Compute + write staged sidecar
+      4. Self-verify staged archive + sidecar
+      5. Atomic place archive
+      6. Atomic place sidecar
+      7. Write channel descriptor LAST
 
     Returns a PackageResult; does NOT raise on expected failures.
     """
@@ -602,7 +602,7 @@ def package_catalogue(
     if marketplace_bytes is not None:
         marketplace_digest = "sha256:" + hashlib.sha256(marketplace_bytes).hexdigest()
 
-    # --- Step 2: Build archive bytes in memory ---
+    # --- Step 2+3: Build and write archive directly to staged path ---
     manifest_bytes = _generate_manifest(
         bundle=bundle,
         release=release,
@@ -616,20 +616,18 @@ def package_catalogue(
         marketplace_digest=marketplace_digest,
         profiles_metadata=profiles_metadata,
     )
-    archive_bytes = _build_archive(file_bytes, manifest_bytes)
-
-    # Compute sha256
-    sha256_hex = hashlib.sha256(archive_bytes).hexdigest()
 
     # --- Create output directories ---
     archive_path.parent.mkdir(parents=True, exist_ok=True)
     (output / "catalogues" / bundle / "channels").mkdir(parents=True, exist_ok=True)
 
-    # --- Step 3: Write staged archive ---
     staged_archive = _staging_path(archive_path)
     staged_sidecar = _staging_path(sidecar_path)
     try:
-        staged_archive.write_bytes(archive_bytes)
+        _write_archive(file_bytes, manifest_bytes, staged_archive)
+
+        # sha256 of the published archive bytes (what the sidecar and channel descriptor attest to)
+        sha256_hex = hashlib.sha256(staged_archive.read_bytes()).hexdigest()
 
         # --- Step 4: Write staged sidecar ---
         staged_sidecar.write_text(sha256_hex + "\n", encoding="utf-8", newline="\n")

--- a/packages/agentbundle/agentbundle/commands/package_catalogue.py
+++ b/packages/agentbundle/agentbundle/commands/package_catalogue.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 # Re-export all helpers from the new engine so tests importing from here
 # continue to work.
 from agentbundle.catalogue_tooling.package import (  # noqa: F401
-    _build_archive,
     _check_required_files,
     _compute_file_digests,
     _generate_manifest,
@@ -24,6 +23,7 @@ from agentbundle.catalogue_tooling.package import (  # noqa: F401
     _scan_content,
     _validate_content,
     _validate_flag_value,
+    _write_archive,
     _write_channel_descriptor,
     package_catalogue,
 )

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -19,6 +19,7 @@ from agentbundle.catalogue_tooling.package import (
     _check_required_files,
     _generate_manifest,
     _scan_content,
+    _write_archive,
     package_catalogue,
 )
 
@@ -758,3 +759,33 @@ def test_package_default_required_still_enforced(tmp_path: Path) -> None:
 
     assert not result.ok
     assert any("LICENSE-APACHE" in d.message for d in result.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Streaming archive: no top-level BytesIO buffer
+# ---------------------------------------------------------------------------
+
+
+def test_write_archive_does_not_use_BytesIO_for_main_buffer(tmp_path: Path) -> None:
+    """_write_archive must not create an io.BytesIO() as the top-level gzip buffer."""
+    file_bytes = {"foo.txt": b"hello world"}
+    manifest_bytes = b'{"schema": 2}'
+    dest = tmp_path / "test.tar.gz"
+
+    no_arg_calls: list[tuple] = []
+    original_bytesio = io.BytesIO
+
+    def tracking_bytesio(*args, **kwargs):
+        if not args and not kwargs:
+            no_arg_calls.append(())
+        return original_bytesio(*args, **kwargs)
+
+    target = "agentbundle.catalogue_tooling.package.io.BytesIO"
+    with mock.patch(target, side_effect=tracking_bytesio):
+        _write_archive(file_bytes, manifest_bytes, dest)
+
+    assert dest.exists(), "archive was not written to disk"
+    assert no_arg_calls == [], (
+        f"io.BytesIO() called with no args {len(no_arg_calls)} time(s)"
+        " — top-level buffer not eliminated"
+    )

--- a/packages/agentbundle/tests/unit/test_package_catalogue.py
+++ b/packages/agentbundle/tests/unit/test_package_catalogue.py
@@ -26,12 +26,12 @@ import pytest
 from agentbundle import cli
 from agentbundle.commands import package_catalogue
 from agentbundle.commands.package_catalogue import (
-    _build_archive,
     _compute_file_digests,
     _generate_manifest,
     _read_content_files,
     _scan_content,
     _validate_content,
+    _write_archive,
     _write_channel_descriptor,
     run,
 )
@@ -374,7 +374,7 @@ def test_validate_content_invalid_profile_toml_rejected(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T2: _compute_file_digests, _generate_manifest, _build_archive
+# T2: _compute_file_digests, _generate_manifest, _write_archive
 # ---------------------------------------------------------------------------
 
 
@@ -509,36 +509,42 @@ def test_generate_manifest_accepts_fixed_generated_at() -> None:
     assert json.loads(manifest_bytes)["generated_at"] == ts
 
 
-def test_build_archive_deterministic() -> None:
+def test_write_archive_deterministic(tmp_path: Path) -> None:
     file_bytes = {"packs/core/pack.toml": b"[pack]\nname='core'\nversion='0.1.0'\n"}
     manifest = b'{"schema": 1}'
-    a1 = _build_archive(file_bytes, manifest)
-    a2 = _build_archive(file_bytes, manifest)
-    assert hashlib.sha256(a1).digest() == hashlib.sha256(a2).digest()
+    d1 = tmp_path / "a1.tar.gz"
+    d2 = tmp_path / "a2.tar.gz"
+    _write_archive(file_bytes, manifest, d1)
+    _write_archive(file_bytes, manifest, d2)
+    assert hashlib.sha256(d1.read_bytes()).digest() == hashlib.sha256(d2.read_bytes()).digest()
 
 
-def test_build_archive_gzip_mtime_zero() -> None:
-    archive_bytes = _build_archive({"a.txt": b"hello"}, b"{}")
+def test_write_archive_gzip_mtime_zero(tmp_path: Path) -> None:
+    dest = tmp_path / "out.tar.gz"
+    _write_archive({"a.txt": b"hello"}, b"{}", dest)
+    archive_bytes = dest.read_bytes()
     # gzip header bytes 4-7 are the modification time field
     assert archive_bytes[4:8] == b"\x00\x00\x00\x00"
 
 
-def test_build_archive_members_sorted() -> None:
+def test_write_archive_members_sorted(tmp_path: Path) -> None:
     file_bytes = {
         "z/last.txt": b"last",
         "a/first.txt": b"first",
         "m/middle.txt": b"middle",
     }
-    archive_bytes = _build_archive(file_bytes, b"{}")
-    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
+    dest = tmp_path / "out.tar.gz"
+    _write_archive(file_bytes, b"{}", dest)
+    with tarfile.open(fileobj=io.BytesIO(dest.read_bytes()), mode="r:gz") as tf:
         names = tf.getnames()
     # catalogue-manifest.json sorts between 'a' and 'd' ('c' = 0x63)
     assert names == sorted(names)
 
 
-def test_build_archive_member_metadata_files() -> None:
-    archive_bytes = _build_archive({"test.txt": b"data"}, b"{}")
-    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
+def test_write_archive_member_metadata_files(tmp_path: Path) -> None:
+    dest = tmp_path / "out.tar.gz"
+    _write_archive({"test.txt": b"data"}, b"{}", dest)
+    with tarfile.open(fileobj=io.BytesIO(dest.read_bytes()), mode="r:gz") as tf:
         for member in tf.getmembers():
             assert member.uid == 0
             assert member.gid == 0
@@ -546,31 +552,32 @@ def test_build_archive_member_metadata_files() -> None:
             assert member.mode == 0o644
 
 
-def test_build_archive_contains_manifest() -> None:
+def test_write_archive_contains_manifest(tmp_path: Path) -> None:
     manifest_content = b'{"schema": 1, "bundle": "test"}'
-    archive_bytes = _build_archive({}, manifest_content)
-    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tf:
+    dest = tmp_path / "out.tar.gz"
+    _write_archive({}, manifest_content, dest)
+    with tarfile.open(fileobj=io.BytesIO(dest.read_bytes()), mode="r:gz") as tf:
         names = tf.getnames()
         assert "catalogue-manifest.json" in names
         f = tf.extractfile("catalogue-manifest.json")
         assert f is not None
         data = json.loads(f.read())
-        assert data["schema"] == 1  # build_archive stores bytes as-is; schema in bytes is 1
+        assert data["schema"] == 1  # _write_archive stores bytes as-is; schema in bytes is 1
 
 
-def test_build_archive_rejects_traversal_member_name() -> None:
+def test_write_archive_rejects_traversal_member_name(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsafe"):
-        _build_archive({"../evil": b"x"}, b"{}")
+        _write_archive({"../evil": b"x"}, b"{}", tmp_path / "out.tar.gz")
 
 
-def test_build_archive_rejects_absolute_member_name() -> None:
+def test_write_archive_rejects_absolute_member_name(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsafe"):
-        _build_archive({"/etc/passwd": b"x"}, b"{}")
+        _write_archive({"/etc/passwd": b"x"}, b"{}", tmp_path / "out.tar.gz")
 
 
-def test_build_archive_rejects_drive_letter_member_name() -> None:
+def test_write_archive_rejects_drive_letter_member_name(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsafe"):
-        _build_archive({"C:evil": b"x"}, b"{}")
+        _write_archive({"C:evil": b"x"}, b"{}", tmp_path / "out.tar.gz")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_build_archive` renamed to `_write_archive(file_bytes, manifest_bytes, dest: Path) -> None`; writes the compressed archive directly to the staged file on disk instead of accumulating into an `io.BytesIO` buffer
- SHA-256 computed over the compressed staged file (`staged_archive.read_bytes()`) rather than the in-memory uncompressed buffer — reads the compressed bytes, which are substantially smaller
- All determinism guarantees preserved: sorted members, normalised metadata (`uid=0 gid=0 mtime=0 mode=0o644`), zeroed gzip FNAME and mtime header fields, `GNU_FORMAT`

## Test plan

- [ ] All existing packaging, round-trip, and determinism tests pass (`test_catalogue_tooling_package.py`, `test_package_catalogue.py`)
- [ ] New test `test_write_archive_does_not_use_BytesIO_for_main_buffer` verifies `io.BytesIO()` is not called with no args (top-level buffer eliminated)
- [ ] Determinism test writes two archives to different paths — guards the `filename=""` fix that keeps FNAME header bytes stable regardless of output path

## Deferred

- Streaming SHA-256 computation over the file in chunks (rather than `read_bytes()`): out of scope for this PR; a future contributor can stream the hash if needed.

## Bundled fixes

- `commands/package_catalogue.py` compat shim: swapped `_build_archive` re-export for `_write_archive`
- `test_package_catalogue.py`: renamed `test_build_archive_*` functions to `test_write_archive_*` to match the operative symbol