### PR TITLE
feat(product-docs): Phase 4B — product docs rollout completion + catalogue convergence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -81,7 +81,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     {
       "author": {
@@ -292,7 +292,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": {
@@ -371,7 +371,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": {
@@ -502,7 +502,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     {
       "author": {
@@ -529,7 +529,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.6"
+      "version": "0.1.7"
     },
     {
       "author": {

--- a/docs/specs/phase4b-product-docs-completion/spec.md
+++ b/docs/specs/phase4b-product-docs-completion/spec.md
@@ -1,0 +1,111 @@
+---
+**Feature:** phase4b-product-docs-completion
+**Status:** Shipped
+**Mode:** full (multi-feature, structural/public-interface change — public routes, guide index, cross-pack READMEs)
+---
+
+# Phase 4B — Product Documentation Rollout Completion and Catalogue Convergence
+
+## Objective
+
+Close every remaining gap in the Product Documentation contract across all active packs, and converge the shared catalogue surfaces (guide index, guide-author doctrine, pack grouping, machine-fact parity).
+
+Phase 4 shipped READMEs and JOURNEYs for the core workflow packs. Phase 4B retrofits the five remaining packs (product-strategy, frontend-engineering, catalogue-curation, iac-terraform, release-engineering) and fixes the shared convergence gaps the Phase 4 migration matrix left open.
+
+## Boundaries
+
+**In scope:**
+- Rewrite `packs/product-strategy/README.md` — replace framework-first entry with strategic-question-led entry
+- Rewrite `packs/frontend-engineering/README.md` — add "Start here", common jobs, task-led entry
+- Rewrite `packs/catalogue-curation/README.md` — add "Start here", operator-job-led entry, confirmation/permission boundaries, maintainer-vs-adopter distinction
+- Rewrite `packs/iac-terraform/README.md` — add "Start here", explicit plan/apply/destructive-action/state/secret boundaries
+- Add `## Start here` to `packs/release-engineering/README.md`
+- Update `web/src/content/packs/product-strategy.md` — user-job-first tagline and description
+- Fix `web/src/content/packs/frontend-engineering.md` `docsUrl` — `/docs/guides/...` → `/guides/frontend-engineering/`
+- Update `guides/README.md` — add iac-terraform, product-strategy, catalogue-curation, frontend-engineering to All packs table; update guide-author doctrine to describe metadata-based kinds
+- Fix `packs/user-guide-diataxis/pack.toml` lifecycle field (`active` → `deprecated`)
+- Bump patch versions for all packs with distributed README changes
+- Add `tools/check-guide-index.py` — drift check: active pack missing from guides/README.md All packs table
+- Sync plugin metadata after version bumps: `FORCE=1 make build-self`
+
+**Not in scope:**
+- Phase 5 deployment-integrity system
+- Redesigning the global homepage or documentation shell
+- Removing `user-guide-diataxis`
+- Rewriting already-conforming packs (architect, atlassian, contracts, core, credential-brokers, desk-research, experience-design, figma, github, governance-extras, linear, monorepo-extras, product-documentation, product-engineering)
+- Adding missing guide frontmatter to the 159 migration-warning guides (deferred from Phase 4)
+- Adding JOURNEY.md to atomic packs (converters, contracts, figma, github, linear, monorepo-extras)
+
+## Assumptions
+
+1. All Phase 4 packs remain green — pre-flight baseline confirms build-check passed, lint-pack-journeys 11 files valid, pre-pr-catalogue clean.
+2. Patch version bumps are appropriate for README-only distributed content changes.
+3. `FORCE=1 make build-self` regenerates plugin metadata and marketplace files after version bumps.
+4. The guide-author doctrine update in guides/README.md does not change any canonical skill or schema — it corrects the prose description to match the already-shipped Phase 2A metadata model.
+
+**Declined patterns:**
+- Tempted to add frontmatter to all 159 migration-warning guides — declining; deferred from Phase 4 and not a blocker for Phase 4B ACs.
+- Tempted to add JOURNEY.md to release-engineering (workflow has stages) — declining; the pack is a single-skill pack where the journey is the skill itself; adding a JOURNEY.md would duplicate the skill's own description.
+- Tempted to add first-value metadata starter-task/prompt to catalogue-curation, iac-terraform, release-engineering — declining; these are advanced technical packs; level-b is for non-technical first-value workflows.
+- Tempted to create a multi-check catalogue audit tool — declining; a lightweight guide-index parity check is sufficient for Phase 4B regression prevention; Phase 5 handles full attestation.
+
+## Residual Migration Matrix
+
+| Pack | Lifecycle | Archetype | JOURNEY? | README issue | Pack page issue | Phase 4B action |
+|------|-----------|-----------|----------|--------------|-----------------|-----------------|
+| architect | active | C. Analysis | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| atlassian | active | B. Integration | ✓ exists | ✓ Outcome-led, boundary visible | OK | Verified complete |
+| catalogue-curation | active | F. Platform | no — correct | ✗ No Start here; skill table leads | OK | Lane C rewrite |
+| contracts | active | E. Atomic | no — correct | ✓ Start here, outcome-led | OK | Verified complete |
+| converters | active | E. Atomic | no — correct | ✓ Outcome-led (Phase 4 rewrite) | OK | Verified complete |
+| core | active | A. Workflow | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| credential-brokers | active | F. Platform | no — correct | ✓ Platform description | OK | Verified complete |
+| desk-research | active | C. Analysis | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| experience-design | active | C. Analysis | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| figma | active | B. Integration | no — correct | ✓ Outcome-led | OK | Verified complete |
+| frontend-engineering | active | D. Engineering | no — correct | ✗ No Start here; skills list early | docsUrl wrong | Lane B rewrite |
+| github | active | B. Integration | no — correct | OK (1-skill pack) | OK | Verified complete |
+| governance-extras | active | D. Engineering | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| iac-terraform | active | D. Engineering | ✓ exists | ✗ No Start here; skills table leads | OK | Lane B rewrite |
+| linear | active | B. Integration | no — correct | OK (3-skill pack) | OK | Verified complete |
+| monorepo-extras | active | E. Atomic | no — correct | ✓ Outcome-led | OK | Verified complete |
+| product-documentation | active | F. Platform | ✓ exists | ✓ Outcome-led, Get started visible | OK | Verified complete |
+| product-engineering | active | A. Workflow | ✓ exists | ✓ Start here, outcome-led | OK | Verified complete |
+| product-strategy | active | C. Analysis | ✓ exists | ✗ Framework-first; skill inventory leads | Framework-first tagline | Lane A rewrite |
+| release-engineering | active | D. Engineering | ✓ exists | ✗ Architecture-first; no Start here | OK | Lane B small fix |
+| user-guide-diataxis | deprecated (README) / active (pack.toml) | — | no | ✓ Shows deprecated notice | — | Lane E: fix lifecycle |
+
+## Acceptance Criteria
+
+- [x] AC0: Pre-flight baseline — build-check green, lint-pack-journeys 11 files valid, pre-pr-catalogue clean (confirmed)
+- [x] AC1: `packs/product-strategy/README.md` leads with strategic questions, shows decision/artifact before skill list
+- [x] AC2: `packs/frontend-engineering/README.md` has "Start here", common jobs, natural first request, side-effect/approval/rollback visible
+- [x] AC3: `packs/catalogue-curation/README.md` has "Start here", operator-job-led, confirms local-only, distinguishes maintainer from adopter
+- [x] AC4: `packs/iac-terraform/README.md` has "Start here", plan/apply boundary explicit, destructive-action boundary visible
+- [x] AC5: `packs/release-engineering/README.md` has "Start here" with natural first request
+- [x] AC6: `web/src/content/packs/product-strategy.md` tagline and description are user-job-first
+- [x] AC7: `web/src/content/packs/frontend-engineering.md` docsUrl is `/guides/frontend-engineering/`
+- [x] AC8: `guides/README.md` All packs table includes iac-terraform, product-strategy, catalogue-curation, frontend-engineering
+- [x] AC9: `guides/README.md` guide-author doctrine section describes `kind` as frontmatter metadata, flat source paths, no mandatory quadrant folders
+- [x] AC10: `packs/user-guide-diataxis/pack.toml` — no schema `lifecycle` field exists; deprecated status already expressed via `display_name = "User Guide (Diátaxis) — Deprecated"` and `keywords: ["deprecated"]`; no change required
+- [x] AC11: Pack versions bumped for all packs with distributed README changes; plugin metadata synchronized via `FORCE=1 make build-self`
+- [x] AC12: `tools/check-guide-index.py` exits 0 on current repo; exits 1 when an active pack is absent from guides/README.md All packs table
+- [x] AC13: `SKIP_SAST=1 make build-check` passes after all changes
+- [x] AC14: `python3 tools/lint-pack-journeys.py` exits 0 (11 files still valid)
+- [x] AC15: `python3 tools/validate_guides.py guides/` exits with 0 errors
+- [x] AC16: `python3 tools/pre-pr-catalogue.py` passes
+- [x] AC17: Cold-read verified for all 5 residual packs — product-strategy, frontend-engineering, catalogue-curation, iac-terraform, release-engineering all answer the 7 cold-read questions
+- [x] AC18: adversarial-reviewer returns `Clean — ready to commit.`
+
+## Testing Strategy
+
+Goal-based verification for each README change (cold-read: first request visible within 120 words).
+Goal-based for drift tool (exits 0 on clean, exits 1 when pack missing).
+Mechanical gates:
+```bash
+python3 tools/validate_guides.py guides/          # AC15: 0 errors
+python3 tools/lint-pack-journeys.py               # AC14: 0 errors
+python3 tools/pre-pr-catalogue.py                  # AC16: all green
+python3 tools/check-guide-index.py                # AC12: exits 0
+SKIP_SAST=1 make build-check                       # AC13: exits 0
+```

--- a/guides/README.md
+++ b/guides/README.md
@@ -65,6 +65,10 @@ Each loop is autonomous where the work is reversible, and surfaces to a human wh
 | [`governance-extras`](governance-extras/) | [home](governance-extras/) | A written trail for decisions — `new-rfc`, `new-adr`, `update-conventions`. |
 | [`monorepo-extras`](monorepo-extras/) | [home](monorepo-extras/) | Monorepo scaffolding — `new-package` and a package template. |
 | [`product-documentation`](product-documentation/) | [home](product-documentation/) | Product documentation authoring — create, revise, retrofit, audit, and verify guides, pack READMEs, and journeys using `author-product-docs`. |
+| [`product-strategy`](product-strategy/) | [home](product-strategy/) | Answer the committed strategic questions upstream of every initiative — `write-prfaq`, `run-swot`, `run-pestle-analysis`, `run-porters-five-forces`, `run-bcg-matrix`, `run-okr-cascade`, `synthesize-stakeholder-research`, `define-ux-strategy`, `define-content-strategy`. |
+| [`frontend-engineering`](frontend-engineering/) | [home](frontend-engineering/) | Build, audit, and ship production-quality web surfaces — `frontend-engineering` (four modes), `token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`, `fe-status`, and the `frontend-reviewer` agent. |
+| [`iac-terraform`](iac-terraform/) | [home](iac-terraform/) | Governed Terraform from plain-language intent — `generate-iac` (ADR gate → spec → plan, stops before apply) and `reconcile-iac` (drift audit). Opt-in, repo-scope. |
+| [`catalogue-curation`](catalogue-curation/) | [home](catalogue-curation/) | Grow and maintain a catalogue — `assimilate-primitive`, `assimilate-repo`, `propose-catalogue-pack`, `export-catalogue`. For catalogue maintainers. |
 
 ---
 
@@ -82,14 +86,49 @@ Cross-cutting topics — about the catalogue itself, not any single pack — liv
 
 ## For guide authors — the four Diátaxis kinds
 
-Within every pack (and within `_shared/`), guides are sorted into the four Diátaxis kinds. Each piece of content belongs in **exactly one** — mixing kinds is the most common cause of docs that frustrate everyone.
+Each guide has exactly one `kind` — declared as frontmatter metadata, not derived from its directory. Mixing kinds is the most common cause of docs that frustrate everyone.
 
 |  | Practical (you *do* something) | Theoretical (you *understand* something) |
 | --- | --- | --- |
-| **Learning** (acquiring a skill) | **tutorials/** — *lessons.* "Take me through it from the start." | **explanation/** — *discussions.* "Help me understand why." |
-| **Task** (getting something done) | **how-to/** — *recipes.* "Help me solve this specific problem." | **reference/** — *information.* "Tell me exactly what this does." |
+| **Learning** (acquiring a skill) | `kind: tutorial` — *lessons.* "Take me through it from the start." | `kind: explanation` — *discussions.* "Help me understand why." |
+| **Task** (getting something done) | `kind: how-to` — *recipes.* "Help me solve this specific problem." | `kind: reference` — *information.* "Tell me exactly what this does." |
 
-The discipline that makes it work is **link out**: when a tutorial wants to explain *why*, it links to an explanation instead of digressing; when a how-to wants to list every option, it links to the reference. Each quadrant's writing rules live in the per-quadrant READMEs under [`_shared/`](_shared/) — read the matching one before you write a guide (or run `author-product-docs`, which applies the contract automatically).
+### Source layout
+
+New guides are **flat by default**:
+
+```
+guides/<pack>/<slug>.md
+```
+
+Topic-first grouping is permitted where a user perceives a real domain:
+
+```
+guides/<pack>/<topic>/<slug>.md
+```
+
+Physical quadrant directories (`tutorials/`, `how-to/`, `reference/`, `explanation/`) are a migration-compatible legacy structure — they still work, but **new guides do not require them**. Do not create four empty quadrant directories. Do not create one guide of each type. Let the reader's need determine what you write.
+
+### Required frontmatter
+
+Every new guide needs four fields:
+
+```yaml
+---
+title: "What this guide is called"
+summary: "One sentence for navigation surfaces."
+pack: core                  # must match a directory in packs/
+kind: how-to                # tutorial | how-to | reference | explanation
+---
+```
+
+Optional: `slug` (overrides the output path), `aliases` (generates redirect stubs), `journey`, `order`, `status`.
+
+The `author-product-docs` skill applies the correct page contract automatically. The `validate_guides.py` tool checks frontmatter compliance. Navigation in the docs site derives from reader needs and metadata — not from physical folder structure.
+
+### What belongs in `docs/guides/`?
+
+`docs/guides/` is **internal maintainer documentation** — how-tos for repo contributors, not for pack adopters. It is not published as public documentation.
 
 ## How this fits with the rest of the repo
 

--- a/packs/catalogue-curation/.claude-plugin/plugin.json
+++ b/packs/catalogue-curation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "catalogue-curation",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Catalogue-operator skills: assimilate external primitives, survey repos, propose packs, and export white-label / attributed derivatives of the catalogue."
 }

--- a/packs/catalogue-curation/README.md
+++ b/packs/catalogue-curation/README.md
@@ -1,49 +1,104 @@
 # catalogue-curation
 
-The **catalogue-operator's toolkit** — the skills a maintainer reaches for to
-*grow and maintain* an agent-skill catalogue, one meta-level above
-`governance-extras`. It is **domain-agnostic**: the same toolkit serves this
-software-delivery catalogue, a creative-writing catalogue, or an
-investment-research one.
+Grow and maintain an agent-skill catalogue — bring in new skills, survey external repos, propose new packs, and produce redistributable derivatives.
 
-Growing a catalogue means several recurring jobs — standing up a new pack,
-shaping a new skill to convention, bringing in good work from outside, and
-producing a redistributable copy for another org or domain. Each was hand-run,
-un-resumable, and craft-inconsistent. This pack makes them **gated, resumable,
-and shaped to the repo's craft** — and it's the **home for catalogue operations
-generally**, so new ones land here as they come up (see *Roadmap*).
+---
 
-## The toolkit today
+## Start here
 
-| Skill | The catalogue job it serves |
-| --- | --- |
-| **`propose-catalogue-pack`** | Stand up a **new pack** — justify it's additive and fits the catalogue's charter, scaffold the shell, and emit an RFC (or reject it). |
-| **`assimilate-primitive`** | Bring **one** external skill / subagent / hook (or a small bundle) in from a local path or URL — safely, then **reshaped to our craft** (activation, progressive disclosure, anti-pattern steering), or rejected. |
-| **`assimilate-repo`** | Survey a **whole external repo/catalogue** into a reviewable RFC of per-candidate verdicts, resumable across sessions and worktrees via a ledger. |
-| **`export-catalogue`** | Produce a **redistributable derivative** (organization rebrand or domain re-purposing) in `white-label` or `attributed` mode, with a fail-closed leak check. |
+Decide what you're trying to do, then describe it.
 
-The **craft-shaping** engine that `assimilate-primitive` uses to bring an
-external skill up to convention — activation-optimized description, collision
-check, progressive disclosure, anti-pattern steering — is the same discipline a
-maintainer applies when **authoring a new skill from scratch**; it's written to
-be reused for both.
+```text
+I found a well-crafted research skill in an external repo.
+Can we bring it into our catalogue?
+```
+
+```text
+I want to stand up a new pack for our data-engineering team.
+```
+
+The pack identifies the job (assimilate, propose, survey, or export), runs the appropriate gates, and presents a preview before writing anything to the repository. All changes are local — nothing is published remotely. An RFC is emitted wherever the work requires one.
+
+---
+
+## Common jobs
+
+**Bring an external skill or agent into the catalogue**
+Describe the source (a local path or public URL) and the skill you want to assimilate.
+Returns an activation review, a collision check against existing skills, a craft-shaping proposal (activation description, progressive disclosure, anti-pattern steering), and a diff preview. You review and approve each step. Result: skill lands in the correct pack directory, shaped to your catalogue's craft, with a gate-passing record.
+
+```text
+assimilate-primitive
+
+  Source: https://github.com/example-org/research-skills/tree/main/deep-research
+  ● Activation check: description routes correctly — no collision
+  ● Craft gap: missing progressive-disclosure depth
+  ● Proposed reshape: [preview shown]
+
+  Approve and land? ›
+```
+
+**Survey a whole external repo for candidates**
+Say `assimilate-repo` and point to a repo path or URL.
+Returns a per-candidate verdict (in / out / reshape / defer) written to a resumable ledger file. You review the ledger; each approved candidate can then be assimilated individually. Nothing is changed in your repo during the survey step.
+
+**Propose a new pack**
+Say `propose-catalogue-pack` and describe the new pack's purpose.
+Tests whether the pack is additive (doesn't duplicate an existing pack) and fits the catalogue's charter, then scaffolds a pack shell and emits an RFC for human review. No RFC means no new pack.
+
+**Produce a redistributable derivative**
+Say `export-catalogue` and specify white-label or attributed mode and the target organization name.
+Produces a redistributable copy of the catalogue with upstream identity either stripped or credited. Runs a fail-closed leak check before writing any output — the command hard-fails if any identity signal would escape. Result is a local directory; you publish it.
+
+---
 
 ## Guardrails
 
-- **Never** mutates the `agentbundle` engine or `credential-brokers` through any skill — a path-gate blocks protected-tree changes absent a deliberate, human-authored RFC.
-- **Ingested code runs the repo's own gates** (lints + CodeQL/Snyk) before it lands, and known anti-patterns (a script that triggers a skill/agent, a misused agent, a flooding "skill") are steered to our shape or rejected — never laundered in.
-- **Fail-closed export** — a run hard-fails if any upstream identity would leak.
-- **No new engine, no new dependency** — skills plus declarative manifests only.
+- **All changes are local** — no remote publish, no direct commit to a shared branch; you approve the diff, then commit.
+- **Preview before any write** — every assimilation and export shows a diff and waits for your approval.
+- **RFC gate** — `propose-catalogue-pack` always emits an RFC; a new pack cannot land without it.
+- **Ingested code runs gates** — skills brought in via `assimilate-primitive` pass the repo's lint + CodeQL/Snyk before landing.
+- **Protected paths are blocked** — a path-gate prevents any skill from mutating the `agentbundle` engine or `credential-brokers` pack absent a human-authored RFC.
+- **Fail-closed export** — `export-catalogue` hard-fails if any upstream identity would leak to the derivative.
 
-## Roadmap
+---
 
-The pack is the deliberate home for catalogue operations as they arise —
-e.g. retiring a primitive, deprecating a pack, or a dedicated greenfield
-skill-authoring flow. Deferred items live in `workspace.toml [backlog]`.
+## Who this is for
 
-## Learn it
+`catalogue-curation` is for **catalogue maintainers** — the people who own the shape of the catalogue and decide what lands in it. It is not for ordinary adopters who want to install and use skills.
 
-Full walkthroughs, references, and the "why" live in the per-pack guide:
-[`guides/catalogue-curation/`](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/catalogue-curation/).
+For internal procedures and how-tos, see [`docs/guides/`](../../docs/guides/) (maintainer documentation, not published as adopter-first content).
 
-Requires `core` and `governance-extras`. Repo-scope, opt-in; not in any default profile.
+For users who want to install and use skills from the catalogue, see the [catalogue guide](../../guides/README.md).
+
+---
+
+## Installation and trust
+
+- **Scope:** repo — operates within the catalogue repo; not a portable user skill
+- **Reads:** external repos, pack metadata, existing skill sources (read-only during survey and review steps)
+- **Local writes:** new skill files, pack scaffolding, RFC documents — only after you approve
+- **Remote reads:** public URLs provided by you (for `assimilate-primitive` and `assimilate-repo`)
+- **Remote writes:** none
+- **Requires:** `core` and `governance-extras` installed at repo scope
+
+```bash
+agentbundle install --pack catalogue-curation
+```
+
+---
+
+## Skills included — under the hood
+
+| Skill | The catalogue job it serves |
+|-------|---------------------------|
+| `assimilate-primitive` | Bring one external skill / agent / hook in from a local path or URL |
+| `assimilate-repo` | Survey a whole external repo into a reviewable per-candidate verdict ledger |
+| `propose-catalogue-pack` | Stand up a new pack — justify fit, scaffold the shell, emit an RFC |
+| `export-catalogue` | Produce a redistributable derivative (white-label or attributed mode) |
+
+---
+
+## Go deeper
+
+→ [`guides/catalogue-curation/`](../../guides/catalogue-curation/)

--- a/packs/catalogue-curation/pack.toml
+++ b/packs/catalogue-curation/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "catalogue-curation"
-version = "0.1.6"
+version = "0.1.7"
 description = "Catalogue-operator skills: assimilate external primitives, survey repos, propose packs, and export white-label / attributed derivatives of the catalogue."
 readme = "README.md"
 display_name = "Catalogue Curation"

--- a/packs/frontend-engineering/.claude-plugin/plugin.json
+++ b/packs/frontend-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-engineering",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 }

--- a/packs/frontend-engineering/README.md
+++ b/packs/frontend-engineering/README.md
@@ -1,48 +1,113 @@
 # frontend-engineering
 
-Say "build this component from the design handoff" or "audit the accessibility of this surface" — and the agent works through it from token architecture to shipped, WCAG 2.2–clean HTML, CSS, and JS.
+Build, audit, and ship production-quality web surfaces — WCAG 2.2–clean HTML, CSS, and JS with a CWV-passing evidence manifest.
 
-`frontend-engineering` covers the full implementation arc: the primary `frontend-engineering` skill handles creation, retrofit, audit, and verification in four modes; specialist skills go deep on tokens, accessibility, performance, rendering strategy, component contracts, responsive layout, and CSS architecture at scale. The `frontend-reviewer` agent reads diffs cold — no authoring context — and catches CSS token drift, ARIA mutation gaps, and WCAG 2.2 Focus Appearance / Target Size items that automated tooling misses.
+---
 
-## Skills
+## Start here
+
+Describe the task — what you're building, auditing, or improving.
+
+```text
+Build the notification panel from this design brief:
+- Three states: empty, unread, overflow
+- Token colors from the DS design-system foundation
+- Keyboard-navigable list; focus trap in overlay mode
+```
+
+```text
+Audit the accessibility of the checkout flow — I need to find
+what's blocking WCAG 2.2 AA compliance.
+```
+
+The pack runs in four modes — **create**, **retrofit**, **audit**, or **verify** — and picks the mode from your description. Every create or retrofit run ends with an evidence manifest: routes, viewports, browsers, states, screenshots, a11y result, performance result, and known exceptions.
+
+---
+
+## Common jobs
+
+**Create a new surface from a design handoff**
+Describe the surface and point to the design brief or screen spec.
+Returns a genre-route pre-flight (pick `conversion-design`, `documentation-design`, or `analytical-design` if `experience-design` is co-installed), then implement through token setup, semantic HTML, base CSS, responsive, states, a11y, and performance gates. Result: committed source files + evidence manifest. Nothing is committed until you approve.
+
+**Retrofit an existing surface**
+Say "retrofit this surface to pass WCAG 2.2 AA" or "bring this component up to the design system tokens."
+Runs a brownfield inspection (what-to-preserve, a11y debt, token drift, responsive debt, visual regression risk) before any change. Proposes a plan and previews the delta before touching files. Result: committed changes + updated evidence manifest.
+
+**Deep accessibility audit**
+Say "audit the accessibility of this surface" or describe a specific interaction pattern (combobox, data grid, drag-and-drop).
+Returns structured findings against WCAG 2.2 with severity (blocker / concern / suggestion) — including the two manual-verification items (Focus Appearance, Target Size) that automated tools miss. No changes are made unless you ask.
+
+**Verify a surface before shipping**
+Say "verify this surface before the release."
+Runs the full gate sequence: lint, typecheck, Playwright baseline, a11y scan, CWV measurement. Returns a pass/fail verdict per gate and a completed evidence manifest you can attach to the release record. Read-only — no writes.
+
+---
+
+## How it works
+
+```text
+Build the notification panel from this design brief: ...
+
+  ● Genre route: documentation-design (co-installed XD detected)
+  ● Token audit: DS tokens loaded — 3 colour tokens, 1 spacing token
+  ● Component contract: NotificationPanel(items, onDismiss, maxVisible)
+  ● Implement: HTML structure ✓ → base CSS ✓ → responsive ✓ → states ✓
+  ● A11y check: keyboard nav ✓ | focus trap ✓ | ARIA list ✓
+  ● Performance: LCP 0.8s ✓ | CLS 0.01 ✓ | INP 90ms ✓
+
+  Evidence manifest written to docs/evidence/notification-panel.md
+
+  Review the diff? ›
+  Approve and commit? ›
+```
+
+**What will be read:** your design brief, existing CSS/token files, a11y scanner output, browser performance trace.  
+**What will be changed:** source HTML, CSS, JS files — only after you approve the diff.  
+**Nothing is committed without your review.** The `frontend-reviewer` agent reads the diff cold (no authoring context) and catches CSS token drift, ARIA gaps, and manual WCAG 2.2 items before you confirm.
+
+---
+
+## Installation and trust
+
+- **Scope:** user — installs portably across all your repos (co-install `experience-design` for full genre routing)
+- **Reads:** your design briefs, existing source files, a11y scanner output, Playwright results
+- **Local writes:** source files and evidence manifest — only after you approve
+- **Remote reads/writes:** none (Lighthouse / axe run locally)
+- **Approval:** diff shown before any file is written; evidence manifest captures every exception you acknowledge
+- **Rollback:** revert the commit — the evidence manifest records what changed and why
+
+```bash
+agentbundle install --pack frontend-engineering --scope user
+agentbundle install --pack experience-design --scope user   # for full genre routing
+```
+
+---
+
+## Skills included — under the hood
 
 | Skill | When to use |
-|---|---|
+|-------|-------------|
 | `frontend-engineering` | Create, retrofit, audit, or verify a surface — four modes |
 | `token-architecture` | Design or audit a three-tier CSS token system |
-| `a11y-engineering` | Accessibility audit, retrofit, or complex interaction design |
-| `fe-performance` | CWV diagnosis or asset budget remediation |
+| `a11y-engineering` | Dedicated accessibility audit, complex interaction design |
+| `fe-performance` | CWV diagnosis and asset-budget remediation |
 | `rendering-strategy` | Select or audit the rendering model for a route (CSR/SSR/SSG/ISR/RSC) |
 | `component-contract` | Design a shared component's public interface before implementation |
 | `responsive-layout` | Design or debug adaptive layouts across breakpoints |
-| `css-architecture` | Set up or refactor CSS at scale — cascade layers, specificity budgets, scoping |
+| `css-architecture` | Set up or refactor CSS at scale — cascade layers, specificity budgets |
 | `fe-status` | Orient to an existing surface's gate history and quality floor status |
 
 **Reviewer:** `frontend-reviewer` — forked-context, read-only diff reviewer.
 
+---
+
 ## Sole owner of `frontend-engineering`
 
-This pack is the sole owner of the `frontend-engineering` skill. The `core` pack's resident skill was deleted in ADR-0057 (2026-07-27) to resolve a footprint-gate conflict that prevented this pack from installing alongside `core`. Load this pack's skill — it is the canonical content owner (four modes, evidence manifest, WCAG 2.2 AA, CWV targets).
+This pack is the sole owner of the `frontend-engineering` skill. The `core` pack's resident skill was deleted in ADR-0057 (2026-07-27) to resolve a footprint-gate conflict. Load this pack's skill — it is the canonical content owner (four modes, evidence manifest, WCAG 2.2 AA, CWV targets).
 
-## Co-install
+---
 
-For full genre routing in the frontend pre-flight, co-install with `experience-design`:
-
-```
-agentbundle install --pack frontend-engineering --scope user
-agentbundle install --pack experience-design --scope user
-```
-
-If `experience-design` is absent, `frontend-engineering` records a named skip and proceeds.
-
-## Install
-
-```
-agentbundle install --pack frontend-engineering --scope user
-```
-
-Projects to: Claude Code, Codex, Copilot, Cursor, Gemini, Kiro.
-
-## Guides
+## Go deeper
 
 → [`guides/frontend-engineering/`](../../guides/frontend-engineering/)

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "frontend-engineering"
-version = "0.1.2"
+version = "0.1.3"
 description = "The implementation layer for product web surfaces — HTML, CSS, and JS. Nine skills covering the build journey from design handoff to shipped component: the full create/retrofit/audit/verify workflow, CSS token system architecture, deep accessibility engineering (WCAG 2.2 AA, focus management, ARIA role correctness), Core Web Vitals measurement and remediation, rendering strategy selection (SSR/SSG/RSC/CSR), component API design, responsive layout craft, CSS architecture at scale, and a surface-orient skill. A forked-context `frontend-reviewer` provides a diff-level review for HTML/CSS/JS diffs, covering token drift, ARIA mutation completeness, state coverage regression, and CWV regression signals. Co-installs with `experience-design` for full genre routing in the frontend pre-flight."
 readme = "README.md"
 display_name = "Frontend Engineering"

--- a/packs/iac-terraform/.claude-plugin/plugin.json
+++ b/packs/iac-terraform/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "iac-terraform",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Opt-in Terraform/OpenTofu IaC generator: turn a plain-language intent into governed, best-practice, cloud-agnostic Terraform plus a human-gated CI/CD pipeline. Decision-record-gated; stops at `terraform plan`; reuses core's infra-verification + operational-safety depth."
 }

--- a/packs/iac-terraform/README.md
+++ b/packs/iac-terraform/README.md
@@ -1,59 +1,124 @@
 # `iac-terraform` pack
 
-> **Opt-in, repo-scope.** Not included in any default profile — install explicitly:
-> `agentbundle install --pack iac-terraform <catalogue>` (`<catalogue>` is a local clone path or a `git+https://…` URL)
+> **Opt-in, repo-scope.** Not included in any default profile.
+> `agentbundle install --pack iac-terraform <catalogue>`
+> (`<catalogue>` is a local clone path or a `git+https://…` URL)
 
-Turn a plain-language infrastructure intent into governed, best-practice
-Terraform/OpenTofu — decision-record-driven, cloud-agnostic, and human-gated
-at apply time.
+Turn a plain-language infrastructure intent into governed, best-practice Terraform/OpenTofu — decision-record-driven, cloud-agnostic, and human-gated at apply time.
 
-## Skills
+**The agent produces the plan. You gate apply.**
 
-| Skill | Trigger | What it does |
-| --- | --- | --- |
-| `generate-iac` | "provision X", "create Terraform for", "generate IaC for" | Governance-first authoring: ADR gate → spec → plan → tasks → Terraform → verify. Stops at a digest-pinned `plan` (the G4 handoff). Never runs `apply`. |
-| `reconcile-iac` | "reconcile my infrastructure", "check for drift", "drift audit" | `plan`-based drift audit → proposed disposition → route. Two triggers: before-change preflight (mandatory) and on-demand/scheduled. Never autonomously applies. |
+---
 
-## Design
+## Start here
 
-- **Zero seeds** — all provider configs, pipeline YAML, and OPA rules are
-  generated into the adopter repo from progressive references; the pack ships
-  none.
-- **Zero agents** — reuses `core`'s `adversarial-reviewer`, `quality-engineer`,
-  and `security-reviewer` via the existing orchestrator-inlining mechanism.
-- **Dual-engine** — Terraform and OpenTofu share an HCL-compatible baseline;
-  divergences are in `references/opentofu-differences.md`, loaded only when
-  `engine = opentofu`.
-- **Loop-arc aligned** — `generate-iac` targets the G4 handoff (`plan`);
-  `apply` is `release-loop`'s act on ephemeral environments, human-gated at
-  irreversible exits. Where `release-loop` is absent, the generated CI pipeline
-  is the degraded-mode fallback.
-- **Category taxonomy** — provider coverage tracks the Terraform registry's
-  own category list (MECE); each category gets a fit-for-purpose reference,
-  not the cloud four-file mold.
+Describe what infrastructure you need.
 
-## Validated in v1 (D5)
+```text
+Provision an S3 bucket with versioning enabled and a lifecycle policy
+that moves objects to Glacier after 90 days.
+```
+
+```text
+Check whether my infrastructure has drifted from the last plan.
+```
+
+The pack runs in two modes:
+
+- **generate-iac** — governance gate → spec → plan → `.tf` files → `terraform plan` pinned for your review. Stops before `apply`.
+- **reconcile-iac** — drift audit against the last plan → proposed disposition per resource → route for your decision.
+
+---
+
+## Common jobs
+
+**Generate governed Terraform from an intent**
+Describe the infrastructure you want to provision.
+The pack starts with a mandatory **Stage 0 ADR gate** — the infrastructure decision is recorded before any code is written. Then it produces a vocabulary-firewalled spec, schema-grounded `.tf` files, and an OPA policy + security preflight. It stops at a digest-pinnable `terraform plan` output.
+
+```text
+provision-vpc
+
+  Stage 0 (ADR gate)
+  ● Decision recorded → docs/adr/0042-vpc-design.md
+  Approve to continue? ›
+
+  Generating .tf files ...
+  ● terraform fmt -check ✓
+  ● terraform validate ✓
+  ● OPA policy check ✓
+  ● Security preflight ✓
+
+  Plan output: infra/plans/vpc-2026-07-29.plan (digest pinned)
+
+  Review the plan? ›   Gate apply? ›
+```
+
+**Audit infrastructure drift**
+Say `reconcile-iac` — before a change, or on a schedule.
+Runs a `terraform plan`-based drift audit and proposes a per-resource disposition (accept / correct / defer). You decide what to do with each resource. Nothing is applied.
+
+---
+
+## Infrastructure boundary — what the agent does and does not do
+
+| Zone | Who acts |
+|------|----------|
+| ADR gate, spec, `.tf` generation, preflight, `plan` | Agent (autonomous) |
+| Review the `terraform plan` output | **You** |
+| `terraform apply` | **You** (or your CI pipeline at G4 handoff) |
+| Irreversible destructive actions (resource deletion, data migration) | **You** — always human-gated |
+
+**State files** are never touched by the agent — state management (`terraform state`, backends, locking) is the responsibility of your CI pipeline and your `terraform apply` step.
+
+**Secrets** (API keys, service-account credentials) are never generated, stored, or read by the agent. Use your credential store; reference them as environment variables or Vault references in the generated configuration.
+
+**Rollback:** if you need to roll back a change, re-run `reconcile-iac` from the last known-good plan to produce a reverse disposition, then review and apply it.
+
+---
+
+## Validated in v1
 
 | Provider | Status | Note |
-| --- | --- | --- |
+|----------|--------|------|
 | AWS | **validated** | Passes `init -backend=false && fmt -check && validate` on both `terraform` and `tofu` |
 | GCP | **validated** | Passes `init -backend=false && fmt -check && validate` on `terraform` |
 | Databricks | **validated** | Passes `init -backend=false && fmt -check && validate` on `terraform` |
 | Azure | contract-complete | Unvalidated in v1 — stamped **experimental** |
 | All other categories | contract-complete | Stamped **experimental — not validated in v1** |
 
-## Dependencies
+---
 
-- `core` ^0.1 — infra-verification, operational-safety, security-checklists,
-  contract-acquisition, and the three forked-context reviewers
-- `governance-extras` ≥0.6 — governance-index template, new-adr infra mode
+## Installation and trust
 
-## Guides
-
-Full user-facing documentation: [`guides/iac-terraform/`](../../../../guides/iac-terraform/)
+- **Scope:** repo — installs into the repo where your infrastructure code lives
+- **Reads:** your infrastructure intent, existing `.tf` files, provider schemas (via `terraform providers schema`)
+- **Local writes:** `.tf` files, ADR records, plan digest file — only after you approve each gate
+- **Remote reads:** provider registries (via `terraform init`); no direct cloud API calls
+- **Remote writes:** none — `apply` is always yours
+- **Requires:** `core` ≥0.1, `governance-extras` ≥0.6, `terraform` or `tofu` CLI in PATH
 
 ---
 
-*Establishing precedent: RFC-0065 (D2 charter exception — opt-in accelerator
-packs for common tech stacks are explicitly in scope). Future tool-specific
-packs are judged against this RFC.*
+## Design
+
+- **Zero seeds** — all provider configs, pipeline YAML, and OPA rules are generated into the adopter repo; the pack ships none.
+- **Zero agents** — reuses `core`'s `adversarial-reviewer`, `quality-engineer`, and `security-reviewer` via the existing orchestrator-inlining mechanism.
+- **Dual-engine** — Terraform and OpenTofu share an HCL-compatible baseline; divergences are in `references/opentofu-differences.md`, loaded only when `engine = opentofu`.
+- **Category taxonomy** — provider coverage tracks the Terraform registry's own category list (MECE); each category gets a fit-for-purpose reference.
+
+---
+
+## Skills included — under the hood
+
+| Skill | Trigger | What it does |
+|-------|---------|-------------|
+| `generate-iac` | "provision X", "create Terraform for", "generate IaC for" | ADR gate → spec → plan → Terraform → `terraform plan` pinned for G4 handoff. Never runs `apply`. |
+| `reconcile-iac` | "reconcile my infrastructure", "check for drift", "drift audit" | `plan`-based drift audit → proposed disposition → route for your decision. Never applies autonomously. |
+
+---
+
+## Go deeper
+
+→ [`guides/iac-terraform/`](../../guides/iac-terraform/)
+→ [`JOURNEY.md`](JOURNEY.md) — the seven-stage governance loop from intent to plan

--- a/packs/iac-terraform/pack.toml
+++ b/packs/iac-terraform/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "iac-terraform"
-version = "0.1.3"
+version = "0.1.4"
 description = "Opt-in Terraform/OpenTofu IaC generator: turn a plain-language intent into governed, best-practice, cloud-agnostic Terraform plus a human-gated CI/CD pipeline. Decision-record-gated; stops at `terraform plan`; reuses core's infra-verification + operational-safety depth."
 readme = "README.md"
 display_name = "IaC (Terraform)"

--- a/packs/product-strategy/.claude-plugin/plugin.json
+++ b/packs/product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-strategy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The strategy seat upstream of product engineering and experience design \u2014 SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis (Pillar 1); UX strategy with NN/g three-layer model, Jaime Levy four tenets, and Gothelf/Seiden OKR-linked UX framing (Pillar 2); content strategy via the Halvorson quad: Purpose + Process + Structure + Governance (Pillar 3). Pure method: no growth tooling, no primary research production, no stack tokens."
 }

--- a/packs/product-strategy/README.md
+++ b/packs/product-strategy/README.md
@@ -1,12 +1,25 @@
 # product-strategy
 
-The strategy seat upstream of every initiative — committed artifacts.
+Answer the committed strategic questions upstream of every product initiative.
 
 ---
 
 ## Start here
 
-Type `write-prfaq` and describe the product concept you want to pressure-test.
+You don't need to know which method to use. Start with the question you're trying to answer.
+
+> "Who should we serve first?"  
+> "Which problem should we commit to?"  
+> "Why would users switch to this?"  
+> "How will they reach first value?"  
+> "What retained behavior would prove the strategy is working?"  
+> "What would cause us to change course?"
+
+Type the question, or describe the product concept — the pack selects the method.
+
+```text
+Who should we serve first — enterprise teams or individual practitioners?
+```
 
 ```text
 write-prfaq
@@ -21,30 +34,38 @@ write-prfaq
   Solution:  workspace.toml — a version-controlled queue the agent
              reads at session start. One grep, full context.
 
-  draft  docs/product/shaping/prfaq.md
+  Approve the PRFAQ? ›
 ```
 
-On any session return, type `workspace-status` to see the strategy queue.
+The result is a committed artifact in `docs/product/shaping/` — a PRFAQ, a situation picture, a portfolio position, a cascaded OKR set, or a strategic narrative. Not a slide. A record the next stage can act on.
 
 ---
 
-## Entry points
+## Common jobs
 
-| Say this | Give it | What happens |
-|----------|---------|--------------|
-| `write-prfaq` | A product concept, elevator pitch, or problem statement | Drafts the press release + FAQ before the product exists — the altitude-0 forcing function |
-| `run-pestle-analysis` | The scope: organization, market entry, or product line | Scans the macro environment across six lenses — Political, Economic, Social, Technological, Legal, Environmental |
-| `run-porters-five-forces` | The industry and the competitive reference point | Maps the competitive landscape — supplier and buyer power, new entrants, substitutes, rivalry |
-| `run-bcg-matrix` | A list of initiatives or products with their relative market position | Positions each in the portfolio matrix — Stars, Cash Cows, Question Marks, Dogs |
-| `run-swot` | Scope alone (elicits inline), or prior PESTLE / Porter's / BCG artifacts | Synthesizes the situation picture — Strengths, Weaknesses, Opportunities, Threats |
-| `run-okr-cascade` | Company OKRs (text, doc, or described inline) | Cascades to team level, identifies gaps, and routes them to the PE shaping queue in `workspace.toml` |
-| `synthesize-stakeholder-research` | One or more `desk-research-project-synthesize` briefs | Converts research evidence into a committed strategic narrative by theme |
-| `define-ux-strategy` | The approved PRFAQ and market situation (optional but improves grounding) | Sets the experience vision, goals with measures, and plan — upstream of `journey-mapping` |
-| `define-content-strategy` | Organizational context and any prior strategy artifacts | Sets the governance layer for content — Purpose, Process, Structure, Governance — upstream of `content-design` |
+**Pressure-test a product concept before building it**
+Say `write-prfaq` and describe the product idea, problem, or elevator pitch.
+Returns a press-release-and-FAQ document that forces an honest answer to "who is this for, what's the headline, and what's the FAQ critique?" Approve the PRFAQ or revise it. Written to `docs/product/shaping/`.
+
+**Map the strategic situation before committing to an approach**
+Say `run-swot` (or `run-pestle-analysis`, `run-porters-five-forces`). Describe the scope — organization, market, or product.
+Returns a committed situation picture (quadrant map, five-force diagram, or PESTLE scan) as the foundation for the PRFAQ. Only reads information you provide; nothing is written until you approve.
+
+**Position a product portfolio**
+Say `run-bcg-matrix` and provide a list of initiatives with their relative market position.
+Returns a portfolio matrix placing each initiative in a quadrant — Stars, Cash Cows, Question Marks, Dogs — with a disposition recommendation per initiative. You decide whether to act on the recommendation.
+
+**Cascade strategy to the engineering queue**
+Say `run-okr-cascade` and provide company OKRs (as text, a doc, or described inline).
+Returns team-level OKRs and exposes the gaps — initiatives or KRs that no team owns. The gaps are written as `{type = "strategy"}` entries to `workspace.toml`, where `product-engineering`'s `frame-situation` picks them up.
+
+**Synthesize research into a strategic narrative**
+Say `synthesize-stakeholder-research` and attach one or more completed `desk-research-project-synthesize` briefs.
+Returns a committed strategic narrative organized by theme — direct evidence converted to a record the PRFAQ or initiative brief can cite.
 
 ---
 
-## How a session runs
+## How it works
 
 ```text
 run-swot
@@ -62,15 +83,7 @@ run-swot
 ```text
 write-prfaq
 
-  Headline:  [Company] ships workspace.toml — product engineers who
-             coordinate AI agent work across sessions.
-
-  Customer:  A solo engineer shipping a 3-person startup's backlog
-             with AI coding agents.
-  Problem:   Every session starts blind. The agent doesn't know
-             what was decided, what's blocked, or what ships next.
-  Solution:  workspace.toml — a version-controlled queue the agent
-             reads at session start. One grep, full context.
+  ...
 
   Approve the PRFAQ? ›
 ```
@@ -91,13 +104,46 @@ The gaps appear in `workspace-status` for product engineers to pick up via `fram
 
 ---
 
-## Cross-pack
+## Installation and trust
 
-**Downstream — `product-engineering`:** `run-okr-cascade` writes `{type = "strategy"}` gap entries to `workspace.toml`. The PE pack's `frame-situation` reads them from the shaping queue.
+- **Scope:** user — installs portably across all your repos
+- **Reads:** information you provide in the conversation; prior strategy artifacts you reference
+- **Local writes:** approved artifacts to `docs/product/shaping/` inside your current repo
+- **Remote reads/writes:** none
+- **Approval:** every artifact is approved before being written; the pack proposes, you commit
+- **No growth or marketing execution tooling** — see `[backlog].open: growth-strategy-pack` for scope rationale
 
-**Downstream — `experience-design`:** `define-ux-strategy` produces `ux-strategy.md` and `define-content-strategy` produces `content-strategy.md`. Both are strategic anchors the experience-design pack's `journey-mapping` and `content-design` read from.
+```bash
+agentbundle install --pack product-strategy --scope user
+```
 
 ---
 
-→ **How it works:** [DESIGN.md](DESIGN.md) — philosophy, pillars, invariants, and decision log.  
-→ **Go deeper:** the [`product-strategy` guides](https://github.com/eugenelim/agent-ready-repo/tree/main/guides/product-strategy/).
+## Skills included — under the hood
+
+| Skill | Method | When to reach for it |
+|-------|--------|----------------------|
+| `write-prfaq` | Amazon-style press release + FAQ | Pressure-testing a new product concept |
+| `run-swot` | SWOT synthesis (optionally from prior PESTLE / Porter's / BCG) | Situation picture before committing to direction |
+| `run-pestle-analysis` | PESTLE scan | Macro-environment scan for market entry or product line |
+| `run-porters-five-forces` | Porter's Five Forces | Competitive landscape map |
+| `run-bcg-matrix` | BCG Matrix | Portfolio positioning across multiple initiatives |
+| `run-okr-cascade` | OKR cascade | Cascading company OKRs to team level; exposing gaps |
+| `synthesize-stakeholder-research` | Research synthesis | Converting desk-research output into strategic narrative |
+| `define-ux-strategy` | Experience vision + goals/measures + plan | Upstream anchor for `journey-mapping` and `content-design` |
+| `define-content-strategy` | Halvorson Purpose · Process · Structure · Governance | Governance layer for content above per-surface design |
+
+---
+
+## Cross-pack handoffs
+
+**→ `product-engineering`:** `run-okr-cascade` writes `{type = "strategy"}` gap entries to `workspace.toml`. The PE pack's `frame-situation` reads them from the shaping queue.
+
+**→ `experience-design`:** `define-ux-strategy` produces `ux-strategy.md` and `define-content-strategy` produces `content-strategy.md`. Both anchor `journey-mapping` and `content-design`.
+
+---
+
+## Go deeper
+
+→ [Product Strategy guides](../../guides/product-strategy/)
+→ [JOURNEY.md](JOURNEY.md) — the three-artifact strategy workflow from situation → decision → queue

--- a/packs/product-strategy/pack.toml
+++ b/packs/product-strategy/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "product-strategy"
-version = "0.2.2"
+version = "0.2.3"
 description = "The strategy seat upstream of product engineering and experience design. Pillar 1 — Market & competitive strategy: SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, and stakeholder-research synthesis — seven frameworks that produce committed artifacts in docs/product/shaping/ and feed the PE pack's shaping queue. Pillar 2 — UX strategy: defines the experience vision, goals/measures, and plan (NN/g three-layer model · Jaime Levy four tenets · Gothelf/Seiden OKR-linked UX framing) upstream of journey-mapping. Pillar 3 — Content strategy: the Halvorson quad (Purpose + Process + Structure + Governance) — the organizational/governance layer above per-surface content-design. Pure method: no growth tooling, no primary research production, no stack tokens — references canonical frameworks by name, never reprints them."
 readme = "README.md"
 display_name = "Product Strategy"

--- a/packs/release-engineering/.claude-plugin/plugin.json
+++ b/packs/release-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "release-engineering",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "The SRE/ops outer loop \u2014 deployed end-to-end validation above work-loop's inner build loop. Ships the `release-lead` agent and the `release-loop` skill: deploy the integrated whole to an ephemeral environment, run e2e, observe telemetry, feed deployed findings back to the inner loop (no human relay), redeploy, and iterate until the deployed whole converges \u2014 then stop at the human consent gate for the prod ship (G5), surfaced as a release-readiness record to ratify rather than a bare go/no-go. Autonomy is carved by minimum-regret: the agent runs the inner and outer loops on reversible ephemeral envs unwatched; humans gate the irreversible exits (first real users or data, data migrations, spend over threshold, security/auth-boundary changes, anything irreversible, and the prod ship). Reuses core's operational-safety depth modules + quality-engineer + security-reviewer, consumes the discovery sidecar schema by convention, and ships no new runtime engine and no new reviewer. Completes the company OS: product (discovery) \u2192 engineering (build) \u2192 SRE/ops (release). Markdown skill + agent definition, repo-scope."
 }

--- a/packs/release-engineering/README.md
+++ b/packs/release-engineering/README.md
@@ -1,5 +1,22 @@
 # release-engineering
 
+Deploy the integrated whole to an ephemeral environment, run end-to-end tests, converge, and surface a release-readiness record for the human prod-ship gate (G5).
+
+---
+
+## Start here
+
+After `work-loop` reaches G4 — build done, component ready — hand it to `release-lead`:
+
+```text
+Run the release loop on the integrated whole — deploy to an ephemeral env,
+run e2e, and iterate until it converges, then surface the prod ship for me to ratify.
+```
+
+The agent deploys, runs e2e, observes telemetry, feeds findings back to the inner loop without a human relay, redeploys, and iterates until the deployed whole converges. It then stops and presents a **release-readiness record** — a structured go/no-go recommendation — for you to ratify (G5). **The prod ship is always yours.**
+
+---
+
 The **SRE/ops outer loop** — deployed end-to-end validation above `work-loop`'s
 inner build loop. This pack completes the **company OS**: product (discovery, the
 `product-engineering` pack) → engineering (build, `work-loop`) → **SRE/ops

--- a/packs/release-engineering/pack.toml
+++ b/packs/release-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "release-engineering"
-version = "0.1.6"
+version = "0.1.7"
 description = "The SRE/ops outer loop — deployed end-to-end validation above work-loop's inner build loop. Ships the `release-lead` agent and the `release-loop` skill: deploy the integrated whole to an ephemeral environment, run e2e, observe telemetry, feed deployed findings back to the inner loop (no human relay), redeploy, and iterate until the deployed whole converges — then stop at the human consent gate for the prod ship (G5), surfaced as a release-readiness record to ratify rather than a bare go/no-go. Autonomy is carved by minimum-regret: the agent runs the inner and outer loops on reversible ephemeral envs unwatched; humans gate the irreversible exits (first real users or data, data migrations, spend over threshold, security/auth-boundary changes, anything irreversible, and the prod ship). Reuses core's operational-safety depth modules + quality-engineer + security-reviewer, consumes the discovery sidecar schema by convention, and ships no new runtime engine and no new reviewer. Completes the company OS: product (discovery) → engineering (build) → SRE/ops (release). Markdown skill + agent definition, repo-scope."
 readme = "README.md"
 display_name = "Release Engineering"

--- a/tools/check-guide-index.py
+++ b/tools/check-guide-index.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Phase 4B regression check: verify every active pack appears in guides/README.md
+All-packs table.
+
+Exit 0 = all packs accounted for.
+Exit 1 = at least one active pack is absent from the guide index.
+
+Usage:
+  python3 tools/check-guide-index.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PACKS_DIR = REPO_ROOT / "packs"
+GUIDE_INDEX = REPO_ROOT / "guides" / "README.md"
+
+# Packs excluded from the guide index — internal or compatibility-only
+EXCLUDED_PACKS = {
+    "_example",          # internal example only
+    "user-guide-diataxis",  # deprecated compatibility pack; not a current recommendation
+}
+
+# Additional packs that are correctly omitted because they have no public guide
+# (atomic 1-skill packs whose README is their only guide surface) — add here if needed
+GUIDE_OPTIONAL_PACKS: set[str] = set()
+
+
+def discover_active_packs() -> list[str]:
+    """Return pack IDs for all packs with a pack.toml, excluding EXCLUDED_PACKS."""
+    packs = []
+    for pack_dir in sorted(PACKS_DIR.iterdir()):
+        if not pack_dir.is_dir():
+            continue
+        if (pack_dir / "pack.toml").exists() and pack_dir.name not in EXCLUDED_PACKS:
+            packs.append(pack_dir.name)
+    return packs
+
+
+def extract_indexed_packs(guide_index: Path) -> set[str]:
+    """
+    Extract pack IDs from the '## All packs' table in guides/README.md.
+    Only scans between the '## All packs' heading and the next '##' heading
+    to avoid false-positives from role/loop tables earlier in the file.
+    """
+    if not guide_index.exists():
+        return set()
+    content = guide_index.read_text(encoding="utf-8")
+    # Slice to the "## All packs" section only
+    match = re.search(r"^## All packs\b", content, re.MULTILINE)
+    if not match:
+        return set()
+    section_start = match.end()
+    next_heading = re.search(r"^##", content[section_start:], re.MULTILINE)
+    if next_heading:
+        section = content[section_start : section_start + next_heading.start()]
+    else:
+        section = content[section_start:]
+    # Match rows like: | [`core`](core/) | ...
+    return set(re.findall(r"\|\s*\[`([a-z][a-z\-]+)`\]", section))
+
+
+def main() -> int:
+    active_packs = discover_active_packs()
+    indexed_packs = extract_indexed_packs(GUIDE_INDEX)
+
+    missing = [
+        p for p in active_packs
+        if p not in indexed_packs and p not in GUIDE_OPTIONAL_PACKS
+    ]
+
+    if missing:
+        print("check-guide-index: FAIL — active packs missing from guides/README.md:")
+        for p in missing:
+            print(f"  ✗ {p}")
+        guide_index_rel = GUIDE_INDEX.relative_to(REPO_ROOT)
+        print(f"\nFix: add each missing pack to the 'All packs' table in {guide_index_rel}")
+        return 1
+
+    print(
+        f"check-guide-index: OK — all {len(active_packs)} active packs present in guide index"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -109,7 +109,7 @@ humanGates:
     whatToCheck:
       - "Did the reviewer flag any handle-all-states violations? (Missing empty, loading, error, or success states are the most common finding.)"
       - "Are all WCAG 2.2 AA requirements met — color contrast, label associations, focus order?"
-      - "Is reduced-motion handled — are transitions guarded with prefers-reduced-motion?"
+      - "Is reduced-motion handled — are transitions guarded for users who have requested reduced animation?"
       - "Are the screens consistent with the approved aesthetic direction — or did any screen introduce its own visual language?"
     whatGoodLooksLike: "A design set that the independent reviewer marks clean — all states handled, accessibility floor met, aesthetic direction consistently applied across every screen."
     whatBadLooksLike: "Screens that look good in the happy-path state but have no designed empty state, loading state, or error recovery. Or screens that pass visually but fail the accessibility audit."

--- a/web/src/content/packs/frontend-engineering.md
+++ b/web/src/content/packs/frontend-engineering.md
@@ -13,7 +13,7 @@ skills:
   - css-architecture
   - fe-status
 installCommand: "agentbundle install --pack frontend-engineering --scope user"
-docsUrl: /docs/guides/frontend-engineering/
+docsUrl: /guides/frontend-engineering/
 ---
 
 Frontend Engineering installs 9 skills covering the full build journey from design handoff to shipped component: the create/retrofit/audit/verify workflow (`frontend-engineering`), CSS token system architecture (`token-architecture`), deep accessibility engineering beyond automated tooling (`a11y-engineering`), Core Web Vitals measurement and remediation (`fe-performance`), rendering strategy selection (`rendering-strategy`), component API design (`component-contract`), responsive layout craft (`responsive-layout`), CSS architecture at scale (`css-architecture`), and surface orientation (`fe-status`). A forked-context `frontend-reviewer` agent provides a diff-level review for HTML/CSS/JS diffs covering CSS token drift, ARIA mutation completeness, state coverage regression, and the two WCAG 2.2 manual-verification items automated tooling misses.

--- a/web/src/content/packs/product-strategy.md
+++ b/web/src/content/packs/product-strategy.md
@@ -1,7 +1,7 @@
 ---
 name: Product Strategy
 scope: user
-tagline: "The strategy seat — market, UX, and content strategy upstream of the build."
+tagline: "Answer the committed strategic questions upstream of every initiative."
 skills:
   - run-swot
   - run-porters-five-forces
@@ -16,4 +16,4 @@ installCommand: "agentbundle install --pack product-strategy --scope user"
 docsUrl: /guides/product-strategy/
 ---
 
-Product Strategy is the seat upstream of product engineering and experience design. Three pillars: **market & competitive strategy** (SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis) that produce committed artifacts in `docs/product/shaping/` and feed the PE pack's shaping queue; **UX strategy** (experience vision, goals/measures, plan) upstream of journey-mapping; and **content strategy** — the Halvorson quad (Purpose · Process · Structure · Governance) that sits above per-surface content design. Pure method: it references the canonical frameworks by name and applies them to your context — no growth tooling, no stack tokens.
+Start with the strategic question you're trying to answer — "Who should we serve first?", "Which problem should we commit to?", "Why would users switch?" — and the pack selects the method. Every run produces a committed artifact in `docs/product/shaping/` (a PRFAQ, situation picture, portfolio position, OKR cascade, or strategic narrative) that the `product-engineering` shaping queue or `experience-design` can act on directly. Methods include SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis, UX strategy, and content strategy. No growth or marketing execution tooling.


### PR DESCRIPTION
## Summary

- **5 README rewrites** (product-strategy, frontend-engineering, catalogue-curation, iac-terraform, release-engineering) bring all active packs to Product Documentation contract compliance: user outcome, natural first request, expected result, and side-effect boundary all visible within 120 words; common jobs before skill inventory; skill table in "under the hood" section.
- **Catalogue convergence**: `guides/README.md` now lists all 20 active packs in the All packs table; guide-author doctrine updated from physical-folder-first to Phase 2A metadata model (`kind` as frontmatter, flat `guides/<pack>/<slug>.md` paths, no mandatory quadrant directories).
- **Drift prevention**: new `tools/check-guide-index.py` — exits 1 if any active pack is absent from the All packs table (scoped to that section to prevent false-positives from By-role and Three-loops tables).
- **Pack page updates**: product-strategy tagline/description is now user-question-led; frontend-engineering `docsUrl` corrected from `/docs/guides/...` to `/guides/frontend-engineering/`.
- **Adversarial review passed** — all 4 actionable findings resolved: `plugin.json` version parity fixed for all 5 packs, drift-check scoped to All packs section, broken catalogue-curation docs link fixed, docstring trimmed.

## Pack version bumps

| Pack | Before | After |
|------|--------|-------|
| product-strategy | 0.2.2 | 0.2.3 |
| frontend-engineering | 0.1.2 | 0.1.3 |
| catalogue-curation | 0.1.6 | 0.1.7 |
| iac-terraform | 0.1.3 | 0.1.4 |
| release-engineering | 0.1.6 | 0.1.7 |

## Spec

`docs/specs/phase4b-product-docs-completion/spec.md` — all 19 ACs complete, Status: Shipped.

## Bundled build-self byproduct

`web/src/content/journeys/experience-design.md`: minor reduced-motion phrasing sync from `packs/experience-design/JOURNEY.md` projection (source unchanged this PR; `FORCE=1 make build-self` corrected pre-existing drift).

## Gates passed

```
SKIP_SAST=1 make build-check          ✓ exit 0
make lint-ruff                         ✓ all checks passed
python3 tools/lint-pack-journeys.py   ✓ 11 files valid
python3 tools/validate_guides.py      ✓ 0 errors, 159 warnings
python3 tools/pre-pr-catalogue.py     ✓ all green
python3 tools/check-guide-index.py    ✓ 20 packs present
```

## READY FOR PHASE 5

All active packs satisfy the Product Documentation contract. Shared catalogue surfaces (guide index, guide-author doctrine, plugin metadata parity) are converged. Regression drift check in place.