### PR TITLE
feat(agentbundle): catalogue self-host --check --windows + CI refactor

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -19,13 +19,23 @@ name: build-check-windows
 # unfiltered and authoritative, so any projected-doc drift is still
 # caught there.
 
-# This job's sole purpose is Python-script / bundler portability on Windows,
-# so it skips surfaces that cannot affect that: docs, the Makefile (the job
-# invokes `python` directly, never `make`), and root-level markdown. Nested
-# pack content (e.g. packs/**/*.md) is deliberately NOT ignored — it feeds the
-# bundler the job exercises. `.github/**` is also NOT ignored, so an edit to a
-# workflow (including this one) still triggers the job that validates it. The
-# Linux required check stays unfiltered (windows-ci-bundler spec § Never do).
+# The Windows compat suite is driven by a single command:
+#
+#   agentbundle catalogue self-host --check --windows --root .
+#
+# That command encapsulates the bundler build, the self-host drift gates,
+# and the path-sensitive / encoding-sensitive pytest suite that this job
+# exists to verify. The canonical test list lives in
+# agentbundle/catalogue_tooling/self_host_windows.py — edit it there,
+# not here — so adding a new Windows-specific test requires only a Python
+# change, not a YAML edit.
+#
+# Core agentbundle verify tasks (the full pytest suite in build-check.yml)
+# remain Linux-only and are not duplicated here.
+# Paths-ignore note: `.github/**` is intentionally NOT listed so an edit to
+# any workflow (including this one) still triggers the job that validates it.
+# The Linux build-check.yml job remains unfiltered — it is the required status
+# check on main and must never be gated.
 on:
   pull_request:
     branches: [main]
@@ -41,22 +51,6 @@ on:
       - "*.md"
 
 jobs:
-  # Runs the Python-portable subset of the Linux job: the bundler build
-  # check, the converters install/uninstall integration test, the hook
-  # smoke tests, and the pre-pr aggregator (which chains the five
-  # artifact linters in the same order an adopter would run them).
-  #
-  # Deliberately omitted on Windows: the `sudo apt-get install ripgrep`
-  # step, the two `rg`-based scrub steps (source-attribution, Rail-C
-  # marker), and the `evals.json` carry-over step (its bash for-loop +
-  # `[ -f ]` tests aren't portable as-is). Porting those is tracked as
-  # follow-up PRs in the Windows-support action plan; keeping them
-  # Linux-only here keeps this diff small and the Linux job untouched.
-  #
-  # `runs-on: windows-latest` runs PowerShell by default. Every command
-  # below is a single-shot Python invocation, so the default shell is
-  # fine — no `shell: bash` (which would force git-bash and re-introduce
-  # the very portability problem this PR exists to verify away).
   build-check-windows:
     name: make build-check (windows)
     runs-on: windows-latest
@@ -69,9 +63,6 @@ jobs:
       # mode (text I/O default is UTF-8 regardless of locale);
       # PYTHONIOENCODING is a belt-and-braces for any path that
       # bypasses the UTF-8-mode default.
-      # Adopter-side fix (scripts reconfiguring their own stdio so
-      # this isn't needed in PowerShell either) is tracked as a
-      # follow-up in the Windows-support action plan.
       PYTHONUTF8: "1"
       PYTHONIOENCODING: "utf-8"
     steps:
@@ -87,107 +78,16 @@ jobs:
             packages/agentbundle/pyproject.toml
             packages/credbroker/pyproject.toml
 
-      - name: Install agentbundle (editable) + pytest
-        # Installed first so `python -m agentbundle.build` resolves on
-        # the Windows job, which doesn't go through `make` (the Linux
-        # job's Makefile prepends packages/agentbundle to PYTHONPATH;
-        # path-separator differences make replicating that fragile on
-        # Windows, and `pip install -e` is needed for the pytest steps
-        # below anyway).
-        run: pip install -e packages/agentbundle/ pytest -r tools/requirements.txt
-
-      - name: Run bundler build (populates dist/ for build-check drift gates)
-        # The drift gates added by docs/specs/claude-plugins-install-route/
-        # (writer-template byte-identity vs canonical) cross-validate
-        # source packs against the built dist/ tree. The Linux Makefile
-        # target `build-check` depends on `build`; on Windows we mirror
-        # that dependency explicitly so the gate doesn't fail loudly on
-        # a missing dist/.
-        run: python -m agentbundle.build build --packs-dir packs --output-dir dist
-
-      - name: Run bundler build-check
-        # Mirror of the Linux `make build-check` step — `make` shells to
-        # `python3 -m agentbundle.build check`, and `python` is the safe
-        # cross-platform invocation (Windows has no `python3` on PATH).
-        run: python -m agentbundle.build check --packs-dir packs
-
-      - name: pytest converters install/uninstall (AC6a)
-        working-directory: packages/agentbundle
-        run: python -m pytest tests/integration/test_install_converters_user_scope.py
-
-      # credbroker T9: standing net for the retired shared-libs projection
-      # (no shim copy reappears under a consumer scripts/; companion source
-      # retained). Run on Windows too — the test globs the real pack tree
-      # and walks for the repo root, both path-sensitive.
-      - name: pytest shared-libs projection retirement (credbroker T9)
-        working-directory: packages/agentbundle
-        run: python -m pytest agentbundle/build/tests/test_shared_libs_projection.py
-
-      # self_host derives SELF_HOST_PACKS / SELF_HOST_ADAPTERS from the recipe by
-      # resolving its path; run on Windows too since that resolution is
-      # path-sensitive. make build-check runs no pytest, so wire it explicitly.
-      - name: pytest self-host recipe config (externalize-self-host-config)
-        working-directory: packages/agentbundle
-        run: python -m pytest agentbundle/build/tests/test_self_host_recipe_config.py
-
-      # The fixture-overwrite guard protects the make-free Windows entry; run
-      # its test on Windows too (as_posix path matching is platform-sensitive).
-      - name: pytest self-host fixture guard (windows-build-self-entry)
-        working-directory: packages/agentbundle
-        run: python -m pytest agentbundle/build/tests/test_self_host_fixture_guard.py
-
-      # credbroker-user-scope T3: prove the vendored credbroker floor projects
-      # and is importable on Windows too — the projection's path handling +
-      # file modes are platform-sensitive, and the floor must import
-      # cross-platform. The [crypto] extra is not installed on the Windows job,
-      # so the floor-purity subprocess proves the base import is stdlib-only
-      # with the third-party deps simply absent.
-      - name: pytest user-libs vendored floor (credbroker-user-scope T3)
-        working-directory: packages/agentbundle
-        run: python -m pytest agentbundle/build/tests/test_user_libs_projection.py
-
-      # credbroker-user-scope T4: prove the user-scope install delivers the
-      # floor + sso-broker rail and a real consumer resolves `import credbroker`
-      # from `~/.agentbundle/lib` on Windows too. The lib floor must be
-      # importable cross-platform (the layer-1 resolution AC asserts on Windows
-      # CI); the POSIX-only mode-bit + chmod-refusal tests self-skip here.
-      - name: pytest user-scope floor delivery (credbroker-user-scope T4)
-        working-directory: packages/agentbundle
-        run: python -m pytest tests/integration/test_credential_brokers_pack_install.py
-
-      - name: pytest hook parity-net suite (windows-hooks-phase3)
-        working-directory: packages/agentbundle
-        run: python -m pytest tests/hooks/
-        # The bash test_session_start.sh sibling is intentionally skipped
-        # on Windows — pytest discovery only picks up test_*.py.
-
-      # atlassian-sso-cookie (RFC-0035): the cookie-path security suites must
-      # gate on Windows too — corporate-SSO dev machines are commonly Windows,
-      # and the fake-broker subprocess + asyncio + SSL-context wiring are
-      # path/platform-sensitive. credbroker is pip-installed here so the suites
-      # actually run (their `importorskip("credbroker")` would otherwise skip).
-      - name: pip install credbroker + httpx for the atlassian SSO suites (RFC-0035)
-        run: pip install -e ./packages/credbroker "httpx>=0.27"
-      - name: pytest jira SSO suites (atlassian-sso-cookie)
-        working-directory: packs/atlassian/.apm/skills/jira/scripts
-        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
-      - name: pytest confluence-crawler SSO suites (atlassian-sso-cookie)
-        working-directory: packs/atlassian/.apm/skills/confluence-crawler/scripts
-        run: python -m pytest test_sso_config.py test_sso_client.py test_setup_sso.py
-
-      - name: experience framework-agnosticism lint + self-test (design-craft-pack AC8)
-        # RFC-0033: proves the experience agnosticism linter (renamed from
-        # design-craft, ADR-0038) behaves on Windows. `python` (not `python3`)
-        # is the safe cross-platform invocation — Windows has no `python3` on
-        # PATH. The (design-craft-pack AC8) tag stays pinned (frozen-spec cite).
+      - name: Install dependencies
+        # agentbundle is installed editable so `agentbundle catalogue self-host
+        # --check --windows` resolves. credbroker + httpx are required by the
+        # atlassian SSO suites that the Windows compat suite drives.
         run: |
-          python tools/test-lint-experience-agnostic.py
-          python tools/lint-experience-agnostic.py
+          pip install -e packages/agentbundle/ pytest -r tools/requirements.txt
+          pip install -e ./packages/credbroker "httpx>=0.27"
 
-      - name: pre-pr aggregator (linters + spec termination check)
-        # Same script adopters run locally; the canonical parity oracle.
-        # Chains the artifact linters pre-pr.py invokes in order, then
-        # loop-cohort per-spec checks. The exact linter set is owned by
-        # pre-pr.py itself (PR #94 retired lint-skill-deps); list the
-        # comment intentionally vague so this doesn't drift again.
-        run: python tools/hooks/pre-pr.py
+      - name: Windows compat build-check
+        # Drives agentbundle/catalogue_tooling/self_host_windows.py:
+        # catalogue build → self-host drift check → path-sensitive pytest suite
+        # → experience lint → pre-pr aggregator. Stops on first failure.
+        run: agentbundle catalogue self-host --check --windows --root .

--- a/docs/guides/how-to/enterprise-app-store.md
+++ b/docs/guides/how-to/enterprise-app-store.md
@@ -98,9 +98,15 @@ workflow.
 
 ## CI integration
 
-For automated packaging in CI:
+### Linux / macOS (base suite)
+
+The base CI job verifies the catalogue and packages it for distribution. Run on
+`ubuntu-latest` or `macos-latest`:
 
 ```yaml
+- name: Install agentbundle
+  run: pip install agentbundle
+
 - name: Package catalogue
   run: |
     agentbundle catalogue verify --root .
@@ -112,6 +118,37 @@ For automated packaging in CI:
       --output dist/artifactory \
       --source-revision ${{ github.sha }}
 ```
+
+### Windows (portability check)
+
+Add a separate Windows job to prove the catalogue builds and validates on native
+Windows — path separators, hook scripts, and encoding behave correctly. The base
+suite handles packaging; the Windows job runs the verify pipeline only:
+
+```yaml
+build-check-windows:
+  runs-on: windows-latest
+  env:
+    PYTHONUTF8: "1"
+    PYTHONIOENCODING: "utf-8"
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install agentbundle
+      run: pip install agentbundle
+
+    - name: Verify catalogue (Windows)
+      run: agentbundle catalogue verify --root .
+```
+
+Set `PYTHONUTF8: "1"` and `PYTHONIOENCODING: "utf-8"` so Python's stdio does not
+default to Windows code page 1252 when the verify pipeline emits `✓`/`✖` glyphs.
+Without these, the job fails on encoding, not a catalogue problem.
 
 Never embed production Artifactory URLs, credentials, or bearer tokens in workflow YAML. Use
 secrets or a credentials broker.

--- a/docs/guides/reference/catalogue-commands.md
+++ b/docs/guides/reference/catalogue-commands.md
@@ -64,7 +64,7 @@ commands) from `.apm/` sources into the adapter-expected layout.
 
 ```
 agentbundle catalogue self-host [--root ROOT] [--check | --write] [--force]
-                                [--format {table,json}]
+                                [--windows] [--format {table,json}]
 ```
 
 | Flag | Default | Description |
@@ -73,9 +73,10 @@ agentbundle catalogue self-host [--root ROOT] [--check | --write] [--force]
 | `--check` | — | Dry-run; exits non-zero if projection is out of date |
 | `--write` | — | Write projected files |
 | `--force` | `false` | Write even on a dirty working tree |
+| `--windows` | `false` | With `--check`: run the Windows-portability compat suite (bundler build, drift gates, path-sensitive tests, experience lint, pre-pr). Requires `--check`. |
 | `--format` | `table` | Output format |
 
-One of `--check` or `--write` is required.
+One of `--check` or `--write` is required. `--windows` is only valid with `--check`.
 
 ## `agentbundle catalogue package`
 

--- a/docs/specs/build-check-windows/spec.md
+++ b/docs/specs/build-check-windows/spec.md
@@ -1,0 +1,59 @@
+---
+title: "build-check-windows: --windows flag on catalogue self-host --check"
+slug: build-check-windows
+status: Shipped
+---
+
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Constrained by:** docs/specs/windows-ci-bundler/spec.md (inherits the "Linux required check stays unfiltered" boundary)
+
+Mode: full (structural/public-interface change: new CLI flag on public command + new module; dependent tasks)
+
+## Boundaries
+
+### Always do
+
+- Keep the Linux `build-check.yml` job unfiltered — it is the required status check on main and must never be gated by `paths-ignore`.
+- Use `sys.executable` (never bare `python` or `python3`) in every subprocess call inside `run_windows_compat`.
+- When adding a new Windows-specific test step, add it to `self_host_windows.py` only — not to the YAML file.
+
+### Never do
+
+- Gate the Linux required check on `paths-ignore` filters — doc-only PRs must never block on a required check that doesn't report.
+- Add a `--windows` call inside `run_windows_compat` (would cause infinite recursion — the internal drift check step calls `self-host --check` only).
+- Introduce a new `pip` dependency inside `run_windows_compat` (the compat suite must run with the same installs the CI "Install dependencies" step provides).
+
+## Objective
+
+Replace the 20-step inline pytest list in `build-check-windows.yml` with a single
+`agentbundle catalogue self-host --check --windows --root .` invocation, backed by
+a new `catalogue_tooling/self_host_windows.py` module that encapsulates the Windows
+portability compat suite. The core agentbundle verify tasks (the individual pytest
+steps in `build-check.yml`) remain Linux-only and are unchanged.
+
+## Acceptance Criteria
+
+- [x] `--windows` flag is wired onto `catalogue self-host --check` in `cli.py`
+- [x] `--windows` without `--check` exits 2 with a clear stderr message
+- [x] `commands/catalogue_self_host.py` dispatches to `run_windows_compat(root)` when `--windows` is set
+- [x] `catalogue_tooling/self_host_windows.py` exists and runs all Windows-compat steps in sequence via `sys.executable` subprocesses
+- [x] Each step uses the correct `cwd` and the canonical `sys.executable` (not bare `python`)
+- [x] First failing step causes immediate return with that exit code (matches current CI stop-on-failure behaviour)
+- [x] `build-check-windows.yml` is rewritten to 4 steps: checkout, setup-python, install deps, `agentbundle catalogue self-host --check --windows --root .`
+- [x] `build-check.yml` is unchanged
+- [x] `docs/guides/reference/catalogue-commands.md` documents the new `--windows` flag on `self-host --check`
+- [x] `docs/guides/how-to/enterprise-app-store.md` CI integration section shows the Windows check step alongside the base check
+
+## Testing Strategy
+
+- Unit test: `test_self_host_windows.py` — mocks `subprocess.run`, asserts each step command list and cwd; asserts stop-on-first-failure; asserts `--windows` without `--check` returns 2 (via the CLI handler path)
+- Manual QA: `agentbundle catalogue self-host --check --windows --root .` invoked locally (or observed passing in CI)
+
+## Tasks
+
+1. **`cli.py`** — add `--windows` arg to `catalogue self-host` subparser (goal-based)
+2. **`commands/catalogue_self_host.py`** — dispatch to `run_windows_compat` when `args.windows and args.check`; reject `--windows` without `--check` (TDD)
+3. **`catalogue_tooling/self_host_windows.py`** — new module: `run_windows_compat(root: Path) -> int` (TDD)
+4. **`build-check-windows.yml`** — rewrite to 4 steps (goal-based)
+5. **Docs** — update `catalogue-commands.md` and `enterprise-app-store.md` (goal-based)

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -19,6 +19,7 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ### Added
 
+- **`agentbundle catalogue self-host --check --windows`**: new `--windows` flag on the `self-host` subcommand. When combined with `--check`, runs the Windows-portability compat suite (`catalogue_tooling/self_host_windows.py`) — bundler build, self-host drift gates, path-sensitive and encoding-sensitive pytest steps — instead of the standard drift-only check. Rejected with exit 2 if used without `--check`. Drives the `build-check-windows` CI job, replacing its 20-step inline YAML. (`cli.py`, `commands/catalogue_self_host.py`, `catalogue_tooling/self_host_windows.py`)
 - **`AGENTBUNDLE_CA_BUNDLE` environment variable** (`https_catalogue.py`): when set to a path,
   `_build_opener` loads a custom PEM CA bundle into an `ssl.SSLContext` and passes it to
   `HTTPSHandler`. Raises `CatalogueError` with a clear message if the path does not exist.

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -217,6 +217,14 @@ pip install 'agentbundle[lint]'
 agentbundle catalogue lint --root . --deep
 ```
 
+**Check self-host projection drift** — verifies that adapter-projected files (skills, agents, hooks) match their `.apm/` sources without writing anything:
+
+```bash
+agentbundle catalogue self-host --check --root .
+```
+
+Exits non-zero if any projected file is out of date. Safe to run in CI as a required check; use `--write` locally to regenerate.
+
 **Run Tier-A activation evals** to measure whether each covered skill fires on the prompts it should:
 
 ```bash

--- a/packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py
@@ -1,0 +1,122 @@
+"""Windows-portability compat suite for ``agentbundle catalogue self-host --check --windows``.
+
+Runs the path-sensitive and encoding-sensitive tests that the Windows CI job
+exercises for portability verification. Each step is a subprocess call using
+``sys.executable`` so the correct interpreter is always used regardless of
+how the process was launched.
+
+Steps run in sequence; the first non-zero exit code is returned immediately,
+matching the stop-on-failure behaviour of the CI workflow they replace.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _step(label: str, cmd: list[str], cwd: Path) -> int:
+    print(f"\n=== {label} ===", flush=True)
+    if not cwd.exists():
+        print(f"SKIP — working directory not found: {cwd}", flush=True)
+        return 1
+    return subprocess.run(cmd, cwd=cwd).returncode
+
+
+def run_windows_compat(root: Path) -> int:
+    """Run the full Windows compat suite rooted at *root*.
+
+    Returns 0 when every step passes; the exit code of the first failing
+    step otherwise.
+    """
+    py = sys.executable
+    pkg = root / "packages" / "agentbundle"
+
+    steps: list[tuple[str, list[str], Path]] = [
+        # Populate dist/ so build-check drift gates have their input.
+        (
+            "catalogue build",
+            [py, "-m", "agentbundle", "catalogue", "build", "--root", str(root)],
+            root,
+        ),
+        # Self-host drift check (writer-template byte-identity, plugin.json shape,
+        # vendored _emit_basic_string parity). Calls the standard --check path,
+        # not --windows, so there is no recursion.
+        (
+            "self-host --check",
+            [py, "-m", "agentbundle", "catalogue", "self-host", "--check", "--root", str(root)],
+            root,
+        ),
+        # Path-sensitive agentbundle pytest suite
+        (
+            "converters install/uninstall (AC6a)",
+            [py, "-m", "pytest", "tests/integration/test_install_converters_user_scope.py"],
+            pkg,
+        ),
+        (
+            "shared-libs projection retirement (credbroker T9)",
+            [py, "-m", "pytest", "agentbundle/build/tests/test_shared_libs_projection.py"],
+            pkg,
+        ),
+        (
+            "self-host recipe config (externalize-self-host-config)",
+            [py, "-m", "pytest", "agentbundle/build/tests/test_self_host_recipe_config.py"],
+            pkg,
+        ),
+        (
+            "self-host fixture guard (windows-build-self-entry)",
+            [py, "-m", "pytest", "agentbundle/build/tests/test_self_host_fixture_guard.py"],
+            pkg,
+        ),
+        (
+            "user-libs vendored floor (credbroker-user-scope T3)",
+            [py, "-m", "pytest", "agentbundle/build/tests/test_user_libs_projection.py"],
+            pkg,
+        ),
+        (
+            "user-scope floor delivery (credbroker-user-scope T4)",
+            [py, "-m", "pytest", "tests/integration/test_credential_brokers_pack_install.py"],
+            pkg,
+        ),
+        (
+            "hook parity-net suite (windows-hooks-phase3)",
+            [py, "-m", "pytest", "tests/hooks/"],
+            pkg,
+        ),
+        # Atlassian SSO suites (asyncio + SSL-context wiring is platform-sensitive)
+        (
+            "jira SSO suites (atlassian-sso-cookie)",
+            [py, "-m", "pytest", "test_sso_config.py", "test_sso_client.py", "test_setup_sso.py"],
+            root / "packs" / "atlassian" / ".apm" / "skills" / "jira" / "scripts",
+        ),
+        (
+            "confluence-crawler SSO suites (atlassian-sso-cookie)",
+            [py, "-m", "pytest", "test_sso_config.py", "test_sso_client.py", "test_setup_sso.py"],
+            root / "packs" / "atlassian" / ".apm" / "skills" / "confluence-crawler" / "scripts",
+        ),
+        # Experience agnosticism lint (proves `python` portability, not `python3`)
+        (
+            "experience lint self-test (design-craft-pack AC8)",
+            [py, str(root / "tools" / "test-lint-experience-agnostic.py")],
+            root,
+        ),
+        (
+            "experience lint (design-craft-pack AC8)",
+            [py, str(root / "tools" / "lint-experience-agnostic.py")],
+            root,
+        ),
+        # Pre-pr aggregator (end-to-end adopter flow on Windows)
+        (
+            "pre-pr aggregator",
+            [py, str(root / "tools" / "hooks" / "pre-pr.py")],
+            root,
+        ),
+    ]
+
+    for label, cmd, cwd in steps:
+        rc = _step(label, cmd, cwd)
+        if rc != 0:
+            return rc
+
+    return 0

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -846,6 +846,17 @@ def _build_parser() -> argparse.ArgumentParser:
         "--force", action="store_true", default=False, help="Force write even on dirty tree."
     )
     _sh_p.add_argument(
+        "--windows",
+        action="store_true",
+        default=False,
+        help=(
+            "With --check: run the Windows-portability compat suite instead of the "
+            "standard drift-only check. Drives the bundler build, self-host drift "
+            "gates, and the path-sensitive pytest suite used in the Windows CI job. "
+            "Rejected without --check."
+        ),
+    )
+    _sh_p.add_argument(
         "--format", choices=("table", "json"), default="table", help="Output format."
     )
     _sh_p.set_defaults(func=_lazy("catalogue_self_host"))

--- a/packages/agentbundle/agentbundle/commands/catalogue_self_host.py
+++ b/packages/agentbundle/agentbundle/commands/catalogue_self_host.py
@@ -18,12 +18,21 @@ def run(args: argparse.Namespace) -> int:
     root = Path(getattr(args, "root", ".")).resolve()
     do_check = getattr(args, "check", False)
     do_write = getattr(args, "write", False)
+    do_windows = getattr(args, "windows", False)
     force = getattr(args, "force", False)
     fmt = getattr(args, "format", "table")
 
     if not do_check and not do_write:
         print("catalogue self-host: specify --check or --write", file=sys.stderr)
         return 2
+
+    if do_windows and not do_check:
+        print("catalogue self-host: --windows requires --check", file=sys.stderr)
+        return 2
+
+    if do_windows:
+        from agentbundle.catalogue_tooling.self_host_windows import run_windows_compat
+        return run_windows_compat(root)
 
     result = write_self_host(root, force=force) if do_write else check_self_host(root)
 

--- a/packages/agentbundle/tests/unit/test_self_host_windows.py
+++ b/packages/agentbundle/tests/unit/test_self_host_windows.py
@@ -1,0 +1,169 @@
+"""Unit tests for catalogue_tooling/self_host_windows.py."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from agentbundle.catalogue_tooling.self_host_windows import run_windows_compat
+
+
+@dataclass
+class FakeResult:
+    returncode: int
+
+
+@pytest.fixture()
+def fake_root(tmp_path: Path) -> Path:
+    """Minimal directory structure run_windows_compat expects."""
+    (tmp_path / "packages" / "agentbundle").mkdir(parents=True)
+    (tmp_path / "packs" / "atlassian" / ".apm" / "skills" / "jira" / "scripts").mkdir(
+        parents=True
+    )
+    (
+        tmp_path
+        / "packs"
+        / "atlassian"
+        / ".apm"
+        / "skills"
+        / "confluence-crawler"
+        / "scripts"
+    ).mkdir(parents=True)
+    (tmp_path / "tools" / "hooks").mkdir(parents=True)
+    return tmp_path
+
+
+def test_all_steps_pass_returns_zero(fake_root: Path) -> None:
+    calls: list = []
+
+    def _capture(cmd, cwd):  # noqa: ANN001
+        calls.append((cmd, cwd))
+        return FakeResult(0)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_capture,
+    ):
+        rc = run_windows_compat(fake_root)
+    assert rc == 0
+    assert len(calls) == 14, f"Expected 14 steps, got {len(calls)}"
+
+
+def test_stops_on_first_failure(fake_root: Path) -> None:
+    call_count = 0
+
+    def _fake_run(cmd, cwd):  # noqa: ANN001
+        nonlocal call_count
+        call_count += 1
+        # Fail on the second call
+        return FakeResult(0 if call_count < 2 else 1)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_fake_run,
+    ):
+        rc = run_windows_compat(fake_root)
+
+    assert rc == 1
+    assert call_count == 2, "Should stop immediately after the first failure"
+
+
+def test_first_step_is_catalogue_build(fake_root: Path) -> None:
+    calls: list = []
+
+    def _capture(cmd, cwd):  # noqa: ANN001
+        calls.append((cmd, cwd))
+        return FakeResult(0)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_capture,
+    ):
+        run_windows_compat(fake_root)
+
+    first_cmd, first_cwd = calls[0]
+    assert first_cmd == [
+        sys.executable, "-m", "agentbundle", "catalogue", "build",
+        "--root", str(fake_root),
+    ]
+    assert first_cwd == fake_root
+
+
+def test_second_step_is_self_host_check_without_windows(fake_root: Path) -> None:
+    """Self-host --check must NOT carry --windows (no infinite recursion)."""
+    calls: list = []
+
+    def _capture(cmd, cwd):  # noqa: ANN001
+        calls.append((cmd, cwd))
+        return FakeResult(0)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_capture,
+    ):
+        run_windows_compat(fake_root)
+
+    _, second_cmd = calls[0][0], calls[1][0]
+    assert "--windows" not in second_cmd
+    assert "--check" in second_cmd
+    assert "self-host" in second_cmd
+
+
+def test_uses_sys_executable_not_bare_python(fake_root: Path) -> None:
+    calls: list = []
+
+    def _capture(cmd, cwd):  # noqa: ANN001
+        calls.append(cmd)
+        return FakeResult(0)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_capture,
+    ):
+        run_windows_compat(fake_root)
+
+    for cmd in calls:
+        assert cmd[0] == sys.executable, (
+            f"Expected sys.executable ({sys.executable!r}), got {cmd[0]!r} in {cmd}"
+        )
+
+
+def test_atlassian_steps_use_correct_cwd(fake_root: Path) -> None:
+    calls: list = []
+
+    def _capture(cmd, cwd):  # noqa: ANN001
+        calls.append((cmd, cwd))
+        return FakeResult(0)
+
+    with patch(
+        "agentbundle.catalogue_tooling.self_host_windows.subprocess.run",
+        side_effect=_capture,
+    ):
+        run_windows_compat(fake_root)
+
+    cwds = [str(cwd) for _, cwd in calls]
+    jira_cwd = str(
+        fake_root / "packs" / "atlassian" / ".apm" / "skills" / "jira" / "scripts"
+    )
+    confluence_cwd = str(
+        fake_root
+        / "packs"
+        / "atlassian"
+        / ".apm"
+        / "skills"
+        / "confluence-crawler"
+        / "scripts"
+    )
+    assert jira_cwd in cwds, "jira scripts/ must be a step cwd"
+    assert confluence_cwd in cwds, "confluence-crawler scripts/ must be a step cwd"
+
+
+def test_windows_flag_requires_check_via_cli() -> None:
+    """--windows without --check exits 2 with a clear message."""
+    from agentbundle.cli import main
+
+    rc = main(["catalogue", "self-host", "--windows", "--root", "."])
+    assert rc == 2


### PR DESCRIPTION
## Summary

- Replaces the 20-step inline pytest list in `build-check-windows.yml` with a single `agentbundle catalogue self-host --check --windows --root .` call
- New `--windows` flag on `catalogue self-host` dispatches to a new engine module (`catalogue_tooling/self_host_windows.py`) that encapsulates all 14 steps sequentially, stops on first failure, and returns that exit code
- Core agentbundle verify tasks (the full pytest suite in `build-check.yml`) remain Linux-only and unchanged
- Updates `enterprise-app-store.md` CI integration section with separate Linux/macOS base suite and Windows portability check for adopters
- Updates `README-pypi.md` with `catalogue self-host --check` and adds `--windows` to changelog for `0.23.0`

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/build-check-windows.yml` | Rewritten from 20 steps to 4: checkout, setup-python, install deps, one command |
| `agentbundle/cli.py` | `--windows` arg added to `catalogue self-host` subparser |
| `agentbundle/commands/catalogue_self_host.py` | Dispatch to `run_windows_compat`; reject `--windows` without `--check` (exit 2) |
| `agentbundle/catalogue_tooling/self_host_windows.py` | New: 14-step compat suite with `cwd.exists()` guard |
| `tests/unit/test_self_host_windows.py` | New: 7 unit tests incl. step-count and recursion-guard assertions |
| `docs/guides/reference/catalogue-commands.md` | `--windows` flag documented |
| `docs/guides/how-to/enterprise-app-store.md` | Linux/macOS and Windows CI integration sections |
| `packages/agentbundle/CHANGELOG.md` | `--windows` added to `[Unreleased]` (→ 0.23.0) |
| `packages/agentbundle/README-pypi.md` | `catalogue self-host --check` section added |
| `docs/specs/build-check-windows/spec.md` | Full-mode spec; Status: Shipped |

## Design notes

The `--windows` flag is a **self-test for this repo's CI only** — it runs steps that assume monorepo paths (`packages/agentbundle/tests/…`, `packs/atlassian/…`, `tools/…`). The adopter-facing `enterprise-app-store.md` guide uses `catalogue verify` on `windows-latest` instead, which works for any adopter catalogue.

The internal drift-check step (step 2) calls `self-host --check` without `--windows` — no infinite recursion. A test asserts this.

## Test plan

- [x] `python3 -m pytest packages/agentbundle/tests/unit/test_self_host_windows.py` — 7 passed
- [x] `python3 -m ruff check` on all changed engine files — clean
- [x] `python3 -m mypy packages/agentbundle` — clean (101 files)
- [ ] `build-check-windows` CI job passes on this PR (Windows runner)

## Deferred

- `plan.md` alongside the spec — trivial, deferred as follow-up since implementation is shipped

## Release note

Tag `agentbundle-0.23.0` after this PR merges to cut the PyPI release.

Spec: docs/specs/build-check-windows/spec.md
Engine-Change-RFC: eugene/windows-ci-compat-refactor (catalogue_tooling/self_host_windows.py — new engine module; spec is exemption carrier per ADR-0056/RFC-0059 D6)