### PR TITLE
ci(security): pin publication-sensitive workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install agentbundle (editable) + pytest
@@ -78,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -229,8 +229,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -321,8 +321,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -385,7 +385,7 @@ jobs:
           agentbundle list-packs
 
       - name: Upload archive artifact (for Gate E)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: catalogue-smoke-archive
           path: |
@@ -399,8 +399,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -411,7 +411,7 @@ jobs:
         run: mkdir -p /tmp/offline-repo
 
       - name: Download archive from Gate D
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: catalogue-smoke-archive
           path: /tmp/disconnected/
@@ -456,8 +456,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
       - name: Install agentbundle (editable) + pytest
@@ -473,10 +473,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
       - name: Run release impact check

--- a/.github/workflows/publish-catalogue.yml
+++ b/.github/workflows/publish-catalogue.yml
@@ -67,9 +67,9 @@ jobs:
       RELEASE: ${{ inputs.release }}
       CHANNEL: ${{ inputs.channel }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -146,7 +146,7 @@ jobs:
           PY
 
       - name: Upload catalogue-dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: catalogue-dist
           path: /tmp/catalogue-dist/
@@ -183,11 +183,11 @@ jobs:
           fi
 
       - if: steps.guard.outputs.configured == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - if: steps.guard.outputs.configured == 'true'
         name: Download catalogue-dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: catalogue-dist
           path: /tmp/catalogue-dist

--- a/.github/workflows/release-agentbundle.yml
+++ b/.github/workflows/release-agentbundle.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
@@ -96,7 +96,7 @@ jobs:
         run: PATH="/tmp/smokevenv/bin:$PATH" agentbundle --help
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: dist
           path: packages/agentbundle/dist/
@@ -115,9 +115,9 @@ jobs:
       matrix:
         python: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -301,12 +301,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9.0
         with:
           packages-dir: dist/
 
@@ -333,7 +333,7 @@ jobs:
           fi
 
       - if: steps.guard.outputs.configured == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

- Replaces all mutable `@v4` / `@v5` / `@release/v1` action tags with verified 40-char commit SHAs in all three publication-sensitive workflows.
- Every pinned line carries a `# vX.Y.Z` comment for human auditability.
- All SHAs resolved from the GitHub API during this session — none copied from memory.

## Files changed

| Workflow | Action | SHA | Comment |
|---|---|---|---|
| All three | `actions/checkout@v4` | `11d5960a…` | `# v4.4.0` |
| All three | `actions/setup-python@v5` | `a26af69b…` | `# v5.6.0` |
| All three | `actions/upload-artifact@v4` | `ea165f8d…` | `# v4.6.2` |
| All three | `actions/download-artifact@v4` | `d3f86a10…` | `# v4.3.0` |
| `release-agentbundle.yml` | `pypa/gh-action-pypi-publish@release/v1` | `ec4db0b4…` | `# v1.9.0` |

`pypa/gh-action-pypi-publish@release/v1` uses an annotated tag; the tag object SHA was dereferenced to the underlying commit SHA (`ec4db0b4…`).

## No other files changed

Source code, other workflow files, docs, and tests are untouched.

## Test plan

- [ ] Verify all `uses:` lines in the three files reference 40-char SHAs (no `@vN` tags remain)
- [ ] Confirm `release-agentbundle.yml` CI passes on a tag push dry-run
- [ ] Confirm `catalogue-tooling-ci-gates.yml` CI passes on PR/push to main
- [ ] Confirm `publish-catalogue.yml` CI passes on a `workflow_dispatch` dry run