### PR TITLE
docs(ini-007): spec + plan — Wave 3 bundled-contract inspection CLI (RFC-0076 D5)

### DIFF
--- a/docs/specs/catalogue-wave3-enterprise-authoring-discovery/plan.md
+++ b/docs/specs/catalogue-wave3-enterprise-authoring-discovery/plan.md
@@ -1,0 +1,673 @@
+# Plan: catalogue-wave3-enterprise-authoring-discovery
+
+- **Status:** Drafting
+- **Spec:** [`spec.md`](spec.md)
+
+## Mode and declined patterns
+
+Mode: full (new public CLI interface + OQ1 RFC resolution + multi-feature).
+
+Declined:
+- Tempted to implement `contracts check <file> <schema>` (validates a local file against
+  a bundled schema); declining — no caller exists yet; tracked as deferred in spec.
+- Tempted to add `next_steps: list[str]` to `InitResult` for JSON consistency with
+  `SelfHostedInitResult`; declining — changes the stable result schema for a UX-only
+  addition; tracked as `(deferred: init-result-json-next-steps)` in spec.
+- Tempted to auto-discover contract names from the `contracts/` source directory at
+  runtime; declining — the inspector must be air-gapped and `importlib.resources` is the
+  correct source; build-time parity is enforced by `check_contract_parity.py`.
+- Tempted to replace the `catalogue_tooling_stub.py` dispatch; declining — the stub only
+  handles unregistered subcommands; `contracts` will be fully registered in `cli.py`.
+
+## Pre-EXECUTE self-coverage checks
+
+- Domain claim: `agentbundle catalogue contracts` namespace is unoccupied. Verified:
+  current `cli.py` registered catalogue subcommands are lint, verify, build, self-host,
+  package, sync-defaults, init. `contracts` is not in this list.
+- Domain claim: `oplog` demonstrates three-level subparsers in the existing CLI.
+  Verified: `cli.py` lines ~1175–1187 register `oplog show` and `oplog clear` via
+  nested `add_subparsers`.
+- Domain claim: 11 public contracts. Verified by comparing `contracts/*.schema.json`,
+  `contracts/*.toml` against `_data/*.schema.json`, `_data/*.toml` at HEAD.
+  `install-defaults.toml` is `_data/`-only; excluded.
+- Resolve-vs-surface disposition: OQ1 (RFC-0076) requires a surface-level spec decision
+  (check for conflict) before implementing. Verification at PLAN time is sufficient —
+  the spec records the resolution in AC1 and in the RFC.
+
+## Task list
+
+```
+T1  CLI registration          Depends on: none
+T2  contracts_inspector.py    Depends on: none
+T3  catalogue_contracts.py    Depends on: T1, T2
+T4  Init next-step output     Depends on: none
+T5  Hub section 12            Depends on: none
+T6  Offline navigation tests  Depends on: T2
+T7  Version + OQ1 + closeout  Depends on: T1–T6
+```
+
+Parallel opportunities on first wave: T1, T2, T4, T5 (all independent).
+
+---
+
+## T1 — Register `agentbundle catalogue contracts` CLI subcommand group
+
+**Verification mode:** goal-based
+
+**Touches:** `packages/agentbundle/agentbundle/cli.py`
+
+**Tests:** none (goal-based)
+
+**Approach:**
+
+Within the existing `# --- catalogue <sub> ---` block in `_build_parser()`, add a `contracts`
+subcommand after `init`. Wire it as a sub-parser with its own `dest="contracts_sub"` group:
+
+```
+contracts_p = cat_subs.add_parser("contracts", help="Inspect contracts bundled with this agentbundle version.")
+contracts_subs = contracts_p.add_subparsers(dest="contracts_sub", metavar="<sub>")
+contracts_p.set_defaults(func=_lazy("catalogue_contracts"))
+
+# list
+_cl_p = contracts_subs.add_parser("list", help="List all bundled contracts.")
+_cl_p.add_argument("--format", choices=["table", "json"], default="table")
+_cl_p.set_defaults(func=_lazy("catalogue_contracts"))
+
+# show
+_cs_p = contracts_subs.add_parser("show", help="Show content of a bundled contract.")
+_cs_p.add_argument("name", metavar="<name>", help="Contract name (from 'contracts list').")
+_cs_p.set_defaults(func=_lazy("catalogue_contracts"))
+
+# export
+_ce_p = contracts_subs.add_parser("export", help="Export all bundled contracts to a directory.")
+_ce_p.add_argument("--output", required=True, metavar="<dir>", help="Output directory.")
+_ce_p.set_defaults(func=_lazy("catalogue_contracts"))
+```
+
+Add `"output"` to `_PATH_BEARING_ATTRS` if not already present (it is: confirmed at line 50).
+
+**Done when:**
+```bash
+agentbundle catalogue contracts --help  # exit 0, shows list/show/export
+agentbundle catalogue contracts list --help  # exit 0, shows --format
+agentbundle catalogue contracts show --help  # exit 0, shows <name>
+agentbundle catalogue contracts export --help  # exit 0, shows --output
+```
+
+---
+
+## T2 — Implement `agentbundle/catalogue_tooling/contracts_inspector.py`
+
+**Verification mode:** TDD
+
+**Touches:**
+- `packages/agentbundle/agentbundle/catalogue_tooling/contracts_inspector.py` (new)
+- `packages/agentbundle/tests/unit/test_catalogue_wave3_contracts_inspector.py` (new)
+
+**Tests (write these red first):**
+
+```python
+# test_catalogue_wave3_contracts_inspector.py
+
+from pathlib import Path
+import pytest
+from agentbundle.catalogue_tooling.contracts_inspector import (
+    ContractInfo, list_bundled_contracts, show_contract, export_contracts,
+)
+
+_EXPECTED_NAMES = {
+    "adapter.schema.json", "adapter.toml", "catalogue.schema.json",
+    "guide.schema.json", "pack.schema.json", "plugin-manifest.derived.schema.json",
+    "plugin-manifest.schema.json", "profile.schema.json",
+    "skill-manifest.schema.json", "skill.schema.json", "target-vocab.toml",
+}
+
+class TestListBundledContracts:
+    def test_returns_eleven_contracts(self):
+        result = list_bundled_contracts()
+        assert len(result) == 11
+
+    def test_names_match_expected_set(self):
+        names = {c.name for c in list_bundled_contracts()}
+        assert names == _EXPECTED_NAMES
+
+    def test_kind_json_schema_for_schema_files(self):
+        for c in list_bundled_contracts():
+            if c.name.endswith(".schema.json"):
+                assert c.kind == "json-schema"
+
+    def test_kind_toml_for_toml_files(self):
+        for c in list_bundled_contracts():
+            if c.name.endswith(".toml"):
+                assert c.kind == "toml"
+
+    def test_install_defaults_not_included(self):
+        names = {c.name for c in list_bundled_contracts()}
+        assert "install-defaults.toml" not in names
+
+    def test_install_marker_not_included(self):
+        names = {c.name for c in list_bundled_contracts()}
+        assert "install-marker.py" not in names
+
+class TestShowContract:
+    def test_returns_content_for_valid_name(self):
+        content = show_contract("pack.schema.json")
+        assert content is not None and len(content) > 0
+
+    def test_returns_none_for_unknown_name(self):
+        assert show_contract("does-not-exist.json") is None
+
+    def test_returns_none_for_name_with_slash(self):
+        assert show_contract("subdir/pack.schema.json") is None
+
+    def test_returns_none_for_name_with_backslash(self):
+        assert show_contract("subdir\\pack.schema.json") is None
+
+    def test_pack_schema_is_valid_json(self):
+        import json
+        content = show_contract("pack.schema.json")
+        assert content is not None
+        json.loads(content)  # must not raise
+
+class TestExportContracts:
+    def test_creates_output_dir(self, tmp_path):
+        out = tmp_path / "exported"
+        export_contracts(out)
+        assert out.is_dir()
+
+    def test_writes_eleven_files(self, tmp_path):
+        out = tmp_path / "out"
+        written = export_contracts(out)
+        assert len(written) == 11
+
+    def test_content_matches_show(self, tmp_path):
+        out = tmp_path / "out"
+        written = export_contracts(out)
+        for fname in written:
+            disk = (out / fname).read_bytes()
+            shown = show_contract(fname)
+            assert shown is not None
+            assert disk == shown.encode("utf-8")
+
+    def test_no_symlinks_in_output(self, tmp_path):
+        out = tmp_path / "out"
+        export_contracts(out)
+        for f in out.iterdir():
+            assert not f.is_symlink()
+
+    def test_raises_on_symlink_target(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        with pytest.raises(ValueError, match="symlink"):
+            export_contracts(link)
+```
+
+**Approach:**
+
+Define `ContractInfo` as a `dataclasses.dataclass` with `name: str`, `kind: str`, `file: str`.
+
+Define the canonical allowlist as a module-level frozenset of the 11 names verified at spec time.
+Do not discover dynamically from `_data/` at runtime (avoids surprises when new `_data/`-only
+files are added).
+
+```python
+_PUBLIC_CONTRACTS: frozenset[str] = frozenset({
+    "adapter.schema.json", "adapter.toml", "catalogue.schema.json",
+    "guide.schema.json", "pack.schema.json", "plugin-manifest.derived.schema.json",
+    "plugin-manifest.schema.json", "profile.schema.json",
+    "skill-manifest.schema.json", "skill.schema.json", "target-vocab.toml",
+})
+```
+
+Use `importlib.resources.files("agentbundle").joinpath("_data")` to load files:
+
+```python
+from importlib.resources import files as _res_files
+
+def _resource(name: str):
+    return _res_files("agentbundle").joinpath("_data").joinpath(name)
+```
+
+`list_bundled_contracts()`: iterate `_PUBLIC_CONTRACTS` in sorted order, build `ContractInfo`.
+
+`show_contract(name)`: reject names with `/` or `\`; return None if not in allowlist;
+read via `importlib.resources`.
+
+`export_contracts(output_dir)`: check for symlink via `output_dir.is_symlink()` (lstat,
+does **not** call `.resolve()` first — `.resolve().is_symlink()` always returns False after
+following the symlink); create dir; write each contract; return list of filenames.
+
+**Done when:** `python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_wave3_contracts_inspector.py -q` exits 0.
+
+---
+
+## T3 — Implement `agentbundle/commands/catalogue_contracts.py` handler
+
+**Verification mode:** TDD
+
+**Depends on:** T1, T2
+
+**Touches:**
+- `packages/agentbundle/agentbundle/commands/catalogue_contracts.py` (new)
+- `packages/agentbundle/tests/unit/test_catalogue_wave3_contracts_cli.py` (new)
+
+**Tests (write these red first):**
+
+```python
+# test_catalogue_wave3_contracts_cli.py
+
+import argparse, io, json, sys
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+def _make_ns(**kwargs):
+    ns = argparse.Namespace()
+    for k, v in kwargs.items():
+        setattr(ns, k, v)
+    return ns
+
+class TestListSubcommand:
+    def test_table_output_contains_all_11(self, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        ns = _make_ns(contracts_sub="list", format="table")
+        rc = run(ns)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "pack.schema.json" in out
+        assert out.count("\n") >= 12  # header + 11 data rows
+
+    def test_json_output_is_array_of_11(self, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        ns = _make_ns(contracts_sub="list", format="json")
+        rc = run(ns)
+        out = capsys.readouterr().out
+        assert rc == 0
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 11
+        assert all("name" in item and "kind" in item and "file" in item for item in data)
+
+class TestShowSubcommand:
+    def test_valid_name_exits_0(self, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        ns = _make_ns(contracts_sub="show", name="pack.schema.json")
+        rc = run(ns)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert len(out) > 0
+
+    def test_invalid_name_exits_1(self, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        ns = _make_ns(contracts_sub="show", name="does-not-exist.json")
+        rc = run(ns)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "does-not-exist.json" in err or "not found" in err.lower()
+
+class TestExportSubcommand:
+    def test_creates_files_exits_0(self, tmp_path, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        out_dir = tmp_path / "exported"
+        ns = _make_ns(contracts_sub="export", output=str(out_dir))
+        rc = run(ns)
+        captured = capsys.readouterr()
+        assert rc == 0
+        files = list(out_dir.iterdir())
+        assert len(files) == 11
+        # Each written filename must appear in stdout manifest (AC15)
+        for f in files:
+            assert f.name in captured.out, f"{f.name!r} missing from stdout manifest"
+
+    def test_prints_reference_notice(self, tmp_path, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        ns = _make_ns(contracts_sub="export", output=str(tmp_path / "out"))
+        run(ns)
+        err = capsys.readouterr().err
+        assert "reference copies only" in err.lower()
+
+    def test_symlink_output_exits_2(self, tmp_path, capsys):
+        from agentbundle.commands.catalogue_contracts import run
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        ns = _make_ns(contracts_sub="export", output=str(link))
+        rc = run(ns)
+        assert rc == 2
+```
+
+**Approach:**
+
+```python
+def run(args: argparse.Namespace) -> int:
+    sub = getattr(args, "contracts_sub", None)
+    if sub == "list":
+        return _run_list(args)
+    elif sub == "show":
+        return _run_show(args)
+    elif sub == "export":
+        return _run_export(args)
+    else:
+        print("agentbundle catalogue contracts: specify a subcommand (list, show, export)", file=sys.stderr)
+        return 1
+```
+
+`_run_list`: call `list_bundled_contracts()`; format as table (left-padded columns) or JSON array.
+
+`_run_show`: call `show_contract(name)`; print to stdout; return 0 or 1.
+
+`_run_export`: check symlink via `Path(args.output).is_symlink()` (lstat — do **not**
+call `.resolve()` first, as `.resolve().is_symlink()` is always False); exit 2 if symlink.
+Otherwise call `export_contracts(Path(args.output))`; print each returned filename to
+stdout (the file manifest); print reference notice to stderr; return 0.
+
+**Done when:** `python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_wave3_contracts_cli.py -q` exits 0.
+
+---
+
+## T4 — Update `catalogue_init.py` plain-init next-step output
+
+**Verification mode:** TDD
+
+**Depends on:** none
+
+**Touches:**
+- `packages/agentbundle/agentbundle/commands/catalogue_init.py`
+- `packages/agentbundle/tests/unit/test_catalogue_wave3_init_nextsteps.py` (new)
+
+**Tests (write these red first):**
+
+```python
+# test_catalogue_wave3_init_nextsteps.py
+
+import io, json, sys, argparse
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import pytest
+
+def _make_success_result(name="test-cat", target="/tmp/test-cat"):
+    from agentbundle.catalogue_tooling.results import (
+        InitResult, InitCatalogueMeta, InitSummary, InitVerification
+    )
+    return InitResult(
+        ok=True,
+        diagnostics=[],
+        schema_version=1,
+        command="catalogue init",
+        operation="init",
+        agentbundle_version="0.28.0",
+        catalogue_schema_version=1,
+        dry_run=False,
+        target=target,
+        catalogue=InitCatalogueMeta(
+            name=name, display_name=name, description="",
+            owner_name=name, preferred_adapter="claude-code",
+            minimum_agentbundle_version="0.28.0",
+        ),
+        files=[],
+        verification=InitVerification(ok=True, diagnostic_count=0),
+        summary=InitSummary(create=3, already_present=0, conflict=0, total=3),
+    )
+
+class TestInitNextSteps:
+    def test_success_table_output_contains_next_steps(self, tmp_path, capsys):
+        from agentbundle.commands import catalogue_init
+        target = tmp_path / "cat"
+        target.mkdir()
+        with patch("agentbundle.commands.catalogue_init.init_catalogue") as mock:
+            mock.return_value = _make_success_result(target=str(target))
+            ns = argparse.Namespace(
+                preset=None, target=str(target),
+                dry_run=False, name=None, display_name=None,
+                description=None, owner_name=None, preferred_adapter=None,
+                format="table",
+            )
+            for attr, _ in catalogue_init._SELF_HOSTED_ONLY_FLAGS:
+                setattr(ns, attr, None)
+            catalogue_init.run(ns)
+        err = capsys.readouterr().err
+        assert "Next steps" in err
+
+    def test_success_table_mentions_authoring_hub(self, tmp_path, capsys):
+        from agentbundle.commands import catalogue_init
+        target = tmp_path / "cat"
+        target.mkdir()
+        with patch("agentbundle.commands.catalogue_init.init_catalogue") as mock:
+            mock.return_value = _make_success_result(target=str(target))
+            ns = argparse.Namespace(
+                preset=None, target=str(target),
+                dry_run=False, name=None, display_name=None,
+                description=None, owner_name=None, preferred_adapter=None,
+                format="table",
+            )
+            for attr, _ in catalogue_init._SELF_HOSTED_ONLY_FLAGS:
+                setattr(ns, attr, None)
+            catalogue_init.run(ns)
+        err = capsys.readouterr().err
+        assert "catalogue-authoring-standards.md" in err
+
+    def test_success_table_mentions_contracts_list(self, tmp_path, capsys):
+        from agentbundle.commands import catalogue_init
+        target = tmp_path / "cat"
+        target.mkdir()
+        with patch("agentbundle.commands.catalogue_init.init_catalogue") as mock:
+            mock.return_value = _make_success_result(target=str(target))
+            ns = argparse.Namespace(
+                preset=None, target=str(target),
+                dry_run=False, name=None, display_name=None,
+                description=None, owner_name=None, preferred_adapter=None,
+                format="table",
+            )
+            for attr, _ in catalogue_init._SELF_HOSTED_ONLY_FLAGS:
+                setattr(ns, attr, None)
+            catalogue_init.run(ns)
+        err = capsys.readouterr().err
+        assert "catalogue contracts list" in err
+
+    def test_json_output_unchanged(self, tmp_path, capsys):
+        from agentbundle.commands import catalogue_init
+        target = tmp_path / "cat"
+        target.mkdir()
+        with patch("agentbundle.commands.catalogue_init.init_catalogue") as mock:
+            mock.return_value = _make_success_result(target=str(target))
+            ns = argparse.Namespace(
+                preset=None, target=str(target),
+                dry_run=False, name=None, display_name=None,
+                description=None, owner_name=None, preferred_adapter=None,
+                format="json",
+            )
+            for attr, _ in catalogue_init._SELF_HOSTED_ONLY_FLAGS:
+                setattr(ns, attr, None)
+            catalogue_init.run(ns)
+        out = capsys.readouterr().out
+        doc = json.loads(out)
+        assert "next_steps" not in doc  # JSON schema unchanged
+```
+
+**Approach:**
+
+In `_run_plain` in `catalogue_init.py`, after the `result.ok` branch prints the success
+line, add:
+
+```python
+if result.ok and not result.dry_run:
+    print("", file=sys.stderr)
+    print("  Next steps:", file=sys.stderr)
+    print("    • See guides/_shared/reference/catalogue-authoring-standards.md "
+          "for authoring standards.", file=sys.stderr)
+    print("    • Run 'agentbundle catalogue contracts list' to view bundled "
+          "contract schemas.", file=sys.stderr)
+    print("    • Run 'agentbundle catalogue verify --root .' to validate your "
+          "catalogue.", file=sys.stderr)
+```
+
+Emit nothing extra in the dry-run success path (dry-run is a preview, not a completed init).
+
+**Done when:** `python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_wave3_init_nextsteps.py -q` exits 0.
+
+---
+
+## T5 — Add section 12 to `catalogue-authoring-standards.md` + scaffold sync
+
+**Verification mode:** goal-based
+
+**Depends on:** none
+
+**Touches:**
+- `guides/_shared/reference/catalogue-authoring-standards.md`
+- `packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md`
+
+**Tests:** none (goal-based)
+
+**Approach:**
+
+Append section 12 to `guides/_shared/reference/catalogue-authoring-standards.md` after section 11:
+
+```markdown
+---
+
+## 12. Bundled contract inspection
+
+All contracts bundled in the running agentbundle version can be listed, inspected,
+and exported without network access.
+
+```bash
+agentbundle catalogue contracts list              # list all bundled contracts
+agentbundle catalogue contracts show <name>       # print content of a contract
+agentbundle catalogue contracts export --output <dir>  # copy all contracts to a directory
+```
+
+Exported files are reference copies only — they do not override the contracts used
+for validation by this agentbundle version.
+```
+
+Run `python3 tools/catalogue/sync_authoring_scaffold.py` to sync the scaffold copy.
+
+**Done when:**
+```bash
+python3 tools/catalogue/sync_authoring_scaffold.py --check  # exit 0
+grep -c "Bundled contract inspection" guides/_shared/reference/catalogue-authoring-standards.md  # 1
+```
+
+---
+
+## T6 — Offline navigation tests
+
+**Verification mode:** TDD
+
+**Depends on:** T2
+
+**Touches:**
+- `packages/agentbundle/tests/unit/test_catalogue_wave3_offline_navigation.py` (new)
+
+**Tests (write these red first):**
+
+```python
+# test_catalogue_wave3_offline_navigation.py
+
+import socket, contextlib
+from pathlib import Path
+import pytest
+from agentbundle.catalogue_tooling.contracts_inspector import (
+    list_bundled_contracts, show_contract, export_contracts,
+)
+
+class TestColdReadPath:
+    def test_all_listed_names_can_be_shown(self):
+        """Full cold-read: list → show each → non-empty content."""
+        contracts = list_bundled_contracts()
+        assert len(contracts) == 11
+        for info in contracts:
+            content = show_contract(info.name)
+            assert content is not None, f"show_contract({info.name!r}) returned None"
+            assert len(content) > 0, f"show_contract({info.name!r}) returned empty string"
+
+    def test_no_network_during_cold_read(self, monkeypatch):
+        """List + show every contract without opening any socket."""
+        original_connect = socket.socket.connect
+
+        def no_connect(self, *args, **kwargs):
+            raise AssertionError("Network call made during cold-read test")
+
+        monkeypatch.setattr(socket.socket, "connect", no_connect)
+        contracts = list_bundled_contracts()
+        for info in contracts:
+            show_contract(info.name)  # must not open network
+
+class TestExportMatchesShow:
+    def test_exported_files_match_show_content(self, tmp_path):
+        """Each exported file's bytes match show_contract() for the same name."""
+        written = export_contracts(tmp_path)
+        assert len(written) == 11
+        for fname in written:
+            disk_bytes = (tmp_path / fname).read_bytes()
+            shown = show_contract(fname)
+            assert shown is not None
+            assert disk_bytes == shown.encode("utf-8"), (
+                f"Exported {fname!r} differs from show_contract result"
+            )
+
+    def test_no_symlinks_created(self, tmp_path):
+        out = tmp_path / "contracts"
+        export_contracts(out)
+        for f in out.iterdir():
+            assert not f.is_symlink(), f"Symlink created in export output: {f}"
+```
+
+**Done when:** `python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_wave3_offline_navigation.py -q` exits 0.
+
+---
+
+## T7 — Engine change, version, OQ1 resolution, changelog, regression
+
+**Verification mode:** goal-based
+
+**Depends on:** T1, T2, T3, T4, T5, T6
+
+**Touches:**
+- `packages/agentbundle/pyproject.toml`
+- `packages/agentbundle/agentbundle/version.py`
+- `docs/product/changelog.md`
+- `docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md`
+
+**Tests:** none (goal-based)
+
+**Approach:**
+
+1. Bump `pyproject.toml` `version = "0.27.0"` → `"0.28.0"`.
+2. Bump `version.py` `CLI_VERSION = "0.27.0"` → `"0.28.0"`.
+3. Add changelog entry (match 0.27.0 shape).
+4. OQ1 resolution in `docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md`:
+   a. Check the OQ1 box: `- [ ] OQ1 resolved...` → `- [x] OQ1 resolved in Wave 3 spec: D5 surface does not conflict with ini-005 catalogue-tooling-rewire`.
+   b. Append AC1's exact resolved text to the OQ1 prose block (the paragraph at ~line 540)
+      so the RFC records the resolution rationale alongside the checkmark:
+      "`agentbundle catalogue contracts` does not conflict with ini-005 `catalogue-tooling-rewire`
+      (spec not yet authored). Wave 3 claims this path."
+5. Add `(deferred: init-result-json-next-steps)` backlog entry to `workspace.toml [backlog].open`:
+   ```toml
+   # spec/catalogue-wave3-enterprise-authoring-discovery deferred AC. InitResult JSON
+   # output lacks a next_steps field (SelfHostedInitResult has one; consistency gap).
+   # Fix: add next_steps: list[str] to InitResult and populate in init_catalogue(); ensure
+   #   JSON output includes the field when result.ok. Requires updating tests/unit/test_catalogue_tooling_init.py.
+   # Unblocks when: someone decides JSON output consistency matters for automation consumers.
+   {slug = "init-result-json-next-steps", source = "spec/catalogue-wave3-enterprise-authoring-discovery"},
+   ```
+6. Commit the new CLI subcommand commits with footer `Engine-Change-RFC: RFC-0076`.
+7. Run full regression gates:
+
+**Done when:**
+```bash
+SKIP_SAST=1 make build-check   # exit 0
+python3 -m pytest packages/agentbundle/tests/ -q   # exit 0
+python3 tools/catalogue/check_contract_parity.py   # exit 0
+python3 tools/catalogue/sync_authoring_scaffold.py --check  # exit 0
+grep "0.28.0" packages/agentbundle/pyproject.toml   # 1 match
+grep "0.28.0" packages/agentbundle/agentbundle/version.py  # 1 match
+grep -F '- [x] OQ1 resolved' docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md  # 1 match (AC1 checkbox)
+grep -F 'Wave 3 claims this path' docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md  # 1 match (AC1 prose)
+grep "init-result-json-next-steps" workspace.toml   # 1 match (deferred slug registered)
+grep -E "0\.28\.0|\[Unreleased\]" docs/product/changelog.md   # 1+ match (AC26)
+```

--- a/docs/specs/catalogue-wave3-enterprise-authoring-discovery/spec.md
+++ b/docs/specs/catalogue-wave3-enterprise-authoring-discovery/spec.md
@@ -1,0 +1,278 @@
+# Spec: catalogue-wave3-enterprise-authoring-discovery
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0076 D5](../../rfc/0076-catalogue-contracts-composition-semantics-discovery.md)
+- **Contract:** `packages/agentbundle/agentbundle/commands/catalogue_contracts.py` (new), `packages/agentbundle/agentbundle/catalogue_tooling/contracts_inspector.py` (new)
+- **Shape:** new CLI surface + init UX update + hub section + tests
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full (structural: new `agentbundle catalogue contracts` CLI surface; public interface:
+new subcommand group visible to all agentbundle adopters; RFC-0076 OQ1 resolution required
+before implementation; multi-feature: CLI + init update + hub section + tests)
+
+## Objective
+
+Wave 3 implements RFC-0076 D5 — the bundled-contract inspection CLI surface — and
+completes the authoring discovery gap for enterprise and air-gapped adopters. After this
+wave, any adopter with `agentbundle` installed can enumerate, inspect, and export the
+exact contract files their version bundles, without network access. The `agentbundle
+catalogue init` success path surfaces the authoring hub path and the new CLI. Hub section
+12 documents the three commands so offline readers find them without visiting the source repo.
+
+**OQ1 resolution (RFC-0076):** Wave 3 verifies that `agentbundle catalogue contracts`
+does not conflict with ini-005's `catalogue-tooling-rewire` spec. The rewire spec has not
+been authored as of this wave. Current registered `agentbundle catalogue` subcommands:
+`lint`, `verify`, `build`, `self-host`, `package`, `sync-defaults`, `init`. The
+`contracts` subcommand path is not reserved. Wave 3 claims `agentbundle catalogue contracts`
+and marks OQ1 resolved in RFC-0076.
+
+## Boundaries
+
+### Always do
+
+- Use `importlib.resources` to locate bundled files — never fall back to filesystem
+  discovery of the source `contracts/` directory.
+- Keep `contracts/` and `agentbundle/_data/` byte-identical. This wave adds no new
+  contracts but must not disturb byte-parity for existing ones. Run
+  `python3 tools/catalogue/check_contract_parity.py` before committing.
+- Sync `catalogue-authoring-standards.md` to the scaffold after every hub edit.
+  Run `python3 tools/catalogue/sync_authoring_scaffold.py --check` before committing.
+- Add `Engine-Change-RFC: RFC-0076` to the commit(s) that add the new CLI subcommand.
+- Keep the hub content free of host CI workflow requirements, Make target requirements,
+  and internal governance citations (RFC/ADR/spec paths).
+- Keep packs/AGENTS.md ≤ 150 lines and root AGENTS.md ≤ 250 lines.
+
+### Ask first
+
+- Adding a fourth subcommand to `agentbundle catalogue contracts` beyond `list`, `show`,
+  `export`.
+- Including `_data/`-only files (`install-defaults.toml`, `install-marker.py`) in the
+  `contracts list` output — these are internal defaults, not public machine contracts.
+- Including the `catalogue-scaffold/` subdirectory as a contract in `contracts list`.
+- Adding `next_steps` to `InitResult` in `results.py` (changing the stable result
+  schema for the init command). The Wave 3 approach emits hints directly from the table
+  handler; JSON output is unchanged.
+
+### Never do
+
+- Let `export` create symlinks in the output directory — copy regular file bytes only.
+- Accept a `contracts show` or `contracts export` name containing path separators
+  (`/`, `\`); reject with a clear error.
+- Override agentbundle's validation behavior through the `export` command — the exported
+  files are reference copies only and this must be printed explicitly.
+- Make any network call in `contracts_inspector.py` — importlib.resources is the sole
+  source; the module must work air-gapped.
+- Cite RFC, ADR, or spec paths in the shipped hub content
+  (`catalogue-authoring-standards.md`).
+- Edit projected outputs under `.claude-code/`, `.cursor/`, `.kiro/`, etc. directly;
+  edit `.apm/` sources then run `catalogue self-host`.
+- Exceed the AGENTS.md line caps.
+
+## Testing Strategy
+
+- **OQ1 resolution (AC1):** goal-based — `grep '- \[x\] OQ1 resolved'
+  docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md` returns a match
+  after T7. Distinct from CLI registration; verified in T7 Done-when, not by `--help`.
+- **CLI registration (AC2–AC5):** goal-based — `--help` on the new subcommand group and
+  each sub-subcommand exits 0 with the expected flags and positionals visible.
+- **Contracts inspector (AC6–AC10):** TDD — `test_catalogue_wave3_contracts_inspector.py`
+  unit tests: list count, kind mapping, show returns content for valid name / None for
+  invalid, export writes all files with matching content.
+- **contracts list output (AC11–AC12):** TDD — `test_catalogue_wave3_contracts_cli.py`
+  calls the handler with a namespace; asserts table rows and JSON array structure.
+- **contracts show output (AC13–AC14):** TDD — valid name exits 0 with non-empty stdout;
+  invalid name exits non-zero.
+- **contracts export output (AC15–AC17):** TDD — output directory created; all 11 files
+  written; "reference copies only" notice in stderr; symlink target exits 2.
+- **Init next-step output (AC18–AC19):** TDD — success table output contains the hub
+  path and contracts-list hint; JSON output schema unchanged.
+- **Hub section 12 (AC20–AC22):** goal-based — section present; scaffold sync check
+  passes; no governance citations.
+- **Cold-read + offline navigation (AC23–AC24):** TDD —
+  `test_catalogue_wave3_offline_navigation.py`: list → show each → assert non-empty;
+  export → compare to show content.
+- **Engine change + version (AC25–AC26):** grep confirms version strings; git log
+  confirms Engine-Change-RFC footer; grep confirms `0.28.0` or `[Unreleased]` entry
+  present in `docs/product/changelog.md` (AC26).
+- **Regression (AC27–AC30):** `SKIP_SAST=1 make build-check` and pytest exit 0;
+  AGENTS.md line counts pass.
+
+## Acceptance Criteria
+
+### Phase A — OQ1 resolution and CLI registration
+
+- [ ] AC1: RFC-0076 OQ1 is marked resolved. The OQ1 checkbox in
+  `docs/rfc/0076-catalogue-contracts-composition-semantics-discovery.md` is checked.
+  The resolved text states: "`agentbundle catalogue contracts` does not conflict with
+  ini-005 `catalogue-tooling-rewire` (spec not yet authored). Wave 3 claims this path."
+
+- [ ] AC2: `agentbundle catalogue contracts --help` exits 0 and lists three
+  subcommands: `list`, `show`, `export`.
+
+- [ ] AC3: `agentbundle catalogue contracts list --help` exits 0 and shows a
+  `--format` flag accepting `table` (default) and `json`.
+
+- [ ] AC4: `agentbundle catalogue contracts show --help` exits 0 and shows a
+  `<name>` positional.
+
+- [ ] AC5: `agentbundle catalogue contracts export --help` exits 0 and shows an
+  `--output` flag (required).
+
+### Phase B — Contracts inspector module
+
+- [ ] AC6: `agentbundle.catalogue_tooling.contracts_inspector` exists. It exports:
+  - `ContractInfo` — a dataclass with fields `name: str`, `kind: str`, `file: str`.
+  - `list_bundled_contracts() -> list[ContractInfo]`
+  - `show_contract(name: str) -> str | None`
+  - `export_contracts(output_dir: Path) -> list[str]`
+
+- [ ] AC7: `list_bundled_contracts()` returns exactly 11 entries — one for each file
+  present in both `contracts/` and `agentbundle/_data/`. The 11 names are:
+  `adapter.schema.json`, `adapter.toml`, `catalogue.schema.json`, `guide.schema.json`,
+  `pack.schema.json`, `plugin-manifest.derived.schema.json`,
+  `plugin-manifest.schema.json`, `profile.schema.json`, `skill-manifest.schema.json`,
+  `skill.schema.json`, `target-vocab.toml`. The `install-defaults.toml` file and the
+  `catalogue-scaffold/` subdirectory are not included. Each `ContractInfo.kind` is
+  `"json-schema"` for `*.schema.json` files and `"toml"` for `*.toml` files.
+
+- [ ] AC8: `show_contract(name)` returns the full UTF-8 string content of the named
+  bundled file when `name` is one of the 11 public contract names. Returns `None` when
+  `name` is not in the known set. `show_contract` with a name containing `/` or `\`
+  returns `None` (path-separator rejection, no ValueError).
+
+- [ ] AC9: `export_contracts(output_dir)` creates `output_dir` if absent; copies each
+  bundled contract's bytes to `output_dir / contract.file`; returns the list of relative
+  filenames written (same order as `list_bundled_contracts()`). Raises `ValueError`
+  if `output_dir` is a symlink (checked via `output_dir.is_symlink()` — lstat, does not
+  follow the link — not `output_dir.resolve().is_symlink()`, which always returns False
+  after following).
+
+- [ ] AC10: `list_bundled_contracts()`, `show_contract()`, and `export_contracts()` all
+  use `importlib.resources` to access bundled files. None depend on the source
+  `contracts/` directory being present at runtime.
+
+### Phase C — contracts command handler
+
+- [ ] AC11: `agentbundle catalogue contracts list` (table output, default) prints a
+  table with column headers `NAME`, `KIND`, `FILE` and one data row per bundled contract.
+  All 11 contracts appear. Exit code 0. Note: RFC-0076 D5's candidate column list
+  includes `version`; Wave 3 omits it because bundled contracts carry no uniform version
+  field — the agentbundle version (returned by `--version`) is the governing version for
+  the entire bundled set.
+
+- [ ] AC12: `agentbundle catalogue contracts list --format json` prints a JSON array
+  to stdout where each element has at minimum `"name"`, `"kind"`, `"file"` keys and
+  valid string values. Exit code 0.
+
+- [ ] AC13: `agentbundle catalogue contracts show pack.schema.json` prints the full
+  content of the bundled `pack.schema.json` to stdout. Exit code 0.
+
+- [ ] AC14: `agentbundle catalogue contracts show nonexistent-name.json` prints a
+  one-line error message to stderr naming the unrecognized contract, and exits non-zero
+  (exit code 1). No traceback is shown.
+
+- [ ] AC15: `agentbundle catalogue contracts export --output <tmpdir>` creates `<tmpdir>`,
+  writes all 11 contract files into it (one file per contract), and prints a file manifest
+  to stdout listing each written filename. Exit code 0.
+
+- [ ] AC16: `agentbundle catalogue contracts export --output <tmpdir>` prints the
+  following notice to stderr (exact phrase match for the core sentence):
+  "These are reference copies only. They do not override the contracts used for
+  validation by this agentbundle version."
+
+- [ ] AC17: `agentbundle catalogue contracts export --output <symlink-path>` where
+  `<symlink-path>` resolves to a symlink exits with code 2 and a clear error message
+  to stderr. No files are written.
+
+### Phase D — Init command next-step output
+
+- [ ] AC18: `agentbundle catalogue init <target>` (table output) on success emits a
+  "Next steps:" block containing at minimum:
+  - A reference to `guides/_shared/reference/catalogue-authoring-standards.md` (the
+    authoring hub, scaffolded into the new catalogue).
+  - The hint `agentbundle catalogue contracts list` to view bundled contract schemas.
+
+- [ ] AC19: `agentbundle catalogue init <target> --format json` output is unchanged —
+  the JSON schema for `InitResult` is not modified by this wave. No `next_steps` key
+  is added to the JSON output.
+
+### Phase E — Hub section 12 and scaffold sync
+
+- [ ] AC20: `guides/_shared/reference/catalogue-authoring-standards.md` gains section
+  "12. Bundled contract inspection" (after section 11). The section includes:
+  - A statement that bundled contracts can be listed, inspected, and exported without
+    network access using the running agentbundle version.
+  - A code snippet showing all three commands:
+    `agentbundle catalogue contracts list`, `agentbundle catalogue contracts show <name>`,
+    `agentbundle catalogue contracts export --output <dir>`.
+  - The "reference copies only" notice inline.
+  - No RFC, ADR, or spec path citations.
+
+- [ ] AC21: `python3 tools/catalogue/sync_authoring_scaffold.py --check` exits 0 after
+  the hub update. The scaffold copy at
+  `packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md`
+  matches the updated live file.
+
+- [ ] AC22: The updated hub section 12 contains no host CI workflow requirements, Make
+  target requirements, or internal governance citations.
+
+### Phase F — Cold-read and offline navigation
+
+- [ ] AC23: A pytest test in `test_catalogue_wave3_offline_navigation.py` exercises the
+  full cold-read path: calls `list_bundled_contracts()`, then calls `show_contract(name)`
+  for every returned `ContractInfo.name`, and asserts that every call returns a non-None,
+  non-empty string. The test does not make network requests (stdlib `socket` is not
+  opened during the test run, verified by the test).
+
+- [ ] AC24: A pytest test in `test_catalogue_wave3_offline_navigation.py` calls
+  `export_contracts(tmp_path)` and asserts: (a) exactly 11 files are written;
+  (b) each written file's byte content matches the corresponding `show_contract(name)`
+  return value encoded as UTF-8; (c) no symlinks exist in `tmp_path`.
+
+### Phase G — Engine change, version, changelog, regression
+
+- [ ] AC25: `packages/agentbundle/pyproject.toml` version is bumped to `0.28.0`.
+  `packages/agentbundle/agentbundle/version.py` `CLI_VERSION` is set to `"0.28.0"` in
+  lockstep. At least one commit in the PR contains `Engine-Change-RFC: RFC-0076` in
+  its message.
+
+- [ ] AC26: `docs/product/changelog.md` has an `[Unreleased]` or `0.28.0` entry
+  describing: (a) the new `agentbundle catalogue contracts` CLI surface (`list`, `show`,
+  `export`); (b) the `catalogue init` next-step guidance addition; (c) hub section 12.
+
+### Regression
+
+- [ ] AC27: `SKIP_SAST=1 make build-check` exits 0 after all changes.
+- [ ] AC28: `python3 -m pytest packages/agentbundle/tests/ -q` exits 0 after all changes.
+- [ ] AC29: `wc -l packs/AGENTS.md` ≤ 150.
+- [ ] AC30: `wc -l AGENTS.md` ≤ 250.
+
+## Assumptions
+
+- **Technical:** `agentbundle catalogue contracts` is not reserved by ini-005's
+  `catalogue-tooling-rewire` spec (verified: spec not yet authored at time of this wave;
+  current registered `agentbundle catalogue` subcommands do not include `contracts`).
+- **Technical:** Nested subparsers within `agentbundle catalogue contracts` are
+  supported by the existing argparse wiring (verified: `oplog` uses the same three-level
+  pattern in `cli.py`).
+- **Technical:** `importlib.resources` can enumerate and read all files in the
+  `agentbundle._data` package directory — verified at HEAD: all 11 contract files are
+  present in `packages/agentbundle/agentbundle/_data/`.
+- **Technical:** Version `0.28.0` is the next minor from `0.27.0` (Wave 2). Verify
+  before opening the PR that no other in-flight branch has claimed this version number.
+- **Technical:** The 11 public contracts that appear in both `contracts/` and `_data/`
+  are: `adapter.schema.json`, `adapter.toml`, `catalogue.schema.json`, `guide.schema.json`,
+  `pack.schema.json`, `plugin-manifest.derived.schema.json`, `plugin-manifest.schema.json`,
+  `profile.schema.json`, `skill-manifest.schema.json`, `skill.schema.json`,
+  `target-vocab.toml`. The `install-defaults.toml` file is `_data/`-only and excluded.
+- **Deferred:** Adding a `catalogue contracts check` command that validates a given local
+  file against the bundled schema (useful for adopter-local contract validation). Out of
+  scope for Wave 3; file under `backlog` if the need surfaces.
+- **Deferred:** Surfacing `next_steps` in the `InitResult` JSON output (for consistency
+  with `SelfHostedInitResult`). Wave 3 emits hints only in table output; JSON schema is
+  unchanged. Tracked as `(deferred: init-result-json-next-steps)` in
+  `workspace.toml [backlog].open`.

--- a/workspace.toml
+++ b/workspace.toml
@@ -567,6 +567,16 @@ open = [
   # Unblocks when: someone wants to close the profiles/ gap in a focused quick-win PR.
   {slug = "profiles-agents-normative-pointer", source = "spec/catalogue-wave1-contract-convergence"},
 
+  # spec/catalogue-wave3-enterprise-authoring-discovery deferred AC. InitResult JSON
+  # output lacks a next_steps field (SelfHostedInitResult has one; consistency gap).
+  # Wave 3 emits next-step hints only in table output; JSON schema is unchanged.
+  # Fix: add next_steps: list[str] to InitResult in catalogue_tooling/results.py and
+  #   populate in init_catalogue(); update catalogue_init.py JSON branch to include the
+  #   field; update tests/unit/test_catalogue_tooling_init.py JSON snapshot.
+  # File: packages/agentbundle/agentbundle/catalogue_tooling/results.py + initialise.py.
+  # Unblocks when: an automation consumer needs next_steps in the JSON output.
+  {slug = "init-result-json-next-steps", source = "spec/catalogue-wave3-enterprise-authoring-discovery"},
+
   # The credential-brokers pack's shipped .apm/** carries RFC-0023/RFC-0006 citations
   # in credential-setup/scripts/setup.py and user-libs/credbroker/ (files:
   # __init__.py, _core.py, _vault.py). The pack is frozen by RFC-0013 (§4/§4d);


### PR DESCRIPTION
## Summary

- Authors `spec.md` (30 ACs, Approved) and `plan.md` (7-task DAG) for `catalogue-wave3-enterprise-authoring-discovery` — ini-007 Wave 3 of RFC-0076
- Spec covers: OQ1 resolution, `agentbundle catalogue contracts list/show/export` CLI surface (RFC-0076 D5), `catalogue init` next-step guidance, hub section 12, and Phase G regression/version bump to 0.28.0
- Adds `init-result-json-next-steps` backlog entry to `workspace.toml` (deferred: `InitResult` JSON schema unchanged this wave)
- Adversarial review: two passes, all blockers resolved; plan approved via `loop-cohort`

## Deferred

- `catalogue contracts check` command (validate local file against bundled schema) — no current caller
- `next_steps` in `InitResult` JSON output — tracked as `init-result-json-next-steps` in `[backlog].open`

## Test plan

- [ ] CI passes (docs-only change — no code added yet; lint + line-cap gates)
- [ ] `wc -l AGENTS.md` ≤ 250 and `wc -l packs/AGENTS.md` ≤ 150