### PR TITLE
fix(specs): resolve 3 stale spec statuses

### DIFF
--- a/docs/specs/fold-standalone-linters-into-cli/spec.md
+++ b/docs/specs/fold-standalone-linters-into-cli/spec.md
@@ -1,4 +1,4 @@
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none

--- a/docs/specs/unify-path-jail-projection-probe/spec.md
+++ b/docs/specs/unify-path-jail-projection-probe/spec.md
@@ -1,6 +1,6 @@
 # Spec: unify-path-jail-projection-probe
 
-- **Status:** Approved → Shipped (2026-07-23)
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none — internal refactoring within `packages/agentbundle`; no RFC, no ADR, no external interface change


### PR DESCRIPTION
## Summary

- `fold-standalone-linters-into-cli`: was stuck at `Implementing`; all 6 scripts deleted and absorbed into agentbundle (landed at 0.18.0, now 0.26.1). Marked `Shipped`.
- `unify-path-jail-projection-probe`: status used non-standard transition notation (`Approved → Shipped (2026-07-23)`). Normalized to `Shipped`. Arrows and inline dates in the status field break status extraction tooling.
- `catalogue-wave2-pack-integrations`: was in ini-007 `active` with spec showing `Approved`; resolved by rebasing onto main which included PR #812 (wave2 merged, spec `Shipped`, active cleared).

## Test plan
- [ ] `git grep "Status:" docs/specs/fold-standalone-linters-into-cli/spec.md` → `Shipped`
- [ ] `git grep "Status:" docs/specs/unify-path-jail-projection-probe/spec.md` → `Shipped`
- [ ] `SKIP_SAST=1 make build-check` passes