### PR TITLE
test(atlassian): wire test_auth_selector.py into SSO parity gate (AC5)

### DIFF
--- a/docs/specs/atlassian-sso-cookie-selector-integration-test/plan.md
+++ b/docs/specs/atlassian-sso-cookie-selector-integration-test/plan.md
@@ -1,0 +1,27 @@
+# Plan: atlassian-sso-cookie-selector-integration-test
+
+**Mode:** light (AC5 is the only remaining task; one line in one file)
+
+## Assumption trio
+
+- **Files I'll touch:** `tools/test-lint-sso-config.py` (line 90: `_DUPLICATED` tuple)
+- **Tests demonstrate "done":** `python tools/test-lint-sso-config.py` exits 0 — the parity check then verifies both `test_auth_selector.py` copies are byte-identical. `SKIP_SAST=1 make build-check` passes.
+- **Not changing:** `_sso_config.py`, skill scripts (`jira.py`, `crawl_space.py`), `test_auth_selector.py`, or any other file. ACs 1–4 are already in origin/main.
+
+## Declined temptations
+
+- Add `test_exit_codes.py` to `_DUPLICATED` while I'm in the file — not in spec, out of scope.
+- Refactor `_parity_failures()` — no second caller, no spec authorization.
+
+## Task list
+
+1. **Add `"test_auth_selector.py"` to `_DUPLICATED` in `tools/test-lint-sso-config.py`.** (AC5)
+   - Mode: goal-based check
+   - Tests: `python tools/test-lint-sso-config.py` exits 0 (Done when)
+
+## Gates
+
+```
+python tools/test-lint-sso-config.py
+SKIP_SAST=1 make build-check
+```

--- a/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
+++ b/docs/specs/atlassian-sso-cookie-selector-integration-test/spec.md
@@ -1,6 +1,6 @@
 # Spec: atlassian-sso-cookie-selector-integration-test
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Constrained by:** `atlassian-sso-cookie` (parent spec, Shipped; AC13 asserted the selector; tests for each component exist; the wiring is the gap)
 - **Brief:** none
@@ -19,20 +19,20 @@ The fix is a targeted extraction: add a directly-testable `_select_auth_path(con
 
 ## Acceptance Criteria
 
-- [ ] **AC1.** `_select_auth_path(config_path: Path | None = None) -> tuple[str, SsoConfig | None]` exists in `_sso_config.py` in **both** jira/ and confluence-crawler/ `scripts/`. The function:
+- [x] **AC1.** `_select_auth_path(config_path: Path | None = None) -> tuple[str, SsoConfig | None]` exists in `_sso_config.py` in **both** jira/ and confluence-crawler/ `scripts/`. The function:
   - Returns `("token", None)` when `load_sso_config(config_path)` returns `None` (config absent or `auth_default = "creds"`).
   - Returns `("sso-cookie", sso_config)` when `load_sso_config(config_path)` returns an `SsoConfig` (valid `auth_default = "sso-cookie"` config).
   - Propagates any exception from `load_sso_config()` without catching it — callers map this to `EXIT_USER_ACTION`.
   - Is underscore-prefixed (internal helper, not part of any public surface).
-- [ ] **AC2.** `_run()` in `jira/scripts/jira.py` calls `_select_auth_path()` (imported from `._sso_config`) instead of calling `load_sso_config()` inline. The surrounding `try/except Exception → EXIT_USER_ACTION` block remains. The `if sso_config is not None:` branch (the current condition) is replaced by branching on the returned tuple: the `"sso-cookie"` path calls `JiraClient.from_sso_cookies(sso_config)`; the `"token"` path calls `load_credentials()` + `JiraClient(credentials, ...)`. Behavior is identical to today's code.
-- [ ] **AC3.** `main_async()` in `confluence-crawler/scripts/crawl_space.py` applies the same delegation — calls `_select_auth_path()` instead of inline `load_sso_config()`, with equivalent surrounding structure.
-- [ ] **AC4.** A new `test_auth_selector.py` file exists in **both** skills' `scripts/` directories (byte-identical per the parity constraint). The file opens with `pytest.importorskip("credbroker")` and then `from credbroker import SsoConfigError` (mirroring `test_sso_config.py:18-19`). It contains three tests:
+- [x] **AC2.** `_run()` in `jira/scripts/jira.py` calls `_select_auth_path()` (imported from `._sso_config`) instead of calling `load_sso_config()` inline. The surrounding `try/except Exception → EXIT_USER_ACTION` block remains. The `if sso_config is not None:` branch (the current condition) is replaced by branching on the returned tuple: the `"sso-cookie"` path calls `JiraClient.from_sso_cookies(sso_config)`; the `"token"` path calls `load_credentials()` + `JiraClient(credentials, ...)`. Behavior is identical to today's code.
+- [x] **AC3.** `main_async()` in `confluence-crawler/scripts/crawl_space.py` applies the same delegation — calls `_select_auth_path()` instead of inline `load_sso_config()`, with equivalent surrounding structure.
+- [x] **AC4.** A new `test_auth_selector.py` file exists in **both** skills' `scripts/` directories (byte-identical per the parity constraint). The file opens with `pytest.importorskip("credbroker")` and then `from credbroker import SsoConfigError` (mirroring `test_sso_config.py:18-19`). It contains three tests:
   - **absent → token**: `_select_auth_path(tmp_path / "no-such.toml")` returns `("token", None)`.
   - **valid sso-cookie → sso-cookie**: `_select_auth_path(path_to_valid_fixture)` returns `("sso-cookie", <SsoConfig instance>)`.
   - **malformed → raises**: `_select_auth_path(path_to_malformed_fixture)` raises `SsoConfigError`.
-- [ ] **AC5.** `tools/test-lint-sso-config.py`'s `_DUPLICATED` list is extended to include `"test_auth_selector.py"`, and the parity check passes (both copies byte-identical).
-- [ ] **AC6.** All existing sso-cookie tests still pass: `test_sso_config.py`, `test_sso_client.py`, `test_setup_sso.py`, `test_exit_codes.py` in both skills; `tools/test-lint-sso-config.py` passes (parity + schema-parity + upstream-file lint).
-- [ ] **AC7.** The `_ALLOWED_SSO_KEYS` set in `_sso_config.py` is unchanged (no schema drift; adding `_select_auth_path` must not cause the `lint._ALLOWED_SSO_KEYS != loader._ALLOWED_SSO_KEYS` parity check to fail).
+- [x] **AC5.** `tools/test-lint-sso-config.py`'s `_DUPLICATED` list is extended to include `"test_auth_selector.py"`, and the parity check passes (both copies byte-identical).
+- [x] **AC6.** All existing sso-cookie tests still pass: `test_sso_config.py`, `test_sso_client.py`, `test_setup_sso.py`, `test_exit_codes.py` in both skills; `tools/test-lint-sso-config.py` passes (parity + schema-parity + upstream-file lint).
+- [x] **AC7.** The `_ALLOWED_SSO_KEYS` set in `_sso_config.py` is unchanged (no schema drift; adding `_select_auth_path` must not cause the `lint._ALLOWED_SSO_KEYS != loader._ALLOWED_SSO_KEYS` parity check to fail).
 
 ## Boundaries
 

--- a/tools/test-lint-sso-config.py
+++ b/tools/test-lint-sso-config.py
@@ -87,7 +87,13 @@ _CONF = _REPO / "packs/atlassian/.apm/skills/confluence-crawler/scripts"
 # The per-skill SSO files RFC-0023 forbids sharing as a projected module, so they
 # are duplicated byte-for-byte across the two skills. Pin them equal here so a
 # one-sided edit to the security-control loader fails loudly instead of drifting.
-_DUPLICATED = ("_sso_config.py", "setup_sso.py", "test_sso_config.py", "test_setup_sso.py")
+_DUPLICATED = (
+    "_sso_config.py",
+    "setup_sso.py",
+    "test_sso_config.py",
+    "test_setup_sso.py",
+    "test_auth_selector.py",
+)
 
 
 def _load_module(path: Path, name: str):

--- a/workspace.toml
+++ b/workspace.toml
@@ -124,6 +124,7 @@ shipped = [
   "spec/m5-tracker-guides",                    # PR #615 — tracker decision tree + vocabulary mapping table
   "spec/new-guide-conversation-first",         # user-guide-diataxis 0.2.0: conversation-first doctrine (spec.md=Shipped; moved from queue)
   "spec/site-ui-primitives",                  # Phase 2C: 16 reusable UI primitives — spec confirmed Shipped; moved from queue 2026-07-29
+  "spec/atlassian-sso-cookie-selector-integration-test", # AC5: wired test_auth_selector.py into sso parity gate
 ]
 queue   = [
   # ==================================================================
@@ -230,7 +231,6 @@ queue   = [
   # backlog entries have been removed (superseded by the spec). Independent of RFC-0064.
   "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening (3 deferred items)
   "spec/site-design-system-spec",                        # site token spec + zone-violation lint
-  "spec/atlassian-sso-cookie-selector-integration-test", # end-to-end test for the auth selector branch
   # work-loop-step0-observability: AC1 echo already landed ad-hoc in main (commit
   # fb7435e9); remaining work is AC3/AC4/AC6 — trim the "Active spec" bullet's
   # duplicated branch-outcome text and relocate Branch 2's verbatim message to the


### PR DESCRIPTION
## Summary

- Adds `"test_auth_selector.py"` to `_DUPLICATED` in `tools/test-lint-sso-config.py`, closing the final acceptance criterion (AC5) of `spec/atlassian-sso-cookie-selector-integration-test`.
- ACs 1–4 (the `_select_auth_path` function in both `_sso_config.py` files, caller delegation in `jira.py` / `crawl_space.py`, and the three-test `test_auth_selector.py` in both skill `scripts/` dirs) were already in `main`.
- The parity gate now enforces byte-identity of both `test_auth_selector.py` copies going forward — a one-sided edit will fail `tools/test-lint-sso-config.py`.

## Test plan

- [x] `python tools/test-lint-sso-config.py` — 7 cases + repo scan passed
- [x] `SKIP_SAST=1 make build-check` — 41 passed, 0 failed
- [x] Jira SSO test suite (13 passed, 2 skipped — `credbroker` absent locally, expected)
- [x] Confluence-crawler SSO test suite (13 passed, 1 skipped)
- [x] `test_auth_selector.py` in both skills: 2 skipped (credbroker absent; runs in CI)
- [x] Adversarial review: clean after Status field fix
- [x] Codex review round 1: found E501 line-too-long on `_DUPLICATED` → fixed (wrapped to multi-line)
- [x] Codex review round 2: clean