### PR TITLE
docs(agents): consolidate and de-stale AGENTS context files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ package-lock.json
 !web/package-lock.json
 !docs-site/package-lock.json
 
+# Virtual environments.
+.venv/
+
 # Python build artefacts.
 *.egg-info/
 *.pyc

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -1,7 +1,7 @@
 # AGENTS.local.md
 
-Repo-local addendum for maintainers of this checkout. Shared agent instructions belong in
-`packs/core/seeds/AGENTS.md` and are projected to `AGENTS.md`.
+Repo-local addendum for maintainers of this checkout. `AGENTS.md` is adopter-owned — edit it
+directly. To propagate changes to new adopters, also update `packs/core/seeds/AGENTS.md`.
 
 - **Pack and skill development** (version bumps, projection, skill authoring, eval coverage, plugin format):
   [`packs/AGENTS.md`](packs/AGENTS.md).
@@ -13,60 +13,6 @@ Repo-local addendum for maintainers of this checkout. Shared agent instructions 
   [`guides/_shared/reference/catalogue-ci-contract.md`](guides/_shared/reference/catalogue-ci-contract.md).
 
 **Read before modifying:** `packs/` → read [`packs/AGENTS.md`](packs/AGENTS.md) first — version bump rule requires both `pack.toml` + `.claude-plugin/plugin.json`. `packages/` → read [`packages/AGENTS.local.md`](packages/AGENTS.local.md) first — covers when a PyPI release is required.
-
-## Design against the adopter's projected state, not this repo's internal state
-
-This repo is a **pack catalogue**: packs ship into other repositories via APM, Claude
-plugins, and the CLI. A feature that ships inside a pack — a lint, a hook, a skill, a
-gate — does its real work in the adopter's projected/installed tree, not here.
-
-When designing or validating any pack-shipped feature:
-
-- Validate against the **pack template/seed** (e.g. `packs/core/.apm/skills/new-spec/assets/spec.md`),
-  not this repo's hand-authored examples. An adopter's `docs/specs/` are template-shaped from birth.
-- This repo's own `docs/specs/`, `docs/rfc/`, `docs/adr/` are bundle-governance about the catalogue's
-  evolution; this repo is merely the self-host adopter. Internal-corpus quirks never drive pack-feature
-  design — they are self-host edge cases, not requirements.
-- Ask: *does this happen in a fresh adopter's template-shaped tree, or only in this repo's legacy
-  internal corpus?* The former is a design bug; the latter is a self-host cleanup.
-- Coverage that matters is the per-adapter projected layout and the installed runtime surface (CI vs.
-  lifecycle-event hooks), not what happens to be true in this checkout.
-
-## Adopter-facing materials ship; repo-specific tooling stays local-only
-
-Shipped primitives (anything under `.apm/` or `seeds/`) must reference and run **only** things
-that install into an adopter's tree. Catalogue-internal tooling never ships and is never referenced
-by a shipped primitive.
-
-This catalogue's full enforcement gate is **repo-native, never-projected**: `tools/pre-pr-catalogue.py`
-runs the 8 catalogue checks (`lint-agents-md`, `lint-agent-artifacts`, `lint-skill-spec`,
-`lint-knowledge`, `lint-build`, `lint-seeds`, `lint_credentialed_skills`, `test-lint-credentialed-skills`)
-then delegates to the shipped `pre-pr.py`. Do not make any shipped hook/command/template reference
-`tools/lint-*`, `make build-self`, `docs/specs/`, or `.github/workflows/` — those paths don't exist
-in an adopter's repo.
-
-**Repo-gate orchestration is a `tools/` script, never an `agentbundle` package subcommand.** Adding,
-removing, or renaming a `python -m agentbundle` subcommand is an adopter-surface change with a release
-implication — surface it as an explicit decision before building.
-
-### Shipped pack content carries no internal-governance citations
-
-When authoring anything under `.apm/**` (skills, agents, commands, hooks, `scripts/`, `references/`,
-`shared-libs/`, `adapter-root-bins/`), never cite this catalogue's own governance. The four types
-to keep out:
-
-1. **RFC numbers** — `RFC-0001`…`RFC-00NN`.
-2. **ADR numbers** — `ADR-0001`…`ADR-00NN`.
-3. **Spec/plan citations** — `spec § AC15`, `plan §T5 lines 357-362`, `docs/specs/<feature>.md § "Outputs"`.
-4. **Internal doc paths** — `docs/specs/…`, `docs/adr/…`, `docs/rfc/…`, `.github/workflows/…`.
-
-Drop the citation, keep the rule: *"Markers are repo-only per RFC-0004"* → *"Markers are repo-only"*.
-Where the citation carried a "why", reword to self-contained prose ("by convention", "a known gap").
-
-Allowed in shipped content: generic spec-driven workflow vocabulary (`spec.md`, `plan.md`, the words
-"spec" / "plan" / "acceptance criteria"), real external standards (`RFC 9457`, `RFC 8259`), and
-functional fixture content (e.g. `- [ ] AC1` rows in test fixtures, where `AC1` is data the parser
-consumes, not a citation).
 
 ## House style for internal docs
 
@@ -88,89 +34,5 @@ RFCs, ADRs, internal READMEs. The adopter-facing version ships in the `product-d
   list items one line each. Older docs (README, CONVENTIONS) are hard-wrapped near 72 columns; match
   the file you're editing.
 
-## Agents project to multiple adapters — not Claude Code only
-
-The `agent` primitive (e.g. `adversarial-reviewer`, `quality-engineer`) projects to claude-code, kiro,
-and codex today; copilot support is addable. Check `docs/contracts/adapter.toml` for the current map.
-
-When reasoning about reviewer/agent reach, the default is "agents reach claude-code + kiro + codex
-today (copilot addable)."
-
-`AGENTS.md` is a **Manual** file — `build-self` won't regenerate it once it exists. A fix to the
-agent-support statement must edit **both** `packs/core/seeds/AGENTS.md` (the seed) and the working-tree
-`AGENTS.md` directly.
-
-## AGENTS.md line caps — enforced by CI
-
-The AGENTS.md hygiene gate enforces: root `AGENTS.md` ≤ 250 lines; every sub-directory
-`AGENTS.md` ≤ 150 lines. Exceeding the cap blocks all three CI jobs. Keep files tight:
-these files load into agent context; length equals token cost.
-
-## Self-hosting drift — edit the source, not the projection
-
-This repo is self-hosted from `packs/`. Many files are **rendered outputs**, not the source-of-truth.
-Editing them directly trips `make build-check`. Full workflow: [`packs/AGENTS.md`](packs/AGENTS.md#self-hosting-projection).
-
-**Always-projected — edit the source:**
-
-| Target (do not edit) | Source |
-|----------------------|--------|
-| `AGENTS.md`, `CLAUDE.md` | `packs/core/seeds/AGENTS.md` |
-| `docs/CONVENTIONS.md` | `packs/core/seeds/docs/CONVENTIONS.md` |
-| All adapter skill projections | `packs/<pack>/.apm/skills/<name>/**` |
-| All adapter agent / command / hook projections | `packs/<pack>/.apm/{agents,commands,hooks}/...` |
-
-**Manual — edit directly (no build-self needed):**
-`docs/CHARTER.md`, `docs/architecture/overview.md`, `docs/specs/README.md`,
-`docs/knowledge/patterns.jsonl`, `docs/rfc/README.md`, `docs/adr/README.md`,
-`docs/guides/**/README.md`.
 
 
-## Two guide trees — maintainer vs adopter
-
-| Tree | Audience | Ships to adopters? |
-|---|---|---|
-| `docs/guides/` | **Repo maintainers only.** Covers the catalogue's internal tooling, CLI developer workflows, and repo-specific how-tos. Never projected. | No |
-| `guides/` | **Adopters.** Cross-cutting guides live in `guides/_shared/{quadrant}/`; pack-specific guides in `guides/<pack>/{quadrant}/`. Projected by the build pipeline. | Yes |
-
-Write new user-facing guides under `guides/_shared/how-to/` (or the owning pack's subtree).
-Write maintainer-facing guides (tooling, repo setup, CI) under `docs/guides/`.
-
-`docs/guides/` inside this repo uses a flat `{quadrant}/` layout.
-The `author-product-docs` skill (in the `product-documentation` pack) inspects the repo's guide structure and routes to the correct tree based on audience — external users → `guides/`, internal maintainers → `docs/guides/`.
-
-## Install-test coverage rule
-
-Tests that exercise an on-disk projection layout, the per-pack orphan scanner, or the install
-handler's adapter-resolution path **must parametrize over every shipped adapter** — not just the
-default. Each adapter projects to a different directory layout and the per-pack scanner's
-primitive-name heuristic interacts differently with each shape.
-
-Opt-out: tests scoped to adapter-independent logic (scope-resolution, dependency gates,
-state-accumulation) may skip parametrization; the test's docstring must say so.
-
-**Reference shape:** `packages/agentbundle/tests/integration/test_multi_pack_install.py`.
-`packages/agentbundle/agentbundle/_data/adapter.toml` is the source of truth for which adapters ship;
-the test module derives `_SHIPPED_ADAPTERS` from it via `scope.shipped_adapters_from_contract()` —
-adding a new `[adapter.<name>]` table expands every parametrized test in the same PR.
-Adapter-specific behaviour gaps are pinned as their own tests rather than silently elided.
-
-## New tool scripts: Python, not bash
-
-New additions to `tools/` must be pure-stdlib Python (`.py`). Existing `.sh` files stay; the rule
-applies forward. Path triggers in `.github/workflows/docs.yml` must match `python3 <script>`.
-
-## Windows / cross-OS compatibility
-
-Applies to all new code. Production code (`packages/agentbundle/agentbundle/`) is already clean.
-
-- **Encoding:** `Path.read_text()` / `Path.write_text()` / `open()` for text must always pass
-  `encoding="utf-8"`. Exception: `read_bytes()` / `write_bytes()` are inherently correct.
-- **Symlinks:** wrap `os.symlink()` in `try/except OSError: pytest.skip("symlinks not available")`.
-  Production code uses `_is_equivalent_claude_md_shape()` (`self_host.py`) for three equivalent shapes.
-- **POSIX-only assertions:** wrap inode checks (`st_ino`), nanosecond mtimes (`st_mtime_ns`), and
-  permission-bit assertions in `if sys.platform != "win32":`. Gate `os.chmod()` with `if os.name == "posix":`.
-- **Paths:** use `pathlib.Path` or `os.path.join`. No string concatenation with `/`, no
-  `os.environ["HOME"]`, no hardcoded `/tmp`.
-- **Subprocess:** list form only, never `shell=True`. Do not invoke `which`, `grep`, `find`, `sed`,
-  `awk`, `make`, `sh`, or `bash` via subprocess in portable code.

--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -9,6 +9,8 @@ directly. To propagate changes to new adopters, also update `packs/core/seeds/AG
   [`packages/AGENTS.md`](packages/AGENTS.md).
 - **Release coupling** (PyPI release requirements, version bump workflow, tagging):
   [`packages/AGENTS.local.md`](packages/AGENTS.local.md).
+- **Marketing site** (Astro build, Node.js deps, dev server, mobile viewport, link rules):
+  [`web/AGENTS.md`](web/AGENTS.md).
 - **Catalogue CI** (portable commands, publication ordering, exit codes, responsibility boundary):
   [`guides/_shared/reference/catalogue-ci-contract.md`](guides/_shared/reference/catalogue-ci-contract.md).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,11 +127,14 @@ tasks, not most — the work-loop skill covers when it's the right tool.
 <!-- Keep this short. Detailed command reference goes in docs/. -->
 
 ```bash
-pip install -e packages/agentbundle 'packages/credbroker[crypto]' ruff mypy pytest  # one-time setup
-python3 -m pytest packages/<pkg>/tests/ -q  # run tests for the package you're in
-make test                                    # run all tests (slow — usually CI's job)
-python3 tools/lint-ruff.py                  # lint + format check
-make build-self                             # sync projected files after touching packs/
+pip install -e packages/agentbundle 'packages/credbroker[crypto]' ruff mypy pytest  # one-time
+pip install -r tools/requirements.txt          # jsonschema, pyyaml — one-time
+python3 -m pytest packages/<pkg>/tests/ -q    # test the package you're editing
+make lint-ruff                                 # lint + format
+make build-self                               # sync projected files after touching packs/
+make build-check                              # agentbundle verify + repo policy gates + SAST
+SKIP_SAST=1 make build-check                 # same, minus SAST (fast; for non-SAST changes)
+make ci                                       # full local CI: build-check + lint + test (Linux/macOS)
 ```
 
 ## Code style
@@ -215,6 +218,26 @@ PR titles, PR bodies, and PR comments are permanent record. Never use real servi
 vendor names as examples; use `example-service` or `[service type]` instead. When
 authoring governance docs (ADRs, RFCs, specs), populate author and decider fields from
 the project's established conventions only — do not infer them from session context.
+
+## Guide trees
+
+| Tree | Audience | Ships? |
+|---|---|---|
+| `docs/guides/` | Repo maintainers — internal tooling, CLI workflows, repo how-tos. | No |
+| `guides/` | Adopters — `guides/_shared/{quadrant}/`; pack-specific in `guides/<pack>/{quadrant}/`. | Yes |
+
+New user-facing guides → `guides/_shared/how-to/` (or the owning pack's subtree).
+New maintainer guides → `docs/guides/`. The `author-product-docs` skill routes by audience automatically.
+
+## AGENTS.md line caps
+
+CI enforces: root `AGENTS.md` ≤ 250 lines; subdirectory `AGENTS.md` ≤ 150 lines. Exceeding the cap
+blocks CI. Length equals token cost.
+
+## New tool scripts: Python, not bash
+
+New additions to `tools/` must be pure-stdlib Python (`.py`). Existing `.sh` files stay; the rule
+applies forward. Path triggers in `.github/workflows/docs.yml` must match `python3 <script>`.
 
 ## When this file is wrong
 

--- a/packs/AGENTS.local.md
+++ b/packs/AGENTS.local.md
@@ -16,3 +16,38 @@ for dirty trees). Never edit it directly. A pack version bump requires both `pac
 
 `publish-claude-plugins.yml` is the upstream publish workflow; it runs only from `main` on
 a workflow-dispatch or tag event. Forks replace this with their own publish mechanism.
+
+## Design against the adopter's projected state
+
+Validate pack features against `core/.apm/skills/*/assets/` (template-shaped), not this repo's
+hand-authored `docs/specs/`. This repo is the self-host adopter — its internal corpus is a self-host
+edge case, not a requirement. Coverage that matters: the per-adapter projected layout and the installed
+runtime surface, not checkout-local state.
+
+## Adopter-facing materials ship; repo-specific tooling stays local-only
+
+`.apm/` and `seeds/` must reference only things that install into an adopter's tree. The enforcement
+gate (`make build-check`) runs in two tiers: portable checks via `agentbundle catalogue verify/lint`;
+repo-specific policy gates in `tools/catalogue/pre_pr_catalogue.py` (delegates to `tools/hooks/pre-pr.py`).
+Never reference `tools/lint-*`, `make build-self`, `docs/specs/`, or `.github/workflows/` from
+shipped content — those paths don't exist in an adopter's repo.
+
+Adding, removing, or renaming a `python -m agentbundle` subcommand is an adopter-surface change with
+a release implication — surface it before building. Governance-citation rules for `.apm/**`:
+[`AGENTS.md § Shipped pack content`](AGENTS.md#shipped-pack-content-carries-no-internal-governance-citations).
+
+## Self-hosting drift — source vs. projection
+
+Editing projected files directly trips `make build-check`. Workflow: [`AGENTS.md § Self-hosting projection`](AGENTS.md#self-hosting-projection).
+
+**Always-projected — edit the source:**
+
+| Target (do not edit) | Source |
+|----------------------|--------|
+| `docs/CONVENTIONS.md` | `core/seeds/docs/CONVENTIONS.md` |
+| All adapter skill projections | `<pack>/.apm/skills/<name>/**` |
+| All adapter agent/command/hook projections | `<pack>/.apm/{agents,commands,hooks}/...` |
+
+**Manual (edit directly):** `AGENTS.md`, `CLAUDE.md` (adopter-owned; `build-self` won't regenerate),
+`docs/CHARTER.md`, `docs/architecture/overview.md`, `docs/specs/README.md`,
+`docs/knowledge/patterns.jsonl`, `docs/rfc/README.md`, `docs/adr/README.md`, `docs/guides/**/README.md`.


### PR DESCRIPTION
## Summary

- **`.gitignore`**: add `.venv/`
- **Root `AGENTS.local.md`**: removed four sections already present in `packs/AGENTS.md` and `packages/AGENTS.md`; fixed stale self-hosting drift table (`AGENTS.md` is now adopter-owned, not projected); shrunk from 174 → 36 lines (nav + house style only)
- **Root `AGENTS.md`**: moved Guide trees, AGENTS.md line caps, and New tool scripts in from `AGENTS.local.md` (committed rules all contributors need); updated Commands section to reflect actual local CI — `make build-check`, `SKIP_SAST=1 make build-check`, `make ci`, and `tools/requirements.txt` one-time install
- **`packs/AGENTS.local.md`**: added Design-against-adopter, Adopter-facing-materials, and Self-hosting-drift sections (catalogue-insider context that shouldn't travel on export); corrected gate description to reflect the two-tier agentbundle + `tools/` split

## Test plan

- [ ] `wc -l AGENTS.md` ≤ 250; `wc -l packs/AGENTS.md` ≤ 150 (CI enforces these)
- [ ] Verify no content was lost — just moved to the correct home or removed as a duplicate