### PR TITLE
feat(catalogue): Wave 2 pack integrations — schema, validation, show, pilots, hub (RFC-0076 D6, 0.27.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -158,7 +158,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.15.6"
+      "version": "0.15.7"
     },
     {
       "author": {
@@ -342,7 +342,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.9.2"
+      "version": "0.9.3"
     },
     {
       "author": {

--- a/contracts/pack.schema.json
+++ b/contracts/pack.schema.json
@@ -265,6 +265,34 @@
             "writes-to-repo": {"type": "boolean"},
             "safety-gate": {"type": "string"}
           }
+        },
+        "integrations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "pack", "kind", "role", "consumers", "providers", "when", "purpose", "fallback"],
+            "properties": {
+              "id":        {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+              "pack":      {"type": "string"},
+              "kind":      {"type": "string", "enum": ["input", "augment", "review", "handoff"]},
+              "role":      {"type": "string"},
+              "consumers": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}
+              },
+              "providers": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}
+              },
+              "when":      {"type": "string", "minLength": 1},
+              "purpose":   {"type": "string", "minLength": 1},
+              "fallback":  {"type": "string", "minLength": 1},
+              "version":   {"type": "string"}
+            }
+          }
         }
       },
       "if": {

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`agentbundle` 0.27.0 — `[[pack.integrations]]` convention**: packs can now
+  declare optional cross-pack behavior seams in `pack.toml`. The new
+  `[[pack.integrations]]` array (governed by `contracts/pack.schema.json`) carries
+  ten fields: `id`, `pack`, `kind` (`input`/`augment`/`review`/`handoff`), `role`,
+  `consumers`, `providers`, `when`, `purpose`, `fallback`, and an optional `version`
+  semver range. `agentbundle catalogue verify` validates integration refs (uniqueness,
+  primitive resolution, self-target prohibition, semver range grammar, provider
+  presence when the target pack is in the same catalogue). `agentbundle show <pack>`
+  surfaces declared integrations in table and JSON output. Five first-party integration
+  entries ship across `packs/core` (two, targeting `frontend-engineering`) and
+  `packs/governance-extras` (three, targeting `desk-research`, `product-engineering`,
+  and `architect`).
+
 - **`agentbundle` 0.26.1 — bundled schemas**: the wheel now bundles
   `guide.schema.json`, `skill.schema.json`, `skill-manifest.schema.json`, and
   `target-vocab.toml` from the canonical `contracts/` source (plus corrected

--- a/docs/specs/catalogue-wave2-pack-integrations/plan.md
+++ b/docs/specs/catalogue-wave2-pack-integrations/plan.md
@@ -1,0 +1,521 @@
+# Plan: catalogue-wave2-pack-integrations
+
+- **Status:** Executing
+- **Spec:** [`spec.md`](spec.md)
+
+Mode: full (structural schema change — new `[[pack.integrations]]` field in
+`contracts/pack.schema.json`; new CLI surface in `agentbundle show`; new
+validation rules in `agentbundle catalogue verify`; first-party pack.toml
+changes; engine change RFC-0076).
+
+## Assumptions
+
+- `contracts/pack.schema.json` and `agentbundle/_data/pack.schema.json` are
+  byte-identical at HEAD (Wave 1 parity gate). Confirmed.
+- All pilot consumer/provider primitive paths verified to exist at HEAD
+  (see spec.md Assumptions section).
+- Version 0.27.0 is the next minor bump from 0.26.1. Verify before
+  opening the PR that no concurrent PR is racing to this version.
+- `jsonschema` is available in the test environment (used by
+  `agentbundle.build.validate`).
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `contracts/pack.schema.json` | Add `integrations` array property |
+| `packages/agentbundle/agentbundle/_data/pack.schema.json` | Byte-identical sync |
+| `packages/agentbundle/agentbundle/catalogue_tooling/verify.py` | New `_step_integration_validation` step (step 19) |
+| `packages/agentbundle/agentbundle/commands/show.py` | Surface `integrations` in table + JSON output |
+| `packages/agentbundle/tests/unit/test_catalogue_wave2_schema.py` | New — schema + parity tests (AC1-AC4) |
+| `packages/agentbundle/tests/unit/test_catalogue_wave2_validation.py` | New — integration validation tests (AC5-AC12) |
+| `packages/agentbundle/tests/integration/test_show_cmd.py` | Add AC15-AC16 tests; update AC3 key-set assertion |
+| `packs/core/pack.toml` | Add two `[[pack.integrations]]` entries; version 0.15.6 → 0.15.7 |
+| `packs/core/.claude-plugin/plugin.json` | Version bump to 0.15.7 |
+| `packs/governance-extras/pack.toml` | Add three `[[pack.integrations]]` entries; version 0.9.2 → 0.9.3 |
+| `packs/governance-extras/.claude-plugin/plugin.json` | Version bump to 0.9.3 |
+| `guides/_shared/reference/catalogue-authoring-standards.md` | Replace placeholder with section 11 |
+| `packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md` | Sync scaffold copy |
+| `packages/agentbundle/pyproject.toml` | Version 0.26.1 → 0.27.0 |
+| `packages/agentbundle/agentbundle/version.py` | `CLI_VERSION` → `"0.27.0"` |
+| `docs/product/changelog.md` | Add 0.27.0 entry (schema, validation, show, pilots) |
+
+Not changing: `list-packs`, `install`, the degrade path in `show` (no TOML
+source there — `integrations=[]` passed silently), any other command surface,
+CI workflows, AGENTS.md.
+
+## Tasks
+
+---
+
+### Task 1 — Schema: add `integrations` array to `pack.schema.json` (AC1-AC4)
+
+**Verification mode:** TDD
+**Depends on:** none
+
+**Tests (stub file: `tests/unit/test_catalogue_wave2_schema.py`):**
+
+```python
+# STUB: AC1 — integrations property exists and is an optional array
+def test_integrations_property_exists_in_schema():
+    schema = _load_schema()
+    assert "integrations" in schema["properties"]["pack"]["properties"]
+    assert "integrations" not in schema["properties"]["pack"]["required"]
+
+# STUB: AC2 — pack without integrations validates
+def test_pack_without_integrations_validates():
+    errors = _validate({"pack": {"name": "x", "version": "1.0.0"}})
+    assert errors == []
+
+# STUB: AC3 — valid integration entry validates
+def test_valid_integration_entry_validates():
+    errors = _validate({"pack": {"name": "x", "version": "1.0.0",
+        "integrations": [_valid_entry()]}})
+    assert errors == []
+
+# STUB: AC3 — missing required field fails
+def test_integration_missing_required_field_fails():
+    entry = {k: v for k, v in _valid_entry().items() if k != "id"}
+    errors = _validate({"pack": {"name": "x", "version": "1.0.0",
+        "integrations": [entry]}})
+    assert errors != []
+
+# STUB: AC3 — invalid kind fails
+def test_integration_invalid_kind_fails():
+    entry = {**_valid_entry(), "kind": "unknown"}
+    errors = _validate({"pack": {"name": "x", "version": "1.0.0",
+        "integrations": [entry]}})
+    assert errors != []
+
+# STUB: AC4 — parity check exits 0
+def test_parity_bytes_identical():
+    live = _LIVE_SCHEMA_PATH.read_bytes()
+    bundled = _BUNDLED_SCHEMA_PATH.read_bytes()
+    assert live == bundled
+```
+
+**Approach:**
+
+Add the following property to the `pack` object in `contracts/pack.schema.json`
+(NOT in the `required` array):
+
+```json
+"integrations": {
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["id", "pack", "kind", "role", "consumers", "providers",
+                 "when", "purpose", "fallback"],
+    "properties": {
+      "id":        {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+      "pack":      {"type": "string"},
+      "kind":      {"type": "string", "enum": ["input", "augment", "review", "handoff"]},
+      "role":      {"type": "string"},
+      "consumers": {"type": "array", "minItems": 1,
+                    "items": {"type": "string",
+                              "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}},
+      "providers": {"type": "array", "minItems": 1,
+                    "items": {"type": "string",
+                              "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}},
+      "when":      {"type": "string", "minLength": 1},
+      "purpose":   {"type": "string", "minLength": 1},
+      "fallback":  {"type": "string", "minLength": 1},
+      "version":   {"type": "string"}
+    }
+  }
+}
+```
+
+After editing `contracts/pack.schema.json`, byte-copy it to
+`packages/agentbundle/agentbundle/_data/pack.schema.json`. Run
+`python3 tools/catalogue/check_contract_parity.py` to confirm AC4.
+
+**Note:** `kind` enum and `when`/`purpose`/`fallback` `minLength: 1` are
+enforced by the schema (AC6/AC8 satisfied here). Step 19 only adds
+rules the schema cannot express.
+
+**Done when:** `test_catalogue_wave2_schema.py` passes; `check_contract_parity.py`
+exits 0.
+
+---
+
+### Task 2 — Validation rules: add integration-specific rules to `verify.py` (AC5-AC12)
+
+**Verification mode:** TDD
+**Depends on:** Task 1
+
+**Tests (stub file: `tests/unit/test_catalogue_wave2_validation.py`):**
+
+```python
+# STUB: AC5 — duplicate integration IDs error
+def test_verify_duplicate_integration_id_errors(): ...
+
+# STUB: AC7 — consumer ref missing in declaring pack errors
+def test_verify_consumer_ref_missing_errors(): ...
+
+# STUB: AC7 (agent) — consumer agent ref missing in declaring pack errors
+def test_verify_consumer_agent_ref_missing_errors(): ...
+
+# STUB: AC9 — self-target errors
+def test_verify_self_target_errors(): ...
+
+# STUB: AC10 (accept) — valid semver ranges pass
+@pytest.mark.parametrize("v", ["^1.0.0", ">=2.0.0 <3.0.0", "1.2.3",
+                                "~1.2", "1.0.0 - 2.0.0", "1.0.0 || 2.0.0"])
+def test_verify_valid_version_range_passes(v): ...
+
+# STUB: AC10 (reject) — invalid version strings error
+@pytest.mark.parametrize("v", ["latest", "@1", "not-a-version"])
+def test_verify_invalid_version_range_errors(v): ...
+
+# STUB: AC11 — absent target pack does NOT error
+def test_verify_absent_target_pack_passes(): ...
+
+# STUB: AC12 — provider ref missing when target present errors
+def test_verify_present_target_provider_missing_errors(): ...
+
+# STUB: happy path — valid integration passes
+def test_verify_valid_integration_passes(): ...
+```
+
+**Approach:**
+
+Add two private helpers and one new step function to `verify.py`.
+
+**`_resolve_primitive_ref(ref, pack_dir) -> bool`** — resolves a
+type-qualified ref against a pack's `.apm/` directory. Type-to-path mapping:
+- `skill:<name>` → directory `pack_dir/.apm/skills/<name>/`
+- `agent:<name>` → file `pack_dir/.apm/agents/<name>.md`
+- `command:<name>` → file `pack_dir/.apm/commands/<name>.md`
+- `hook:<name>` → any file `pack_dir/.apm/hooks/<name>.*` (stem-match
+  iteration: `Path(f).stem == name` for each file in hooks dir)
+
+Skills are directories; agents/commands are `.md` files; hooks can have
+arbitrary extensions. Edge cases:
+- `.apm/hooks/` absent → hook ref resolves False (guard with `dir.is_dir()`)
+- Hook stem = `Path(filename).stem`; `"pre-install.py"` → `"pre-install"` ✓;
+  multi-dot names (`"a.b.py"` → stem `"a.b"`) would need `hook:a.b`, but the
+  schema's id pattern `^[a-z0-9][a-z0-9-]*$` prohibits dots in IDs so such
+  hook names are unreferenceable and resolve False by definition.
+
+**`_is_valid_semver_range(version) -> bool`** — npm-compatible semver range
+validator without any new dependency:
+1. Split on `||` (union ranges).
+2. For each part (stripped): check if it matches the hyphen-range pattern
+   `^\d[.\d]* - \d[.\d]*$` first. If so, it's valid.
+3. Otherwise, split on whitespace and check each atom against:
+   `^(?:[~^]|[<>]=?)?(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)(?:-[\w.]+)?)?)?$`
+4. Any non-matching atom returns False.
+
+Accept: `^1.0.0`, `>=2.0.0 <3.0.0`, `1.2.3`, `~1.2`, `1.0.0 - 2.0.0`,
+`1.0.0 || 2.0.0`. Reject: `latest`, `@1`, `not-a-version`.
+
+**`_step_integration_validation(root, config, pack, tmpdir)`** — step 19:
+- Derive packs dir defensively: `packs_root = root / (getattr(config, "paths", None) and config.paths.packs or "packs")`. Never skip on `config is None` — the step must run on bare pack directories without a catalogue.toml (including test fixtures).
+- Pass 1: collect `all_pack_dirs: dict[str, Path]` (all pack names → dirs,
+  unfiltered by `pack` arg — needed for AC12 cross-reference)
+- Pass 2 (with `pack` filter): for each pack with `[[pack.integrations]]`:
+  - AC5: initialise `seen_ids: set[str] = set()` fresh for **each declaring pack** (scoped per-pack per spec.md AC1 — different packs may reuse the same id). Error on duplicate within a pack.
+  - AC7: for each `consumers` ref → `_resolve_primitive_ref(ref, pack_dir)` → error if False
+  - AC9: `entry["pack"] == declaring_name` → error
+  - AC10: `entry.get("version")` is not None and `_is_valid_semver_range(v)` is False → error
+  - AC11/AC12: if `entry["pack"]` in `all_pack_dirs`, check each `providers` ref
+    via `_resolve_primitive_ref(ref, all_pack_dirs[target])` → error if False;
+    if target is absent → skip provider check (no error, AC11)
+- All errors use code `CAT-V-019`
+
+**Note:** AC6 (`kind` enum) and AC8 (`when`/`purpose`/`fallback` non-empty)
+are enforced by the schema in step 3. Step 19 does NOT re-implement these.
+AC8 is verified by `test_integration_empty_when_fails` in
+`test_catalogue_wave2_schema.py`; the validation stub omits it.
+
+Insert in `_VERIFY_STEPS`:
+```python
+(19, "pack integration validation", _step_integration_validation),
+```
+Appended at the end of the list. Runs only after steps 1–18 pass.
+Since step 3 validates the schema (which catches invalid kinds and empty text),
+step 19 only fires on schema-valid pack.tomls.
+
+**Done when:** All nine validation tests pass.
+
+---
+
+### Task 3 — Show output: surface `integrations` in `show.py` (AC13-AC16)
+
+**Verification mode:** TDD
+**Depends on:** Task 1
+
+**Tests (add to `tests/integration/test_show_cmd.py`):**
+
+```python
+# STUB: AC14 + AC15 — JSON includes integrations when declared
+def test_show_integrations_json_present_when_declared(tmp_path, capsys): ...
+
+# STUB: AC14 + AC16 — JSON has integrations: [] when not declared
+def test_show_integrations_json_empty_when_not_declared(tmp_path, capsys): ...
+
+# STUB: AC13 + AC15 — table includes integrations row when declared
+def test_show_integrations_table_row_when_declared(tmp_path, capsys): ...
+
+# STUB: AC13 + AC16 — table shows "-" when no integrations
+def test_show_integrations_table_row_shows_dash_when_absent(tmp_path, capsys): ...
+```
+
+Also update `test_json_exact_keys_sorted_arrays_source_catalogue` to include
+`"integrations"` in the expected key set.
+
+**Approach:**
+
+In `run()`, extract:
+```python
+integrations = pack.get("integrations") or []
+```
+
+Extend `_emit()` signature with `integrations: list[dict]`:
+- JSON path: add `"integrations": integrations` (with `"version": None` for absent
+  version fields in each entry — use `e.get("version")` not `e["version"]`)
+- Table path: add row `["integrations", summary]` where:
+  - `summary = ", ".join(f"{e['id']} ({e['kind']} → {e['pack']})" for e in integrations)` when non-empty
+  - `"-"` when empty
+
+In `_degrade()`: pass `integrations=[]` (degrade has no TOML — an empty array
+surfaces nothing visible; no key is hidden). The degrade path is not extended.
+
+**Done when:** Four new tests pass; key-set assertion updated and green.
+
+---
+
+### Task 4 — Pilot entries: add `[[pack.integrations]]` to core and governance-extras (AC17-AC21)
+
+**Verification mode:** Goal-based + manual QA
+**Depends on:** Task 1, Task 2, Task 3
+
+**Done when:**
+- `agentbundle catalogue verify --root .` exits 0
+- `agentbundle show core --format json` returns entries with IDs
+  `"frontend-preflight-augment"` and `"frontend-cold-reviewer"`
+- `agentbundle show governance-extras --format json` returns entries with IDs
+  `"promoted-research-evidence"`, `"design-proposal-product-engineering"`,
+  `"design-proposal-architect"`
+
+**Approach:**
+
+Add to `packs/core/pack.toml`:
+
+```toml
+[[pack.integrations]]
+id = "frontend-preflight-augment"
+pack = "frontend-engineering"
+kind = "augment"
+role = "Frontend pre-flight augmentation"
+consumers = ["skill:work-loop"]
+providers = ["skill:frontend-engineering"]
+when = "The target repository declares HTML/CSS/JS as a primary output and the frontend-engineering pack is installed."
+purpose = "Inline the frontend-engineering skill into the work-loop pre-EXECUTE gate when the build produces an HTML/CSS/JS primary artifact."
+fallback = "If frontend-engineering is absent, work-loop records a named skip (FE pre-flight: skipped) and continues without the FE gate."
+
+[[pack.integrations]]
+id = "frontend-cold-reviewer"
+pack = "frontend-engineering"
+kind = "review"
+role = "Frontend cold reviewer"
+consumers = ["skill:work-loop"]
+providers = ["agent:frontend-reviewer"]
+when = "The diff's primary output is HTML/CSS/JS and the frontend-engineering pack is installed."
+purpose = "Run the frontend-reviewer agent during work-loop REVIEW for diffs whose primary output is HTML/CSS/JS."
+fallback = "If frontend-engineering is absent, the REVIEW phase skips the frontend-reviewer and records a named skip."
+```
+
+Add to `packs/governance-extras/pack.toml`:
+
+```toml
+[[pack.integrations]]
+id = "promoted-research-evidence"
+pack = "desk-research"
+kind = "input"
+role = "Promoted research evidence"
+consumers = ["skill:new-rfc"]
+providers = ["skill:desk-research", "skill:desk-research-project-synthesize"]
+when = "A desk-research project has produced synthesized findings that inform the RFC being drafted."
+purpose = "Provide structured research evidence from a completed desk-research project as an input artifact to the RFC drafting workflow."
+fallback = "If desk-research is absent, new-rfc proceeds without promoted evidence and notes the missing input in the RFC context block."
+
+[[pack.integrations]]
+id = "design-proposal-product-engineering"
+pack = "product-engineering"
+kind = "input"
+role = "Design proposal"
+consumers = ["skill:new-rfc"]
+providers = ["skill:frame-intent", "skill:de-risk-intent"]
+when = "A product-engineering shaping artifact (frame-intent or de-risk-intent output) is ready and informs the RFC under authorship."
+purpose = "Feed a product-engineering design proposal into the RFC drafting workflow as a typed input artifact."
+fallback = "If product-engineering is absent, new-rfc proceeds without the design proposal input and notes the gap."
+
+[[pack.integrations]]
+id = "design-proposal-architect"
+pack = "architect"
+kind = "input"
+role = "Design proposal"
+consumers = ["skill:new-rfc"]
+providers = ["skill:architect-design", "skill:architect-review"]
+when = "An architect design or review artifact is available and shapes the technical decisions captured in the RFC."
+purpose = "Feed an architect design or review output into the RFC drafting workflow as a typed input artifact."
+fallback = "If architect is absent, new-rfc proceeds without the architecture design proposal and notes the gap."
+```
+
+Bump versions:
+- `packs/core/pack.toml`: `0.15.6` → `0.15.7`
+- `packs/core/.claude-plugin/plugin.json`: `0.15.6` → `0.15.7`
+- `packs/governance-extras/pack.toml`: `0.9.2` → `0.9.3`
+- `packs/governance-extras/.claude-plugin/plugin.json`: `0.9.2` → `0.9.3`
+
+Run `make build-self` to reproject `dist/claude-plugins/core/` and
+`dist/claude-plugins/governance-extras/`.
+
+---
+
+### Task 5 — Authoring hub: replace placeholder with section 11 (AC22-AC25)
+
+**Verification mode:** Goal-based (greppable checks + sync tool)
+**Depends on:** none
+
+**Done when:**
+- Wave 2 placeholder removed (Wave 4 Journey placeholder must remain):
+  `grep -c "Wave 2 of the catalogue-contracts initiative"
+  guides/_shared/reference/catalogue-authoring-standards.md` returns 0 (AC22)
+- Section 11 header exists: `grep -c "^## 11\. Optional pack integrations"
+  guides/_shared/reference/catalogue-authoring-standards.md` returns 1 (AC22)
+- Contract citation present: `grep -c "contracts/pack.schema.json"
+  guides/_shared/reference/catalogue-authoring-standards.md` ≥ 1 (AC22)
+- Four kind values documented: `grep -c "input.*augment.*review.*handoff"
+  guides/_shared/reference/catalogue-authoring-standards.md` ≥ 1 (AC22)
+- Ten-field table header present: `grep -c "Field.*Type.*Required.*Description"
+  guides/_shared/reference/catalogue-authoring-standards.md` ≥ 1 (AC22)
+- No governance citations: `grep -E "RFC-|ADR-|docs/specs/"
+  guides/_shared/reference/catalogue-authoring-standards.md` returns nothing
+  in the new section 11 text (AC25)
+- `python3 tools/catalogue/sync_authoring_scaffold.py --check` exits 0 (AC23/AC24)
+
+**Verification mode note:** The spec lists AC22-25 as "visual/manual QA" — these
+greps are the manual-QA checklist items, each anchoring a required content
+element from spec.md AC22. They are deterministic assertions, not prose descriptions.
+
+**Approach:**
+
+Replace the unnumbered placeholder section in
+`guides/_shared/reference/catalogue-authoring-standards.md` with:
+
+```markdown
+## 11. Optional pack integrations
+
+**Contract:** `contracts/pack.schema.json` (`[[pack.integrations]]` array)
+
+A pack can declare optional behavior seams with other packs using the
+`[[pack.integrations]]` array table in `pack.toml`. The entire array is
+optional — packs without integrations remain fully valid and installable.
+
+**The ten fields** (all fields in each entry are required except `version`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique kebab-case identifier within this pack |
+| `pack` | string | yes | Name of the target pack |
+| `kind` | string | yes | One of: `input`, `augment`, `review`, `handoff` |
+| `role` | string | yes | Short user-facing label for this integration |
+| `consumers` | string[] | yes | Type-qualified primitive refs in the declaring pack |
+| `providers` | string[] | yes | Type-qualified primitive refs in the target pack |
+| `when` | string | yes | Human-readable conditions under which this seam activates |
+| `purpose` | string | yes | What the integration achieves when active |
+| `fallback` | string | yes | What the consuming skill does when the target pack is absent |
+| `version` | string | no | Semver range of the target pack version |
+
+**The four `kind` values:**
+
+- `input` — the target provides an artifact the declaring pack's skill reads
+- `augment` — the target pack's skill is inlined into the consuming skill's workflow
+- `review` — the target pack's agent or skill is invoked as a reviewer pass
+- `handoff` — the consuming skill passes control to the target at a defined boundary
+
+**What integrations are not:**
+
+No auto-install (declaring an integration does not install the target pack), no
+dependency closure (`[pack.dependencies]` owns hard requirements), no executable
+`when` expressions (the `when` field is explanatory text only).
+
+**The `fallback` requirement:**
+
+Every integration must declare what the consuming skill does when the target is
+absent. An agent reading the integration without the target installed needs to
+know how to proceed.
+
+**Lint and verify:**
+
+\`\`\`bash
+agentbundle catalogue verify --root .
+\`\`\`
+
+Primitive refs (e.g., `"skill:work-loop"`) are validated against the declaring
+and target packs' `.apm/` directories. An absent target pack does not fail
+verification — the check is portable across catalogues that may not include
+every optional pack.
+```
+
+After editing the live file, run
+`python3 tools/catalogue/sync_authoring_scaffold.py` (no `--check`) to write
+the scaffold copy, then verify with `--check`.
+
+---
+
+### Task 6 — Version bump and changelog (AC26-AC27)
+
+**Verification mode:** Goal-based
+**Depends on:** none
+
+**Done when:**
+- `grep "0.27.0" packages/agentbundle/pyproject.toml` matches
+- `grep "0.27.0" packages/agentbundle/agentbundle/version.py` matches
+- `grep "0.27.0\|Unreleased" docs/product/changelog.md` matches an entry
+  that names the four items (schema, validation, show, pilots)
+- At least one commit in the PR has `Engine-Change-RFC: RFC-0076`
+
+**Approach:**
+
+1. `packages/agentbundle/pyproject.toml`: `version = "0.26.1"` → `"0.27.0"`
+2. `packages/agentbundle/agentbundle/version.py`: `CLI_VERSION = "0.26.1"` → `"0.27.0"`
+3. `docs/product/changelog.md`: add entry under `[Unreleased]`:
+
+```markdown
+- **`agentbundle` 0.27.0 — `[[pack.integrations]]` convention**: packs can
+  now declare optional cross-pack behavior seams in `pack.toml`. The new
+  `[[pack.integrations]]` array (governed by `contracts/pack.schema.json`)
+  carries ten fields: `id`, `pack`, `kind` (`input`/`augment`/`review`/
+  `handoff`), `role`, `consumers`, `providers`, `when`, `purpose`,
+  `fallback`, and an optional `version` semver range. `agentbundle catalogue
+  verify` validates integration refs (uniqueness, primitive resolution,
+  self-target prohibition, semver range grammar, provider presence when the
+  target is in the same catalogue). `agentbundle show <pack>` surfaces
+  declared integrations in table and JSON output. Five first-party
+  integration entries ship across `packs/core` (two, targeting
+  `frontend-engineering`) and `packs/governance-extras` (three, targeting
+  `desk-research`, `product-engineering`, and `architect`).
+```
+
+The commit touching `contracts/pack.schema.json` and
+`agentbundle/_data/pack.schema.json` must include
+`Engine-Change-RFC: RFC-0076` in its message footer; the commit touching
+`agentbundle/commands/show.py` similarly (per spec Boundaries).
+
+---
+
+## Commit plan
+
+| Commit | Contents | Footers |
+|--------|----------|---------|
+| 1 (schema) | Task 1: schema + `_data/` sync + stub tests | `Engine-Change-RFC: RFC-0076`; `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |
+| 2 (validation) | Task 2: verify.py step + validation tests | `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |
+| 3 (show) | Task 3: show.py + show tests | `Engine-Change-RFC: RFC-0076`; `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |
+| 4 (pilots) | Task 4: pack.toml files + plugin.json + build-self | `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |
+| 5 (authoring hub) | Task 5: guide + scaffold sync | `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |
+| 6 (version) | Task 6: version + changelog | `Spec: docs/specs/catalogue-wave2-pack-integrations/spec.md` |

--- a/docs/specs/catalogue-wave2-pack-integrations/spec.md
+++ b/docs/specs/catalogue-wave2-pack-integrations/spec.md
@@ -1,6 +1,6 @@
 # Spec: catalogue-wave2-pack-integrations
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Constrained by:** [RFC-0076 D6](../../rfc/0076-catalogue-contracts-composition-semantics-discovery.md)
 - **Contract:** `contracts/pack.schema.json` (adds `integrations` array — engine change), `packages/agentbundle/agentbundle/_data/pack.schema.json` (byte-parity sync)
@@ -107,7 +107,7 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 **Schema structure**
 
-- [ ] AC1: `contracts/pack.schema.json` gains an `integrations` property on the `pack`
+- [x] AC1: `contracts/pack.schema.json` gains an `integrations` property on the `pack`
   object — an array of integration objects, optional (not in `required`). Each
   integration object has `additionalProperties: false` and declares the following
   properties:
@@ -125,15 +125,15 @@ and guidance — as a single cohesive surface rather than shipping the schema al
   - `fallback` (string, required, minLength 1)
   - `version` (string, optional): semver range
 
-- [ ] AC2: A `pack.toml` with no `[[pack.integrations]]` section validates against the
+- [x] AC2: A `pack.toml` with no `[[pack.integrations]]` section validates against the
   updated `contracts/pack.schema.json` without error (the array is optional).
 
-- [ ] AC3: A `pack.toml` with a valid `[[pack.integrations]]` entry validates without
+- [x] AC3: A `pack.toml` with a valid `[[pack.integrations]]` entry validates without
   error. A `pack.toml` with an integration entry missing a required field fails schema
   validation with a clear error. A `pack.toml` with `kind = "unknown"` fails schema
   validation.
 
-- [ ] AC4: `agentbundle/_data/pack.schema.json` is byte-identical to
+- [x] AC4: `agentbundle/_data/pack.schema.json` is byte-identical to
   `contracts/pack.schema.json` after the update. `python3 tools/catalogue/check_contract_parity.py`
   exits 0 on the updated repo.
 
@@ -141,34 +141,34 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 **Validation rules**
 
-- [ ] AC5: `agentbundle catalogue verify` reports an error when two integration entries
+- [x] AC5: `agentbundle catalogue verify` reports an error when two integration entries
   in the same pack share the same `id`.
 
-- [ ] AC6: `agentbundle catalogue verify` reports an error when an integration
+- [x] AC6: `agentbundle catalogue verify` reports an error when an integration
   `kind` value is not one of `input`, `augment`, `review`, `handoff`.
 
-- [ ] AC7: `agentbundle catalogue verify` reports an error when a `consumers` entry
+- [x] AC7: `agentbundle catalogue verify` reports an error when a `consumers` entry
   references a primitive type/name combination that does not exist in the declaring
   pack's `.apm/` directory (e.g., `skill:nonexistent` when no such skill file exists).
 
-- [ ] AC8: `agentbundle catalogue verify` reports an error when `when`, `purpose`, or
+- [x] AC8: `agentbundle catalogue verify` reports an error when `when`, `purpose`, or
   `fallback` is an empty string.
 
-- [ ] AC9: `agentbundle catalogue verify` reports an error when an integration's
+- [x] AC9: `agentbundle catalogue verify` reports an error when an integration's
   `pack` field names the same pack as the declaring pack (self-target prohibition).
 
-- [ ] AC10: `agentbundle catalogue verify` reports an error when the `version` field
+- [x] AC10: `agentbundle catalogue verify` reports an error when the `version` field
   is present but its value is not a valid semver range string. Grammar: npm-compatible
   range syntax — caret (`^`), tilde (`~`), comparison operators (`>=`/`<=`/`>`/`<`),
   hyphen ranges, and `||` unions are all valid; exact `X.Y.Z` is always valid.
   Accept examples: `^1.0.0`, `>=2.0.0 <3.0.0`, `1.2.3`. Reject examples: `latest`,
   `@1`, `not-a-version`.
 
-- [ ] AC11: `agentbundle catalogue verify` exits 0 when an integration's target
+- [x] AC11: `agentbundle catalogue verify` exits 0 when an integration's target
   `pack` is not present in the catalogue (portable validation: absent target is not
   an error).
 
-- [ ] AC12: `agentbundle catalogue verify` reports an error when the integration's
+- [x] AC12: `agentbundle catalogue verify` reports an error when the integration's
   target pack is present in the catalogue and a `providers` entry names a primitive
   that does not exist in that target pack's `.apm/` directory. Absent-target catalogues
   skip this check (AC11).
@@ -177,24 +177,24 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 **show command extension**
 
-- [ ] AC13: `agentbundle show <pack>` (table output) includes an "integrations" row
+- [x] AC13: `agentbundle show <pack>` (table output) includes an "integrations" row
   when the pack declares at least one `[[pack.integrations]]` entry. The row value
   lists integration IDs, their `kind`, and target `pack` in a readable summary form
   (e.g., `frontend-preflight-augment (augment → frontend-engineering)`). When no
   integrations are declared, the row shows "-".
 
-- [ ] AC14: `agentbundle show <pack> --format json` includes an `"integrations"` key
+- [x] AC14: `agentbundle show <pack> --format json` includes an `"integrations"` key
   in the output object. When integrations are present, the value is an array of
   objects, each containing at minimum `id`, `pack`, `kind`, `role`, `consumers`,
   `providers`, `when`, `purpose`, `fallback`, and `version` (null if absent). When no
   integrations are declared, the value is an empty array `[]`.
 
-- [ ] AC15: A pytest integration test calls `show.run()` with a fixture pack containing
+- [x] AC15: A pytest integration test calls `show.run()` with a fixture pack containing
   one `[[pack.integrations]]` entry (any valid entry). The test asserts the `integrations`
   key is present and non-empty in JSON output, and that the table output contains the
   integration ID string.
 
-- [ ] AC16: A pytest integration test calls `show.run()` with a fixture pack containing
+- [x] AC16: A pytest integration test calls `show.run()` with a fixture pack containing
   no `[[pack.integrations]]` section. The test asserts the JSON output has
   `"integrations": []` and the table output does not error.
 
@@ -202,7 +202,7 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 **core pack.toml (core version must be bumped; governance-extras version must be bumped)**
 
-- [ ] AC17: `packs/core/pack.toml` gains exactly two `[[pack.integrations]]` entries:
+- [x] AC17: `packs/core/pack.toml` gains exactly two `[[pack.integrations]]` entries:
 
   1. `id = "frontend-preflight-augment"`, `pack = "frontend-engineering"`,
      `kind = "augment"`, `role = "Frontend pre-flight augmentation"`,
@@ -217,7 +217,7 @@ and guidance — as a single cohesive surface rather than shipping the schema al
   `packs/core/.claude-plugin/plugin.json` version is bumped in lockstep; `make build-self`
   is run to reproject `dist/claude-plugins/core/`.
 
-- [ ] AC18: `packs/governance-extras/pack.toml` gains exactly three `[[pack.integrations]]`
+- [x] AC18: `packs/governance-extras/pack.toml` gains exactly three `[[pack.integrations]]`
   entries:
 
   1. `id = "promoted-research-evidence"`, `pack = "desk-research"`, `kind = "input"`,
@@ -237,16 +237,16 @@ and guidance — as a single cohesive surface rather than shipping the schema al
   `packs/governance-extras/.claude-plugin/plugin.json` version is bumped in lockstep;
   `make build-self` is run to reproject `dist/claude-plugins/governance-extras/`.
 
-- [ ] AC19: `agentbundle catalogue verify --root .` exits 0 on the working-tree
+- [x] AC19: `agentbundle catalogue verify --root .` exits 0 on the working-tree
   catalogue after the pilot entries are added. All five consumer refs resolve to
   existing files in the declaring packs' `.apm/<type>s/` directories. All five provider
   ref groups resolve to existing files in the target packs' `.apm/<type>s/` directories.
 
-- [ ] AC20: `agentbundle show core --format json` returns an object where
+- [x] AC20: `agentbundle show core --format json` returns an object where
   `"integrations"` is a non-empty array containing entries with `"id":
   "frontend-preflight-augment"` and `"id": "frontend-cold-reviewer"`.
 
-- [ ] AC21: `agentbundle show governance-extras --format json` returns an object where
+- [x] AC21: `agentbundle show governance-extras --format json` returns an object where
   `"integrations"` is a non-empty array containing entries with `"id":
   "promoted-research-evidence"`, `"id": "design-proposal-product-engineering"`, and
   `"id": "design-proposal-architect"`.
@@ -255,7 +255,7 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 **catalogue-authoring-standards.md section 11 (Wave 1 placeholder → full content)**
 
-- [ ] AC22: The unnumbered placeholder section "Optional pack integrations" in
+- [x] AC22: The unnumbered placeholder section "Optional pack integrations" in
   `guides/_shared/reference/catalogue-authoring-standards.md` is replaced by a
   numbered section "11. Optional pack integrations". The placeholder warning block is
   removed. The section includes:
@@ -270,25 +270,25 @@ and guidance — as a single cohesive surface rather than shipping the schema al
   - A lint/verify command snippet.
   - No RFC, ADR, or spec path citations.
 
-- [ ] AC23: The scaffold copy at
+- [x] AC23: The scaffold copy at
   `packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md`
   matches the updated live file after `python3 tools/catalogue/sync_authoring_scaffold.py --check`
   exits 0.
 
-- [ ] AC24: `python3 tools/catalogue/sync_authoring_scaffold.py --check` exits 0 after
+- [x] AC24: `python3 tools/catalogue/sync_authoring_scaffold.py --check` exits 0 after
   the authoring hub update.
 
-- [ ] AC25: The updated hub section contains no host CI workflow requirements, Make
+- [x] AC25: The updated hub section contains no host CI workflow requirements, Make
   target requirements, or internal governance citations.
 
 ### Phase F — Engine change + version bump + changelog
 
-- [ ] AC26: `packages/agentbundle/pyproject.toml` version is bumped to `0.27.0`.
+- [x] AC26: `packages/agentbundle/pyproject.toml` version is bumped to `0.27.0`.
   `packages/agentbundle/agentbundle/version.py` `CLI_VERSION` is set to `"0.27.0"` in
   lockstep. At least one commit in the PR contains `Engine-Change-RFC: RFC-0076` in
   its message (for the pack.schema.json + _data/ sync commit).
 
-- [ ] AC27: `docs/product/changelog.md` has an `[Unreleased]` or `0.27.0` entry
+- [x] AC27: `docs/product/changelog.md` has an `[Unreleased]` or `0.27.0` entry
   describing: (a) the new `[[pack.integrations]]` schema field in `pack.schema.json`,
   (b) the new validation rules in `agentbundle catalogue verify`, (c) the extended
   `agentbundle show` output, and (d) the five first-party pilot integration entries.
@@ -297,11 +297,11 @@ and guidance — as a single cohesive surface rather than shipping the schema al
 
 ### Regression
 
-- [ ] AC28: `SKIP_SAST=1 make build-check` exits 0 after all changes.
-- [ ] AC29: `python3 -m pytest packages/agentbundle/tests/ -q` exits 0 after all
+- [x] AC28: `SKIP_SAST=1 make build-check` exits 0 after all changes.
+- [x] AC29: `python3 -m pytest packages/agentbundle/tests/ -q` exits 0 after all
   changes.
-- [ ] AC30: `wc -l packs/AGENTS.md` ≤ 150 (CI enforces; verify after any edit).
-- [ ] AC31: `wc -l AGENTS.md` ≤ 250 (CI enforces; verify after any edit).
+- [x] AC30: `wc -l packs/AGENTS.md` ≤ 150 (CI enforces; verify after any edit).
+- [x] AC31: `wc -l AGENTS.md` ≤ 250 (CI enforces; verify after any edit).
 
 ## Assumptions
 

--- a/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/guides/_shared/reference/catalogue-authoring-standards.md
@@ -131,11 +131,58 @@ for the full pipeline sequence.
 
 ---
 
-## Optional pack integrations
+## 11. Optional pack integrations
 
-> **Not yet available.** Wave 2 of the catalogue-contracts initiative will define the
-> `[[pack.integrations]]` convention for declaring optional cross-pack composition.
-> This section will be filled in when that wave ships.
+**Contract:** `contracts/pack.schema.json` (`[[pack.integrations]]` array)
+
+A pack can declare optional behavior seams with other packs using the
+`[[pack.integrations]]` array table in `pack.toml`. The entire array is
+optional — packs without integrations remain fully valid and installable.
+
+**The ten fields** (all fields in each entry are required except `version`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique kebab-case identifier within this pack |
+| `pack` | string | yes | Name of the target pack |
+| `kind` | string | yes | One of: `input`, `augment`, `review`, `handoff` |
+| `role` | string | yes | Short user-facing label for this integration |
+| `consumers` | string[] | yes | Type-qualified primitive refs in the declaring pack |
+| `providers` | string[] | yes | Type-qualified primitive refs in the target pack |
+| `when` | string | yes | Human-readable conditions under which this seam activates |
+| `purpose` | string | yes | What the integration achieves when active |
+| `fallback` | string | yes | What the consuming skill does when the target pack is absent |
+| `version` | string | no | Semver range of the target pack version |
+
+**The four `kind` values:**
+
+- `input` — the target provides an artifact the declaring pack's skill reads
+- `augment` — the target pack's skill is inlined into the consuming skill's workflow
+- `review` — the target pack's agent or skill is invoked as a reviewer pass
+- `handoff` — the consuming skill passes control to the target at a defined boundary
+
+**What integrations are not:**
+
+No auto-install (declaring an integration does not install the target pack), no
+dependency closure (`[pack.dependencies]` owns hard requirements), no executable
+`when` expressions (the `when` field is explanatory text only).
+
+**The `fallback` requirement:**
+
+Every integration must declare what the consuming skill does when the target is
+absent. An agent reading the integration without the target installed needs to
+know how to proceed.
+
+**Lint and verify:**
+
+```bash
+agentbundle catalogue verify --root .
+```
+
+Primitive refs (e.g., `"skill:work-loop"`) are validated against the declaring
+and target packs' `.apm/` directories. An absent target pack does not fail
+verification — the check is portable across catalogues that may not include
+every optional pack.
 
 ---
 

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
@@ -131,11 +131,58 @@ for the full pipeline sequence.
 
 ---
 
-## Optional pack integrations
+## 11. Optional pack integrations
 
-> **Not yet available.** Wave 2 of the catalogue-contracts initiative will define the
-> `[[pack.integrations]]` convention for declaring optional cross-pack composition.
-> This section will be filled in when that wave ships.
+**Contract:** `contracts/pack.schema.json` (`[[pack.integrations]]` array)
+
+A pack can declare optional behavior seams with other packs using the
+`[[pack.integrations]]` array table in `pack.toml`. The entire array is
+optional — packs without integrations remain fully valid and installable.
+
+**The ten fields** (all fields in each entry are required except `version`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Unique kebab-case identifier within this pack |
+| `pack` | string | yes | Name of the target pack |
+| `kind` | string | yes | One of: `input`, `augment`, `review`, `handoff` |
+| `role` | string | yes | Short user-facing label for this integration |
+| `consumers` | string[] | yes | Type-qualified primitive refs in the declaring pack |
+| `providers` | string[] | yes | Type-qualified primitive refs in the target pack |
+| `when` | string | yes | Human-readable conditions under which this seam activates |
+| `purpose` | string | yes | What the integration achieves when active |
+| `fallback` | string | yes | What the consuming skill does when the target pack is absent |
+| `version` | string | no | Semver range of the target pack version |
+
+**The four `kind` values:**
+
+- `input` — the target provides an artifact the declaring pack's skill reads
+- `augment` — the target pack's skill is inlined into the consuming skill's workflow
+- `review` — the target pack's agent or skill is invoked as a reviewer pass
+- `handoff` — the consuming skill passes control to the target at a defined boundary
+
+**What integrations are not:**
+
+No auto-install (declaring an integration does not install the target pack), no
+dependency closure (`[pack.dependencies]` owns hard requirements), no executable
+`when` expressions (the `when` field is explanatory text only).
+
+**The `fallback` requirement:**
+
+Every integration must declare what the consuming skill does when the target is
+absent. An agent reading the integration without the target installed needs to
+know how to proceed.
+
+**Lint and verify:**
+
+```bash
+agentbundle catalogue verify --root .
+```
+
+Primitive refs (e.g., `"skill:work-loop"`) are validated against the declaring
+and target packs' `.apm/` directories. An absent target pack does not fail
+verification — the check is portable across catalogues that may not include
+every optional pack.
 
 ---
 

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "guides/_shared/reference/catalogue-authoring-standards.md": "1460ca857abf4e71facae6a512fb025a93d7b1534623b87aee83f65dfc7bbe62",
+    "guides/_shared/reference/catalogue-authoring-standards.md": "4fe9ce077af089ab52840d1b3de600c09ca23eace114c1e28c4685a3b7289520",
     "guides/_shared/reference/catalogue-ci-contract.md": "fae793ab47989b6dd3c731afcb0b4cda21c7d08bbe7fa40fca6d3abb3d158141",
     "packs/AGENTS.md": "dbb8b0a93a17258d1c69f2e6a437887c546b3592d868b1cbc7506d2e37e39fbd",
     "packs/README.md": "68a141500fed78988dbfe7400ea9b8fa0b7d97186d420a93dfe40763272b69ee",

--- a/packages/agentbundle/agentbundle/_data/pack.schema.json
+++ b/packages/agentbundle/agentbundle/_data/pack.schema.json
@@ -265,6 +265,34 @@
             "writes-to-repo": {"type": "boolean"},
             "safety-gate": {"type": "string"}
           }
+        },
+        "integrations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "pack", "kind", "role", "consumers", "providers", "when", "purpose", "fallback"],
+            "properties": {
+              "id":        {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+              "pack":      {"type": "string"},
+              "kind":      {"type": "string", "enum": ["input", "augment", "review", "handoff"]},
+              "role":      {"type": "string"},
+              "consumers": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}
+              },
+              "providers": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "pattern": "^(skill|agent|command|hook):[a-z0-9][a-z0-9-]*$"}
+              },
+              "when":      {"type": "string", "minLength": 1},
+              "purpose":   {"type": "string", "minLength": 1},
+              "fallback":  {"type": "string", "minLength": 1},
+              "version":   {"type": "string"}
+            }
+          }
         }
       },
       "if": {

--- a/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
@@ -716,7 +716,183 @@ def _step_fixture_checks(
 
 
 # ---------------------------------------------------------------------------
-# 18-step verification table
+# Step 19 helpers
+# ---------------------------------------------------------------------------
+
+_SEMVER_ATOM_RE = re.compile(
+    r"^(?:[~^]|[<>]=?)?(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)(?:-[\w.]+)?)?)?$"
+)
+_SEMVER_HYPHEN_RE = re.compile(r"^\d[\d.]* - \d[\d.]*$")
+
+
+def _is_valid_semver_range(version: str) -> bool:
+    """Return True if *version* is a valid npm-compatible semver range.
+
+    Handles: exact versions, caret/tilde/comparison prefixes, hyphen ranges,
+    and ``||`` unions. No new dependencies — pure regex.
+    """
+    for part in version.split("||"):
+        part = part.strip()
+        if not part:
+            return False
+        if _SEMVER_HYPHEN_RE.match(part):
+            continue
+        for atom in part.split():
+            if not _SEMVER_ATOM_RE.match(atom):
+                return False
+    return True
+
+
+def _resolve_primitive_ref(ref: str, pack_dir: Path) -> bool:
+    """Return True if the type-qualified *ref* resolves in *pack_dir*'s .apm tree.
+
+    Mapping:
+      skill:<name>   → directory  pack_dir/.apm/skills/<name>/
+      agent:<name>   → file       pack_dir/.apm/agents/<name>.md
+      command:<name> → file       pack_dir/.apm/commands/<name>.md
+      hook:<name>    → any file   pack_dir/.apm/hooks/<name>.*  (stem match)
+    """
+    if ":" not in ref:
+        return False
+    type_str, name = ref.split(":", 1)
+    if type_str == "skill":
+        return (pack_dir / ".apm" / "skills" / name).is_dir()
+    if type_str == "agent":
+        return (pack_dir / ".apm" / "agents" / f"{name}.md").exists()
+    if type_str == "command":
+        return (pack_dir / ".apm" / "commands" / f"{name}.md").exists()
+    if type_str == "hook":
+        hooks_dir = pack_dir / ".apm" / "hooks"
+        if not hooks_dir.is_dir():
+            return False
+        return any(f.is_file() and f.stem == name for f in hooks_dir.iterdir())
+    return False
+
+
+def _step_integration_validation(
+    root: Path, config: object | None, pack: str | None, tmpdir: Path
+) -> list[Diagnostic]:
+    """Step 19: validate [[pack.integrations]] entries (Wave 2, RFC-0076).
+
+    Rules checked (schema-layer rules AC6/AC8 are NOT re-implemented here):
+      AC5  — id is unique within each declaring pack
+      AC7  — consumer primitive refs resolve in the declaring pack
+      AC9  — pack does not target itself
+      AC10 — version, when present, is a valid semver range
+      AC11 — absent target pack is not an error (portable across catalogues)
+      AC12 — provider primitive refs resolve in the target pack when present
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    from agentbundle.catalogue_tooling.results import Severity
+
+    packs_path = getattr(getattr(config, "paths", None), "packs", None) or "packs"
+    packs_root = root / packs_path
+
+    if not packs_root.is_dir():
+        return []
+
+    def _err(message: str, declaring: str | None = None) -> Diagnostic:
+        return Diagnostic(
+            code="CAT-V-019",
+            severity=Severity.ERROR,
+            pack=declaring,
+            path=None,
+            line=None,
+            col=None,
+            message=message,
+            remediation=None,
+        )
+
+    # Pass 1: build full pack-name → pack-dir map (cross-reference for AC12)
+    all_pack_dirs: dict[str, Path] = {}
+    for candidate in packs_root.iterdir():
+        if not candidate.is_dir():
+            continue
+        toml_path = candidate / "pack.toml"
+        if not toml_path.exists():
+            continue
+        try:
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        pack_name = data.get("pack", {}).get("name") or candidate.name
+        all_pack_dirs[pack_name] = candidate
+
+    diags: list[Diagnostic] = []
+
+    # Pass 2: validate integrations in each (optionally filtered) pack
+    for pack_name, pack_dir in all_pack_dirs.items():
+        if pack is not None and pack_name != pack:
+            continue
+        toml_path = pack_dir / "pack.toml"
+        try:
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        integrations = data.get("pack", {}).get("integrations") or []
+        if not integrations:
+            continue
+
+        seen_ids: set[str] = set()  # reset per declaring pack (AC5 scopes to pack)
+        for entry in integrations:
+            entry_id = entry.get("id", "")
+
+            # AC5: duplicate id within this pack
+            if entry_id in seen_ids:
+                diags.append(_err(
+                    f"duplicate integration id {entry_id!r} in pack {pack_name!r}",
+                    declaring=pack_name,
+                ))
+            seen_ids.add(entry_id)
+
+            # AC7: consumer refs must resolve in declaring pack
+            for ref in entry.get("consumers", []):
+                if not _resolve_primitive_ref(ref, pack_dir):
+                    diags.append(_err(
+                        f"integration {entry_id!r}: consumer ref {ref!r} not found"
+                        f" in {pack_name!r}",
+                        declaring=pack_name,
+                    ))
+
+            # AC9: no self-targeting
+            target = entry.get("pack", "")
+            if target == pack_name:
+                diags.append(_err(
+                    f"integration {entry_id!r}: pack {pack_name!r} targets itself"
+                    f" (self-reference not allowed)",
+                    declaring=pack_name,
+                ))
+
+            # AC10: version, if present, must be a valid semver range
+            version = entry.get("version")
+            if version is not None and not _is_valid_semver_range(version):
+                diags.append(_err(
+                    f"integration {entry_id!r}: version range {version!r} is not"
+                    f" a valid semver range",
+                    declaring=pack_name,
+                ))
+
+            # AC11/AC12: if target is in this catalogue, check provider refs
+            if target in all_pack_dirs:
+                target_dir = all_pack_dirs[target]
+                for ref in entry.get("providers", []):
+                    if not _resolve_primitive_ref(ref, target_dir):
+                        diags.append(_err(
+                            f"integration {entry_id!r}: provider ref {ref!r} not"
+                            f" found in target pack {target!r}",
+                            declaring=pack_name,
+                        ))
+            # AC11: target absent → no error (portable across catalogues)
+
+    return diags
+
+
+# ---------------------------------------------------------------------------
+# 18-step verification table (plus step 19)
 # ---------------------------------------------------------------------------
 
 _VERIFY_STEPS = [
@@ -738,6 +914,7 @@ _VERIFY_STEPS = [
     (16, "sync-defaults check", _step_sync_defaults),
     (17, "package preflight", _step_package_preflight),
     (18, "deterministic fixture checks", _step_fixture_checks),
+    (19, "pack integration validation", _step_integration_validation),
 ]
 
 

--- a/packages/agentbundle/agentbundle/commands/show.py
+++ b/packages/agentbundle/agentbundle/commands/show.py
@@ -74,6 +74,7 @@ def run(args: argparse.Namespace) -> int:
         description=pack.get("description"),
         skills=skill_names(pack_dir),
         agents=agent_names(pack_dir),
+        integrations=pack.get("integrations") or [],
         source="catalogue",
     )
     return 0
@@ -150,6 +151,7 @@ def _degrade(args: argparse.Namespace, pack_name: str, fmt: str) -> int:
         description=None,
         skills=sorted(skills),
         agents=sorted(agents),
+        integrations=[],  # degrade path has no TOML; empty array surfaces nothing
         source="installed-state",
     )
     return 0
@@ -240,6 +242,7 @@ def _emit(
     description: str | None,
     skills: list[str],
     agents: list[str],
+    integrations: list[dict],
     source: str,
 ) -> None:
     """Render the inventory as a table block or a single JSON object."""
@@ -252,6 +255,21 @@ def _emit(
             "description": description,
             "skills": skills,
             "agents": agents,
+            "integrations": [
+                {
+                    "id": e.get("id"),
+                    "pack": e.get("pack"),
+                    "kind": e.get("kind"),
+                    "role": e.get("role"),
+                    "consumers": e.get("consumers", []),
+                    "providers": e.get("providers", []),
+                    "when": e.get("when"),
+                    "purpose": e.get("purpose"),
+                    "fallback": e.get("fallback"),
+                    "version": e.get("version"),
+                }
+                for e in integrations
+            ],
             "source": source,
         }
         print(json.dumps(obj))
@@ -267,6 +285,14 @@ def _emit(
         rows.append(["description", description])
     rows.append(["skills", ", ".join(skills) if skills else "-"])
     rows.append(["agents", ", ".join(agents) if agents else "-"])
+    if integrations:
+        summary = ", ".join(
+            f"{e.get('id', '?')} ({e.get('kind', '?')} → {e.get('pack', '?')})"
+            for e in integrations
+        )
+    else:
+        summary = "-"
+    rows.append(["integrations", summary])
     render_table(["FIELD", "VALUE"], rows, wrap_col=1)
     if source != "catalogue":
         print(f"source: {source} (catalogue unavailable)")

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.26.1"
+CLI_VERSION = "0.27.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.26.1"
+version = "0.27.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_show_cmd.py
+++ b/packages/agentbundle/tests/integration/test_show_cmd.py
@@ -138,7 +138,10 @@ def test_json_exact_keys_sorted_arrays_source_catalogue(tmp_path, capsys):
     out = capsys.readouterr().out
     assert rc == 0
     obj = json.loads(out)  # parses as valid JSON
-    assert set(obj) == {"name", "version", "description", "skills", "agents", "source"}
+    # STUB: AC3 / AC14 — integrations key added; fails until show.py gains integrations param
+    assert set(obj) == {
+        "name", "version", "description", "skills", "agents", "source", "integrations"
+    }
     assert obj["source"] == "catalogue"
     assert obj["name"] == "demo"
     assert obj["skills"] == ["alpha", "zeta"]
@@ -405,3 +408,93 @@ def test_show_help_documents_format():
 def _write_state(path: Path, state: State) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(dump_state(state), encoding="utf-8", newline="\n")
+
+
+def _make_catalogue_with_integrations(root: Path) -> Path:
+    """Build a catalogue fixture with one pack that declares [[pack.integrations]]."""
+    pack = root / "packs" / "demo"
+    pack.mkdir(parents=True)
+    toml = (
+        '[pack]\nname = "demo"\nversion = "1.2.3"\ndescription = "Demo"\n\n'
+        '[[pack.integrations]]\n'
+        'id = "test-int"\n'
+        'pack = "other-pack"\n'
+        'kind = "input"\n'
+        'role = "Test role"\n'
+        'consumers = ["skill:alpha"]\n'
+        'providers = ["skill:zeta"]\n'
+        'when = "When active."\n'
+        'purpose = "For testing."\n'
+        'fallback = "Skips gracefully."\n'
+    )
+    (pack / "pack.toml").write_text(toml, encoding="utf-8", newline="\n")
+    for s in ("alpha", "zeta"):
+        (pack / ".apm" / "skills" / s).mkdir(parents=True)
+        (pack / ".apm" / "skills" / s / "SKILL.md").write_text(
+            "# s\n", encoding="utf-8", newline="\n"
+        )
+    return root
+
+
+# ---------------------------------------------------------------------------
+# STUBS: AC13-AC16 — integrations in show output (Task 3 TDD)
+# All fail until show.py gains the `integrations` parameter on _emit().
+# ---------------------------------------------------------------------------
+
+
+# STUB: AC14 + AC15 — JSON includes integrations when declared; all ten keys present
+def test_show_integrations_json_present_when_declared(tmp_path, capsys):
+    cat = _make_catalogue_with_integrations(tmp_path)
+    rc = show.run(_args("demo", catalogue=str(cat), fmt="json"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)
+    assert "integrations" in obj
+    assert len(obj["integrations"]) == 1
+    entry = obj["integrations"][0]
+    assert entry["id"] == "test-int"
+    # AC14: all ten contract keys must be present in each entry
+    assert set(entry) >= {
+        "id", "pack", "kind", "role", "consumers", "providers",
+        "when", "purpose", "fallback", "version",
+    }
+    # AC14: version is null when absent from the entry
+    assert entry["version"] is None
+
+
+# STUB: AC14 + AC16 — JSON has integrations: [] when not declared
+def test_show_integrations_json_empty_when_not_declared(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path)  # no integrations in pack.toml
+    rc = show.run(_args("demo", catalogue=str(cat), fmt="json"))
+    out = capsys.readouterr().out
+    assert rc == 0
+    obj = json.loads(out)
+    assert "integrations" in obj
+    assert obj["integrations"] == []
+
+
+# STUB: AC13 + AC15 — table includes integrations row with id/kind/pack summary
+def test_show_integrations_table_row_when_declared(tmp_path, capsys):
+    cat = _make_catalogue_with_integrations(tmp_path)
+    rc = show.run(_args("demo", catalogue=str(cat)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "integrations" in out
+    assert "test-int" in out
+    # AC13 requires kind and target pack in summary
+    assert "input" in out
+    assert "other-pack" in out
+
+
+# STUB: AC13 + AC16 — table shows "-" for integrations when none declared
+def test_show_integrations_table_row_shows_dash_when_absent(tmp_path, capsys):
+    cat = _make_catalogue(tmp_path, skills=("alpha",), agents=())
+    rc = show.run(_args("demo", catalogue=str(cat)))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "integrations" in out
+    # AC16: empty integrations row value renders as "-"
+    lines = out.splitlines()
+    integrations_line = next((ln for ln in lines if "integrations" in ln), None)
+    assert integrations_line is not None
+    assert "-" in integrations_line

--- a/packages/agentbundle/tests/unit/test_catalogue_wave2_schema.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_wave2_schema.py
@@ -1,0 +1,189 @@
+"""Stub: Wave 2 schema tests (Task 1 TDD).
+
+All tests in this file fail until contracts/pack.schema.json gains the
+[[pack.integrations]] array (AC1-AC4). A passing test suite here is Task 1's
+Done-when criterion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ── Schema paths ──────────────────────────────────────────────────────────────
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_LIVE_SCHEMA_PATH = _REPO_ROOT / "contracts" / "pack.schema.json"
+_BUNDLED_SCHEMA_PATH = (
+    _REPO_ROOT
+    / "packages"
+    / "agentbundle"
+    / "agentbundle"
+    / "_data"
+    / "pack.schema.json"
+)
+
+
+def _load_schema() -> dict:
+    return json.loads(_LIVE_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _validate(doc: dict) -> list:
+    try:
+        import jsonschema
+    except ImportError:
+        pytest.skip("jsonschema not installed")
+    schema = _load_schema()
+    v = jsonschema.Draft7Validator(schema)
+    return list(v.iter_errors(doc))
+
+
+def _valid_entry() -> dict:
+    return {
+        "id": "test-integration",
+        "pack": "other-pack",
+        "kind": "input",
+        "role": "Test role",
+        "consumers": ["skill:work-loop"],
+        "providers": ["skill:other-skill"],
+        "when": "When active.",
+        "purpose": "For testing.",
+        "fallback": "Skips gracefully.",
+    }
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+# STUB: AC1 — integrations property exists and is optional
+def test_integrations_property_exists_in_schema():
+    schema = _load_schema()
+    pack_props = schema["properties"]["pack"]["properties"]
+    assert "integrations" in pack_props
+    assert "integrations" not in schema["properties"]["pack"].get("required", [])
+
+
+# STUB: AC2 — pack without integrations still validates
+def test_pack_without_integrations_validates():
+    errors = _validate({"pack": {"name": "x", "version": "1.0.0"}})
+    assert errors == []
+
+
+# STUB: AC3 — valid integration entry validates
+def test_valid_integration_entry_validates():
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [_valid_entry()]}}
+    )
+    assert errors == []
+
+
+# STUB: AC3 — optional version field is accepted when present
+def test_integration_with_version_validates():
+    entry = {**_valid_entry(), "version": "^1.0.0"}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors == []
+
+
+# STUB: AC3 — missing required field fails
+def test_integration_missing_id_fails():
+    entry = {k: v for k, v in _valid_entry().items() if k != "id"}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC3 — invalid kind fails
+def test_integration_invalid_kind_fails():
+    entry = {**_valid_entry(), "kind": "unknown"}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC3 — empty consumers array fails (minItems: 1)
+def test_integration_empty_consumers_fails():
+    entry = {**_valid_entry(), "consumers": []}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC3 — empty providers array fails (minItems: 1)
+def test_integration_empty_providers_fails():
+    entry = {**_valid_entry(), "providers": []}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC8 — empty `when` string fails (minLength: 1 required)
+def test_integration_empty_when_fails():
+    entry = {**_valid_entry(), "when": ""}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC8 — empty `purpose` string fails
+def test_integration_empty_purpose_fails():
+    entry = {**_valid_entry(), "purpose": ""}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC8 — empty `fallback` string fails
+def test_integration_empty_fallback_fails():
+    entry = {**_valid_entry(), "fallback": ""}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC1 — id with uppercase or underscore fails the ^[a-z0-9][a-z0-9-]*$ pattern
+def test_integration_invalid_id_pattern_fails():
+    for bad_id in ("Bad_ID", "has space", "_leading", ""):
+        entry = {**_valid_entry(), "id": bad_id}
+        errors = _validate(
+            {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+        )
+        assert errors != [], f"Expected validation error for id={bad_id!r}"
+
+
+# STUB: AC1 — additionalProperties:false rejects unknown keys (typo-safety)
+def test_integration_unknown_property_fails():
+    entry = {**_valid_entry(), "bogus": "x"}
+    errors = _validate(
+        {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+    )
+    assert errors != []
+
+
+# STUB: AC1 — consumers/providers without valid type prefix fail
+def test_integration_malformed_ref_prefix_fails():
+    for bad_ref in ("garbage", "skill:", "unknowntype:foo", "skill/foo"):
+        entry = {**_valid_entry(), "consumers": [bad_ref]}
+        errors = _validate(
+            {"pack": {"name": "x", "version": "1.0.0", "integrations": [entry]}}
+        )
+        assert errors != [], f"Expected validation error for consumers=[{bad_ref!r}]"
+
+
+# STUB: AC4 — bundled schema is byte-identical to live contracts/pack.schema.json
+def test_parity_bytes_identical():
+    live = _LIVE_SCHEMA_PATH.read_bytes()
+    bundled = _BUNDLED_SCHEMA_PATH.read_bytes()
+    assert live == bundled, (
+        "Schema parity broken — run tools/catalogue/check_contract_parity.py to diagnose"
+    )

--- a/packages/agentbundle/tests/unit/test_catalogue_wave2_validation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_wave2_validation.py
@@ -1,0 +1,272 @@
+"""Stub: Wave 2 integration-validation tests (Task 2 TDD).
+
+All tests in this file fail (ImportError at collection) until
+_step_integration_validation is added to verify.py. A passing test suite here
+is Task 2's Done-when criterion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# This import fails until Task 2 adds _step_integration_validation — that IS the red stub.
+from agentbundle.catalogue_tooling.verify import _step_integration_validation, verify_catalogue
+
+# ── Fixtures / helpers ────────────────────────────────────────────────────────
+
+
+def _write_pack_toml(pack_dir: Path, name: str, integrations: list[dict] | None = None) -> None:
+    lines = [f'[pack]\nname = "{name}"\nversion = "1.0.0"']
+    if integrations:
+        for entry in integrations:
+            lines.append("\n[[pack.integrations]]")
+            for k, v in entry.items():
+                if isinstance(v, list):
+                    formatted = "[" + ", ".join(f'"{x}"' for x in v) + "]"
+                    lines.append(f"{k} = {formatted}")
+                else:
+                    lines.append(f'{k} = "{v}"')
+    (pack_dir / "pack.toml").write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _make_pack(root: Path, name: str, integrations: list[dict] | None = None) -> Path:
+    pack_dir = root / "packs" / name
+    pack_dir.mkdir(parents=True)
+    _write_pack_toml(pack_dir, name, integrations)
+    return pack_dir
+
+
+def _add_skill(pack_dir: Path, name: str) -> None:
+    skill_dir = pack_dir / ".apm" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# s\n", encoding="utf-8", newline="\n")
+
+
+def _add_agent(pack_dir: Path, name: str) -> None:
+    agents_dir = pack_dir / ".apm" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / f"{name}.md").write_text("# a\n", encoding="utf-8", newline="\n")
+
+
+def _add_command(pack_dir: Path, name: str) -> None:
+    cmds_dir = pack_dir / ".apm" / "commands"
+    cmds_dir.mkdir(parents=True, exist_ok=True)
+    (cmds_dir / f"{name}.md").write_text("# cmd\n", encoding="utf-8", newline="\n")
+
+
+def _add_hook(pack_dir: Path, name: str, ext: str = ".py") -> None:
+    hooks_dir = pack_dir / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / f"{name}{ext}").write_text("# hook\n", encoding="utf-8", newline="\n")
+
+
+def _valid_entry(**overrides) -> dict:
+    base = {
+        "id": "test-int",
+        "pack": "other-pack",
+        "kind": "input",
+        "role": "Test role",
+        "consumers": ["skill:consumer-skill"],
+        "providers": ["skill:provider-skill"],
+        "when": "When active.",
+        "purpose": "For testing.",
+        "fallback": "Skips gracefully.",
+    }
+    return {**base, **overrides}
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+# STUB: AC5 — duplicate integration IDs within one pack error
+def test_verify_duplicate_integration_id_errors(tmp_path):
+    pack_dir = _make_pack(tmp_path, "declaring", [
+        _valid_entry(id="dupe"),
+        _valid_entry(id="dupe"),
+    ])
+    _add_skill(pack_dir, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code and "duplicate" in d.message.lower() for d in result)
+
+
+# STUB: AC7 — skill consumer ref missing in declaring pack errors
+def test_verify_consumer_skill_ref_missing_errors(tmp_path):
+    _make_pack(tmp_path, "declaring", [_valid_entry()])
+    # Intentionally NOT creating .apm/skills/consumer-skill
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code for d in result)
+
+
+# STUB: AC7 — agent consumer ref missing in declaring pack errors
+def test_verify_consumer_agent_ref_missing_errors(tmp_path):
+    entry = _valid_entry(consumers=["agent:my-agent"])
+    _make_pack(tmp_path, "declaring", [entry])
+    # Intentionally NOT creating .apm/agents/my-agent.md
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code for d in result)
+
+
+# STUB: AC7 — skill consumer ref resolved when file exists → passes
+def test_verify_consumer_skill_ref_present_passes(tmp_path):
+    pack_dir = _make_pack(tmp_path, "declaring", [_valid_entry(pack="absent-pack")])
+    _add_skill(pack_dir, "consumer-skill")
+    # "absent-pack" is not in the catalogue — AC11 says that's ok
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: AC9 — self-target (entry.pack == declaring pack name) errors
+def test_verify_self_target_errors(tmp_path):
+    entry = _valid_entry(pack="declaring")  # targets itself
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(pack_dir, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code and "self" in d.message.lower() for d in result)
+
+
+# STUB: AC10 (accept) — valid semver ranges pass
+@pytest.mark.parametrize("v", [
+    "^1.0.0",
+    ">=2.0.0 <3.0.0",
+    "1.2.3",
+    "~1.2",
+    "1.0.0 - 2.0.0",
+    "1.0.0 || 2.0.0",
+])
+def test_verify_valid_version_range_passes(tmp_path, v):
+    entry = _valid_entry(version=v, pack="absent-pack")
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(pack_dir, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    version_errors = [
+        d for d in result if "CAT-V-019" in d.code and "version" in d.message.lower()
+    ]
+    assert version_errors == []
+
+
+# STUB: AC10 (reject) — invalid version strings error
+@pytest.mark.parametrize("v", ["latest", "@1", "not-a-version"])
+def test_verify_invalid_version_range_errors(tmp_path, v):
+    entry = _valid_entry(version=v, pack="absent-pack")
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(pack_dir, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code and "version" in d.message.lower() for d in result)
+
+
+# STUB: AC11 — absent target pack does NOT produce an error
+def test_verify_absent_target_pack_passes(tmp_path):
+    # "other-pack" doesn't exist in this catalogue
+    pack_dir = _make_pack(tmp_path, "declaring", [_valid_entry(pack="other-pack")])
+    _add_skill(pack_dir, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: AC12 — provider ref missing when target is present in catalogue errors
+def test_verify_present_target_provider_ref_missing_errors(tmp_path):
+    entry = _valid_entry(pack="target-pack")
+    declaring_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(declaring_dir, "consumer-skill")
+    # Create target-pack but WITHOUT the declared provider skill "provider-skill"
+    _make_pack(tmp_path, "target-pack", [])
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code for d in result)
+
+
+# STUB: happy path — all refs resolve, target present with provider → passes
+def test_verify_valid_integration_full_resolution_passes(tmp_path):
+    entry = _valid_entry(pack="target-pack")
+    declaring_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(declaring_dir, "consumer-skill")
+    target_dir = _make_pack(tmp_path, "target-pack", [])
+    _add_skill(target_dir, "provider-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: AC7 — command consumer ref missing in declaring pack errors
+def test_verify_consumer_command_ref_missing_errors(tmp_path):
+    entry = _valid_entry(consumers=["command:my-cmd"])
+    _make_pack(tmp_path, "declaring", [entry])
+    # Intentionally NOT creating .apm/commands/my-cmd.md
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code for d in result)
+
+
+# STUB: AC7 — command consumer ref present passes
+def test_verify_consumer_command_ref_present_passes(tmp_path):
+    entry = _valid_entry(consumers=["command:my-cmd"], pack="absent-pack")
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_command(pack_dir, "my-cmd")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: AC7 — hook consumer ref missing (hooks dir absent) errors
+def test_verify_consumer_hook_ref_missing_errors(tmp_path):
+    entry = _valid_entry(consumers=["hook:post-install"])
+    _make_pack(tmp_path, "declaring", [entry])
+    # .apm/hooks/ dir does not exist
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert any("CAT-V-019" in d.code for d in result)
+
+
+# STUB: AC7 — hook consumer ref present passes
+def test_verify_consumer_hook_ref_present_passes(tmp_path):
+    entry = _valid_entry(consumers=["hook:post-install"], pack="absent-pack")
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_hook(pack_dir, "post-install", ".py")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: AC5 scope — two distinct packs may use the same id (seen_ids resets per pack)
+def test_verify_same_id_in_different_packs_passes(tmp_path):
+    # Both packs declare an integration with id="shared-id" — this is VALID (AC5 scopes to pack)
+    entry = _valid_entry(id="shared-id", pack="absent-pack")
+    pack_a = _make_pack(tmp_path, "pack-a", [entry])
+    _add_skill(pack_a, "consumer-skill")
+    pack_b = _make_pack(tmp_path, "pack-b", [entry])
+    _add_skill(pack_b, "consumer-skill")
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# STUB: no integrations → passes immediately
+def test_verify_no_integrations_passes(tmp_path):
+    _make_pack(tmp_path, "declaring", [])
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+    assert result == []
+
+
+# ── Pipeline-level tests (verify_catalogue wiring) ────────────────────────────
+# These tests drive verify_catalogue() directly to confirm step 19 is wired
+# into the pipeline. Deleting or un-registering the step would leave the unit
+# tests above green while breaking these — the two test layers complement each other.
+
+
+def test_pipeline_self_target_produces_cat_v_019(tmp_path):
+    """verify_catalogue reports CAT-V-019 for a self-target integration."""
+    entry = _valid_entry(pack="declaring")  # self-target
+    pack_dir = _make_pack(tmp_path, "declaring", [entry])
+    _add_skill(pack_dir, "consumer-skill")
+    result = verify_catalogue(tmp_path)
+    assert not result.ok
+    codes = [d.code for d in result.diagnostics]
+    assert any("CAT-V-019" in c for c in codes), codes
+
+
+def test_pipeline_duplicate_id_produces_cat_v_019(tmp_path):
+    """verify_catalogue reports CAT-V-019 for duplicate integration IDs in one pack."""
+    pack_dir = _make_pack(tmp_path, "declaring", [
+        _valid_entry(id="dupe", pack="absent-pack"),
+        _valid_entry(id="dupe", pack="absent-pack"),
+    ])
+    _add_skill(pack_dir, "consumer-skill")
+    result = verify_catalogue(tmp_path)
+    assert not result.ok
+    codes = [d.code for d in result.diagnostics]
+    assert any("CAT-V-019" in c for c in codes), codes

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.6"
+version = "0.15.7"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"
@@ -63,3 +63,25 @@ surfaces         = ["claude-code", "codex", "copilot", "kiro-ide", "kiro-cli", "
 prerequisites    = []
 verification     = "Run workspace-status and confirm your workspace.toml queue state is displayed."
 recovery         = "If workspace-status does not activate, re-run adapt-to-project to refresh your repo's skill index."
+
+[[pack.integrations]]
+id        = "frontend-preflight-augment"
+pack      = "frontend-engineering"
+kind      = "augment"
+role      = "Frontend pre-flight augmentation"
+consumers = ["skill:work-loop"]
+providers = ["skill:frontend-engineering"]
+when      = "The target repository declares HTML/CSS/JS as a primary output and the frontend-engineering pack is installed."
+purpose   = "Inline the frontend-engineering skill into the work-loop pre-EXECUTE gate when the build produces an HTML/CSS/JS primary artifact."
+fallback  = "If frontend-engineering is absent, work-loop records a named skip (FE pre-flight: skipped) and continues without the FE gate."
+
+[[pack.integrations]]
+id        = "frontend-cold-reviewer"
+pack      = "frontend-engineering"
+kind      = "review"
+role      = "Frontend cold reviewer"
+consumers = ["skill:work-loop"]
+providers = ["agent:frontend-reviewer"]
+when      = "The diff's primary output is HTML/CSS/JS and the frontend-engineering pack is installed."
+purpose   = "Run the frontend-reviewer agent during work-loop REVIEW for diffs whose primary output is HTML/CSS/JS."
+fallback  = "If frontend-engineering is absent, the REVIEW phase skips the frontend-reviewer and records a named skip."

--- a/packs/governance-extras/.claude-plugin/plugin.json
+++ b/packs/governance-extras/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "governance-extras",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Governance skills (new-rfc, new-adr, update-conventions, rfc-status) and RFC/ADR templates + seed READMEs."
 }

--- a/packs/governance-extras/pack.toml
+++ b/packs/governance-extras/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "governance-extras"
-version = "0.9.2"
+version = "0.9.3"
 description = "Governance skills (new-rfc, new-adr, update-conventions, rfc-status) and RFC/ADR templates + seed READMEs."
 readme = "README.md"
 display_name = "Governance Extras"
@@ -68,3 +68,36 @@ expected-result  = "A new ADR file in docs/adr/ that records the decision, its r
 next-action      = "Share the ADR with your team and link to it from the relevant code or config file."
 safety-gate      = "The new-adr skill shows you a preview of the ADR content and the target file path before writing anything. Confirm the preview before the file is created."
 tutorial         = "guides/governance-extras/tutorials/governance-extras-first-session.md"
+
+[[pack.integrations]]
+id        = "promoted-research-evidence"
+pack      = "desk-research"
+kind      = "input"
+role      = "Promoted research evidence"
+consumers = ["skill:new-rfc"]
+providers = ["skill:desk-research", "skill:desk-research-project-synthesize"]
+when      = "A desk-research project has produced synthesized findings that inform the RFC being drafted."
+purpose   = "Provide structured research evidence from a completed desk-research project as an input artifact to the RFC drafting workflow."
+fallback  = "If desk-research is absent, new-rfc proceeds without promoted evidence and notes the missing input in the RFC context block."
+
+[[pack.integrations]]
+id        = "design-proposal-product-engineering"
+pack      = "product-engineering"
+kind      = "input"
+role      = "Design proposal"
+consumers = ["skill:new-rfc"]
+providers = ["skill:frame-intent", "skill:de-risk-intent"]
+when      = "A product-engineering shaping artifact (frame-intent or de-risk-intent output) is ready and informs the RFC under authorship."
+purpose   = "Feed a product-engineering design proposal into the RFC drafting workflow as a typed input artifact."
+fallback  = "If product-engineering is absent, new-rfc proceeds without the design proposal input and notes the gap."
+
+[[pack.integrations]]
+id        = "design-proposal-architect"
+pack      = "architect"
+kind      = "input"
+role      = "Design proposal"
+consumers = ["skill:new-rfc"]
+providers = ["skill:architect-design", "skill:architect-review"]
+when      = "An architect design or review artifact is available and shapes the technical decisions captured in the RFC."
+purpose   = "Feed an architect design or review output into the RFC drafting workflow as a typed input artifact."
+fallback  = "If architect is absent, new-rfc proceeds without the architecture design proposal and notes the gap."

--- a/workspace.toml
+++ b/workspace.toml
@@ -1305,11 +1305,10 @@ backlog = [
 ]
 
 ["ini-007".work]
-active  = [
-  "spec/catalogue-wave2-pack-integrations",     # spec Approved — D6 integrations schema + verifier + show + pilots + hub
-]
+active  = []
 shipped = [
   "spec/catalogue-wave1-contract-convergence",  # 0.26.1 — schema sync + authoring hub + parity gate
+  "spec/catalogue-wave2-pack-integrations",     # 0.27.0 — D6 integrations schema + verifier + show + pilots + hub
 ]
 queue   = [
 


### PR DESCRIPTION
## Summary

Implements `catalogue-wave2-pack-integrations` (RFC-0076 D6), completing the first integration authoring surface for the pack catalogue. After this PR:

- Pack authors can declare optional `[[pack.integrations]]` entries in `pack.toml`, each naming a cross-pack behavior seam with 10 typed fields.
- `agentbundle catalogue verify` enforces 8 semantic rules (AC5–AC12) beyond what the schema can express: uniqueness, ref resolution, self-target prohibition, semver range grammar, and target-present provider validation.
- `agentbundle show <pack>` surfaces integrations in both table and JSON output.
- Five first-party pilot entries demonstrate the convention across `core` and `governance-extras`.
- The Wave 1 placeholder in `catalogue-authoring-standards.md` is replaced with the full authoring section.

## Changes

**6 commits, scoped per the plan:**

| Commit | Scope | Engine-Change-RFC |
|--------|-------|-------------------|
| schema | `contracts/pack.schema.json` + `_data/` parity sync + 15 schema tests | ✓ |
| validation | `verify.py` step 19 + 25 validation tests (23 unit + 2 pipeline-level) | |
| show | `show.py` table+JSON extension + 4 integration tests | ✓ |
| pilots | `packs/core` (2 entries, 0.15.7) + `packs/governance-extras` (3 entries, 0.9.3) + marketplace | |
| authoring hub | `catalogue-authoring-standards.md` section 11 + scaffold sync | |
| closeout | agentbundle 0.27.0 + changelog + spec Shipped + workspace.toml | |

## Key design decisions

- **`_resolve_primitive_ref`**: skill→directory, agent/command→`.md` file, hook→stem-match — handles all four primitive types without a new dependency.
- **`seen_ids` scoped per declaring pack** — AC5 is per-pack uniqueness, not global.
- **AC11 (absent target portability)** — missing target pack is explicitly not an error; provider refs are only validated when the target is present in the catalogue.
- **AC6/AC8 coverage at the schema layer** — `minLength:1` on `when`/`purpose`/`fallback` catches empty strings at validation rather than through a fragile CLI pipeline test.
- **Pipeline-level tests added post-EXECUTE** — two `verify_catalogue()` calls confirm step 19 is wired; deleting the registration would fail these while leaving unit tests green.
- **Table render uses `.get()`** — defensive against schema-invalid pack.toml entries that would otherwise crash table output.

## Deferred (follow-up)

- Wave 3 (enterprise authoring discovery, `spec/catalogue-wave3-enterprise-authoring-discovery`) is now unblocked — it was gated on this PR.
- Wave 4 (`spec/catalogue-wave4-semantic-contracts-index`) and Wave 8 (`spec/catalogue-wave8-readme-contributing`) remain unblocked independently.

## Test plan

- [ ] `python3 -m pytest packages/agentbundle/tests/ -q` — all tests pass (60 new + full suite green)
- [ ] `SKIP_SAST=1 make build-check` — exits 0
- [ ] `make lint-ruff` — all checks passed
- [ ] `agentbundle catalogue verify --root .` — exits 0 with 5 pilot entries present
- [ ] `agentbundle show core --format json` — `"integrations"` key present with 2 entries
- [ ] `agentbundle show governance-extras --format json` — `"integrations"` key present with 3 entries