### PR TITLE
fix(tools): wrap long line in lint-pack-journeys

### DIFF
--- a/tools/lint-pack-journeys.py
+++ b/tools/lint-pack-journeys.py
@@ -116,7 +116,10 @@ def _check_stages(body: str) -> list[str]:
             findings.append(f"stage {heading!r}: missing **Output:** label")
 
         if "State" not in label_values:
-            findings.append(f"stage {heading!r}: missing **State:** label (required in pack-local JOURNEY.md stages)")
+            findings.append(
+                f"stage {heading!r}: missing **State:** label"
+                " (required in pack-local JOURNEY.md stages)"
+            )
 
         state_val = label_values.get("State")
         if state_val is not None:


### PR DESCRIPTION
## Summary

- Wraps the E501 line-too-long ruff error at `tools/lint-pack-journeys.py:119` using implicit string concatenation
- No logic change — string content is identical at runtime
- `python3 tools/lint-ruff.py` confirms clean