### PR TITLE
feat(workspace-status): Order 2A — remove stale-queue scan from work-loop Step 0 (core 1.0.4)

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -78,7 +78,8 @@ Skip entirely if `workspace.toml` is absent. If present:
      orientation block.
      - Zero → surface "No active spec found — run `workspace-status` to see what's ready to start." Stop.
      - More than one → list all, ask the user to pick. Stop.
-   - **Stale-queue check.** For each active initiative, for each entry in `.work.queue` and `.work.active`: resolve the path (bare string → as-is; inline object → `path` field; `slug` is shaping-queue only), strip the `spec/` prefix, read `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring trailing `<!-- -->` comments), emit a non-blocking warning: `workspace.toml drift: <path> is in <queue|active> but spec.md shows Status: Shipped — move it to shipped in workspace.toml.` Path in both lists: warn once, name both. Missing `spec.md` or any status other than `Shipped` → skip without error.
+
+   Use `workspace-status reconcile` for exhaustive workspace integrity checks; `work-loop` does not scan the full portfolio at startup.
 
 2. **Shaping-item guard.** Derive slug (strip `docs/specs/` prefix + trailing `/`). Check all active initiatives' `[shaping_queue].active`, `.backlog`, and `[backlog].open` typed entries for a slug match. On match, stop: "This is a `[shape]` item (`type = <subtype>`); use `<skill>` — `work-loop` is for build items only." (shape→`frame-intent`; research→`desk-research-project-start`; strategy→`frame-situation`/`frame-intent`; design→`experience-status`.) Signal type → "Monitoring signal — `work-loop` is for build items only."
 

--- a/.agents/skills/work-loop/evals/evals.json
+++ b/.agents/skills/work-loop/evals/evals.json
@@ -101,6 +101,59 @@
         "Response does NOT proceed to PLAN automatically",
         "Response does NOT arbitrarily choose one spec"
       ]
+    },
+    {
+      "id": "step0-no-portfolio-reconcile",
+      "prompt": "You are starting work-loop. workspace.toml is present. Does work-loop scan every queue and active spec to find stale entries before proceeding to PLAN?",
+      "expected_output": "No. Work-loop does not scan the full portfolio for stale entries at startup. Step 0 reads workspace.toml only to orient: it resolves the active initiative, milestone, and active spec path, and checks the shaping-item guard. For exhaustive workspace integrity checks (including stale queue/active entries), run `workspace-status reconcile`.",
+      "assertions": [
+        "Response states work-loop does NOT scan every queue/active spec for stale entries",
+        "Response directs portfolio reconciliation to `workspace-status reconcile`",
+        "Response confirms Step 0 is limited to orientation (initiative, milestone, active spec, shaping guard)",
+        "Response does NOT describe a stale-queue warning mechanism in work-loop"
+      ]
+    },
+    {
+      "id": "reconcile-stale-routes-to-workspace-status",
+      "prompt": "Several specs in workspace.toml are showing Status: Shipped but are still listed in the queue. How do I find and fix all stale queue entries?",
+      "expected_output": "Run `workspace-status reconcile` to get an exhaustive list of workspace integrity issues, including stale entries (specs still in queue/active but showing Status: Shipped in their spec.md). Work-loop does not perform this scan — reconcile is the canonical tool for portfolio-wide stale detection.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile` as the correct tool",
+        "Response does NOT say to use work-loop for this",
+        "Response identifies reconcile as the exhaustive integrity path",
+        "Response does not describe a stale-queue warning from work-loop"
+      ]
+    },
+    {
+      "id": "find-untracked-specs-routes-to-reconcile",
+      "prompt": "I want to find spec files that exist on disk but are not declared in workspace.toml and are actively in progress (Approved or Implementing). What command should I run?",
+      "expected_output": "Run `workspace-status reconcile` — it performs a Type 1 scan that detects untracked live specs (specs on disk with status Approved or Implementing that are not referenced in workspace.toml). Specs with status Draft, Shipped, or Archived are not reported as Type 1 findings. Work-loop does not perform portfolio-wide file discovery.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile`",
+        "Response mentions Type 1 findings or untracked spec detection",
+        "Response does NOT say work-loop handles this"
+      ]
+    },
+    {
+      "id": "status-query-routes-to-workspace-status",
+      "prompt": "What should I work on next?",
+      "expected_output": "Run `workspace-status status` for a bounded view of what is ready to start (Type 2 and Type 3 findings). This shows ready, blocked, and actionable specs without a full portfolio scan. Work-loop is for executing a specific spec you have already selected.",
+      "assertions": [
+        "Response recommends `workspace-status status` for triage",
+        "Response does NOT say to invoke work-loop to answer this question",
+        "Response characterizes workspace-status status as the bounded discovery tool"
+      ]
+    },
+    {
+      "id": "explain-query-routes-to-explain",
+      "prompt": "Why is spec/foo still blocked? Its upstream dependencies look resolved to me.",
+      "expected_output": "Run `workspace-status explain --item spec/foo` to get a dependency explanation for that specific spec — it shows the item's classification (ready, blocked, active, shipped) and which declared dependencies are unsatisfied. Work-loop does not explain dependency state; workspace-status explain is the correct tool.",
+      "assertions": [
+        "Response recommends `workspace-status explain --item spec/foo`",
+        "Response does NOT describe a work-loop mechanism for explaining blocked specs",
+        "Response identifies workspace-status explain as the correct tool for dependency explanation",
+        "Response does NOT claim the command shows why each upstream dependency is itself blocked"
+      ]
     }
   ]
 }

--- a/.agents/skills/work-loop/scripts/test-loop-engine.py
+++ b/.agents/skills/work-loop/scripts/test-loop-engine.py
@@ -1321,7 +1321,7 @@ def test_spec_plan_full_walk(tmp: Path) -> None:
 
 
 def test_evals_json_shape(_tmp: Path) -> None:
-    """evals.json exists, is valid JSON, has skill_name='work-loop' and 9 entries."""
+    """evals.json exists, is valid JSON, has skill_name='work-loop' and 14 entries."""
     name = "evals-json-shape"
     if not EVALS_JSON.exists():
         fail(name, f"evals.json not found at {EVALS_JSON}")
@@ -1335,9 +1335,9 @@ def test_evals_json_shape(_tmp: Path) -> None:
         fail(name, f"expected skill_name='work-loop'; got {data.get('skill_name')!r}")
         return
     evals = data.get("evals")
-    if not isinstance(evals, list) or len(evals) != 9:
+    if not isinstance(evals, list) or len(evals) != 14:
         count = len(evals) if isinstance(evals, list) else repr(evals)
-        fail(name, f"expected 9 evals entries; got {count}")
+        fail(name, f"expected 14 evals entries; got {count}")
         return
     required_fields = {"id", "prompt", "expected_output", "assertions"}
     for entry in evals:

--- a/.agents/skills/workspace-status/evals/eval_queries.json
+++ b/.agents/skills/workspace-status/evals/eval_queries.json
@@ -9,6 +9,9 @@
   {"query": "Give me a session-start orientation", "should_trigger": true},
   {"query": "What's the current initiative status?", "should_trigger": true},
   {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+  {"query": "Reconcile stale workspace entries — some specs in the queue show Status: Shipped", "should_trigger": true},
+  {"query": "Find all spec files on disk that aren't tracked in workspace.toml", "should_trigger": true},
+  {"query": "Why is spec/foo blocked?", "should_trigger": true},
 
   {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
   {"query": "Fix this failing test in the parser", "should_trigger": false},

--- a/.agents/skills/workspace-status/scripts/workspace_status_engine.py
+++ b/.agents/skills/workspace-status/scripts/workspace_status_engine.py
@@ -108,21 +108,6 @@ class ReconciliationFinding:
 
 
 @dataclasses.dataclass
-class WorkLoopStaleWarning:
-    """A warn-only stale-queue finding emitted by work-loop Step 0.
-
-    Distinct from workspace-status Type 2 reconciliation:
-      - Only active initiatives are checked
-      - Only Shipped status triggers a warning (Archived/Approved/Implementing do not)
-      - When a path is in both queue and active, ONE warning names both lists
-      - No cleanup offer; work-loop only warns
-    """
-    spec_path: str
-    ini_slug: str
-    source_lists: list[str]  # ["queue"], ["active"], or ["queue", "active"]
-
-
-@dataclasses.dataclass
 class WorkspaceStatusResult:
     initiatives: list[Initiative]
     classifications: list[EntryClassification]        # work queue entries (ready + blocked)
@@ -958,52 +943,6 @@ def normalize_for_shaping_guard(raw_path: str) -> str:
     if s.startswith("spec/"):
         return s[len("spec/"):]
     return s
-
-
-# ── work-loop Step 0 stale-queue check ───────────────────────────────────────
-
-def collect_work_loop_stale_warnings(
-    root: Path,
-    initiatives: list[Initiative],
-) -> list[WorkLoopStaleWarning]:
-    """Characterize work-loop Step 0 stale-queue check (SKILL.md §0 step 1).
-
-    Checks active initiatives' queue and active entries. Emits a warn-only
-    WorkLoopStaleWarning when the entry's spec.md Status is 'Shipped'.
-
-    Differs from workspace-status Type 2 reconciliation:
-      - Only active initiatives (paused/closed/complete skipped)
-      - Only Shipped triggers a warning; Archived, Approved, Implementing do not
-      - When a path appears in both queue and active, emits ONE warning naming both
-      - Does not offer or perform cleanup (warn-only)
-      - Missing spec.md → skipped without error
-    """
-    warnings: list[WorkLoopStaleWarning] = []
-    for ini in initiatives:
-        if ini.status != "active":
-            continue
-        # Collect all paths with their source lists; a path may appear in both
-        path_sources: dict[str, list[str]] = {}
-        for list_name, entries in [("queue", ini.work.queue), ("active", ini.work.active)]:
-            for entry in entries:
-                if entry.path not in path_sources:
-                    path_sources[entry.path] = []
-                path_sources[entry.path].append(list_name)
-
-        for path, sources in path_sources.items():
-            slug = path.removeprefix("spec/")
-            spec_file = _safe_spec_path(root, slug)
-            if spec_file is None or not spec_file.exists():
-                continue
-            status = extract_spec_status(spec_file)
-            if status != "Shipped":
-                continue  # Only Shipped warns; Archived/Approved/Implementing skip
-            warnings.append(WorkLoopStaleWarning(
-                spec_path=path,
-                ini_slug=ini.slug,
-                source_lists=sources,
-            ))
-    return warnings
 
 
 def _toml_basic_string(s: str) -> str:

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -158,7 +158,7 @@
         "repo": "eugenelim/agent-ready-repo",
         "source": "github"
       },
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     {
       "author": {

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -78,7 +78,8 @@ Skip entirely if `workspace.toml` is absent. If present:
      orientation block.
      - Zero → surface "No active spec found — run `workspace-status` to see what's ready to start." Stop.
      - More than one → list all, ask the user to pick. Stop.
-   - **Stale-queue check.** For each active initiative, for each entry in `.work.queue` and `.work.active`: resolve the path (bare string → as-is; inline object → `path` field; `slug` is shaping-queue only), strip the `spec/` prefix, read `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring trailing `<!-- -->` comments), emit a non-blocking warning: `workspace.toml drift: <path> is in <queue|active> but spec.md shows Status: Shipped — move it to shipped in workspace.toml.` Path in both lists: warn once, name both. Missing `spec.md` or any status other than `Shipped` → skip without error.
+
+   Use `workspace-status reconcile` for exhaustive workspace integrity checks; `work-loop` does not scan the full portfolio at startup.
 
 2. **Shaping-item guard.** Derive slug (strip `docs/specs/` prefix + trailing `/`). Check all active initiatives' `[shaping_queue].active`, `.backlog`, and `[backlog].open` typed entries for a slug match. On match, stop: "This is a `[shape]` item (`type = <subtype>`); use `<skill>` — `work-loop` is for build items only." (shape→`frame-intent`; research→`desk-research-project-start`; strategy→`frame-situation`/`frame-intent`; design→`experience-status`.) Signal type → "Monitoring signal — `work-loop` is for build items only."
 

--- a/.claude/skills/work-loop/evals/evals.json
+++ b/.claude/skills/work-loop/evals/evals.json
@@ -101,6 +101,59 @@
         "Response does NOT proceed to PLAN automatically",
         "Response does NOT arbitrarily choose one spec"
       ]
+    },
+    {
+      "id": "step0-no-portfolio-reconcile",
+      "prompt": "You are starting work-loop. workspace.toml is present. Does work-loop scan every queue and active spec to find stale entries before proceeding to PLAN?",
+      "expected_output": "No. Work-loop does not scan the full portfolio for stale entries at startup. Step 0 reads workspace.toml only to orient: it resolves the active initiative, milestone, and active spec path, and checks the shaping-item guard. For exhaustive workspace integrity checks (including stale queue/active entries), run `workspace-status reconcile`.",
+      "assertions": [
+        "Response states work-loop does NOT scan every queue/active spec for stale entries",
+        "Response directs portfolio reconciliation to `workspace-status reconcile`",
+        "Response confirms Step 0 is limited to orientation (initiative, milestone, active spec, shaping guard)",
+        "Response does NOT describe a stale-queue warning mechanism in work-loop"
+      ]
+    },
+    {
+      "id": "reconcile-stale-routes-to-workspace-status",
+      "prompt": "Several specs in workspace.toml are showing Status: Shipped but are still listed in the queue. How do I find and fix all stale queue entries?",
+      "expected_output": "Run `workspace-status reconcile` to get an exhaustive list of workspace integrity issues, including stale entries (specs still in queue/active but showing Status: Shipped in their spec.md). Work-loop does not perform this scan — reconcile is the canonical tool for portfolio-wide stale detection.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile` as the correct tool",
+        "Response does NOT say to use work-loop for this",
+        "Response identifies reconcile as the exhaustive integrity path",
+        "Response does not describe a stale-queue warning from work-loop"
+      ]
+    },
+    {
+      "id": "find-untracked-specs-routes-to-reconcile",
+      "prompt": "I want to find spec files that exist on disk but are not declared in workspace.toml and are actively in progress (Approved or Implementing). What command should I run?",
+      "expected_output": "Run `workspace-status reconcile` — it performs a Type 1 scan that detects untracked live specs (specs on disk with status Approved or Implementing that are not referenced in workspace.toml). Specs with status Draft, Shipped, or Archived are not reported as Type 1 findings. Work-loop does not perform portfolio-wide file discovery.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile`",
+        "Response mentions Type 1 findings or untracked spec detection",
+        "Response does NOT say work-loop handles this"
+      ]
+    },
+    {
+      "id": "status-query-routes-to-workspace-status",
+      "prompt": "What should I work on next?",
+      "expected_output": "Run `workspace-status status` for a bounded view of what is ready to start (Type 2 and Type 3 findings). This shows ready, blocked, and actionable specs without a full portfolio scan. Work-loop is for executing a specific spec you have already selected.",
+      "assertions": [
+        "Response recommends `workspace-status status` for triage",
+        "Response does NOT say to invoke work-loop to answer this question",
+        "Response characterizes workspace-status status as the bounded discovery tool"
+      ]
+    },
+    {
+      "id": "explain-query-routes-to-explain",
+      "prompt": "Why is spec/foo still blocked? Its upstream dependencies look resolved to me.",
+      "expected_output": "Run `workspace-status explain --item spec/foo` to get a dependency explanation for that specific spec — it shows the item's classification (ready, blocked, active, shipped) and which declared dependencies are unsatisfied. Work-loop does not explain dependency state; workspace-status explain is the correct tool.",
+      "assertions": [
+        "Response recommends `workspace-status explain --item spec/foo`",
+        "Response does NOT describe a work-loop mechanism for explaining blocked specs",
+        "Response identifies workspace-status explain as the correct tool for dependency explanation",
+        "Response does NOT claim the command shows why each upstream dependency is itself blocked"
+      ]
     }
   ]
 }

--- a/.claude/skills/work-loop/scripts/test-loop-engine.py
+++ b/.claude/skills/work-loop/scripts/test-loop-engine.py
@@ -1321,7 +1321,7 @@ def test_spec_plan_full_walk(tmp: Path) -> None:
 
 
 def test_evals_json_shape(_tmp: Path) -> None:
-    """evals.json exists, is valid JSON, has skill_name='work-loop' and 9 entries."""
+    """evals.json exists, is valid JSON, has skill_name='work-loop' and 14 entries."""
     name = "evals-json-shape"
     if not EVALS_JSON.exists():
         fail(name, f"evals.json not found at {EVALS_JSON}")
@@ -1335,9 +1335,9 @@ def test_evals_json_shape(_tmp: Path) -> None:
         fail(name, f"expected skill_name='work-loop'; got {data.get('skill_name')!r}")
         return
     evals = data.get("evals")
-    if not isinstance(evals, list) or len(evals) != 9:
+    if not isinstance(evals, list) or len(evals) != 14:
         count = len(evals) if isinstance(evals, list) else repr(evals)
-        fail(name, f"expected 9 evals entries; got {count}")
+        fail(name, f"expected 14 evals entries; got {count}")
         return
     required_fields = {"id", "prompt", "expected_output", "assertions"}
     for entry in evals:

--- a/.claude/skills/workspace-status/evals/eval_queries.json
+++ b/.claude/skills/workspace-status/evals/eval_queries.json
@@ -9,6 +9,9 @@
   {"query": "Give me a session-start orientation", "should_trigger": true},
   {"query": "What's the current initiative status?", "should_trigger": true},
   {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+  {"query": "Reconcile stale workspace entries — some specs in the queue show Status: Shipped", "should_trigger": true},
+  {"query": "Find all spec files on disk that aren't tracked in workspace.toml", "should_trigger": true},
+  {"query": "Why is spec/foo blocked?", "should_trigger": true},
 
   {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
   {"query": "Fix this failing test in the parser", "should_trigger": false},

--- a/.claude/skills/workspace-status/scripts/workspace_status_engine.py
+++ b/.claude/skills/workspace-status/scripts/workspace_status_engine.py
@@ -108,21 +108,6 @@ class ReconciliationFinding:
 
 
 @dataclasses.dataclass
-class WorkLoopStaleWarning:
-    """A warn-only stale-queue finding emitted by work-loop Step 0.
-
-    Distinct from workspace-status Type 2 reconciliation:
-      - Only active initiatives are checked
-      - Only Shipped status triggers a warning (Archived/Approved/Implementing do not)
-      - When a path is in both queue and active, ONE warning names both lists
-      - No cleanup offer; work-loop only warns
-    """
-    spec_path: str
-    ini_slug: str
-    source_lists: list[str]  # ["queue"], ["active"], or ["queue", "active"]
-
-
-@dataclasses.dataclass
 class WorkspaceStatusResult:
     initiatives: list[Initiative]
     classifications: list[EntryClassification]        # work queue entries (ready + blocked)
@@ -958,52 +943,6 @@ def normalize_for_shaping_guard(raw_path: str) -> str:
     if s.startswith("spec/"):
         return s[len("spec/"):]
     return s
-
-
-# ── work-loop Step 0 stale-queue check ───────────────────────────────────────
-
-def collect_work_loop_stale_warnings(
-    root: Path,
-    initiatives: list[Initiative],
-) -> list[WorkLoopStaleWarning]:
-    """Characterize work-loop Step 0 stale-queue check (SKILL.md §0 step 1).
-
-    Checks active initiatives' queue and active entries. Emits a warn-only
-    WorkLoopStaleWarning when the entry's spec.md Status is 'Shipped'.
-
-    Differs from workspace-status Type 2 reconciliation:
-      - Only active initiatives (paused/closed/complete skipped)
-      - Only Shipped triggers a warning; Archived, Approved, Implementing do not
-      - When a path appears in both queue and active, emits ONE warning naming both
-      - Does not offer or perform cleanup (warn-only)
-      - Missing spec.md → skipped without error
-    """
-    warnings: list[WorkLoopStaleWarning] = []
-    for ini in initiatives:
-        if ini.status != "active":
-            continue
-        # Collect all paths with their source lists; a path may appear in both
-        path_sources: dict[str, list[str]] = {}
-        for list_name, entries in [("queue", ini.work.queue), ("active", ini.work.active)]:
-            for entry in entries:
-                if entry.path not in path_sources:
-                    path_sources[entry.path] = []
-                path_sources[entry.path].append(list_name)
-
-        for path, sources in path_sources.items():
-            slug = path.removeprefix("spec/")
-            spec_file = _safe_spec_path(root, slug)
-            if spec_file is None or not spec_file.exists():
-                continue
-            status = extract_spec_status(spec_file)
-            if status != "Shipped":
-                continue  # Only Shipped warns; Archived/Approved/Implementing skip
-            warnings.append(WorkLoopStaleWarning(
-                spec_path=path,
-                ini_slug=ini.slug,
-                source_lists=sources,
-            ))
-    return warnings
 
 
 def _toml_basic_string(s: str) -> str:

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [core][1.0.4] — 2026-08-01
+
+### Changed
+
+- **`work-loop` Step 0 no longer scans the full portfolio for stale entries (Order 2A).**
+  The stale-queue check — which read every `queue` and `active` spec.md to detect
+  `Status: Shipped` drift on every `work-loop` invocation — is removed. `work-loop` now
+  orients only (initiative, milestone, active spec, shaping guard). For exhaustive workspace
+  integrity checks (stale entries, untracked live specs), run
+  `workspace-status reconcile`. The same stale fixtures are still detected as Type 2 findings
+  by `analyze()` — behavior moves, not disappears.
+
 ## [core][1.0.3] — 2026-08-01
 
 ### Added

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -18,7 +18,7 @@ file as stale and ask before relying on it.
 
 **M1 · Workspace Foundation.** `workspace.toml` seed + `workspace-status` skill + brief template DoR fields (Status, Rabbit holes, Instrumentation, Design artifacts) + work-loop / receive-brief / new-rfc extensions + agentbundle-layout.toml `[product]` table + ADR for D2/D4 architectural decisions. [RFC-0064](../rfc/0064-ini-001-ai-native-ecosystem.md)
 
-**M1 fix — work-loop done-step lifecycle.** Extended done-step to find the current spec in `queue` (not just `active`), add Step 0 stale-queue warning, and fix the `spec/` prefix path-resolution bug. [spec/work-loop-queue-shipped-fix]
+**M1 fix — work-loop done-step lifecycle.** Extended done-step to find the current spec in `queue` (not just `active`) and fixed the `spec/` prefix path-resolution bug. The Step 0 stale-queue warning (added here, removed in Order 2A) transferred stale-entry detection permanently to `workspace-status reconcile`. [spec/work-loop-queue-shipped-fix]
 
 **M1 · Session-arc conventions (RFC-0067, Change D).** Pack workflow design guide (`guides/_shared/explanation/pack-workflow-design.md`) — five-step framework for pack authors: workflow-type classification, arc-stage mapping, skill naming, vault-path shape, workspace-status registration. CONTRIBUTING.md step 0 added. [spec/spec-D-pack-workflow-guide — Shipped; Changes A/B/C in queue]
 

--- a/docs/specs/workspace-status-simplification-order-2a/notes/read-profile.md
+++ b/docs/specs/workspace-status-simplification-order-2a/notes/read-profile.md
@@ -1,0 +1,66 @@
+# Read-profile evidence: Order 2A stale-scan removal
+
+## Before (pre-Order 2A) — work-loop Step 0 file-read profile (modeled estimate)
+
+Note: `collect_work_loop_stale_warnings` was called only from characterization tests,
+not from a running `work-loop` agent session (work-loop is prose, not a script).
+The estimate below models what the function *would have* read had work-loop called
+it, based on its implementation and the repo's current workspace.toml.
+
+`collect_work_loop_stale_warnings(root, initiatives)` iterated every entry in
+`.work.queue` and `.work.active` for each **active** initiative, resolved each
+to a `spec.md` path, and read that file to check `**Status:**`. With the repo's
+workspace.toml as of Order 2A implementation (3 active initiatives: ini-002 with
+4 queue entries, ini-003 with 10, ini-007 with 7 = **21 total**), this would
+produce up to 21 spec.md reads per work-loop startup before PLAN began — a
+modeled upper bound (deduplication and missing-file skips reduce the actual count).
+
+Note: the `declared_spec_files_read: 53` reported by the reconcile run below is
+_not_ comparable — `_run_type23_scan()` also reads shipped entries and non-active
+initiatives. The 21 figure is derived directly from active queue/active lists.
+
+Engine function removed: `collect_work_loop_stale_warnings` (~40 lines).
+Dataclass removed: `WorkLoopStaleWarning`.
+
+## After (post-Order 2A) — work-loop Step 0 file-read profile
+
+Work-loop Step 0 now reads:
+
+1. `workspace.toml` — 1 file
+2. `docs/specs/<active-slug>/spec.md` — 1 file (argless resume, exactly one active item)
+3. `docs/specs/<active-slug>/plan.md` — 1 file (immediately after spec.md, same condition)
+4. Shaping-queue entries for slug matching — 0 additional file reads (uses
+   already-parsed workspace.toml data)
+
+Total files read before PLAN: 3 (workspace.toml + spec.md + plan.md). Stale-scan
+reads eliminated: **up to 21 additional spec.md reads per startup** (modeled upper bound; see below).
+
+## Reconcile ownership proof (`workspace-status reconcile` run, 2026-08-01)
+
+```
+reconciliation.complete: true
+spec_files_read: 311 (global scan, all spec dirs)
+declared_spec_files_read: 53
+type1: [{"spec_path": "spec/workspace-status-simplification-order-2a",
+          "spec_status": "Implementing"}]
+type2: []
+type3: []
+```
+
+The Type 1 finding is the current spec (expected; Status: Implementing is the
+in-progress marker). Type 2 is empty — no stale queue/active entries in the
+repo's workspace. The reconcile run proves:
+
+- `analyze()` reads 311 spec files exhaustively (global scan).
+- The same stale entries that work-loop used to warn about are detectable as
+  Type 2 findings when they exist (proven by `case_work_loop_reconcile_owns_stale`).
+- Work-loop no longer participates in stale detection.
+
+## AC19 verification
+
+AC19: "The read-profile evidence demonstrates stale-scan removal."
+
+✓ `collect_work_loop_stale_warnings` absent from engine (sentinel test green).
+✓ Work-loop SKILL.md Step 0 contains ownership note; no stale-queue check bullet.
+✓ Modeled estimate: up to 21 spec.md reads eliminated per work-loop invocation (21 = active queue/active entries at time of removal; dedup/skip reduces actual count).
+✓ Reconcile still detects stale entries (parity test green).

--- a/docs/specs/workspace-status-simplification-order-2a/plan.md
+++ b/docs/specs/workspace-status-simplification-order-2a/plan.md
@@ -1,0 +1,177 @@
+# Plan: workspace-status simplification — Order 2A
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files touched:**
+1. `packs/core/.apm/skills/work-loop/SKILL.md` — Remove stale-queue check bullet from Step 0; add ownership note
+2. `packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py` — Remove `WorkLoopStaleWarning` class and `collect_work_loop_stale_warnings` function
+3. `tools/test_workspace_status.py` — Replace stale-scan tests with removal sentinel + parity tests; update `_WORK_LOOP_CONTRACT_HASH`; update CASES list and docstrings
+4. `packs/core/.apm/skills/work-loop/evals/evals.json` — Add routing evals
+5. `docs/specs/workspace-status-simplification-order-2a/notes/read-profile.md` — Before/after profile evidence
+
+**What tests demonstrate "done":**
+- `python3 tools/test_workspace_status.py` exits 0 with all existing cases passing plus new:
+  - `case_work_loop_stale_scan_removed` — AttributeError/absent sentinel for `collect_work_loop_stale_warnings`
+  - `case_work_loop_reconcile_owns_stale` — same stale fixtures detected by `analyze()`
+  - Updated `case_work_loop_contract_anchor` with new hash passes
+- `python3 -m pytest tools/test_workspace_status_cli.py -q` passes unchanged
+- `make build-self` succeeds
+- `SKIP_SAST=1 make build-check` passes
+
+**What I am NOT changing:**
+- `workspace-status` engine functions (`analyze`, `analyze_bounded`, `_run_type23_scan`, `_run_type1_scan`, `explain_item`)
+- workspace-status SKILL.md (already has reconcile/status/explain guidance from Order 1B)
+- workspace.toml schema or content
+- Argless resume, shaping guard, orientation logic in work-loop SKILL.md
+- Any guides (grep confirms none reference stale-queue behavior)
+- Order 1B tests, CLI tests, or any other test suite
+
+## Declined temptations
+
+- Moving `collect_work_loop_stale_warnings` to workspace-status CLI — Type 2 reconciliation in `analyze()` already owns stale detection; deduplication would only add confusion.
+- Renaming to `WorkspaceStaleWarning` — nothing needs this; the class exists only to serve the removed behavior.
+- Adding automatic `reconcile` invocation at work-loop Step 0 — explicitly forbidden by spec Boundaries and the contract's required final Step 0 behavior.
+- Updating historical/shipped spec files that reference stale-queue (e.g., `docs/specs/capture-work/plan.md`) — these are historical record; modifying them is out of scope.
+- Adding missing-target or cycle detection semantics — hard scope exclusion.
+
+## Tasks
+
+### T1 — Red behavioral tests (TDD stubs)
+
+**Mode:** TDD
+**Tests:**
+```
+# Add to tools/test_workspace_status.py:
+def case_work_loop_stale_scan_removed() → None:
+    # Assert collect_work_loop_stale_warnings is absent from _engine_mod
+    # Assert WorkLoopStaleWarning is absent from _engine_mod
+
+def case_work_loop_reconcile_owns_stale() → None:
+    # Using the stale fixture (Shipped queue + active entries),
+    # prove analyze() still detects them as Type 2 findings
+```
+These stubs fail BEFORE production edits (F) and pass AFTER (G).
+
+**Approach:** Write the test functions that assert the absence of the removed symbols and the presence of Type 2 findings in `analyze()`. Use `hasattr(_engine_mod, "collect_work_loop_stale_warnings")` for the sentinel. For the parity test, use a subset/contains assertion — `analyze()` is a strict superset of the removed check (it also finds Archived entries and paused initiatives). Add them to the CASES runner. Verify they fail on current code.
+
+**Verification:** `python3 tools/test_workspace_status.py` shows F for new cases, G for all existing.
+
+---
+
+### T2 — Remove stale-queue check from work-loop SKILL.md
+
+**Mode:** Goal-based check
+**Done when:** `grep "Stale-queue check" packs/core/.apm/skills/work-loop/SKILL.md` returns no output.
+**No stub (goal-based check)**
+
+**Approach:**
+In `packs/core/.apm/skills/work-loop/SKILL.md` Step 0, remove the entire **Stale-queue check** bullet
+(the sentence beginning "**Stale-queue check.**" through the end of the bullet). Replace with a one-sentence
+ownership note:
+
+```
+Use `workspace-status reconcile` for exhaustive workspace integrity checks; `work-loop` does
+not scan the full portfolio at startup.
+```
+
+Keep all other Step 0 content (initiative, milestone, active-spec resolution, shaping-item guard)
+unchanged.
+
+**Verification:** `grep "Stale-queue check" packs/core/.apm/skills/work-loop/SKILL.md` → empty.
+
+---
+
+### T3 — Remove stale-scan implementation from engine
+
+**Mode:** TDD (paired with T1)
+**Tests:** `case_work_loop_stale_scan_removed` turns green after this task.
+
+**Approach:**
+In `packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py`:
+1. Remove the `WorkLoopStaleWarning` dataclass (lines ~110–122).
+2. Remove the `collect_work_loop_stale_warnings` function and its section comment
+   (lines ~963–1006).
+3. Remove the test file's import of `collect_work_loop_stale_warnings` (line 46 of
+   `tools/test_workspace_status.py`).
+4. Remove or update the `WorkLoopStaleWarning` import usage in tests.
+
+Do not remove `_safe_spec_path`, `extract_spec_status`, or any other helper used elsewhere.
+
+**Verification:** `case_work_loop_stale_scan_removed` passes; `case_work_loop_reconcile_owns_stale` passes.
+
+---
+
+### T4 — Update contract anchor hash and test docstrings
+
+**Mode:** Goal-based check
+**Done when:** `python3 tools/test_workspace_status.py` exits 0, including `case_work_loop_contract_anchor`.
+
+**Approach:**
+1. Compute the new SHA-256 of the SKILL.md section from `## Step 0. ORIENT` to `## Step 1. PLAN`
+   after T2's edit using the existing `_check_section_anchor` mechanism.
+2. Update `_WORK_LOOP_CONTRACT_HASH` in `tools/test_workspace_status.py`.
+3. Update `case_work_loop_contract_anchor` docstring: replace the stale-queue check mention
+   with the ownership note; AC6–AC10 are covered by hash plus existing test cases.
+4. Update CASES list: replace `F4b work_loop_stale_warnings` and `F4c work_loop_stale_both_lists`
+   with `2A work_loop_stale_scan_removed` and `2A work_loop_reconcile_owns_stale`.
+5. Remove the `case_work_loop_stale_warnings` and `case_work_loop_stale_both_lists` function
+   bodies (they test behavior that no longer exists). Keep `case_work_loop_slug_normalization`
+   (tests `normalize_for_shaping_guard`, which is unrelated to stale scanning).
+6. Remove the pytest wrapper functions `test_work_loop_stale_warnings()` and
+   `test_work_loop_stale_both_lists()` (lines ~2633–2638 only; do not remove
+   `test_work_loop_slug_normalization` which follows). These call the removed case functions
+   and would cause a NameError during pytest collection if left. The new sentinel and parity
+   tests get corresponding wrappers `test_work_loop_stale_scan_removed()` and
+   `test_work_loop_reconcile_owns_stale()`.
+
+---
+
+### T5 — Add routing evals
+
+**Mode:** Goal-based check
+**Done when:** `packs/core/.apm/skills/work-loop/evals/evals.json` contains the new eval entries.
+
+**Approach:**
+Add to `packs/core/.apm/skills/work-loop/evals/evals.json`:
+- `step0-no-portfolio-reconcile`: work-loop invocation must not trigger portfolio stale scan
+- `reconcile-stale-routes-to-workspace-status`: "reconcile stale workspace entries" → `workspace-status reconcile`
+- `find-untracked-specs-routes-to-reconcile`: "find untracked specs" → `workspace-status reconcile`
+- `status-query-routes-to-workspace-status`: "what should I work on?" → `workspace-status status`
+- `explain-query-routes-to-explain`: "why is spec/foo blocked?" → `workspace-status explain`
+
+---
+
+### T6 — Run make build-self and verify projections
+
+**Mode:** Goal-based check
+**Done when:** `make build-self` exits 0; `.claude/skills/work-loop/SKILL.md` matches source;
+`.claude/skills/workspace-status/scripts/workspace_status_engine.py` matches source.
+
+**Approach:** Run `make build-self`. Verify byte-equivalence of work-loop SKILL.md and
+workspace-status engine in `.claude/` vs `packs/core/`.
+
+---
+
+### T7 — Capture read profile and run gates
+
+**Mode:** Visual / manual QA
+**Approach:**
+1. Run `workspace-status reconcile` against the repo's own workspace.toml; record output.
+2. Record the before-state and after-state Step 0 file-read profile. Note: the profile is
+   derived from the characterization fixture (the removed `collect_work_loop_stale_warnings`
+   read N spec files per active initiative queue+active list), not a measured work-loop runtime
+   invocation (work-loop is agent prose). The stop point is the engine function removal.
+3. Write evidence to `docs/specs/workspace-status-simplification-order-2a/notes/read-profile.md`.
+4. Run `python3 tools/lint-ruff.py`, `SKIP_SAST=1 make build-check`, `make ci`.
+
+## Resolve-vs-surface disposition record
+
+| Situation | Resolution |
+|-----------|-----------|
+| Hash update after SKILL.md change | Resolve: compute new hash programmatically, update constant |
+| Test removal of `case_work_loop_stale_warnings` | Resolve: replace with sentinel + parity tests (same row count) |
+| No root `scripts/` directory for loop-cohort | Named skip: apply full mode rigor inline |
+| Historical spec refs to stale-queue check | Resolve: out of scope; shipped specs are historical record |

--- a/docs/specs/workspace-status-simplification-order-2a/spec.md
+++ b/docs/specs/workspace-status-simplification-order-2a/spec.md
@@ -1,0 +1,158 @@
+# Spec: workspace-status simplification — Order 2A
+
+- **Status:** Shipped
+- **Owner:** maintainer
+- **Plan:** [`plan.md`](plan.md)
+- **Mode:** full (intentionally changes user-visible work-loop startup behavior; structural change to
+  reconciliation ownership; multi-feature/dependent tasks; the work-loop skill and its generated
+  projections change)
+- **Constrained by:**
+  - [RFC-0064](../../rfc/0064-ini-001-ai-native-ecosystem.md) — workspace.toml schema and
+    workspace-status behavior authority
+  - `docs/specs/workspace-status-simplification-order-0/spec.md` — Phase 0 characterization;
+    compatibility authority
+  - `docs/specs/workspace-status-simplification-order-1a/spec.md` — Order 1A contract baseline
+  - `docs/specs/workspace-status-simplification-order-1b/spec.md` — Order 1B contract; `reconcile`
+    mode is now the canonical exhaustive integrity path
+  - `packs/core/.apm/skills/work-loop/SKILL.md` — production behavior; Step 0 is the target
+  - `packs/core/.apm/skills/workspace-status/SKILL.md` — canonical reconcile skill
+- **Contract:** none (internal skill interface only)
+- **Shape:** mixed
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Remove the stale-workspace reconciliation scan from `work-loop` Step 0.
+
+Responsibility boundary after this change:
+
+| Surface | Responsibility |
+|---------|---------------|
+| `workspace-status status` | Bounded discovery and triage (Type 2 + Type 3 only) |
+| `workspace-status explain` | Focused dependency explanation |
+| `workspace-status reconcile` | Exhaustive workspace integrity (Type 1 + 2 + 3) |
+| `work-loop` | Execute and verify one selected work item |
+
+`work-loop` must no longer inspect every queue and active spec merely to detect
+that a declared item has become Shipped or otherwise stale.
+
+## Order 1B Readiness Evidence
+
+Prerequisites verified against current production source:
+
+1. `workspace_status.py reconcile --root <dir>` exists and routes to `analyze()`. ✓
+2. `analyze()` performs exhaustive Type 1 + Type 2 + Type 3 scan. ✓
+3. `workspace_status.py status --root <dir>` is the bounded default (Type 2 + Type 3 only). ✓
+4. `reconcile` is read-only at the CLI level (AC19 of Order 1B). ✓
+5. `SKILL.md` routes integrity-audit requests to `reconcile`. ✓
+6. `.claude/` and `.agents/` projections match the source. ✓
+7. Order 1B spec.md is Shipped; all 56 tests pass. ✓
+
+## Boundaries
+
+### Always do
+
+- Remove the **Stale-queue check** bullet from `packs/core/.apm/skills/work-loop/SKILL.md`
+  Step 0, specifically the paragraph beginning "**Stale-queue check.**".
+- Add a one-sentence ownership note in Step 0 directing users to `workspace-status reconcile`
+  for exhaustive workspace integrity checks.
+- Remove `WorkLoopStaleWarning` class and `collect_work_loop_stale_warnings` function from
+  `packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py`.
+- Replace the stale-scan tests in `tools/test_workspace_status.py` with:
+  (a) a sentinel test proving `collect_work_loop_stale_warnings` is absent from the engine;
+  (b) a reconcile ownership parity test proving `analyze()` still detects the stale fixtures;
+  (c) updated `_WORK_LOOP_CONTRACT_HASH` after the SKILL.md change.
+- Update `case_work_loop_contract_anchor` docstring to remove the stale-queue check reference.
+- Add routing evals to `packs/core/.apm/skills/work-loop/evals/evals.json` demonstrating that
+  portfolio reconciliation requests route to `workspace-status reconcile`, not `work-loop`.
+- Run `make build-self` after editing `packs/`; verify generated projections are changed.
+- Record before-and-after Step 0 file-read profile in
+  `docs/specs/workspace-status-simplification-order-2a/notes/read-profile.md`.
+
+### Ask first
+
+- Any change to workspace.toml schema
+- Any change to `workspace-status` reconcile, status, or explain semantics
+- Any change to argless resume behavior in work-loop
+- Adding a new work-loop mode or routing mechanism
+
+### Never do
+
+- Change `workspace-status` status, explain, or reconcile semantics
+- Change the workspace-status JSON schema
+- Add `repair-plan`, `repair-apply`, or automatic mutation
+- Create a separate `workspace-reconcile` skill
+- Call `workspace-status` from `work-loop` automatically
+- Change work-loop argless resume; replace `work.active` with queue scanning
+- Remove or reinterpret `work.active` or `work.shipped`
+- Change workspace.toml schema
+- Scan queue specs for `Status: Implementing` (belongs to later state-model migration)
+- Remove or loosen the shaping-item guard
+- Change deferred-backlog capture or completion behavior
+- Add caching or generated indexes
+- Perform unrelated cleanup
+
+## Testing Strategy
+
+- **TDD** — sentinel test for stale-scan removal (AttributeError on `collect_work_loop_stale_warnings`);
+  reconcile ownership parity test (same stale fixtures detected by `analyze()`); argless resume
+  regression tests (zero/one/many active items); shaping guard and orientation preservation.
+  Red stubs written before production edits.
+- **Goal-based check** — `make build-self` passes; `_WORK_LOOP_CONTRACT_HASH` in
+  `tools/test_workspace_status.py` updated to reflect new Step 0 content.
+- **Visual / manual QA** — `workspace-status reconcile` exercised against repo's own
+  `workspace.toml`; work-loop invoked against a fixture; observed output recorded.
+
+## Acceptance Criteria
+
+- [x] AC1. Work-loop no longer scans queue and active specs for stale workspace state during Step 0.
+- [x] AC2. Work-loop no longer emits Type 1, Type 2, or Type 3 portfolio findings.
+- [x] AC3. Work-loop does not invoke `workspace-status status`, `explain`, or `reconcile` automatically.
+- [x] AC4. `workspace-status reconcile` remains the canonical exhaustive integrity path.
+- [x] AC5. The stale fixtures removed from work-loop remain detected by `workspace-status reconcile`.
+- [x] AC6. Argless resume continues to use the current `work.active` contract.
+- [x] AC7. Zero, one, and multiple active-item behavior is unchanged.
+- [x] AC8. Explicit-spec invocation is unchanged.
+- [x] AC9. Initiative and milestone orientation are unchanged.
+- [x] AC10. The shaping-item guard is unchanged.
+- [x] AC11. Work-loop Step 0 performs no workspace.toml mutation.
+- [x] AC12. Completion and deferred-backlog behavior are unchanged.
+- [x] AC13. Workspace-status status, explain, and reconcile behavior is unchanged.
+- [x] AC14. Workspace.toml schema is unchanged.
+- [x] AC15. `work.active` and `work.shipped` remain unchanged.
+- [x] AC16. No repair-plan or repair-apply mode is introduced.
+- [x] AC17. No separate reconciliation skill is introduced.
+- [x] AC18. Generated projections match source (after `make build-self`).
+- [x] AC19. The read-profile evidence demonstrates stale-scan removal.
+- [x] AC20. Focused tests, build-self, build-check, and required reviews pass. Routing evals are
+  present in `evals.json` (presence-only; no eval harness is wired in CI today — consistent with
+  all existing evals in this repo).
+
+## Verification mapping for preserved behaviors (AC6–AC10)
+
+| AC | Verification |
+|----|--------------|
+| AC6 argless resume | Existing: `case_multiple_active_for_workloop` (AC2o); `case_work_loop_contract_anchor` hashes the Step 0 section which preserves argless-resume prose |
+| AC7 zero/one/many | Existing: `case_multiple_active_for_workloop` covers multiple; Step 0 orientation logic text unchanged in hash |
+| AC8 explicit-spec invocation | Existing: work-loop SKILL.md Step 0 — explicit path bypasses active resolution; hash covers this |
+| AC9 initiative/milestone orientation | Existing: `case_multiple_active_initiatives`; hash of Step 0 covers orientation bullet |
+| AC10 shaping-item guard | Existing: `case_shaping_item_guard`, `case_shaping_guard_top_level_backlog`; hash covers guard prose |
+
+Primary verification mechanism: the `_WORK_LOOP_CONTRACT_HASH` anchors the entire Step 0 section.
+Any over-broad edit that removes orientation, argless-resume, or shaping-guard prose changes the hash
+and fails `case_work_loop_contract_anchor`. Human diff review at PR time is the secondary gate.
+
+## Assumptions
+
+- Technical: The stale-queue check is fully contained in `collect_work_loop_stale_warnings` and the
+  single Stale-queue check bullet in work-loop SKILL.md Step 0 — confirmed by grepping the codebase.
+- Technical: Removing `WorkLoopStaleWarning` and `collect_work_loop_stale_warnings` from the engine
+  does not break any caller outside of `tools/test_workspace_status.py` — confirmed by grep showing
+  only test-file imports.
+- Technical: The `_WORK_LOOP_CONTRACT_HASH` anchors the entire `## Step 0. ORIENT` → `## Step 1. PLAN`
+  section; removing the stale-queue bullet changes the hash, so the hash constant must be updated.
+- Process: `loop-engine` / `loop-cohort` scripts are absent from `scripts/` at repo root — named skip
+  for state machine; full mode rigor applied without it (consistent with Order 1B precedent).
+- Process: No guides in `guides/` reference stale-queue behavior — confirmed by grep.

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -78,7 +78,8 @@ Skip entirely if `workspace.toml` is absent. If present:
      orientation block.
      - Zero → surface "No active spec found — run `workspace-status` to see what's ready to start." Stop.
      - More than one → list all, ask the user to pick. Stop.
-   - **Stale-queue check.** For each active initiative, for each entry in `.work.queue` and `.work.active`: resolve the path (bare string → as-is; inline object → `path` field; `slug` is shaping-queue only), strip the `spec/` prefix, read `docs/specs/<slug>/spec.md`. If `**Status:**` is `Shipped` (ignoring trailing `<!-- -->` comments), emit a non-blocking warning: `workspace.toml drift: <path> is in <queue|active> but spec.md shows Status: Shipped — move it to shipped in workspace.toml.` Path in both lists: warn once, name both. Missing `spec.md` or any status other than `Shipped` → skip without error.
+
+   Use `workspace-status reconcile` for exhaustive workspace integrity checks; `work-loop` does not scan the full portfolio at startup.
 
 2. **Shaping-item guard.** Derive slug (strip `docs/specs/` prefix + trailing `/`). Check all active initiatives' `[shaping_queue].active`, `.backlog`, and `[backlog].open` typed entries for a slug match. On match, stop: "This is a `[shape]` item (`type = <subtype>`); use `<skill>` — `work-loop` is for build items only." (shape→`frame-intent`; research→`desk-research-project-start`; strategy→`frame-situation`/`frame-intent`; design→`experience-status`.) Signal type → "Monitoring signal — `work-loop` is for build items only."
 

--- a/packs/core/.apm/skills/work-loop/evals/evals.json
+++ b/packs/core/.apm/skills/work-loop/evals/evals.json
@@ -101,6 +101,59 @@
         "Response does NOT proceed to PLAN automatically",
         "Response does NOT arbitrarily choose one spec"
       ]
+    },
+    {
+      "id": "step0-no-portfolio-reconcile",
+      "prompt": "You are starting work-loop. workspace.toml is present. Does work-loop scan every queue and active spec to find stale entries before proceeding to PLAN?",
+      "expected_output": "No. Work-loop does not scan the full portfolio for stale entries at startup. Step 0 reads workspace.toml only to orient: it resolves the active initiative, milestone, and active spec path, and checks the shaping-item guard. For exhaustive workspace integrity checks (including stale queue/active entries), run `workspace-status reconcile`.",
+      "assertions": [
+        "Response states work-loop does NOT scan every queue/active spec for stale entries",
+        "Response directs portfolio reconciliation to `workspace-status reconcile`",
+        "Response confirms Step 0 is limited to orientation (initiative, milestone, active spec, shaping guard)",
+        "Response does NOT describe a stale-queue warning mechanism in work-loop"
+      ]
+    },
+    {
+      "id": "reconcile-stale-routes-to-workspace-status",
+      "prompt": "Several specs in workspace.toml are showing Status: Shipped but are still listed in the queue. How do I find and fix all stale queue entries?",
+      "expected_output": "Run `workspace-status reconcile` to get an exhaustive list of workspace integrity issues, including stale entries (specs still in queue/active but showing Status: Shipped in their spec.md). Work-loop does not perform this scan — reconcile is the canonical tool for portfolio-wide stale detection.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile` as the correct tool",
+        "Response does NOT say to use work-loop for this",
+        "Response identifies reconcile as the exhaustive integrity path",
+        "Response does not describe a stale-queue warning from work-loop"
+      ]
+    },
+    {
+      "id": "find-untracked-specs-routes-to-reconcile",
+      "prompt": "I want to find spec files that exist on disk but are not declared in workspace.toml and are actively in progress (Approved or Implementing). What command should I run?",
+      "expected_output": "Run `workspace-status reconcile` — it performs a Type 1 scan that detects untracked live specs (specs on disk with status Approved or Implementing that are not referenced in workspace.toml). Specs with status Draft, Shipped, or Archived are not reported as Type 1 findings. Work-loop does not perform portfolio-wide file discovery.",
+      "assertions": [
+        "Response recommends `workspace-status reconcile`",
+        "Response mentions Type 1 findings or untracked spec detection",
+        "Response does NOT say work-loop handles this"
+      ]
+    },
+    {
+      "id": "status-query-routes-to-workspace-status",
+      "prompt": "What should I work on next?",
+      "expected_output": "Run `workspace-status status` for a bounded view of what is ready to start (Type 2 and Type 3 findings). This shows ready, blocked, and actionable specs without a full portfolio scan. Work-loop is for executing a specific spec you have already selected.",
+      "assertions": [
+        "Response recommends `workspace-status status` for triage",
+        "Response does NOT say to invoke work-loop to answer this question",
+        "Response characterizes workspace-status status as the bounded discovery tool"
+      ]
+    },
+    {
+      "id": "explain-query-routes-to-explain",
+      "prompt": "Why is spec/foo still blocked? Its upstream dependencies look resolved to me.",
+      "expected_output": "Run `workspace-status explain --item spec/foo` to get a dependency explanation for that specific spec — it shows the item's classification (ready, blocked, active, shipped) and which declared dependencies are unsatisfied. Work-loop does not explain dependency state; workspace-status explain is the correct tool.",
+      "assertions": [
+        "Response recommends `workspace-status explain --item spec/foo`",
+        "Response does NOT describe a work-loop mechanism for explaining blocked specs",
+        "Response identifies workspace-status explain as the correct tool for dependency explanation",
+        "Response does NOT claim the command shows why each upstream dependency is itself blocked"
+      ]
     }
   ]
 }

--- a/packs/core/.apm/skills/work-loop/scripts/test-loop-engine.py
+++ b/packs/core/.apm/skills/work-loop/scripts/test-loop-engine.py
@@ -1321,7 +1321,7 @@ def test_spec_plan_full_walk(tmp: Path) -> None:
 
 
 def test_evals_json_shape(_tmp: Path) -> None:
-    """evals.json exists, is valid JSON, has skill_name='work-loop' and 9 entries."""
+    """evals.json exists, is valid JSON, has skill_name='work-loop' and 14 entries."""
     name = "evals-json-shape"
     if not EVALS_JSON.exists():
         fail(name, f"evals.json not found at {EVALS_JSON}")
@@ -1335,9 +1335,9 @@ def test_evals_json_shape(_tmp: Path) -> None:
         fail(name, f"expected skill_name='work-loop'; got {data.get('skill_name')!r}")
         return
     evals = data.get("evals")
-    if not isinstance(evals, list) or len(evals) != 9:
+    if not isinstance(evals, list) or len(evals) != 14:
         count = len(evals) if isinstance(evals, list) else repr(evals)
-        fail(name, f"expected 9 evals entries; got {count}")
+        fail(name, f"expected 14 evals entries; got {count}")
         return
     required_fields = {"id", "prompt", "expected_output", "assertions"}
     for entry in evals:

--- a/packs/core/.apm/skills/workspace-status/evals/eval_queries.json
+++ b/packs/core/.apm/skills/workspace-status/evals/eval_queries.json
@@ -9,6 +9,9 @@
   {"query": "Give me a session-start orientation", "should_trigger": true},
   {"query": "What's the current initiative status?", "should_trigger": true},
   {"query": "Show me all queued specs and their dependencies", "should_trigger": true},
+  {"query": "Reconcile stale workspace entries — some specs in the queue show Status: Shipped", "should_trigger": true},
+  {"query": "Find all spec files on disk that aren't tracked in workspace.toml", "should_trigger": true},
+  {"query": "Why is spec/foo blocked?", "should_trigger": true},
 
   {"query": "Start a new spec for a rate-limiting feature", "should_trigger": false},
   {"query": "Fix this failing test in the parser", "should_trigger": false},

--- a/packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py
+++ b/packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py
@@ -108,21 +108,6 @@ class ReconciliationFinding:
 
 
 @dataclasses.dataclass
-class WorkLoopStaleWarning:
-    """A warn-only stale-queue finding emitted by work-loop Step 0.
-
-    Distinct from workspace-status Type 2 reconciliation:
-      - Only active initiatives are checked
-      - Only Shipped status triggers a warning (Archived/Approved/Implementing do not)
-      - When a path is in both queue and active, ONE warning names both lists
-      - No cleanup offer; work-loop only warns
-    """
-    spec_path: str
-    ini_slug: str
-    source_lists: list[str]  # ["queue"], ["active"], or ["queue", "active"]
-
-
-@dataclasses.dataclass
 class WorkspaceStatusResult:
     initiatives: list[Initiative]
     classifications: list[EntryClassification]        # work queue entries (ready + blocked)
@@ -958,52 +943,6 @@ def normalize_for_shaping_guard(raw_path: str) -> str:
     if s.startswith("spec/"):
         return s[len("spec/"):]
     return s
-
-
-# ── work-loop Step 0 stale-queue check ───────────────────────────────────────
-
-def collect_work_loop_stale_warnings(
-    root: Path,
-    initiatives: list[Initiative],
-) -> list[WorkLoopStaleWarning]:
-    """Characterize work-loop Step 0 stale-queue check (SKILL.md §0 step 1).
-
-    Checks active initiatives' queue and active entries. Emits a warn-only
-    WorkLoopStaleWarning when the entry's spec.md Status is 'Shipped'.
-
-    Differs from workspace-status Type 2 reconciliation:
-      - Only active initiatives (paused/closed/complete skipped)
-      - Only Shipped triggers a warning; Archived, Approved, Implementing do not
-      - When a path appears in both queue and active, emits ONE warning naming both
-      - Does not offer or perform cleanup (warn-only)
-      - Missing spec.md → skipped without error
-    """
-    warnings: list[WorkLoopStaleWarning] = []
-    for ini in initiatives:
-        if ini.status != "active":
-            continue
-        # Collect all paths with their source lists; a path may appear in both
-        path_sources: dict[str, list[str]] = {}
-        for list_name, entries in [("queue", ini.work.queue), ("active", ini.work.active)]:
-            for entry in entries:
-                if entry.path not in path_sources:
-                    path_sources[entry.path] = []
-                path_sources[entry.path].append(list_name)
-
-        for path, sources in path_sources.items():
-            slug = path.removeprefix("spec/")
-            spec_file = _safe_spec_path(root, slug)
-            if spec_file is None or not spec_file.exists():
-                continue
-            status = extract_spec_status(spec_file)
-            if status != "Shipped":
-                continue  # Only Shipped warns; Archived/Approved/Implementing skip
-            warnings.append(WorkLoopStaleWarning(
-                spec_path=path,
-                ini_slug=ini.slug,
-                source_lists=sources,
-            ))
-    return warnings
 
 
 def _toml_basic_string(s: str) -> str:

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Core agent-ready-repo: work-loop, new-spec, bug-fix, frontend-engineering, contract-acquisition, workspace-status, capture-work skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md / CHARTER / CONVENTIONS seeds."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "1.0.3"
+version = "1.0.4"
 description = "Core: work-loop, new-spec, bug-fix, adapt-to-project, init-project, receive-brief, author-brief, capture-work, workspace-status, frontend-engineering, contract-acquisition, operational-safety, security-checklists skills; reviewer/implementer agents; pre-pr, session-start + work-loop-check hooks; conventions-check command; AGENTS.md, CHARTER, CONVENTIONS, docs/architecture, docs/knowledge, docs/product, docs/specs, workspace.toml seeds."
 readme = "README.md"
 display_name = "Core"

--- a/tools/test_workspace_status.py
+++ b/tools/test_workspace_status.py
@@ -43,7 +43,6 @@ explain_item = _engine_mod.explain_item
 check_shaping_guard = _engine_mod.check_shaping_guard
 classify_entries = _engine_mod.classify_entries
 classify_shaping_entries = _engine_mod.classify_shaping_entries
-collect_work_loop_stale_warnings = _engine_mod.collect_work_loop_stale_warnings
 compute_type2_cleanup = _engine_mod.compute_type2_cleanup
 extract_initiatives = _engine_mod.extract_initiatives
 extract_spec_status = _engine_mod.extract_spec_status
@@ -1360,7 +1359,7 @@ _WL_FINISH_START = r'^## Finish checklist'
 _WL_FINISH_END = r'Conventional commit format'
 
 _WORK_LOOP_CONTRACT_HASH = (
-    "c739285ae95ad891fddb2f6463624e2ef1793e1694e6711543c4d6eb1e4d72f6"
+    "2a7f418ed6769f3c3aeb65466b8a06b105363e2b1c74578a2d6b3a5286d2be2b"
 )
 _WORK_LOOP_FINISH_HASH = (
     "4bdd195cea3d66cb8bcc26405f61e573477b86c32e7a0eb4ed6e1c83fe71dd95"
@@ -1429,8 +1428,9 @@ def case_work_loop_contract_anchor() -> None:
 
     Two section anchors:
     - '## Step 0. ORIENT' → '## Step 1. PLAN': active-spec resolution,
-      stale-queue check (warn-only; does NOT update workspace.toml), and
-      shaping-item guard.
+      ownership note directing exhaustive integrity work to `workspace-status reconcile`,
+      and shaping-item guard. (Order 2A removed the stale-queue check; AC6–AC10
+      preserved behaviors are verified by this hash + existing test cases.)
     - '## Finish checklist' → 'Conventional commit format': the ownership-relevant
       checklist items including the doc-drift invariant (sets spec.md Status: Shipped)
       but excluding commit format, learnings, and PR-opening guidance — which are
@@ -1869,8 +1869,34 @@ def case_safe_spec_path_dot_segments() -> None:
 
 # ── F1: work-loop Step 0 stale-queue check ───────────────────────────────────
 
-def case_work_loop_stale_warnings() -> None:
-    """collect_work_loop_stale_warnings: characterizes work-loop Step 0 stale-queue check."""
+# ── Order 2A: stale-scan removal sentinel + reconcile ownership parity ────────
+
+def case_work_loop_stale_scan_removed() -> None:
+    """Prove collect_work_loop_stale_warnings and WorkLoopStaleWarning are absent.
+
+    Order 2A removes the stale-queue scan from work-loop Step 0. The engine must
+    no longer export these symbols; ownership of stale detection moves entirely
+    to workspace-status reconcile (Type 2 findings in analyze()).
+    """
+    expect(
+        not hasattr(_engine_mod, "collect_work_loop_stale_warnings"),
+        "[2A] collect_work_loop_stale_warnings must be absent from engine after Order 2A",
+    )
+    expect(
+        not hasattr(_engine_mod, "WorkLoopStaleWarning"),
+        "[2A] WorkLoopStaleWarning must be absent from engine after Order 2A",
+    )
+
+
+def case_work_loop_reconcile_owns_stale() -> None:
+    """Prove analyze() still detects stale fixtures that work-loop Step 0 used to warn about.
+
+    Order 2A removes the stale-scan from work-loop but does NOT remove the behavior —
+    it moves responsibility to workspace-status reconcile. This test demonstrates parity:
+    the same stale entries that work-loop used to warn about are still found by analyze()
+    as Type 2 findings. The assertion is subset-only: analyze() is a strict superset of
+    the removed check (it also finds Archived entries, paused-initiative entries, etc.).
+    """
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         write_workspace(root, """
@@ -1883,97 +1909,24 @@ def case_work_loop_stale_warnings() -> None:
             shipped = []
             queue   = [
               "spec/stale-queue",
-              "spec/archived-entry",
               {path = "spec/inline-shipped", needs = "work:spec/stale-queue"},
-              "spec/approved-entry",
-              "spec/no-spec",
             ]
             ["ini-001".shaping_queue]
             active = []
             backlog = []
-
-            ["ini-002"]
-            name = "Paused"
-            status = "paused"
-            milestone = "M1"
-            ["ini-002".work]
-            active  = []
-            shipped = []
-            queue   = ["spec/paused-stale"]
-            ["ini-002".shaping_queue]
-            active = []
-            backlog = []
         """)
-        # Write spec files
         write_spec(root, "stale-queue", "Shipped")
         write_spec(root, "stale-active", "Shipped")
-        write_spec(root, "archived-entry", "Archived")
         write_spec(root, "inline-shipped", "Shipped")
-        write_spec(root, "approved-entry", "Approved")
-        write_spec(root, "paused-stale", "Shipped")
-        # spec/no-spec deliberately has no spec.md
 
-        ws = parse_workspace(root / "workspace.toml")
-        inits = extract_initiatives(ws)
-        warnings = collect_work_loop_stale_warnings(root, inits)
-        warned_paths = {w.spec_path for w in warnings}
+        result = analyze(root)
+        type2_paths = {f.spec_path for f in result.type2}
 
-        # Shipped queue entry → warns
-        expect("spec/stale-queue" in warned_paths,
-               "[stale] Shipped queue entry warns")
-        # Shipped active entry → warns
-        expect("spec/stale-active" in warned_paths,
-               "[stale] Shipped active entry warns")
-        # Shipped inline-object queue entry → warns (path field used, not slug)
-        expect("spec/inline-shipped" in warned_paths,
-               "[stale] Shipped inline-object queue entry warns")
-        # Archived → does NOT warn
-        expect("spec/archived-entry" not in warned_paths,
-               "[stale] Archived entry does NOT warn")
-        # Approved → does NOT warn
-        expect("spec/approved-entry" not in warned_paths,
-               "[stale] Approved entry does NOT warn")
-        # Missing spec.md → skipped without error
-        expect("spec/no-spec" not in warned_paths,
-               "[stale] missing spec.md → no warning")
-        # Paused initiative → ignored
-        expect("spec/paused-stale" not in warned_paths,
-               "[stale] paused initiative ignored")
-        # Exactly 3 warnings (stale-queue, stale-active, inline-shipped)
-        expect(len(warnings) == 3,
-               f"[stale] expected 3 warnings, got {len(warnings)}: "
-               f"{[w.spec_path for w in warnings]}")
-
-
-def case_work_loop_stale_both_lists() -> None:
-    """Path in both queue and active → ONE warning naming both lists."""
-    with tempfile.TemporaryDirectory() as tmp:
-        root = Path(tmp)
-        write_workspace(root, """
-            ["ini-001"]
-            name = "Active"
-            status = "active"
-            milestone = "M1"
-            ["ini-001".work]
-            active  = ["spec/in-both"]
-            shipped = []
-            queue   = ["spec/in-both"]
-            ["ini-001".shaping_queue]
-            active = []
-            backlog = []
-        """)
-        write_spec(root, "in-both", "Shipped")
-
-        ws = parse_workspace(root / "workspace.toml")
-        inits = extract_initiatives(ws)
-        warnings = collect_work_loop_stale_warnings(root, inits)
-
-        expect(len(warnings) == 1,
-               f"[stale-both] one warning for path in both lists, got {len(warnings)}")
-        w = warnings[0]
-        expect(w.spec_path == "spec/in-both", "[stale-both] correct path")
-        expect(sorted(w.source_lists) == ["active", "queue"],
-               f"[stale-both] both lists named: {w.source_lists!r}")
+        # All three formerly-work-loop-warned entries must still appear as Type 2 findings
+        for path in ("spec/stale-queue", "spec/stale-active", "spec/inline-shipped"):
+            expect(path in type2_paths,
+                   f"[2A parity] {path} must still be a Type 2 finding in analyze(): "
+                   f"type2_paths={type2_paths}")
 
 
 def case_work_loop_slug_normalization() -> None:
@@ -2630,12 +2583,12 @@ def test_shaping_deduplication() -> None:
     _run_case(case_shaping_deduplication)
 
 
-def test_work_loop_stale_warnings() -> None:
-    _run_case(case_work_loop_stale_warnings)
+def test_work_loop_stale_scan_removed() -> None:
+    _run_case(case_work_loop_stale_scan_removed)
 
 
-def test_work_loop_stale_both_lists() -> None:
-    _run_case(case_work_loop_stale_both_lists)
+def test_work_loop_reconcile_owns_stale() -> None:
+    _run_case(case_work_loop_reconcile_owns_stale)
 
 
 def test_work_loop_slug_normalization() -> None:
@@ -2756,8 +2709,8 @@ CASES = [
     ("work_loop_contract_anchor", case_work_loop_contract_anchor),
     ("integration full_analyze", case_full_analyze),
     ("F4a shaping_deduplication", case_shaping_deduplication),
-    ("F4b work_loop_stale_warnings", case_work_loop_stale_warnings),
-    ("F4c work_loop_stale_both_lists", case_work_loop_stale_both_lists),
+    ("2A work_loop_stale_scan_removed", case_work_loop_stale_scan_removed),
+    ("2A work_loop_reconcile_owns_stale", case_work_loop_reconcile_owns_stale),
     ("F4d work_loop_slug_normalization", case_work_loop_slug_normalization),
     ("F4e missing_status_not_active", case_missing_status_not_active),
     ("F4f nonletter_transition_segment", case_nonletter_transition_segment),


### PR DESCRIPTION
## Summary

- **Removes the stale-queue check from `work-loop` Step 0.** The scan that read every `queue` and `active` spec.md on every work-loop invocation to find `Status: Shipped` drift is gone.
- **Ownership moves to `workspace-status reconcile`.** The same stale entries are still detected as Type 2 findings by `analyze()` — behavior moves, not disappears.
- **`work-loop` now orients only:** initiative, milestone, active spec path, shaping-item guard.

## What changed

| File | Change |
|------|--------|
| `work-loop` SKILL.md | Remove Stale-queue check bullet; add ownership note to `workspace-status reconcile` |
| `workspace_status_engine.py` | Remove `WorkLoopStaleWarning` dataclass + `collect_work_loop_stale_warnings` (~61 lines) |
| `tools/test_workspace_status.py` | Replace F4b/F4c stale-scan tests with 2A sentinel + parity tests; update `_WORK_LOOP_CONTRACT_HASH` |
| `work-loop` `evals.json` | 5 routing evals covering Step 0 boundary + workspace-status verb routing |
| `workspace-status` `eval_queries.json` | 3 Tier-A activation entries for router coverage |
| `pack.toml` + `plugin.json` | Bump core to 1.0.4 |
| `changelog.md` + `roadmap.md` | 1.0.4 entry; M1-fix entry updated to reflect removal |
| Projections (`.claude/`, `.agents/`) | Updated via `make build-self` |
| `docs/specs/workspace-status-simplification-order-2a/` | Spec (Shipped), plan (Done), read-profile note |

## Test plan

- [x] `python3 tools/test_workspace_status.py` — 56 passed, 0 failed
- [x] New: `case_work_loop_stale_scan_removed` — proves `collect_work_loop_stale_warnings` absent
- [x] New: `case_work_loop_reconcile_owns_stale` — proves same fixtures detected by `analyze()` as Type 2
- [x] `case_work_loop_contract_anchor` — passes with updated `_WORK_LOOP_CONTRACT_HASH`
- [x] `python3 tools/lint-ruff.py` — clean
- [x] `SKIP_SAST=1 make build-check` — clean
- [x] `make ci` — clean (exit 0)
- [x] Projections byte-equivalent (`diff packs/core/... .claude/...` → identical)
- [x] Codex review: 5 rounds to convergence; 12 findings total, all addressed

## Codex review convergence (5 rounds)

| Round | Findings | Theme |
|-------|----------|-------|
| 1 | 3 (1×P1, 2×P2) | Version bump missing; internal codename in eval; roadmap stale |
| 2 | 3 (2×P2, 1×P3) | Type 1 scope overstated; orphan-reference claim; read profile as estimate |
| 3 | 2 (1×P2, 1×P3) | `--item` required on explain CLI; plan.md read missing from profile |
| 4 | 3 (2×P2, 1×P3) | Activation evals in wrong file; explain scope overstated; read upper bound wrong |
| 5 | 1 (P2) | Spec Shape field out of vocabulary |
| 6 | Pre-existing | Unrelated agentbundle/CI findings; Order 2A converged |

**Notable learnings captured** (apply to reviewer agents / work-loop):
- Routing evals for behavior moved from skill A→B belong in skill B's `eval_queries.json`, not skill A's judge rubric
- Eval `expected_output` must be grounded in the actual function return dict, not an idealized description
- When citing a tool metric as evidence, verify its scope matches the claim
- Version bump check should be in the adversarial-reviewer's diff checklist
- Roadmap "Now" entries referencing removed behaviors should be swept at finish time