### PR TITLE
fix(catalogue-curation-qa-coverage): correct skill-source path and AGENTS.md line ref

### DIFF
--- a/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook-notes.md
+++ b/docs/specs/catalogue-curation-qa-coverage/fixtures/hook-confirm/sample-hook-notes.md
@@ -30,7 +30,7 @@ C-quoting would break the `endswith("/.env")` check.
 The hook is self-contained — no external companion is required. It can be
 safely landed without depending on any other projected artifact. The
 `sys.stdout.reconfigure` / `sys.stderr.reconfigure` guard immediately after
-`import sys` is required by `packs/AGENTS.md:117-125` for any `.apm/` Python
+`import sys` is required by `packs/AGENTS.md:127-134` for any `.apm/` Python
 script that prints to stdout or stderr — it is already present in the fixture. Using Python
 (not bash) satisfies the repo policy that new additions to `tools/` must be
 pure-stdlib Python (`AGENTS.md:238-241`); `build-self` projects the hook to

--- a/docs/specs/catalogue-curation-qa-coverage/spec.md
+++ b/docs/specs/catalogue-curation-qa-coverage/spec.md
@@ -70,7 +70,7 @@ The autonomous portion of this work — authoring fixture files and documenting 
 
 ### Never do
 
-- Modify the `catalogue-curation` skill source (`packs/core/.apm/skills/catalogue-curation/`) as part of this spec — if a QA session reveals a bug, open a separate bug PR.
+- Modify the `catalogue-curation` skill source (`packs/catalogue-curation/.apm/skills/`) as part of this spec — if a QA session reveals a bug, open a separate bug PR.
 - Auto-invoke `propose-catalogue-pack` from `assimilate-repo` (existing Never-do from parent spec).
 - Invent fictional QA session outcomes — AC4–AC7 require real runs.
 


### PR DESCRIPTION
## Summary

- `spec.md:73` — wrong Never-do path `packs/core/.apm/skills/catalogue-curation/` → `packs/catalogue-curation/.apm/skills/` (the pack lives at the top-level, not under `core`)
- `fixtures/hook-confirm/sample-hook-notes.md` — AGENTS.md line citation corrected from `117-125` to `127-134` (the Windows-safe Python scripts section starts at 127)

## Context

Adversarial-reviewer pass on the autonomous deliverables (Tasks 1–3, shipped in #828) caught two documentation accuracy issues. Codex review (`gpt-5.6-sol`) confirmed clean on the first pass with no further changes needed.

The spec remains `Status: Implementing` — AC4–AC7 (live QA sessions) are human-gated.

## Test plan

- [x] `make lint-ruff` — passes
- [x] `SKIP_SAST=1 make build-check` — passes
- [x] `agentbundle` tests — passes
- [x] Adversarial reviewer — Clean (findings applied)
- [x] Codex review `--base main` — Clean (first pass, no changes needed)