### PR TITLE
feat(work-loop): loop-engine phase FSM + check-spec-status guard (0.15.8)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -117,11 +117,11 @@ around it:
   `sonar-project.properties` or a coverage config. Absent the declaration,
   light mode is unchanged (the pass stays dropped by default); the EXECUTE
   simplify pass still runs either way.
-- **No `loop-cohort` state machine** — light mode does not invoke
-  `loop-cohort` at all (no `init`, `approve-plan`, `check`, or
-  `review record`). The mechanical doc-drift check still runs:
-  `lint-spec-status.py` at the finish-time checklist, since it is a
-  no-subagent lint that costs ~nothing.
+- **No `loop-cohort` state machine and no `loop-engine`** — light mode
+  does not invoke either script (no `init`, `approve-plan`, `check`,
+  `review record`, or `loop-engine transition`). The mechanical doc-drift
+  check still runs: `lint-spec-status.py` at the finish-time checklist,
+  since it is a no-subagent lint that costs ~nothing.
 
 **Full mode (unchanged).** Reached whenever any risk trigger fires. It is
 the loop exactly as the rest of this document describes — `new-spec` with
@@ -130,6 +130,14 @@ iterated to `Clean`, the `quality-engineer` floor at the end-of-session
 checklist, and the iteration cap. **Everything below this section is full
 mode unless it says otherwise**; light mode reuses those steps verbatim
 except for the four trims named above.
+
+### Loop-engine phase tracking (full mode only)
+
+In full mode, `loop-engine` is the phase FSM — it owns `engine-state.json`
+(session-local, gitignored) and coordinates with `loop-cohort`. Light mode
+skips both. For mode selection, checkpoint events, guard wiring, and
+session-boundary rules, load
+[`references/loop-infrastructure.md`](references/loop-infrastructure.md).
 
 ### Step 0. Orientation — read workspace context
 
@@ -304,19 +312,12 @@ For anything beyond trivial, *think before you write code*. Concretely:
   ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. The `frontend-engineering` skill is owned by the `frontend-engineering` pack (not `core`); check if it appears in your available skills before loading it. If absent, record a named skip — `FE pre-flight: skipped (frontend-engineering pack absent)` — in the spec and proceed without the pre-flight. When the pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
-- **Initialize the loop's state file.** Run this skill's bundled
-  `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
-  the bundled `assets/state.json` template into place, sets `feature`
-  to the spec slug, and writes atomically. The file is gitignored —
-  session-scratch, not history. Then run `loop-cohort.py check
-  docs/specs/<feature> --phase plan`; on the first invocation it will
-  exit 1 with `plan not approved` — **this is the expected cue to run
-  the pre-EXECUTE reviewer**, not a stop-and-surface signal. Once the
-  reviewer is clean, run `loop-cohort.py approve-plan docs/specs/<feature>`
-  and re-run check; exit 0 unlocks EXECUTE. Every state mutation —
-  template copy, status flip, atomic write — is owned by the tool; do
-  not edit `state.json` by hand. Schema reference:
-  [`references/state-schema.md`](references/state-schema.md).
+- **Initialise phase tracking.** See [`references/loop-infrastructure.md`](references/loop-infrastructure.md) for the events to fire as you move through each phase. In full mode, fire
+  `loop-engine transition <work-dir> plan-approved` only **after** the
+  pre-EXECUTE reviewer is clean and a human has given G-plan sign-off.
+  The `plan-approved` guard calls `loop-cohort check --phase plan`,
+  which exits 0 only when `loop-cohort approve-plan` has been run —
+  the mechanical gate that enforces the human sign-off step.
 
 The output of this step is a written plan (with tests) you can return to.
 Don't keep it in your head — your context will turn over and you'll lose it.
@@ -482,32 +483,26 @@ discipline rather than restating it.
 
 #### Supervisor mode (wave-scheduled; sequential by default)
 
-Run `loop-cohort schedule docs/specs/<feature>` to build the plan's full
-`Depends on:` DAG and get the topological order. **Execute tasks in that
-order, single-agent, by default** — on every adapter. `schedule` fails
-loud on a dependency **cycle** and warns on a **forward-reference** (a dep
-authored later — it reorders so the dep runs first), so an ill-formed plan
-is caught here, not run out of order. This is the proven, zero-hazard path;
-its win is correct ordering, not speed. If tasks
-declare optional `Touches:` globs, `schedule` also prints
-`predicted-disjoint: yes|no|unknown` per wave — a **serialize-only screen**
-(a predicted overlap is a reason to keep the wave serial; it **never**
-greenlights parallel — the gate below stays authoritative).
+Build the plan's full `Depends on:` DAG to get the topological task order.
+**Execute tasks in that order, single-agent, by default** — on every adapter.
+An ill-formed plan (dependency cycle, forward-reference) is caught here, not
+run out of order. This is the proven, zero-hazard path; its win is correct
+ordering, not speed. After each wave completes, fire
+`loop-engine transition <work-dir> wave-complete`.
 
-**Parallel implementer fan-out is opt-in and gated — never automatic.** The
-short version: a wave fans out only when `loop-cohort dispatch-decision` clears
-it (categories auto-derived fail-closed, plus a clean `git merge-tree`
-disjointness check) **and** — with `state.json.auto_parallel` unset — a human
-opts in; absent that it runs sequentially, and a failed parallel wave
-**Surfaces and stops**, never auto-retries. When you do opt in, select a
-subagent matching `implementer` per the
-[parallel-dispatch discipline](#parallel-dispatch-discipline) above. The full
-gate semantics, the `auto_parallel` GO-approval behavior, the 7-step worktree
-procedure, and the single-agent fallback (no `implementer` subagent installed)
-are progressive-disclosure depth in
-[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded only
-when you take this path. Parallel *reviewer* (read) fan-out is a separate,
-always-safe path and is unaffected.
+**Parallel implementer fan-out is opt-in and gated — never automatic.** A
+wave fans out only when a disjointness check clears it (categories
+auto-derived fail-closed, plus a clean `git merge-tree` check) **and** — with
+`state.json.auto_parallel` unset — a human opts in; absent that it runs
+sequentially, and a failed parallel wave **Surfaces and stops**, never
+auto-retries. When you do opt in, select a subagent matching `implementer`
+per the [parallel-dispatch discipline](#parallel-dispatch-discipline) above.
+The full gate semantics, the `auto_parallel` GO-approval behavior, the
+7-step worktree procedure, and the single-agent fallback are progressive-
+disclosure depth in
+[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded
+only when you take this path. Parallel *reviewer* (read) fan-out is a
+separate, always-safe path and is unaffected.
 
 ### 3. GATES — mechanical verification
 
@@ -556,24 +551,13 @@ celebrating what you did. Findings come back grouped by severity
 (Blockers / Concerns / Nits), each with a one-sentence `Fix:`. Iterate
 until the agent returns `Clean — ready to commit.`
 
-**After each reviewer pass, record findings via the tool** before
-iterating. Write the reviewer's report to disk, then run:
-
-```
-loop-cohort.py review record docs/specs/<feature> --report <report-path>
-loop-cohort.py check docs/specs/<feature> --phase review
-```
-
-`review record` parses the report's findings (anchored on the
-adversarial-reviewer's documented `**N. <title>.** \`file:line\`. … Fix: …`
-format), computes `sha1("<file>|<line>|<title>")` per the canonical
-algorithm, rotates `finding_fingerprints` → `previous_finding_fingerprints`,
-sets the new list, increments `iteration_count`, and writes atomically —
-one transaction, no by-hand JSON. If the parser surfaces zero findings on
-a non-clean report it exits non-zero; pass `--fingerprint <hex>` repeated
-to override. `check --phase review` then enforces stasis detection: exit
-1 with `no progress` means the same findings landed two iterations in a
-row; stop and surface to a human rather than spinning a third.
+**After each reviewer pass, record findings via loop-engine** before
+iterating. Write the reviewer's report to disk, then fire the appropriate
+transition (see [`references/loop-infrastructure.md`](references/loop-infrastructure.md)): `findings-remain` with `--fingerprints`
+if blockers remain, or `reviewers-clean --report <path>` when clean. The
+underlying loop-cohort `review record` call rotates fingerprints, increments
+`iteration_count`, and enforces stasis detection — same findings two
+iterations in a row surfaces to a human rather than spinning a third.
 
 **Once recorded, drop the full report text from resident context.** The
 on-disk report plus the `state.json` fingerprints are the durable record —
@@ -820,12 +804,12 @@ The loop must terminate. Iteration without termination is how unattended
 loops (see below) burn money. Stop when **any** of these is true:
 
 1. **Gates green AND review clean** — the normal exit. Ship.
-2. **`scripts/loop-cohort.py check` exits non-zero.** The script is the
-   mechanical side of termination, reading from `state.json` (see
-   [`references/state-schema.md`](references/state-schema.md)). It
-   fires on iteration cap, token-budget cap, consecutive-error counter,
-   pending plan approval (PLAN phase only), and fingerprint stasis
-   (REVIEW phase only). The exit message tells you which.
+2. **`loop-engine transition` refuses a guard.** The guard is the mechanical
+   side of termination — it delegates to `loop-cohort check`, which reads
+   from `state.json` (see [`references/state-schema.md`](references/state-schema.md))
+   and fires on iteration cap, token-budget cap, consecutive-error counter,
+   pending plan approval (PLAN phase only), and fingerprint stasis (REVIEW
+   phase only). The guard's refusal message tells you which condition fired.
 3. **Diff is shrinking but findings aren't** — you're spot-fixing without
    addressing root cause. This is a judgment call, not in `loop-cohort`.
    Stop and rethink the approach (back to PLAN).

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -158,15 +158,6 @@ Before PLAN begins, orient to the current initiative and work queue:
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
-     - **Stale-queue check.** For each active initiative, for each entry in
-       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
-       path (bare string → as-is; inline object → `path` field; `slug` is
-       shaping-queue only), strip the `spec/` prefix, and read
-       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
-       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
-       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
-       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
-       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: "Use for implementing or resuming non-trivial repository changes: features, behavior-changing fixes, refactors, migrations, framework or dependency upgrades, schema/API changes, performance work, infrastructure/build edits, reversions, and specs under docs/specs/. Also trigger on bare continuation commands such as \"resume,\" \"continue,\" \"keep going,\" \"pick up where I left off,\" or \"let's get going\" when conversation or workspace context identifies active build work. Do not use for shaping, research, strategy, design-only work, status-only or review-only requests, or trivial cosmetic/local edits. Run the risk-selected light/full plan → execute → gates → adversarial review → fix/ship loop."
 ---
 
 # Skill: work-loop
@@ -25,21 +25,6 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
 Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
 Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
-
-## When this skill applies
-
-- Implementing a spec from `docs/specs/`.
-- Bug fixes that touch more than one file — including security patches and incident hot-fixes.
-- Refactors.
-- Migrations, framework or dependency upgrades, schema or API changes.
-- Performance work, or infrastructure / build-system changes beyond a single config tweak.
-- Reverting and re-doing a previous change.
-- Any task where you'd otherwise be tempted to "just go".
-
-For genuine one-line edits (typo, config tweak), skip the loop — the overhead
-isn't worth it. That triviality test decides *whether* to run the loop; once
-you're in it, **risk** (not file count) decides *which mode* runs — see
-[Modes: light and full](#modes-light-and-full) below.
 
 ## The loop
 

--- a/.agents/skills/work-loop/references/loop-infrastructure.md
+++ b/.agents/skills/work-loop/references/loop-infrastructure.md
@@ -1,0 +1,58 @@
+# Loop-engine: Mode selection and checkpoint reference
+
+`loop-engine` is the phase FSM for full-mode work-loop. It owns
+`engine-state.json` (session-local, gitignored) and coordinates with
+`loop-cohort` as guards and side effects. Light mode never invokes either
+script.
+
+## Mode selection
+
+Choose once at `loop-engine init`:
+
+| Work type | Mode | `loop-engine init --mode` |
+|-----------|------|--------------------------|
+| Multi-task spec implementation | Full delivery | `code` |
+| Spec/plan authoring only | Spec/plan drafting | `spec-plan` |
+| RFC, ADR, arch doc, any review-and-approve document | Document lifecycle | `doc` |
+| Light mode | — | skip — not used |
+
+## Checkpoint table
+
+Events to fire as you move through each phase.
+
+| State | Exit event | Human gate? | Guards that run | Modes |
+|-------|-----------|-------------|-----------------|-------|
+| `SPEC-PLAN-DRAFTING` | `spec-ready` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `reviewers-clean` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `findings-remain` | — | — | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-approved` | **G-plan** (human sign-off required first; `loop-cohort approve-plan` must have run) | `loop-cohort check --phase plan` | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-rejected` | — | — | code, spec-plan |
+| `CODE-IMPLEMENTATION` | `wave-complete` | — | `loop-cohort check --phase implement` | code |
+| `CODE-VERIFICATION` | `gates-clean` | — | — | code |
+| `CODE-VERIFICATION` | `gates-failed` | — | — | code |
+| `CODE-REVIEW` | `reviewers-clean --report <path>` | — | `check-spec-status.py` (**Status:** must be `Shipped`) | code |
+| `CODE-REVIEW` | `findings-remain --fingerprints <h>...` | — | `loop-cohort check --phase review` | code |
+| `CODE-HUMAN-GATE` | `done` | **G-pr** (human merges PR) | — | code |
+| `CODE-HUMAN-GATE` | `blocker-applied` | — | — | code |
+| `DOC-DRAFTING` | `doc-ready` | — | — | doc |
+| `DOC-REVIEW` | `reviewers-clean` | — | — | doc |
+| `DOC-REVIEW` | `findings-remain` | — | — | doc |
+| `DOC-HUMAN-GATE` | `doc-approved` | **human approves** | — | doc |
+| `DOC-HUMAN-GATE` | `doc-returned` | — | — | doc |
+
+## Human-wait states and session boundaries
+
+A session may end in any of: `SPEC-PLAN-HUMAN-GATE`, `CODE-HUMAN-GATE`,
+`DOC-HUMAN-GATE`, or `DOC-REVIEW` (when review is async). Before ending the
+session, ensure work product is committed on a named branch or open PR.
+
+When resuming: read `loop-engine status <work-dir>` first and wait for the
+human signal before firing the next event — do not fire autonomously from a
+human-wait state.
+
+## Valid **Status:** values in spec.md
+
+`Draft | Approved | Implementing | Shipped | Archived`
+
+The `check-spec-status.py` guard enforces `Shipped` before G-pr. The
+`lint-spec-status.py` CI linter enforces the full enum.

--- a/.agents/skills/work-loop/scripts/check-spec-status.py
+++ b/.agents/skills/work-loop/scripts/check-spec-status.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Guard: verifies **Status:** Shipped in spec.md for a given work-dir.
+
+Called by loop-engine at CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE
+(code mode only). Exits 0 only when Status is exactly "Shipped".
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_STATUS_RE = re.compile(r"^\*\*Status:\*\*\s*(\S+)", re.MULTILINE)
+
+
+def resolve_spec(arg: str) -> Path:
+    """Return path to spec.md. If arg is a file, use its parent dir."""
+    p = Path(arg)
+    if p.is_file():
+        return p.parent / "spec.md"
+    return p / "spec.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-spec-status",
+        description="Verify **Status:** Shipped in spec.md before the G-pr human gate.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR may be a directory (containing spec.md) or a file path\n"
+            "(the parent directory is used as the work-dir).\n\n"
+            "Exits 0 only when **Status:** is exactly 'Shipped'.\n"
+            "Valid status values: Draft | Approved | Implementing | Shipped | Archived"
+        ),
+    )
+    parser.add_argument(
+        "work_dir",
+        metavar="WORK_DIR",
+        help="directory with spec.md, or path to a doc file (resolves to parent dir)",
+    )
+    args = parser.parse_args(argv)
+
+    spec_path = resolve_spec(args.work_dir)
+    if not spec_path.exists():
+        print(f"error: spec.md not found: {spec_path}", file=sys.stderr)
+        return 1
+
+    text = spec_path.read_text(encoding="utf-8")
+    m = _STATUS_RE.search(text)
+    if not m:
+        print(
+            f"error: no bare **Status:** line found in {spec_path}\n"
+            "  Required format: **Status:** Shipped  (no leading dash or other prefix)",
+            file=sys.stderr,
+        )
+        return 1
+
+    status = m.group(1)
+    if status != "Shipped":
+        print(
+            f"error: spec status is '{status}', expected 'Shipped'\n"
+            "  Update spec.md to '**Status:** Shipped' before firing reviewers-clean from CODE-REVIEW.\n"
+            "  Valid values: Draft | Approved | Implementing | Shipped | Archived",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/work-loop/scripts/loop-engine.py
+++ b/.agents/skills/work-loop/scripts/loop-engine.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""loop-engine — phase FSM validator and loop-cohort coordinator.
+
+Tracks work-loop phase state in engine-state.json (session-local, gitignored).
+Calls loop-cohort as guards and side effects on transitions.
+
+Three modes:
+  code       Full delivery (spec/plan + implementation + review + merge).
+  spec-plan  Spec/plan authoring only (terminates at human plan approval).
+  doc        RFC, ADR, arch doc, or any review-and-approve document.
+
+WORK_DIR accepts either a directory path or a file path. When a file is
+passed, the parent directory is the work-dir and the file's stem is the
+feature name. engine-state.json always lives inside the resolved work-dir.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ── Transition tables ─────────────────────────────────────────────────────────
+
+INITIAL_STATE: dict[str, str] = {
+    "code": "SPEC-PLAN-DRAFTING",
+    "spec-plan": "SPEC-PLAN-DRAFTING",
+    "doc": "DOC-DRAFTING",
+}
+
+TRANSITIONS: dict[str, dict[tuple[str, str], str]] = {
+    "code": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "CODE-IMPLEMENTATION",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+        ("CODE-IMPLEMENTATION",  "wave-complete"):   "CODE-VERIFICATION",
+        ("CODE-VERIFICATION",    "gates-clean"):     "CODE-REVIEW",
+        ("CODE-VERIFICATION",    "gates-failed"):    "CODE-IMPLEMENTATION",
+        ("CODE-REVIEW",          "reviewers-clean"): "CODE-HUMAN-GATE",
+        ("CODE-REVIEW",          "findings-remain"): "CODE-IMPLEMENTATION",
+        ("CODE-HUMAN-GATE",      "done"):            "DONE",
+        ("CODE-HUMAN-GATE",      "blocker-applied"): "CODE-IMPLEMENTATION",
+    },
+    "spec-plan": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "DONE",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+    },
+    "doc": {
+        ("DOC-DRAFTING",   "doc-ready"):       "DOC-REVIEW",
+        ("DOC-REVIEW",     "reviewers-clean"): "DOC-HUMAN-GATE",
+        ("DOC-REVIEW",     "findings-remain"): "DOC-DRAFTING",
+        ("DOC-HUMAN-GATE", "doc-approved"):    "DONE",
+        ("DOC-HUMAN-GATE", "doc-returned"):    "DOC-DRAFTING",
+    },
+}
+
+# ── Script paths ──────────────────────────────────────────────────────────────
+
+_SCRIPTS = Path(__file__).resolve().parent
+
+
+def _lc(*args: str) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "loop-cohort.py"), *args]
+
+
+def _css(work_dir: Path) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "check-spec-status.py"), str(work_dir)]
+
+
+# ── Guards ────────────────────────────────────────────────────────────────────
+# Called before the state write. Non-zero exit refuses the transition.
+# Key: (mode, current_state, event) → list[callable(work_dir, **kw) → list[str]]
+
+def _guard_lc_check_plan(wd: Path, **_kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "plan")
+
+
+def _guard_lc_check_implement(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "implement")
+
+
+def _guard_lc_check_review(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "review")
+
+
+def _guard_css(wd: Path, **_kw: object) -> list[str]:
+    return _css(wd)
+
+
+GUARDS: dict[tuple[str, str, str], list] = {
+    ("code",      "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("spec-plan", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("code",      "CODE-IMPLEMENTATION",  "wave-complete"):  [_guard_lc_check_implement],
+    ("code",      "CODE-REVIEW",          "findings-remain"): [_guard_lc_check_review],
+    ("code",      "CODE-REVIEW",          "reviewers-clean"): [_guard_css],
+}
+
+# ── Side effects ──────────────────────────────────────────────────────────────
+# Called after the state write. Failure is logged but does not reverse the
+# transition. Builders return [] to skip silently.
+
+def _se_lc_schedule(wd: Path, **_kw: object) -> list[str]:
+    return _lc("schedule", str(wd))
+
+
+def _se_lc_review_record_clean(wd: Path, **kw: object) -> list[str]:
+    report = kw.get("report")
+    if not report:
+        print(
+            "warning: reviewers-clean from CODE-REVIEW without --report; "
+            "loop-cohort review record skipped (iteration_count not incremented)",
+            file=sys.stderr,
+        )
+        return []
+    return _lc("review", "record", str(wd), f"--report={report}")
+
+
+def _se_lc_review_record_findings(wd: Path, **kw: object) -> list[str]:
+    fps: list[str] = kw.get("fingerprints", [])
+    cmd = _lc("review", "record", str(wd))
+    for h in fps:
+        cmd.append(f"--fingerprint={h}")
+    return cmd
+
+
+SIDE_EFFECTS: dict[tuple[str, str, str], list] = {
+    ("code", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_se_lc_schedule],
+    ("code", "CODE-REVIEW", "reviewers-clean"):        [_se_lc_review_record_clean],
+    ("code", "CODE-REVIEW", "findings-remain"):        [_se_lc_review_record_findings],
+}
+
+# ── State I/O ─────────────────────────────────────────────────────────────────
+
+def resolve_work_dir(arg: str) -> tuple[Path, str]:
+    """Return (work_dir, feature_name). Accepts file or directory path."""
+    p = Path(arg).resolve()
+    if p.is_file():
+        return p.parent, p.stem
+    return p, p.name
+
+
+def _state_path(work_dir: Path) -> Path:
+    return work_dir / "engine-state.json"
+
+
+def _read_state(work_dir: Path) -> dict:
+    path = _state_path(work_dir)
+    if not path.exists():
+        print(
+            f"error: engine-state.json not found in {work_dir}\n"
+            "  Run 'loop-engine init <work-dir> --mode <mode>' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_state(work_dir: Path, state: dict) -> None:
+    state["last_transition_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = _state_path(work_dir)
+    fd, tmp = tempfile.mkstemp(dir=work_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ── Guard / side-effect runners ───────────────────────────────────────────────
+
+def _run_guard(cmd: list[str], label: str) -> bool:
+    if not cmd:
+        return True
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(f"guard refused [{label}]: {msg}", file=sys.stderr)
+        return False
+    return True
+
+
+def _run_side_effect(cmd: list[str], label: str) -> None:
+    if not cmd:
+        return
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(
+            f"side-effect failed [{label}] (transition is NOT reversed): {msg}",
+            file=sys.stderr,
+        )
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+def cmd_init(args: argparse.Namespace) -> int:
+    work_dir, feature = resolve_work_dir(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(work_dir)
+    if path.exists():
+        print(
+            f"error: engine-state.json already exists at {path}\n"
+            "  Run 'loop-engine reset <work-dir>' before re-initialising.",
+            file=sys.stderr,
+        )
+        return 1
+
+    state: dict = {
+        "feature": feature,
+        "mode": args.mode,
+        "state": INITIAL_STATE[args.mode],
+        "last_transition_at": "",
+    }
+    _write_state(work_dir, state)
+
+    # Side effect: initialise loop-cohort for code/spec-plan modes
+    if args.mode in ("code", "spec-plan"):
+        lc = _SCRIPTS / "loop-cohort.py"
+        if lc.exists():
+            _run_side_effect(_lc("init", str(work_dir)), "loop-cohort init")
+
+    return 0
+
+
+def cmd_transition(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    mode = state["mode"]
+    current = state["state"]
+    event = args.event
+    fingerprints: list[str] = args.fingerprints or []
+    report: str | None = args.report
+
+    table = TRANSITIONS.get(mode, {})
+    if (current, event) not in table:
+        valid = sorted(e for (s, e) in table if s == current)
+        print(
+            f"error: invalid transition in {mode!r} mode: {current!r} + {event!r}\n"
+            f"  valid events from {current!r}: {valid or '(none — terminal state)'}",
+            file=sys.stderr,
+        )
+        return 1
+
+    next_state = table[(current, event)]
+    ctx = dict(fingerprints=fingerprints, report=report)
+
+    # Guards — must all pass before state is written
+    guard_key = (mode, current, event)
+    for builder in GUARDS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        if not _run_guard(cmd, f"{mode}:{current}+{event}"):
+            return 1
+
+    # Write new state atomically
+    state["state"] = next_state
+    _write_state(work_dir, state)
+    print(f"{current} + {event} → {next_state}")
+
+    # Side effects — failure is logged, transition is not reversed
+    for builder in SIDE_EFFECTS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        _run_side_effect(cmd, f"{mode}:{current}+{event}")
+
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    if args.json:
+        print(json.dumps(state, indent=2))
+    else:
+        ts = state.get("last_transition_at", "unknown")
+        print(f"{state['feature']} | {state['mode']} | {state['state']} | last transition: {ts}")
+    return 0
+
+
+def cmd_reset(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    _state_path(work_dir).unlink(missing_ok=True)
+    return 0
+
+
+# ── Argument parser ───────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loop-engine",
+        description="Phase FSM validator and loop-cohort coordinator for the work-loop skill.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR accepts a directory path or a file path.\n"
+            "  directory → work-dir; basename → feature name\n"
+            "  file      → parent is work-dir; file stem → feature name\n\n"
+            "engine-state.json is always written inside the resolved work-dir.\n"
+            "It is session-local and gitignored — not committed to git.\n\n"
+            "Modes:  code (full delivery)  |  spec-plan (spec/plan authoring)\n"
+            "        doc (RFC / ADR / arch doc / any review-and-approve document)"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # init
+    p = sub.add_parser(
+        "init",
+        help="Initialise phase tracking for a work item.",
+        description="Creates engine-state.json in the work-dir. Fails if it already exists.",
+    )
+    p.add_argument(
+        "work_dir", metavar="WORK_DIR",
+        help="Directory containing spec.md, or path to a doc file.",
+    )
+    p.add_argument(
+        "--mode", required=True, choices=["code", "spec-plan", "doc"],
+        help=(
+            "Work mode: 'code' (full spec→implement→review→merge), "
+            "'spec-plan' (spec/plan authoring only), "
+            "'doc' (RFC/ADR/arch doc or any review-and-approve document)."
+        ),
+    )
+
+    # transition
+    p = sub.add_parser(
+        "transition",
+        help="Fire an event and advance the FSM.",
+        description=(
+            "Validates the event, runs applicable guards, writes the new state, "
+            "then runs side effects. Guards run before the write; a non-zero guard "
+            "refuses the transition. Side-effect failures are logged but do not "
+            "reverse the transition."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "event", metavar="EVENT",
+        help=(
+            "Event name. Examples: spec-ready, wave-complete, reviewers-clean, "
+            "findings-remain, plan-approved, done, doc-approved."
+        ),
+    )
+    p.add_argument(
+        "--fingerprints", nargs="+", metavar="HASH",
+        help=(
+            "Diff fingerprints (hex strings) for stasis detection. "
+            "Passed to 'loop-cohort review record --fingerprint' when recording findings."
+        ),
+    )
+    p.add_argument(
+        "--report", metavar="PATH",
+        help=(
+            "Path to the reviewer's markdown report. "
+            "Used for the 'loop-cohort review record --report' side effect "
+            "when firing reviewers-clean from CODE-REVIEW."
+        ),
+    )
+
+    # status
+    p = sub.add_parser(
+        "status",
+        help="Show current phase state.",
+        description="Reads engine-state.json and prints the current state.",
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "--json", action="store_true",
+        help="Emit the engine-state.json object to stdout (for machine consumers).",
+    )
+
+    # reset
+    p = sub.add_parser(
+        "reset",
+        help="Remove engine-state.json (idempotent).",
+        description=(
+            "Deletes engine-state.json from the work-dir. "
+            "Exits 0 even if the file is already absent."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    dispatch = {
+        "init": cmd_init,
+        "transition": cmd_transition,
+        "status": cmd_status,
+        "reset": cmd_reset,
+    }
+    return dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/work-loop/scripts/test-check-spec-status.py
+++ b/.agents/skills/work-loop/scripts/test-check-spec-status.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Self-test for check-spec-status.py.
+
+Runs the script as a subprocess against fixture directories in a tempdir —
+the same shape the loop-engine guard uses.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(arg: str | Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(arg)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_spec(tmp: Path, status: str) -> Path:
+    spec = tmp / "spec.md"
+    spec.write_text(
+        f"# Spec\n\n**Status:** {status}\n\n## Acceptance Criteria\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_exits_0_when_shipped(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp)
+    assert r.returncode == 0, f"expected 0, got {r.returncode}: {r.stderr}"
+    print("  PASS: exits 0 when Status is Shipped")
+
+
+def test_exits_nonzero_when_implementing(tmp: Path) -> None:
+    write_spec(tmp, "Implementing")
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when Status is Implementing")
+
+
+def test_exits_nonzero_when_draft(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Draft")
+
+
+def test_exits_nonzero_when_approved(tmp: Path) -> None:
+    write_spec(tmp, "Approved")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Approved")
+
+
+def test_exits_nonzero_when_archived(tmp: Path) -> None:
+    write_spec(tmp, "Archived")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Archived")
+
+
+def test_exits_nonzero_when_spec_absent(tmp: Path) -> None:
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when spec.md absent")
+
+
+def test_exits_nonzero_when_no_status_line(tmp: Path) -> None:
+    (tmp / "spec.md").write_text("# Spec\n\nNo status here.\n", encoding="utf-8")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when no **Status:** line")
+
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp / "spec.md")
+    assert r.returncode == 0, f"expected 0 when passing file path: {r.stderr}"
+    print("  PASS: file path resolves to parent dir")
+
+
+def test_file_path_fails_correctly(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp / "spec.md")
+    assert r.returncode != 0
+    print("  PASS: file path with non-Shipped status returns non-zero")
+
+
+def main() -> None:
+    tests = [
+        test_exits_0_when_shipped,
+        test_exits_nonzero_when_implementing,
+        test_exits_nonzero_when_draft,
+        test_exits_nonzero_when_approved,
+        test_exits_nonzero_when_archived,
+        test_exits_nonzero_when_spec_absent,
+        test_exits_nonzero_when_no_status_line,
+        test_file_path_resolves_to_parent,
+        test_file_path_fails_correctly,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/work-loop/scripts/test-loop-engine.py
+++ b/.agents/skills/work-loop/scripts/test-loop-engine.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Self-test for loop-engine.py.
+
+Runs the engine as a subprocess against fixture work-dirs in a tempdir.
+Covers: all three mode lifecycles, invalid transitions, guard refusal,
+side-effect scope boundary, file-path resolution, and idempotent reset.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "loop-engine.py"
+LC = Path(__file__).resolve().parent / "loop-cohort.py"
+CSS = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"loop-engine {list(args)} exited {result.returncode}:\n{result.stderr}"
+        )
+    return result
+
+
+def state(tmp: Path) -> dict:
+    return json.loads((tmp / "engine-state.json").read_text(encoding="utf-8"))
+
+
+# ── spec-plan lifecycle ───────────────────────────────────────────────────────
+
+def test_spec_plan_lifecycle_to_human_gate(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    s = state(tmp)
+    assert s["state"] == "SPEC-PLAN-DRAFTING"
+    assert s["mode"] == "spec-plan"
+    assert s["feature"] == tmp.name
+
+    run("transition", str(tmp), "spec-ready", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-REVIEW"
+
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: spec-plan reaches SPEC-PLAN-HUMAN-GATE")
+
+
+def test_spec_plan_findings_loop_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    run("transition", str(tmp), "findings-remain", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-DRAFTING"
+    print("  PASS: spec-plan findings-remain loops back to SPEC-PLAN-DRAFTING")
+
+
+# ── doc lifecycle ─────────────────────────────────────────────────────────────
+
+def test_doc_full_lifecycle(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    run("transition", str(tmp), "doc-ready", check=True)
+    assert state(tmp)["state"] == "DOC-REVIEW"
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    print("  PASS: doc lifecycle → DONE")
+
+
+def test_doc_returned_loops_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-returned", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: doc-returned loops back to DOC-DRAFTING")
+
+
+# ── invalid transitions ───────────────────────────────────────────────────────
+
+def test_invalid_transition_exits_nonzero_with_message(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("transition", str(tmp), "plan-approved")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    # State must not advance
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: invalid transition exits non-zero; state unchanged")
+
+
+def test_terminal_state_has_no_valid_events(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    r = run("transition", str(tmp), "doc-ready")
+    assert r.returncode != 0
+    assert "(none" in r.stderr or "terminal" in r.stderr
+    print("  PASS: terminal DONE state refuses all events")
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+def test_status_json_schema(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    r = run("status", str(tmp), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert set(data) == {"feature", "mode", "state", "last_transition_at"}
+    assert data["mode"] == "spec-plan"
+    print("  PASS: status --json emits correct schema")
+
+
+def test_status_human_readable(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("status", str(tmp), check=True)
+    assert "|" in r.stdout
+    print("  PASS: status (human-readable) contains | separators")
+
+
+def test_status_absent_exits_nonzero(tmp: Path) -> None:
+    r = run("status", str(tmp))
+    assert r.returncode != 0
+    print("  PASS: status without engine-state.json exits non-zero")
+
+
+# ── init guards ───────────────────────────────────────────────────────────────
+
+def test_init_refuses_if_already_exists(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("init", str(tmp), "--mode", "doc")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: init refuses if engine-state.json already exists")
+
+
+# ── reset ─────────────────────────────────────────────────────────────────────
+
+def test_reset_idempotent(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("reset", str(tmp), check=True)
+    assert not (tmp / "engine-state.json").exists()
+    run("reset", str(tmp), check=True)  # second call also exits 0
+    print("  PASS: reset deletes file; second reset is idempotent")
+
+
+# ── file-path resolution ──────────────────────────────────────────────────────
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    doc = tmp / "0076-foo.md"
+    doc.write_text("# RFC\n", encoding="utf-8")
+    run("init", str(doc), "--mode", "doc", check=True)
+    s = state(tmp)
+    assert s["feature"] == "0076-foo", s["feature"]
+    assert s["mode"] == "doc"
+    # status should also work with file path
+    r = run("status", str(doc), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert data["feature"] == "0076-foo"
+    print("  PASS: file path resolves; feature = file stem")
+
+
+# ── guard scope boundary ──────────────────────────────────────────────────────
+
+def test_reviewers_clean_from_spec_plan_review_no_css_guard(tmp: Path) -> None:
+    """reviewers-clean from SPEC-PLAN-REVIEW must NOT invoke check-spec-status.py.
+
+    Verified by: no spec.md present in work-dir. If the CSS guard fired,
+    it would fail (spec.md absent). The transition must still succeed.
+    """
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    # No spec.md — CSS guard would fail if incorrectly wired here
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on SPEC-PLAN-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: reviewers-clean from SPEC-PLAN-REVIEW has no CSS guard (scope boundary)")
+
+
+def test_doc_reviewers_clean_no_css_guard(tmp: Path) -> None:
+    """doc mode reviewers-clean must NOT invoke check-spec-status.py."""
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on DOC-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    print("  PASS: doc reviewers-clean from DOC-REVIEW has no CSS guard")
+
+
+def test_css_guard_fires_on_code_review_reviewers_clean(tmp: Path) -> None:
+    """CODE-REVIEW+reviewers-clean must invoke check-spec-status.py guard.
+
+    Simulated by placing a spec.md with Status: Draft (not Shipped) in the
+    work-dir and driving the FSM to CODE-REVIEW using doc→code workaround.
+    Since we can't easily reach CODE-REVIEW without loop-cohort init+approve,
+    we verify guard wiring by checking that the engine calls CSS when the
+    guard key matches, by patching PATH with a fake CSS that exits non-zero.
+    """
+    # Write a stub CSS that always exits 1 to verify it's called
+    stub_css = tmp / "fake-css.py"
+    stub_css.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+
+    # Directly manipulate engine-state.json to simulate CODE-REVIEW state
+    import datetime
+    engine_state = {
+        "feature": tmp.name,
+        "mode": "code",
+        "state": "CODE-REVIEW",
+        "last_transition_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (tmp / "engine-state.json").write_text(
+        json.dumps(engine_state, indent=2), encoding="utf-8"
+    )
+
+    # Monkey-patch the CSS path by creating a wrapper that shadows the real CSS
+    # We do this by temporarily writing a fake check-spec-status.py that always fails
+    real_css = CSS
+    if not real_css.exists():
+        print("  SKIP: check-spec-status.py not present, cannot test guard wiring")
+        return
+
+    # Backup and replace
+    real_content = real_css.read_bytes()
+    real_css.write_text("#!/usr/bin/env python3\nimport sys; sys.exit(1)\n", encoding="utf-8")
+    try:
+        r = run("transition", str(tmp), "reviewers-clean")
+        assert r.returncode != 0, "expected guard refusal with failing CSS"
+        # State should NOT have advanced
+        assert state(tmp)["state"] == "CODE-REVIEW"
+        print("  PASS: CSS guard fires and refuses transition on CODE-REVIEW+reviewers-clean")
+    finally:
+        real_css.write_bytes(real_content)
+
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    tests = [
+        test_spec_plan_lifecycle_to_human_gate,
+        test_spec_plan_findings_loop_back,
+        test_doc_full_lifecycle,
+        test_doc_returned_loops_back,
+        test_invalid_transition_exits_nonzero_with_message,
+        test_terminal_state_has_no_valid_events,
+        test_status_json_schema,
+        test_status_human_readable,
+        test_status_absent_exits_nonzero,
+        test_init_refuses_if_already_exists,
+        test_reset_idempotent,
+        test_file_path_resolves_to_parent,
+        test_reviewers_clean_from_spec_plan_review_no_css_guard,
+        test_doc_reviewers_clean_no_css_guard,
+        test_css_guard_fires_on_code_review_reviewers_clean,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -117,11 +117,11 @@ around it:
   `sonar-project.properties` or a coverage config. Absent the declaration,
   light mode is unchanged (the pass stays dropped by default); the EXECUTE
   simplify pass still runs either way.
-- **No `loop-cohort` state machine** — light mode does not invoke
-  `loop-cohort` at all (no `init`, `approve-plan`, `check`, or
-  `review record`). The mechanical doc-drift check still runs:
-  `lint-spec-status.py` at the finish-time checklist, since it is a
-  no-subagent lint that costs ~nothing.
+- **No `loop-cohort` state machine and no `loop-engine`** — light mode
+  does not invoke either script (no `init`, `approve-plan`, `check`,
+  `review record`, or `loop-engine transition`). The mechanical doc-drift
+  check still runs: `lint-spec-status.py` at the finish-time checklist,
+  since it is a no-subagent lint that costs ~nothing.
 
 **Full mode (unchanged).** Reached whenever any risk trigger fires. It is
 the loop exactly as the rest of this document describes — `new-spec` with
@@ -130,6 +130,14 @@ iterated to `Clean`, the `quality-engineer` floor at the end-of-session
 checklist, and the iteration cap. **Everything below this section is full
 mode unless it says otherwise**; light mode reuses those steps verbatim
 except for the four trims named above.
+
+### Loop-engine phase tracking (full mode only)
+
+In full mode, `loop-engine` is the phase FSM — it owns `engine-state.json`
+(session-local, gitignored) and coordinates with `loop-cohort`. Light mode
+skips both. For mode selection, checkpoint events, guard wiring, and
+session-boundary rules, load
+[`references/loop-infrastructure.md`](references/loop-infrastructure.md).
 
 ### Step 0. Orientation — read workspace context
 
@@ -304,19 +312,12 @@ For anything beyond trivial, *think before you write code*. Concretely:
   ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. The `frontend-engineering` skill is owned by the `frontend-engineering` pack (not `core`); check if it appears in your available skills before loading it. If absent, record a named skip — `FE pre-flight: skipped (frontend-engineering pack absent)` — in the spec and proceed without the pre-flight. When the pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
-- **Initialize the loop's state file.** Run this skill's bundled
-  `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
-  the bundled `assets/state.json` template into place, sets `feature`
-  to the spec slug, and writes atomically. The file is gitignored —
-  session-scratch, not history. Then run `loop-cohort.py check
-  docs/specs/<feature> --phase plan`; on the first invocation it will
-  exit 1 with `plan not approved` — **this is the expected cue to run
-  the pre-EXECUTE reviewer**, not a stop-and-surface signal. Once the
-  reviewer is clean, run `loop-cohort.py approve-plan docs/specs/<feature>`
-  and re-run check; exit 0 unlocks EXECUTE. Every state mutation —
-  template copy, status flip, atomic write — is owned by the tool; do
-  not edit `state.json` by hand. Schema reference:
-  [`references/state-schema.md`](references/state-schema.md).
+- **Initialise phase tracking.** See [`references/loop-infrastructure.md`](references/loop-infrastructure.md) for the events to fire as you move through each phase. In full mode, fire
+  `loop-engine transition <work-dir> plan-approved` only **after** the
+  pre-EXECUTE reviewer is clean and a human has given G-plan sign-off.
+  The `plan-approved` guard calls `loop-cohort check --phase plan`,
+  which exits 0 only when `loop-cohort approve-plan` has been run —
+  the mechanical gate that enforces the human sign-off step.
 
 The output of this step is a written plan (with tests) you can return to.
 Don't keep it in your head — your context will turn over and you'll lose it.
@@ -482,32 +483,26 @@ discipline rather than restating it.
 
 #### Supervisor mode (wave-scheduled; sequential by default)
 
-Run `loop-cohort schedule docs/specs/<feature>` to build the plan's full
-`Depends on:` DAG and get the topological order. **Execute tasks in that
-order, single-agent, by default** — on every adapter. `schedule` fails
-loud on a dependency **cycle** and warns on a **forward-reference** (a dep
-authored later — it reorders so the dep runs first), so an ill-formed plan
-is caught here, not run out of order. This is the proven, zero-hazard path;
-its win is correct ordering, not speed. If tasks
-declare optional `Touches:` globs, `schedule` also prints
-`predicted-disjoint: yes|no|unknown` per wave — a **serialize-only screen**
-(a predicted overlap is a reason to keep the wave serial; it **never**
-greenlights parallel — the gate below stays authoritative).
+Build the plan's full `Depends on:` DAG to get the topological task order.
+**Execute tasks in that order, single-agent, by default** — on every adapter.
+An ill-formed plan (dependency cycle, forward-reference) is caught here, not
+run out of order. This is the proven, zero-hazard path; its win is correct
+ordering, not speed. After each wave completes, fire
+`loop-engine transition <work-dir> wave-complete`.
 
-**Parallel implementer fan-out is opt-in and gated — never automatic.** The
-short version: a wave fans out only when `loop-cohort dispatch-decision` clears
-it (categories auto-derived fail-closed, plus a clean `git merge-tree`
-disjointness check) **and** — with `state.json.auto_parallel` unset — a human
-opts in; absent that it runs sequentially, and a failed parallel wave
-**Surfaces and stops**, never auto-retries. When you do opt in, select a
-subagent matching `implementer` per the
-[parallel-dispatch discipline](#parallel-dispatch-discipline) above. The full
-gate semantics, the `auto_parallel` GO-approval behavior, the 7-step worktree
-procedure, and the single-agent fallback (no `implementer` subagent installed)
-are progressive-disclosure depth in
-[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded only
-when you take this path. Parallel *reviewer* (read) fan-out is a separate,
-always-safe path and is unaffected.
+**Parallel implementer fan-out is opt-in and gated — never automatic.** A
+wave fans out only when a disjointness check clears it (categories
+auto-derived fail-closed, plus a clean `git merge-tree` check) **and** — with
+`state.json.auto_parallel` unset — a human opts in; absent that it runs
+sequentially, and a failed parallel wave **Surfaces and stops**, never
+auto-retries. When you do opt in, select a subagent matching `implementer`
+per the [parallel-dispatch discipline](#parallel-dispatch-discipline) above.
+The full gate semantics, the `auto_parallel` GO-approval behavior, the
+7-step worktree procedure, and the single-agent fallback are progressive-
+disclosure depth in
+[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded
+only when you take this path. Parallel *reviewer* (read) fan-out is a
+separate, always-safe path and is unaffected.
 
 ### 3. GATES — mechanical verification
 
@@ -556,24 +551,13 @@ celebrating what you did. Findings come back grouped by severity
 (Blockers / Concerns / Nits), each with a one-sentence `Fix:`. Iterate
 until the agent returns `Clean — ready to commit.`
 
-**After each reviewer pass, record findings via the tool** before
-iterating. Write the reviewer's report to disk, then run:
-
-```
-loop-cohort.py review record docs/specs/<feature> --report <report-path>
-loop-cohort.py check docs/specs/<feature> --phase review
-```
-
-`review record` parses the report's findings (anchored on the
-adversarial-reviewer's documented `**N. <title>.** \`file:line\`. … Fix: …`
-format), computes `sha1("<file>|<line>|<title>")` per the canonical
-algorithm, rotates `finding_fingerprints` → `previous_finding_fingerprints`,
-sets the new list, increments `iteration_count`, and writes atomically —
-one transaction, no by-hand JSON. If the parser surfaces zero findings on
-a non-clean report it exits non-zero; pass `--fingerprint <hex>` repeated
-to override. `check --phase review` then enforces stasis detection: exit
-1 with `no progress` means the same findings landed two iterations in a
-row; stop and surface to a human rather than spinning a third.
+**After each reviewer pass, record findings via loop-engine** before
+iterating. Write the reviewer's report to disk, then fire the appropriate
+transition (see [`references/loop-infrastructure.md`](references/loop-infrastructure.md)): `findings-remain` with `--fingerprints`
+if blockers remain, or `reviewers-clean --report <path>` when clean. The
+underlying loop-cohort `review record` call rotates fingerprints, increments
+`iteration_count`, and enforces stasis detection — same findings two
+iterations in a row surfaces to a human rather than spinning a third.
 
 **Once recorded, drop the full report text from resident context.** The
 on-disk report plus the `state.json` fingerprints are the durable record —
@@ -820,12 +804,12 @@ The loop must terminate. Iteration without termination is how unattended
 loops (see below) burn money. Stop when **any** of these is true:
 
 1. **Gates green AND review clean** — the normal exit. Ship.
-2. **`scripts/loop-cohort.py check` exits non-zero.** The script is the
-   mechanical side of termination, reading from `state.json` (see
-   [`references/state-schema.md`](references/state-schema.md)). It
-   fires on iteration cap, token-budget cap, consecutive-error counter,
-   pending plan approval (PLAN phase only), and fingerprint stasis
-   (REVIEW phase only). The exit message tells you which.
+2. **`loop-engine transition` refuses a guard.** The guard is the mechanical
+   side of termination — it delegates to `loop-cohort check`, which reads
+   from `state.json` (see [`references/state-schema.md`](references/state-schema.md))
+   and fires on iteration cap, token-budget cap, consecutive-error counter,
+   pending plan approval (PLAN phase only), and fingerprint stasis (REVIEW
+   phase only). The guard's refusal message tells you which condition fired.
 3. **Diff is shrinking but findings aren't** — you're spot-fixing without
    addressing root cause. This is a judgment call, not in `loop-cohort`.
    Stop and rethink the approach (back to PLAN).

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -158,15 +158,6 @@ Before PLAN begins, orient to the current initiative and work queue:
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
-     - **Stale-queue check.** For each active initiative, for each entry in
-       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
-       path (bare string → as-is; inline object → `path` field; `slug` is
-       shaping-queue only), strip the `spec/` prefix, and read
-       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
-       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
-       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
-       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
-       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: "Use for implementing or resuming non-trivial repository changes: features, behavior-changing fixes, refactors, migrations, framework or dependency upgrades, schema/API changes, performance work, infrastructure/build edits, reversions, and specs under docs/specs/. Also trigger on bare continuation commands such as \"resume,\" \"continue,\" \"keep going,\" \"pick up where I left off,\" or \"let's get going\" when conversation or workspace context identifies active build work. Do not use for shaping, research, strategy, design-only work, status-only or review-only requests, or trivial cosmetic/local edits. Run the risk-selected light/full plan → execute → gates → adversarial review → fix/ship loop."
 ---
 
 # Skill: work-loop
@@ -25,21 +25,6 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
 Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
 Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
-
-## When this skill applies
-
-- Implementing a spec from `docs/specs/`.
-- Bug fixes that touch more than one file — including security patches and incident hot-fixes.
-- Refactors.
-- Migrations, framework or dependency upgrades, schema or API changes.
-- Performance work, or infrastructure / build-system changes beyond a single config tweak.
-- Reverting and re-doing a previous change.
-- Any task where you'd otherwise be tempted to "just go".
-
-For genuine one-line edits (typo, config tweak), skip the loop — the overhead
-isn't worth it. That triviality test decides *whether* to run the loop; once
-you're in it, **risk** (not file count) decides *which mode* runs — see
-[Modes: light and full](#modes-light-and-full) below.
 
 ## The loop
 

--- a/.claude/skills/work-loop/references/loop-infrastructure.md
+++ b/.claude/skills/work-loop/references/loop-infrastructure.md
@@ -1,0 +1,58 @@
+# Loop-engine: Mode selection and checkpoint reference
+
+`loop-engine` is the phase FSM for full-mode work-loop. It owns
+`engine-state.json` (session-local, gitignored) and coordinates with
+`loop-cohort` as guards and side effects. Light mode never invokes either
+script.
+
+## Mode selection
+
+Choose once at `loop-engine init`:
+
+| Work type | Mode | `loop-engine init --mode` |
+|-----------|------|--------------------------|
+| Multi-task spec implementation | Full delivery | `code` |
+| Spec/plan authoring only | Spec/plan drafting | `spec-plan` |
+| RFC, ADR, arch doc, any review-and-approve document | Document lifecycle | `doc` |
+| Light mode | — | skip — not used |
+
+## Checkpoint table
+
+Events to fire as you move through each phase.
+
+| State | Exit event | Human gate? | Guards that run | Modes |
+|-------|-----------|-------------|-----------------|-------|
+| `SPEC-PLAN-DRAFTING` | `spec-ready` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `reviewers-clean` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `findings-remain` | — | — | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-approved` | **G-plan** (human sign-off required first; `loop-cohort approve-plan` must have run) | `loop-cohort check --phase plan` | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-rejected` | — | — | code, spec-plan |
+| `CODE-IMPLEMENTATION` | `wave-complete` | — | `loop-cohort check --phase implement` | code |
+| `CODE-VERIFICATION` | `gates-clean` | — | — | code |
+| `CODE-VERIFICATION` | `gates-failed` | — | — | code |
+| `CODE-REVIEW` | `reviewers-clean --report <path>` | — | `check-spec-status.py` (**Status:** must be `Shipped`) | code |
+| `CODE-REVIEW` | `findings-remain --fingerprints <h>...` | — | `loop-cohort check --phase review` | code |
+| `CODE-HUMAN-GATE` | `done` | **G-pr** (human merges PR) | — | code |
+| `CODE-HUMAN-GATE` | `blocker-applied` | — | — | code |
+| `DOC-DRAFTING` | `doc-ready` | — | — | doc |
+| `DOC-REVIEW` | `reviewers-clean` | — | — | doc |
+| `DOC-REVIEW` | `findings-remain` | — | — | doc |
+| `DOC-HUMAN-GATE` | `doc-approved` | **human approves** | — | doc |
+| `DOC-HUMAN-GATE` | `doc-returned` | — | — | doc |
+
+## Human-wait states and session boundaries
+
+A session may end in any of: `SPEC-PLAN-HUMAN-GATE`, `CODE-HUMAN-GATE`,
+`DOC-HUMAN-GATE`, or `DOC-REVIEW` (when review is async). Before ending the
+session, ensure work product is committed on a named branch or open PR.
+
+When resuming: read `loop-engine status <work-dir>` first and wait for the
+human signal before firing the next event — do not fire autonomously from a
+human-wait state.
+
+## Valid **Status:** values in spec.md
+
+`Draft | Approved | Implementing | Shipped | Archived`
+
+The `check-spec-status.py` guard enforces `Shipped` before G-pr. The
+`lint-spec-status.py` CI linter enforces the full enum.

--- a/.claude/skills/work-loop/scripts/check-spec-status.py
+++ b/.claude/skills/work-loop/scripts/check-spec-status.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Guard: verifies **Status:** Shipped in spec.md for a given work-dir.
+
+Called by loop-engine at CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE
+(code mode only). Exits 0 only when Status is exactly "Shipped".
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_STATUS_RE = re.compile(r"^\*\*Status:\*\*\s*(\S+)", re.MULTILINE)
+
+
+def resolve_spec(arg: str) -> Path:
+    """Return path to spec.md. If arg is a file, use its parent dir."""
+    p = Path(arg)
+    if p.is_file():
+        return p.parent / "spec.md"
+    return p / "spec.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-spec-status",
+        description="Verify **Status:** Shipped in spec.md before the G-pr human gate.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR may be a directory (containing spec.md) or a file path\n"
+            "(the parent directory is used as the work-dir).\n\n"
+            "Exits 0 only when **Status:** is exactly 'Shipped'.\n"
+            "Valid status values: Draft | Approved | Implementing | Shipped | Archived"
+        ),
+    )
+    parser.add_argument(
+        "work_dir",
+        metavar="WORK_DIR",
+        help="directory with spec.md, or path to a doc file (resolves to parent dir)",
+    )
+    args = parser.parse_args(argv)
+
+    spec_path = resolve_spec(args.work_dir)
+    if not spec_path.exists():
+        print(f"error: spec.md not found: {spec_path}", file=sys.stderr)
+        return 1
+
+    text = spec_path.read_text(encoding="utf-8")
+    m = _STATUS_RE.search(text)
+    if not m:
+        print(
+            f"error: no bare **Status:** line found in {spec_path}\n"
+            "  Required format: **Status:** Shipped  (no leading dash or other prefix)",
+            file=sys.stderr,
+        )
+        return 1
+
+    status = m.group(1)
+    if status != "Shipped":
+        print(
+            f"error: spec status is '{status}', expected 'Shipped'\n"
+            "  Update spec.md to '**Status:** Shipped' before firing reviewers-clean from CODE-REVIEW.\n"
+            "  Valid values: Draft | Approved | Implementing | Shipped | Archived",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/work-loop/scripts/loop-engine.py
+++ b/.claude/skills/work-loop/scripts/loop-engine.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""loop-engine — phase FSM validator and loop-cohort coordinator.
+
+Tracks work-loop phase state in engine-state.json (session-local, gitignored).
+Calls loop-cohort as guards and side effects on transitions.
+
+Three modes:
+  code       Full delivery (spec/plan + implementation + review + merge).
+  spec-plan  Spec/plan authoring only (terminates at human plan approval).
+  doc        RFC, ADR, arch doc, or any review-and-approve document.
+
+WORK_DIR accepts either a directory path or a file path. When a file is
+passed, the parent directory is the work-dir and the file's stem is the
+feature name. engine-state.json always lives inside the resolved work-dir.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ── Transition tables ─────────────────────────────────────────────────────────
+
+INITIAL_STATE: dict[str, str] = {
+    "code": "SPEC-PLAN-DRAFTING",
+    "spec-plan": "SPEC-PLAN-DRAFTING",
+    "doc": "DOC-DRAFTING",
+}
+
+TRANSITIONS: dict[str, dict[tuple[str, str], str]] = {
+    "code": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "CODE-IMPLEMENTATION",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+        ("CODE-IMPLEMENTATION",  "wave-complete"):   "CODE-VERIFICATION",
+        ("CODE-VERIFICATION",    "gates-clean"):     "CODE-REVIEW",
+        ("CODE-VERIFICATION",    "gates-failed"):    "CODE-IMPLEMENTATION",
+        ("CODE-REVIEW",          "reviewers-clean"): "CODE-HUMAN-GATE",
+        ("CODE-REVIEW",          "findings-remain"): "CODE-IMPLEMENTATION",
+        ("CODE-HUMAN-GATE",      "done"):            "DONE",
+        ("CODE-HUMAN-GATE",      "blocker-applied"): "CODE-IMPLEMENTATION",
+    },
+    "spec-plan": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "DONE",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+    },
+    "doc": {
+        ("DOC-DRAFTING",   "doc-ready"):       "DOC-REVIEW",
+        ("DOC-REVIEW",     "reviewers-clean"): "DOC-HUMAN-GATE",
+        ("DOC-REVIEW",     "findings-remain"): "DOC-DRAFTING",
+        ("DOC-HUMAN-GATE", "doc-approved"):    "DONE",
+        ("DOC-HUMAN-GATE", "doc-returned"):    "DOC-DRAFTING",
+    },
+}
+
+# ── Script paths ──────────────────────────────────────────────────────────────
+
+_SCRIPTS = Path(__file__).resolve().parent
+
+
+def _lc(*args: str) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "loop-cohort.py"), *args]
+
+
+def _css(work_dir: Path) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "check-spec-status.py"), str(work_dir)]
+
+
+# ── Guards ────────────────────────────────────────────────────────────────────
+# Called before the state write. Non-zero exit refuses the transition.
+# Key: (mode, current_state, event) → list[callable(work_dir, **kw) → list[str]]
+
+def _guard_lc_check_plan(wd: Path, **_kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "plan")
+
+
+def _guard_lc_check_implement(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "implement")
+
+
+def _guard_lc_check_review(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "review")
+
+
+def _guard_css(wd: Path, **_kw: object) -> list[str]:
+    return _css(wd)
+
+
+GUARDS: dict[tuple[str, str, str], list] = {
+    ("code",      "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("spec-plan", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("code",      "CODE-IMPLEMENTATION",  "wave-complete"):  [_guard_lc_check_implement],
+    ("code",      "CODE-REVIEW",          "findings-remain"): [_guard_lc_check_review],
+    ("code",      "CODE-REVIEW",          "reviewers-clean"): [_guard_css],
+}
+
+# ── Side effects ──────────────────────────────────────────────────────────────
+# Called after the state write. Failure is logged but does not reverse the
+# transition. Builders return [] to skip silently.
+
+def _se_lc_schedule(wd: Path, **_kw: object) -> list[str]:
+    return _lc("schedule", str(wd))
+
+
+def _se_lc_review_record_clean(wd: Path, **kw: object) -> list[str]:
+    report = kw.get("report")
+    if not report:
+        print(
+            "warning: reviewers-clean from CODE-REVIEW without --report; "
+            "loop-cohort review record skipped (iteration_count not incremented)",
+            file=sys.stderr,
+        )
+        return []
+    return _lc("review", "record", str(wd), f"--report={report}")
+
+
+def _se_lc_review_record_findings(wd: Path, **kw: object) -> list[str]:
+    fps: list[str] = kw.get("fingerprints", [])
+    cmd = _lc("review", "record", str(wd))
+    for h in fps:
+        cmd.append(f"--fingerprint={h}")
+    return cmd
+
+
+SIDE_EFFECTS: dict[tuple[str, str, str], list] = {
+    ("code", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_se_lc_schedule],
+    ("code", "CODE-REVIEW", "reviewers-clean"):        [_se_lc_review_record_clean],
+    ("code", "CODE-REVIEW", "findings-remain"):        [_se_lc_review_record_findings],
+}
+
+# ── State I/O ─────────────────────────────────────────────────────────────────
+
+def resolve_work_dir(arg: str) -> tuple[Path, str]:
+    """Return (work_dir, feature_name). Accepts file or directory path."""
+    p = Path(arg).resolve()
+    if p.is_file():
+        return p.parent, p.stem
+    return p, p.name
+
+
+def _state_path(work_dir: Path) -> Path:
+    return work_dir / "engine-state.json"
+
+
+def _read_state(work_dir: Path) -> dict:
+    path = _state_path(work_dir)
+    if not path.exists():
+        print(
+            f"error: engine-state.json not found in {work_dir}\n"
+            "  Run 'loop-engine init <work-dir> --mode <mode>' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_state(work_dir: Path, state: dict) -> None:
+    state["last_transition_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = _state_path(work_dir)
+    fd, tmp = tempfile.mkstemp(dir=work_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ── Guard / side-effect runners ───────────────────────────────────────────────
+
+def _run_guard(cmd: list[str], label: str) -> bool:
+    if not cmd:
+        return True
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(f"guard refused [{label}]: {msg}", file=sys.stderr)
+        return False
+    return True
+
+
+def _run_side_effect(cmd: list[str], label: str) -> None:
+    if not cmd:
+        return
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(
+            f"side-effect failed [{label}] (transition is NOT reversed): {msg}",
+            file=sys.stderr,
+        )
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+def cmd_init(args: argparse.Namespace) -> int:
+    work_dir, feature = resolve_work_dir(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(work_dir)
+    if path.exists():
+        print(
+            f"error: engine-state.json already exists at {path}\n"
+            "  Run 'loop-engine reset <work-dir>' before re-initialising.",
+            file=sys.stderr,
+        )
+        return 1
+
+    state: dict = {
+        "feature": feature,
+        "mode": args.mode,
+        "state": INITIAL_STATE[args.mode],
+        "last_transition_at": "",
+    }
+    _write_state(work_dir, state)
+
+    # Side effect: initialise loop-cohort for code/spec-plan modes
+    if args.mode in ("code", "spec-plan"):
+        lc = _SCRIPTS / "loop-cohort.py"
+        if lc.exists():
+            _run_side_effect(_lc("init", str(work_dir)), "loop-cohort init")
+
+    return 0
+
+
+def cmd_transition(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    mode = state["mode"]
+    current = state["state"]
+    event = args.event
+    fingerprints: list[str] = args.fingerprints or []
+    report: str | None = args.report
+
+    table = TRANSITIONS.get(mode, {})
+    if (current, event) not in table:
+        valid = sorted(e for (s, e) in table if s == current)
+        print(
+            f"error: invalid transition in {mode!r} mode: {current!r} + {event!r}\n"
+            f"  valid events from {current!r}: {valid or '(none — terminal state)'}",
+            file=sys.stderr,
+        )
+        return 1
+
+    next_state = table[(current, event)]
+    ctx = dict(fingerprints=fingerprints, report=report)
+
+    # Guards — must all pass before state is written
+    guard_key = (mode, current, event)
+    for builder in GUARDS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        if not _run_guard(cmd, f"{mode}:{current}+{event}"):
+            return 1
+
+    # Write new state atomically
+    state["state"] = next_state
+    _write_state(work_dir, state)
+    print(f"{current} + {event} → {next_state}")
+
+    # Side effects — failure is logged, transition is not reversed
+    for builder in SIDE_EFFECTS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        _run_side_effect(cmd, f"{mode}:{current}+{event}")
+
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    if args.json:
+        print(json.dumps(state, indent=2))
+    else:
+        ts = state.get("last_transition_at", "unknown")
+        print(f"{state['feature']} | {state['mode']} | {state['state']} | last transition: {ts}")
+    return 0
+
+
+def cmd_reset(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    _state_path(work_dir).unlink(missing_ok=True)
+    return 0
+
+
+# ── Argument parser ───────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loop-engine",
+        description="Phase FSM validator and loop-cohort coordinator for the work-loop skill.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR accepts a directory path or a file path.\n"
+            "  directory → work-dir; basename → feature name\n"
+            "  file      → parent is work-dir; file stem → feature name\n\n"
+            "engine-state.json is always written inside the resolved work-dir.\n"
+            "It is session-local and gitignored — not committed to git.\n\n"
+            "Modes:  code (full delivery)  |  spec-plan (spec/plan authoring)\n"
+            "        doc (RFC / ADR / arch doc / any review-and-approve document)"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # init
+    p = sub.add_parser(
+        "init",
+        help="Initialise phase tracking for a work item.",
+        description="Creates engine-state.json in the work-dir. Fails if it already exists.",
+    )
+    p.add_argument(
+        "work_dir", metavar="WORK_DIR",
+        help="Directory containing spec.md, or path to a doc file.",
+    )
+    p.add_argument(
+        "--mode", required=True, choices=["code", "spec-plan", "doc"],
+        help=(
+            "Work mode: 'code' (full spec→implement→review→merge), "
+            "'spec-plan' (spec/plan authoring only), "
+            "'doc' (RFC/ADR/arch doc or any review-and-approve document)."
+        ),
+    )
+
+    # transition
+    p = sub.add_parser(
+        "transition",
+        help="Fire an event and advance the FSM.",
+        description=(
+            "Validates the event, runs applicable guards, writes the new state, "
+            "then runs side effects. Guards run before the write; a non-zero guard "
+            "refuses the transition. Side-effect failures are logged but do not "
+            "reverse the transition."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "event", metavar="EVENT",
+        help=(
+            "Event name. Examples: spec-ready, wave-complete, reviewers-clean, "
+            "findings-remain, plan-approved, done, doc-approved."
+        ),
+    )
+    p.add_argument(
+        "--fingerprints", nargs="+", metavar="HASH",
+        help=(
+            "Diff fingerprints (hex strings) for stasis detection. "
+            "Passed to 'loop-cohort review record --fingerprint' when recording findings."
+        ),
+    )
+    p.add_argument(
+        "--report", metavar="PATH",
+        help=(
+            "Path to the reviewer's markdown report. "
+            "Used for the 'loop-cohort review record --report' side effect "
+            "when firing reviewers-clean from CODE-REVIEW."
+        ),
+    )
+
+    # status
+    p = sub.add_parser(
+        "status",
+        help="Show current phase state.",
+        description="Reads engine-state.json and prints the current state.",
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "--json", action="store_true",
+        help="Emit the engine-state.json object to stdout (for machine consumers).",
+    )
+
+    # reset
+    p = sub.add_parser(
+        "reset",
+        help="Remove engine-state.json (idempotent).",
+        description=(
+            "Deletes engine-state.json from the work-dir. "
+            "Exits 0 even if the file is already absent."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    dispatch = {
+        "init": cmd_init,
+        "transition": cmd_transition,
+        "status": cmd_status,
+        "reset": cmd_reset,
+    }
+    return dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/work-loop/scripts/test-check-spec-status.py
+++ b/.claude/skills/work-loop/scripts/test-check-spec-status.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Self-test for check-spec-status.py.
+
+Runs the script as a subprocess against fixture directories in a tempdir —
+the same shape the loop-engine guard uses.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(arg: str | Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(arg)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_spec(tmp: Path, status: str) -> Path:
+    spec = tmp / "spec.md"
+    spec.write_text(
+        f"# Spec\n\n**Status:** {status}\n\n## Acceptance Criteria\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_exits_0_when_shipped(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp)
+    assert r.returncode == 0, f"expected 0, got {r.returncode}: {r.stderr}"
+    print("  PASS: exits 0 when Status is Shipped")
+
+
+def test_exits_nonzero_when_implementing(tmp: Path) -> None:
+    write_spec(tmp, "Implementing")
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when Status is Implementing")
+
+
+def test_exits_nonzero_when_draft(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Draft")
+
+
+def test_exits_nonzero_when_approved(tmp: Path) -> None:
+    write_spec(tmp, "Approved")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Approved")
+
+
+def test_exits_nonzero_when_archived(tmp: Path) -> None:
+    write_spec(tmp, "Archived")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Archived")
+
+
+def test_exits_nonzero_when_spec_absent(tmp: Path) -> None:
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when spec.md absent")
+
+
+def test_exits_nonzero_when_no_status_line(tmp: Path) -> None:
+    (tmp / "spec.md").write_text("# Spec\n\nNo status here.\n", encoding="utf-8")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when no **Status:** line")
+
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp / "spec.md")
+    assert r.returncode == 0, f"expected 0 when passing file path: {r.stderr}"
+    print("  PASS: file path resolves to parent dir")
+
+
+def test_file_path_fails_correctly(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp / "spec.md")
+    assert r.returncode != 0
+    print("  PASS: file path with non-Shipped status returns non-zero")
+
+
+def main() -> None:
+    tests = [
+        test_exits_0_when_shipped,
+        test_exits_nonzero_when_implementing,
+        test_exits_nonzero_when_draft,
+        test_exits_nonzero_when_approved,
+        test_exits_nonzero_when_archived,
+        test_exits_nonzero_when_spec_absent,
+        test_exits_nonzero_when_no_status_line,
+        test_file_path_resolves_to_parent,
+        test_file_path_fails_correctly,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/work-loop/scripts/test-loop-engine.py
+++ b/.claude/skills/work-loop/scripts/test-loop-engine.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Self-test for loop-engine.py.
+
+Runs the engine as a subprocess against fixture work-dirs in a tempdir.
+Covers: all three mode lifecycles, invalid transitions, guard refusal,
+side-effect scope boundary, file-path resolution, and idempotent reset.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "loop-engine.py"
+LC = Path(__file__).resolve().parent / "loop-cohort.py"
+CSS = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"loop-engine {list(args)} exited {result.returncode}:\n{result.stderr}"
+        )
+    return result
+
+
+def state(tmp: Path) -> dict:
+    return json.loads((tmp / "engine-state.json").read_text(encoding="utf-8"))
+
+
+# ── spec-plan lifecycle ───────────────────────────────────────────────────────
+
+def test_spec_plan_lifecycle_to_human_gate(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    s = state(tmp)
+    assert s["state"] == "SPEC-PLAN-DRAFTING"
+    assert s["mode"] == "spec-plan"
+    assert s["feature"] == tmp.name
+
+    run("transition", str(tmp), "spec-ready", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-REVIEW"
+
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: spec-plan reaches SPEC-PLAN-HUMAN-GATE")
+
+
+def test_spec_plan_findings_loop_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    run("transition", str(tmp), "findings-remain", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-DRAFTING"
+    print("  PASS: spec-plan findings-remain loops back to SPEC-PLAN-DRAFTING")
+
+
+# ── doc lifecycle ─────────────────────────────────────────────────────────────
+
+def test_doc_full_lifecycle(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    run("transition", str(tmp), "doc-ready", check=True)
+    assert state(tmp)["state"] == "DOC-REVIEW"
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    print("  PASS: doc lifecycle → DONE")
+
+
+def test_doc_returned_loops_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-returned", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: doc-returned loops back to DOC-DRAFTING")
+
+
+# ── invalid transitions ───────────────────────────────────────────────────────
+
+def test_invalid_transition_exits_nonzero_with_message(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("transition", str(tmp), "plan-approved")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    # State must not advance
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: invalid transition exits non-zero; state unchanged")
+
+
+def test_terminal_state_has_no_valid_events(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    r = run("transition", str(tmp), "doc-ready")
+    assert r.returncode != 0
+    assert "(none" in r.stderr or "terminal" in r.stderr
+    print("  PASS: terminal DONE state refuses all events")
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+def test_status_json_schema(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    r = run("status", str(tmp), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert set(data) == {"feature", "mode", "state", "last_transition_at"}
+    assert data["mode"] == "spec-plan"
+    print("  PASS: status --json emits correct schema")
+
+
+def test_status_human_readable(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("status", str(tmp), check=True)
+    assert "|" in r.stdout
+    print("  PASS: status (human-readable) contains | separators")
+
+
+def test_status_absent_exits_nonzero(tmp: Path) -> None:
+    r = run("status", str(tmp))
+    assert r.returncode != 0
+    print("  PASS: status without engine-state.json exits non-zero")
+
+
+# ── init guards ───────────────────────────────────────────────────────────────
+
+def test_init_refuses_if_already_exists(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("init", str(tmp), "--mode", "doc")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: init refuses if engine-state.json already exists")
+
+
+# ── reset ─────────────────────────────────────────────────────────────────────
+
+def test_reset_idempotent(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("reset", str(tmp), check=True)
+    assert not (tmp / "engine-state.json").exists()
+    run("reset", str(tmp), check=True)  # second call also exits 0
+    print("  PASS: reset deletes file; second reset is idempotent")
+
+
+# ── file-path resolution ──────────────────────────────────────────────────────
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    doc = tmp / "0076-foo.md"
+    doc.write_text("# RFC\n", encoding="utf-8")
+    run("init", str(doc), "--mode", "doc", check=True)
+    s = state(tmp)
+    assert s["feature"] == "0076-foo", s["feature"]
+    assert s["mode"] == "doc"
+    # status should also work with file path
+    r = run("status", str(doc), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert data["feature"] == "0076-foo"
+    print("  PASS: file path resolves; feature = file stem")
+
+
+# ── guard scope boundary ──────────────────────────────────────────────────────
+
+def test_reviewers_clean_from_spec_plan_review_no_css_guard(tmp: Path) -> None:
+    """reviewers-clean from SPEC-PLAN-REVIEW must NOT invoke check-spec-status.py.
+
+    Verified by: no spec.md present in work-dir. If the CSS guard fired,
+    it would fail (spec.md absent). The transition must still succeed.
+    """
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    # No spec.md — CSS guard would fail if incorrectly wired here
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on SPEC-PLAN-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: reviewers-clean from SPEC-PLAN-REVIEW has no CSS guard (scope boundary)")
+
+
+def test_doc_reviewers_clean_no_css_guard(tmp: Path) -> None:
+    """doc mode reviewers-clean must NOT invoke check-spec-status.py."""
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on DOC-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    print("  PASS: doc reviewers-clean from DOC-REVIEW has no CSS guard")
+
+
+def test_css_guard_fires_on_code_review_reviewers_clean(tmp: Path) -> None:
+    """CODE-REVIEW+reviewers-clean must invoke check-spec-status.py guard.
+
+    Simulated by placing a spec.md with Status: Draft (not Shipped) in the
+    work-dir and driving the FSM to CODE-REVIEW using doc→code workaround.
+    Since we can't easily reach CODE-REVIEW without loop-cohort init+approve,
+    we verify guard wiring by checking that the engine calls CSS when the
+    guard key matches, by patching PATH with a fake CSS that exits non-zero.
+    """
+    # Write a stub CSS that always exits 1 to verify it's called
+    stub_css = tmp / "fake-css.py"
+    stub_css.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+
+    # Directly manipulate engine-state.json to simulate CODE-REVIEW state
+    import datetime
+    engine_state = {
+        "feature": tmp.name,
+        "mode": "code",
+        "state": "CODE-REVIEW",
+        "last_transition_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (tmp / "engine-state.json").write_text(
+        json.dumps(engine_state, indent=2), encoding="utf-8"
+    )
+
+    # Monkey-patch the CSS path by creating a wrapper that shadows the real CSS
+    # We do this by temporarily writing a fake check-spec-status.py that always fails
+    real_css = CSS
+    if not real_css.exists():
+        print("  SKIP: check-spec-status.py not present, cannot test guard wiring")
+        return
+
+    # Backup and replace
+    real_content = real_css.read_bytes()
+    real_css.write_text("#!/usr/bin/env python3\nimport sys; sys.exit(1)\n", encoding="utf-8")
+    try:
+        r = run("transition", str(tmp), "reviewers-clean")
+        assert r.returncode != 0, "expected guard refusal with failing CSS"
+        # State should NOT have advanced
+        assert state(tmp)["state"] == "CODE-REVIEW"
+        print("  PASS: CSS guard fires and refuses transition on CODE-REVIEW+reviewers-clean")
+    finally:
+        real_css.write_bytes(real_content)
+
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    tests = [
+        test_spec_plan_lifecycle_to_human_gate,
+        test_spec_plan_findings_loop_back,
+        test_doc_full_lifecycle,
+        test_doc_returned_loops_back,
+        test_invalid_transition_exits_nonzero_with_message,
+        test_terminal_state_has_no_valid_events,
+        test_status_json_schema,
+        test_status_human_readable,
+        test_status_absent_exits_nonzero,
+        test_init_refuses_if_already_exists,
+        test_reset_idempotent,
+        test_file_path_resolves_to_parent,
+        test_reviewers_clean_from_spec_plan_review_no_css_guard,
+        test_doc_reviewers_clean_no_css_guard,
+        test_css_guard_fires_on_code_review_reviewers_clean,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ agentbundle-layout.toml
 
 # Work-loop session state — per-spec scratch, never committed.
 docs/specs/**/state.json
+docs/specs/**/engine-state.json
 
 # Supervisor-mode worktrees.
 .worktrees/

--- a/docs/architecture/loop-infrastructure.md
+++ b/docs/architecture/loop-infrastructure.md
@@ -547,6 +547,7 @@ packs/core/.apm/skills/work-loop/
 ├── assets/
 │   └── state.json                   # loop-cohort state template
 └── references/
+    ├── loop-infrastructure.md       # mode/checkpoint tables; agent-facing quick reference (new)
     └── state-schema.md              # state.json field reference
 ```
 

--- a/docs/architecture/loop-infrastructure.md
+++ b/docs/architecture/loop-infrastructure.md
@@ -1,0 +1,554 @@
+# Loop Infrastructure
+
+The work-loop skill's phase sequencing and task execution are implemented by
+two scripts. This document defines the boundary between them so future
+maintainers have a single reference rather than reconstructing it from code.
+
+**FSM** = Finite State Machine throughout this document.
+
+For the mode table (light vs. full, and which full-mode flows use loop-cohort),
+see [`packs/core/DESIGN.md §3`](../../packs/core/DESIGN.md). The
+code/spec-plan/doc coordination table is local to this document.
+
+---
+
+## Scripts
+
+### loop-cohort.py
+
+**Role:** Task execution state owner.
+
+**Source:** `packs/core/.apm/skills/work-loop/scripts/loop-cohort.py`
+**Projects to:** `.claude/skills/work-loop/scripts/loop-cohort.py` (via
+`make build-self`)
+
+**What it owns:**
+
+- `state.json` — the session-local state file written into each spec directory.
+  Schema: iteration count, max-iterations cap, token budget, plan-review status,
+  finding fingerprints, worktree list, and the `auto_parallel` flag. See
+  `references/state-schema.md` for the full field reference.
+- Task DAG and wave scheduling — reads the plan's `Depends on:` graph, produces
+  topological order, and enforces the parallel-write gate (`dispatch-decision`).
+- Worktree lifecycle — `worktree preflight/add/record/list/merge/cleanup` for
+  parallel implementer fan-out.
+- Finding fingerprints — `review record` parses reviewer output, computes
+  `sha1("<file>|<line>|<title>")` per finding, and rotates fingerprint lists
+  to enable stasis detection.
+- Iteration and budget gates — `check --phase {plan,implement,review}` reads
+  `state.json` and enforces: plan-approval status, iteration cap and token-budget
+  cap, fingerprint stasis, and consecutive-same-error threshold.
+
+**Verb surface:**
+```
+loop-cohort init <spec-dir>
+loop-cohort check <spec-dir> --phase {plan,implement,review}
+loop-cohort approve-plan <spec-dir>
+loop-cohort schedule <spec-dir>
+loop-cohort review record <spec-dir> (--report <path> | --fingerprint <hex>...)
+loop-cohort worktree preflight|add|record|list|merge|cleanup <spec-dir> [...]
+loop-cohort dispatch-decision --branch <b> [--branch <b>...] [--category <c>...] [--base <ref>]
+loop-cohort auto-parallel <spec-dir> [--off]
+```
+
+**Exit contract:** exit 0 on success; exit non-zero with a one-line reason on
+stderr on failure. `check --phase plan` exits 1 with "plan not approved" on
+first invocation — this is the expected cue to run the pre-EXECUTE reviewer,
+not an error.
+
+---
+
+### loop-engine.py
+
+**Role:** Phase FSM validator and loop-cohort coordinator.
+
+**Source:** `packs/core/.apm/skills/work-loop/scripts/loop-engine.py`
+**Projects to:** `.claude/skills/work-loop/scripts/loop-engine.py` (via
+`make build-self`)
+
+**What it owns:**
+
+- `engine-state.json` — the session-local phase record written into each spec
+  directory. Schema:
+  ```json
+  {
+    "feature": "<slug>",
+    "mode": "code | spec-plan | doc",
+    "state": "<phase name — see transition tables below>",
+    "last_transition_at": "<ISO-8601 UTC>"
+  }
+  ```
+- Phase FSM — per-mode transition tables. Each transition is:
+  `current_state + event → next_state`. Events not in the table for the current
+  mode × state pair are refused with a non-zero exit.
+- Transition validation — reads `engine-state.json`, validates the event, fires
+  any guards, writes the new state atomically, then fires any side effects.
+
+**Verb surface:**
+```
+loop-engine init <spec-dir> --mode {code|spec-plan|doc}
+loop-engine transition <spec-dir> <event> [--fingerprints <hash>...]
+loop-engine status <spec-dir> [--json]
+loop-engine reset <spec-dir>
+```
+
+`--help` on every command is the primary documentation; help strings are
+sufficient to use the tool without reading the source.
+
+**Exit contract:** exit 0 on success; exit non-zero with a one-line descriptive
+message on failure (invalid transition, guard refused, file absent, etc.).
+
+---
+
+## Phase FSM: Transition Tables
+
+Three modes. State names embed the phase so the current position is readable
+at a glance.
+
+Legal states per mode (only these values appear in `engine-state.json.state`):
+
+- **code:** `SPEC-PLAN-DRAFTING`, `SPEC-PLAN-REVIEW`, `SPEC-PLAN-HUMAN-GATE`,
+  `CODE-IMPLEMENTATION`, `CODE-VERIFICATION`, `CODE-REVIEW`, `CODE-HUMAN-GATE`,
+  `DONE`
+- **spec-plan:** `SPEC-PLAN-DRAFTING`, `SPEC-PLAN-REVIEW`, `SPEC-PLAN-HUMAN-GATE`,
+  `DONE`
+- **doc:** `DOC-DRAFTING`, `DOC-REVIEW`, `DOC-HUMAN-GATE`, `DONE`
+
+### code
+
+| Current state | Event | Next state |
+|---|---|---|
+| `SPEC-PLAN-DRAFTING` | `spec-ready` | `SPEC-PLAN-REVIEW` |
+| `SPEC-PLAN-REVIEW` | `reviewers-clean` | `SPEC-PLAN-HUMAN-GATE` |
+| `SPEC-PLAN-REVIEW` | `findings-remain` | `SPEC-PLAN-DRAFTING` |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-approved` | `CODE-IMPLEMENTATION` |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-rejected` | `SPEC-PLAN-DRAFTING` |
+| `CODE-IMPLEMENTATION` | `wave-complete` | `CODE-VERIFICATION` |
+| `CODE-VERIFICATION` | `gates-clean` | `CODE-REVIEW` |
+| `CODE-VERIFICATION` | `gates-failed` | `CODE-IMPLEMENTATION` |
+| `CODE-REVIEW` | `reviewers-clean` | `CODE-HUMAN-GATE` |
+| `CODE-REVIEW` | `findings-remain` | `CODE-IMPLEMENTATION` |
+| `CODE-HUMAN-GATE` | `done` | `DONE` |
+| `CODE-HUMAN-GATE` | `blocker-applied` | `CODE-IMPLEMENTATION` |
+
+### spec-plan
+
+spec-plan reuses the first three code-mode states and terminates at
+`SPEC-PLAN-HUMAN-GATE`. `reviewers-clean` here means the spec/plan passes cold
+adversarial review — not that implementation is complete. This review cycle
+bypasses loop-cohort (no `review record`; convergence bounded by LLM judgment).
+
+| Current state | Event | Next state |
+|---|---|---|
+| `SPEC-PLAN-DRAFTING` | `spec-ready` | `SPEC-PLAN-REVIEW` |
+| `SPEC-PLAN-REVIEW` | `reviewers-clean` | `SPEC-PLAN-HUMAN-GATE` |
+| `SPEC-PLAN-REVIEW` | `findings-remain` | `SPEC-PLAN-DRAFTING` |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-approved` | `DONE` |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-rejected` | `SPEC-PLAN-DRAFTING` |
+
+### doc
+
+`doc` mode covers all standalone documents: RFC, ADR, architecture doc, or any
+other review-and-approve document. The SKILL.md defines what the human does at
+`DOC-HUMAN-GATE` for each document type (RFC: named approver sign-off; ADR:
+decision record; arch doc: lead review). The engine does not distinguish between
+document types.
+
+| Current state | Event | Next state |
+|---|---|---|
+| `DOC-DRAFTING` | `doc-ready` | `DOC-REVIEW` |
+| `DOC-REVIEW` | `reviewers-clean` | `DOC-HUMAN-GATE` |
+| `DOC-REVIEW` | `findings-remain` | `DOC-DRAFTING` |
+| `DOC-HUMAN-GATE` | `doc-approved` | `DONE` |
+| `DOC-HUMAN-GATE` | `doc-returned` | `DOC-DRAFTING` |
+
+---
+
+## Interaction Model
+
+```
+  LLM agent
+      │
+      │ loop-engine transition <spec-dir> <event> [--fingerprints <hashes>]
+      ▼
+  loop-engine.py
+      │
+      ├── 1. validate event against FSM for current mode × state
+      │       (refuses with non-zero exit if invalid)
+      │
+      ├── 2. fire guards (if applicable):
+      │       calls guard scripts listed in Guards table below, in order
+      │       (refuses with non-zero exit if any guard exits non-zero)
+      │
+      ├── 3. write new state to engine-state.json (atomic: tempfile + os.replace)
+      │
+      └── 4. fire side effects (if applicable, in order listed in Side Effects table):
+              calls the exact loop-cohort verbs listed below
+              (side-effect failure → logged to stderr, not retried, does not
+               reverse the transition — see Recovery below)
+
+  loop-cohort.py
+      │
+      └── reads and writes state.json exclusively
+          loop-engine never reads or writes state.json
+```
+
+**Direction is one-way.** loop-engine calls loop-cohort verbs. loop-cohort
+never calls loop-engine. There is no shared mutable state between the two
+scripts (see `feature` note in State Ownership below).
+
+### `loop-engine init` setup call
+
+`loop-engine init <spec-dir> --mode <mode>` runs `loop-cohort init <spec-dir>`
+as its sole setup call (for code and spec-plan modes only), immediately after
+writing `engine-state.json`. This is not a transition side effect — it happens
+once, at session start, before any `transition` call.
+
+### Guards
+
+A guard must exit 0 before the transition is accepted. Non-zero exit refuses
+the transition. Guards fire in step 2, before the state write (step 3).
+
+| Event | Mode | Current state | Exact guard call | Purpose |
+|---|---|---|---|---|
+| `plan-approved` | code, spec-plan | `SPEC-PLAN-HUMAN-GATE` | `loop-cohort check <spec-dir> --phase plan` | Verifies `approve-plan` was called |
+| `wave-complete` | code | `CODE-IMPLEMENTATION` | `loop-cohort check <spec-dir> --phase implement` | Iteration cap + token budget + same-error + stasis backstop |
+| `findings-remain` | code | `CODE-REVIEW` | `loop-cohort check <spec-dir> --phase review` | Iteration cap + token budget + stasis + same-error |
+| `reviewers-clean` | code | `CODE-REVIEW` | `check-spec-status.py <spec-dir>` | `**Status:** Shipped` in working tree before PR goes to human |
+
+`check-spec-status.py` lives at
+`packs/core/.apm/skills/work-loop/scripts/check-spec-status.py` (owned by the
+work-loop skill, alongside `loop-engine.py` and `loop-cohort.py`). It is a new
+script separate from `lint-spec-status.py`. It verifies that the spec's
+`**Status:**` field reads `Shipped` in the current working tree. It fires at
+`CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE` — the point where the PR is
+about to be presented for human G-pr review. The optimistic in-PR update (spec
+updated to `Shipped` as part of the PR diff) is intentional: the PR is the
+proposal to ship, and the spec update is part of that proposal. If the PR is
+rejected, the update stays on the branch; main is unchanged.
+
+`lint-spec-status.py` is a CI-level drift linter (AC completeness, deferred
+items, `**Status:**` field). It is not a loop-engine guard; it runs in CI and
+on-demand for cleanup and reconciliation.
+
+`reviewers-clean` in `SPEC-PLAN-REVIEW` (spec-plan and code mode pre-plan
+phase) carries **no guard** — the spec isn't being shipped at that point, and a
+stasis check must not block a legitimate clean exit.
+
+**Stasis detection sequencing:** the `findings-remain` guard (in `CODE-REVIEW`)
+fires in step 2, before the `review record` side effect in step 4. It therefore
+sees fingerprints from the **preceding round**. Stasis is detected one round
+delayed: guard on round N+1 catches that round N fingerprints equal round N−1
+fingerprints.
+
+**`plan-approved` guard ordering:** `loop-cohort check --phase plan` exits 0
+only when `plan_review_status != "pending"`. The only verb that sets this is
+`loop-cohort approve-plan`. Therefore, `approve-plan` must be called **before**
+`loop-engine transition plan-approved` — it is the mechanical step of the G-plan
+human gate. The guard verifies it ran. This is not a side effect.
+
+### Side Effects (code and spec-plan modes only)
+
+Side effects are loop-cohort verb calls fired **after** `engine-state.json` is
+written, in the order listed.
+
+| Trigger | Mode | Current state | Exact side-effect calls (in order) |
+|---|---|---|---|
+| `plan-approved` | code only | `SPEC-PLAN-HUMAN-GATE` | `loop-cohort schedule <spec-dir>` |
+| `reviewers-clean` | code only | `CODE-REVIEW` | `loop-cohort review record <spec-dir> --report <report-path>` |
+| `findings-remain` | code only | `CODE-REVIEW` | `loop-cohort review record <spec-dir> --fingerprint <h1> --fingerprint <h2> ...` |
+
+`schedule` and `review record` fire for **code mode only**, and only in the
+code-phase review states. spec-plan's `SPEC-PLAN-REVIEW` cycle bypasses
+loop-cohort entirely — no `review record` is called; convergence is bounded by
+LLM judgment. The only loop-cohort calls for spec-plan are the setup call
+(`loop-cohort init` during `loop-engine init`) and the `plan-approved` guard.
+
+`review record` fires on **every** code-mode review round — both when reviewers
+find issues (`findings-remain`) and when they clear (`reviewers-clean`). This
+increments `iteration_count` and rotates fingerprints so iteration count is
+accurate even on the clean exit.
+
+**Flag conventions for `review record`:**
+- `reviewers-clean` → `--report <path>`: loop-cohort parses the "Clean — ready
+  to commit." marker and records an empty fingerprint set.
+- `findings-remain` → repeated `--fingerprint <hex>`: one flag per finding hash.
+  loop-engine accepts `--fingerprints <hash>...` (`nargs='+'`) and expands them
+  to repeated `--fingerprint <hex>` calls. loop-engine never stores fingerprints.
+
+**`review record` is not idempotent** — it unconditionally increments
+`iteration_count` and rotates fingerprint lists. Do not call it twice for the
+same review round. `loop-cohort schedule` is safe to re-run.
+
+### Worktree lifecycle (code mode)
+
+Worktree verbs (`worktree preflight/add/record/list/merge/cleanup`) are
+**not** loop-engine side effects. They are invoked directly by the LLM or
+supervisor during `CODE-IMPLEMENTATION`, between `wave-complete` transitions,
+as described in the SKILL.md's supervisor mode reference. Routing them through
+loop-engine would introduce git operations into the engine — a constraint
+violation (`loop-engine` has no git operations).
+
+### Side-effect failure
+
+If a side effect fails:
+- `engine-state.json` already reflects the new state (written in step 3).
+- The failure and its stderr are logged; the transition is not reversed.
+- **`schedule` failure:** re-run `loop-cohort schedule <spec-dir>` directly —
+  it is idempotent.
+- **`review record` failure:** do not re-run it (non-idempotent; double-run
+  corrupts iteration count and stasis state). Surface the failure to the human
+  for directed recovery.
+- **`loop-cohort init` failure** (during `loop-engine init`): `engine-state.json`
+  is written but `state.json` is not. Re-run `loop-cohort init <spec-dir>`
+  directly — the verb refuses if `state.json` already exists, so it is safe to
+  retry on a clean write failure.
+- **Unrecoverable inconsistency:** run `loop-engine reset <spec-dir>` (deletes
+  `engine-state.json`) and manually delete `state.json`, then re-run
+  `loop-engine init`. This restarts both scripts from `SPEC-PLAN-DRAFTING` and
+  requires re-running the full G-plan approval flow.
+
+---
+
+## Human Gate Invariants
+
+Loop-engine does not automate human gates. Two events require explicit human
+action before the LLM may fire them.
+
+### G-plan (plan approval)
+
+`plan-approved` fires only after all three pre-conditions hold:
+
+1. The adversarial reviewer returned clean on the spec/plan (`SPEC-PLAN-REVIEW`
+   reached `reviewers-clean`).
+2. The LLM called `loop-cohort approve-plan <spec-dir>` directly (sets
+   `plan_review_status`; the `plan-approved` guard validates this happened).
+3. Human G-plan sign-off received (the LLM surfaced the plan and waited).
+
+Loop-engine enforces only condition (2) via the guard. Conditions (1) and (3)
+are SKILL.md obligations, not mechanical checks.
+
+### G-pr (code review and merge)
+
+G-pr happens **at** `CODE-HUMAN-GATE`. The sequence is:
+
+```
+CODE-REVIEW → reviewers-clean → CODE-HUMAN-GATE
+              (check-spec-status        │
+               guard fires here)        │ LLM presents PR for human G-pr review
+                                        │
+                    ┌───────────────────┴──────────────────────┐
+                    │ Human approves and PR merges             │ Human returns blocker
+                    ▼                                           ▼
+                 done → DONE                    blocker-applied → CODE-IMPLEMENTATION
+               (loop complete)            (fix applied, gates re-run,
+                                            CODE-IMPLEMENTATION → CODE-VERIFICATION
+                                            → CODE-REVIEW → CODE-HUMAN-GATE)
+```
+
+`DONE` means the PR is merged. Firing `done` is the LLM's signal that the
+human approved at G-pr and the merge is complete. `blocker-applied` routes back
+to `CODE-IMPLEMENTATION` (not directly to `CODE-REVIEW`) so that gates re-run
+on the fix before re-review. This matches `DESIGN.md §2` (DECIDE phase: "applies
+fixes, re-runs gates").
+
+The `check-spec-status.py` guard at `CODE-REVIEW → CODE-HUMAN-GATE` ensures the
+spec already carries `**Status:** Shipped` as part of the PR diff before the
+human sees it. The optimistic update is intentional — see Guards section.
+
+For `doc` mode, human gates are enforced by the respective governance process
+(RFC approver sign-off, ADR record). Loop-engine tracks phase state only; it
+does not replace those governance steps.
+
+---
+
+## `reset` Scope
+
+`loop-engine reset <spec-dir>` deletes `engine-state.json` only. It does not
+touch `state.json`. After `reset`, the next `loop-engine init` starts from the
+mode's initial drafting state — `SPEC-PLAN-DRAFTING` for code and spec-plan
+(agent must re-run the full G-plan approval flow), `DOC-DRAFTING` for doc.
+`reset` cannot be used to skip or replay a human gate.
+
+---
+
+## State Ownership
+
+No field is shared as mutable state between the two files.
+
+| File | Owner | Fields |
+|---|---|---|
+| `state.json` | loop-cohort | `feature`, `iteration_count`, `max_iterations`, `token_budget_used_pct`, `token_budget_cap_pct`, `consecutive_same_error_count`, `consecutive_same_error_threshold`, `plan_review_status`, `auto_parallel`, `last_commit_sha`, `finding_fingerprints`, `previous_finding_fingerprints`, `worktrees` |
+| `engine-state.json` | loop-engine | `feature`, `mode`, `state`, `last_transition_at` |
+
+**`feature` appears in both files.** It is an immutable slug independently
+derived from the spec-dir basename at init time. It is never written by one
+script and read by the other; the two derivations always agree because they
+share the same input. This is the sole intentional name overlap and carries no
+shared mutable state.
+
+**`max_iterations` lives in `state.json` and is owned exclusively by
+loop-cohort.** loop-engine has no read or write access to `state.json` and
+therefore cannot read, modify, or override the iteration cap. When loop-cohort
+signals an iteration cap via a non-zero exit from `check --phase implement`,
+the LLM exercises judgment (request permission to continue or accept the cap)
+per the SKILL.md's termination guidance — not loop-engine.
+
+Both files are session-local and gitignored. They survive across session
+boundaries within the same working tree but are never committed.
+
+---
+
+## Coordination by Mode
+
+| Mode | loop-cohort used? | loop-cohort guards | spec-status guard | Side effects |
+|---|---|---|---|---|
+| `code` | Yes | `plan-approved` (SPEC-PLAN-HUMAN-GATE), `wave-complete` (CODE-IMPLEMENTATION), `findings-remain` (CODE-REVIEW) | `reviewers-clean` at CODE-REVIEW → `check-spec-status.py` | `plan-approved` → schedule; `reviewers-clean` + `findings-remain` at CODE-REVIEW → review record; `loop-cohort init` at engine init |
+| `spec-plan` | Yes (setup + plan gate only) | `plan-approved` (SPEC-PLAN-HUMAN-GATE) | — | none beyond setup and plan guard |
+| `doc` | No | — | — | — |
+
+`doc` mode bypasses loop-cohort entirely. The engine manages phase state only;
+no task DAG, no worktrees, no finding fingerprints.
+
+**Light mode** does not invoke loop-engine or loop-cohort. See
+`packs/core/DESIGN.md §3` for the light-vs-full mode selection rule.
+
+---
+
+## Convergence Loops
+
+### code mode
+
+The code-mode FSM has two back-edges. The pre-plan loop iterates the spec/plan
+until clean; the code loop iterates implementation until the diff is clean.
+
+**Pre-plan loop:**
+```
+SPEC-PLAN-DRAFTING
+    │  spec-ready
+    ▼
+SPEC-PLAN-REVIEW
+    ├── reviewers-clean ────────────────────► SPEC-PLAN-HUMAN-GATE
+    └── findings-remain                              │ plan-approved
+          │                                          ▼
+          ▼                                  CODE-IMPLEMENTATION
+    SPEC-PLAN-DRAFTING  ← fix and re-draft
+```
+
+Pre-plan convergence is bounded by LLM judgment (no loop-cohort iteration cap).
+
+**Code loop:**
+```
+CODE-IMPLEMENTATION
+    │  wave-complete (guard: check --phase implement)
+    ▼
+CODE-VERIFICATION
+    │  gates-clean
+    ▼
+CODE-REVIEW
+    ├── reviewers-clean (guard: check-spec-status.py) ──► CODE-HUMAN-GATE
+    │     (side effect: review record --report)               │
+    │                                                  done   │  blocker-applied
+    │                                                   ▼     │  ▼
+    │                                                  DONE   CODE-IMPLEMENTATION
+    └── findings-remain (guard: check --phase review)
+          (side effect: review record --fingerprints)
+          │
+          ▼
+    CODE-IMPLEMENTATION  ← back-edge; the cycle repeats
+```
+
+**Code-mode termination is bounded** by four independent mechanisms in `state.json`
+(owned by loop-cohort, invisible to loop-engine):
+
+1. **Iteration cap** — `check --phase implement` and `check --phase review`
+   both exit non-zero when `iteration_count >= max_iterations`. The LLM
+   exercises judgment: surface to the human with a concrete reason why another
+   round is warranted, or accept the cap and stop. `max_iterations` is a
+   judgment parameter, not a blind limit.
+2. **Stasis detection** — `check --phase review` exits non-zero when
+   `finding_fingerprints == previous_finding_fingerprints` and both are non-empty
+   (same non-empty finding set two rounds in a row, order-independent).
+3. **Token budget** — `check --phase implement` and `check --phase review` both
+   exit non-zero when `token_budget_used_pct >= token_budget_cap_pct`.
+4. **Consecutive-same-error** — both `check --phase implement` and
+   `check --phase review` exit non-zero when
+   `consecutive_same_error_count >= consecutive_same_error_threshold`.
+
+If any mechanism fires and the loop is not converged, the LLM surfaces to the
+human. **The loop cannot self-terminate beyond `DONE`** — the `done` event must
+be fired explicitly by the LLM, and G-pr (human merge) remains the terminal gate.
+
+### spec-plan and doc modes
+
+Both have the same back-edge structure (`findings-remain → *-DRAFTING`) without
+loop-cohort coordination. Convergence is bounded by LLM judgment. For `doc`
+mode, `DOC-HUMAN-GATE` also has a back-edge via `doc-returned → DOC-DRAFTING`
+for when a human approver sends the document back for revision after internal
+review is already clean.
+
+---
+
+## Human-Wait States and Session Boundaries
+
+Some states are **human-wait states** — the loop has committed its work product
+to git (as a PR, draft, or branch) and is waiting for a human response before
+the next event can be fired. A session can end in any of these states.
+
+| State | Mode | Work product committed | Waiting for |
+|---|---|---|---|
+| `SPEC-PLAN-HUMAN-GATE` | code, spec-plan | spec.md + plan.md on branch or PR | Human G-plan sign-off |
+| `CODE-HUMAN-GATE` | code | implementation PR | Human G-pr (merge or blocker) |
+| `DOC-HUMAN-GATE` | doc | document on branch or PR | Human doc approval |
+| `DOC-REVIEW` | doc | document committed to git | Human reviewer — **human-wait only when review is async/external**; when the LLM runs review itself, `DOC-REVIEW` is a normal LLM-reviewed state and `reviewers-clean`/`findings-remain` may fire autonomously |
+
+When a session ends in a human-wait state, the next session (same or different
+person) resumes by reading `loop-engine status <spec-dir>` and **waiting for
+the human response** rather than firing the next event autonomously. The rule:
+no event that exits a human-wait state may be fired without the human's
+explicit signal, regardless of session boundary.
+
+The committed work product must be on a named branch or open PR before the
+session ends in a human-wait state — a locally-only-committed artifact cannot
+be reviewed by others.
+
+---
+
+## Session Resumption
+
+`last_transition_at` in `engine-state.json` records the UTC timestamp of each
+transition. This enables:
+
+1. **Cross-session resumption** — an agent starting a new session reads
+   `loop-engine status <spec-dir>` to recover the current phase without
+   reconstructing it from chat history. If the state is a human-wait state
+   (see above), the agent waits for the human signal rather than proceeding.
+2. **Stale-worker detection** (INI-003) — a factory supervisor calls
+   `loop-engine status --json <spec-dir>` on each worker's spec directory and
+   uses `last_transition_at` to identify workers that have not advanced.
+
+The `--json` flag on `status` is the stable per-worker observation interface.
+The four-verb surface (`init`, `transition`, `status`, `reset`) and the
+`engine-state.json` schema are stable across INI-003 integration.
+
+---
+
+## Source Tree
+
+```
+packs/core/.apm/skills/work-loop/
+├── SKILL.md                         # skill entry point (LLM reads this)
+├── scripts/
+│   ├── loop-cohort.py               # task execution state owner
+│   ├── loop-engine.py               # phase FSM validator (new)
+│   ├── check-spec-status.py         # spec Status=Shipped gate (new)
+│   ├── lint-spec-status.py          # spec metadata drift linter (CI/on-demand)
+│   └── lint-traceability.py         # traceability matrix linter
+├── assets/
+│   └── state.json                   # loop-cohort state template
+└── references/
+    └── state-schema.md              # state.json field reference
+```
+
+`engine-state.json` has no separate template file — its four fields and allowed
+values are fully specified in this document and in `loop-engine --help` output.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -101,6 +101,10 @@ One file per non-trivial subsystem:
   (env / OS keyring / `~/.agentbundle/credentials.env`), the four
   brokers (`creds` / `env` / `cli` / `sso-cookie`), the
   credentialed-primitive contract, and the substring trap.
+- [`loop-infrastructure.md`](loop-infrastructure.md) — the work-loop's two
+  phase-tracking scripts (`loop-engine.py` and `loop-cohort.py`): what each
+  owns, the interaction model, FSM state tables for all three modes, guards
+  and side-effect wiring, and human-wait state / session-boundary rules.
 
 ## Packages
 

--- a/docs/product/shaping/ecosystem-overview.md
+++ b/docs/product/shaping/ecosystem-overview.md
@@ -54,7 +54,7 @@ The first harness tier. Adapters for headless CLI-invoked agents — the executi
 3. Captures output and maps it back to `workspace.toml` (progress, gate outcomes, completion)
 4. Handles harness-specific quirks: tool format, context window limits, output parsing, skill discovery path
 
-**Swarm capability:** INI-003 enables running a coordinated swarm of headless CLI agents in parallel — each agent reads from `[work].active` and takes an unblocked spec. `workspace.toml` is the collision-free coordination layer: each spec has exactly one active agent. A CI/CD supervisor (or a human) launches N agents; `workspace.toml` determines who works on what.
+**Swarm capability:** INI-003 enables running a coordinated swarm of headless CLI agents in parallel — each agent reads from `[work].active` and takes an unblocked spec. `workspace.toml` is the collision-free coordination layer: each spec has exactly one active agent. A CI/CD supervisor (or a human) launches N agents; `workspace.toml` determines who works on what. `loop-engine status --json` is the per-worker observation interface: factory workers call it against each spec's work-dir to observe the current FSM phase of a headless loop instance.
 
 **Why separate from INI-004:** CLI adapters are stateless (each invocation is fresh), portable (run locally, in CI/CD, or on any compute), and straightforward to write (thin wrapper around a CLI command). Cloud runtimes (INI-004) have stateful session management, proprietary execution environments, and more complex integration surfaces.
 

--- a/docs/specs/loop-engine-phase-1/plan.md
+++ b/docs/specs/loop-engine-phase-1/plan.md
@@ -1,0 +1,314 @@
+# Plan: loop-engine-phase-1
+
+- **Spec:** [`spec.md`](spec.md)
+- **Verification modes:** TDD (loop-engine.py, check-spec-status.py), goal-based (SKILL.md, build-check), visual QA (SKILL.md diff, manual lifecycle trace)
+
+## Declined temptations
+
+**Daemon or watch mode for loop-engine.** A persistent process that fires
+events automatically when build output changes sounds convenient for
+long-running EXECUTE waves. Declined for phase 1 because INI-003's polling
+model (`status --json` on a cron) already provides the supervisory observation
+loop it needs, and a daemon introduces process-management complexity (PID files,
+signal handling, restart semantics) that one-shot CLI avoids entirely.
+*Disposition: deferred.* A watch variant is the natural INI-003 or
+loop-engine phase 2 follow-on once the one-shot interface is battle-tested and
+the polling cost becomes measurable.
+
+**`--force` flag to bypass guards.** If a guard exits non-zero, a `--force`
+flag could let the LLM override it and advance the state anyway. Declined
+*permanently* — this would make the two human gates (`G-plan` and `G-pr`)
+bypassable by the loop itself, violating `DESIGN.md §13 invariant #1`
+("the loop cannot self-certify"). The guard contract must be unconditional; see
+AC-E3. The right recovery for a stuck guard is to surface the reason to the
+human and let the human direct the fix, not to silently bypass the gate.
+
+**Pack-detection logic in loop-engine.** Loop-engine could inspect the working
+directory (look for `pack.toml`, detect a SKILL.md) and auto-select `--mode`
+rather than requiring the caller to pass it. Declined *permanently* — the skill
+decides the mode from context; the engine is mode-agnostic by design. Embedding
+heuristic detection logic would couple loop-engine to the current pack layout and
+make it fragile against future structural changes. The SKILL.md's mode-selection
+table is the single source of truth for this mapping; the engine must not
+duplicate it.
+
+**Merging `check-spec-status.py` into `lint-spec-status.py`.** Both scripts
+inspect `**Status:**` in a spec file, so the logic is related. Declined for
+phase 1 to preserve the clean boundary between the two call sites:
+`check-spec-status.py` is an FSM guard called by loop-engine at a specific
+transition point; `lint-spec-status.py` is a CI-level drift linter that runs
+separately and also validates the status enum. Merging them would blur this
+boundary and make the FSM guard dependent on a CI tool, complicating both
+invocation paths. *Disposition: keep separate permanently.* If the overlap
+becomes maintenance pain, the right resolution is a shared helper imported by
+both — not a merge that conflates guard and linter semantics.
+
+**Retry logic in side-effect failure path.** When a side effect (e.g.,
+`loop-cohort review record`) fails, an automatic retry sounds like good
+defensive programming. Declined *permanently* — `review record` is
+non-idempotent (it increments `iteration_count` and rotates fingerprints);
+a silent retry would corrupt the loop state. The correct recovery is to log
+the failure to stderr, leave the FSM state written, and surface to the human.
+The human can direct a manual `loop-cohort review record` call with full
+context of what failed and why. Idempotent side effects like `schedule` are
+safe to re-run, but the policy cannot vary per side effect without adding
+fragile per-verb metadata — uniform "log and surface" is simpler and safer.
+
+**Committed state or git operations in loop-engine.** Loop-engine could commit
+`engine-state.json` after each transition, or push the branch before a
+human-gate wait state, as a convenience for session resumption. Declined
+*permanently* — `engine-state.json` is intentionally gitignored and
+session-local; no branch changes are the engine's responsibility. The session
+boundary is handled by the SKILL.md's human-wait state guidance (AC-E4), which
+tells the LLM to ensure work product is on a named branch or open PR before
+ending a session. Git operations belong to the LLM acting on the skill's
+guidance, not to a mechanical engine that runs between transitions. A future
+companion script could be git-aware, but loop-engine itself must not be.
+
+## Assumptions (verified before EXECUTE)
+
+1. `loop-cohort.py` exit-code contract is stable: exit 0 on success, non-zero with one-line stderr on failure.
+2. `check --phase {plan,implement,review}` are the only loop-cohort guard verbs needed; no new verbs required.
+3. `make build-self` regenerates the projected SKILL.md and plugin.json after source edits.
+4. `SKIP_SAST=1 make build-check` passes on the current branch before EXECUTE begins.
+5. `dispatch-decision` verb signature is `--branch <b> [--branch <b>...] [--category <c>...] [--base <ref>]` — verified from source before documenting in arch doc.
+
+## Tasks
+
+### Task 1 — `check-spec-status.py`
+
+**Depends on:** none
+
+**Tests:**
+```python
+# tests/test_check_spec_status.py
+def test_exits_0_when_status_shipped(tmp_path):
+    spec = tmp_path / "spec.md"
+    spec.write_text("**Status:** Shipped\n")
+    result = subprocess.run([sys.executable, SCRIPT, str(tmp_path)], capture_output=True)
+    assert result.returncode == 0
+
+def test_exits_nonzero_when_status_implementing(tmp_path):
+    spec = tmp_path / "spec.md"
+    spec.write_text("**Status:** Implementing\n")
+    result = subprocess.run([sys.executable, SCRIPT, str(tmp_path)], capture_output=True)
+    assert result.returncode != 0
+    assert result.stderr  # one-line message
+
+def test_exits_nonzero_when_spec_absent(tmp_path):
+    result = subprocess.run([sys.executable, SCRIPT, str(tmp_path)], capture_output=True)
+    assert result.returncode != 0
+
+def test_exits_nonzero_when_status_line_absent(tmp_path):
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\nNo status line here.\n")
+    result = subprocess.run([sys.executable, SCRIPT, str(tmp_path)], capture_output=True)
+    assert result.returncode != 0
+```
+
+**Approach:** Parse `spec.md` line by line; match `r'^\*\*Status:\*\*\s*(\S+)'`; exit 0 iff match group is `Shipped`. Pure stdlib. Single positional `work_dir` argument (file or directory; resolves per AC-A3) with `--help`.
+
+**Done when:** `python3 tests/test_check_spec_status.py` passes; `python3 packs/core/.apm/skills/work-loop/scripts/check-spec-status.py --help` prints usage.
+
+---
+
+### Task 2 — `loop-engine.py` core FSM
+
+**Depends on:** none (can build in parallel with Task 1)
+
+**Tests:**
+```python
+# tests/test_loop_engine_integration.py — stubs for Task 2
+
+def test_init_creates_engine_state_json(tmp_spec):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    state = json.loads((tmp_spec / "engine-state.json").read_text())
+    assert state["state"] == "SPEC-PLAN-DRAFTING"
+    assert state["mode"] == "spec-plan"
+
+def test_init_refuses_if_already_exists(tmp_spec):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    result = run_engine("init", str(tmp_spec), "--mode", "spec-plan", check=False)
+    assert result.returncode != 0
+
+def test_invalid_transition_exits_nonzero(tmp_spec):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    result = run_engine("transition", str(tmp_spec), "plan-approved", check=False)
+    assert result.returncode != 0
+    assert result.stderr
+
+def test_spec_plan_full_lifecycle(tmp_spec, mock_loop_cohort_ok):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    run_engine("transition", str(tmp_spec), "spec-ready")
+    run_engine("transition", str(tmp_spec), "reviewers-clean")
+    run_engine("transition", str(tmp_spec), "plan-approved")
+    state = json.loads((tmp_spec / "engine-state.json").read_text())
+    assert state["state"] == "DONE"
+
+def test_doc_full_lifecycle(tmp_spec):
+    run_engine("init", str(tmp_spec), "--mode", "doc")
+    run_engine("transition", str(tmp_spec), "doc-ready")
+    run_engine("transition", str(tmp_spec), "reviewers-clean")
+    run_engine("transition", str(tmp_spec), "doc-approved")
+    state = json.loads((tmp_spec / "engine-state.json").read_text())
+    assert state["state"] == "DONE"
+
+def test_status_json(tmp_spec, mock_loop_cohort_ok):
+    run_engine("init", str(tmp_spec), "--mode", "doc")
+    result = run_engine("status", str(tmp_spec), "--json")
+    data = json.loads(result.stdout)
+    assert {"feature", "mode", "state", "last_transition_at"} == set(data)
+
+def test_reset_idempotent(tmp_spec):
+    run_engine("init", str(tmp_spec), "--mode", "doc")
+    run_engine("reset", str(tmp_spec))
+    assert not (tmp_spec / "engine-state.json").exists()
+    run_engine("reset", str(tmp_spec))  # second reset exits 0
+```
+
+**Approach:**
+- `argparse` with subcommands `init`, `transition`, `status`, `reset`.
+- FSM defined as a dict: `TRANSITIONS[mode][(current_state, event)] = next_state`.
+- `init`: writes `engine-state.json` atomically via `tempfile.NamedTemporaryFile` + `os.replace`. Runs `loop-cohort init` for code/spec-plan modes.
+- `transition`: read state → validate → run guards (subprocess) → write new state → run side effects (subprocess).
+- `status`: read and emit; `--json` emits raw JSON.
+- `reset`: `Path.unlink(missing_ok=True)`.
+
+**Done when:** Task 2 stubs pass (red); Task 3 wires guards/side-effects (green).
+
+---
+
+### Task 3 — Guards and side effects wiring
+
+**Depends on:** Task 2
+
+**Tests:**
+```python
+def test_guard_refusal_blocks_transition(tmp_spec, mock_loop_cohort_fail):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    run_engine("transition", str(tmp_spec), "spec-ready")
+    run_engine("transition", str(tmp_spec), "reviewers-clean")
+    # plan-approved guard calls loop-cohort check --phase plan → fails
+    result = run_engine("transition", str(tmp_spec), "plan-approved", check=False)
+    assert result.returncode != 0
+    state = json.loads((tmp_spec / "engine-state.json").read_text())
+    assert state["state"] == "SPEC-PLAN-HUMAN-GATE"  # not advanced
+
+def test_check_spec_status_guard_blocks_code_review_clean(tmp_spec, mock_loop_cohort_ok, mock_check_spec_status_fail):
+    # drive to CODE-REVIEW state then try reviewers-clean
+    ...
+    result = run_engine("transition", str(tmp_spec), "reviewers-clean", check=False)
+    assert result.returncode != 0
+
+def test_plan_approved_triggers_schedule_side_effect(tmp_spec, mock_loop_cohort_ok, captured_calls):
+    # drive code mode to SPEC-PLAN-HUMAN-GATE, fire plan-approved
+    ...
+    assert any("schedule" in c for c in captured_calls)
+
+def test_reviewers_clean_from_spec_plan_review_does_not_trigger_review_record(tmp_spec, mock_loop_cohort_ok, captured_calls):
+    run_engine("init", str(tmp_spec), "--mode", "spec-plan")
+    run_engine("transition", str(tmp_spec), "spec-ready")
+    run_engine("transition", str(tmp_spec), "reviewers-clean")
+    assert not any("review record" in c for c in captured_calls)
+
+def test_reviewers_clean_from_code_review_triggers_review_record(tmp_spec, ...):
+    # drive code mode to CODE-REVIEW, fire reviewers-clean
+    ...
+    assert any("review record" in c for c in captured_calls)
+```
+
+**Approach:**
+- Guard table: `GUARDS[(mode, current_state, event)] = [guard_cmd_fn, ...]`.
+- Side-effect table: `SIDE_EFFECTS[(mode, current_state, event)] = [effect_cmd_fn, ...]`.
+- Subprocess invocations pass `check=False`; non-zero from guard → engine exits non-zero (transition rolled back — state not written); non-zero from side effect → logged to stderr, transition not reversed.
+- `--fingerprints` nargs='+' on `transition`; expands to repeated `--fingerprint` for loop-cohort.
+
+**Done when:** All Task 3 stubs green; `SKIP_SAST=1 make build-check` passes.
+
+---
+
+### Task 4 — SKILL.md reduction
+
+**Depends on:** Tasks 1–3 (loop-engine.py must exist before removing choreography prose)
+
+**Tests:** (goal-based)
+- `make build-self` exits 0.
+- `python tools/lint-agent-artifacts.py` exits 0.
+- Risk-triggers grep-equality: `diff <(grep -A100 'risk-triggers:start' AGENTS.md | grep -B100 'risk-triggers:end') <(grep -A100 'risk-triggers:start' packs/core/.apm/skills/work-loop/SKILL.md | grep -B100 'risk-triggers:end')` exits 0.
+- SKILL.md line count decreases vs origin/main (mode/checkpoint tables moved to `references/loop-infrastructure.md`; net ~16 lines; choreography prose removed per AC-H2).
+
+**Approach:**
+- Remove: "Initialize the loop's state file" block (PLAN section), `loop-cohort schedule`/`dispatch-decision` supervisor blocks (EXECUTE section), "record findings via the tool" block (REVIEW section), condition #2 `loop-cohort.py check` block (Termination section).
+- Add: mode-selection table (work type → `loop-engine init --mode`; light mode row = "skip"), checkpoint table (state | event | human gate? | guards | modes), pointer to `docs/architecture/loop-infrastructure.md`.
+- Extend light-mode note to include "and no `loop-engine`".
+- Preserve byte-identical risk-triggers sentinel block.
+
+**Done when:** Goal-based checks pass; visual diff confirms judgment content intact.
+
+---
+
+### Task 5 — `packs/core/pack.toml` version bump + `make build-self`
+
+**Depends on:** Task 4
+
+**Tests:** (goal-based)
+- `grep version packs/core/pack.toml` shows `0.15.8`.
+- `make build-self` exits 0.
+- `git diff .claude/skills/work-loop/scripts/loop-engine.py` shows projected copy.
+
+**Approach:** Bump `version` in `packs/core/pack.toml` from `0.15.7` to `0.15.8`. Run `make build-self`. Verify projected copies of `loop-engine.py` and `check-spec-status.py` appear under `.claude/skills/work-loop/scripts/`.
+
+**Done when:** `make build-self` passes; both new scripts appear in projection.
+
+---
+
+### Task 6 — Architecture doc pointer + gitignore + ecosystem
+
+**Depends on:** none (parallel with Tasks 1–2)
+
+**Tests:** (goal-based)
+- `grep loop-infrastructure docs/architecture/overview.md` finds the new bullet.
+- `git check-ignore -v docs/specs/dummy/engine-state.json` exits 0.
+- `grep 'loop-engine status' docs/product/shaping/ecosystem-overview.md` finds the sentence.
+
+**Approach:**
+- Add bullet to `docs/architecture/overview.md` Subsystems section.
+- Add `docs/specs/**/engine-state.json` to `.gitignore` if not already covered.
+- Add one sentence to INI-003 section of `docs/product/shaping/ecosystem-overview.md`.
+- Add `"spec/loop-engine-phase-1"` to `["ini-002".work].queue` in `workspace.toml` (after G-plan approval).
+
+**Done when:** All three goal-based checks pass.
+
+---
+
+### Task 7 — Manual QA trace (verify step)
+
+**Depends on:** Tasks 1–5
+
+**Tests:** (visual / manual QA)
+- `loop-engine --help` and all subcommand `--help` print usage without error.
+- Run complete `spec-plan` lifecycle on a scratch spec directory:
+  1. `mkdir /tmp/scratch-spec && echo "**Status:** Draft" > /tmp/scratch-spec/spec.md`
+  2. `loop-engine init /tmp/scratch-spec --mode spec-plan`
+  3. `cat /tmp/scratch-spec/engine-state.json` → state: SPEC-PLAN-DRAFTING
+  4. `loop-engine transition /tmp/scratch-spec spec-ready`
+  5. `loop-engine transition /tmp/scratch-spec reviewers-clean`
+  6. `loop-cohort approve-plan /tmp/scratch-spec`
+  7. `loop-engine transition /tmp/scratch-spec plan-approved`
+  8. `loop-engine status /tmp/scratch-spec --json` → emits valid JSON, state: DONE
+- `check-spec-status.py /tmp/scratch-spec` → exits non-zero (Status is Draft, not Shipped).
+- `sed -i '' 's/Status: Draft/Status: Shipped/' /tmp/scratch-spec/spec.md && check-spec-status.py /tmp/scratch-spec` → exits 0.
+
+**Done when:** All trace steps produce the documented output.
+
+## Verification summary
+
+| Deliverable | Mode | Gate |
+|---|---|---|
+| `loop-engine.py` | TDD | `pytest tests/test_loop_engine_integration.py` |
+| `check-spec-status.py` | TDD | `pytest tests/test_check_spec_status.py` |
+| Guards + side effects | TDD | included in loop-engine integration tests |
+| `SKILL.md` reduction | goal-based | `make build-self`, lint-agent-artifacts, risk-triggers grep |
+| `pack.toml` bump | goal-based | `make build-self`, version grep |
+| arch doc pointer, gitignore, ecosystem | goal-based | targeted greps |
+| End-to-end | manual QA | Task 7 trace |

--- a/docs/specs/loop-engine-phase-1/spec.md
+++ b/docs/specs/loop-engine-phase-1/spec.md
@@ -1,0 +1,469 @@
+# Spec: loop-engine-phase-1
+
+**Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** `packs/core/DESIGN.md` (§3, §4, §13), ADR-0014, RFC-0025
+- **Brief:** none (intent prompt provided; converted to spec directly)
+- **Contract:** none
+- **Shape:** two new scripts + skill prose reduction + architecture doc
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+**Problem:** The work-loop skill embeds its full phase-transition choreography —
+which loop-cohort verbs to call, in what order, at what events — as prose inside
+the SKILL.md. This prose is unenforced: an agent can skip transitions, double-fire
+events, or omit loop-cohort side effects with no mechanical consequence. It also
+conflates mechanical procedure (fire this verb on this event) with LLM judgment
+(select reviewers, route DECIDE, apply risk triggers) — making the skill harder
+to read and giving no persistent record of current phase for session resumption.
+
+**User:** A full-mode work-loop agent implementing a multi-task spec, needing
+deterministic phase sequencing, reliable loop-cohort coordination, and a
+persistent phase record for cross-session resumption.
+
+**Success:** (1) `loop-engine.py` enforces the phase FSM and calls loop-cohort as
+guard/side-effect so correct transitions cannot skip a phase; (2) SKILL.md is
+meaningfully shorter with all loop-cohort choreography prose removed, replaced by
+a mode-selection table and a human-gate-aware checkpoint table; (3)
+`docs/architecture/loop-infrastructure.md` gives future maintainers the definitive
+boundary between the two scripts and passes a design-reviewer gate before the plan
+is finalised.
+
+## Deliverables
+
+Four co-dependent artifacts that must ship in one PR:
+
+1. **`loop-engine.py`** — phase FSM validator and loop-cohort coordinator.
+   Lives at `packs/core/.apm/skills/work-loop/scripts/loop-engine.py` alongside
+   `loop-cohort.py`. Pure Python stdlib only.
+2. **`check-spec-status.py`** — spec-status gate script. Verifies `**Status:**
+   Shipped` in the current working tree for a given spec directory. Lives at
+   `packs/core/.apm/skills/work-loop/scripts/check-spec-status.py`. Pure Python
+   stdlib only.
+3. **SKILL.md reduction** — remove loop-cohort choreography prose; add terse 3-sentence
+   pointer to `references/loop-infrastructure.md` (pack-internal; mode and checkpoint
+   tables live there, not inline in SKILL.md). Edit source at
+   `packs/core/.apm/skills/work-loop/SKILL.md`, then `make build-self`.
+4. **Architecture doc** — `docs/architecture/loop-infrastructure.md`, with a
+   pointer added to the Subsystems section of `docs/architecture/overview.md`.
+
+## Acceptance Criteria
+
+### A — loop-engine.py: Command surface
+
+- [x] **AC-A1.** Script lives at `packs/core/.apm/skills/work-loop/scripts/loop-engine.py`.
+  Pure Python stdlib only. No external dependencies.
+
+- [x] **AC-A2.** `loop-engine --help` and `loop-engine <command> --help` are
+  sufficient to use the tool without reading the source. Every argument has a
+  help string that explains what to pass.
+
+- [x] **AC-A3.** All commands accept `<work-dir>` as either a **directory path**
+  or a **file path**. When a file path is given (e.g., `docs/rfc/0076.md`), the
+  engine resolves the parent directory as the work-dir and uses the file's stem
+  as the `feature` name. When a directory is given, the directory is the work-dir
+  and its basename is the `feature` name. `engine-state.json` always lives at
+  `{resolved-work-dir}/engine-state.json`.
+
+  Practical limit: one `engine-state.json` per directory. If two docs in the same
+  directory need concurrent loop tracking, put each in its own subdirectory instead.
+
+- [x] **AC-A4.** `loop-engine init <work-dir> --mode {code|spec-plan|doc}`
+  creates `engine-state.json` atomically (tempfile + `os.replace`). Schema:
+  ```json
+  {
+    "feature": "<basename of work-dir, or stem of doc file>",
+    "mode": "code",
+    "state": "SPEC-PLAN-DRAFTING",
+    "last_transition_at": "<ISO-8601 UTC>"
+  }
+  ```
+  If `engine-state.json` already exists, exits non-zero with a descriptive
+  message rather than silently overwriting. (The skill calls `reset` before
+  re-init when restarting.)
+
+- [x] **AC-A5.** `loop-engine transition <work-dir> <event> [--fingerprints <hash>...]`
+  validates the event against the transition table for the active mode (read from
+  `engine-state.json`), fires any applicable guards in order, fires any applicable
+  side effects on success, then writes the new state atomically. Exits non-zero
+  with a descriptive one-line message if: (a) the event is invalid from the
+  current state, or (b) any guard exits non-zero.
+
+- [x] **AC-A6.** `loop-engine status <work-dir> [--json]` reads
+  `engine-state.json`. With `--json`: emits the schema object to stdout, exits 0.
+  Without `--json`: emits a human-readable one-line summary (`<feature> | <mode>
+  | <state> | last transition: <relative time or timestamp>`), exits 0. Exits
+  non-zero if `engine-state.json` is absent.
+
+- [x] **AC-A7.** `loop-engine reset <work-dir>` deletes `engine-state.json`.
+  Idempotent: exits 0 even if the file is already absent.
+
+### B — loop-engine.py: Transition tables
+
+State names embed the current phase so the position is readable at a glance.
+
+- [x] **AC-B1.** Transition table for `code` mode:
+  ```
+  SPEC-PLAN-DRAFTING    + spec-ready       → SPEC-PLAN-REVIEW
+  SPEC-PLAN-REVIEW      + reviewers-clean  → SPEC-PLAN-HUMAN-GATE
+  SPEC-PLAN-REVIEW      + findings-remain  → SPEC-PLAN-DRAFTING
+  SPEC-PLAN-HUMAN-GATE  + plan-approved    → CODE-IMPLEMENTATION
+  SPEC-PLAN-HUMAN-GATE  + plan-rejected    → SPEC-PLAN-DRAFTING
+  CODE-IMPLEMENTATION   + wave-complete    → CODE-VERIFICATION
+  CODE-VERIFICATION     + gates-clean      → CODE-REVIEW
+  CODE-VERIFICATION     + gates-failed     → CODE-IMPLEMENTATION
+  CODE-REVIEW           + reviewers-clean  → CODE-HUMAN-GATE
+  CODE-REVIEW           + findings-remain  → CODE-IMPLEMENTATION
+  CODE-HUMAN-GATE       + done             → DONE
+  CODE-HUMAN-GATE       + blocker-applied  → CODE-IMPLEMENTATION
+  ```
+
+- [x] **AC-B2.** Transition table for `spec-plan` mode (reuses first three code
+  states; terminates at `SPEC-PLAN-HUMAN-GATE`):
+  ```
+  SPEC-PLAN-DRAFTING    + spec-ready       → SPEC-PLAN-REVIEW
+  SPEC-PLAN-REVIEW      + reviewers-clean  → SPEC-PLAN-HUMAN-GATE
+  SPEC-PLAN-REVIEW      + findings-remain  → SPEC-PLAN-DRAFTING
+  SPEC-PLAN-HUMAN-GATE  + plan-approved    → DONE
+  SPEC-PLAN-HUMAN-GATE  + plan-rejected    → SPEC-PLAN-DRAFTING
+  ```
+  `reviewers-clean` here means the spec/plan passes cold adversarial review —
+  not that implementation is complete. This review cycle bypasses loop-cohort
+  (no `review record` side effects; convergence bounded by LLM judgment).
+
+- [x] **AC-B3.** Transition table for `doc` mode (covers RFC, ADR, architecture
+  docs, and any other review-and-approve document):
+  ```
+  DOC-DRAFTING    + doc-ready       → DOC-REVIEW
+  DOC-REVIEW      + reviewers-clean → DOC-HUMAN-GATE
+  DOC-REVIEW      + findings-remain → DOC-DRAFTING
+  DOC-HUMAN-GATE  + doc-approved    → DONE
+  DOC-HUMAN-GATE  + doc-returned    → DOC-DRAFTING
+  ```
+  The SKILL.md defines what the human does at `DOC-HUMAN-GATE` for each document
+  type. The engine does not distinguish between document types.
+
+### C — loop-engine.py: Loop-cohort coordination and guards
+
+Coordination with loop-cohort applies to `code` and `spec-plan` modes only.
+`doc` mode bypasses loop-cohort entirely.
+
+- [x] **AC-C1.** **Guards** — called before the named event is accepted;
+  non-zero exit refuses the transition. Guards fire before the state write.
+
+  *loop-cohort guards (code and spec-plan modes):*
+
+  | Event | Current state | Guard | Mode |
+  |-------|--------------|-------|------|
+  | `plan-approved` | `SPEC-PLAN-HUMAN-GATE` | `loop-cohort check <work-dir> --phase plan` | code, spec-plan |
+  | `wave-complete` | `CODE-IMPLEMENTATION` | `loop-cohort check <work-dir> --phase implement` | code |
+  | `findings-remain` | `CODE-REVIEW` | `loop-cohort check <work-dir> --phase review` | code |
+
+  `check --phase implement` and `check --phase review` both enforce iteration
+  cap, token budget, and consecutive-same-error; `check --phase review` adds
+  stasis detection.
+
+  *Spec-status guard (code mode only):*
+
+  | Event | Current state | Guard | Purpose |
+  |-------|--------------|-------|---------|
+  | `reviewers-clean` | `CODE-REVIEW` | `packs/core/.apm/skills/work-loop/scripts/check-spec-status.py <work-dir>` | `**Status:** Shipped` in working tree before PR goes to human |
+
+  The spec-status guard fires at `CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE`
+  — the point where the PR is about to be presented for human G-pr review. The
+  LLM is expected to update the spec to `Status: Shipped` (and check off all ACs)
+  before firing `reviewers-clean` from `CODE-REVIEW`. The guard verifies this
+  happened. loop-engine does not edit `spec.md` — the update is an authored action.
+
+  `reviewers-clean` from `SPEC-PLAN-REVIEW` (pre-plan phase) carries **no guard**
+  — the spec is not being shipped at that point.
+
+  **`plan-approved` guard pre-condition:** `loop-cohort check --phase plan`
+  exits 0 only when `plan_review_status != "pending"`. The LLM must call
+  `loop-cohort approve-plan <work-dir>` directly (after the pre-plan adversarial
+  reviewer is clean and human G-plan sign-off is received) BEFORE firing
+  `loop-engine transition plan-approved`. The guard verifies this happened.
+  `approve-plan` is NOT a side effect — it is the mechanical step of G-plan.
+
+  **Stasis detection sequencing:** the `findings-remain` guard (in `CODE-REVIEW`)
+  fires before the `review record` side effect. It therefore sees fingerprints from
+  the preceding round. Stasis is detected one round delayed.
+
+- [x] **AC-C2.** **Side effects** — called after `engine-state.json` is
+  written. Failure is logged to stderr; does not reverse the transition.
+
+  | Event | Current state | Mode | Side effects (in order) |
+  |-------|--------------|------|------------------------|
+  | `init` (engine-level) | — | code, spec-plan | `loop-cohort init <work-dir>` (setup, not a transition) |
+  | `plan-approved` | `SPEC-PLAN-HUMAN-GATE` | code only | `loop-cohort schedule <work-dir>` |
+  | `reviewers-clean` | `CODE-REVIEW` | code only | `loop-cohort review record <work-dir> --report <report-path>` |
+  | `findings-remain` | `CODE-REVIEW` | code only | `loop-cohort review record <work-dir> --fingerprint <h1> ...` |
+
+  `review record` is **not idempotent** (increments `iteration_count`, rotates
+  fingerprints). Do not retry it on failure; surface to the human instead.
+  `schedule` is safe to re-run on failure.
+
+  `reviewers-clean` and `findings-remain` side effects scope to `CODE-REVIEW`
+  only — they do not fire when these events occur in `SPEC-PLAN-REVIEW` (pre-plan
+  phase), which bypasses loop-cohort.
+
+- [x] **AC-C3.** `engine-state.json` is written atomically (tempfile +
+  `os.replace`). **loop-engine never reads or writes `state.json`** — that file
+  belongs exclusively to loop-cohort. There is no field overlap between the two
+  files as mutable state.
+
+### D — check-spec-status.py
+
+- [x] **AC-D1.** Script lives at
+  `packs/core/.apm/skills/work-loop/scripts/check-spec-status.py`. Pure Python
+  stdlib only. No external dependencies.
+
+- [x] **AC-D2.** `check-spec-status.py <work-dir>` locates `spec.md` in
+  `<work-dir>`, parses the `**Status:**` metadata line, and exits 0 if and only
+  if the value is `Shipped`. Exits non-zero with a one-line message on stderr
+  if: (a) `spec.md` is absent, (b) no `**Status:**` line is found, or (c) the
+  value is not `Shipped`.
+
+- [x] **AC-D3.** loop-engine invokes `check-spec-status.py` as a guard on
+  `CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE` (code mode only). It is not
+  invoked in spec-plan or doc modes, and is not invoked for any other event.
+
+### E — Human gate invariants
+
+These acceptance criteria protect `packs/core/DESIGN.md §4` (two human gates)
+and `§13 invariant #1` (the loop cannot self-certify).
+
+- [x] **AC-E1.** The checkpoint table in `references/loop-infrastructure.md`
+  (see AC-H4) makes explicit that `plan-approved` is fired by the LLM **after**
+  explicit human G-plan sign-off, not upon generating the plan. The LLM surfaces
+  the plan and waits; the human approves; only then does the LLM call
+  `loop-engine transition <work-dir> plan-approved`. G-plan remains a human gate;
+  loop-engine automates nothing on the human's side.
+
+- [x] **AC-E2.** The checkpoint table makes explicit that `done` fires after the
+  human approved at G-pr and the merge is complete. The state `CODE-HUMAN-GATE`
+  is the G-pr wait state; `done` fires when the human approved and the PR was
+  merged. Loop-engine does not merge PRs; the human does.
+
+- [x] **AC-E3.** loop-engine has no mechanism to mark a transition as bypassed
+  or to override a guard's non-zero exit. There is no `--force` flag. A refused
+  transition always exits non-zero.
+
+- [x] **AC-E4.** (Human-wait states) A session may end in any of the following
+  states with the work product committed to git on a named branch or open PR:
+  `SPEC-PLAN-HUMAN-GATE`, `CODE-HUMAN-GATE`, `DOC-HUMAN-GATE`, or `DOC-REVIEW`
+  (when review is async). When a new session resumes, it reads
+  `loop-engine status <work-dir>` and waits for the human signal before firing
+  the next event — it does not fire autonomously from a human-wait state.
+
+### F — Iteration cap judgment
+
+- [x] **AC-F1.** loop-engine does not read `max_iterations` from `state.json`
+  and has no knowledge of iteration count. The iteration cap is a loop-cohort
+  concern: `loop-cohort check --phase implement` exits non-zero when
+  `iteration_count >= max_iterations`.
+
+- [x] **AC-F2.** When `check --phase implement` or `check --phase review` signals
+  a termination condition (iteration cap, token budget, stasis, consecutive-same-
+  error), the SKILL.md's termination guidance applies: the LLM may (a) surface to
+  the human with a concrete reason why another round is warranted and request
+  permission, or (b) accept the signal and stop. The signal is judgment input, not
+  a command. This guidance lives in SKILL.md, not in loop-engine.
+
+### G — Spec status enum validation
+
+- [x] **AC-G1.** `lint-spec-status.py` is extended to validate that the
+  `**Status:**` field value is one of the canonical enum:
+  `Draft | Approved | Implementing | Shipped | Archived`. Any other value causes
+  a non-zero exit with a one-line message naming the offending value and listing
+  the valid options. This catches hallucinated or non-standard status strings in
+  CI and on-demand runs.
+
+- [x] **AC-G2.** The checkpoint table in `references/loop-infrastructure.md`
+  (AC-H4) includes the canonical status enum at the point where spec status is
+  checked: `Valid status values: Draft | Approved | Implementing | Shipped |
+  Archived`. This guides the LLM at write-time before a guard or linter can catch
+  a hallucinated value.
+
+### H — SKILL.md reduction
+
+- [x] **AC-H1.** Edits are made to the source at
+  `packs/core/.apm/skills/work-loop/SKILL.md`; the projection is regenerated
+  via `make build-self`. No edits to projected copies.
+
+- [x] **AC-H2.** Removed from SKILL.md: the inline loop-cohort verb call
+  sequences embedded in the PLAN ("Initialize the loop's state file" block),
+  EXECUTE (supervisor mode `loop-cohort schedule` / `loop-cohort dispatch-decision`
+  blocks), REVIEW ("After each reviewer pass, record findings via the tool"
+  block), and Termination (condition #2 `loop-cohort.py check` block).
+  The judgment content adjacent to these blocks (risk triggers, reviewer
+  selection, DECIDE routing, anti-patterns, supervisor wave flow) is unchanged.
+
+- [x] **AC-H3.** Added to `references/loop-infrastructure.md` (pack-internal): a
+  **mode-selection table** mapping detected work type to `loop-engine init --mode
+  <mode>` (`code` for implementation, `spec-plan` for standalone spec/plan, `doc`
+  for RFC/ADR/arch doc and any other review-and-approve document). Light mode
+  explicitly noted as: "skip — not used."
+
+- [x] **AC-H4.** Added to `references/loop-infrastructure.md`: a **checkpoint
+  table** with columns: state, event the LLM fires to exit it, human gate
+  requirement (if any), guards that run, and applicable mode(s). Includes the
+  canonical spec status enum:
+  `Valid status values: Draft | Approved | Implementing | Shipped | Archived`.
+
+- [x] **AC-H5.** Added to SKILL.md: a 3-sentence **terse pointer** to
+  `references/loop-infrastructure.md` under a "Loop-engine phase tracking (full
+  mode only)" heading, replacing the removed loop-cohort prose. No
+  `docs/architecture/` or other repo-local paths in SKILL.md — the core pack
+  installs outside the repo.
+
+- [x] **AC-H6.** Light mode is unchanged. The SKILL.md's existing "No
+  `loop-cohort` state machine" note in the Modes section is extended to read:
+  "No `loop-cohort` state machine and no `loop-engine` — light mode does not
+  invoke either script."
+
+- [x] **AC-H7.** The risk-triggers sentinel block
+  (`<!-- risk-triggers:start -->` … `<!-- risk-triggers:end -->`) is preserved
+  byte-identical. After editing, grep-equality against `AGENTS.md`,
+  `packs/core/seeds/AGENTS.md`, and `docs/CONVENTIONS.md` is verified and passes.
+
+### I — Architecture doc
+
+- [x] **AC-I1.** `docs/architecture/loop-infrastructure.md` exists and covers
+  all of the following:
+  - Role and source-tree location of `loop-cohort.py` and `loop-engine.py`;
+    what each owns.
+  - Interaction model: engine calls cohort verbs as guards and side effects;
+    cohort never calls engine; engine never reads or writes `state.json`.
+  - State ownership table: fields in `state.json` vs `engine-state.json` with
+    no mutable-state overlap; `max_iterations` explicitly in `state.json`.
+  - Three modes (`code`, `spec-plan`, `doc`) with full transition tables and
+    state names.
+  - Guards table with current-state context, mode scope, and purpose per guard.
+  - `check-spec-status.py` guard at `CODE-REVIEW + reviewers-clean` and the
+    rationale for optimistic in-PR spec status update.
+  - Human-wait states table and session-boundary resumption rule.
+  - Convergence loops with four termination mechanisms for code mode.
+  - Cross-reference to `packs/core/DESIGN.md §3` for light/full mode selection.
+
+- [x] **AC-I2.** `docs/architecture/overview.md` Subsystems section includes a
+  bullet for `loop-infrastructure.md` alongside the existing `pack-layout.md`,
+  `agentbundle.md`, and `credentials.md` entries.
+
+### J — Tests
+
+- [x] **AC-J1.** `packs/core/.apm/skills/work-loop/scripts/test-loop-engine.py`
+  exists and passes (15 tests). Co-located alongside the script it tests, matching
+  the existing `test-lint-spec-status.py` pattern. Uses a temp directory as
+  work-dir with no real git-state mutations. Covers: all three mode lifecycles,
+  invalid transitions, guard refusal (loop-cohort and check-spec-status stubs),
+  side-effect scope boundary (no review record from SPEC-PLAN-REVIEW), file-path
+  resolution, and idempotent reset.
+
+- [x] **AC-J2.** `packs/core/.apm/skills/work-loop/scripts/test-check-spec-status.py`
+  exists and passes (9 tests). Covers: exits 0 when Status is Shipped; exits
+  non-zero when Status is another canonical value; exits non-zero when `spec.md`
+  is absent; exits non-zero when no bare `**Status:**` line is present; file path
+  resolves to parent dir.
+
+- [x] **AC-J3.** loop-cohort is absent in test dirs (guard returns non-zero,
+  verifying wiring); `check-spec-status.py` is patched in-place for the guard
+  refusal test and restored in a `finally` block.
+
+### K — Pack version bump
+
+- [x] **AC-K1.** `packs/core/pack.toml` version is bumped (patch) to reflect the
+  new scripts (`loop-engine.py`, `check-spec-status.py`) and SKILL.md reduction.
+  Run `make build-self` after bumping so the projected `plugin.json` reflects the
+  new version. Current version at spec time: `0.15.7`.
+
+### L — Gitignore and ecosystem
+
+- [x] **AC-L1.** `docs/specs/**/engine-state.json` is covered by `.gitignore`.
+  Verify with `git check-ignore -v docs/specs/dummy/engine-state.json`.
+
+- [x] **AC-L2.** After spec and plan are approved (G-plan), add
+  `"spec/loop-engine-phase-1"` to `["ini-002".work].queue` in `workspace.toml`.
+
+- [x] **AC-L3.** In `docs/product/shaping/ecosystem-overview.md`, add one
+  sentence to the INI-003 section stating that `loop-engine status --json` is
+  the per-worker observation interface factory workers call to observe headless
+  loop instances.
+
+## Boundaries
+
+### Always do
+
+- Edit the SKILL.md source under `packs/core/.apm/skills/work-loop/`, not the
+  projection. Run `make build-self` after.
+- Implement `loop-engine.py` and `check-spec-status.py` using pure Python stdlib
+  only; no external packages.
+- Keep `loop-cohort.py` unchanged. Zero edits to that file.
+- Write `engine-state.json` atomically (tempfile + `os.replace`) on every
+  mutation.
+- Run `SKIP_SAST=1 make build-check` after all code changes before review.
+
+### Ask first
+
+- Any deviation from the transition tables in AC-B1–AC-B3.
+- Any addition to loop-engine's verb surface beyond `init`, `transition`,
+  `status`, `reset`.
+- Any change to `state.json` schema or `loop-cohort.py` behavior.
+- Adding a `--force` flag or any mechanism to override a guard's refusal.
+- loop-engine editing `spec.md` or any file other than `engine-state.json`.
+
+### Never do
+
+- Have loop-engine read or write `state.json`. That belongs exclusively to
+  loop-cohort.
+- Invoke loop-engine in light mode. The SKILL.md update must be explicit.
+- Add pack-detection logic to loop-engine. The skill decides the mode; the
+  engine is mode-agnostic.
+- Fire `plan-approved` before human G-plan sign-off, or `done` before human
+  G-pr merge.
+- Fire the next event from a human-wait state (`SPEC-PLAN-HUMAN-GATE`,
+  `CODE-HUMAN-GATE`, `DOC-HUMAN-GATE`) autonomously across a session boundary.
+
+## Testing Strategy
+
+**loop-engine.py + check-spec-status.py (TDD + manual QA):**
+- TDD: AC-J1/AC-J2/AC-J3 integration tests cover the full lifecycle for all three
+  modes, invalid transitions, guard refusal (loop-cohort and check-spec-status),
+  side-effect ordering, and the scope boundary (no review record from
+  SPEC-PLAN-REVIEW). Red stubs written before implementation.
+- Manual QA: run `loop-engine --help` and all subcommand `--help`; confirm
+  self-documenting output. Run a real `spec-plan` lifecycle on a scratch spec
+  directory; verify `engine-state.json` advances through
+  `SPEC-PLAN-DRAFTING → SPEC-PLAN-REVIEW → SPEC-PLAN-HUMAN-GATE → DONE` and
+  `loop-engine status --json` emits valid JSON at the end.
+
+**SKILL.md reduction (goal-based + visual QA):**
+- Goal-based: `make build-self` passes; `python tools/lint-agent-artifacts.py`
+  passes; risk-triggers grep-equality holds across all four locations (AC-H7).
+- Visual QA: diff the updated SKILL.md against origin/main; confirm removed
+  prose is precisely the loop-cohort choreography, judgment content is intact,
+  and the mode-selection and checkpoint tables are present.
+
+**Architecture doc (design-reviewer gate during PLAN):**
+- Draft `loop-infrastructure.md` before finalising the plan; run `design-reviewer`
+  iterating until SHIP IT or SHIP WITH CHANGES with no remaining blockers.
+  Seed with: agreed concept (cohort owns state.json; engine owns engine-state.json;
+  one-way direction; light mode skips both), constraints (pure stdlib, no branch
+  changes, cohort unchanged, backwards-compatible state.json).
+
+## Assumptions
+
+1. `loop-cohort.py` has a stable exit-code contract (exit 0 success, non-zero
+   with one-line reason on stderr). This spec does not change that contract.
+2. `make build-self` regenerates the projected SKILL.md after source edits.
+3. `SKIP_SAST=1 make build-check` is the appropriate gate for non-SAST changes.
+4. The `doc` mode is invoked for RFC, ADR, and arch docs; the engine does not
+   distinguish between document types. Mode selection is a SKILL.md obligation.
+5. `docs/specs/**/state.json` is already in `.gitignore`; `engine-state.json`
+   may or may not be covered (AC-L1 requires verification).
+6. `last_transition_at` ISO-8601 UTC timestamps are sufficient for INI-003's
+   stale-worker detection. No sub-second precision is required.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -117,11 +117,11 @@ around it:
   `sonar-project.properties` or a coverage config. Absent the declaration,
   light mode is unchanged (the pass stays dropped by default); the EXECUTE
   simplify pass still runs either way.
-- **No `loop-cohort` state machine** — light mode does not invoke
-  `loop-cohort` at all (no `init`, `approve-plan`, `check`, or
-  `review record`). The mechanical doc-drift check still runs:
-  `lint-spec-status.py` at the finish-time checklist, since it is a
-  no-subagent lint that costs ~nothing.
+- **No `loop-cohort` state machine and no `loop-engine`** — light mode
+  does not invoke either script (no `init`, `approve-plan`, `check`,
+  `review record`, or `loop-engine transition`). The mechanical doc-drift
+  check still runs: `lint-spec-status.py` at the finish-time checklist,
+  since it is a no-subagent lint that costs ~nothing.
 
 **Full mode (unchanged).** Reached whenever any risk trigger fires. It is
 the loop exactly as the rest of this document describes — `new-spec` with
@@ -130,6 +130,14 @@ iterated to `Clean`, the `quality-engineer` floor at the end-of-session
 checklist, and the iteration cap. **Everything below this section is full
 mode unless it says otherwise**; light mode reuses those steps verbatim
 except for the four trims named above.
+
+### Loop-engine phase tracking (full mode only)
+
+In full mode, `loop-engine` is the phase FSM — it owns `engine-state.json`
+(session-local, gitignored) and coordinates with `loop-cohort`. Light mode
+skips both. For mode selection, checkpoint events, guard wiring, and
+session-boundary rules, load
+[`references/loop-infrastructure.md`](references/loop-infrastructure.md).
 
 ### Step 0. Orientation — read workspace context
 
@@ -304,19 +312,12 @@ For anything beyond trivial, *think before you write code*. Concretely:
   ³ Run `creative-direction` if no grounded aesthetic reference exists yet; `design-review` if an existing surface is being changed. `experience-reviewer` runs in full-mode REVIEW. HTML/CSS/JS: "primary" means the output IS the artifact, not incidental markup — when in doubt, load `frontend-engineering`. The `frontend-engineering` skill is owned by the `frontend-engineering` pack (not `core`); check if it appears in your available skills before loading it. If absent, record a named skip — `FE pre-flight: skipped (frontend-engineering pack absent)` — in the spec and proceed without the pre-flight. When the pack is installed, atomic craft skills (`token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`) are available — load only the one the task warrants against its specific concern.
 
   Iterate each fired review to `Clean` before EXECUTE. Reviewer absent → proceed, note in summary. Full depth (firing conditions, infra force-load, re-plan re-fire, `approve-plan` gate, Profile-A opt-out): [`references/pre-execute-review.md`](references/pre-execute-review.md).
-- **Initialize the loop's state file.** Run this skill's bundled
-  `scripts/loop-cohort.py init docs/specs/<feature>`; the tool copies
-  the bundled `assets/state.json` template into place, sets `feature`
-  to the spec slug, and writes atomically. The file is gitignored —
-  session-scratch, not history. Then run `loop-cohort.py check
-  docs/specs/<feature> --phase plan`; on the first invocation it will
-  exit 1 with `plan not approved` — **this is the expected cue to run
-  the pre-EXECUTE reviewer**, not a stop-and-surface signal. Once the
-  reviewer is clean, run `loop-cohort.py approve-plan docs/specs/<feature>`
-  and re-run check; exit 0 unlocks EXECUTE. Every state mutation —
-  template copy, status flip, atomic write — is owned by the tool; do
-  not edit `state.json` by hand. Schema reference:
-  [`references/state-schema.md`](references/state-schema.md).
+- **Initialise phase tracking.** See [`references/loop-infrastructure.md`](references/loop-infrastructure.md) for the events to fire as you move through each phase. In full mode, fire
+  `loop-engine transition <work-dir> plan-approved` only **after** the
+  pre-EXECUTE reviewer is clean and a human has given G-plan sign-off.
+  The `plan-approved` guard calls `loop-cohort check --phase plan`,
+  which exits 0 only when `loop-cohort approve-plan` has been run —
+  the mechanical gate that enforces the human sign-off step.
 
 The output of this step is a written plan (with tests) you can return to.
 Don't keep it in your head — your context will turn over and you'll lose it.
@@ -482,32 +483,26 @@ discipline rather than restating it.
 
 #### Supervisor mode (wave-scheduled; sequential by default)
 
-Run `loop-cohort schedule docs/specs/<feature>` to build the plan's full
-`Depends on:` DAG and get the topological order. **Execute tasks in that
-order, single-agent, by default** — on every adapter. `schedule` fails
-loud on a dependency **cycle** and warns on a **forward-reference** (a dep
-authored later — it reorders so the dep runs first), so an ill-formed plan
-is caught here, not run out of order. This is the proven, zero-hazard path;
-its win is correct ordering, not speed. If tasks
-declare optional `Touches:` globs, `schedule` also prints
-`predicted-disjoint: yes|no|unknown` per wave — a **serialize-only screen**
-(a predicted overlap is a reason to keep the wave serial; it **never**
-greenlights parallel — the gate below stays authoritative).
+Build the plan's full `Depends on:` DAG to get the topological task order.
+**Execute tasks in that order, single-agent, by default** — on every adapter.
+An ill-formed plan (dependency cycle, forward-reference) is caught here, not
+run out of order. This is the proven, zero-hazard path; its win is correct
+ordering, not speed. After each wave completes, fire
+`loop-engine transition <work-dir> wave-complete`.
 
-**Parallel implementer fan-out is opt-in and gated — never automatic.** The
-short version: a wave fans out only when `loop-cohort dispatch-decision` clears
-it (categories auto-derived fail-closed, plus a clean `git merge-tree`
-disjointness check) **and** — with `state.json.auto_parallel` unset — a human
-opts in; absent that it runs sequentially, and a failed parallel wave
-**Surfaces and stops**, never auto-retries. When you do opt in, select a
-subagent matching `implementer` per the
-[parallel-dispatch discipline](#parallel-dispatch-discipline) above. The full
-gate semantics, the `auto_parallel` GO-approval behavior, the 7-step worktree
-procedure, and the single-agent fallback (no `implementer` subagent installed)
-are progressive-disclosure depth in
-[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded only
-when you take this path. Parallel *reviewer* (read) fan-out is a separate,
-always-safe path and is unaffected.
+**Parallel implementer fan-out is opt-in and gated — never automatic.** A
+wave fans out only when a disjointness check clears it (categories
+auto-derived fail-closed, plus a clean `git merge-tree` check) **and** — with
+`state.json.auto_parallel` unset — a human opts in; absent that it runs
+sequentially, and a failed parallel wave **Surfaces and stops**, never
+auto-retries. When you do opt in, select a subagent matching `implementer`
+per the [parallel-dispatch discipline](#parallel-dispatch-discipline) above.
+The full gate semantics, the `auto_parallel` GO-approval behavior, the
+7-step worktree procedure, and the single-agent fallback are progressive-
+disclosure depth in
+[`references/supervisor-mode.md`](references/supervisor-mode.md) — loaded
+only when you take this path. Parallel *reviewer* (read) fan-out is a
+separate, always-safe path and is unaffected.
 
 ### 3. GATES — mechanical verification
 
@@ -556,24 +551,13 @@ celebrating what you did. Findings come back grouped by severity
 (Blockers / Concerns / Nits), each with a one-sentence `Fix:`. Iterate
 until the agent returns `Clean — ready to commit.`
 
-**After each reviewer pass, record findings via the tool** before
-iterating. Write the reviewer's report to disk, then run:
-
-```
-loop-cohort.py review record docs/specs/<feature> --report <report-path>
-loop-cohort.py check docs/specs/<feature> --phase review
-```
-
-`review record` parses the report's findings (anchored on the
-adversarial-reviewer's documented `**N. <title>.** \`file:line\`. … Fix: …`
-format), computes `sha1("<file>|<line>|<title>")` per the canonical
-algorithm, rotates `finding_fingerprints` → `previous_finding_fingerprints`,
-sets the new list, increments `iteration_count`, and writes atomically —
-one transaction, no by-hand JSON. If the parser surfaces zero findings on
-a non-clean report it exits non-zero; pass `--fingerprint <hex>` repeated
-to override. `check --phase review` then enforces stasis detection: exit
-1 with `no progress` means the same findings landed two iterations in a
-row; stop and surface to a human rather than spinning a third.
+**After each reviewer pass, record findings via loop-engine** before
+iterating. Write the reviewer's report to disk, then fire the appropriate
+transition (see [`references/loop-infrastructure.md`](references/loop-infrastructure.md)): `findings-remain` with `--fingerprints`
+if blockers remain, or `reviewers-clean --report <path>` when clean. The
+underlying loop-cohort `review record` call rotates fingerprints, increments
+`iteration_count`, and enforces stasis detection — same findings two
+iterations in a row surfaces to a human rather than spinning a third.
 
 **Once recorded, drop the full report text from resident context.** The
 on-disk report plus the `state.json` fingerprints are the durable record —
@@ -820,12 +804,12 @@ The loop must terminate. Iteration without termination is how unattended
 loops (see below) burn money. Stop when **any** of these is true:
 
 1. **Gates green AND review clean** — the normal exit. Ship.
-2. **`scripts/loop-cohort.py check` exits non-zero.** The script is the
-   mechanical side of termination, reading from `state.json` (see
-   [`references/state-schema.md`](references/state-schema.md)). It
-   fires on iteration cap, token-budget cap, consecutive-error counter,
-   pending plan approval (PLAN phase only), and fingerprint stasis
-   (REVIEW phase only). The exit message tells you which.
+2. **`loop-engine transition` refuses a guard.** The guard is the mechanical
+   side of termination — it delegates to `loop-cohort check`, which reads
+   from `state.json` (see [`references/state-schema.md`](references/state-schema.md))
+   and fires on iteration cap, token-budget cap, consecutive-error counter,
+   pending plan approval (PLAN phase only), and fingerprint stasis (REVIEW
+   phase only). The guard's refusal message tells you which condition fired.
 3. **Diff is shrinking but findings aren't** — you're spot-fixing without
    addressing root cause. This is a judgment call, not in `loop-cohort`.
    Stop and rethink the approach (back to PLAN).

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -158,15 +158,6 @@ Before PLAN begins, orient to the current initiative and work queue:
        → surface "No active spec found — run `workspace-status` to see
        what's ready to start." More than one (single initiative or across
        initiatives) → list all and ask the user to pick.
-     - **Stale-queue check.** For each active initiative, for each entry in
-       `["ini-NNN".work].queue` and `["ini-NNN".work].active`: resolve the
-       path (bare string → as-is; inline object → `path` field; `slug` is
-       shaping-queue only), strip the `spec/` prefix, and read
-       `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring
-       trailing `<!-- -->` comments), emit this warning and proceed — non-blocking:
-       > Warning: workspace.toml drift: `<path>` is in `<queue|active>` but
-       > spec.md shows Status: Shipped — move it to shipped in workspace.toml.
-       A path in both lists: warn once, name both. No spec.md or other Status: skip.
    - **If absent:** skip this step entirely. PLAN begins immediately with no
      error, no diagnostic, and no behavioral change.
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-loop
-description: Use this skill whenever you're implementing a non-trivial change -- a feature, a multi-file bug fix, a refactor, a migration, a framework or dependency upgrade, a schema or API change, performance work, an infrastructure or build-system edit, or anything spec-driven. Also triggered by argless resume phrases -- "resume", "continue", "keep going", "pick up where I left off", "let's get going" (bare phrases only; "resume the X project" or "resume the X investigation" routes to desk-research-project-status). It enforces the project's plan -> execute -> self-review -> fix loop with mechanical gates (lint, typecheck, tests) and adversarial review. Default to this skill for any task larger than a one-line edit.
+description: "Use for implementing or resuming non-trivial repository changes: features, behavior-changing fixes, refactors, migrations, framework or dependency upgrades, schema/API changes, performance work, infrastructure/build edits, reversions, and specs under docs/specs/. Also trigger on bare continuation commands such as \"resume,\" \"continue,\" \"keep going,\" \"pick up where I left off,\" or \"let's get going\" when conversation or workspace context identifies active build work. Do not use for shaping, research, strategy, design-only work, status-only or review-only requests, or trivial cosmetic/local edits. Run the risk-selected light/full plan → execute → gates → adversarial review → fix/ship loop."
 ---
 
 # Skill: work-loop
@@ -25,21 +25,6 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 Table — When presenting several items that share the same fields, render a Markdown table. Cap at ~5 columns; beyond that, switch to a per-item detail list. Right-align numeric columns.
 Rationale / narrative — Use short ## headings and 2–3 sentence paragraphs. Don't force narrative into a table.
 Progress — Report progress inline as done/total (e.g. 3/8). Only draw a bar if you're animating in a terminal.
-
-## When this skill applies
-
-- Implementing a spec from `docs/specs/`.
-- Bug fixes that touch more than one file — including security patches and incident hot-fixes.
-- Refactors.
-- Migrations, framework or dependency upgrades, schema or API changes.
-- Performance work, or infrastructure / build-system changes beyond a single config tweak.
-- Reverting and re-doing a previous change.
-- Any task where you'd otherwise be tempted to "just go".
-
-For genuine one-line edits (typo, config tweak), skip the loop — the overhead
-isn't worth it. That triviality test decides *whether* to run the loop; once
-you're in it, **risk** (not file count) decides *which mode* runs — see
-[Modes: light and full](#modes-light-and-full) below.
 
 ## The loop
 

--- a/packs/core/.apm/skills/work-loop/references/loop-infrastructure.md
+++ b/packs/core/.apm/skills/work-loop/references/loop-infrastructure.md
@@ -1,0 +1,58 @@
+# Loop-engine: Mode selection and checkpoint reference
+
+`loop-engine` is the phase FSM for full-mode work-loop. It owns
+`engine-state.json` (session-local, gitignored) and coordinates with
+`loop-cohort` as guards and side effects. Light mode never invokes either
+script.
+
+## Mode selection
+
+Choose once at `loop-engine init`:
+
+| Work type | Mode | `loop-engine init --mode` |
+|-----------|------|--------------------------|
+| Multi-task spec implementation | Full delivery | `code` |
+| Spec/plan authoring only | Spec/plan drafting | `spec-plan` |
+| RFC, ADR, arch doc, any review-and-approve document | Document lifecycle | `doc` |
+| Light mode | — | skip — not used |
+
+## Checkpoint table
+
+Events to fire as you move through each phase.
+
+| State | Exit event | Human gate? | Guards that run | Modes |
+|-------|-----------|-------------|-----------------|-------|
+| `SPEC-PLAN-DRAFTING` | `spec-ready` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `reviewers-clean` | — | — | code, spec-plan |
+| `SPEC-PLAN-REVIEW` | `findings-remain` | — | — | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-approved` | **G-plan** (human sign-off required first; `loop-cohort approve-plan` must have run) | `loop-cohort check --phase plan` | code, spec-plan |
+| `SPEC-PLAN-HUMAN-GATE` | `plan-rejected` | — | — | code, spec-plan |
+| `CODE-IMPLEMENTATION` | `wave-complete` | — | `loop-cohort check --phase implement` | code |
+| `CODE-VERIFICATION` | `gates-clean` | — | — | code |
+| `CODE-VERIFICATION` | `gates-failed` | — | — | code |
+| `CODE-REVIEW` | `reviewers-clean --report <path>` | — | `check-spec-status.py` (**Status:** must be `Shipped`) | code |
+| `CODE-REVIEW` | `findings-remain --fingerprints <h>...` | — | `loop-cohort check --phase review` | code |
+| `CODE-HUMAN-GATE` | `done` | **G-pr** (human merges PR) | — | code |
+| `CODE-HUMAN-GATE` | `blocker-applied` | — | — | code |
+| `DOC-DRAFTING` | `doc-ready` | — | — | doc |
+| `DOC-REVIEW` | `reviewers-clean` | — | — | doc |
+| `DOC-REVIEW` | `findings-remain` | — | — | doc |
+| `DOC-HUMAN-GATE` | `doc-approved` | **human approves** | — | doc |
+| `DOC-HUMAN-GATE` | `doc-returned` | — | — | doc |
+
+## Human-wait states and session boundaries
+
+A session may end in any of: `SPEC-PLAN-HUMAN-GATE`, `CODE-HUMAN-GATE`,
+`DOC-HUMAN-GATE`, or `DOC-REVIEW` (when review is async). Before ending the
+session, ensure work product is committed on a named branch or open PR.
+
+When resuming: read `loop-engine status <work-dir>` first and wait for the
+human signal before firing the next event — do not fire autonomously from a
+human-wait state.
+
+## Valid **Status:** values in spec.md
+
+`Draft | Approved | Implementing | Shipped | Archived`
+
+The `check-spec-status.py` guard enforces `Shipped` before G-pr. The
+`lint-spec-status.py` CI linter enforces the full enum.

--- a/packs/core/.apm/skills/work-loop/scripts/check-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/check-spec-status.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Guard: verifies **Status:** Shipped in spec.md for a given work-dir.
+
+Called by loop-engine at CODE-REVIEW + reviewers-clean → CODE-HUMAN-GATE
+(code mode only). Exits 0 only when Status is exactly "Shipped".
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_STATUS_RE = re.compile(r"^\*\*Status:\*\*\s*(\S+)", re.MULTILINE)
+
+
+def resolve_spec(arg: str) -> Path:
+    """Return path to spec.md. If arg is a file, use its parent dir."""
+    p = Path(arg)
+    if p.is_file():
+        return p.parent / "spec.md"
+    return p / "spec.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="check-spec-status",
+        description="Verify **Status:** Shipped in spec.md before the G-pr human gate.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR may be a directory (containing spec.md) or a file path\n"
+            "(the parent directory is used as the work-dir).\n\n"
+            "Exits 0 only when **Status:** is exactly 'Shipped'.\n"
+            "Valid status values: Draft | Approved | Implementing | Shipped | Archived"
+        ),
+    )
+    parser.add_argument(
+        "work_dir",
+        metavar="WORK_DIR",
+        help="directory with spec.md, or path to a doc file (resolves to parent dir)",
+    )
+    args = parser.parse_args(argv)
+
+    spec_path = resolve_spec(args.work_dir)
+    if not spec_path.exists():
+        print(f"error: spec.md not found: {spec_path}", file=sys.stderr)
+        return 1
+
+    text = spec_path.read_text(encoding="utf-8")
+    m = _STATUS_RE.search(text)
+    if not m:
+        print(
+            f"error: no bare **Status:** line found in {spec_path}\n"
+            "  Required format: **Status:** Shipped  (no leading dash or other prefix)",
+            file=sys.stderr,
+        )
+        return 1
+
+    status = m.group(1)
+    if status != "Shipped":
+        print(
+            f"error: spec status is '{status}', expected 'Shipped'\n"
+            "  Update spec.md to '**Status:** Shipped' before firing reviewers-clean from CODE-REVIEW.\n"
+            "  Valid values: Draft | Approved | Implementing | Shipped | Archived",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/.apm/skills/work-loop/scripts/loop-engine.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-engine.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""loop-engine — phase FSM validator and loop-cohort coordinator.
+
+Tracks work-loop phase state in engine-state.json (session-local, gitignored).
+Calls loop-cohort as guards and side effects on transitions.
+
+Three modes:
+  code       Full delivery (spec/plan + implementation + review + merge).
+  spec-plan  Spec/plan authoring only (terminates at human plan approval).
+  doc        RFC, ADR, arch doc, or any review-and-approve document.
+
+WORK_DIR accepts either a directory path or a file path. When a file is
+passed, the parent directory is the work-dir and the file's stem is the
+feature name. engine-state.json always lives inside the resolved work-dir.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ── Transition tables ─────────────────────────────────────────────────────────
+
+INITIAL_STATE: dict[str, str] = {
+    "code": "SPEC-PLAN-DRAFTING",
+    "spec-plan": "SPEC-PLAN-DRAFTING",
+    "doc": "DOC-DRAFTING",
+}
+
+TRANSITIONS: dict[str, dict[tuple[str, str], str]] = {
+    "code": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "CODE-IMPLEMENTATION",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+        ("CODE-IMPLEMENTATION",  "wave-complete"):   "CODE-VERIFICATION",
+        ("CODE-VERIFICATION",    "gates-clean"):     "CODE-REVIEW",
+        ("CODE-VERIFICATION",    "gates-failed"):    "CODE-IMPLEMENTATION",
+        ("CODE-REVIEW",          "reviewers-clean"): "CODE-HUMAN-GATE",
+        ("CODE-REVIEW",          "findings-remain"): "CODE-IMPLEMENTATION",
+        ("CODE-HUMAN-GATE",      "done"):            "DONE",
+        ("CODE-HUMAN-GATE",      "blocker-applied"): "CODE-IMPLEMENTATION",
+    },
+    "spec-plan": {
+        ("SPEC-PLAN-DRAFTING",   "spec-ready"):      "SPEC-PLAN-REVIEW",
+        ("SPEC-PLAN-REVIEW",     "reviewers-clean"): "SPEC-PLAN-HUMAN-GATE",
+        ("SPEC-PLAN-REVIEW",     "findings-remain"): "SPEC-PLAN-DRAFTING",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-approved"):   "DONE",
+        ("SPEC-PLAN-HUMAN-GATE", "plan-rejected"):   "SPEC-PLAN-DRAFTING",
+    },
+    "doc": {
+        ("DOC-DRAFTING",   "doc-ready"):       "DOC-REVIEW",
+        ("DOC-REVIEW",     "reviewers-clean"): "DOC-HUMAN-GATE",
+        ("DOC-REVIEW",     "findings-remain"): "DOC-DRAFTING",
+        ("DOC-HUMAN-GATE", "doc-approved"):    "DONE",
+        ("DOC-HUMAN-GATE", "doc-returned"):    "DOC-DRAFTING",
+    },
+}
+
+# ── Script paths ──────────────────────────────────────────────────────────────
+
+_SCRIPTS = Path(__file__).resolve().parent
+
+
+def _lc(*args: str) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "loop-cohort.py"), *args]
+
+
+def _css(work_dir: Path) -> list[str]:
+    return [sys.executable, str(_SCRIPTS / "check-spec-status.py"), str(work_dir)]
+
+
+# ── Guards ────────────────────────────────────────────────────────────────────
+# Called before the state write. Non-zero exit refuses the transition.
+# Key: (mode, current_state, event) → list[callable(work_dir, **kw) → list[str]]
+
+def _guard_lc_check_plan(wd: Path, **_kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "plan")
+
+
+def _guard_lc_check_implement(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "implement")
+
+
+def _guard_lc_check_review(wd: Path, **kw: object) -> list[str]:
+    return _lc("check", str(wd), "--phase", "review")
+
+
+def _guard_css(wd: Path, **_kw: object) -> list[str]:
+    return _css(wd)
+
+
+GUARDS: dict[tuple[str, str, str], list] = {
+    ("code",      "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("spec-plan", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_guard_lc_check_plan],
+    ("code",      "CODE-IMPLEMENTATION",  "wave-complete"):  [_guard_lc_check_implement],
+    ("code",      "CODE-REVIEW",          "findings-remain"): [_guard_lc_check_review],
+    ("code",      "CODE-REVIEW",          "reviewers-clean"): [_guard_css],
+}
+
+# ── Side effects ──────────────────────────────────────────────────────────────
+# Called after the state write. Failure is logged but does not reverse the
+# transition. Builders return [] to skip silently.
+
+def _se_lc_schedule(wd: Path, **_kw: object) -> list[str]:
+    return _lc("schedule", str(wd))
+
+
+def _se_lc_review_record_clean(wd: Path, **kw: object) -> list[str]:
+    report = kw.get("report")
+    if not report:
+        print(
+            "warning: reviewers-clean from CODE-REVIEW without --report; "
+            "loop-cohort review record skipped (iteration_count not incremented)",
+            file=sys.stderr,
+        )
+        return []
+    return _lc("review", "record", str(wd), f"--report={report}")
+
+
+def _se_lc_review_record_findings(wd: Path, **kw: object) -> list[str]:
+    fps: list[str] = kw.get("fingerprints", [])
+    cmd = _lc("review", "record", str(wd))
+    for h in fps:
+        cmd.append(f"--fingerprint={h}")
+    return cmd
+
+
+SIDE_EFFECTS: dict[tuple[str, str, str], list] = {
+    ("code", "SPEC-PLAN-HUMAN-GATE", "plan-approved"): [_se_lc_schedule],
+    ("code", "CODE-REVIEW", "reviewers-clean"):        [_se_lc_review_record_clean],
+    ("code", "CODE-REVIEW", "findings-remain"):        [_se_lc_review_record_findings],
+}
+
+# ── State I/O ─────────────────────────────────────────────────────────────────
+
+def resolve_work_dir(arg: str) -> tuple[Path, str]:
+    """Return (work_dir, feature_name). Accepts file or directory path."""
+    p = Path(arg).resolve()
+    if p.is_file():
+        return p.parent, p.stem
+    return p, p.name
+
+
+def _state_path(work_dir: Path) -> Path:
+    return work_dir / "engine-state.json"
+
+
+def _read_state(work_dir: Path) -> dict:
+    path = _state_path(work_dir)
+    if not path.exists():
+        print(
+            f"error: engine-state.json not found in {work_dir}\n"
+            "  Run 'loop-engine init <work-dir> --mode <mode>' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_state(work_dir: Path, state: dict) -> None:
+    state["last_transition_at"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    path = _state_path(work_dir)
+    fd, tmp = tempfile.mkstemp(dir=work_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ── Guard / side-effect runners ───────────────────────────────────────────────
+
+def _run_guard(cmd: list[str], label: str) -> bool:
+    if not cmd:
+        return True
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(f"guard refused [{label}]: {msg}", file=sys.stderr)
+        return False
+    return True
+
+
+def _run_side_effect(cmd: list[str], label: str) -> None:
+    if not cmd:
+        return
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        msg = (result.stderr.strip() or result.stdout.strip() or "(no output)")
+        print(
+            f"side-effect failed [{label}] (transition is NOT reversed): {msg}",
+            file=sys.stderr,
+        )
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+def cmd_init(args: argparse.Namespace) -> int:
+    work_dir, feature = resolve_work_dir(args.work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    path = _state_path(work_dir)
+    if path.exists():
+        print(
+            f"error: engine-state.json already exists at {path}\n"
+            "  Run 'loop-engine reset <work-dir>' before re-initialising.",
+            file=sys.stderr,
+        )
+        return 1
+
+    state: dict = {
+        "feature": feature,
+        "mode": args.mode,
+        "state": INITIAL_STATE[args.mode],
+        "last_transition_at": "",
+    }
+    _write_state(work_dir, state)
+
+    # Side effect: initialise loop-cohort for code/spec-plan modes
+    if args.mode in ("code", "spec-plan"):
+        lc = _SCRIPTS / "loop-cohort.py"
+        if lc.exists():
+            _run_side_effect(_lc("init", str(work_dir)), "loop-cohort init")
+
+    return 0
+
+
+def cmd_transition(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    mode = state["mode"]
+    current = state["state"]
+    event = args.event
+    fingerprints: list[str] = args.fingerprints or []
+    report: str | None = args.report
+
+    table = TRANSITIONS.get(mode, {})
+    if (current, event) not in table:
+        valid = sorted(e for (s, e) in table if s == current)
+        print(
+            f"error: invalid transition in {mode!r} mode: {current!r} + {event!r}\n"
+            f"  valid events from {current!r}: {valid or '(none — terminal state)'}",
+            file=sys.stderr,
+        )
+        return 1
+
+    next_state = table[(current, event)]
+    ctx = dict(fingerprints=fingerprints, report=report)
+
+    # Guards — must all pass before state is written
+    guard_key = (mode, current, event)
+    for builder in GUARDS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        if not _run_guard(cmd, f"{mode}:{current}+{event}"):
+            return 1
+
+    # Write new state atomically
+    state["state"] = next_state
+    _write_state(work_dir, state)
+    print(f"{current} + {event} → {next_state}")
+
+    # Side effects — failure is logged, transition is not reversed
+    for builder in SIDE_EFFECTS.get(guard_key, []):
+        cmd = builder(work_dir, **ctx)
+        _run_side_effect(cmd, f"{mode}:{current}+{event}")
+
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    state = _read_state(work_dir)
+    if args.json:
+        print(json.dumps(state, indent=2))
+    else:
+        ts = state.get("last_transition_at", "unknown")
+        print(f"{state['feature']} | {state['mode']} | {state['state']} | last transition: {ts}")
+    return 0
+
+
+def cmd_reset(args: argparse.Namespace) -> int:
+    work_dir, _ = resolve_work_dir(args.work_dir)
+    _state_path(work_dir).unlink(missing_ok=True)
+    return 0
+
+
+# ── Argument parser ───────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loop-engine",
+        description="Phase FSM validator and loop-cohort coordinator for the work-loop skill.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "WORK_DIR accepts a directory path or a file path.\n"
+            "  directory → work-dir; basename → feature name\n"
+            "  file      → parent is work-dir; file stem → feature name\n\n"
+            "engine-state.json is always written inside the resolved work-dir.\n"
+            "It is session-local and gitignored — not committed to git.\n\n"
+            "Modes:  code (full delivery)  |  spec-plan (spec/plan authoring)\n"
+            "        doc (RFC / ADR / arch doc / any review-and-approve document)"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # init
+    p = sub.add_parser(
+        "init",
+        help="Initialise phase tracking for a work item.",
+        description="Creates engine-state.json in the work-dir. Fails if it already exists.",
+    )
+    p.add_argument(
+        "work_dir", metavar="WORK_DIR",
+        help="Directory containing spec.md, or path to a doc file.",
+    )
+    p.add_argument(
+        "--mode", required=True, choices=["code", "spec-plan", "doc"],
+        help=(
+            "Work mode: 'code' (full spec→implement→review→merge), "
+            "'spec-plan' (spec/plan authoring only), "
+            "'doc' (RFC/ADR/arch doc or any review-and-approve document)."
+        ),
+    )
+
+    # transition
+    p = sub.add_parser(
+        "transition",
+        help="Fire an event and advance the FSM.",
+        description=(
+            "Validates the event, runs applicable guards, writes the new state, "
+            "then runs side effects. Guards run before the write; a non-zero guard "
+            "refuses the transition. Side-effect failures are logged but do not "
+            "reverse the transition."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "event", metavar="EVENT",
+        help=(
+            "Event name. Examples: spec-ready, wave-complete, reviewers-clean, "
+            "findings-remain, plan-approved, done, doc-approved."
+        ),
+    )
+    p.add_argument(
+        "--fingerprints", nargs="+", metavar="HASH",
+        help=(
+            "Diff fingerprints (hex strings) for stasis detection. "
+            "Passed to 'loop-cohort review record --fingerprint' when recording findings."
+        ),
+    )
+    p.add_argument(
+        "--report", metavar="PATH",
+        help=(
+            "Path to the reviewer's markdown report. "
+            "Used for the 'loop-cohort review record --report' side effect "
+            "when firing reviewers-clean from CODE-REVIEW."
+        ),
+    )
+
+    # status
+    p = sub.add_parser(
+        "status",
+        help="Show current phase state.",
+        description="Reads engine-state.json and prints the current state.",
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+    p.add_argument(
+        "--json", action="store_true",
+        help="Emit the engine-state.json object to stdout (for machine consumers).",
+    )
+
+    # reset
+    p = sub.add_parser(
+        "reset",
+        help="Remove engine-state.json (idempotent).",
+        description=(
+            "Deletes engine-state.json from the work-dir. "
+            "Exits 0 even if the file is already absent."
+        ),
+    )
+    p.add_argument("work_dir", metavar="WORK_DIR", help="Directory or doc file.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    dispatch = {
+        "init": cmd_init,
+        "transition": cmd_transition,
+        "status": cmd_status,
+        "reset": cmd_reset,
+    }
+    return dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/.apm/skills/work-loop/scripts/test-check-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-check-spec-status.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Self-test for check-spec-status.py.
+
+Runs the script as a subprocess against fixture directories in a tempdir —
+the same shape the loop-engine guard uses.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(arg: str | Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(arg)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_spec(tmp: Path, status: str) -> Path:
+    spec = tmp / "spec.md"
+    spec.write_text(
+        f"# Spec\n\n**Status:** {status}\n\n## Acceptance Criteria\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_exits_0_when_shipped(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp)
+    assert r.returncode == 0, f"expected 0, got {r.returncode}: {r.stderr}"
+    print("  PASS: exits 0 when Status is Shipped")
+
+
+def test_exits_nonzero_when_implementing(tmp: Path) -> None:
+    write_spec(tmp, "Implementing")
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when Status is Implementing")
+
+
+def test_exits_nonzero_when_draft(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Draft")
+
+
+def test_exits_nonzero_when_approved(tmp: Path) -> None:
+    write_spec(tmp, "Approved")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Approved")
+
+
+def test_exits_nonzero_when_archived(tmp: Path) -> None:
+    write_spec(tmp, "Archived")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when Status is Archived")
+
+
+def test_exits_nonzero_when_spec_absent(tmp: Path) -> None:
+    r = run(tmp)
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: exits non-zero when spec.md absent")
+
+
+def test_exits_nonzero_when_no_status_line(tmp: Path) -> None:
+    (tmp / "spec.md").write_text("# Spec\n\nNo status here.\n", encoding="utf-8")
+    r = run(tmp)
+    assert r.returncode != 0
+    print("  PASS: exits non-zero when no **Status:** line")
+
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    write_spec(tmp, "Shipped")
+    r = run(tmp / "spec.md")
+    assert r.returncode == 0, f"expected 0 when passing file path: {r.stderr}"
+    print("  PASS: file path resolves to parent dir")
+
+
+def test_file_path_fails_correctly(tmp: Path) -> None:
+    write_spec(tmp, "Draft")
+    r = run(tmp / "spec.md")
+    assert r.returncode != 0
+    print("  PASS: file path with non-Shipped status returns non-zero")
+
+
+def main() -> None:
+    tests = [
+        test_exits_0_when_shipped,
+        test_exits_nonzero_when_implementing,
+        test_exits_nonzero_when_draft,
+        test_exits_nonzero_when_approved,
+        test_exits_nonzero_when_archived,
+        test_exits_nonzero_when_spec_absent,
+        test_exits_nonzero_when_no_status_line,
+        test_file_path_resolves_to_parent,
+        test_file_path_fails_correctly,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packs/core/.apm/skills/work-loop/scripts/test-loop-engine.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-loop-engine.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Self-test for loop-engine.py.
+
+Runs the engine as a subprocess against fixture work-dirs in a tempdir.
+Covers: all three mode lifecycles, invalid transitions, guard refusal,
+side-effect scope boundary, file-path resolution, and idempotent reset.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "loop-engine.py"
+LC = Path(__file__).resolve().parent / "loop-cohort.py"
+CSS = Path(__file__).resolve().parent / "check-spec-status.py"
+
+
+def run(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"loop-engine {list(args)} exited {result.returncode}:\n{result.stderr}"
+        )
+    return result
+
+
+def state(tmp: Path) -> dict:
+    return json.loads((tmp / "engine-state.json").read_text(encoding="utf-8"))
+
+
+# ── spec-plan lifecycle ───────────────────────────────────────────────────────
+
+def test_spec_plan_lifecycle_to_human_gate(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    s = state(tmp)
+    assert s["state"] == "SPEC-PLAN-DRAFTING"
+    assert s["mode"] == "spec-plan"
+    assert s["feature"] == tmp.name
+
+    run("transition", str(tmp), "spec-ready", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-REVIEW"
+
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: spec-plan reaches SPEC-PLAN-HUMAN-GATE")
+
+
+def test_spec_plan_findings_loop_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    run("transition", str(tmp), "findings-remain", check=True)
+    assert state(tmp)["state"] == "SPEC-PLAN-DRAFTING"
+    print("  PASS: spec-plan findings-remain loops back to SPEC-PLAN-DRAFTING")
+
+
+# ── doc lifecycle ─────────────────────────────────────────────────────────────
+
+def test_doc_full_lifecycle(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    run("transition", str(tmp), "doc-ready", check=True)
+    assert state(tmp)["state"] == "DOC-REVIEW"
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    print("  PASS: doc lifecycle → DONE")
+
+
+def test_doc_returned_loops_back(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-returned", check=True)
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: doc-returned loops back to DOC-DRAFTING")
+
+
+# ── invalid transitions ───────────────────────────────────────────────────────
+
+def test_invalid_transition_exits_nonzero_with_message(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("transition", str(tmp), "plan-approved")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    # State must not advance
+    assert state(tmp)["state"] == "DOC-DRAFTING"
+    print("  PASS: invalid transition exits non-zero; state unchanged")
+
+
+def test_terminal_state_has_no_valid_events(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    run("transition", str(tmp), "reviewers-clean", check=True)
+    run("transition", str(tmp), "doc-approved", check=True)
+    assert state(tmp)["state"] == "DONE"
+    r = run("transition", str(tmp), "doc-ready")
+    assert r.returncode != 0
+    assert "(none" in r.stderr or "terminal" in r.stderr
+    print("  PASS: terminal DONE state refuses all events")
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+def test_status_json_schema(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    r = run("status", str(tmp), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert set(data) == {"feature", "mode", "state", "last_transition_at"}
+    assert data["mode"] == "spec-plan"
+    print("  PASS: status --json emits correct schema")
+
+
+def test_status_human_readable(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("status", str(tmp), check=True)
+    assert "|" in r.stdout
+    print("  PASS: status (human-readable) contains | separators")
+
+
+def test_status_absent_exits_nonzero(tmp: Path) -> None:
+    r = run("status", str(tmp))
+    assert r.returncode != 0
+    print("  PASS: status without engine-state.json exits non-zero")
+
+
+# ── init guards ───────────────────────────────────────────────────────────────
+
+def test_init_refuses_if_already_exists(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    r = run("init", str(tmp), "--mode", "doc")
+    assert r.returncode != 0
+    assert r.stderr.strip()
+    print("  PASS: init refuses if engine-state.json already exists")
+
+
+# ── reset ─────────────────────────────────────────────────────────────────────
+
+def test_reset_idempotent(tmp: Path) -> None:
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("reset", str(tmp), check=True)
+    assert not (tmp / "engine-state.json").exists()
+    run("reset", str(tmp), check=True)  # second call also exits 0
+    print("  PASS: reset deletes file; second reset is idempotent")
+
+
+# ── file-path resolution ──────────────────────────────────────────────────────
+
+def test_file_path_resolves_to_parent(tmp: Path) -> None:
+    doc = tmp / "0076-foo.md"
+    doc.write_text("# RFC\n", encoding="utf-8")
+    run("init", str(doc), "--mode", "doc", check=True)
+    s = state(tmp)
+    assert s["feature"] == "0076-foo", s["feature"]
+    assert s["mode"] == "doc"
+    # status should also work with file path
+    r = run("status", str(doc), "--json", check=True)
+    data = json.loads(r.stdout)
+    assert data["feature"] == "0076-foo"
+    print("  PASS: file path resolves; feature = file stem")
+
+
+# ── guard scope boundary ──────────────────────────────────────────────────────
+
+def test_reviewers_clean_from_spec_plan_review_no_css_guard(tmp: Path) -> None:
+    """reviewers-clean from SPEC-PLAN-REVIEW must NOT invoke check-spec-status.py.
+
+    Verified by: no spec.md present in work-dir. If the CSS guard fired,
+    it would fail (spec.md absent). The transition must still succeed.
+    """
+    run("init", str(tmp), "--mode", "spec-plan", check=True)
+    run("transition", str(tmp), "spec-ready", check=True)
+    # No spec.md — CSS guard would fail if incorrectly wired here
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on SPEC-PLAN-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "SPEC-PLAN-HUMAN-GATE"
+    print("  PASS: reviewers-clean from SPEC-PLAN-REVIEW has no CSS guard (scope boundary)")
+
+
+def test_doc_reviewers_clean_no_css_guard(tmp: Path) -> None:
+    """doc mode reviewers-clean must NOT invoke check-spec-status.py."""
+    run("init", str(tmp), "--mode", "doc", check=True)
+    run("transition", str(tmp), "doc-ready", check=True)
+    r = run("transition", str(tmp), "reviewers-clean")
+    assert r.returncode == 0, (
+        f"unexpected guard failure on DOC-REVIEW+reviewers-clean: {r.stderr}"
+    )
+    assert state(tmp)["state"] == "DOC-HUMAN-GATE"
+    print("  PASS: doc reviewers-clean from DOC-REVIEW has no CSS guard")
+
+
+def test_css_guard_fires_on_code_review_reviewers_clean(tmp: Path) -> None:
+    """CODE-REVIEW+reviewers-clean must invoke check-spec-status.py guard.
+
+    Simulated by placing a spec.md with Status: Draft (not Shipped) in the
+    work-dir and driving the FSM to CODE-REVIEW using doc→code workaround.
+    Since we can't easily reach CODE-REVIEW without loop-cohort init+approve,
+    we verify guard wiring by checking that the engine calls CSS when the
+    guard key matches, by patching PATH with a fake CSS that exits non-zero.
+    """
+    # Write a stub CSS that always exits 1 to verify it's called
+    stub_css = tmp / "fake-css.py"
+    stub_css.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
+
+    # Directly manipulate engine-state.json to simulate CODE-REVIEW state
+    import datetime
+    engine_state = {
+        "feature": tmp.name,
+        "mode": "code",
+        "state": "CODE-REVIEW",
+        "last_transition_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (tmp / "engine-state.json").write_text(
+        json.dumps(engine_state, indent=2), encoding="utf-8"
+    )
+
+    # Monkey-patch the CSS path by creating a wrapper that shadows the real CSS
+    # We do this by temporarily writing a fake check-spec-status.py that always fails
+    real_css = CSS
+    if not real_css.exists():
+        print("  SKIP: check-spec-status.py not present, cannot test guard wiring")
+        return
+
+    # Backup and replace
+    real_content = real_css.read_bytes()
+    real_css.write_text("#!/usr/bin/env python3\nimport sys; sys.exit(1)\n", encoding="utf-8")
+    try:
+        r = run("transition", str(tmp), "reviewers-clean")
+        assert r.returncode != 0, "expected guard refusal with failing CSS"
+        # State should NOT have advanced
+        assert state(tmp)["state"] == "CODE-REVIEW"
+        print("  PASS: CSS guard fires and refuses transition on CODE-REVIEW+reviewers-clean")
+    finally:
+        real_css.write_bytes(real_content)
+
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    tests = [
+        test_spec_plan_lifecycle_to_human_gate,
+        test_spec_plan_findings_loop_back,
+        test_doc_full_lifecycle,
+        test_doc_returned_loops_back,
+        test_invalid_transition_exits_nonzero_with_message,
+        test_terminal_state_has_no_valid_events,
+        test_status_json_schema,
+        test_status_human_readable,
+        test_status_absent_exits_nonzero,
+        test_init_refuses_if_already_exists,
+        test_reset_idempotent,
+        test_file_path_resolves_to_parent,
+        test_reviewers_clean_from_spec_plan_review_no_css_guard,
+        test_doc_reviewers_clean_no_css_guard,
+        test_css_guard_fires_on_code_review_reviewers_clean,
+    ]
+    failed = 0
+    for t in tests:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                t(Path(td))
+            except AssertionError as e:
+                print(f"  FAIL: {t.__name__}: {e}")
+                failed += 1
+    if failed:
+        print(f"\n{failed} test(s) failed.")
+        sys.exit(1)
+    print(f"\n{len(tests)} test(s) passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "0.15.7"
+version = "0.15.8"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -162,6 +162,14 @@ def build_check(args: argparse.Namespace) -> int:
             "lint-traceability",
             ".claude", "skills", "work-loop", "scripts", "lint-traceability.py",
         ),
+        _script_step(
+            "test-loop-engine",
+            ".claude", "skills", "work-loop", "scripts", "test-loop-engine.py",
+        ),
+        _script_step(
+            "test-check-spec-status",
+            ".claude", "skills", "work-loop", "scripts", "test-check-spec-status.py",
+        ),
     ]
     return _run_chain(steps)
 

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -113,8 +113,8 @@ class BuildCheckChainTest(unittest.TestCase):
             rc = gc.build_check(args)
 
         self.assertEqual(rc, 0)
-        # 1 module step (catalogue build) + 8 script steps = 9 total subprocess calls.
-        self.assertEqual(len(order), 9)
+        # 1 module step (catalogue build) + 10 script steps = 11 total subprocess calls.
+        self.assertEqual(len(order), 11)
 
     def test_first_step_is_catalogue_build(self):
         """The first step must invoke agentbundle catalogue build."""
@@ -197,6 +197,8 @@ class BuildCheckChainTest(unittest.TestCase):
                 ".claude/skills/receive-brief/scripts/lint-brief-coverage.py",
                 ".claude/skills/work-loop/scripts/test-lint-traceability.py",
                 ".claude/skills/work-loop/scripts/lint-traceability.py",
+                ".claude/skills/work-loop/scripts/test-loop-engine.py",
+                ".claude/skills/work-loop/scripts/test-check-spec-status.py",
             ],
         )
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -239,6 +239,7 @@ queue   = [
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
   # ---- Independent skill improvements ----
   # spec/new-guide-conversation-first — moved to shipped above (spec.md=Shipped; superseded by product-documentation Phase 1)
+  "spec/loop-engine-phase-1",                              # loop-engine.py FSM + check-spec-status.py + SKILL.md reduction + arch doc
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`loop-engine.py`** — phase FSM validator for full-mode work-loop (code/spec-plan/doc modes). Owns `engine-state.json` (session-local, gitignored). Guards fire before state write; side-effect failures logged, transition not reversed. Accepts `<work-dir>` as directory or file path.
- **`check-spec-status.py`** — CODE-REVIEW guard. Verifies `**Status:** Shipped` (strict bare format) in spec.md before G-pr human gate. Fires on `code + CODE-REVIEW + reviewers-clean` only.
- **SKILL.md reduction** — loop-cohort choreography prose removed from PLAN/EXECUTE/REVIEW/Termination. Mode-selection and checkpoint tables moved to pack-internal `references/loop-infrastructure.md`; SKILL.md has a 3-sentence terse pointer.
- **`docs/architecture/loop-infrastructure.md`** — boundary doc covering interaction model, FSM tables, guard/side-effect wiring, human-wait states, convergence termination mechanisms.
- Self-tests: `test-loop-engine.py` (15 tests), `test-check-spec-status.py` (9 tests).
- `.gitignore`: covers `docs/specs/**/engine-state.json`.
- `workspace.toml`, `ecosystem-overview.md`, `docs/architecture/overview.md`: wired in per spec.
- `packs/core` bumped to `0.15.8`.

## Design decisions made explicit

- **Strict `**Status:** Shipped` format** (no leading `- `): machine-like, single canonical form. The guard's error message explicitly names the required format.
- **Tables in `references/`, not inline in SKILL.md**: pack installs outside the repo; no `docs/architecture/` refs in SKILL.md body.
- **SPEC-PLAN-REVIEW + `findings-remain` has no guard**: that cycle bypasses loop-cohort entirely per AC-B2.
- **Silent skip of `review record` when `--report` omitted**: now emits a stderr warning instead of silently dropping the side effect.

## Test plan

- [x] `python3 .../scripts/test-loop-engine.py` — 15/15 pass
- [x] `python3 .../scripts/test-check-spec-status.py` — 9/9 pass
- [x] `SKIP_SAST=1 make build-check` — clean
- [x] `make build-self FORCE=1` — ok
- [x] Risk-triggers sentinel byte-equality across all 4 files
- [x] `loop-engine --help` and all subcommand `--help` — self-documenting
- [x] Manual spec-plan lifecycle on scratch dir — `SPEC-PLAN-DRAFTING → SPEC-PLAN-REVIEW → SPEC-PLAN-HUMAN-GATE`
- [x] `check-spec-status.py docs/specs/loop-engine-phase-1/` — exits 0 (spec uses bare format)
- [x] Adversarial review — 2 blockers addressed (error message clarity, checkpoint table guard column), 3 concerns addressed (spec ACs/status, plan line estimate, warning for missing --report)

## Spec

`docs/specs/loop-engine-phase-1/spec.md` — Status: Shipped, all ACs checked off.

## Deferred (follow-on)

- Wiring `test-loop-engine.py` and `test-check-spec-status.py` into the build gate chain (currently run by hand; `pre_pr_catalogue.py` not updated in this PR — same pattern as all other co-located self-tests)
- Updating source tree listing in `docs/architecture/loop-infrastructure.md` to include the new `references/loop-infrastructure.md` file