### PR TITLE
docs(catalogue): add provider-neutral catalogue CI contract guide

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -9,6 +9,8 @@ Repo-local addendum for maintainers of this checkout. Shared agent instructions 
   [`packages/AGENTS.md`](packages/AGENTS.md).
 - **Release coupling** (PyPI release requirements, version bump workflow, tagging):
   [`packages/AGENTS.local.md`](packages/AGENTS.local.md).
+- **Catalogue CI** (portable commands, publication ordering, exit codes, responsibility boundary):
+  [`guides/_shared/reference/catalogue-ci-contract.md`](guides/_shared/reference/catalogue-ci-contract.md).
 
 **Read before modifying:** `packs/` → read [`packs/AGENTS.md`](packs/AGENTS.md) first — version bump rule requires both `pack.toml` + `.claude-plugin/plugin.json`. `packages/` → read [`packages/AGENTS.local.md`](packages/AGENTS.local.md) first — covers when a PyPI release is required.
 

--- a/docs/specs/catalogue-ci-contract-guide/plan.md
+++ b/docs/specs/catalogue-ci-contract-guide/plan.md
@@ -1,0 +1,353 @@
+# Plan: catalogue-ci-contract-guide
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Done <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+Write one new guide (`guides/_shared/reference/catalogue-ci-contract.md`), add
+three discovery hooks (README link, agentbundle.md paragraph, catalogue-format.md
+cross-reference), two link-only references in AGENTS.md files, and a contract
+test file that verifies the guide's claims against HEAD CLI behaviour. All tasks
+except T7 are documentation edits with goal-based or visual/manual QA; T7 is TDD
+against the existing fixture infrastructure.
+
+Order: T1 (guide) first so every cross-reference target exists before we add the
+links; T2–T6 (link placements) immediately after, each independent of each other
+but each depends on T1 being committed; T7 (tests) can run concurrently with T2–T6
+since it only reads the CLI, not the guide.
+
+## Constraints
+
+- `packs/AGENTS.md` cap is 150 lines (currently 142). T6 may add at most 1 line.
+- `AGENTS.local.md` cap is 250 lines (currently 174). T5 is unconstrained in practice.
+- Guide must be adopter-clean: no RFC/ADR/spec citations, no internal paths.
+- `catalogue package --format json` must NOT appear in the guide or tests.
+- `guides/_shared/reference/` is the correct location (Diátaxis: reference quadrant,
+  cross-pack catalogue tooling).
+
+## Construction tests (cross-cutting)
+
+T7 adds `packages/agentbundle/tests/unit/test_catalogue_ci_contract.py`. The
+existing `test_catalogue_tooling_foundation.py` has a helper that returns a
+valid fixture catalogue root; T7 imports it rather than duplicating fixture setup.
+The contract tests exercise the CLI via subprocess (same pattern as the foundation
+tests) to avoid mock-shape divergence from real CLI behaviour.
+
+Manual QA (T1): after writing the guide, run `agentbundle catalogue lint --root .
+--format json` and `agentbundle catalogue verify --root . --format json` against
+the working catalogue and confirm the JSON structure and exit codes match what the
+guide claims. Record stdout in the PR's *How to verify* section.
+
+## Design (LLD)
+
+No new code modules. The agentbundle CLI is unchanged. The test file follows the
+subprocess invocation pattern established in
+`packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py` lines 1–60.
+
+### Fixture catalogue for T7
+
+`test_catalogue_tooling_foundation.py` exposes a private constant `_REPO_ROOT`
+(line 487) — not a pytest fixture, and `_`-prefixed. T7 defines its own fixture:
+
+```python
+@pytest.fixture
+def working_catalogue_root():
+    return Path(__file__).resolve().parents[4]  # same derivation as _REPO_ROOT
+```
+
+For the "exits 1 on errors" branch, T7 creates a `tmp_path` directory with a
+`catalogue.toml` containing invalid TOML or missing required fields. The
+autouse `_isolate_user_config_dir` fixture in `conftest.py` redirects `HOME` and
+`XDG_CONFIG_HOME` to a sandbox; T7's subprocess calls inherit this env, which is
+harmless as long as every invocation passes `--root` explicitly.
+
+### Guide structure
+
+```
+# Catalogue CI contract
+(frontmatter)
+
+## Overview  ← one-paragraph orientation
+
+## Responsibility boundary  ← table: party / owns / never does
+
+## CI lifecycle phases
+### Phase 1: Tool acquisition
+### Phase 2: Change validation
+### Phase 3: Release packaging
+### Phase 4: Publication
+### Phase 5: Post-publication verification
+### Phase 6: Evidence retention
+
+## Exit codes  ← AC7 table
+
+## Secrets and network calls  ← AC9
+
+## Command reference
+### catalogue lint
+### catalogue verify
+### catalogue package
+
+## See also  ← AC10
+```
+
+## Tasks
+
+### T1: Write `guides/_shared/reference/catalogue-ci-contract.md`
+
+**Depends on:** none
+
+**Verification mode:** visual/manual QA
+
+**Touches:** `guides/_shared/reference/catalogue-ci-contract.md` (new)
+
+**Tests:**
+- No stub (visual/manual QA). After writing: run
+  `agentbundle catalogue lint --root . --format json` and confirm stdout parses as
+  JSON with `ok: true`; run `agentbundle catalogue verify --root . --format json`
+  and confirm same. Record both in the PR's *How to verify* block.
+- Confirm `agentbundle catalogue package --help` — verify `--format` flag does
+  NOT appear in help output, confirming the guide's omission is accurate.
+
+**Approach:**
+- Frontmatter: `title`, `summary`, `pack: _shared`, `kind: reference`, `status: stable`.
+- Write the responsibility-boundary table first — it is the load-bearing concept
+  every reader needs before any command detail.
+- Document each phase with portable, provider-neutral commands (no YAML blocks).
+- Exit codes section: 0/1/2 with the `catalogue package`-returns-1 note.
+- Secrets section: three bullets (AgentBundle CLI never reads secrets / never
+  issues network calls / TLS + credentials are Organization CI's responsibility).
+- Command reference: lint + verify with `--format json` JSON schema; package with
+  full flag list and output layout, explicit no-`--format json`.
+- See also: two links (agentbundle.md, catalogue-format.md).
+- No internal governance citations anywhere.
+
+**Done when:** file exists, frontmatter parses, manual QA run recorded, guide has
+all sections from AC1–AC10.
+
+---
+
+### T2: Update `guides/_shared/README.md` — Reference link
+
+**Depends on:** T1
+
+**Verification mode:** goal-based
+
+**Touches:** `guides/_shared/README.md`
+
+**Tests:**
+- `grep "catalogue-ci-contract" guides/_shared/README.md` exits 0.
+
+**Approach:**
+- Add one entry in the `## Reference` section:
+  `- [Catalogue CI contract](reference/catalogue-ci-contract.md) — ...`
+
+**Done when:** grep passes.
+
+---
+
+### T3: Update `guides/_shared/reference/agentbundle.md` — Catalogue CI paragraph
+
+**Depends on:** T1
+
+**Verification mode:** goal-based
+
+**Touches:** `guides/_shared/reference/agentbundle.md`
+
+**Tests:**
+- `grep "catalogue-ci-contract" guides/_shared/reference/agentbundle.md` exits 0.
+
+**Approach:**
+- Add a short `## Catalogue CI` section after the existing subcommand list
+  (before or after `## Preview before applying`) with 2–3 sentences explaining
+  that `catalogue lint`, `catalogue verify`, and `catalogue package` are the
+  portable CI commands, and point to the CI contract guide for the full pipeline
+  contract.
+
+**Done when:** grep passes; agentbundle.md still reads coherently end-to-end.
+
+---
+
+### T4: Update `guides/_reference/catalogue-format.md` — Validation cross-reference
+
+**Depends on:** T1
+
+**Verification mode:** goal-based
+
+**Touches:** `guides/_reference/catalogue-format.md`
+
+**Tests:**
+- `grep "catalogue-ci-contract" guides/_reference/catalogue-format.md` exits 0.
+
+**Approach:**
+- In the `## Validation` section, after the existing `agentbundle catalogue verify`
+  block, add one sentence: "For CI pipeline patterns using these commands, see the
+  [Catalogue CI contract](../_shared/reference/catalogue-ci-contract.md)."
+
+**Done when:** grep passes.
+
+---
+
+### T5: Update `AGENTS.local.md` — link-only CI reference
+
+**Depends on:** T1
+
+**Verification mode:** goal-based
+
+**Touches:** `AGENTS.local.md`
+
+**Tests:**
+- `grep "catalogue-ci-contract" AGENTS.local.md` exits 0.
+- `wc -l AGENTS.local.md | awk '{print $1}'` ≤ 250.
+
+**Approach:**
+- In the CI pipeline context section (or create a brief "Catalogue CI" bullet in
+  the cross-references at the top), add one line linking to the guide. No content
+  duplication — link only.
+
+**Done when:** grep passes; line count ≤ 250.
+
+---
+
+### T6: Update `packs/AGENTS.md` — link-only CI reference
+
+**Depends on:** T1
+
+**Verification mode:** goal-based
+
+**Touches:** `packs/AGENTS.md`
+
+**Tests:**
+- `grep "catalogue-ci-contract" packs/AGENTS.md` exits 0.
+- `wc -l packs/AGENTS.md | awk '{print $1}'` ≤ 150.
+
+**Approach:**
+- In the `## Primary workflow (any catalogue)` section, after the `make build-check`
+  block, add one sentence linking to the CI contract guide for CI pipeline
+  orchestration beyond the dev-loop commands.
+
+**Done when:** grep passes; line count ≤ 150.
+
+---
+
+### T7: Add command-contract tests
+
+**Depends on:** none
+
+**Verification mode:** TDD
+
+**Touches:** `packages/agentbundle/tests/unit/test_catalogue_ci_contract.py` (new)
+
+**Tests (these ARE the deliverable for this task):**
+
+```python
+import json, subprocess, sys
+from pathlib import Path
+import pytest
+
+@pytest.fixture
+def working_catalogue_root():
+    return Path(__file__).resolve().parents[4]  # repo root = catalogue root
+
+# AC16: lint --format json stdout parses as JSON with required keys
+def test_catalogue_lint_json_output_parses(working_catalogue_root):
+    result = subprocess.run(
+        [sys.executable, "-m", "agentbundle", "catalogue", "lint",
+         "--root", str(working_catalogue_root), "--format", "json"],
+        capture_output=True, text=True, encoding="utf-8"
+    )
+    doc = json.loads(result.stdout)  # raw stdout — no strip; proves AC18 too
+    for key in ("schema_version", "command", "ok", "diagnostics"):
+        assert key in doc
+
+# AC17: verify --format json stdout parses as JSON with required keys
+def test_catalogue_verify_json_output_parses(working_catalogue_root):
+    result = subprocess.run(
+        [sys.executable, "-m", "agentbundle", "catalogue", "verify",
+         "--root", str(working_catalogue_root), "--format", "json"],
+        capture_output=True, text=True, encoding="utf-8"
+    )
+    doc = json.loads(result.stdout)
+    for key in ("schema_version", "command", "ok", "diagnostics"):
+        assert key in doc
+
+# AC18: covered implicitly — json.loads on raw (unstripped) stdout
+
+# AC19a: clean catalogue → exit 0
+def test_catalogue_lint_exits_0_on_clean(working_catalogue_root): ...
+def test_catalogue_verify_exits_0_on_clean(working_catalogue_root): ...
+
+# AC19b: invalid catalogue → exit 1
+# Use tmp_path with a catalogue.toml that is missing required fields
+def test_catalogue_lint_exits_1_on_errors(tmp_path): ...
+def test_catalogue_verify_exits_1_on_errors(tmp_path): ...
+
+# AC20: package exit 0 + output layout
+# No --pack flag; supply required flags: --bundle, --release, --channel, --output
+def test_catalogue_package_exits_0_and_layout(working_catalogue_root, tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "agentbundle", "catalogue", "package",
+         "--root", str(working_catalogue_root),
+         "--bundle", "test-bundle",
+         "--release", "0.0.1-ci",
+         "--channel", "stable",
+         "--output", str(tmp_path)],
+        capture_output=True, text=True, encoding="utf-8"
+    )
+    assert result.returncode == 0
+    base = tmp_path / "catalogues" / "test-bundle" / "releases" / "0.0.1-ci"
+    assert (base / "catalogue-0.0.1-ci.tar.gz").exists()
+    assert (base / "catalogue-0.0.1-ci.tar.gz.sha256").exists()
+    assert (tmp_path / "catalogues" / "test-bundle" / "channels" / "stable.json").exists()
+
+# AC21: package exits 2 on missing required flags
+def test_catalogue_package_exits_2_on_missing_flags():
+    result = subprocess.run(
+        [sys.executable, "-m", "agentbundle", "catalogue", "package"],
+        capture_output=True, text=True, encoding="utf-8"
+    )
+    assert result.returncode == 2
+```
+
+**Approach:**
+- Define `working_catalogue_root` fixture inline (not imported from foundation).
+- For invalid-catalogue tests: write `[catalogue]\nname = "x"` to `tmp_path/catalogue.toml`
+  (missing `version`, `schema`, `packs/`) — lint should exit 1.
+- `_isolate_user_config_dir` autouse fixture in conftest.py sets sandbox `HOME`;
+  subprocess calls inherit this env; pass `--root` explicitly on every call so
+  no command silently reads user config from the sandbox.
+
+**Done when:** all six test functions pass under
+`python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_ci_contract.py -q`.
+
+---
+
+### T8: Gates
+
+**Depends on:** T1–T7
+
+**Verification mode:** goal-based
+
+**Touches:** nothing (read-only gates)
+
+**Tests:** none (this task IS the test run)
+
+**Approach:**
+```bash
+python3 tools/lint-ruff.py
+python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_ci_contract.py -q
+python3 -m pytest packages/agentbundle/tests/ -q   # regression check
+python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .
+```
+
+**Done when:** all four commands exit 0.
+
+## Changelog
+
+- 2026-07-28: Initial plan authored.

--- a/docs/specs/catalogue-ci-contract-guide/spec.md
+++ b/docs/specs/catalogue-ci-contract-guide/spec.md
@@ -1,0 +1,178 @@
+# Spec: catalogue-ci-contract-guide
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none
+- **Contract:** none
+- **Shape:** docs
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full (structural: new shipped guide in `guides/_shared/reference/`; public
+interface: documents stable exit-code + JSON contracts that adopters will rely on)
+
+## Objective
+
+Any organization wiring a CI pipeline for an AgentBundle catalogue — whether
+they use GitHub Actions, GitLab CI, Jenkins, or Buildkite — has a single
+canonical reference: `guides/_shared/reference/catalogue-ci-contract.md`. The
+guide defines the six CI lifecycle phases with portable commands, documents the
+responsibility boundary among three parties (AgentBundle CLI, Organization CI,
+Host Repository), specifies the stable exit-code and JSON-output contracts for
+each catalogue command, and makes publication ordering explicit. It is adopted
+clean: no internal RFC/ADR citations, no repo-specific paths.
+
+Three discovery hooks ensure adopters can find the guide from the surfaces they
+already read: the `_shared` guide index, the agentbundle CLI reference, and the
+catalogue-format reference. AGENTS.local.md and packs/AGENTS.md carry link-only
+references for agents working in this repo.
+
+Command-contract tests added alongside the guide verify that the documented
+exit codes and JSON output shapes match HEAD, so guide drift produces a CI
+failure rather than a silent lie.
+
+## Boundaries
+
+### Always do
+
+- Document commands against HEAD behaviour only — verify flags and exit codes
+  with `agentbundle catalogue <cmd> --help` and subprocess invocations before writing.
+- Keep the guide in the adopter-facing `guides/` tree; the AGENTS.md entries
+  must be link-only (no content duplication).
+- Maintain the packs/AGENTS.md line count ≤ 150 and AGENTS.local.md ≤ 250.
+
+### Ask first
+
+- Any new `catalogue` subcommand documentation (self-host, sync-defaults, archive
+  verify) beyond lint/verify/package — a separate spec owns that surface.
+- Promoting `docs/guides/how-to/create-external-catalogue.md` into the adopter
+  `guides/` tree — scoped to `spec/catalogue-ci-documentation`.
+
+### Never do
+
+- Document `--format json` for `catalogue package` — it is not supported in HEAD.
+- Include CI provider-specific YAML syntax — the contract is provider-neutral.
+- Cite RFC, ADR, or spec paths in shipped guide content.
+- Duplicate the exit-code table or command signatures in AGENTS.local.md or
+  packs/AGENTS.md — those files link to the guide, period.
+
+## Testing Strategy
+
+- **Guide content (AC1–AC10):** visual/manual QA. Read the guide end-to-end and
+  verify each documented command flag and exit code against `agentbundle catalogue
+  <cmd> --help` output (goal-based check). The full "happy path" verification:
+  run `agentbundle catalogue lint --root . --format json` and
+  `agentbundle catalogue verify --root . --format json` against the working
+  catalogue, confirm JSON parses and `ok` is true, record stdout + exit code in
+  the implementing PR's *How to verify* section.
+- **Discovery links (AC11–AC15):** goal-based. `grep` confirms the link is present
+  in each target file; `wc -l` confirms no file exceeds its cap.
+- **Command contract (AC16–AC21):** TDD. Subprocess invocations of the CLI against
+  a fixture catalogue (T7 defines its own `working_catalogue_root` fixture — the
+  module-level `_REPO_ROOT` in `test_catalogue_tooling_foundation.py` is private and
+  not a pytest fixture). Assert JSON parseability, stdout-only JSON (no mixed output),
+  exit codes 0/1 on clean/errors, package exit 0 with output layout, and package
+  exit 2 on missing required flags.
+
+## Acceptance Criteria
+
+**Guide content**
+
+- [x] AC1: Guide exists at `guides/_shared/reference/catalogue-ci-contract.md`
+  with frontmatter `title`, `summary`, `pack: _shared`, `kind: reference`,
+  `status: stable`.
+- [x] AC2: Guide documents the responsibility boundary for three parties:
+  *AgentBundle CLI* (owns lint/verify/package correctness, stable JSON + exit-code
+  contracts, never reads secrets or issues network calls); *Organization CI* (owns
+  secrets, network credentials, upload mechanics, publication serialization,
+  rollback policy, artifact retention); *Host Repository* (owns workflow files,
+  trigger config, internal governance).
+- [x] AC3: Guide documents all six CI lifecycle phases in order: (1) tool
+  acquisition, (2) change validation, (3) release packaging, (4) publication,
+  (5) post-publication verification, (6) evidence retention — each with the
+  portable command(s) or responsibilities for that phase.
+- [x] AC4: Guide documents `agentbundle catalogue lint --root . --format json`:
+  stdout is a JSON object with keys `schema_version`, `command`, `operation`,
+  `agentbundle_version`, `catalogue_schema_version`, `ok`, `diagnostics`; human
+  output goes to stderr; exits 0 if all checks pass, 1 if any error is emitted.
+- [x] AC5: Guide documents `agentbundle catalogue verify --root . --format json`
+  with the same JSON schema as lint; exits 0 on clean, 1 on any failure.
+- [x] AC6: Guide documents `agentbundle catalogue package` with the four required
+  flags (`--bundle`, `--release`, `--channel`, `--output`) and the optional flags
+  (`--root` defaults to `.`; `--source-revision`; `--minimum-agentbundle-version`;
+  `--published-at`) — without `--format json` (not supported). Documents the output
+  layout: `<output>/catalogues/<bundle>/releases/<release>/catalogue-<release>.tar.gz`,
+  `.sha256` sidecar, `channels/<channel>.json` descriptor.
+- [x] AC7: Guide documents exit codes: 0 success, 1 validation/operational failure,
+  2 CLI usage error. `catalogue package` follows the standard convention: exits 2
+  on missing required flags (argparse intercepts before the handler runs).
+- [x] AC8: Guide makes publication ordering explicit: write the archive first, the
+  SHA256 sidecar second, and the channel descriptor (`channels/<channel>.json`)
+  last. The channel descriptor is the live pointer; writing it last minimises the
+  window in which the descriptor references a not-yet-present archive.
+- [x] AC9: Guide has a secrets / TLS section that clearly states AgentBundle CLI
+  commands never read secrets and never issue network calls; TLS verification and
+  credential injection are exclusively Organization CI's responsibility.
+- [x] AC10: Guide includes a *See also* or *Related* section that cross-references
+  `guides/_shared/reference/agentbundle.md` and `guides/_reference/catalogue-format.md`.
+
+**Discovery**
+
+- [x] AC11: `guides/_shared/README.md` Reference section links to the guide.
+- [x] AC12: `guides/_shared/reference/agentbundle.md` has a short "Catalogue CI"
+  paragraph pointing readers to the CI contract guide.
+- [x] AC13: `guides/_reference/catalogue-format.md` Validation section links to the
+  CI contract guide for CI pipeline patterns.
+
+**AGENTS.md references**
+
+- [x] AC14: `AGENTS.local.md` has a one-line cross-reference to the CI contract
+  guide; file remains ≤ 250 lines.
+- [x] AC15: `packs/AGENTS.md` has a one-line cross-reference to the CI contract
+  guide; file remains ≤ 150 lines.
+
+**Command contract tests**
+
+- [x] AC16: `catalogue lint --root <fixture> --format json` stdout `json.loads()`
+  without error and the resulting dict contains keys `schema_version`, `command`,
+  `ok`, `diagnostics`.
+- [x] AC17: `catalogue verify --root <fixture> --format json` stdout `json.loads()`
+  without error with the same required keys.
+- [x] AC18: With `--format json`, the stdout of lint and verify contains only the
+  JSON object — no non-JSON lines mixed in (verified by confirming the raw stdout
+  parses cleanly without stripping).
+- [x] AC19: `catalogue lint` and `catalogue verify` return exit code 0 on a clean
+  catalogue and exit code 1 when the run reports at least one error-severity
+  diagnostic.
+- [x] AC20: `catalogue package` with all required flags returns exit code 0 on
+  success; the output directory contains the expected archive, SHA256 sidecar, and
+  channel descriptor at the documented paths.
+- [x] AC21: `catalogue package` invoked without required flags exits 2 (argparse
+  usage error), confirming the standard 0/1/2 convention applies.
+
+## Assumptions
+
+- Technical: HEAD `catalogue lint` and `catalogue verify` both support `--format json`
+  (source: `commands/catalogue_lint.py`, `commands/catalogue_verify.py` — verified
+  pre-session).
+- Technical: HEAD `catalogue package` does NOT support `--format json` (source:
+  `commands/catalogue_package.py` — verified pre-session; guide must not document it).
+- Technical: `catalogue package` exits 2 when required flags are absent (argparse
+  intercepts before the handler runs — verified against HEAD: `python3 -m agentbundle
+  catalogue package` → exit 2). Follows the standard 0/1/2 convention.
+- Technical: publication ordering (archive → SHA256 → channel.json) is the correct
+  safe upload order because the channel descriptor is the live pointer read by
+  consumers; writing it last minimises the window where a descriptor references a
+  not-yet-uploaded archive.
+- Technical: existing test infrastructure in
+  `packages/agentbundle/tests/unit/test_catalogue_tooling_foundation.py` provides
+  fixture catalogue helpers that the new contract tests can reuse.
+- Product: the target reader of this guide is an organization CI engineer who knows
+  basic CI concepts but may not know the AgentBundle toolchain; the guide must be
+  self-contained for that reader.
+- Process: `spec/catalogue-ci-documentation` (the follow-on spec) handles the
+  deeper adopter-facing surfaces: a how-to for setting up catalogue CI, cross-links
+  from `guides/catalogue-curation/`, and the PyPI README update. Those are
+  out of scope here.

--- a/guides/_reference/catalogue-format.md
+++ b/guides/_reference/catalogue-format.md
@@ -38,3 +38,7 @@ agentbundle catalogue verify --root .
 ```
 Runs the full 18-step pipeline including schema validation, pack lint,
 post-build artifact checks, and self-host drift detection.
+
+For CI pipeline patterns using `verify`, `lint`, and `package` — including
+publication ordering, exit codes, and JSON output shapes — see the
+[Catalogue CI contract](../_shared/reference/catalogue-ci-contract.md).

--- a/guides/_shared/README.md
+++ b/guides/_shared/README.md
@@ -16,6 +16,7 @@ Guides about the catalogue itself — installing it, upgrading it, seeing what e
 ## Reference
 
 - [`agentbundle` reference](reference/agentbundle.md) — install the CLI, install a pack, configure the default adapter, source-resolution chain, environment variables.
+- [Catalogue CI contract](reference/catalogue-ci-contract.md) — provider-neutral contract for validation, packaging, publication ordering, exit codes, and responsibility boundaries in a catalogue CI pipeline.
 - [Adapter support matrix](reference/adapter-support.md) — which primitives each agent tool receives, and where it degrades.
 - [Tracker vocabulary](reference/tracker-vocabulary.md) — how brief and spec levels map across GitHub, Linear, Jira, and Jira Align; skill routing table.
 - [Output rendering directives](reference/output-rendering.md) — the canonical directive catalog: which shape to declare in `## Output rendering` (Table, Status list, Severity list, Diagram, etc.) and when to omit.

--- a/guides/_shared/reference/agentbundle.md
+++ b/guides/_shared/reference/agentbundle.md
@@ -167,6 +167,14 @@ Setting `AGENTBUNDLE_NO_REMOTE=1` skips Layers 3 and 4 (the org Artifactory boot
 | `HTTPS_PROXY` | unset | Proxy URL for outbound HTTPS requests. Read automatically by Python's `urllib.request.ProxyHandler`; no `agentbundle`-specific wiring needed. Example: `HTTPS_PROXY=http://proxy.example.com:3128 agentbundle install --pack core` |
 | `NO_PROXY` | unset | Comma-separated list of hostnames that bypass the HTTPS proxy. Read automatically by Python's `urllib.request.ProxyHandler`. Example: `NO_PROXY=internal.example.com,localhost` |
 
+## Catalogue CI
+
+`agentbundle catalogue lint`, `agentbundle catalogue verify`, and
+`agentbundle catalogue package` are the portable commands for validating and
+packaging a catalogue in CI. For the full pipeline contract — publication
+ordering, exit codes, responsibility boundaries, and JSON output shapes — see
+the [Catalogue CI contract](catalogue-ci-contract.md).
+
 ## Other subcommands
 
 See `agentbundle --help` for the full set (`list-packs`, `list-profiles`, `list-targets`, `list-installed`, `validate`, `render`, `adapt`, `diff`, `upgrade`, `uninstall`, `reconcile`, etc.). Each has its own `--help` page documenting its flags.

--- a/guides/_shared/reference/catalogue-ci-contract.md
+++ b/guides/_shared/reference/catalogue-ci-contract.md
@@ -1,0 +1,250 @@
+---
+title: "Catalogue CI contract"
+summary: "The provider-neutral validation, packaging, publication, and evidence contract for an AgentBundle catalogue CI pipeline."
+pack: _shared
+kind: reference
+status: stable
+---
+
+# Catalogue CI contract
+
+This page defines the portable contract any CI system can implement to validate,
+package, and publish an AgentBundle catalogue. It names the commands, outputs,
+exit codes, publication ordering, and responsibility boundaries — without
+prescribing a CI provider or a specific workflow shape.
+
+## Responsibility boundary
+
+Three parties share responsibility for a catalogue CI pipeline. No party may
+silently assume another's obligations.
+
+| Party | Owns | Never does |
+|---|---|---|
+| **AgentBundle CLI** | Correct catalogue validation; deterministic archive + SHA256 sidecar; stable JSON output shapes; stable exit-code contract | Read secrets; issue network calls; control upload order; manage retention |
+| **Organization CI** | Secrets and credential injection; HTTPS upload; publication serialization (ensuring one release lands at a time); rollback policy; artifact retention | Implement validation logic; bypass exit-code signals; skip the admission command |
+| **Host Repository** | CI workflow files and trigger config; internal governance gates; tests proving the portable commands work in this repository | Alter the portable command signatures; branch AgentBundle's output format |
+
+## CI lifecycle phases
+
+### Phase 1 — Tool acquisition
+
+The CI environment must have `agentbundle` available before any catalogue
+command runs. Two patterns are equally valid:
+
+**Externally managed.** The CI step installs agentbundle from a package registry:
+
+```bash
+pip install agentbundle
+```
+
+Pin the version for reproducibility:
+
+```bash
+pip install 'agentbundle==<version>'
+```
+
+**Vendored.** The organization pre-installs agentbundle into a shared CI image or
+tool layer. The CI step runs catalogue commands without an explicit install.
+
+Either way, confirm the tool is present:
+
+```bash
+agentbundle --version
+```
+
+### Phase 2 — Change validation
+
+Every pipeline run that touches catalogue content must pass the admission
+command before proceeding to packaging:
+
+```bash
+agentbundle catalogue verify --root . --format json
+```
+
+`--format json` writes a machine-readable result to stdout and exits 0 (clean)
+or 1 (failures). The CI step fails on any non-zero exit, blocking packaging.
+
+`catalogue lint` runs as an earlier, faster check against pack sources only. It
+is optional but recommended as a pre-commit or fast-path gate:
+
+```bash
+agentbundle catalogue lint --root . --format json
+```
+
+### Phase 3 — Release packaging
+
+After verify exits 0, package the release:
+
+```bash
+agentbundle catalogue package \
+  --root . \
+  --bundle  "$BUNDLE" \
+  --release "$RELEASE" \
+  --channel "$CHANNEL" \
+  --output  "$OUTPUT"
+```
+
+The command writes three artifacts under `$OUTPUT`:
+
+```
+$OUTPUT/
+  catalogues/
+    $BUNDLE/
+      releases/
+        $RELEASE/
+          catalogue-$RELEASE.tar.gz       ← immutable archive
+          catalogue-$RELEASE.tar.gz.sha256 ← SHA256 sidecar
+      channels/
+        $CHANNEL.json                      ← mutable channel descriptor
+```
+
+The archive is deterministic given the same source content. The SHA256 sidecar
+is computed over the archive and stored alongside it. The channel descriptor is a
+small JSON file that records which release the channel currently points to; it is
+the live pointer consumers use to resolve the latest version.
+
+Re-run `agentbundle catalogue verify --archive <path>.tar.gz` after packaging to
+confirm the archive is valid before uploading it.
+
+### Phase 4 — Publication
+
+Upload artifacts in this exact order:
+
+1. The archive (`.tar.gz`)
+2. The SHA256 sidecar (`.sha256`)
+3. The channel descriptor (`channels/<channel>.json`) — **upload last**
+
+The channel descriptor is the live pointer. Writing it last minimises the window
+during which the descriptor references an archive that has not yet landed in the
+target store. A consumer that resolves the channel between steps 2 and 3 finds no
+channel pointer and fails cleanly; a consumer that resolves after step 3 finds the
+archive already present.
+
+Publication serialization — preventing two concurrent releases from interleaving
+their uploads — is the CI system's responsibility.
+
+### Phase 5 — Post-publication verification
+
+After the channel descriptor is published, download the archive and sidecar from
+the publication store and verify them locally:
+
+```bash
+# Download from the store first (provider-specific step)
+# Then verify the local copies:
+agentbundle catalogue verify \
+  --archive "/path/to/downloaded/catalogue-$RELEASE.tar.gz" \
+  --sha256-file "/path/to/downloaded/catalogue-$RELEASE.tar.gz.sha256"
+```
+
+`--archive` accepts a local filesystem path only; pass the path to the downloaded
+archive. This confirms the archive round-trips through the publication store
+without corruption.
+
+Optionally, smoke-test pack installation from the published catalogue to confirm
+consumer-side resolution.
+
+### Phase 6 — Evidence retention
+
+The CI system is responsible for retaining the evidence needed for rollback,
+audit, and incident response. Minimum retention artifacts:
+
+- The archive and SHA256 sidecar for every published release
+- The JSON output of `catalogue verify --format json` from Phase 2
+- The JSON output of `catalogue verify --archive ...` from Phase 5
+
+Retention period and storage location are Organization CI policy, not
+AgentBundle's.
+
+## Exit codes
+
+All `agentbundle catalogue` commands follow the same convention:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Validation or operational failure (errors in the catalogue, archive mismatch, internal error) |
+| `2` | CLI usage error (missing required flag, unknown option) |
+
+These codes are stable. A CI step that treats any non-zero exit as a failure
+gets the correct behaviour.
+
+## Secrets and network calls
+
+`agentbundle catalogue lint`, `agentbundle catalogue verify`, and
+`agentbundle catalogue package` do not read secrets and do not issue network
+calls. They operate entirely on the local filesystem.
+
+TLS certificate verification, bearer-token injection, proxy configuration, and
+upload credentials are exclusively Organization CI responsibilities. The
+`AGENTBUNDLE_HTTP_BEARER_TOKEN`, `AGENTBUNDLE_CA_BUNDLE`, and `HTTPS_PROXY`
+environment variables control AgentBundle's behaviour when resolving a remote
+catalogue source (used by install and upgrade verbs, not by the catalogue
+pipeline commands above).
+
+## Command reference
+
+### `agentbundle catalogue lint`
+
+```
+agentbundle catalogue lint [--root ROOT] [--pack PACK] [--format {table,json}] [--deep]
+```
+
+Validates pack sources against contracts without building. Exits 0 when all
+checks pass, 1 on any error.
+
+`--format json` writes to stdout:
+
+```json
+{
+  "schema_version": "1",
+  "command": "catalogue lint",
+  "operation": "lint",
+  "agentbundle_version": "<version>",
+  "catalogue_schema_version": "<version>",
+  "ok": true,
+  "diagnostics": []
+}
+```
+
+Human-readable output (table format) goes to stderr and is absent when
+`--format json` is used.
+
+### `agentbundle catalogue verify`
+
+```
+agentbundle catalogue verify [--root ROOT] [--pack PACK]
+                             [--archive ARCHIVE] [--sha256-file SHA256_FILE]
+                             [--format {table,json}]
+```
+
+Runs the full source pipeline (source mode) or validates an archive against its
+SHA256 sidecar and checks the extracted layout (archive mode).
+Exits 0 on clean, 1 on any failure.
+
+`--format json` writes the same JSON shape as `catalogue lint` to stdout.
+
+### `agentbundle catalogue package`
+
+```
+agentbundle catalogue package --bundle BUNDLE --release RELEASE
+                               --channel CHANNEL --output OUTPUT
+                               [--root ROOT]
+                               [--source-revision SOURCE_REVISION]
+                               [--minimum-agentbundle-version VERSION]
+                               [--published-at DATETIME]
+```
+
+Required flags: `--bundle`, `--release`, `--channel`, `--output`.
+Optional: `--root` (defaults to `.`), `--source-revision`, `--minimum-agentbundle-version`,
+`--published-at`.
+
+`catalogue package` does not support `--format json`; its result is the output
+directory layout described in [Phase 3](#phase-3--release-packaging). Exits 0
+on success, 1 on failure, 2 on missing required flags.
+
+## See also
+
+- [`agentbundle` reference](agentbundle.md) — install the CLI, install a pack,
+  configure the default adapter, source-resolution chain, environment variables.
+- [Catalogue format](../../_reference/catalogue-format.md) — what makes a
+  directory a valid catalogue, schema contracts, and validation.

--- a/packages/agentbundle/tests/unit/test_catalogue_ci_contract.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_ci_contract.py
@@ -1,0 +1,185 @@
+"""Command-contract tests for the catalogue CI contract guide.
+
+Verifies that the exit codes and JSON output shapes documented in
+guides/_shared/reference/catalogue-ci-contract.md match HEAD CLI behaviour.
+All tests use subprocess invocation to exercise the real CLI surface, not
+internal imports.
+
+Verification modes per plan.md:
+  T7 — TDD: AC16–AC21 (JSON output, exit codes, package layout)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The autouse _isolate_user_config_dir fixture in conftest.py redirects HOME and
+# XDG_CONFIG_HOME to a tmp sandbox; subprocess calls inherit this env. All calls
+# below pass --root explicitly so no command reads user config from the sandbox.
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]  # packages/agentbundle/tests/unit -> repo root
+
+
+@pytest.fixture
+def working_catalogue_root() -> Path:
+    """Return the working-tree catalogue root (this repo)."""
+    return _REPO_ROOT
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "agentbundle", *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC16 / AC18: catalogue lint --format json → parseable JSON, stdout-only
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_lint_json_output_parses(working_catalogue_root: Path) -> None:
+    """AC16: lint --format json stdout json.loads() cleanly with required keys."""
+    result = _run(
+        "catalogue", "lint",
+        "--root", str(working_catalogue_root),
+        "--format", "json",
+    )
+    # AC18: json.loads on raw (unstripped) stdout — no non-JSON lines mixed in
+    doc = json.loads(result.stdout)
+    for key in ("schema_version", "command", "ok", "diagnostics"):
+        assert key in doc, f"missing key {key!r} in lint JSON output"
+
+
+# ---------------------------------------------------------------------------
+# AC17 / AC18: catalogue verify --format json → parseable JSON, stdout-only
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_verify_json_output_parses(working_catalogue_root: Path) -> None:
+    """AC17: verify --format json stdout json.loads() cleanly with required keys."""
+    result = _run(
+        "catalogue", "verify",
+        "--root", str(working_catalogue_root),
+        "--format", "json",
+    )
+    doc = json.loads(result.stdout)
+    for key in ("schema_version", "command", "ok", "diagnostics"):
+        assert key in doc, f"missing key {key!r} in verify JSON output"
+
+
+# ---------------------------------------------------------------------------
+# AC19: exit 0 on clean catalogue
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_lint_exits_0_on_clean(working_catalogue_root: Path) -> None:
+    """AC19a: lint returns 0 on a clean catalogue."""
+    result = _run(
+        "catalogue", "lint",
+        "--root", str(working_catalogue_root),
+        "--format", "json",
+    )
+    assert result.returncode == 0, (
+        f"catalogue lint exited {result.returncode}; stderr: {result.stderr[:400]}"
+    )
+
+
+def test_catalogue_verify_exits_0_on_clean(working_catalogue_root: Path) -> None:
+    """AC19a: verify returns 0 on a clean catalogue."""
+    result = _run(
+        "catalogue", "verify",
+        "--root", str(working_catalogue_root),
+        "--format", "json",
+    )
+    assert result.returncode == 0, (
+        f"catalogue verify exited {result.returncode}; stderr: {result.stderr[:400]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC19: exit 1 on an invalid catalogue
+# ---------------------------------------------------------------------------
+
+
+def _write_invalid_catalogue(tmp_path: Path) -> Path:
+    """Write a catalogue directory that lint and verify will reject."""
+    # A catalogue.toml that is missing required fields (name, version, schema).
+    (tmp_path / "catalogue.toml").write_text("[catalogue]\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_catalogue_lint_exits_1_on_errors(tmp_path: Path) -> None:
+    """AC19b: lint returns 1 when the catalogue has errors."""
+    root = _write_invalid_catalogue(tmp_path)
+    result = _run("catalogue", "lint", "--root", str(root), "--format", "json")
+    assert result.returncode == 1, (
+        f"expected exit 1 for invalid catalogue, got {result.returncode}"
+    )
+
+
+def test_catalogue_verify_exits_1_on_errors(tmp_path: Path) -> None:
+    """AC19b: verify returns 1 when the catalogue has errors."""
+    root = _write_invalid_catalogue(tmp_path)
+    result = _run("catalogue", "verify", "--root", str(root), "--format", "json")
+    assert result.returncode == 1, (
+        f"expected exit 1 for invalid catalogue, got {result.returncode}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC20: catalogue package exit 0 + output layout
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_package_exits_0_and_layout(
+    working_catalogue_root: Path, tmp_path: Path
+) -> None:
+    """AC20: package with required flags exits 0 and writes the documented layout."""
+    bundle = "test-ci-contract"
+    release = "0.0.1-ci"
+    channel = "stable"
+
+    result = _run(
+        "catalogue", "package",
+        "--root", str(working_catalogue_root),
+        "--bundle", bundle,
+        "--release", release,
+        "--channel", channel,
+        "--output", str(tmp_path),
+    )
+    assert result.returncode == 0, (
+        f"catalogue package exited {result.returncode}; stderr: {result.stderr[:400]}"
+    )
+
+    releases_dir = tmp_path / "catalogues" / bundle / "releases" / release
+    assert (releases_dir / f"catalogue-{release}.tar.gz").exists(), (
+        "archive missing from output layout"
+    )
+    assert (releases_dir / f"catalogue-{release}.tar.gz.sha256").exists(), (
+        "SHA256 sidecar missing from output layout"
+    )
+    channels_dir = tmp_path / "catalogues" / bundle / "channels"
+    assert (channels_dir / f"{channel}.json").exists(), (
+        "channel descriptor missing from output layout"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC21: catalogue package exits 2 on missing required flags
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_package_exits_2_on_missing_flags() -> None:
+    """AC21: package with no flags exits 2 (argparse usage error, standard convention)."""
+    result = _run("catalogue", "package")
+    assert result.returncode == 2, (
+        f"expected exit 2 for missing required flags, got {result.returncode}"
+    )

--- a/packs/AGENTS.md
+++ b/packs/AGENTS.md
@@ -49,6 +49,8 @@ Home-repository additional gate (not required for external catalogues):
 make build-check   # agentbundle catalogue verify + repo governance + SAST
 ```
 
+For CI pipeline orchestration beyond the dev loop — publication ordering, exit codes, JSON output contract — see [`guides/_shared/reference/catalogue-ci-contract.md`](../guides/_shared/reference/catalogue-ci-contract.md).
+
 ## Version bump rule
 
 Every **non-cosmetic** change to pack content requires a version bump in both:

--- a/workspace.toml
+++ b/workspace.toml
@@ -1166,3 +1166,103 @@ queue   = [
   # ci-gates needs all Wave 4+5 specs; Gate F specifically needs rewire
   {path = "spec/catalogue-tooling-ci-gates", needs = "work:spec/catalogue-tooling-package-enhanced,work:spec/catalogue-tooling-rewire"},
 ]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ini-006 · Catalogue CI Contract
+#
+# Create one canonical, provider-neutral catalogue CI contract at
+# guides/_shared/catalogue-ci-contract.md. The contract defines the portable
+# commands, outputs, exit behavior, publication ordering, evidence, and
+# responsibility boundaries that any organization can implement in its chosen
+# CI system.
+#
+# The contract must not prescribe, generate, copy, or depend on CI workflows
+# or a particular CI provider.
+#
+# Responsibility boundary:
+#   AgentBundle owns: valid catalogue definition, portable lint/verify/package,
+#     deterministic archive, stable JSON and exit-code contracts.
+#   Organization CI owns: when commands run, secrets, upload, publication
+#     serialization, artifact retention, rollback approval.
+#   Host repository owns: CI workflow implementation, trigger config, internal
+#     governance, tests proving the portable contract works.
+#
+# Non-goals: agentbundle catalogue init, self-hosted preset, CI workflow
+#   generators, Artifactory upload command, complete export-catalogue replacement,
+#   top-level catalogue/ directory.
+#
+# Source brief: .context/attachments/7w1trN/pasted_text_2026-07-28_18-19-01.txt
+# ─────────────────────────────────────────────────────────────────────────────
+["ini-006"]
+name      = "Catalogue CI Contract"
+status    = "active"
+milestone = "M1 · Provider-Neutral CI Contract"
+
+["ini-006".shaping_queue]
+active  = []
+backlog = []
+
+["ini-006".work]
+active  = []
+shipped = ["spec/catalogue-ci-contract-guide"]
+queue   = [
+  # M1 · Core guide + command verification + agent guidance
+  # Problem: no canonical document defines the portable commands, exit behavior,
+  #   publication ordering, evidence requirements, and responsibility boundaries
+  #   for a catalogue CI pipeline. Adopters reverse-engineer these from host CI
+  #   workflows, which are not portable catalogue content.
+  # Deliver: guides/_shared/catalogue-ci-contract.md (Catalogue CI Contract v1,
+  #   pack: _shared, kind: reference, status: stable); lifecycle diagram; 6
+  #   contract phases — (1) tool acquisition: externally managed + vendored
+  #   tooling models; (2) change validation: `agentbundle catalogue verify --root .
+  #   --format json` as required admission command, optional `catalogue lint`;
+  #   (3) release packaging: `catalogue package` with re-verification at immutable
+  #   boundary, deterministic archive + checksum sidecar + mutable channel
+  #   descriptor; (4) publication: upload ordering — immutable archive → checksum
+  #   → channel descriptor last; (5) post-publication verification: clean-consumer
+  #   check, optional smoke-test pack install; (6) evidence retention; secrets/TLS/
+  #   proxy responsibility boundary; exit-code contract (0/1/2) verified against
+  #   current HEAD for catalogue lint/verify/package with fixes or tracked follow-ups
+  #   where behavior diverges; focused command-contract tests parsing JSON output
+  #   via json.loads, verifying stderr/stdout separation and exit codes;
+  #   AGENTS.local.md and packs/AGENTS.md updated — CI workflows are host-local,
+  #   portable admission command is `agentbundle catalogue verify --root .`, public
+  #   JSON and exit-code contract changes require release review; host CI dogfood
+  #   confirmation that public AgentBundle commands are invoked.
+  # Done: guide validates under current guide contract; all documented command
+  #   behavior is tested and matches implementation; AGENTS guidance updated;
+  #   host CI dogfood check passes; all existing tests pass.
+  # M2a · Export boundary update
+  # Problem: export-catalogue skill may pass CI workflow implementation to target
+  #   catalogues, and may not include the neutral CI contract guide. Adopters
+  #   receive host-specific CI as if it were portable catalogue content.
+  # Deliver: export-catalogue skill updated so guides/_shared/catalogue-ci-contract.md
+  #   is eligible for export; all CI workflow and pipeline implementation excluded —
+  #   workflow definitions, trigger config, release/deployment automation,
+  #   package-publication automation, CI-specific helper scripts, workflow badges,
+  #   provider-specific secret names; exclusion is provider-neutral (positive allowlist
+  #   preferred over filename denylist); export guidance states: target chooses CI
+  #   system, receives neutral contract, no CI workflow is generated or copied, no
+  #   credentials are transported, no CI provider is assumed; export-boundary tests —
+  #   neutral guide is eligible, CI implementation is excluded, workflow badges and
+  #   host secret names don't escape, policy does not rely solely on known provider
+  #   filenames, white-label behavior remains fail-closed.
+  # Done: export-boundary tests pass; white-label behavior verified fail-closed.
+  {path = "spec/catalogue-ci-export-boundary", needs = "work:spec/catalogue-ci-contract-guide"},
+
+  # M2b · Documentation integration
+  # Problem: guides/_shared/README.md, guides/README.md, Artifactory packaging and
+  #   publication guides, AgentBundle CLI reference, disconnected-operation guidance,
+  #   and enterprise distribution guidance don't reference the new contract. Adopters
+  #   can't discover canonical CI orchestration guidance from existing entry points.
+  # Deliver: guides/_shared/README.md and guides/README.md link to the new guide;
+  #   Artifactory packaging and publication guides link to contract (no duplication);
+  #   CLI reference links to contract; disconnected-operation and enterprise
+  #   distribution guides updated; site regenerated through normal rendering system
+  #   (no hand-editing generated output); all internal links validated;
+  #   documentation tests — guide appears in rendered site output, internal links
+  #   resolve, related Artifactory pages link to it, doc generation leaves repo clean,
+  #   no CI workflow implementation appears in portable catalogue output.
+  # Done: site regenerated and clean; all documentation tests pass; no broken links.
+  {path = "spec/catalogue-ci-documentation", needs = "work:spec/catalogue-ci-contract-guide"},
+]


### PR DESCRIPTION
## Summary

- Adds `guides/_shared/reference/catalogue-ci-contract.md` — a new adopter-facing reference guide defining the portable CI contract for any AgentBundle catalogue pipeline (six phases, responsibility boundary, portable commands, exit codes, publication ordering, secrets/TLS boundary)
- Adds `packages/agentbundle/tests/unit/test_catalogue_ci_contract.py` — command-contract tests (AC16–AC21) that verify the documented JSON output shapes and exit codes match HEAD, so guide drift produces a CI failure
- Three discovery hooks: link in `guides/_shared/README.md`, Catalogue CI section in `guides/_shared/reference/agentbundle.md`, cross-reference in `guides/_reference/catalogue-format.md`
- Link-only references in `AGENTS.local.md` and `packs/AGENTS.md` (no content duplication)
- `workspace.toml` ini-006 spec moved to `shipped`

## How to verify

```bash
# Guide exists with correct frontmatter
head -10 guides/_shared/reference/catalogue-ci-contract.md

# Contract tests pass
python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_ci_contract.py -v

# Discovery links present
grep "catalogue-ci-contract" guides/_shared/README.md guides/_shared/reference/agentbundle.md guides/_reference/catalogue-format.md AGENTS.local.md packs/AGENTS.md

# Line caps hold
wc -l packs/AGENTS.md AGENTS.local.md   # 143 and 176 respectively, within caps
```

## Notes / deferred

- `spec/catalogue-ci-export-boundary` and `spec/catalogue-ci-documentation` remain in `ini-006.work.queue` for follow-on PRs
- `catalogue package --format json` intentionally absent from the guide — not supported in HEAD; a tracked follow-on would add machine-readable package output
- `docs/guides/how-to/create-external-catalogue.md` not promoted to `guides/` — deferred to `spec/catalogue-ci-documentation`

## Spec

`docs/specs/catalogue-ci-contract-guide/` — Status: Shipped