### PR TITLE
fix(atlassian): close Phase 3 work-loop — plan to Done, AC gap-fills

### DIFF
--- a/docs/specs/atlassian-phase3/plan.md
+++ b/docs/specs/atlassian-phase3/plan.md
@@ -1,6 +1,6 @@
 # Atlassian Phase 3 — Implementation Plan
 
-## Status: Executing
+## Status: Done
 
 ## Tasks
 
@@ -47,7 +47,7 @@
 - Old subdirectory guide files deleted
 - `web/src/content/journeys/atlassian.md` (hand-authored) deleted
 - `docs-site/astro.config.ts` sidebar updated
-- `packs/atlassian/pack.toml` version = `0.8.0`
+- `packs/atlassian/pack.toml` version unchanged at 0.7.0 (documentation-only change; AC24 user-confirmed no bump)
 - `python tools/build-site.py --journeys-only` exits 0 and generates `web/src/content/journeys/atlassian.md`
 - `python tools/build-site.py` exits 0
 - `make build-check` exits 0

--- a/guides/atlassian/atlassian-skills.md
+++ b/guides/atlassian/atlassian-skills.md
@@ -11,6 +11,10 @@ status: stable
 
 Look up what a skill reads, what it writes, what requires confirmation, and what its limits are. Use the intent index to find the right skill by what you want to accomplish.
 
+:::tip[TRY ASKING]
+Show me the whole Atlas team backlog across APP and API. Do not change Jira.
+:::
+
 ## Intent index
 
 | I want to… | Use |

--- a/guides/atlassian/review-your-team-backlog.md
+++ b/guides/atlassian/review-your-team-backlog.md
@@ -159,6 +159,7 @@ Some issues have questions only the product owner can answer. APP-206 has one. Y
 1. Given a client exceeds the rate limit, when the API returns 429, then the response includes Retry-After: \<integer seconds\>
 2. Given the token-bucket drain time is known, when 429 is returned, then Retry-After value equals ceil(drain\_seconds)
 3. Given drain time is unavailable, when 429 is returned, then Retry-After value is 30
+4. Given any 429 response, then body contains {"error": "rate\_limited", "retry\_after\_seconds": \<integer\>}
 
 **Unresolved question:** None.
 

--- a/packs/atlassian/README.md
+++ b/packs/atlassian/README.md
@@ -42,7 +42,7 @@ Get: per-story analysis — which readiness question failed, a proposed descript
 
 ```
 Update APP-206 and API-104 with the approved drafts.
-Do not change status, assignee, or labels.
+Do not change status, assignee, priority, sprint, or labels.
 ```
 
 Get: a preview of the exact fields, current and proposed values, and protected fields — then confirmation before any write. **Writes only after you confirm.** Protected fields are never touched.
@@ -88,7 +88,7 @@ The Jira and Confluence skills authenticate with either an API token (Atlassian 
 
 Install the `credential-brokers` pack, then say **"set up credentials"** — the agent prompts for the right credential type and stores it in your OS keychain (or a `0600` dotfile on Linux). Secrets never go on the command line and never enter the repo. See the [`credential-brokers` README](../credential-brokers/README.md).
 
-If your organisation uses SSO-only access, see the [SSO authentication guide](../../guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md) for the SSO-broker setup.
+If your organisation uses SSO-only access, see the [SSO authentication guide](/agent-ready-repo/docs/guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies/) for the SSO-broker setup.
 
 ## Scope and permissions
 


### PR DESCRIPTION
## Summary

Closes the open EXECUTE→REVIEW→DECIDE gap left in the `atlassian-phase3` work-loop after PR #797 shipped the six public surfaces. The implementation was complete but the REVIEW and DECIDE phases of the work-loop were not run.

- **Plan status**: flipped from `Executing` → `Done`; corrected Task 9's stale `version = 0.8.0` instruction that contradicted AC24 (pack stays at 0.7.0, documentation-only change)
- **AC14 cold-read gap**: added `:::tip[TRY ASKING]` block before the intent index in `atlassian-skills.md` so the first copyable request appears within the 120-word window
- **AC3 scenario drift**: added the 4th canonical API-104 proposed AC to the tutorial to match `canonical-scenario.json`
- **AC16/README cleanup**: completed the five protected fields in the README example (was missing `sprint` and `priority`); converted one relative SSO guide link to the absolute site-path convention

## Verification

- `validate_guides.py guides/atlassian/` → 0 errors
- `lint-pack-journeys.py` → 2 JOURNEY.md files valid
- `check-atlassian-phase3-readiness.py` → **READY FOR PHASE 3** (all 17 checks pass)
- `make build-check` (SKIP_SAST) → exit 0
- `adversarial-reviewer` → **Clean — ready to commit.**

## Test plan

- [ ] `python3 tools/validate_guides.py guides/atlassian/` exits 0
- [ ] `python3 tools/check-atlassian-phase3-readiness.py` shows READY FOR PHASE 3
- [ ] `make build-check` exits 0
- [ ] `atlassian-skills.md` shows a copyable request within the first 120 words
- [ ] `review-your-team-backlog.md` API-104 block has all 4 proposed ACs
- [ ] `packs/atlassian/README.md` lists all 5 protected fields and uses absolute links consistently

Bundled fixes: four tightly scoped ride-alongs on the Phase 3 diff; no scope creep.