### PR TITLE
feat(product-docs): add github and linear marketing-site pack pages + fix first-value drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -319,7 +319,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": {
@@ -397,7 +397,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.1.5"
+      "version": "0.1.6"
     },
     {
       "author": {

--- a/packs/github/.claude-plugin/plugin.json
+++ b/packs/github/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "github",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "GitHub integration: `github-brief-intake` \u2014 turn a GitHub Milestone into a product brief and hand off to `receive-brief`."
 }

--- a/packs/github/pack.toml
+++ b/packs/github/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "github"
-version = "0.1.2"
+version = "0.1.3"
 description = "GitHub integration: `github-brief-intake` — turn a GitHub Milestone into a product brief and hand off to `receive-brief`."
 readme = "README.md"
 display_name = "GitHub"
@@ -30,13 +30,13 @@ documentation = "https://github.com/eugenelim/agent-ready-repo/tree/main/guides/
 name = "eugenelim"
 email = "eugenelim@users.noreply.github.com"
 
-# Level B: mixed audience (developers + PMs); requires GitHub token for first run.
+# Level B: mixed audience (developers + PMs); requires gh CLI installed + authenticated.
 [pack.first-value]
 audience-posture = "mixed"
 surfaces         = ["claude-code"]
-prerequisites    = ["GitHub token with `repo` scope — configure via the credential-brokers pack"]
+prerequisites    = ["Install `gh` CLI (https://cli.github.com); for private repos: `gh auth login`"]
 verification     = "Run `github-brief-intake` on a GitHub Milestone and confirm a product brief draft is returned without an error."
-recovery         = "If authentication fails, reconfigure your GitHub token via the credential-brokers pack; ensure the token has `repo` scope and access to the target repository."
+recovery         = "If the `gh` CLI is not installed, install it from https://cli.github.com and run `gh auth login` before retrying."
 level-b          = true
 starter-task     = "Turn a GitHub Milestone into a product brief"
 starter-prompt   = "Use github-brief-intake to convert my most recent open GitHub milestone into a product brief."

--- a/packs/linear/.claude-plugin/plugin.json
+++ b/packs/linear/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "linear",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Linear primitives: linear (credentialed GraphQL CLI), plus the linear-brief-intake and linear-brief-sync workflows that compose it with receive-brief."
 }

--- a/packs/linear/pack.toml
+++ b/packs/linear/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "linear"
-version = "0.1.5"
+version = "0.1.6"
 description = "Linear primitives: linear (credentialed GraphQL CLI), plus the linear-brief-intake and linear-brief-sync workflows that compose it with receive-brief."
 readme = "README.md"
 display_name = "Linear"
@@ -39,7 +39,7 @@ prerequisites    = ["Linear Personal API Key — configure via the credential-br
 verification     = "Run `linear check` to confirm your credentials are working and your workspace is accessible."
 recovery         = "If authentication fails, reconfigure your Linear API key via the credential-brokers pack; verify the key has read access to the correct Linear workspace."
 level-b          = true
-starter-task     = "Check your Linear credentials and see your open issues"
-starter-prompt   = "Run linear check to confirm my credentials, then show me the open issues assigned to me in Linear."
-expected-result  = "Confirmation that your Linear credentials are valid, followed by a list of your open assigned issues."
-next-action      = "Ask the agent to run linear-brief-intake on one of the issues to convert it into a product brief."
+starter-task     = "Verify your Linear credentials"
+starter-prompt   = "Run linear check to confirm my credentials."
+expected-result  = "Confirmation that your Linear credentials are valid — workspace name and your identity shown."
+next-action      = "Ask the agent to run linear-brief-intake on a Linear Issue ID (e.g. LIN-123) to convert it into a product brief."

--- a/web/src/content/packs/github.md
+++ b/web/src/content/packs/github.md
@@ -1,0 +1,78 @@
+---
+name: GitHub
+scope: user
+tagline: "Turn a GitHub Milestone into a product brief"
+skills:
+  - github-brief-intake
+installCommand: "agentbundle install --pack github --scope user"
+docsUrl: /guides/github/
+---
+
+Reads a GitHub Milestone — title, description, and all linked issues — and
+maps it onto a structured product brief. Nothing is written until you approve
+the draft. The brief lands in `docs/product/briefs/` and hands off to
+`receive-brief` for gap elicitation, decomposition, and spec-chained execution.
+
+**Starts read-only.** No files are written until you confirm the brief.
+
+---
+
+Try this first:
+
+```
+Turn our Q3 milestone into a product brief.
+```
+
+What you get: milestone and issues read from GitHub · a structured brief drafted
+with problem statement, user jobs, acceptance criteria, and a `receive-brief`
+handoff — ready for your review before anything is written.
+
+---
+
+### What you can do
+
+**Turn a Milestone into a product brief**
+
+Point the agent at any GitHub Milestone — by name, number, or `org/repo` path.
+The agent reads the milestone and its issues, extracts shape, problem statement,
+and user stories, and presents a draft brief for your review.
+Nothing is written until you approve.
+
+```
+Intake the 'v2 launch' milestone from your-org/my-repo as a product brief.
+```
+
+---
+
+**Hand off to the build queue**
+
+Once you approve the brief, the agent writes it to
+`docs/product/briefs/<slug>.md` and runs `receive-brief` to elicit any gaps,
+decompose the brief into specs, and chain `new-spec` → `work-loop`.
+
+```
+The brief looks good. Write it and hand off to receive-brief.
+```
+
+---
+
+### What changes
+
+**Reads:** the Milestone title and description; all linked issues (title,
+description, labels, assignees). Requires the `gh` CLI installed; for private
+repos, run `gh auth login` first.
+
+**Writes:** `docs/product/briefs/<slug>.md` — only after you approve the draft.
+`workspace.toml` is updated when `receive-brief` registers the brief in the queue.
+
+Nothing else changes. The Milestone and issues in GitHub are never modified.
+
+---
+
+### Skills included — under the hood
+
+You do not need to name these skills. They activate from natural-language requests.
+
+| Skill | What it does |
+| --- | --- |
+| `github-brief-intake` | Reads a GitHub Milestone and its issues; maps them to a Shape B product brief; writes to `docs/product/briefs/` on approval; hands off to `receive-brief`. |

--- a/web/src/content/packs/linear.md
+++ b/web/src/content/packs/linear.md
@@ -1,0 +1,105 @@
+---
+name: Linear
+scope: user
+tagline: "Turn a Linear Issue into a product brief and keep it in sync"
+skills:
+  - linear
+  - linear-brief-intake
+  - linear-brief-sync
+installCommand: "agentbundle install --pack linear --scope user"
+docsUrl: /guides/linear/
+---
+
+Turns a Linear Issue or Project into a structured product brief, then keeps
+the brief in sync as the Issue evolves. Read-only during the review — nothing
+is written until you confirm the draft or the sync diff.
+
+**The agent never sees your API key.** Credentials resolve in-process via
+the `credential-brokers` pack.
+
+---
+
+Try this first:
+
+```
+Run linear check to confirm my credentials.
+```
+
+What you get: credentials confirmed — workspace name and your identity shown.
+Nothing changed, nothing written to Linear.
+
+---
+
+### What you can do
+
+**Turn an Issue into a product brief**
+
+Point the agent at a Linear Issue or Project ID. It reads the issue,
+maps it onto a structured brief (problem statement, user jobs, acceptance
+criteria), and presents the draft for your review.
+
+```
+Intake Linear issue LIN-456 as a product brief.
+```
+
+---
+
+**Keep the brief in sync**
+
+When the Linear Issue changes after the brief is written, run `linear-brief-sync`
+to pull the delta. It shows only the fields that changed, section by section,
+and waits for your approval before writing anything.
+
+```
+Sync the brief for LIN-456 with the latest changes in Linear.
+```
+
+`linear-brief-sync` refuses to run if the brief status is `Executing` — it
+won't modify a brief that engineering is actively building against.
+
+---
+
+**Hand off to the build queue**
+
+After you approve the brief, `receive-brief` elicits any gaps, decomposes
+into specs, and chains `new-spec` → `work-loop`.
+
+```
+The brief looks good. Hand it off to receive-brief.
+```
+
+---
+
+### What changes
+
+**Reads:** the Linear Issue or Project via the `linear` primitive (credentialed
+GraphQL). The API key is stored under namespace `linear` via `credential-setup`
+and never passed to the model.
+
+**Writes:** `docs/product/briefs/<slug>.md` — on initial intake, after your
+approval. `workspace.toml` is updated when the brief enters the queue.
+Linear-sourced fields in an existing brief — on sync, only the fields you
+approve.
+
+Nothing is written to Linear. Issues and Projects in Linear are never modified.
+
+---
+
+### The sync lifecycle
+
+Issue created → `linear-brief-intake` → brief at `Draft` → `receive-brief` →
+specs + `work-loop` → brief at `Executing` → Issue updated in Linear →
+`linear-brief-sync` (only when brief is not `Executing`) → approved delta
+applied → brief updated
+
+---
+
+### Skills included — under the hood
+
+You do not need to name these skills. They activate from natural-language requests.
+
+| Skill | What it does |
+| --- | --- |
+| `linear` | Credentialed GraphQL primitive — `check`, `get-issue`, `get-project` subcommands. The agent never sees the API key. |
+| `linear-brief-intake` | First-time intake: reads an Issue or Project via `linear`, maps to a product brief, writes to `docs/product/briefs/` on approval, hands off to `receive-brief`. |
+| `linear-brief-sync` | Delta catch-up: re-fetches the Issue, diffs Linear-sourced fields against the existing brief, presents section-level changes for your approval. Refuses when brief is `Executing`. |


### PR DESCRIPTION
## Summary

- Adds `web/src/content/packs/github.md` and `web/src/content/packs/linear.md` — marketing site pack pages for the GitHub and Linear integration packs, matching the atlassian treatment (same integration archetype, previously missing from the marketing site while present in guides/README.md and site.toml).
- Fixes machine-fact drift in `packs/github/pack.toml` first-value (prerequisites/recovery incorrectly described a GitHub token via credential-brokers; the skill uses the `gh` CLI exclusively).
- Fixes machine-fact drift in `packs/linear/pack.toml` first-value (starter-prompt/expected-result claimed "list open issues assigned to me" but the `linear` primitive only exposes `check`, `get-issue`, `get-project` subcommands).
- Bumps github 0.1.2 → 0.1.3 and linear 0.1.5 → 0.1.6 for first-value metadata changes per versioning policy; plugin.json and marketplace.json synced.

## Test plan

- [x] `python3 tools/pre-pr-catalogue.py` — all checks passed
- [x] `python3 tools/check-guide-index.py` — all 20 active packs present
- [x] `python3 tools/lint-pack-journeys.py` — 11 files valid
- [x] `python3 tools/validate_guides.py guides/` — 0 errors
- [x] `FORCE=1 make build-self` — ok
- [x] Adversarial review: blocker (linear false-promise starter) fixed; concerns (github auth description, linear credential tool name) fixed

## Deferred

None.

## Bundled fixes

- `packs/github/pack.toml` first-value: corrected auth mechanism from credential-brokers/token to `gh` CLI
- `packs/linear/pack.toml` first-value: corrected starter-prompt/expected-result to match actual `linear check` capability