### PR TITLE
chore(workspace): reconcile credbroker-security-hardening to shipped; trim stale queue comments

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -126,115 +126,17 @@ shipped = [
   "spec/new-guide-conversation-first",         # user-guide-diataxis 0.2.0: conversation-first doctrine (spec.md=Shipped; moved from queue)
   "spec/site-ui-primitives",                  # Phase 2C: 16 reusable UI primitives — spec confirmed Shipped; moved from queue 2026-07-29
   "spec/atlassian-sso-cookie-selector-integration-test", # AC5: wired test_auth_selector.py into sso parity gate
+  "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening
 ]
 queue   = [
-  # ==================================================================
-  # RFC-0064 remaining work, sequenced by JOURNEY PHASE (see RFC-0064
-  # Amendment #3). Phase order = PRIORITY (pick up P1 first), NOT a hard
-  # dependency — `needs` encodes only real "cannot start until" edges. Each
-  # phase is a per-repo Project (docs/product/projects/<slug>.md, 3–8 wks)
-  # that ships its tooling AND its guides together; guides ride with the
-  # capability they document — no terminal doc wave. Sub-RFC gates (P2, P4)
-  # are noted in the phase header, not as entries (an RFC is not a spec).
-  # Independent (non-RFC-0064) work is grouped at the bottom.
-  # ==================================================================
-
-  # ---------------- P1 · Orient + Capture ----------------
-  # P1 guides + plan-by-phase doctrine (Amendment #3 e/f). Guides (guides/core/):
-  # ---------------- P2 · Shape (M2 PE skills) ----------------
-  # GATE: open + accept RFC-00XX pe-pack-strategic-shaping FIRST — it resolves skill
-  # boundaries (RFC-0064 M2 ACs + Known Unknowns). Each skill spec is authored after
-  # that sub-RFC and ships WITH its guide (phase-slice doctrine — not all-skills-then-
-  # all-guides). frame-situation + map-capabilities unblock the shaping_queue items
-  # opp-assessment-pe-pack + capability-map-ini-002 (their `needs` already point here).
-  # "spec/m2-diverge-solutions" — shipped; moved to ["ini-002".work].shipped
-  # "spec/m2-place-bet" — shipped; moved to ["ini-002".work].shipped
-  # "spec/m2-map-capabilities" — shipped; moved to ["ini-002".work].shipped
-  # "spec/m2-frame-intent-jtbd" — shipped; moved to ["ini-002".work].shipped
-
-  # ---------------- P3 · Brief → Build ----------------
-  # Tooling already shipped (receive-brief, work-loop, brief queue). Docs only.
-  # spec/author-brief-docs shipped — moved to work.shipped above.
-
-  # ---------------- P4 · Intake edges (M5 trackers) ----------------
-  # github-brief-intake first (independent, builds pattern confidence). GATE for the
-  # rest: open + accept RFC-0068 linear-pack (delta diff format, AC-export scope).
-  # Field mapping and protected-field convention resolved in the m5 spec. Each ships
-  # with its guide slice.
-  # "spec/m5-github-brief-intake" — shipped; moved to ["ini-002".work].shipped
-  # "spec/m5-linear-brief-intake-and-sync" — shipped; moved to ["ini-002".work].shipped
-  # "spec/m5-jira-align-brief-intake" — shipped; moved to ["ini-002".work].shipped
-
-  # ---------------- P5 · Adopt (terminal — needs whole journey stable) ----------------
-  # Authoring gate: each P5 spec must consume the adopter-persona research findings
-  # and the three pilot transcripts (portfolio-first-run-pilot-architect/figma/
-  # governance-extras) as evidence base. Do not author P5 specs before those work
-  # items complete — the evidence does not yet exist.
-  # `needs` encodes the P5 authoring gate above: the adopter-persona research must
-  # complete first (its findings are the evidence base). The three pilot transcripts
-  # (portfolio-first-run-pilot-architect/figma/governance-extras) are already Shipped,
-  # so they are omitted here — adopter-persona is the only open edge.
+  # P5 · Adopt — gated on adopter-persona research (evidence base)
   {path = "spec/m6-astro-project-index",         needs = "research:adopter-persona"},  # Astro site: PM-facing project index from docs/product/projects/
   {path = "spec/m6-live-demo-guide",             needs = "research:adopter-persona"},  # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
   {path = "spec/m6-enterprise-rollout-playbook", needs = "research:adopter-persona"},  # champion→CTO→platform→engineers; staged rollout + retro template
 
-  # ---- RFC-0064 Amendment #4: Cross-pack first-value overlay ----
-  # Complements P1–P5 phases; may progress in parallel where dependencies allow;
-  # feeds P5 adoption evidence. Group order = priority; `needs` encodes only the
-  # hard "cannot start until" edges stated in Amendment #4.
-
-  # Problem: pack audience, surface, install, verification, recovery, first-task,
-  # artifact, tutorial, and next-action facts are distributed across pack metadata,
-  # guides, journeys, README prose, and generated manifests without one maintained
-  # ownership contract.
-  # Deliver: ratified Level A/Level B obligations and membership; smallest
-  # authoritative semantic record; all seventeen current packs migrated; schema/
-  # parity validation; one real consumer and one independent parity proof.
-  # Done: inventory reconciles; required fields and negative fixtures pass; one
-  # source change propagates or fails every governed consumer; manifest validation
-  # green.
-  # spec/portfolio-pack-first-value-contract — moved to active
-
-  # Problem: Architect is explicitly non-technical by setup posture, but portfolio
-  # readiness is not proven by its existing tutorial or manifest alone
-  # (local/no-credential archetype — simplest pilot risk profile).
-  # Deliver: no-terminal, supported-surface path from architecture outcome to one
-  # bounded concept/diagram/review artifact; install verification, exact starter
-  # prompt, visible result, recovery, next action, cold-start transcript; only
-  # evidence-led skill changes.
-  # Done: fresh evaluator completes path without undocumented terminal/repo knowledge;
-  # tutorial/contract/eval stay in parity.
-  # "spec/portfolio-first-run-pilot-architect" — shipped; moved to ["ini-002".work].shipped
-  # "spec/portfolio-first-run-pilot-figma" — shipped; moved to ["ini-002".work].shipped
-
-  # Problem: repository-writing packs need a non-technical first run that explains
-  # the decision and prevents an unexpected shared-state write (preview-confirm write
-  # archetype).
-  # Deliver: preview-confirm path to one bounded ADR/RFC artifact in a user-owned
-  # repo; plain-language decision framing, target path/effect preview, confirmation,
-  # recovery/resume, next action, cold-start evidence.
-  # Done: evaluator can explain what will be written, where, why, and how to stop
-  # or revise before confirmation.
-  # spec/portfolio-first-run-pilot-governance-extras — shipped; moved to ["ini-002".work].shipped
-
-  # Problem: successful terminal installation can end in dense file-operation output
-  # without pack-specific verification, expected first result, or a copy-ready next
-  # prompt.
-  # Deliver: consume the accepted contract in concise human-default install completion
-  # output while preserving dry-run, detailed, and structured automation behavior.
-  # Done: a successful install ends with pack-specific verification, expected first
-  # result, and next prompt; automation snapshots and advanced modes remain compatible.
-  # Graphical onboarding remains the Level B default.
-  # "spec/agentbundle-first-value-handoff" — moved to active (spec + plan authored)
-
-  # ---- Backlog-graduated specs (reconciled from [backlog]; Approved, evidence in #627) ----
-  # These were authored from [backlog] items and are Approved-not-shipped; their origin
-  # backlog entries have been removed (superseded by the spec). Independent of RFC-0064.
-  "spec/credbroker-security-hardening",                  # credbroker test-suite security hardening (3 deferred items)
+  # Backlog-graduated specs — Approved, independent of RFC-0064
   "spec/site-design-system-spec",                        # site token spec + zone-violation lint
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
-  # ---- Independent skill improvements ----
-  # spec/new-guide-conversation-first — moved to shipped above (spec.md=Shipped; superseded by product-documentation Phase 1)
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1231,50 +1133,7 @@ shipped = [
   "spec/catalogue-ci-documentation",
 ]
 queue   = [
-  # M1 · Core guide + command verification + agent guidance
-  # Problem: no canonical document defines the portable commands, exit behavior,
-  #   publication ordering, evidence requirements, and responsibility boundaries
-  #   for a catalogue CI pipeline. Adopters reverse-engineer these from host CI
-  #   workflows, which are not portable catalogue content.
-  # Deliver: guides/_shared/catalogue-ci-contract.md (Catalogue CI Contract v1,
-  #   pack: _shared, kind: reference, status: stable); lifecycle diagram; 6
-  #   contract phases — (1) tool acquisition: externally managed + vendored
-  #   tooling models; (2) change validation: `agentbundle catalogue verify --root .
-  #   --format json` as required admission command, optional `catalogue lint`;
-  #   (3) release packaging: `catalogue package` with re-verification at immutable
-  #   boundary, deterministic archive + checksum sidecar + mutable channel
-  #   descriptor; (4) publication: upload ordering — immutable archive → checksum
-  #   → channel descriptor last; (5) post-publication verification: clean-consumer
-  #   check, optional smoke-test pack install; (6) evidence retention; secrets/TLS/
-  #   proxy responsibility boundary; exit-code contract (0/1/2) verified against
-  #   current HEAD for catalogue lint/verify/package with fixes or tracked follow-ups
-  #   where behavior diverges; focused command-contract tests parsing JSON output
-  #   via json.loads, verifying stderr/stdout separation and exit codes;
-  #   AGENTS.local.md and packs/AGENTS.md updated — CI workflows are host-local,
-  #   portable admission command is `agentbundle catalogue verify --root .`, public
-  #   JSON and exit-code contract changes require release review; host CI dogfood
-  #   confirmation that public AgentBundle commands are invoked.
-  # Done: guide validates under current guide contract; all documented command
-  #   behavior is tested and matches implementation; AGENTS guidance updated;
-  #   host CI dogfood check passes; all existing tests pass.
-  # M2a · Export boundary update
-  # Problem: export-catalogue skill may pass CI workflow implementation to target
-  #   catalogues, and may not include the neutral CI contract guide. Adopters
-  #   receive host-specific CI as if it were portable catalogue content.
-  # Deliver: export-catalogue skill updated so guides/_shared/catalogue-ci-contract.md
-  #   is eligible for export; all CI workflow and pipeline implementation excluded —
-  #   workflow definitions, trigger config, release/deployment automation,
-  #   package-publication automation, CI-specific helper scripts, workflow badges,
-  #   provider-specific secret names; exclusion is provider-neutral (positive allowlist
-  #   preferred over filename denylist); export guidance states: target chooses CI
-  #   system, receives neutral contract, no CI workflow is generated or copied, no
-  #   credentials are transported, no CI provider is assumed; export-boundary tests —
-  #   neutral guide is eligible, CI implementation is excluded, workflow badges and
-  #   host secret names don't escape, policy does not rely solely on known provider
-  #   filenames, white-label behavior remains fail-closed.
-  # Done: export-boundary tests pass; white-label behavior verified fail-closed.
-  # spec/catalogue-ci-export-boundary — shipped (moved to shipped above)
-  # spec/catalogue-ci-documentation — shipped (moved to shipped above)
+  # All M1–M2 entries shipped; see work.shipped above.
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Moves `spec/credbroker-security-hardening` from `[work].queue` to `[work].shipped` (Type 2 reconciliation — spec `Status: Shipped` confirmed)
- Removes stale queue comments from ini-002: empty P1–P4 phase headers, Amendment #4 problem/deliver/done blocks for already-shipped specs, and all `# "spec/..." — shipped; moved` markers
- Removes stale spec descriptions from ini-006 queue (M1/M2 entries already in `work.shipped`)

## Test plan

- [ ] `workspace-status` backend exits 0 with no reconciliation findings