### PR TITLE
test(credbroker-security-hardening): close AC2–AC5 dotfile-read bypass coverage; ship spec

### DIFF
--- a/docs/specs/credbroker-security-hardening/plan.md
+++ b/docs/specs/credbroker-security-hardening/plan.md
@@ -122,3 +122,4 @@ Run all gates in order (AC13 must run before AC15 — `make build-self` produces
 
 - 2026-07-23: Initial plan authored.
 - 2026-07-31: Plan reconciled with corrected spec after v0.13.0 (96232e62) folded standalone linters into agentbundle CLI. AC1/AC6–AC11 confirmed shipped; remaining work scoped to T1 (D3 fixture tests) + T2 (gates). All `_cs_` prefixes and correct file paths applied; LLD updated to match shipped implementation; AC16 gate updated from deleted `tools/test-lint-credentialed-skills.py` to `SKIP_SAST=1 make build-check`.
+- 2026-08-01: Work-loop completed. Added AC1-fallback test (keyword-arg open(file=...) form caught by substring scan), narrowed Declined keyword-arg item to the part-composed-path gap, added os.environ["HOME"] bypass to Declined, fixed Testing Strategy to Regression/characterization, asserted AC2 line number per spec. Status → Shipped.

--- a/docs/specs/credbroker-security-hardening/plan.md
+++ b/docs/specs/credbroker-security-hardening/plan.md
@@ -4,129 +4,121 @@
 
 ## Approach
 
-Three tasks that can run in parallel (D3 AST walk, shim path anchor, and test parametrisation have no shared edits). T4 runs final gates after all three are done. D3 has the highest security impact and the most verification overhead (TDD with bypass-proof fixtures). The shim path anchor is a pure function guard with two unit tests. The test parametrisation is purely additive.
+AC1, AC6–AC11 are already implemented and passing in origin/main (all three D3/shim/parametrisation fixes landed as part of the v0.13.0 CLI-fold and prior spec work). Remaining work is two sequential tasks:
+
+- **T1** — Add `TestD3CheckDotfileRead` class to `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` (AC2/AC3/AC4/AC5).
+- **T2** — Run gate verification (AC13–AC16).
+
+*Note on location: the standalone `tools/lint_credentialed_skills.py` and `tools/test-lint-credentialed-skills.py` were deleted in commit 96232e62 (v0.13.0). All lint logic is in `packages/agentbundle/agentbundle/catalogue_tooling/lint.py` under `_cs_`-prefixed symbols.*
 
 ## Design (LLD)
 
-### D3: `_check_dotfile_read`
+### D3 — `_cs_check_dotfile_read` (already shipped)
 
 ```python
-def _check_dotfile_read(py_path: Path) -> list[tuple[int, str]]:
-    """Walk AST, return (lineno, desc) for each dotfile-read call site."""
+# packages/agentbundle/agentbundle/catalogue_tooling/lint.py
+
+def _cs_check_dotfile_read(py_path: Path) -> list[tuple[int, str]]:
     source = py_path.read_text(encoding="utf-8")
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        return []
+    tree = ast.parse(source)
     lines = source.splitlines()
-    findings = []
+    results: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         if isinstance(node.func, ast.Name) and node.func.id == "open":
             if node.args:
-                arg = node.args[0]
-                result = _path_chain_components(arg)
-                if result and _is_dotfile_chain(result):
+                chain = _cs_path_chain_components(node.args[0])
+                if _cs_is_dotfile_chain(chain):
                     lineno = node.lineno
-                    if OPTOUT_MARKER not in lines[lineno - 1]:
-                        findings.append((lineno, "open() reads dotfile credentials"))
-        elif isinstance(node.func, ast.Attribute) and node.func.attr in {"read_text", "read_bytes"}:
-            result = _path_chain_components(node.func.value)
-            if result and _is_dotfile_chain(result):
+                    if _CS_OPTOUT_MARKER not in lines[lineno - 1]:
+                        results.append((lineno, "open() reads dotfile credentials"))
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in {"read_text", "read_bytes", "open"}
+        ):
+            chain = _cs_path_chain_components(node.func.value)
+            if _cs_is_dotfile_chain(chain):
                 lineno = node.lineno
-                if OPTOUT_MARKER not in lines[lineno - 1]:
-                    findings.append((lineno, f".{node.func.attr}() reads dotfile credentials"))
-    return findings
-
-def _is_dotfile_chain(result) -> bool:
-    _, components = result
-    return (len(components) >= 2
-            and components[-2] == DOTFILE_PARENT
-            and components[-1] == DOTFILE_BASENAME)
+                if _CS_OPTOUT_MARKER not in lines[lineno - 1]:
+                    results.append((lineno, f".{node.func.attr}() reads dotfile credentials"))
+    # Fallback: substring scan for lines not already flagged (defense-in-depth).
+    flagged_linenos = {lineno for lineno, _ in results}
+    for i, line in enumerate(lines, start=1):
+        if i in flagged_linenos:
+            continue
+        if _CS_DOTFILE_SUBSTRING in line and _CS_OPTOUT_MARKER not in line.rstrip():
+            results.append((i, f"skill reads {_CS_DOTFILE_SUBSTRING} directly"))
+    return results
 ```
 
-Replace the substring-scan block (lines 908–925) in `lint_credentialed_skills.py` with a call to `_check_dotfile_read(py_path)`.
-
-### `_is_canonical_shim` path anchor
+### `_cs_is_canonical_shim` path anchor (already shipped)
 
 ```python
-def _is_canonical_shim(py: pathlib.Path) -> bool:
-    if py.parent.name not in {"scripts", "shared-libs"}:  # ADD FIRST
+def _cs_is_canonical_shim(py: pathlib.Path, shim_source_dir: pathlib.Path) -> bool:
+    if py.name not in _CS_SHIM_BASENAMES:
         return False
-    # ... existing byte-equality check ...
+    if py.parent.name not in {"scripts", "shared-libs"}:  # path anchor
+        return False
+    expected_path = shim_source_dir / py.name
+    try:
+        expected = expected_path.read_bytes()
+    except OSError:
+        return False
+    try:
+        return py.read_bytes() == expected
+    except OSError:
+        return False
 ```
 
-### `_load_cli_module` helper
+### `_load_cli_module` helper (already shipped)
 
 ```python
 def _load_cli_module(py_path: pathlib.Path) -> types.ModuleType:
-    import importlib.util, sys
-    spec = importlib.util.spec_from_file_location("_loaded_module", py_path)
+    spec = importlib.util.spec_from_file_location(py_path.stem, py_path)
     module = importlib.util.module_from_spec(spec)
     sys.path.insert(0, str(py_path.parent))
     try:
         spec.loader.exec_module(module)
     finally:
-        sys.path.pop(0)
+        sys.path.remove(str(py_path.parent))
     return module
 ```
 
 ## Tasks
 
-### T1 — Rewrite D3 dotfile-read check as AST walk
+### T1 — Add D3 fixture tests to `test_credbroker_lint_hardening.py`
 
 **Depends on:** none
-**Mode:** TDD (AC1–AC5)
+**Mode:** Regression/characterization (AC2–AC5; `_cs_check_dotfile_read` already shipped in origin/main — tests pin bypass invariants after the fact)
 
-Write TDD fixtures first:
-- Fixture for AC2: inline part-composition `(Path.home() / ("." + "agentbundle") / ("credentials" + ".env")).read_text()` — verify it has no literal `.agentbundle/credentials.env` substring (AC2(a)), then confirm AST walk catches it.
-- Fixture for AC3: inline `.read_bytes()` form `(Path.home() / ".agentbundle" / "credentials.env").read_bytes()`.
+Add `TestD3CheckDotfileRead` class to `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py`. Each test method writes a fixture file to `tmp_path` and calls `_cs_check_dotfile_read(fixture)` directly.
 
-Then implement `_check_dotfile_read()` and `_is_dotfile_chain()`. Replace the substring-scan block with the AST walk.
-
-**Verification:**
-- `python3 tools/test-lint-credentialed-skills.py` exits 0 (AC1, AC4, AC5 regression)
-- New test cases for AC2 (bypass fixture) and AC3 (read_bytes) pass
-- `assert ".agentbundle/credentials.env" not in ac2_fixture_source` (AC2(a) inline assertion)
-
-### T2 — Add `_is_canonical_shim` path anchor
-
-**Depends on:** none (parallel with T1)
-**Mode:** Unit/TDD (AC6, AC7, AC8)
-
-Add `py.parent.name not in {"scripts", "shared-libs"}` early-return to `_is_canonical_shim`.
+**Test cases:**
+- `test_part_composition_bypass_caught` (AC2): fixture uses `("." + "agentbundle")` — assert (a) `".agentbundle/credentials.env" not in source` and (b) findings non-empty with `"read_text"` in description.
+- `test_read_bytes_inline_caught` (AC3): `.read_bytes()` inline — assert findings non-empty with `"read_bytes"` in description.
+- `test_optout_marker_suppresses_finding` (AC4): opt-out marker on same line — assert findings empty.
+- `test_bare_open_caught` (AC5): `open('.agentbundle/credentials.env')` — assert findings non-empty with `"open() reads dotfile credentials"` in description (isolates AST `open()` branch from fallback substring scan).
 
 **Verification:**
-- Unit test: canonical bytes at `arbitrary/credentials_shim.py` → `False` (AC7)
-- Unit test: canonical bytes at `scripts/credentials_shim.py` → `True` (AC8a)
-- Unit test: canonical bytes at `shared-libs/credentials_shim.py` → `True` (AC8b)
-- `python3 tools/test-lint-credentialed-skills.py` exits 0 (AC6/AC8 regression)
+- `pytest packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py -x` exits 0
 
-### T3 — Add `_load_cli_module()` and parametrise integration tests
+### T2 — Gate verification
 
-**Depends on:** none (parallel with T1/T2)
-**Mode:** Integration (AC9, AC10, AC11)
-
-Add `_load_cli_module()` helper. Parametrise `broker` fixture in `test_sso_broker_verbs.py` over source + projected paths. Add projected-path variant to `test_entry_point_imports_resolve_under_user_scope_layout`.
-
-**Verification:**
-- `pytest packages/agentbundle/tests/unit/test_sso_broker_verbs.py` passes (AC10)
-- `pytest packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py` passes (AC11)
-- If `dist/apm/` absent, projected variants report skip (not error)
-
-### T4 — Gate verification
-
-**Depends on:** T1, T2, T3
+**Depends on:** T1
 **Mode:** Goal-based (AC12–AC16)
 
-Run all gates in order (AC13 must run before AC15 — `make build-self` produces the `dist/apm/` projected copies that AC11's projected variant checks; without it, AC11's projected parametrisation will always skip):
-1. `make build-self FORCE=1` → exits 0 (AC13 prerequisite for projected test variants)
+Run all gates in order (AC13 must run before AC15 — `make build-self` produces the `dist/apm/` projected copies that AC11's projected variant checks):
+
+0. Mark AC2–AC5 `[x]` in `spec.md` (tests exist and pass).
+1. `make build-self FORCE=1` → exits 0
 2. `git status --short` → shows no changes (AC13)
 3. `python3 tools/hooks/pre-pr.py` → exits 0 (AC14)
-4. `pytest packages/agentbundle/tests/ -x` → exits 0 (AC15; projected variants now have build output to test against)
-5. `python3 tools/test-lint-credentialed-skills.py` → exits 0 (AC16)
+4. `pytest packages/agentbundle/tests/ -x` → exits 0 (AC12, AC15)
+5. `SKIP_SAST=1 make build-check` → exits 0 (AC16; covers `agentbundle catalogue verify --root .` and all build gates)
+6. Set `Status: Shipped` in `spec.md` after all reviewers return Clean (done at REVIEW, not here).
 
 ## Changelog
 
 - 2026-07-23: Initial plan authored.
+- 2026-07-31: Plan reconciled with corrected spec after v0.13.0 (96232e62) folded standalone linters into agentbundle CLI. AC1/AC6–AC11 confirmed shipped; remaining work scoped to T1 (D3 fixture tests) + T2 (gates). All `_cs_` prefixes and correct file paths applied; LLD updated to match shipped implementation; AC16 gate updated from deleted `tools/test-lint-credentialed-skills.py` to `SKIP_SAST=1 make build-check`.

--- a/docs/specs/credbroker-security-hardening/plan.md
+++ b/docs/specs/credbroker-security-hardening/plan.md
@@ -108,7 +108,7 @@ Add `TestD3CheckDotfileRead` class to `packages/agentbundle/tests/unit/test_cred
 **Depends on:** T1
 **Mode:** Goal-based (AC12–AC16)
 
-Run all gates in order (AC13 must run before AC15 — `make build-self` produces the `dist/apm/` projected copies that AC11's projected variant checks):
+Run all gates in order. Note: AC11's projected-path variant (`dist/apm/`) requires a prior `make build` run to produce the output directory; on a clean checkout without `dist/apm/`, those cases `pytest.skip` per the spec's explicit design (AC11). In this checkout `dist/apm/` is pre-existing so the projected-path tests run and pass.
 
 0. Mark AC2–AC5 `[x]` in `spec.md` (tests exist and pass).
 1. `make build-self FORCE=1` → exits 0

--- a/docs/specs/credbroker-security-hardening/spec.md
+++ b/docs/specs/credbroker-security-hardening/spec.md
@@ -1,6 +1,6 @@
 # Spec: credbroker-security-hardening
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** `credential-broker-contract` spec (round-4 security review, Concerns 1 and 4 deferred)
@@ -13,9 +13,9 @@ Mode: full (security boundary — credbroker test hardening)
 
 Close three deferred security-hardening items recorded in the `credential-broker-contract` spec's 2026-05-26 Changelog (round-4 security review, Concerns 1 and 4 — deferred by that PR, unblocked now):
 
-**D3 — substring scan is bypassable.** The dotfile-read detection in `tools/lint_credentialed_skills.py` (lines 908–925) is a line-by-line substring scan for `.agentbundle/credentials.env`. A consumer that constructs the path from concatenated string fragments — e.g. `Path.home() / (".agent" + "bundle") / ("credentials" + ".env")` then calls `.read_text()` — opens the dotfile without the literal substring `.agentbundle/credentials.env` ever appearing on any single source line. The fix rewrites D3 as an AST walk over `open()`, `.read_text()`, and `.read_bytes()` call sites, using the existing `_path_chain_components()` helper (already in the file) to reconstruct part-composed path chains before matching.
+**D3 — substring scan is bypassable.** The dotfile-read detection in the credentialed-skills lint (now at `packages/agentbundle/agentbundle/catalogue_tooling/lint.py`, function `_cs_check_dotfile_read`) originally used a line-by-line substring scan for `.agentbundle/credentials.env`. A consumer that constructs the path from concatenated string fragments — e.g. `(Path.home() / ("." + "agentbundle") / ("credentials" + ".env")).read_text()` — opens the dotfile without the literal substring `.agentbundle/credentials.env` ever appearing on any single source line. The fix rewrites D3 as an AST walk over `open()`, `.read_text()`, `.read_bytes()`, and `.open()` call sites alongside a retained fallback substring scan (defense-in-depth), using the existing `_cs_path_chain_components()` helper to reconstruct part-composed path chains before matching.
 
-**`_is_canonical_shim` — exemption is not path-anchored.** The current shim exemption (`_is_canonical_shim`) grants bypass treatment to any file whose basename is in `SHIM_BASENAMES` and whose bytes match the canonical source. This means a file named `credentials_shim.py` at an arbitrary location in the repo tree (e.g. `packs/evil-pack/.apm/some-dir/credentials_shim.py`) would be exempt if it carries canonical bytes — even though the build pipeline never places files in such a location. The fix adds a path-anchor requirement: the file must reside inside a directory named `scripts` (consumer skill projection target) or `shared-libs` (canonical source directory) for the exemption to apply. Byte-equality is kept as a secondary check.
+**`_cs_is_canonical_shim` — exemption is not path-anchored.** The current shim exemption (`_cs_is_canonical_shim`) grants bypass treatment to any file whose basename is in `_CS_SHIM_BASENAMES` and whose bytes match the canonical source. This means a file named `credentials_shim.py` at an arbitrary location in the repo tree (e.g. `packs/evil-pack/.apm/some-dir/credentials_shim.py`) would be exempt if it carries canonical bytes — even though the build pipeline never places files in such a location. The fix adds a path-anchor requirement: the file must reside inside a directory named `scripts` (consumer skill projection target) or `shared-libs` (canonical source directory) for the exemption to apply. Byte-equality is kept as a secondary check.
 
 **`_load_cli_module()` — integration tests load from pack source only.** The SSO broker verb tests (`test_sso_broker_verbs.py`) load the broker exclusively from the pack source path. The user-scope invocation tests (`test_credential_user_scope_invocation.py`) stage consumer skills exclusively from the pack source. Neither test suite exercises the projected copies that `make build-self` emits (in `dist/apm/`) or that `agentbundle install` places in `~/.agentbundle/bin/`. The fix introduces a `_load_cli_module(path)` staging helper and parametrises affected tests over both the source path and the projected path, with `pytest.skip` when the projected copy is absent (unbuilt checkout).
 
@@ -23,128 +23,129 @@ Close three deferred security-hardening items recorded in the `credential-broker
 
 ### D3: AST walk for dotfile-read detection
 
-- [ ] **AC1 (D3 — implementation):** The dotfile-read check in `tools/lint_credentialed_skills.py` is rewritten from a line-by-line substring scan to an AST walk implemented as a helper `_check_dotfile_read(py_path) -> list[tuple[int, str]]`. The walk visits every `ast.Call` node and raises a finding when: (a) the call is `open(<arg>)` (i.e. `func` is `ast.Name` with `id == "open"`) and the first positional argument resolves to the dotfile path; OR (b) the call is `<expr>.read_text(...)` or `<expr>.read_bytes(...)` (i.e. `func` is `ast.Attribute` with `attr` in `{"read_text", "read_bytes"}`) and the object expression `func.value` resolves to the dotfile path. Path resolution uses the existing `_path_chain_components()` helper; a finding is raised when the resolved components' last two entries match `(DOTFILE_PARENT, DOTFILE_BASENAME)` in order. The opt-out marker check is applied by reading the corresponding source line at the reported `lineno` and suppressing the finding when `OPTOUT_MARKER` appears on that line.
+- [x] **AC1 (D3 — implementation):** The dotfile-read check in `packages/agentbundle/agentbundle/catalogue_tooling/lint.py` is implemented as an AST walk in `_cs_check_dotfile_read(py_path) -> list[tuple[int, str]]`. The walk visits every `ast.Call` node and raises a finding when: (a) the call is `open(<arg>)` (i.e. `func` is `ast.Name` with `id == "open"`) and the first positional argument resolves to the dotfile path; OR (b) the call is `<expr>.read_text(...)`, `<expr>.read_bytes(...)`, or `<expr>.open(...)` (i.e. `func` is `ast.Attribute` with `attr` in `{"read_text", "read_bytes", "open"}`) and the object expression `func.value` resolves to the dotfile path. A retained fallback substring scan for `_CS_DOTFILE_SUBSTRING` catches any plain-string dotfile reference not resolved by the AST walk (defense-in-depth). Path resolution uses the existing `_cs_path_chain_components()` helper; a finding is raised when the resolved components' last two entries match `(_CS_DOTFILE_PARENT, _CS_DOTFILE_BASENAME)` in order. The opt-out marker check is applied by reading the corresponding source line at the reported `lineno` and suppressing the finding when `_CS_OPTOUT_MARKER` appears on that line.
 
-- [ ] **AC2 (D3 — part-composition bypass caught):** A new test case in `tools/test-lint-credentialed-skills.py` supplies a fixture script that uses inline part-composition (fully inline in the method call, so `_path_chain_components()` can resolve it):
+- [x] **AC2 (D3 — part-composition bypass caught):** A new test class `TestD3CheckDotfileRead` in `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` includes a case `test_part_composition_bypass_caught` that writes a temporary fixture file using inline part-composition (fully inline in the method call, so `_cs_path_chain_components()` can resolve it):
   ```python
   (Path.home() / ("." + "agentbundle") / ("credentials" + ".env")).read_text()
   ```
-  The fixture verifies: (a) that no line in the fixture source contains `.agentbundle/credentials.env` as a contiguous substring (proving the old substring scan would miss it); and (b) the new AST walk catches the `.read_text()` call and reports a finding with the call's lineno. Note: `_path_chain_components()` resolves inline `BinOp(Add)` string concatenation within `BinOp(Div)` path chains, but cannot resolve identifiers bound to intermediate variables — the fixture must use the fully-inline form.
+  The test verifies: (a) that no substring `.agentbundle/credentials.env` appears in the fixture source (proving the old substring scan would miss it); and (b) `_cs_check_dotfile_read(fixture_file)` returns a non-empty findings list with the call's lineno and a description containing `"read_text"`. Note: `_cs_path_chain_components()` resolves inline `BinOp(Add)` string concatenation within `BinOp(Div)` path chains, but cannot resolve identifiers bound to intermediate variables — the fixture uses the fully-inline form.
 
-- [ ] **AC3 (D3 — `Path.read_bytes()` form caught):** A second test case supplies a fixture script using the inline `.read_bytes()` form:
+- [x] **AC3 (D3 — `Path.read_bytes()` form caught):** The same test class includes `test_read_bytes_inline_caught` with a fixture using the inline `.read_bytes()` form:
   ```python
   (Path.home() / ".agentbundle" / "credentials.env").read_bytes()
   ```
-  The AST walk catches the `.read_bytes()` call on the inline-constructed path and reports a finding. (The cross-variable-assignment form — binding the path to a name then calling `.read_bytes()` on the name — is explicitly Declined; this AC covers the inline form only.)
+  `_cs_check_dotfile_read` on the fixture returns a non-empty list with a description containing `"read_bytes"`. (The cross-variable-assignment form is explicitly Declined; this AC covers the inline form only.)
 
-- [ ] **AC4 (D3 — opt-out still works):** The existing test case `dotfile-read-with-opt-out-allowed` continues to pass under the rewritten D3 check: a skill whose dotfile-read call is on the same line as `# credentialed-primitive: reads-creds-directly` exits the lint clean.
+- [x] **AC4 (D3 — opt-out still works):** The same test class includes `test_optout_marker_suppresses_finding` with a fixture placing the opt-out marker on the same line as the `.read_text()` call:
+  ```python
+  (Path.home() / ".agentbundle" / "credentials.env").read_text()  # credentialed-primitive: reads-creds-directly
+  ```
+  `_cs_check_dotfile_read` on this fixture returns an empty list.
 
-- [ ] **AC5 (D3 — existing `dotfile-read-refused` test still passes):** The existing `dotfile-read-refused` case (a bare `open('.agentbundle/credentials.env').read()` call on one line) continues to be caught by the AST walk and exits non-zero.
+- [x] **AC5 (D3 — bare `open()` form caught):** The same test class includes `test_bare_open_caught` with a fixture using a bare `open()` call whose first positional argument is the relative string path `'.agentbundle/credentials.env'`:
+  ```python
+  data = open('.agentbundle/credentials.env').read()
+  ```
+  `_cs_check_dotfile_read` on this fixture returns a non-empty list. (The inner `open()` call is visited by `ast.walk`; `_cs_path_chain_components` resolves the string literal to `("relative", [".agentbundle", "credentials.env"])`; `_cs_is_dotfile_chain` returns True.)
 
-### `_is_canonical_shim`: path-anchor
+### `_cs_is_canonical_shim`: path-anchor
 
-- [ ] **AC6 (`_is_canonical_shim` — path anchor added):** `_is_canonical_shim(py: pathlib.Path) -> bool` adds a path-anchor check before the byte-equality comparison: the function returns `False` immediately when `py.parent.name` is not in `{"scripts", "shared-libs"}`, even if the file's bytes match the canonical source. The anchor uses `py.parent.name` (a single path segment, not a substring match) per `feedback_credentialed_lint_substring_trap`. Note: `credentials_shim.py` also ships tracked at `.agentbundle/bin/credentials_shim.py` (parent `bin`), but the lint's scan roots (`packs/*/.apm/skills/*`, `.claude/skills/*`, `skills/*`) never reach `.agentbundle/bin/`, so `bin`-projected shims are intentionally outside the scanned set and are not affected by this anchor.
+- [x] **AC6 (`_cs_is_canonical_shim` — path anchor added):** `_cs_is_canonical_shim(py: pathlib.Path, shim_source_dir: pathlib.Path) -> bool` adds a path-anchor check before the byte-equality comparison: the function returns `False` immediately when `py.parent.name` is not in `{"scripts", "shared-libs"}`, even if the file's bytes match the canonical source. The anchor uses `py.parent.name` (a single path segment, not a substring match) per `feedback_credentialed_lint_substring_trap`. Note: `credentials_shim.py` also ships tracked at `.agentbundle/bin/credentials_shim.py` (parent `bin`), but the lint's scan roots (`packs/*/.apm/skills/*`, `.claude/skills/*`, `skills/*`) never reach `.agentbundle/bin/`, so `bin`-projected shims are intentionally outside the scanned set and are not affected by this anchor.
 
-- [ ] **AC7 (`_is_canonical_shim` — non-canonical path not exempt):** A unit test asserts that a copy of `credentials_shim.py` placed at a non-canonical parent directory (e.g. `some-pack/arbitrary/credentials_shim.py` where `parent.name == "arbitrary"`) returns `False` from `_is_canonical_shim` even when its bytes match the canonical source byte-for-byte.
+- [x] **AC7 (`_cs_is_canonical_shim` — non-canonical path not exempt):** A unit test in `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` asserts that a copy of `credentials_shim.py` placed at a non-canonical parent directory (e.g. `some-pack/arbitrary/credentials_shim.py` where `parent.name == "arbitrary"`) returns `False` from `_cs_is_canonical_shim(path, shim_source_dir)` even when its bytes match the canonical source byte-for-byte.
 
-- [ ] **AC8 (`_is_canonical_shim` — canonical paths remain exempt):** A unit test asserts that `credentials_shim.py` under a `scripts/` parent and under a `shared-libs/` parent (with matching canonical bytes) each return `True`.
+- [x] **AC8 (`_cs_is_canonical_shim` — canonical paths remain exempt):** A unit test asserts that `credentials_shim.py` under a `scripts/` parent and under a `shared-libs/` parent (with matching canonical bytes and the correct `shim_source_dir`) each return `True` from `_cs_is_canonical_shim`.
 
 ### `_load_cli_module()`: parametrised integration tests
 
-- [ ] **AC9 (`_load_cli_module` helper added):** A helper `_load_cli_module(py_path: pathlib.Path) -> types.ModuleType` is added to the credbroker test suite (either as a module-level function in a new `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` or as a shared helper imported from a new `packages/agentbundle/tests/_credbroker_helpers.py`). The implementation loads the file via `importlib.util.spec_from_file_location` with the file's directory prepended to `sys.path` for the duration of the load (the same pattern as the existing `_load_broker_module()` in `test_sso_broker_verbs.py`).
+- [x] **AC9 (`_load_cli_module` helper added):** A helper `_load_cli_module(py_path: pathlib.Path) -> types.ModuleType` exists in both `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py` and `packages/credbroker/tests/unit/test_sso_broker_verbs.py`. The implementation loads the file via `importlib.util.spec_from_file_location` with the file's directory prepended to `sys.path` for the duration of the load.
 
-- [ ] **AC10 (SSO broker verb tests — source + projected parametrisation):** The `broker` fixture in `packages/agentbundle/tests/unit/test_sso_broker_verbs.py` is parametrised over two paths:
-  - **source**: `packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py` (existing behavior)
-  - **projected**: `REPO_ROOT / ".agentbundle" / "bin" / "sso-broker.py"` (the `make build-self` output in this checkout)
+- [x] **AC10 (SSO broker verb tests — source + projected parametrisation):** The `broker` fixture in `packages/credbroker/tests/unit/test_sso_broker_verbs.py` is parametrised over two paths via `params=["source", "projected"]`:
+  - **source**: `packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py`
+  - **projected**: `REPO_ROOT / ".agentbundle" / "bin" / "sso-broker.py"` (the `make build-self` output)
 
-  The projected variant uses `pytest.skip(f"{path} not present — run make build-self")` when the file is absent. Both variants must pass when the projected file exists.
+  The projected variant uses `pytest.skip(f"{path} not present — run make build-self")` when the file is absent.
 
-- [ ] **AC11 (user-scope invocation tests — source + projected parametrisation):** The `test_entry_point_imports_resolve_under_user_scope_layout` parametrisation in `packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py` gains a second staging variant for each consumer skill:
-  - **source**: `packs/<pack>/.apm/skills/<skill>/scripts/` (existing `PACKS / skill_relpath` staging — unchanged)
-  - **projected**: `dist/apm/<pack>/.apm/skills/<skill>/scripts/` (the `make build-self` output)
+- [x] **AC11 (user-scope invocation tests — source + projected parametrisation):** The `test_entry_point_imports_resolve_under_user_scope_layout` parametrisation in `packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py` is parametrised over `variant in ["source", "projected"]`. The projected variant uses `pytest.skip` when `dist/apm/` is absent or the specific skill path does not exist.
 
-  The projected variant uses `pytest.skip` when `dist/apm/` is absent or the specific skill path does not exist. Both variants must pass when built. Note: `dist/` is gitignored, so the projected variant always skips in CI unless `make build-self` runs first; AC13 (`make build-self FORCE=1`) must be run before AC15 (`pytest`) in the same gate pass to give the projected variant a non-absent `dist/apm/` to test against (see `plan.md` T4 ordering).
-
-- [ ] **AC12 (all existing tests pass):** All test cases that existed before this PR continue to pass. No existing test may be deleted or have its assertions weakened to satisfy this spec.
+- [x] **AC12 (all existing tests pass):** All test cases that existed before this PR continue to pass. No existing test may be deleted or have its assertions weakened to satisfy this spec.
 
 ### Gates
 
-- [ ] **AC13:** `make build-self FORCE=1 && git status --short` shows no changes on the merged tree.
-- [ ] **AC14:** `python3 tools/hooks/pre-pr.py` exits 0.
-- [ ] **AC15:** `pytest packages/agentbundle/tests/ -x` exits 0 on the merged tree.
-- [ ] **AC16:** `python3 tools/test-lint-credentialed-skills.py` exits 0 on the merged tree.
+- [x] **AC13:** `make build-self FORCE=1 && git status --short` shows no changes on the merged tree.
+- [x] **AC14:** `python3 tools/hooks/pre-pr.py` exits 0.
+- [x] **AC15:** `pytest packages/agentbundle/tests/ -x` exits 0 on the merged tree.
+- [x] **AC16:** `SKIP_SAST=1 make build-check` exits 0 on the merged tree (covers `agentbundle catalogue verify --root .`, the credentialed-skills lint, and all build gates). Note: replaces the original `python3 tools/test-lint-credentialed-skills.py` gate — that standalone script was deleted in commit 96232e62 (v0.13.0) when standalone linters were folded into the agentbundle CLI.
 
 ## Boundaries
 
 ### Always do
 
-- **New checks land with a failing fixture.** Each new D3 test case (AC2, AC3) must be verified to produce no finding under the old substring scan before showing the finding under the new AST walk. This asymmetry is the load-bearing proof that the bypass existed.
-- **Path checks use `pathlib` parts, not substring matching.** The `_is_canonical_shim` path anchor uses `py.parent.name in {"scripts", "shared-libs"}` — a single-segment comparison via Python's standard attribute, not a string `in` substring check. This is consistent with `feedback_credentialed_lint_substring_trap`.
-- **AST walk reuses `_path_chain_components()`.** Do not re-implement path chain resolution for D3; reuse the existing helper that already handles `BinOp(Add)` part-composition inside `BinOp(Div)` path chains.
-- **Projected-path variants use `pytest.skip`, not `pytest.xfail`.** A missing projected copy is an expected state in an unbuilt checkout; `skip` is the correct disposition. `xfail` would imply the failure is a known bug.
-- **`_load_cli_module` respects the no-synthesised-import convention.** Per `feedback_test_real_invocation_not_synthesised_import`, tests that exercise verb behaviour use real `subprocess.run` invocation (as in `test_credential_user_scope_invocation.py`). `_load_cli_module` using `importlib` is appropriate only for tests that inspect the module's namespace (attribute checks) rather than drive it as a CLI.
+- **New D3 tests verify the bypass proof.** Each new D3 test (AC2) must include the assertion `".agentbundle/credentials.env" not in source` to prove the old substring scan would miss it.
+- **Path checks use `pathlib` parts, not substring matching.** The `_cs_is_canonical_shim` path anchor uses `py.parent.name in {"scripts", "shared-libs"}` — a single-segment comparison via Python's standard attribute, not a string `in` substring check.
+- **AST walk reuses `_cs_path_chain_components()`.** Do not re-implement path chain resolution for D3; reuse the existing helper that already handles `BinOp(Add)` part-composition inside `BinOp(Div)` path chains.
+- **Projected-path variants use `pytest.skip`, not `pytest.xfail`.** A missing projected copy is an expected state in an unbuilt checkout.
+- **`_load_cli_module` respects the no-synthesised-import convention.** Per `feedback_test_real_invocation_not_synthesised_import`, tests that exercise verb behaviour use real `subprocess.run` invocation. `_load_cli_module` using `importlib` is appropriate only for tests that inspect the module's namespace.
 
 ### Never do
 
-- **No changes to production pack files.** The scope is test and lint hardening only. `packs/credential-brokers/.apm/`, `packs/*/skills/*/scripts/`, consumer skill `.py` files, `pack.toml` manifests, the canonical shim sources, and `sso-broker.py` are all out of scope.
-- **No changes to `SHIM_BASENAMES` or `DOTFILE_PARENT`/`DOTFILE_BASENAME` constants.** The path anchor and AST walk use the existing named constants without widening them.
-- **Do not delete or weaken the existing byte-equality check in `_is_canonical_shim`.** The path anchor is an additional narrowing requirement; the byte-equality check remains to prevent a file at a canonical-looking path but with different bytes from being treated as canonical.
-- **No new third-party Python dependency** in `tools/lint_credentialed_skills.py` or in any new test file. The lint is stdlib-only (`ast`, `pathlib`); the tests use `pytest` and `unittest` (both already in dev dependencies).
-- **No sign-and-verify at build time.** That approach requires a key-management surface that does not exist in this repo.
+- **No changes to production pack files.** The scope is test and lint hardening only.
+- **No changes to `_CS_SHIM_BASENAMES` or `_CS_DOTFILE_PARENT`/`_CS_DOTFILE_BASENAME` constants.**
+- **Do not delete or weaken the existing byte-equality check in `_cs_is_canonical_shim`.**
+- **No new third-party Python dependency** in `catalogue_tooling/lint.py` or in any new test file.
+- **No sign-and-verify at build time.**
 
 ### Ask first
 
-- Widening `SHIM_BASENAMES` to include new filenames.
-- Adding a third canonical parent directory to the `_is_canonical_shim` path anchor.
+- Widening `_CS_SHIM_BASENAMES` to include new filenames.
+- Adding a third canonical parent directory to the `_cs_is_canonical_shim` path anchor.
 - Extending the D3 AST walk to track dotfile paths across variable assignments.
 
 ## Testing Strategy
 
 | Behaviour | Verification mode | Why this mode |
 | --- | --- | --- |
-| D3 AST walk catches part-composition bypass | TDD — write bypass fixture first, prove old scan misses it, then write AST walk that catches it | The bypass is only proved by running the old code against the fixture and observing silence |
-| D3 AST walk catches `.read_bytes()` inline path | TDD — fixture + assertion | Same as above; different call form |
-| D3 opt-out marker still suppresses findings | Regression — existing test case, no change needed | Existing test covers it; must continue to pass |
-| `_is_canonical_shim` path anchor | Unit test — place canonical bytes at non-canonical parent, assert `False` | Pure function; deterministic over path position |
-| `_is_canonical_shim` canonical paths remain exempt | Unit test — place canonical bytes at `scripts/` and `shared-libs/`, assert `True` | Regression pin on the positive case |
-| `_load_cli_module` + SSO broker projected path | Integration — `pytest.skip` if absent, real file load if present | The projected file is real output of the build pipeline; load it as the real consumer does |
+| D3 AST walk catches part-composition bypass | Regression/characterization — fixture written after code shipped; AC2(a) assertion proves old scan misses it, AST walk catches it | `_cs_check_dotfile_read` shipped in origin/main before tests; tests pin bypass invariants after the fact |
+| D3 AST walk catches `.read_bytes()` inline path | Regression/characterization — fixture + assertion | Same rationale; different call form |
+| D3 opt-out marker suppresses findings | Unit test — inline fixture with marker on same line | Pure function; deterministic |
+| D3 bare `open()` form caught | Unit test — inline fixture with string-literal path | `_cs_path_chain_components` resolves string literals |
+| D3 fallback scan catches literal keyword-arg `open(file=...)` | Regression/characterization — `open(file="<literal>")` fixture asserts fallback "skill reads" description | AST branch cannot fire (no positional arg); fallback is the only net for the literal form |
+| `_cs_is_canonical_shim` path anchor | Unit test — canonical bytes at non-canonical parent → False | Pure function; deterministic over path position |
+| `_cs_is_canonical_shim` canonical paths remain exempt | Unit test — canonical bytes at `scripts/` and `shared-libs/` → True | Regression pin on the positive case |
+| `_load_cli_module` + SSO broker projected path | Integration — `pytest.skip` if absent, real file load if present | The projected file is real output of the build pipeline |
 | User-scope invocation from projected path | Integration — `pytest.skip` if `dist/apm/` absent, subprocess invocation if present | Matches the `feedback_test_real_invocation_not_synthesised_import` convention |
 
 ## Assumptions
 
 - **Python ≥ 3.11** on all CI platforms (source: `packages/agentbundle/pyproject.toml`).
-- **`_path_chain_components()` resolves `BinOp(Add)` inside `BinOp(Div)` chains.** The existing helper calls `_literal_string()` on each right-hand side of the div chain; `_literal_string()` handles `BinOp(Add)` by recursion. This means `Path.home() / (".agent" + "bundle") / ("credentials" + ".env")` resolves to `(seed_kind="home", components=[".agentbundle", "credentials.env"])` — the AC2 bypass is provably caught.
-- **`dist/apm/` is the `make build-self` output in this checkout.** The projected path parametrisation uses `REPO_ROOT / "dist" / "apm"` as the root for projected consumer skills.
-- **`.agentbundle/bin/sso-broker.py` relative to `REPO_ROOT` is the local user-scope projection of the SSO broker.** This is confirmed by the presence of `pattaya-v2/.agentbundle/bin/sso-broker.py` in the working tree.
-- **The opt-out marker suppression check works at the AST level via lineno lookup.** After finding a Call node at a given `lineno`, the implementation reads the corresponding line from the source text to check for `OPTOUT_MARKER`.
-- **Two test roots exist.** Per `reference_agentbundle_two_test_roots`: `packages/agentbundle/tests/{unit,integration}/` and `packages/agentbundle/agentbundle/build/tests/`. The new tests go under `packages/agentbundle/tests/unit/`.
+- **Lint code is in `packages/agentbundle/agentbundle/catalogue_tooling/lint.py`.** The standalone `tools/lint_credentialed_skills.py` and `tools/test-lint-credentialed-skills.py` were deleted in commit 96232e62 (v0.13.0, "fold standalone linters into CLI as catalogue subcommands"). All symbols use the `_cs_` prefix (e.g. `_cs_check_dotfile_read`, `_cs_is_canonical_shim`, `_cs_path_chain_components`, `_CS_DOTFILE_PARENT`, `_CS_DOTFILE_BASENAME`, `_CS_OPTOUT_MARKER`).
+- **`_cs_path_chain_components()` resolves `BinOp(Add)` inside `BinOp(Div)` chains.** The helper calls `_cs_literal_string()` on each segment; `_cs_literal_string()` handles `BinOp(Add)` by recursion. This means `Path.home() / ("." + "agentbundle") / ("credentials" + ".env")` resolves to `("home", [".agentbundle", "credentials.env"])`.
+- **`dist/apm/` is the `make build-self` output in this checkout.**
+- **`.agentbundle/bin/sso-broker.py` relative to `REPO_ROOT` is the local user-scope projection of the SSO broker.**
+- **The SSO broker verb tests live at `packages/credbroker/tests/unit/test_sso_broker_verbs.py`.** Not `packages/agentbundle/tests/unit/`.
+- **Two test roots exist.** Per `reference_agentbundle_two_test_roots`: `packages/agentbundle/tests/{unit,integration}/` and `packages/agentbundle/agentbundle/build/tests/`. New D3 tests go under `packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py`.
 
 ## Tasks
 
-1. **D3: Rewrite dotfile-read check as AST walk** (`tools/lint_credentialed_skills.py`)
-   - Implement `_check_dotfile_read(py_path) -> list[tuple[int, str]]` using `_path_chain_components()` to detect `open()`, `.read_text()`, and `.read_bytes()` calls on the dotfile path.
-   - Replace the existing substring-scan block (lines 908–925) with a call to `_check_dotfile_read()`.
-   - Handle opt-out marker by lineno lookup.
-   - Construction tests: AC1, AC2 (bypass fixture), AC3 (read_bytes), AC4 (opt-out), AC5 (existing case).
+1. **D3: Add bypass-proof fixture tests** (`packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py`)
+   - Add `TestD3CheckDotfileRead` class with test cases for AC1 (fallback), AC2, AC3, AC4, AC5.
+   - Each test writes a fixture Python file to `tmp_path`, calls `_cs_check_dotfile_read(fixture_file)`, and asserts expected findings.
+   - AC2 requires the `".agentbundle/credentials.env" not in source` assertion.
+   - AC1 (fallback) uses `open(file="<literal>")` to exercise the substring-scan fallback independently of the AST branch.
 
-2. **`_is_canonical_shim`: add path anchor** (`tools/lint_credentialed_skills.py`)
-   - Add `py.parent.name not in {"scripts", "shared-libs"}` early-return guard in `_is_canonical_shim`.
-   - Construction tests: AC7 (non-canonical path → `False`), AC8 (canonical paths under `scripts/` and `shared-libs/` → `True`).
+2. **Gate verification**: mark AC2–AC5 [x] (tests written and passing); confirm AC12–AC16 pass on the merged tree; set `Status: Shipped` after all reviewers return Clean.
 
-3. **Integration: add `_load_cli_module()` and parametrise** (`packages/agentbundle/tests/unit/test_sso_broker_verbs.py`, `packages/agentbundle/tests/integration/test_credential_user_scope_invocation.py`)
-   - Add `_load_cli_module(py_path)` helper (generalises `_load_broker_module`).
-   - Parametrise `broker` fixture in `test_sso_broker_verbs.py` over source and projected SSO broker paths.
-   - Add projected-path variant to `test_entry_point_imports_resolve_under_user_scope_layout` parametrisation.
-   - Construction tests: AC9, AC10, AC11.
-
-4. **Gate verification**: confirm AC13–AC16 pass on the merged tree.
+*Note: AC1 implementation is shipped in origin/main; the AC1 fallback regression test was added in this PR. AC6–AC11 are implemented and passing in origin/main. Implementation work is tasks 1–2 only.*
 
 ## Declined
 
-- **Cross-variable assignment tracking in D3.** The bypass `dotfile = Path.home() / ".agentbundle" / "credentials.env"; dotfile.read_text()` is not caught by the AST walk. Tracking assignments across statements would require dataflow analysis. Deferred until a concrete false-negative surfaces.
+- **Cross-variable assignment tracking in D3.** The bypass `dotfile = Path.home() / ".agentbundle" / "credentials.env"; dotfile.read_text()` is not caught by the AST walk. Tracking assignments across statements would require dataflow analysis.
 
-- **Keyword-arg `open(file=...)` form in D3.** `open(file=".agentbundle/credentials.env").read()` uses a keyword argument rather than a positional argument, so `node.args` is empty and the AST walk's `open()` branch (which reads `node.args[0]`) does not flag it. This form is out of scope — it is a second bypass pattern strictly simpler than the part-composition case this spec addresses. Deferred until a concrete false-negative surfaces.
+- **Keyword-arg `open(file=...)` with part-composed path in D3.** `open(file=".agentbundle/credentials.env").read()` uses a keyword argument rather than a positional argument; the AST branch misses it (requires `node.args`), but the literal `.agentbundle/credentials.env` substring on the line is still caught by the retained fallback scan. The genuine uncaught form is the keyword-arg combined with part-composed arguments — e.g. `open(file="." + "agentbundle/credentials.env")` — where neither the AST branch nor the fallback fires. Deferred until a concrete false-negative surfaces in a PR review.
 
-- **Sign-and-verify at build time for `_is_canonical_shim`.** Requires key-management infrastructure that doesn't exist in this repo. Path-anchoring (AC6) closes the immediate concern without new infrastructure.
+- **Sign-and-verify at build time for `_cs_is_canonical_shim`.** Requires key-management infrastructure that doesn't exist in this repo.
 
-- **Extending projected-path parametrisation to `test_sso_broker_verbs.py` in-process verb tests.** Adding projected-path parametrisation to the full verb test matrix would multiply test count significantly with redundant coverage. AC10 covers the load-from-projected-path case for the broker.
+- **Recreating `tools/test-lint-credentialed-skills.py`.** This standalone script was intentionally deleted in v0.13.0 when the credentialed-skills lint was folded into `agentbundle catalogue lint`. Recreating it would reintroduce the standalone structure the refactor removed and create a `tools/` script importing from `packages/agentbundle`. Tests go in the existing `packages/agentbundle/tests/unit/` tree.
+
+- **`os.environ["HOME"]`/`os.getenv("HOME")` home seeds in D3.** `Path(os.environ["HOME"]) / ".agentbundle" / "credentials.env"` uses a home seed that `_cs_literal_string` returns `None` for, so `_cs_path_chain_components` resolves the chain to `(None, [])` and the AST branch never fires. Because the path components are joined with `/` operators (not a contiguous string literal), the fallback substring scan also misses it. Fixing this requires extending `_cs_path_chain_components` to recognise `os.environ[...]`/`os.getenv()`/`os.environ.get()` seeds as equivalent to `Path.home()` — deferred until a concrete false-negative surfaces in a PR review.

--- a/packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py
+++ b/packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py
@@ -1,5 +1,11 @@
-"""credbroker test-suite hardening — AC7 / AC8 / AC9.
+"""credbroker test-suite hardening — AC1 (fallback) / AC2 / AC3 / AC4 / AC5 / AC7 / AC8 / AC9.
 
+AC1  — _cs_check_dotfile_read retained fallback substring scan catches the literal
+        keyword-arg open(file="<path>") form that the AST branch misses (defense-in-depth).
+AC2  — _cs_check_dotfile_read catches inline part-composition bypass.
+AC3  — _cs_check_dotfile_read catches inline .read_bytes() form.
+AC4  — _cs_check_dotfile_read suppresses findings when opt-out marker is present.
+AC5  — _cs_check_dotfile_read catches bare open('.agentbundle/credentials.env') form.
 AC7  — _cs_is_canonical_shim returns False for canonical bytes at a
         non-canonical parent directory.
 AC8  — _cs_is_canonical_shim returns True for canonical bytes at "scripts/"
@@ -15,7 +21,7 @@ import sys
 import types
 
 import pytest
-from agentbundle.catalogue_tooling.lint import _cs_is_canonical_shim
+from agentbundle.catalogue_tooling.lint import _cs_check_dotfile_read, _cs_is_canonical_shim
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 _CANONICAL_SHIM_SRC = (
@@ -112,3 +118,109 @@ class TestIsCanonicalShimPathAnchor:
         """AC8b: canonical bytes at a shared-libs/ parent → True."""
         shim = self._write_shim("shared-libs")
         assert _cs_is_canonical_shim(shim, _SHIM_SOURCE_DIR) is True
+
+
+# ── AC2 / AC3 / AC4 / AC5: _cs_check_dotfile_read ───────────────────────────
+
+
+class TestD3CheckDotfileRead:
+    """D3 dotfile-read detection — AST walk and fallback scan (AC1 fallback / AC2-AC5).
+
+    Each test writes a minimal fixture Python file to tmp_path and calls
+    _cs_check_dotfile_read() directly to verify finding presence/absence.
+    """
+
+    _DOTFILE_SUBSTRING = ".agentbundle/credentials.env"
+
+    def _run(self, tmp_path: pathlib.Path, source: str) -> list[tuple[int, str]]:
+        fixture = tmp_path / "fixture.py"
+        fixture.write_text(source, encoding="utf-8")
+        return _cs_check_dotfile_read(fixture)
+
+    def test_part_composition_bypass_caught(self, tmp_path: pathlib.Path) -> None:
+        """AC2: inline part-composition is caught; old substring scan would miss it.
+
+        The fixture uses ("." + "agentbundle") so no literal
+        '.agentbundle/credentials.env' substring appears on any line.
+        _cs_path_chain_components() resolves BinOp(Add) inside BinOp(Div)
+        and the AST walk flags the .read_text() call.
+        """
+        # Split across adjacent string literals to stay under 99 chars while
+        # keeping the part-composition fully inline (required for _cs_path_chain_components).
+        source = (
+            "from pathlib import Path\n"
+            "result = ("
+            'Path.home() / ("." + "agentbundle") / ("credentials" + ".env")'
+            ").read_text()\n"
+        )
+        # AC2(a): prove the old substring scan would have missed this.
+        assert self._DOTFILE_SUBSTRING not in source, (
+            "fixture must not contain the literal dotfile substring "
+            "(that would make the test a tautology for the old scan)"
+        )
+        # AC2(b): AST walk catches it.
+        findings = self._run(tmp_path, source)
+        assert findings, "expected a finding for inline part-composition bypass"
+        assert any("read_text" in desc for _, desc in findings), (
+            f"expected 'read_text' in finding description; got {findings}"
+        )
+
+    def test_read_bytes_inline_caught(self, tmp_path: pathlib.Path) -> None:
+        """AC3: inline .read_bytes() form is caught by the AST walk."""
+        source = (
+            "from pathlib import Path\n"
+            "result = (Path.home() / '.agentbundle' / 'credentials.env').read_bytes()\n"
+        )
+        findings = self._run(tmp_path, source)
+        assert findings, "expected a finding for .read_bytes() inline form"
+        assert any("read_bytes" in desc for _, desc in findings), (
+            f"expected 'read_bytes' in finding description; got {findings}"
+        )
+
+    def test_optout_marker_suppresses_finding(self, tmp_path: pathlib.Path) -> None:
+        """AC4: opt-out marker on the same line as the call suppresses the finding."""
+        source = (
+            "from pathlib import Path\n"
+            "result = (Path.home() / '.agentbundle' / 'credentials.env').read_text()"
+            "  # credentialed-primitive: reads-creds-directly\n"
+        )
+        findings = self._run(tmp_path, source)
+        assert not findings, (
+            "opt-out marker on the call line must suppress the finding; "
+            f"got: {findings}"
+        )
+
+    def test_fallback_substring_scan_caught(self, tmp_path: pathlib.Path) -> None:
+        """AC1 defense-in-depth: keyword-arg open() evades the AST branch but is
+        caught by the retained fallback substring scan.
+
+        _cs_check_dotfile_read's AST branch requires a positional arg in node.args;
+        open(file=...) uses only node.keywords so the branch never fires.
+        The fallback scan catches any line whose text contains the dotfile substring
+        that the AST branch did not already flag.
+        """
+        source = 'f = open(file=".agentbundle/credentials.env").read()\n'
+        findings = self._run(tmp_path, source)
+        assert findings, (
+            "expected fallback scan to catch keyword-arg open(file=...) form"
+        )
+        assert any("skill reads" in desc for _, desc in findings), (
+            f"expected fallback-branch description 'skill reads'; got {findings}"
+        )
+
+    def test_bare_open_caught(self, tmp_path: pathlib.Path) -> None:
+        """AC5: bare open('.agentbundle/credentials.env') is caught by the AST walk.
+
+        _cs_path_chain_components() resolves the string literal to
+        ("relative", [".agentbundle", "credentials.env"]); _cs_is_dotfile_chain()
+        returns True. ast.walk() visits the inner open() call even when it is
+        chained with .read(). Asserting the AST-branch description
+        "open() reads dotfile credentials" distinguishes this from the retained
+        fallback substring scan (which would produce "skill reads ... directly").
+        """
+        source = "data = open('.agentbundle/credentials.env').read()\n"
+        findings = self._run(tmp_path, source)
+        assert findings, "expected a finding for bare open('.agentbundle/credentials.env')"
+        assert any("open() reads dotfile credentials" in desc for _, desc in findings), (
+            f"expected AST-branch description 'open() reads dotfile credentials'; got {findings}"
+        )

--- a/packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py
+++ b/packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py
@@ -158,11 +158,13 @@ class TestD3CheckDotfileRead:
             "fixture must not contain the literal dotfile substring "
             "(that would make the test a tautology for the old scan)"
         )
-        # AC2(b): AST walk catches it.
+        # AC2(b): AST walk catches it on the correct line.
         findings = self._run(tmp_path, source)
         assert findings, "expected a finding for inline part-composition bypass"
-        assert any("read_text" in desc for _, desc in findings), (
-            f"expected 'read_text' in finding description; got {findings}"
+        matching = [(ln, desc) for ln, desc in findings if "read_text" in desc]
+        assert matching, f"expected 'read_text' in finding description; got {findings}"
+        assert matching[0][0] == 2, (
+            f"expected call reported on line 2; got lineno={matching[0][0]}"
         )
 
     def test_read_bytes_inline_caught(self, tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `TestD3CheckDotfileRead` class (5 tests) to `test_credbroker_lint_hardening.py` pinning `_cs_check_dotfile_read` invariants: part-composition bypass (AC2, with line-number assertion), `.read_bytes()` (AC3), opt-out suppression (AC4), bare `open()` AST branch (AC5), and keyword-arg `open(file=...)` fallback scan (AC1 defense-in-depth).
- Reconciles spec/plan with v0.13.0 (commit 96232e62): updates all references from deleted `tools/lint_credentialed_skills.py` to `_cs_`-prefixed symbols in `packages/agentbundle/agentbundle/catalogue_tooling/lint.py`; marks AC1/AC6–AC11 as already shipped in origin/main; corrects Testing Strategy to Regression/characterization.
- Adds `os.environ["HOME"]` and keyword-arg+part-composed-path bypass gaps to spec Declined (documented, not fixed — both require extending `_cs_path_chain_components`).

## Test plan

- [x] `make lint-ruff` — clean
- [x] `pytest packages/agentbundle/tests/unit/test_credbroker_lint_hardening.py -x` — 9 passed
- [x] `make build-self FORCE=1` — exits 0, no projected drift
- [x] `python3 tools/hooks/pre-pr.py` — all checks passed
- [x] `pytest packages/agentbundle/tests/ -x` — exits 0
- [x] `SKIP_SAST=1 make build-check` — 41 passed, 0 failed
- [x] Adversarial-reviewer × 4 rounds → Clean
- [x] Security-reviewer × 2 rounds → Clean
- [x] Quality-engineer × 1 round → findings addressed
- [x] Codex review × 4 rounds → no findings

## Bundled fixes

- Corrected plan.md note: `dist/apm/` is produced by `make build`, not `make build-self`; AC11 projected-path tests skip by design on a clean checkout.