### PR TITLE
feat(export-catalogue): make CI boundary explicit and verifiable (ini-006 M2a)

### DIFF
--- a/.agents/skills/export-catalogue/SKILL.md
+++ b/.agents/skills/export-catalogue/SKILL.md
@@ -39,9 +39,16 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    while excluding: catalogue-governance (`docs/rfc/`, `docs/adr/`,
    `docs/specs/`, `docs/backlog.md`), the running repo's own
    `CHARTER`/`CONVENTIONS`/`**/AGENTS.local.md` (root and all subdirectories),
-   `**/README-pypi.md`, the internal doc site, and
-   build/scan/release tooling. Strip runs on the running-repo content copy only;
-   seeds (step 4) are planted fresh afterward and are not affected.
+   `**/README-pypi.md`, the internal doc site, and build/scan/release tooling.
+   **CI workflow and pipeline implementation is also excluded from the export
+   surface.** The export surface is bounded to `guides/`, projected tools, and
+   seeded scaffold — CI implementation files are outside this surface; no
+   credentials are transported. Excluded CI artifacts include: `.github/workflows/`
+   (GitHub Actions; note `.github/skills|agents|hooks|instructions/` are legitimate
+   Copilot adapter paths and travel when projected), `.gitlab-ci.yml`, `Jenkinsfile`,
+   `.travis.yml`, provider-specific CI trigger config, CI-specific helper scripts
+   not part of the pack, and workflow status badges. Strip runs on the running-repo
+   content copy only; seeds (step 4) are planted fresh afterward and are not affected.
 4. **Plant seeds.** For each projected tool (core, governance-extras) and any
    pack in the include-set with a `seeds/` directory, copy the seed tree to the
    target repo root. Establishes the scaffold the skills navigate: `AGENTS.md`,
@@ -58,9 +65,13 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    anchors all future `assimilate-repo` runs from within the fork.
 6. **Stage transportable guides.** For each pack in the include-set, copy
    `guides/<pack-name>/` into the target. Always include
-   `guides/_shared/`. Guides for packs outside the include-set are
-   omitted (omit-not-leak). The four-anchor substitution pass in step 7 covers
-   any identity references inside staged guide content.
+   `guides/_shared/` — this includes `guides/_shared/reference/catalogue-ci-contract.md`,
+   the portable CI contract the target organization receives. The contract is the
+   adopter's CI reference: the target chooses its own CI system; no CI workflow is
+   generated or copied; no credentials are transported; no CI provider is assumed.
+   Guides for packs outside the include-set are omitted (omit-not-leak). The
+   four-anchor substitution pass in step 7 covers any identity references inside
+   staged guide content.
 7. **Substitute** the four identity anchors from *this* catalogue's own sources
    (URL + slug + owner from `.adapt-discovery.toml`; email from `pack.toml`
    maintainer + git) — so the tooling carries no hardcoded upstream literal. URL
@@ -84,14 +95,20 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    own catalogue — so the fork can self-curate from day one without inheriting
    agent-ready-repo's pack catalogue. Apply the four-anchor substitution to any
    projected file that still carries upstream identity.
-10. **Verify, fail-closed.** Grep the target for surviving upstream **URL, email,
-    slug, and owner** (the same four anchors, so verify and substitute agree),
-    **case-insensitively**, over **text files** (binary out of scope, declared),
-    matching declared **literals only** after a normalization pass. In
-    `white-label` mode: zero hits anywhere. In `attributed` mode: hits only inside
-    the declared attribution surface. Also fail on a dangling `CLAUDE.md` symlink
-    or a non-blank target `install-defaults.toml` source. Any hit **hard-fails the
-    export** — omit-not-leak.
+10. **Verify, fail-closed.** Run two checks; either failing hard-fails the export
+    (omit-not-leak):
+    - **Identity check** (`export_verify.verify()`): grep the target for surviving
+      upstream **URL, email, slug, and owner** (the same four anchors), case-insensitively,
+      over text files (binary out of scope, declared), matching declared literals only
+      after a normalization pass. In `white-label` mode: zero hits anywhere. In
+      `attributed` mode: hits only inside the declared attribution surface.
+    - **CI boundary check** (`export_verify.check_ci_boundary()`): scan the target
+      for CI implementation files — `.github/workflows/` content, known root-level CI
+      config files, files under unknown dot-directories, and GitHub Actions badge URLs
+      in text files. Any hit means CI workflow implementation reached the export
+      target and must be removed before re-running.
+    Also fail on a dangling `CLAUDE.md` symlink or a non-blank target
+    `install-defaults.toml` source.
 
 ## Never do
 

--- a/.agents/skills/export-catalogue/references/transform-manifest.md
+++ b/.agents/skills/export-catalogue/references/transform-manifest.md
@@ -34,8 +34,25 @@ attribution never re-admits governance:
   `CONTRIBUTING.md`. (A *projected* CONVENTIONS template that
   ships to adopters via the self-host recipe is a different artifact — it rides
   with the recipe; keep it.)
-- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, release
-  workflows, `tools/*` self-tests.
+- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, `tools/*`
+  self-tests.
+- **CI workflow and pipeline implementation.** The export surface is bounded to
+  `guides/`, projected tools, and seeded scaffold — CI implementation files are
+  outside this surface; no credentials are transported. Stripped CI artifacts:
+  - `.github/workflows/` — GitHub Actions workflow definitions and any helper
+    scripts they reference. Note: `.github/skills/`, `.github/agents/`,
+    `.github/hooks/`, and `.github/instructions/` are legitimate Copilot adapter
+    projection targets and are NOT stripped when present in the export target.
+  - Root-level CI config files: `.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`,
+    and equivalent provider files at the repo root.
+  - Any other provider-specific CI trigger config, pipeline definition, or
+    deployment/release automation not covered by the positive allowlist above.
+  - Workflow status badges (GitHub Actions badge URLs of the form
+    `https://github.com/<owner>/<repo>/actions/workflows/…`) embedded in any
+    guide or README file.
+  - Host-specific CI environment variable names (e.g. `ARTIFACTORY_TOKEN`,
+    `ANTHROPIC_API_KEY`) — these appear only inside CI workflow files and are
+    excluded transitively by path exclusion.
 - Provenance-only comments citing a stripped governance doc (keep comments that
   explain *why the code does what it does*).
 
@@ -67,10 +84,14 @@ catalogue) — this is the domain-repurposing lever.
 ## 4. GUIDES (per-pack, with _shared always)
 For each pack in the include-set, copy `guides/<pack-name>/` into the
 target at the same path. Always copy `guides/_shared/` (agentbundle
-infrastructure guides; adopter-facing, not catalogue-internal). Guides for
-packs outside the include-set are **omitted** (omit-not-leak). The SUBSTITUTE
-pass applies to all staged guide content; any identity references in `_shared/`
-guides survive into the target only in substituted form.
+infrastructure guides; adopter-facing, not catalogue-internal) — this includes
+`guides/_shared/reference/catalogue-ci-contract.md`, the portable provider-neutral
+CI contract the target organization receives. The contract is the adopter's
+canonical CI reference: the target chooses its own CI system; no CI workflow is
+generated or copied; no credentials are transported; no CI provider is assumed.
+Guides for packs outside the include-set are **omitted** (omit-not-leak). The
+SUBSTITUTE pass applies to all staged guide content; any identity references in
+`_shared/` guides survive into the target only in substituted form.
 
 ## 5. TOOL PROJECTION (core + governance-extras + catalogue-curation)
 After all content writes, project the three required packs from this
@@ -80,14 +101,22 @@ as catalogue packs in the fork's own `packs/`), so the fork can self-curate
 without inheriting the upstream pack catalogue. The SUBSTITUTE pass applies to
 projected files before they are written.
 
-## 6. VERIFY (fail-closed, mode-aware) — hard-fails the export
-- Grep the target for surviving upstream **URL, email, slug, owner** (all four
-  substitute anchors) — **case-insensitive**, over **text files** (binary out of
-  scope, declared), matching declared **literals only** after a normalization
-  pass (not case-folded-split / encoded / base64 derived forms; that blind spot
-  is stated, so the guarantee is honest).
+## 6. VERIFY (fail-closed, two checks) — hard-fails the export
+**Identity check** (`export_verify.verify()`): grep the target for surviving upstream
+**URL, email, slug, owner** (all four substitute anchors) — **case-insensitive**, over
+**text files** (binary out of scope, declared), matching declared **literals only** after
+a normalization pass (not case-folded-split / encoded / base64 derived forms; that blind
+spot is stated, so the guarantee is honest).
   - `white-label`: **zero** hits anywhere.
   - `attributed`: hits allowed **only** inside the declared attribution surface.
+
+**CI boundary check** (`export_verify.check_ci_boundary()`): scan the target for CI
+implementation files — `.github/workflows/` content, known root-level CI config files
+(`.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`), files under unknown dot-directories,
+and GitHub Actions badge URLs in any text file. Any violation means CI workflow
+implementation reached the export target and must be removed before re-running.
+
+Both checks hard-fail the export on a non-empty result (omit-not-leak). Also fail on:
 - No dangling symlink (`CLAUDE.md` is a real file).
 - Target `install-defaults.toml` `source` is blank/absent.
 - All writes went through `agentbundle.safety.write_jailed`; the target path was

--- a/.agents/skills/export-catalogue/scripts/export_verify.py
+++ b/.agents/skills/export-catalogue/scripts/export_verify.py
@@ -20,6 +20,7 @@ Pure-stdlib; reads the target tree, writes nothing.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 # Extensions we treat as binary and skip (out-of-scope, declared).
@@ -51,6 +52,75 @@ def _in_attribution(rel: str, allowed: set[str]) -> bool:
     """Exact-file match OR under a listed directory prefix — so an operator can
     list either `legal/NOTICE` or `legal/` and have it work."""
     return any(rel == a or rel.startswith(a.rstrip("/") + "/") for a in allowed)
+
+
+# GitHub Actions badge URL pattern (owner+repo+/actions/workflows/ form).
+_BADGE_RE = re.compile(
+    r"https?://[^)\s]*github[^)\s]*/[^)\s]+/[^)\s]+/actions/workflows/",
+    re.IGNORECASE,
+)
+
+# Dot-directories legitimately projected by adapters into export targets.
+# .github is included: .github/workflows/ is caught by check_ci_boundary's
+# Check 1 (path-parts), and .github/skills|agents|hooks|instructions/ are
+# legitimate Copilot adapter projection paths.
+_ALLOWED_DOT_DIRS = frozenset({".claude", ".agents", ".github"})
+
+# Known root-level CI config file names (not directories).
+_CI_ROOT_FILES = frozenset({".gitlab-ci.yml", ".travis.yml", "Jenkinsfile"})
+
+
+def check_ci_boundary(target: Path) -> list[Violation]:
+    """Check for CI implementation files in the export output.
+
+    Returns Violations for:
+    - Files under .github/workflows/ (GitHub Actions; path-parts, cross-platform)
+    - Root-level known CI config files (.gitlab-ci.yml, Jenkinsfile, .travis.yml)
+    - Files under a dot-directory not in _ALLOWED_DOT_DIRS (structural
+      unknown-provider detection; len(parts) > 1 guard skips root dotfiles)
+    - Files containing a GitHub Actions badge URL (all text files)
+
+    Does NOT flag .github/skills/, .github/agents/, .github/hooks/, or
+    .github/instructions/ — legitimate Copilot adapter projection paths.
+    """
+    target = Path(target)
+    violations: list[Violation] = []
+    for p in sorted(target.rglob("*")):
+        if not p.is_file() or _skip_by_ext(p):
+            continue
+        rel = str(p.relative_to(target))
+        parts = Path(rel).parts
+        root = parts[0] if parts else ""
+
+        # Check 1: .github/workflows/ by path parts — cross-platform.
+        # str(p.relative_to(target)) is \-separated on Windows; parts[] is safe.
+        if len(parts) >= 2 and parts[0] == ".github" and parts[1] == "workflows":
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 2: known root-level CI config files.
+        if root in _CI_ROOT_FILES:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 3: files *under* dot-directories not in the projected-tool allowlist.
+        # len(parts) > 1: root-level dotfiles (.gitignore, .editorconfig) are not
+        # CI suspects — only files inside an unknown dot-directory are.
+        if len(parts) > 1 and root.startswith(".") and root not in _ALLOWED_DOT_DIRS:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 4: GitHub Actions badge URL in any text file.
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = _BADGE_RE.search(content)
+        if m:
+            lineno = content[: m.start()].count("\n") + 1
+            violations.append(Violation(rel, "ci_badge_url", lineno))
+
+    return violations
 
 
 def verify(

--- a/.agents/skills/export-catalogue/scripts/test_export_ci_boundary.py
+++ b/.agents/skills/export-catalogue/scripts/test_export_ci_boundary.py
@@ -1,0 +1,99 @@
+"""Tests for check_ci_boundary (spec/catalogue-ci-export-boundary AC7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import export_verify as V
+
+
+def _tree(tmp: Path, files: dict[str, str]) -> Path:
+    root = tmp / "target"
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return root
+
+
+def test_ci_contract_guide_eligible(tmp_path: Path) -> None:  # STUB: AC7
+    """guides/_shared/reference/catalogue-ci-contract.md is not flagged."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_github_workflow_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/workflows/ file is flagged as ci_path."""
+    root = _tree(tmp_path, {
+        ".github/workflows/publish-catalogue.yml": "on: push\n",
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_github_adapter_path_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/skills/ file (Copilot adapter projection) is NOT flagged."""
+    root = _tree(tmp_path, {
+        ".github/skills/core/SKILL.md": "# core skill\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_ci_root_file_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root Jenkinsfile is flagged as ci_path (exercises Check 2)."""
+    root = _tree(tmp_path, {"Jenkinsfile": "pipeline {}\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_unknown_provider_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A fictional .ci/step.yml (dot-directory, not in allowlist) is flagged."""
+    root = _tree(tmp_path, {".ci/step.yml": "steps: []\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_badge_url_in_guide_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A guide file containing a GitHub Actions badge URL is flagged."""
+    root = _tree(tmp_path, {
+        "guides/core/README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_badge_url_outside_guides_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root README.md containing a badge URL is also flagged (badge scan is not
+    limited to guides/)."""
+    root = _tree(tmp_path, {
+        "README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_clean_export_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A realistic export scaffold with no CI files passes check_ci_boundary and
+    the existing white-label verify(). Includes root dotfiles (.gitignore) seeded
+    by step 4 — guards the len(parts) > 1 invariant in Check 3."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+        "guides/core/how-to/get-started.md": "# Getting started\n",
+        "docs/CONVENTIONS.md": "# Conventions\n",
+        ".claude/skills/core/SKILL.md": "# core skill\n",
+        ".agents/skills/core/SKILL.md": "# core skill\n",
+        ".github/skills/core/SKILL.md": "# core skill\n",
+        ".gitignore": "__pycache__/\n*.pyc\n",
+        ".editorconfig": "[*]\nindent_style = space\n",
+        "AGENTS.md": "# Agents\n",
+        "workspace.toml": "[workspace]\n",
+    })
+    assert V.check_ci_boundary(root) == []
+    anchors = {"url": "https://example.com", "email": "", "slug": "", "owner": ""}
+    assert V.verify(root, anchors, mode="white-label") == []

--- a/.claude/skills/export-catalogue/SKILL.md
+++ b/.claude/skills/export-catalogue/SKILL.md
@@ -39,9 +39,16 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    while excluding: catalogue-governance (`docs/rfc/`, `docs/adr/`,
    `docs/specs/`, `docs/backlog.md`), the running repo's own
    `CHARTER`/`CONVENTIONS`/`**/AGENTS.local.md` (root and all subdirectories),
-   `**/README-pypi.md`, the internal doc site, and
-   build/scan/release tooling. Strip runs on the running-repo content copy only;
-   seeds (step 4) are planted fresh afterward and are not affected.
+   `**/README-pypi.md`, the internal doc site, and build/scan/release tooling.
+   **CI workflow and pipeline implementation is also excluded from the export
+   surface.** The export surface is bounded to `guides/`, projected tools, and
+   seeded scaffold — CI implementation files are outside this surface; no
+   credentials are transported. Excluded CI artifacts include: `.github/workflows/`
+   (GitHub Actions; note `.github/skills|agents|hooks|instructions/` are legitimate
+   Copilot adapter paths and travel when projected), `.gitlab-ci.yml`, `Jenkinsfile`,
+   `.travis.yml`, provider-specific CI trigger config, CI-specific helper scripts
+   not part of the pack, and workflow status badges. Strip runs on the running-repo
+   content copy only; seeds (step 4) are planted fresh afterward and are not affected.
 4. **Plant seeds.** For each projected tool (core, governance-extras) and any
    pack in the include-set with a `seeds/` directory, copy the seed tree to the
    target repo root. Establishes the scaffold the skills navigate: `AGENTS.md`,
@@ -58,9 +65,13 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    anchors all future `assimilate-repo` runs from within the fork.
 6. **Stage transportable guides.** For each pack in the include-set, copy
    `guides/<pack-name>/` into the target. Always include
-   `guides/_shared/`. Guides for packs outside the include-set are
-   omitted (omit-not-leak). The four-anchor substitution pass in step 7 covers
-   any identity references inside staged guide content.
+   `guides/_shared/` — this includes `guides/_shared/reference/catalogue-ci-contract.md`,
+   the portable CI contract the target organization receives. The contract is the
+   adopter's CI reference: the target chooses its own CI system; no CI workflow is
+   generated or copied; no credentials are transported; no CI provider is assumed.
+   Guides for packs outside the include-set are omitted (omit-not-leak). The
+   four-anchor substitution pass in step 7 covers any identity references inside
+   staged guide content.
 7. **Substitute** the four identity anchors from *this* catalogue's own sources
    (URL + slug + owner from `.adapt-discovery.toml`; email from `pack.toml`
    maintainer + git) — so the tooling carries no hardcoded upstream literal. URL
@@ -84,14 +95,20 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    own catalogue — so the fork can self-curate from day one without inheriting
    agent-ready-repo's pack catalogue. Apply the four-anchor substitution to any
    projected file that still carries upstream identity.
-10. **Verify, fail-closed.** Grep the target for surviving upstream **URL, email,
-    slug, and owner** (the same four anchors, so verify and substitute agree),
-    **case-insensitively**, over **text files** (binary out of scope, declared),
-    matching declared **literals only** after a normalization pass. In
-    `white-label` mode: zero hits anywhere. In `attributed` mode: hits only inside
-    the declared attribution surface. Also fail on a dangling `CLAUDE.md` symlink
-    or a non-blank target `install-defaults.toml` source. Any hit **hard-fails the
-    export** — omit-not-leak.
+10. **Verify, fail-closed.** Run two checks; either failing hard-fails the export
+    (omit-not-leak):
+    - **Identity check** (`export_verify.verify()`): grep the target for surviving
+      upstream **URL, email, slug, and owner** (the same four anchors), case-insensitively,
+      over text files (binary out of scope, declared), matching declared literals only
+      after a normalization pass. In `white-label` mode: zero hits anywhere. In
+      `attributed` mode: hits only inside the declared attribution surface.
+    - **CI boundary check** (`export_verify.check_ci_boundary()`): scan the target
+      for CI implementation files — `.github/workflows/` content, known root-level CI
+      config files, files under unknown dot-directories, and GitHub Actions badge URLs
+      in text files. Any hit means CI workflow implementation reached the export
+      target and must be removed before re-running.
+    Also fail on a dangling `CLAUDE.md` symlink or a non-blank target
+    `install-defaults.toml` source.
 
 ## Never do
 

--- a/.claude/skills/export-catalogue/references/transform-manifest.md
+++ b/.claude/skills/export-catalogue/references/transform-manifest.md
@@ -34,8 +34,25 @@ attribution never re-admits governance:
   `CONTRIBUTING.md`. (A *projected* CONVENTIONS template that
   ships to adopters via the self-host recipe is a different artifact — it rides
   with the recipe; keep it.)
-- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, release
-  workflows, `tools/*` self-tests.
+- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, `tools/*`
+  self-tests.
+- **CI workflow and pipeline implementation.** The export surface is bounded to
+  `guides/`, projected tools, and seeded scaffold — CI implementation files are
+  outside this surface; no credentials are transported. Stripped CI artifacts:
+  - `.github/workflows/` — GitHub Actions workflow definitions and any helper
+    scripts they reference. Note: `.github/skills/`, `.github/agents/`,
+    `.github/hooks/`, and `.github/instructions/` are legitimate Copilot adapter
+    projection targets and are NOT stripped when present in the export target.
+  - Root-level CI config files: `.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`,
+    and equivalent provider files at the repo root.
+  - Any other provider-specific CI trigger config, pipeline definition, or
+    deployment/release automation not covered by the positive allowlist above.
+  - Workflow status badges (GitHub Actions badge URLs of the form
+    `https://github.com/<owner>/<repo>/actions/workflows/…`) embedded in any
+    guide or README file.
+  - Host-specific CI environment variable names (e.g. `ARTIFACTORY_TOKEN`,
+    `ANTHROPIC_API_KEY`) — these appear only inside CI workflow files and are
+    excluded transitively by path exclusion.
 - Provenance-only comments citing a stripped governance doc (keep comments that
   explain *why the code does what it does*).
 
@@ -67,10 +84,14 @@ catalogue) — this is the domain-repurposing lever.
 ## 4. GUIDES (per-pack, with _shared always)
 For each pack in the include-set, copy `guides/<pack-name>/` into the
 target at the same path. Always copy `guides/_shared/` (agentbundle
-infrastructure guides; adopter-facing, not catalogue-internal). Guides for
-packs outside the include-set are **omitted** (omit-not-leak). The SUBSTITUTE
-pass applies to all staged guide content; any identity references in `_shared/`
-guides survive into the target only in substituted form.
+infrastructure guides; adopter-facing, not catalogue-internal) — this includes
+`guides/_shared/reference/catalogue-ci-contract.md`, the portable provider-neutral
+CI contract the target organization receives. The contract is the adopter's
+canonical CI reference: the target chooses its own CI system; no CI workflow is
+generated or copied; no credentials are transported; no CI provider is assumed.
+Guides for packs outside the include-set are **omitted** (omit-not-leak). The
+SUBSTITUTE pass applies to all staged guide content; any identity references in
+`_shared/` guides survive into the target only in substituted form.
 
 ## 5. TOOL PROJECTION (core + governance-extras + catalogue-curation)
 After all content writes, project the three required packs from this
@@ -80,14 +101,22 @@ as catalogue packs in the fork's own `packs/`), so the fork can self-curate
 without inheriting the upstream pack catalogue. The SUBSTITUTE pass applies to
 projected files before they are written.
 
-## 6. VERIFY (fail-closed, mode-aware) — hard-fails the export
-- Grep the target for surviving upstream **URL, email, slug, owner** (all four
-  substitute anchors) — **case-insensitive**, over **text files** (binary out of
-  scope, declared), matching declared **literals only** after a normalization
-  pass (not case-folded-split / encoded / base64 derived forms; that blind spot
-  is stated, so the guarantee is honest).
+## 6. VERIFY (fail-closed, two checks) — hard-fails the export
+**Identity check** (`export_verify.verify()`): grep the target for surviving upstream
+**URL, email, slug, owner** (all four substitute anchors) — **case-insensitive**, over
+**text files** (binary out of scope, declared), matching declared **literals only** after
+a normalization pass (not case-folded-split / encoded / base64 derived forms; that blind
+spot is stated, so the guarantee is honest).
   - `white-label`: **zero** hits anywhere.
   - `attributed`: hits allowed **only** inside the declared attribution surface.
+
+**CI boundary check** (`export_verify.check_ci_boundary()`): scan the target for CI
+implementation files — `.github/workflows/` content, known root-level CI config files
+(`.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`), files under unknown dot-directories,
+and GitHub Actions badge URLs in any text file. Any violation means CI workflow
+implementation reached the export target and must be removed before re-running.
+
+Both checks hard-fail the export on a non-empty result (omit-not-leak). Also fail on:
 - No dangling symlink (`CLAUDE.md` is a real file).
 - Target `install-defaults.toml` `source` is blank/absent.
 - All writes went through `agentbundle.safety.write_jailed`; the target path was

--- a/.claude/skills/export-catalogue/scripts/export_verify.py
+++ b/.claude/skills/export-catalogue/scripts/export_verify.py
@@ -20,6 +20,7 @@ Pure-stdlib; reads the target tree, writes nothing.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 # Extensions we treat as binary and skip (out-of-scope, declared).
@@ -51,6 +52,75 @@ def _in_attribution(rel: str, allowed: set[str]) -> bool:
     """Exact-file match OR under a listed directory prefix — so an operator can
     list either `legal/NOTICE` or `legal/` and have it work."""
     return any(rel == a or rel.startswith(a.rstrip("/") + "/") for a in allowed)
+
+
+# GitHub Actions badge URL pattern (owner+repo+/actions/workflows/ form).
+_BADGE_RE = re.compile(
+    r"https?://[^)\s]*github[^)\s]*/[^)\s]+/[^)\s]+/actions/workflows/",
+    re.IGNORECASE,
+)
+
+# Dot-directories legitimately projected by adapters into export targets.
+# .github is included: .github/workflows/ is caught by check_ci_boundary's
+# Check 1 (path-parts), and .github/skills|agents|hooks|instructions/ are
+# legitimate Copilot adapter projection paths.
+_ALLOWED_DOT_DIRS = frozenset({".claude", ".agents", ".github"})
+
+# Known root-level CI config file names (not directories).
+_CI_ROOT_FILES = frozenset({".gitlab-ci.yml", ".travis.yml", "Jenkinsfile"})
+
+
+def check_ci_boundary(target: Path) -> list[Violation]:
+    """Check for CI implementation files in the export output.
+
+    Returns Violations for:
+    - Files under .github/workflows/ (GitHub Actions; path-parts, cross-platform)
+    - Root-level known CI config files (.gitlab-ci.yml, Jenkinsfile, .travis.yml)
+    - Files under a dot-directory not in _ALLOWED_DOT_DIRS (structural
+      unknown-provider detection; len(parts) > 1 guard skips root dotfiles)
+    - Files containing a GitHub Actions badge URL (all text files)
+
+    Does NOT flag .github/skills/, .github/agents/, .github/hooks/, or
+    .github/instructions/ — legitimate Copilot adapter projection paths.
+    """
+    target = Path(target)
+    violations: list[Violation] = []
+    for p in sorted(target.rglob("*")):
+        if not p.is_file() or _skip_by_ext(p):
+            continue
+        rel = str(p.relative_to(target))
+        parts = Path(rel).parts
+        root = parts[0] if parts else ""
+
+        # Check 1: .github/workflows/ by path parts — cross-platform.
+        # str(p.relative_to(target)) is \-separated on Windows; parts[] is safe.
+        if len(parts) >= 2 and parts[0] == ".github" and parts[1] == "workflows":
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 2: known root-level CI config files.
+        if root in _CI_ROOT_FILES:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 3: files *under* dot-directories not in the projected-tool allowlist.
+        # len(parts) > 1: root-level dotfiles (.gitignore, .editorconfig) are not
+        # CI suspects — only files inside an unknown dot-directory are.
+        if len(parts) > 1 and root.startswith(".") and root not in _ALLOWED_DOT_DIRS:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 4: GitHub Actions badge URL in any text file.
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = _BADGE_RE.search(content)
+        if m:
+            lineno = content[: m.start()].count("\n") + 1
+            violations.append(Violation(rel, "ci_badge_url", lineno))
+
+    return violations
 
 
 def verify(

--- a/.claude/skills/export-catalogue/scripts/test_export_ci_boundary.py
+++ b/.claude/skills/export-catalogue/scripts/test_export_ci_boundary.py
@@ -1,0 +1,99 @@
+"""Tests for check_ci_boundary (spec/catalogue-ci-export-boundary AC7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import export_verify as V
+
+
+def _tree(tmp: Path, files: dict[str, str]) -> Path:
+    root = tmp / "target"
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return root
+
+
+def test_ci_contract_guide_eligible(tmp_path: Path) -> None:  # STUB: AC7
+    """guides/_shared/reference/catalogue-ci-contract.md is not flagged."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_github_workflow_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/workflows/ file is flagged as ci_path."""
+    root = _tree(tmp_path, {
+        ".github/workflows/publish-catalogue.yml": "on: push\n",
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_github_adapter_path_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/skills/ file (Copilot adapter projection) is NOT flagged."""
+    root = _tree(tmp_path, {
+        ".github/skills/core/SKILL.md": "# core skill\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_ci_root_file_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root Jenkinsfile is flagged as ci_path (exercises Check 2)."""
+    root = _tree(tmp_path, {"Jenkinsfile": "pipeline {}\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_unknown_provider_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A fictional .ci/step.yml (dot-directory, not in allowlist) is flagged."""
+    root = _tree(tmp_path, {".ci/step.yml": "steps: []\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_badge_url_in_guide_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A guide file containing a GitHub Actions badge URL is flagged."""
+    root = _tree(tmp_path, {
+        "guides/core/README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_badge_url_outside_guides_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root README.md containing a badge URL is also flagged (badge scan is not
+    limited to guides/)."""
+    root = _tree(tmp_path, {
+        "README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_clean_export_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A realistic export scaffold with no CI files passes check_ci_boundary and
+    the existing white-label verify(). Includes root dotfiles (.gitignore) seeded
+    by step 4 — guards the len(parts) > 1 invariant in Check 3."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+        "guides/core/how-to/get-started.md": "# Getting started\n",
+        "docs/CONVENTIONS.md": "# Conventions\n",
+        ".claude/skills/core/SKILL.md": "# core skill\n",
+        ".agents/skills/core/SKILL.md": "# core skill\n",
+        ".github/skills/core/SKILL.md": "# core skill\n",
+        ".gitignore": "__pycache__/\n*.pyc\n",
+        ".editorconfig": "[*]\nindent_style = space\n",
+        "AGENTS.md": "# Agents\n",
+        "workspace.toml": "[workspace]\n",
+    })
+    assert V.check_ci_boundary(root) == []
+    anchors = {"url": "https://example.com", "email": "", "slug": "", "owner": ""}
+    assert V.verify(root, anchors, mode="white-label") == []

--- a/docs/specs/catalogue-ci-export-boundary/plan.md
+++ b/docs/specs/catalogue-ci-export-boundary/plan.md
@@ -1,0 +1,246 @@
+# Plan: catalogue-ci-export-boundary
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Source-of-truth path
+
+The export-catalogue skill is a projected primitive. All edits go to:
+
+```
+packs/catalogue-curation/.apm/skills/export-catalogue/
+```
+
+After code or doc changes, run `make build-self` to project to `.claude/` and
+`.agents/`. The build-check gate verifies projection parity.
+
+## Constraints
+
+- Do not modify existing `verify()` behavior or its call signature.
+- Do not touch `test_export_verify.py` or `test_integration_export.py`.
+- All new files land in `packs/catalogue-curation/.apm/skills/export-catalogue/scripts/`.
+
+## Risks
+
+- `Violation` reuse: CI boundary findings use `anchor` values `"ci_path"` and
+  `"ci_badge_url"`, distinct from identity anchors `url/email/slug/owner`.
+  No existing caller pattern-matches on anchor name; adding new values is safe.
+- Dot-directory check could over-flag if a legitimate dot-directory (not
+  `.claude`, `.agents`, `.github`) is in the export target. Mitigated by: the
+  check fires in the step 10 verify pass — non-CI dot-directories should not
+  appear in the target by construction.
+
+## Tasks
+
+### Task 1 — Write red stubs in `test_export_ci_boundary.py`
+
+**Mode:** TDD (red phase)
+**Depends on:** none
+
+**Approach (stub: true):** Create
+`packs/catalogue-curation/.apm/skills/export-catalogue/scripts/test_export_ci_boundary.py`
+importing `export_verify as V`. Add the eight test functions from AC7 with
+`tmp_path` fixtures, a `_tree(tmp, files)` helper, and each assertion calling
+`V.check_ci_boundary(root)` (which doesn't exist yet). Each function carries
+`# STUB: AC7` so Task 4 can identify it. Tests fail with `AttributeError` on
+`V.check_ci_boundary`.
+
+Eight tests: `test_ci_contract_guide_eligible`, `test_github_workflow_flagged`,
+`test_github_adapter_path_passes`, `test_ci_root_file_flagged`,
+`test_unknown_provider_flagged`, `test_badge_url_in_guide_flagged`,
+`test_badge_url_outside_guides_flagged`, `test_clean_export_passes`.
+
+**Done when:** `pytest scripts/test_export_ci_boundary.py` from the `scripts/`
+directory exits non-zero; all eight tests collected.
+
+---
+
+### Task 2 — Update `SKILL.md` (strip, guide eligibility, verify scope)
+
+**Mode:** visual/manual QA
+**Depends on:** none
+**Path:** `packs/catalogue-curation/.apm/skills/export-catalogue/SKILL.md`
+
+**Approach:**
+1. Step 3 (Strip): replace "release workflows" with the explicit scoped list and
+   positive allowlist statement from AC1. Name `.github/workflows/` (not the
+   `.github/` root), `.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`, badges,
+   no-credentials clause.
+2. Step 6 (Stage transportable guides): add AC2's sentence naming
+   `catalogue-ci-contract.md` as eligible with the CI-neutrality principle.
+3. Step 10 (Verify, fail-closed): add `check_ci_boundary()` as an additional
+   check.
+
+**Done when:**
+- `grep -n "workflows\|check_ci_boundary\|positive allowlist" SKILL.md` returns
+  hits in the three correct sections (steps 3, 6, 10).
+- Manual read confirms step 3 explicitly names `.github/workflows/` (with
+  `/workflows/`) and does NOT exclude a bare `.github/` root — the scoping is
+  the key correctness boundary; grep alone cannot verify it.
+- File has no RFC/ADR/spec citations.
+
+---
+
+### Task 3 — Update `transform-manifest.md` (STRIP and GUIDES sections)
+
+**Mode:** visual/manual QA
+**Depends on:** none
+**Path:** `packs/catalogue-curation/.apm/skills/export-catalogue/references/transform-manifest.md`
+
+**Approach:**
+1. Section 1 (STRIP): replace/extend the "release workflows" line with the
+   explicit exclusion list from AC4 and the positive allowlist statement.
+   Name `.github/workflows/` precisely (not the root), `.gitlab-ci.yml`,
+   `Jenkinsfile`, badges, no-credentials clause.
+2. Section 4 (GUIDES): add the `guides/_shared/reference/catalogue-ci-contract.md`
+   eligibility statement and CI-neutrality guidance from AC5.
+
+**Done when:**
+- `grep -n "catalogue-ci-contract\|positive allowlist\|no credentials"
+  transform-manifest.md` returns expected hits.
+- Manual read confirms section 1 scopes to `.github/workflows/` not bare
+  `.github/`.
+- File has no RFC/ADR/spec citations.
+
+---
+
+### Task 4 — Implement `check_ci_boundary` in `export_verify.py`
+
+**Mode:** TDD (green phase)
+**Depends on:** Task 1 (red stubs collected)
+**Path:** `packs/catalogue-curation/.apm/skills/export-catalogue/scripts/export_verify.py`
+
+**Tests:** all eight stubs from `test_export_ci_boundary.py` (AC7).
+
+**Implementation:**
+
+Add to `export_verify.py`: move `import re` into the existing top-level import
+block (alongside `from pathlib import Path`); add the constants and the function
+after the existing `verify` function:
+
+```python
+# In the top import block (beside existing imports):
+import re
+
+# After the existing `verify` function — constants then function:
+
+# GitHub Actions badge URL pattern (owner+repo+/actions/workflows/).
+_BADGE_RE = re.compile(
+    r"https?://[^)\s]*github[^)\s]*/[^)\s]+/[^)\s]+/actions/workflows/",
+    re.IGNORECASE,
+)
+
+# Dot-directories that adapters legitimately project into export targets.
+# .github is included because .github/workflows/ is caught by Check 1's early
+# continue, and .github/skills|agents|hooks|instructions/ are legitimate
+# Copilot adapter projection paths.
+_ALLOWED_DOT_DIRS = frozenset({".claude", ".agents", ".github"})
+
+# Known root-level CI config file names (not directories; no leading dot).
+_CI_ROOT_FILES = frozenset({".gitlab-ci.yml", ".travis.yml", "Jenkinsfile"})
+
+# No prefix constant — use path parts for cross-platform correctness (Windows uses \).
+
+
+def check_ci_boundary(target: Path) -> list[Violation]:
+    """Check for CI implementation files in the export output.
+
+    Returns Violations for:
+    - Files under .github/workflows/ (GitHub Actions; path-parts check, not string prefix)
+    - Root-level known CI config files (.gitlab-ci.yml, Jenkinsfile, .travis.yml)
+    - Files under a dot-directory not in _ALLOWED_DOT_DIRS (structural
+      unknown-provider detection — len(parts) > 1 guard skips root dotfiles)
+    - Files whose content contains a GitHub Actions badge URL (all text files)
+
+    Does NOT flag .github/skills/, .github/agents/, .github/hooks/, or
+    .github/instructions/ — these are legitimate Copilot adapter projection paths.
+    """
+    target = Path(target)
+    violations: list[Violation] = []
+    for p in sorted(target.rglob("*")):
+        if not p.is_file() or _skip_by_ext(p):
+            continue
+        rel = str(p.relative_to(target))
+        parts = Path(rel).parts
+        root = parts[0] if parts else ""
+
+        # Check 1: .github/workflows/ by path parts — cross-platform.
+        # str(p.relative_to(target)) is \-separated on Windows; parts[] is safe.
+        if len(parts) >= 2 and parts[0] == ".github" and parts[1] == "workflows":
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 2: known root-level CI config files.
+        if root in _CI_ROOT_FILES:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 3: files *under* dot-directories not in the projected-tool allowlist.
+        # len(parts) > 1 guard: root-level dotfiles (.gitignore, .editorconfig)
+        # are not CI suspects; only files inside an unknown dot-directory are.
+        if len(parts) > 1 and root.startswith(".") and root not in _ALLOWED_DOT_DIRS:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 4: GitHub Actions badge URL in any text file.
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = _BADGE_RE.search(content)
+        if m:
+            lineno = content[: m.start()].count("\n") + 1
+            violations.append(Violation(rel, "ci_badge_url", lineno))
+
+    return violations
+```
+
+**Why this design:**
+- Check 1 uses `parts[0] == ".github" and parts[1] == "workflows"` — cross-platform.
+  `.github/skills/core/SKILL.md` has `parts[1] == "skills"` → no match → falls
+  through to Check 3 where `.github` IS in `_ALLOWED_DOT_DIRS` → passes.
+- Check 2 catches known root-level CI filenames (no dot-directory — `Jenkinsfile`,
+  `.gitlab-ci.yml`, `.travis.yml`).
+- Check 3 uses `len(parts) > 1` so root-level dotfiles (`.gitignore`) are not
+  flagged; `.ci/step.yml` has root `.ci` (starts with `.`, not in `_ALLOWED_DOT_DIRS`,
+  len > 1) → flagged as `ci_path`.
+- Check 4 covers all text files (not guides-only) per AC6.
+
+**Done when:** `pytest scripts/test_export_ci_boundary.py` exits 0 (all eight pass).
+
+---
+
+### Task 5 — Project and verify
+
+**Mode:** goal-based
+**Depends on:** Tasks 2, 3, 4
+
+**Approach:**
+1. From repo root: `make build-self` — projects the updated `.apm/` source to
+   `.claude/` and `.agents/`.
+2. Confirm three-copy parity: the updated `export_verify.py` and
+   `SKILL.md` appear in all three trees with the same content.
+
+**Done when:**
+- `make build-self` exits 0.
+- `diff packs/catalogue-curation/.apm/skills/export-catalogue/scripts/export_verify.py \
+  .claude/skills/export-catalogue/scripts/export_verify.py` exits 0.
+
+---
+
+## Post-task GATES
+
+After all tasks and `make build-self` complete:
+
+```bash
+make build-check                                             # parity + lint gate
+# From the export-catalogue scripts/ directory:
+python3 -m pytest scripts/test_export_ci_boundary.py -v    # new tests (AC7)
+python3 -m pytest scripts/test_export_verify.py -v         # regression (AC8)
+python3 -m pytest scripts/test_integration_export.py -v    # regression (AC8)
+```
+
+All pass → GATES green.
+
+Run `scripts/lint-spec-status.py` (work-loop sibling) at DECIDE to check
+spec metadata invariants.

--- a/docs/specs/catalogue-ci-export-boundary/spec.md
+++ b/docs/specs/catalogue-ci-export-boundary/spec.md
@@ -1,0 +1,210 @@
+# Spec: catalogue-ci-export-boundary
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** `spec/catalogue-ci-contract-guide` (Shipped)
+- **Contract:** none
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full (structural/public-interface change — the export-catalogue skill's documented
+export surface is a public interface that adopters depend on)
+
+## Objective
+
+The export-catalogue skill must make its CI boundary unambiguous and verifiable.
+Today, `guides/_shared/` always travels by step 6, so the CI contract guide is
+eligible by construction — but the skill says nothing about it. The strip list says
+"release workflows" without naming CI provider directories, leaving open the
+possibility that an agent interpreting the skill broadly would copy `.github/workflows/`
+or similar CI implementation files to the export target.
+
+After this spec ships:
+1. `SKILL.md` and `transform-manifest.md` explicitly state that
+   `guides/_shared/reference/catalogue-ci-contract.md` is eligible for export.
+2. The strip documentation explicitly excludes CI workflow and pipeline
+   implementation using positive allowlist framing — the export surface is bounded
+   to `guides/`, projected tools, and seeded scaffold; CI files are outside it.
+3. `export_verify.py` gains a `check_ci_boundary()` function that the agent calls
+   in step 10 (Verify, fail-closed) to detect CI implementation files in the
+   export target.
+4. Tests verify: neutral guide eligible, CI implementation excluded (known and
+   unknown providers), legitimate `.github/` adapter content passes, policy does
+   not rely solely on known provider filenames, white-label behavior fail-closed.
+
+## Boundaries
+
+### Always do
+
+- Use positive allowlist framing in documentation: name what IS in the export
+  surface, not only what is excluded.
+- Scope `.github/` detection to `.github/workflows/` — Copilot legitimately
+  projects to `.github/skills/`, `.github/agents/`, `.github/hooks/`, and
+  `.github/instructions/`; these must not be flagged.
+- Test both known-provider CI paths (`.github/workflows/`) and structural
+  unknown-provider detection; include a negative test for legitimate `.github/`
+  adapter content.
+- Extend `export_verify.py` — add to it, do not change existing behavior.
+
+### Ask first
+
+- Any change to export procedure steps 1–9 beyond strip/include wording
+  clarifications and the verify scope addition.
+- Adding a pre-export scrubber that rewrites CI badge URLs inside guide content
+  before staging them — that's a different mechanism; raise if the need surfaces.
+
+### Never do
+
+- Implement the full export procedure as Python code — it is agent-executed by
+  design; automating it duplicates agent behavior.
+- Modify existing `verify()` function logic or the identity-anchor leak check.
+- Flag `.github/skills/`, `.github/agents/`, `.github/hooks/`, or
+  `.github/instructions/` as CI violations — these are Copilot adapter
+  projection paths that are legitimate export content.
+- Add CI content to, or remove any guide from, `guides/_shared/` — this spec only
+  updates skill documentation and the verify helper.
+- Cite RFC, ADR, or spec paths in the shipped skill files (SKILL.md,
+  transform-manifest.md, scripts/).
+- Scope into `spec/catalogue-ci-documentation` — discovery hooks for adopters
+  (guides/README.md, CLI reference, etc.) belong to that spec.
+
+## Testing Strategy
+
+- **AC1–AC5 (documentation):** visual/manual QA. Read the updated SKILL.md and
+  transform-manifest.md end-to-end; confirm positive allowlist framing is present
+  and CI boundary is explicit with the `.github/workflows/`-specific scope.
+- **AC6–AC7 (check_ci_boundary):** TDD. Red stubs first, then implement, then
+  confirm tests are green. Run with `pytest scripts/test_export_ci_boundary.py`
+  from the skill's `scripts/` directory (matches existing test runner pattern for
+  `test_export_verify.py`).
+- **AC8 (regression):** Run all existing tests in `scripts/` and confirm no
+  regressions: `pytest scripts/test_export_verify.py scripts/test_integration_export.py`.
+
+## Acceptance Criteria
+
+**Documentation — SKILL.md**
+
+- [x] AC1: `SKILL.md` step 3 (Strip) explicitly states that CI workflow and
+  pipeline implementation files are excluded from the export surface. Named
+  examples scoped precisely: `.github/workflows/` (not the `.github/` root —
+  adapter projection paths `.github/skills|agents|hooks|instructions/` are
+  legitimate export content), `.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`,
+  CI-specific trigger config and helper scripts, workflow status badges.
+  Uses positive allowlist framing: "The export surface is bounded to guides/,
+  projected tools, and seeded scaffold — CI implementation files are outside
+  this surface; no credentials are transported."
+- [x] AC2: `SKILL.md` step 6 (Stage transportable guides) explicitly states that
+  `guides/_shared/reference/catalogue-ci-contract.md` is eligible for export as
+  part of `guides/_shared/`, and that the guide is the portable CI contract
+  adopters receive — target chooses its own CI system; no CI workflow is generated
+  or copied; no credentials are transported; no CI provider is assumed.
+- [x] AC3: `SKILL.md` step 10 (Verify, fail-closed) explicitly states that the
+  fail-closed check includes `check_ci_boundary()` — no CI implementation files in
+  the export target — in addition to the existing upstream-identity anchor check.
+
+**Documentation — transform-manifest.md**
+
+- [x] AC4: `transform-manifest.md` section 1 (STRIP) is updated to explicitly list
+  CI workflow/pipeline exclusions — `.github/workflows/` (not the broader `.github/`
+  root), `.gitlab-ci.yml`, `Jenkinsfile`, workflow status badges, CI-specific
+  env-var names — and includes the positive allowlist statement: "CI implementation
+  files are not part of the export surface; the surface is bounded to guides/,
+  projected tools, and seeded scaffold; no credentials are transported."
+- [x] AC5: `transform-manifest.md` section 4 (GUIDES) explicitly states that
+  `guides/_shared/` always travels and includes `catalogue-ci-contract.md`; adds
+  the guidance: the target receives the neutral CI contract and chooses its own CI
+  system — no CI workflow is copied, no credentials are transported, and no CI
+  provider is assumed.
+
+**Code — export_verify.py**
+
+- [x] AC6: `export_verify.py` gains `check_ci_boundary(target: Path) -> list[Violation]`
+  that returns non-empty on a target containing any of:
+  - A file under `.github/workflows/` (scoped path prefix — NOT the `.github/`
+    root; `.github/skills/`, `.github/agents/`, `.github/hooks/`, and
+    `.github/instructions/` are legitimate and must not be flagged)
+  - A root-level file named `.gitlab-ci.yml`, `Jenkinsfile`, or `.travis.yml`
+    (known provider root files)
+  - A file *under* (not at root-level beside) a dot-directory at the target root
+    that is not `.claude`, `.agents`, or `.github` — flagged as structural
+    unknown-provider detection (`.github` is allowlisted because `.github/workflows/`
+    is already caught by Check 1 above, and `.github/skills|agents|hooks|instructions/`
+    are legitimate Copilot adapter paths; this satisfies "policy does not rely solely
+    on known provider filenames")
+  - A file in any location whose content contains a GitHub Actions badge URL
+    (pattern: `https?://[^)\s]*github[^)\s]*/[^)\s]+/[^)\s]+/actions/workflows/`,
+    which requires owner + repo before `/actions/workflows/` — matching the canonical
+    badge URL shape); badge scan covers all text files in the target, not only guide files
+  Returns empty list on a target containing only legitimately exported content:
+  guide files, docs scaffold, `.claude/skills/`, `.agents/skills/`, root scaffold
+  files, and `.github/skills/`, `.github/agents/`, `.github/hooks/`,
+  `.github/instructions/`.
+  Note on host-specific secret names (e.g. `ARTIFACTORY_TOKEN`,
+  `ANTHROPIC_API_KEY`): these are covered transitively — they appear only in CI
+  workflow files that the path-based checks already exclude. No separate content
+  scan for secret variable names is added; the path exclusion is the sufficient
+  boundary.
+
+**Tests — test_export_ci_boundary.py**
+
+- [x] AC7: `scripts/test_export_ci_boundary.py` (new) contains and all pass:
+  - `test_ci_contract_guide_eligible`: a target with only
+    `guides/_shared/reference/catalogue-ci-contract.md` passes `check_ci_boundary`
+    (returns `[]`).
+  - `test_github_workflow_flagged`: a target with
+    `.github/workflows/publish-catalogue.yml` fails `check_ci_boundary` with a
+    violation.
+  - `test_github_adapter_path_passes`: a target with
+    `.github/skills/core/SKILL.md` (a legitimate Copilot adapter projection)
+    passes `check_ci_boundary` (returns `[]`). This test guards against false
+    positives on the `.github/` root.
+  - `test_ci_root_file_flagged`: a target with a root `Jenkinsfile` fails
+    `check_ci_boundary` with a `ci_path` violation (exercises Check 2, the
+    known root-level CI file path; guards against Check 2 being deleted while
+    all other tests remain green).
+  - `test_unknown_provider_flagged`: a target with `.ci/step.yml` (a fictional
+    provider's dot-directory — not in `.claude` or `.agents`) fails
+    `check_ci_boundary` via the dot-directory structural check (satisfies "policy
+    does not rely solely on known provider filenames").
+  - `test_badge_url_in_guide_flagged`: a target with
+    `guides/core/README.md` containing a GitHub Actions badge URL fails
+    `check_ci_boundary` with anchor `"ci_badge_url"`.
+  - `test_badge_url_outside_guides_flagged`: a target with a root `README.md`
+    containing a GitHub Actions badge URL also fails `check_ci_boundary`
+    (confirms badge scan is not limited to `guides/`).
+  - `test_clean_export_passes`: a target with a realistic scaffold (guides,
+    docs, `.claude/skills/`, `.agents/skills/`, `.github/skills/`) and no CI
+    files passes `check_ci_boundary` (returns `[]`) and the existing `verify()`
+    in white-label mode with no anchors.
+
+**Regression**
+
+- [x] AC8: All tests in `scripts/test_export_verify.py` and
+  `scripts/test_integration_export.py` still pass unchanged.
+
+## Assumptions
+
+- Technical: `export_verify.py` is the right extension point — step 10 of the
+  export procedure already calls this script; extending it keeps the verify step
+  unified.
+- Technical: `Violation` in `export_verify.py` is a usable type for CI boundary
+  findings; reusing it avoids introducing a new type.
+- Technical: The `_skip_by_ext` helper in `export_verify.py` covers binary files;
+  `check_ci_boundary` reuses it for all file reads.
+- Technical: Copilot projects to `.github/skills/`, `.github/agents/`,
+  `.github/hooks/`, `.github/instructions/` — these must not be flagged
+  (confirmed from `packages/agentbundle/agentbundle/_data/adapter.toml`).
+- Product: No current `guides/_shared/` files contain GitHub Actions badge URLs
+  (confirmed during spec authoring: adapter-support.md has `.github/instructions/`
+  adapter-path references, not CI badge URLs).
+- Product: Host-specific secret variable names (e.g. `ARTIFACTORY_TOKEN`) appear
+  only inside CI workflow files; path exclusion of those files is the sufficient
+  boundary without a separate content scan.
+- Product: The export procedure is agent-executed (not automated Python) — the
+  `check_ci_boundary` function is a verify-step helper the agent calls, not a
+  replacement for the procedure's strip logic.
+- Process: `spec/catalogue-ci-documentation` owns the adopter-discovery surfaces
+  (guides/README.md, CLI reference, etc.); this spec does not touch them.

--- a/packs/catalogue-curation/.apm/skills/export-catalogue/SKILL.md
+++ b/packs/catalogue-curation/.apm/skills/export-catalogue/SKILL.md
@@ -39,9 +39,16 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    while excluding: catalogue-governance (`docs/rfc/`, `docs/adr/`,
    `docs/specs/`, `docs/backlog.md`), the running repo's own
    `CHARTER`/`CONVENTIONS`/`**/AGENTS.local.md` (root and all subdirectories),
-   `**/README-pypi.md`, the internal doc site, and
-   build/scan/release tooling. Strip runs on the running-repo content copy only;
-   seeds (step 4) are planted fresh afterward and are not affected.
+   `**/README-pypi.md`, the internal doc site, and build/scan/release tooling.
+   **CI workflow and pipeline implementation is also excluded from the export
+   surface.** The export surface is bounded to `guides/`, projected tools, and
+   seeded scaffold — CI implementation files are outside this surface; no
+   credentials are transported. Excluded CI artifacts include: `.github/workflows/`
+   (GitHub Actions; note `.github/skills|agents|hooks|instructions/` are legitimate
+   Copilot adapter paths and travel when projected), `.gitlab-ci.yml`, `Jenkinsfile`,
+   `.travis.yml`, provider-specific CI trigger config, CI-specific helper scripts
+   not part of the pack, and workflow status badges. Strip runs on the running-repo
+   content copy only; seeds (step 4) are planted fresh afterward and are not affected.
 4. **Plant seeds.** For each projected tool (core, governance-extras) and any
    pack in the include-set with a `seeds/` directory, copy the seed tree to the
    target repo root. Establishes the scaffold the skills navigate: `AGENTS.md`,
@@ -58,9 +65,13 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    anchors all future `assimilate-repo` runs from within the fork.
 6. **Stage transportable guides.** For each pack in the include-set, copy
    `guides/<pack-name>/` into the target. Always include
-   `guides/_shared/`. Guides for packs outside the include-set are
-   omitted (omit-not-leak). The four-anchor substitution pass in step 7 covers
-   any identity references inside staged guide content.
+   `guides/_shared/` — this includes `guides/_shared/reference/catalogue-ci-contract.md`,
+   the portable CI contract the target organization receives. The contract is the
+   adopter's CI reference: the target chooses its own CI system; no CI workflow is
+   generated or copied; no credentials are transported; no CI provider is assumed.
+   Guides for packs outside the include-set are omitted (omit-not-leak). The
+   four-anchor substitution pass in step 7 covers any identity references inside
+   staged guide content.
 7. **Substitute** the four identity anchors from *this* catalogue's own sources
    (URL + slug + owner from `.adapt-discovery.toml`; email from `pack.toml`
    maintainer + git) — so the tooling carries no hardcoded upstream literal. URL
@@ -84,14 +95,20 @@ Status list — Lead each row with a status glyph — ● running, ✓ done, ○
    own catalogue — so the fork can self-curate from day one without inheriting
    agent-ready-repo's pack catalogue. Apply the four-anchor substitution to any
    projected file that still carries upstream identity.
-10. **Verify, fail-closed.** Grep the target for surviving upstream **URL, email,
-    slug, and owner** (the same four anchors, so verify and substitute agree),
-    **case-insensitively**, over **text files** (binary out of scope, declared),
-    matching declared **literals only** after a normalization pass. In
-    `white-label` mode: zero hits anywhere. In `attributed` mode: hits only inside
-    the declared attribution surface. Also fail on a dangling `CLAUDE.md` symlink
-    or a non-blank target `install-defaults.toml` source. Any hit **hard-fails the
-    export** — omit-not-leak.
+10. **Verify, fail-closed.** Run two checks; either failing hard-fails the export
+    (omit-not-leak):
+    - **Identity check** (`export_verify.verify()`): grep the target for surviving
+      upstream **URL, email, slug, and owner** (the same four anchors), case-insensitively,
+      over text files (binary out of scope, declared), matching declared literals only
+      after a normalization pass. In `white-label` mode: zero hits anywhere. In
+      `attributed` mode: hits only inside the declared attribution surface.
+    - **CI boundary check** (`export_verify.check_ci_boundary()`): scan the target
+      for CI implementation files — `.github/workflows/` content, known root-level CI
+      config files, files under unknown dot-directories, and GitHub Actions badge URLs
+      in text files. Any hit means CI workflow implementation reached the export
+      target and must be removed before re-running.
+    Also fail on a dangling `CLAUDE.md` symlink or a non-blank target
+    `install-defaults.toml` source.
 
 ## Never do
 

--- a/packs/catalogue-curation/.apm/skills/export-catalogue/references/transform-manifest.md
+++ b/packs/catalogue-curation/.apm/skills/export-catalogue/references/transform-manifest.md
@@ -34,8 +34,25 @@ attribution never re-admits governance:
   `CONTRIBUTING.md`. (A *projected* CONVENTIONS template that
   ships to adopters via the self-host recipe is a different artifact — it rides
   with the recipe; keep it.)
-- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, release
-  workflows, `tools/*` self-tests.
+- Build/scan/release tooling: `Makefile`, `.snyk`, scanner config, `tools/*`
+  self-tests.
+- **CI workflow and pipeline implementation.** The export surface is bounded to
+  `guides/`, projected tools, and seeded scaffold — CI implementation files are
+  outside this surface; no credentials are transported. Stripped CI artifacts:
+  - `.github/workflows/` — GitHub Actions workflow definitions and any helper
+    scripts they reference. Note: `.github/skills/`, `.github/agents/`,
+    `.github/hooks/`, and `.github/instructions/` are legitimate Copilot adapter
+    projection targets and are NOT stripped when present in the export target.
+  - Root-level CI config files: `.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`,
+    and equivalent provider files at the repo root.
+  - Any other provider-specific CI trigger config, pipeline definition, or
+    deployment/release automation not covered by the positive allowlist above.
+  - Workflow status badges (GitHub Actions badge URLs of the form
+    `https://github.com/<owner>/<repo>/actions/workflows/…`) embedded in any
+    guide or README file.
+  - Host-specific CI environment variable names (e.g. `ARTIFACTORY_TOKEN`,
+    `ANTHROPIC_API_KEY`) — these appear only inside CI workflow files and are
+    excluded transitively by path exclusion.
 - Provenance-only comments citing a stripped governance doc (keep comments that
   explain *why the code does what it does*).
 
@@ -67,10 +84,14 @@ catalogue) — this is the domain-repurposing lever.
 ## 4. GUIDES (per-pack, with _shared always)
 For each pack in the include-set, copy `guides/<pack-name>/` into the
 target at the same path. Always copy `guides/_shared/` (agentbundle
-infrastructure guides; adopter-facing, not catalogue-internal). Guides for
-packs outside the include-set are **omitted** (omit-not-leak). The SUBSTITUTE
-pass applies to all staged guide content; any identity references in `_shared/`
-guides survive into the target only in substituted form.
+infrastructure guides; adopter-facing, not catalogue-internal) — this includes
+`guides/_shared/reference/catalogue-ci-contract.md`, the portable provider-neutral
+CI contract the target organization receives. The contract is the adopter's
+canonical CI reference: the target chooses its own CI system; no CI workflow is
+generated or copied; no credentials are transported; no CI provider is assumed.
+Guides for packs outside the include-set are **omitted** (omit-not-leak). The
+SUBSTITUTE pass applies to all staged guide content; any identity references in
+`_shared/` guides survive into the target only in substituted form.
 
 ## 5. TOOL PROJECTION (core + governance-extras + catalogue-curation)
 After all content writes, project the three required packs from this
@@ -80,14 +101,22 @@ as catalogue packs in the fork's own `packs/`), so the fork can self-curate
 without inheriting the upstream pack catalogue. The SUBSTITUTE pass applies to
 projected files before they are written.
 
-## 6. VERIFY (fail-closed, mode-aware) — hard-fails the export
-- Grep the target for surviving upstream **URL, email, slug, owner** (all four
-  substitute anchors) — **case-insensitive**, over **text files** (binary out of
-  scope, declared), matching declared **literals only** after a normalization
-  pass (not case-folded-split / encoded / base64 derived forms; that blind spot
-  is stated, so the guarantee is honest).
+## 6. VERIFY (fail-closed, two checks) — hard-fails the export
+**Identity check** (`export_verify.verify()`): grep the target for surviving upstream
+**URL, email, slug, owner** (all four substitute anchors) — **case-insensitive**, over
+**text files** (binary out of scope, declared), matching declared **literals only** after
+a normalization pass (not case-folded-split / encoded / base64 derived forms; that blind
+spot is stated, so the guarantee is honest).
   - `white-label`: **zero** hits anywhere.
   - `attributed`: hits allowed **only** inside the declared attribution surface.
+
+**CI boundary check** (`export_verify.check_ci_boundary()`): scan the target for CI
+implementation files — `.github/workflows/` content, known root-level CI config files
+(`.gitlab-ci.yml`, `Jenkinsfile`, `.travis.yml`), files under unknown dot-directories,
+and GitHub Actions badge URLs in any text file. Any violation means CI workflow
+implementation reached the export target and must be removed before re-running.
+
+Both checks hard-fail the export on a non-empty result (omit-not-leak). Also fail on:
 - No dangling symlink (`CLAUDE.md` is a real file).
 - Target `install-defaults.toml` `source` is blank/absent.
 - All writes went through `agentbundle.safety.write_jailed`; the target path was

--- a/packs/catalogue-curation/.apm/skills/export-catalogue/scripts/export_verify.py
+++ b/packs/catalogue-curation/.apm/skills/export-catalogue/scripts/export_verify.py
@@ -20,6 +20,7 @@ Pure-stdlib; reads the target tree, writes nothing.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 # Extensions we treat as binary and skip (out-of-scope, declared).
@@ -51,6 +52,75 @@ def _in_attribution(rel: str, allowed: set[str]) -> bool:
     """Exact-file match OR under a listed directory prefix — so an operator can
     list either `legal/NOTICE` or `legal/` and have it work."""
     return any(rel == a or rel.startswith(a.rstrip("/") + "/") for a in allowed)
+
+
+# GitHub Actions badge URL pattern (owner+repo+/actions/workflows/ form).
+_BADGE_RE = re.compile(
+    r"https?://[^)\s]*github[^)\s]*/[^)\s]+/[^)\s]+/actions/workflows/",
+    re.IGNORECASE,
+)
+
+# Dot-directories legitimately projected by adapters into export targets.
+# .github is included: .github/workflows/ is caught by check_ci_boundary's
+# Check 1 (path-parts), and .github/skills|agents|hooks|instructions/ are
+# legitimate Copilot adapter projection paths.
+_ALLOWED_DOT_DIRS = frozenset({".claude", ".agents", ".github"})
+
+# Known root-level CI config file names (not directories).
+_CI_ROOT_FILES = frozenset({".gitlab-ci.yml", ".travis.yml", "Jenkinsfile"})
+
+
+def check_ci_boundary(target: Path) -> list[Violation]:
+    """Check for CI implementation files in the export output.
+
+    Returns Violations for:
+    - Files under .github/workflows/ (GitHub Actions; path-parts, cross-platform)
+    - Root-level known CI config files (.gitlab-ci.yml, Jenkinsfile, .travis.yml)
+    - Files under a dot-directory not in _ALLOWED_DOT_DIRS (structural
+      unknown-provider detection; len(parts) > 1 guard skips root dotfiles)
+    - Files containing a GitHub Actions badge URL (all text files)
+
+    Does NOT flag .github/skills/, .github/agents/, .github/hooks/, or
+    .github/instructions/ — legitimate Copilot adapter projection paths.
+    """
+    target = Path(target)
+    violations: list[Violation] = []
+    for p in sorted(target.rglob("*")):
+        if not p.is_file() or _skip_by_ext(p):
+            continue
+        rel = str(p.relative_to(target))
+        parts = Path(rel).parts
+        root = parts[0] if parts else ""
+
+        # Check 1: .github/workflows/ by path parts — cross-platform.
+        # str(p.relative_to(target)) is \-separated on Windows; parts[] is safe.
+        if len(parts) >= 2 and parts[0] == ".github" and parts[1] == "workflows":
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 2: known root-level CI config files.
+        if root in _CI_ROOT_FILES:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 3: files *under* dot-directories not in the projected-tool allowlist.
+        # len(parts) > 1: root-level dotfiles (.gitignore, .editorconfig) are not
+        # CI suspects — only files inside an unknown dot-directory are.
+        if len(parts) > 1 and root.startswith(".") and root not in _ALLOWED_DOT_DIRS:
+            violations.append(Violation(rel, "ci_path", 0))
+            continue
+
+        # Check 4: GitHub Actions badge URL in any text file.
+        try:
+            content = p.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = _BADGE_RE.search(content)
+        if m:
+            lineno = content[: m.start()].count("\n") + 1
+            violations.append(Violation(rel, "ci_badge_url", lineno))
+
+    return violations
 
 
 def verify(

--- a/packs/catalogue-curation/.apm/skills/export-catalogue/scripts/test_export_ci_boundary.py
+++ b/packs/catalogue-curation/.apm/skills/export-catalogue/scripts/test_export_ci_boundary.py
@@ -1,0 +1,99 @@
+"""Tests for check_ci_boundary (spec/catalogue-ci-export-boundary AC7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import export_verify as V
+
+
+def _tree(tmp: Path, files: dict[str, str]) -> Path:
+    root = tmp / "target"
+    for rel, content in files.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return root
+
+
+def test_ci_contract_guide_eligible(tmp_path: Path) -> None:  # STUB: AC7
+    """guides/_shared/reference/catalogue-ci-contract.md is not flagged."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_github_workflow_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/workflows/ file is flagged as ci_path."""
+    root = _tree(tmp_path, {
+        ".github/workflows/publish-catalogue.yml": "on: push\n",
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_github_adapter_path_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A .github/skills/ file (Copilot adapter projection) is NOT flagged."""
+    root = _tree(tmp_path, {
+        ".github/skills/core/SKILL.md": "# core skill\n",
+    })
+    assert V.check_ci_boundary(root) == []
+
+
+def test_ci_root_file_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root Jenkinsfile is flagged as ci_path (exercises Check 2)."""
+    root = _tree(tmp_path, {"Jenkinsfile": "pipeline {}\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_unknown_provider_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A fictional .ci/step.yml (dot-directory, not in allowlist) is flagged."""
+    root = _tree(tmp_path, {".ci/step.yml": "steps: []\n"})
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_path" for x in v)
+
+
+def test_badge_url_in_guide_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A guide file containing a GitHub Actions badge URL is flagged."""
+    root = _tree(tmp_path, {
+        "guides/core/README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_badge_url_outside_guides_flagged(tmp_path: Path) -> None:  # STUB: AC7
+    """A root README.md containing a badge URL is also flagged (badge scan is not
+    limited to guides/)."""
+    root = _tree(tmp_path, {
+        "README.md": (
+            "![CI](https://github.com/acme/repo/actions/workflows/ci.yml/badge.svg)\n"
+        ),
+    })
+    v = V.check_ci_boundary(root)
+    assert v and any(x.anchor == "ci_badge_url" for x in v)
+
+
+def test_clean_export_passes(tmp_path: Path) -> None:  # STUB: AC7
+    """A realistic export scaffold with no CI files passes check_ci_boundary and
+    the existing white-label verify(). Includes root dotfiles (.gitignore) seeded
+    by step 4 — guards the len(parts) > 1 invariant in Check 3."""
+    root = _tree(tmp_path, {
+        "guides/_shared/reference/catalogue-ci-contract.md": "# CI contract\n",
+        "guides/core/how-to/get-started.md": "# Getting started\n",
+        "docs/CONVENTIONS.md": "# Conventions\n",
+        ".claude/skills/core/SKILL.md": "# core skill\n",
+        ".agents/skills/core/SKILL.md": "# core skill\n",
+        ".github/skills/core/SKILL.md": "# core skill\n",
+        ".gitignore": "__pycache__/\n*.pyc\n",
+        ".editorconfig": "[*]\nindent_style = space\n",
+        "AGENTS.md": "# Agents\n",
+        "workspace.toml": "[workspace]\n",
+    })
+    assert V.check_ci_boundary(root) == []
+    anchors = {"url": "https://example.com", "email": "", "slug": "", "owner": ""}
+    assert V.verify(root, anchors, mode="white-label") == []

--- a/workspace.toml
+++ b/workspace.toml
@@ -1183,7 +1183,7 @@ queue   = [
 # ─────────────────────────────────────────────────────────────────────────────
 ["ini-006"]
 name      = "Catalogue CI Contract"
-status    = "active"
+status    = "complete"
 milestone = "M1 · Provider-Neutral CI Contract"
 
 ["ini-006".shaping_queue]
@@ -1194,6 +1194,7 @@ backlog = []
 active  = []
 shipped = [
   "spec/catalogue-ci-contract-guide",
+  "spec/catalogue-ci-export-boundary",
   "spec/catalogue-ci-documentation",
 ]
 queue   = [
@@ -1239,5 +1240,6 @@ queue   = [
   #   host secret names don't escape, policy does not rely solely on known provider
   #   filenames, white-label behavior remains fail-closed.
   # Done: export-boundary tests pass; white-label behavior verified fail-closed.
-  {path = "spec/catalogue-ci-export-boundary", needs = "work:spec/catalogue-ci-contract-guide"},
+  # spec/catalogue-ci-export-boundary — shipped (moved to shipped above)
+  # spec/catalogue-ci-documentation — shipped (moved to shipped above)
 ]


### PR DESCRIPTION
## Summary

- Adds `check_ci_boundary()` to `export_verify.py` as a new fail-closed check in export step 10, detecting: `.github/workflows/` content (path-parts, cross-platform), known root-level CI config files, files under unknown dot-directories, and GitHub Actions badge URLs in any text file.
- Updates `SKILL.md` steps 3, 6, and 10 and `transform-manifest.md` sections 1, 4, and 6 to use positive allowlist framing — the export surface is bounded to `guides/`, projected tools, and seeded scaffold; CI implementation is explicitly outside it.
- Explicitly states that `guides/_shared/reference/catalogue-ci-contract.md` (the portable CI contract shipped in PR #794) is eligible for export.

## Boundaries

- Does not flag `.github/skills/`, `.github/agents/`, `.github/hooks/`, `.github/instructions/` — legitimate Copilot adapter projection paths.
- Does not modify `verify()` or the identity-anchor leak check.
- Does not scope into `spec/catalogue-ci-documentation` (M2b, still in queue).

## Test plan

- [ ] `pytest scripts/test_export_ci_boundary.py -v` — 8 new tests, all green
- [ ] `pytest scripts/test_export_verify.py scripts/test_integration_export.py -v` — 12 existing tests, no regression
- [ ] `make build-check SKIP_SAST=1` — lint + drift gate passes

## Deferred

- `spec/catalogue-ci-documentation` (M2b) — adopter-discovery surfaces (guides/README.md, CLI reference links, etc.) remain in ini-006 queue.