### PR TITLE
fix(catalogue-curation): update assimilate-primitive for deleted lint-agent-artifacts (0.2.1)

### DIFF
--- a/.agents/skills/assimilate-primitive/SKILL.md
+++ b/.agents/skills/assimilate-primitive/SKILL.md
@@ -37,7 +37,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
    internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
-   `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
+   `agentbundle catalogue verify`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses
    the gates the repo runs on its own code.
@@ -119,4 +119,4 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 - Write outside `agentbundle.safety.write_jailed`, or launder an anti-pattern
   (step 6) into the catalogue unshaped.
 
-_Depends on `core` + `governance-extras`. Repo-scope; not in any default profile._
+_Repo-scope; not in any default profile._

--- a/.agents/skills/assimilate-primitive/references/ingest-safety.md
+++ b/.agents/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `agentbundle catalogue verify`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -79,7 +79,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "author": {

--- a/.claude/skills/assimilate-primitive/SKILL.md
+++ b/.claude/skills/assimilate-primitive/SKILL.md
@@ -37,7 +37,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
    internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
-   `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
+   `agentbundle catalogue verify`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses
    the gates the repo runs on its own code.
@@ -119,4 +119,4 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 - Write outside `agentbundle.safety.write_jailed`, or launder an anti-pattern
   (step 6) into the catalogue unshaped.
 
-_Depends on `core` + `governance-extras`. Repo-scope; not in any default profile._
+_Repo-scope; not in any default profile._

--- a/.claude/skills/assimilate-primitive/references/ingest-safety.md
+++ b/.claude/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `agentbundle catalogue verify`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`catalogue-curation` pack 0.2.1**: `assimilate-primitive` lint gate updated from
+  `lint-agent-artifacts` (deleted at v0.13.0) to `agentbundle catalogue verify`; stale
+  `_Depends on core + governance-extras` footer removed (those deps were dropped in 0.2.0).
+
 - **`catalogue-curation` pack 0.2.0**: `export-catalogue` skill removed (superseded by
   `agentbundle catalogue init --preset self-hosted`). Hard dependencies on `core` and
   `governance-extras` removed — the three remaining skills operate portably against the

--- a/packs/catalogue-curation/.apm/skills/assimilate-primitive/SKILL.md
+++ b/packs/catalogue-curation/.apm/skills/assimilate-primitive/SKILL.md
@@ -37,7 +37,7 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
    an explicit "yes, land this code" before proceeding.
 4. **Run the repo's own gates on the candidate.** Before it lands, run the
    internal lints that apply to the artifact kind (`agentbundle catalogue lint --deep`,
-   `lint-agent-artifacts`) and the SAST/SCA scanners (`.snyk` / dependency scan
+   `agentbundle catalogue verify`) and the SAST/SCA scanners (`.snyk` / dependency scan
    where runnable; CodeQL runs on the PR this opens). A failure **blocks the
    landing** or is surfaced for an explicit confirm — ingestion never bypasses
    the gates the repo runs on its own code.
@@ -119,4 +119,4 @@ Severity list — Lead each finding with a severity glyph — 🟥 blocker, 🟧
 - Write outside `agentbundle.safety.write_jailed`, or launder an anti-pattern
   (step 6) into the catalogue unshaped.
 
-_Depends on `core` + `governance-extras`. Repo-scope; not in any default profile._
+_Repo-scope; not in any default profile._

--- a/packs/catalogue-curation/.apm/skills/assimilate-primitive/references/ingest-safety.md
+++ b/packs/catalogue-curation/.apm/skills/assimilate-primitive/references/ingest-safety.md
@@ -45,7 +45,7 @@ An assimilated **hook/script** is code that runs on git/session events. So:
 
 Ingestion never bypasses the gates the repo runs on its own code:
 
-- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `lint-agent-artifacts`.
+- **Lints** for the artifact kind: `agentbundle catalogue lint --deep`, `agentbundle catalogue verify`.
 - **SAST/SCA:** the repo's `.snyk` / dependency scan where runnable; CodeQL runs
   on the PR the change opens.
 - A lint or scanner failure **blocks the landing** or is surfaced for an explicit

--- a/packs/catalogue-curation/.claude-plugin/plugin.json
+++ b/packs/catalogue-curation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "catalogue-curation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Catalogue-operator skills: assimilate external primitives, survey repos, and propose new packs — portable against any catalogue's own contracts."
 }

--- a/packs/catalogue-curation/pack.toml
+++ b/packs/catalogue-curation/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "catalogue-curation"
-version = "0.2.0"
+version = "0.2.1"
 description = "Catalogue-operator skills: assimilate external primitives, survey repos, and propose new packs — portable against any catalogue's own contracts."
 readme = "README.md"
 display_name = "Catalogue Curation"


### PR DESCRIPTION
## Summary

- `assimilate-primitive` SKILL.md step 4 and `references/ingest-safety.md` referenced `lint-agent-artifacts` as a lint gate, but that standalone tool was deleted at v0.13.0 and fully folded into `agentbundle catalogue verify` at v0.18.0. Updated to `agentbundle catalogue verify`.
- `assimilate-primitive` footer still claimed "Depends on `core` + `governance-extras`" — those hard deps were dropped in 0.2.0. Removed.
- Pack bumped to 0.2.1; changelog entry added under `[Unreleased]`.
- All three projections (pack source, `.claude/`, `.agents/`) regenerated via `build-self --force`.

`assimilate-repo` is clean — it delegates per-unit safety to `assimilate-primitive`, so the fix propagates transitively.

## Test plan

- [x] `SKIP_SAST=1 make build-check` passes
- [x] `agentbundle catalogue lint --deep` and `agentbundle catalogue verify` both exist as valid CLI verbs (confirmed in investigation)
- [x] All three projection copies are byte-identical (confirmed via grep)