### PR TITLE
research(adopter-persona): complete desk-research pass; ungate P5 m6-* specs

### DIFF
--- a/docs/product/research/adopter-persona-brief.md
+++ b/docs/product/research/adopter-persona-brief.md
@@ -1,0 +1,190 @@
+# adopter-persona — brief
+
+**Bottom line:** The Level B pack set has two primary adopter pathways —
+enterprise customers reached through forward-deployed engineer practitioners
+(FDE-mediated) and solo software engineers working independently. These
+pathways fail for opposite reasons: FDE-mediated adoption fails at the handoff
+moment (post-FDE vocabulary exposure, ~90-day credential expiry, governance
+maintenance); solo adoption fails at the activation window (60–80% of
+developer-tool signups never reach activation; 68% cite too much setup time).
+Five cross-segment design changes address both simultaneously. The enterprise
+rollout playbook needs three tracks, not two: a well-resourced FDE track, a
+solo self-serve track, and a mid-market unsupported-enterprise track that is
+currently the highest churn risk.
+
+---
+
+## What the evidence shows
+
+- **Four dimensions jointly determine whether a cold adopter reaches first
+  value: vocabulary, visible prerequisites, safe-action posture, and result
+  findability.** These recur independently across W3C accessibility guidance,
+  Diátaxis tutorial structure, IBM's progressive-disclosure model, Nielsen
+  usability heuristics, and the Level B pack portfolio audit.
+  [high — ≥5 independent sources; segmentation survey synthesis]
+
+- **FDE-mediated adoption achieves 60–80% automation rates versus ~20% for
+  self-service — a structural, not marginal, difference.** The primary variable
+  is whether the client receives a human specialist during deployment, not the
+  model, prompt, or vendor.
+  [moderate — SaaStr practitioner analysis; consistent across fde.academy,
+  Baseten engineering blog, Everest Group; no RCT-level evidence]
+
+- **FDE deployment absorbs installation friction but not vocabulary transfer.**
+  The dominant post-FDE failure modes are: knowledge vacuum at handoff, custom-
+  integration orphaning, silent system degradation, and escalation-chain
+  breakdown — not credential misconfiguration during the engagement itself.
+  [high — Palantir Foundry Phase 3 documentation (primary); corroborated by
+  fde.academy, Webvillee, Everest Group]
+
+- **Atlassian OAuth refresh tokens expire after 90 days of inactivity; Figma
+  OAuth access tokens expire after 90 days unconditionally.** Every FDE-deployed
+  atlassian or figma integration will require client-side re-authentication
+  before or shortly after the first 90-day post-engagement window.
+  [high — developer.atlassian.com OAuth 2.0 3LO documentation;
+  developers.figma.com OAuth apps documentation]
+
+- **60–80% of developer-tool signups never reach activation; 68% cite "too much
+  setup time" as the reason.** The industry TTFHW (time to first working value
+  without external help) target is under 15 minutes; the first meaningful action
+  within 10 minutes produces a 3–4× conversion lift.
+  [moderate — daily.dev developer onboarding research; directional signal
+  consistent across Stack Overflow 2025 and ICSE 2024; no controlled study]
+
+- **AI agent toolkit adoption (30.9% regular use) significantly lags coding-
+  assistant adoption (70%+).** A solo engineer arriving at Agent Ready Repo
+  may be comfortable with coding assistants but is a first-time agent-toolkit
+  adopter. Onboarding must bridge chat-assistant vocabulary to pack-activation
+  vocabulary within the activation window.
+  [high — Stack Overflow Developer Survey 2025, N=49,000+]
+
+- **For solo engineers doing client-facing work, output ambiguity carries
+  reputational cost that raises the adoption threshold.** Freelancers lack
+  organisational support and depend on client positive feedback; unreliable
+  tool output is a direct professional risk, not just a personal frustration.
+  [moderate — Dolata, Lange, Schwabe, ICSE 2024, N=52 freelancers; Skywork.ai
+  2025 survey; consistent directional signal, qualitative]
+
+- **The three expert walkthroughs (architect, figma, governance-extras) at
+  baseline revision `b43ae2e` identified five categories of mechanical defect:
+  invalid install commands, vocabulary before outcomes, missing prerequisite
+  order, ambiguous mutation status, and incomplete receipts.** All identified
+  defects were mechanically addressed at revision `d9ebec99`; verified by
+  repository diff inspection.
+  [high — mechanical fix verification; direct repository inspection]
+
+- **product-strategy is standalone — no product-engineering dependency.**
+  `pack.toml` declares `prerequisites = []`; the starter task (`write-prfaq`)
+  is explicitly defined with a ready-to-use prompt. Highest first-value
+  clarity of any Level B pack.
+  [high — direct `pack.toml` inspection]
+
+---
+
+## Segment profiles
+
+### Segment A — enterprise customer via FDE practitioner
+
+The FDE installs, configures credentials, and establishes governance
+conventions during the engagement. The client organisation is the end adopter.
+The FDE absorbs installation friction; the client inherits vocabulary barriers
+and credential lifecycle without direct support.
+
+**High-priority packs for FDE deployment:** atlassian and figma (credential
+lifecycle risk); governance-extras and user-guide-diataxis (governance
+vocabulary recurs in every artifact the client maintains post-handoff).
+
+**Critical handoff requirements:** (1) re-authentication documentation for
+atlassian and figma (step-by-step, client-legible, covering the ~90-day
+expiry window); (2) pre-exit vocabulary transfer — the FDE must not close the
+engagement until the client has demonstrated independent artifact-type
+selection (ADR vs. RFC; Diátaxis kind); (3) one client-independent workflow
+run before engagement close.
+
+**Third track — unsupported mid-market enterprise.** The FDE model scales only
+to roughly 5,000+ employee organisations. Mid-market and less-resourced
+enterprise clients must self-serve packs with enterprise-grade complexity.
+This population — sold on FDE-level outcomes, given self-service documentation —
+is the highest churn risk in the Level B set. The rollout playbook must address
+it as a distinct track, not as a variant of either the FDE or solo tracks.
+
+### Segment B — solo software engineer
+
+The solo engineer is installer and end user in one person. Time budget is the
+primary binding constraint; motivation and available time decay faster than
+vocabulary barriers.
+
+**High-friction packs:** atlassian and figma (full credential self-service; no
+admin to call); governance-extras (highest vocabulary load; first repository
+write is high-anxiety).
+
+**Critical solo requirements:** (1) prerequisites at the decision point before
+the attempt — not as error messages; (2) outcome-first framing at every pack
+entry — vocabulary after first value, not before; (3) explicit artifact status
+in every receipt (chat-only OR exact path, never implied); (4) for client-facing
+use: output confidence tags and explicit mutation status in every receipt.
+
+**Low-friction entry point for solo adoption:** product-strategy (`write-prfaq`)
+is the best-positioned Level B pack for a solo first experience. No credential,
+no configuration, explicit starter prompt, PRFAQ output is immediately shareable
+with a client or colleague.
+
+---
+
+## Pack-level design implications
+
+Five design changes address both segments:
+
+1. **Prerequisites at the decision point, not on failure** — converters (runtime),
+   atlassian (admin pre-config), figma (PAT/OAuth). Affects both segments for
+   opposite reasons: FDE client has no FDE to call; solo engineer burns the
+   activation budget.
+
+2. **Outcome-first vocabulary at every pack entry point** — plain-language
+   outcome label before internal terminology. Affects: all Level B packs.
+   Post-fix improvements verified for architect, figma, governance-extras.
+
+3. **Explicit artifact status in every receipt** — chat-only OR exact path,
+   stated, never implied. Affects: architect (concept stop), converters
+   (output file), figma (render vs. remote), governance-extras (ADR/RFC path
+   and index).
+
+4. **Credential lifecycle section in atlassian and figma documentation** —
+   re-authentication steps (trigger, steps, token storage location) as a
+   named, findable section, not buried in prerequisites. Required as FDE
+   handoff artefact; required as inline self-service for solo.
+
+5. **Mutation status stated, not implied** — "No Figma changes made" / "no
+   Jira items modified" in every read-only receipt. Post-fix verified for
+   figma; atlassian requires equivalent treatment.
+
+---
+
+## Known unknowns
+
+- **Known-unknown:** Does a non-technical enterprise client trust and act on
+  the governance-extras preview-confirm flow without external reassurance?
+  The mechanical fix (rev `d9ebec99`) documented the cues; whether a first-time
+  adopter uses them correctly is unverifiable without participant observation.
+  Would be closed by: a moderated first-use session with a non-technical
+  governance-extras adopter. Until closed: the P5 governance-extras build AC
+  should include a usability check; the rollout playbook should recommend
+  facilitated first use.
+
+- **Known-unknown:** What proportion of Level B deployments are FDE-mediated
+  versus self-service? No activation or deployment-pathway data exists.
+  Would be closed by: deployment telemetry or FDE practitioner survey.
+
+- **Known-unknown:** Does the unsupported mid-market enterprise segment require
+  a distinct pack subset, a distinct onboarding flow, or both? The segment is
+  identified but not characterised in detail. Would be closed by: FDE
+  practitioner interviews + mid-market self-serve attempt sessions.
+
+- **Unknowable:** Which provisional segment labels adopters will self-identify
+  with before experiencing the product. Segment identity is behavioural and
+  contextual; self-identification cannot substitute for observed task behaviour.
+
+- **Unknowable:** Whether the five-posture model will remain stable after pack
+  designs change in response to these findings. The model is inferred from
+  documentation and secondary research, not from observed behaviour; it will
+  require revision as the product evolves.

--- a/docs/product/research/adopter-persona-comparison-matrix.md
+++ b/docs/product/research/adopter-persona-comparison-matrix.md
@@ -1,0 +1,171 @@
+# Comparison matrix — adopter-persona
+
+Two primary adopter segments for the Level B pack set, compared across the
+dimensions that determine whether they reach first value and sustain use.
+
+---
+
+## Segment profiles
+
+### Segment A — enterprise customer via FDE practitioner
+
+A technically proficient forward-deployed engineer installs and configures the
+toolkit on behalf of an enterprise client. The FDE is the installer; the client
+organisation is the end adopter. The FDE absorbs installation friction and
+credential setup, but vocabulary barriers, token lifecycle, and governance
+maintenance land on the client unaided after the engagement ends. The CoE
+the FDE hands off to — if one exists at all — must include named role owners
+who are long-term domain participants, not rotational staff.
+
+The binding constraint is **handoff quality**: whether the client can operate
+the toolkit independently after the FDE exits. The FDE model achieves 60–80%
+automation rates in mature deployments; self-service achieves ~20%. The gap
+is structural. [moderate — SaaStr practitioner analysis; consistent across
+fde.academy, Baseten, Everest Group]
+
+### Segment B — solo software engineer
+
+A technically proficient developer installs and uses the toolkit for their own
+side projects or to assist a colleague or client with a business problem. They
+are installer and end user in one person, with no team support to absorb output
+uncertainty or troubleshoot credential failures. The binding constraint is
+**time budget**: 60–80% of developer-tool signups never reach activation;
+68% cite "too much setup time" as the reason. The industry target for time to
+first working value (TTFHW) is under 15 minutes. [moderate — daily.dev
+practitioner research; consistent with Stack Overflow 2025 and ICSE 2024]
+
+For solo engineers doing client-facing work, a second constraint overlays the
+time budget: **reputational cost of uncertain output**. Ambiguous results or
+unclear mutation status that would be absorbed in a team context carry direct
+professional cost when the audience is a paying client. [moderate — ICSE 2024,
+N=52 freelancers; Skywork.ai 2025 survey]
+
+---
+
+## Dimension comparison
+
+| Dimension | FDE-mediated (Segment A) | Solo engineer (Segment B) |
+|---|---|---|
+| **Activation failure mode** | Vocabulary exposure post-handoff: the FDE absorbed install friction, but pack vocabulary (ADR, RFC, OAuth scope, Diátaxis type) lands on the client unaided after exit | Activation window exceeded: prerequisite friction, vocabulary, or configuration steps consume the sub-15-min budget before first value lands; 60–80% drop-off rate |
+| **Prerequisite timing** | FDE configures prerequisites during the engagement; client must re-authenticate (~90-day token expiry for atlassian and figma) without FDE support | Prerequisites must surface at the decision point before the attempt — not as error messages. Solo engineer is their own IT department; a blocking error mid-task triggers abandonment |
+| **First-value boundary** | First value = client produces a result independently after FDE exit. Chat-only vs. exact-path ambiguity and wrong artifact type selection (ADR vs. RFC, Diátaxis kind) are the two most common post-handoff failure points | First value = reaching a useful result within the activation window. Stop-at-concept ambiguity (is this in chat or saved?) is the primary boundary-marking failure across conversational-shaper packs |
+| **Credential lifecycle** | FDE must document re-authentication steps as a mandatory handoff artefact. Atlassian OAuth refresh tokens expire after 90 days of inactivity; Figma OAuth access tokens expire after 90 days unconditionally. A client who is slow to adopt after FDE exit may hit expiry before their first independent use | Solo engineer must self-serve re-authentication from inline guidance alone. If the token-regeneration steps are not self-contained inline, there is no support channel. Same 90-day expiry windows apply |
+| **Sustainability mechanism** | CoE role staffing + pre-exit vocabulary transfer + one client-independent run before FDE closes the engagement. Governance packs require the client to make the right vocabulary choice every time post-handoff — this is a recurring, not a one-time, sustainability requirement | Peer discovery (78% primary channel) + documentation depth signal (5+ pages = 340% conversion lift) + pragmatic task-test on a real problem. Client-facing work raises the bar: output confidence and explicit mutation status are not cosmetic for this sub-segment |
+
+---
+
+## Pack groupings by segment risk
+
+### High FDE deployment priority — packs where handoff quality determines sustained adoption
+
+**atlassian, figma** — Credential setup is FDE-handled; client must re-authenticate
+independently after ~90-day token expiry. The re-auth documentation gap is a
+confirmed design requirement, not a marginal edge case. [high — official
+Atlassian and Figma OAuth documentation]
+
+**governance-extras, user-guide-diataxis** — Governance vocabulary (ADR, RFC,
+amendment/errata; Diátaxis type selection) appears in every artifact the client
+must extend post-handoff. Wrong type selection is a recurring failure point.
+The pre-exit vocabulary transfer must include at least one client-performed
+write before the FDE closes. [moderate — expert walkthrough + mechanical fix
+verification; post-fix repairs verified at rev `d9ebec99`]
+
+### High solo activation friction — packs where the activation window is most at risk
+
+**atlassian, figma** — Full credential self-service from a standing start. No
+admin to call; OAuth/token setup must be self-sufficient from inline guidance.
+[moderate — figma expert walkthrough; mechanical fix verification]
+
+**governance-extras** — Highest vocabulary load of any Level B pack. Anxiety
+around a first repository write is the primary friction point. Preview-confirm
+flow verified in documentation (post-fix); whether a first-time adopter trusts
+it without moderator support is the one remaining unverifiable confidence gap.
+[moderate — governance-extras expert walkthrough; mechanical fix verification;
+client confidence unverifiable without participant observation]
+
+### Low friction for both segments
+
+**converters, desk-research** — No credential, no SaaS admin. Low FDE overhead
+(likely written instructions rather than a live session). Solo activation
+risk is limited to runtime prerequisites surfacing on failure rather than
+before the attempt. [moderate — segmentation survey; pack coverage table]
+
+**product-strategy** — Declared standalone with no product-engineering
+dependency (`prerequisites = []` in `pack.toml`). Starter task (`write-prfaq`)
+is explicitly defined with a ready-to-use prompt. Clearest first-value path of
+any Level B pack. [high — direct pack.toml inspection]
+
+### Medium friction — vocabulary or runtime, but no credential
+
+**architect, experience-design, product-engineering** — Conversational entry;
+no credential. Vocabulary barriers (C4, RFC/ADR, forked-context; JTBD, screen
+brief; work-loop, Gate: Idea) are present but manageable with outcome-first
+framing. Post-fix improvements (rev `d9ebec99`) address the Architect
+vocabulary and receipt gaps. [moderate — expert walkthrough + mechanical fix
+verification]
+
+---
+
+## Cross-segment design requirements
+
+Five requirements hold for both segments — their rationale differs, but the
+design change is identical:
+
+1. **Prerequisites at the decision point, not on failure.** FDE rationale:
+   the client who hits a blocking error post-handoff has no FDE to call.
+   Solo rationale: a blocking error mid-attempt burns the activation budget.
+   Implementation: "Do you have X?" before the attempt, not as an error
+   message. Affects: converters (runtime), atlassian (admin pre-config),
+   figma (PAT/OAuth).
+
+2. **Outcome-first vocabulary.** FDE rationale: vocabulary barriers land on
+   the client unaided post-handoff; plain outcomes reduce maintenance calls.
+   Solo rationale: vocabulary exploration consumes the activation window.
+   Implementation: plain-language outcome label before internal pack
+   terminology at every entry point. Affects: all Level B packs.
+
+3. **Explicit artifact status in every receipt.** FDE rationale: the client
+   must be able to locate what the FDE produced. Solo rationale: uncertainty
+   about whether a result was saved or is chat-only triggers a re-run.
+   Implementation: chat-only OR exact path, stated in the receipt — never
+   implied. Affects: architect (concept), converters (output file), figma
+   (render vs. remote), governance-extras (ADR/RFC path + index).
+
+4. **Credential lifecycle documentation.** FDE rationale: ~90-day token expiry
+   is a guaranteed post-handoff event for every atlassian and figma deployment.
+   Solo rationale: self-service re-authentication with no support channel.
+   Implementation: a re-authentication section (trigger, steps, token storage)
+   in atlassian and figma pack documentation — not optional appendix material.
+
+5. **Mutation status stated, not implied.** FDE rationale: enterprise clients
+   using connected-system packs in a governance context cannot assume no
+   remote change without an explicit statement. Solo rationale: client-facing
+   use has reputational cost if a "read" session is ambiguous. Implementation:
+   "No Figma changes made" / "no Jira items modified" in every read receipt.
+   Affects: atlassian, figma. Post-fix verified for figma; atlassian requires
+   the same treatment.
+
+---
+
+## Synthesis verdict
+
+The two segments are not alternatives to the five-segment posture model — they
+are a layer above it. The FDE-mediated pathway and the solo pathway explain
+*how an adopter arrives* at a pack; the five postures explain *what they need
+once they're there*. Both framings are required for the P5 persona, the
+live-demo design, and the enterprise rollout playbook.
+
+**The enterprise rollout playbook needs three tracks, not two.** The well-resourced
+enterprise (FDE-mediated) track and the solo self-serve track are defined by
+the corpus. The mid-market or less-resourced enterprise track — too small for
+FDE support, too complex for unassisted self-service — is the highest churn
+risk and must be named as a distinct design concern in the rollout playbook,
+even if its detailed design is deferred.
+
+**Governance-extras write-confidence is the one remaining unresolvable gap.**
+The mechanical fix (rev `d9ebec99`) documented the preview-confirm flow; the
+expert walkthrough confirmed the cues exist. Whether a non-technical client
+trusts the preview and proceeds without external reassurance is unverifiable
+without participant observation. The P5 governance-extras build AC should
+include a usability check; the rollout playbook should flag this as a
+facilitated first-use recommendation.

--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -527,12 +527,20 @@ ACs are grouped by delivery batch (see spec map above). Each batch ships as one 
 **P3 · Brief → Build — shipped**
 - [x] `author-brief` documentation: how-to (intake-an-external-brief) + DoR field definitions reference — `spec/author-brief-docs` (Shipped)
 
-**P5 · Adopt — in progress, gated on adopter-persona desk-research**
+**P5 · Adopt — adopter-persona research complete; three specs ready to start**
 - [ ] Astro site: project index view for non-engineer (PM) visibility — `spec/m6-astro-project-index`; `docs/product/projects/` contains only `_template.md`; no Astro page reads from it yet
 - [ ] Live-demo guide: ≥3 representative team types; pre-flight checklist; ≤30-min shaping→brief→spec narration on the org's own codebase — `spec/m6-live-demo-guide`
 - [ ] Enterprise rollout playbook: champion → CTO → platform team → engineers adoption arc; staged rollout phases (pilot → wave → org-wide); rollout checklist and retrospective template — `spec/m6-enterprise-rollout-playbook`; distinct from the technical catalogue enterprise-distribution guides already shipped
 
-All three P5 specs gate on `research:adopter-persona` completing (type = "research" desk-research project; personal vault, phase=capture; not a formal UX study — formative evaluation folds into the pilot transcripts and P5/rollout ACs).
+The `research:adopter-persona` gate is now clear (2026-08-02). Desk-research only;
+participant sessions deferred. Two-segment hypothesis (FDE-mediated enterprise /
+solo engineer) confirmed as adoption-pathway framing complementary to the five-
+segment posture model. Five cross-segment design requirements identified (prerequisites
+at decision point; outcome-first vocabulary; explicit artifact status; credential
+lifecycle documentation; mutation status stated). Third segment (unsupported
+mid-market enterprise) identified as highest churn risk — address in rollout playbook.
+
+Evidence base: [`docs/product/research/adopter-persona-brief.md`](../product/research/adopter-persona-brief.md) (governance brief, self-contained) · [`docs/product/research/adopter-persona-comparison-matrix.md`](../product/research/adopter-persona-comparison-matrix.md) (full comparison).
 
 ## Sub-RFCs
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -32,18 +32,14 @@ milestone = "P5 · Adopt (M1–M5 shipped)"
 parent    = "INI-001"
 
 ["ini-002".shaping_queue]
-# adopter-persona: deliverable must cover pack-segmented setup posture across the
-# proposed Level B set (architect, atlassian, converters, desk-research,
-# experience-design, figma, governance-extras, product-engineering,
-# product-strategy, product-documentation); include terminology comprehension,
-# prerequisite visibility, artifact discovery, and inputs to P5 persona and
-# live-demo design. Do not add a second generic user-study item — broaden this
-# one; formative evaluation folds into the pilots and later P5/rollout ACs.
-# Project (personal vault): efforts/research/2026-07-22-adopter-persona; phase=capture.
-# Un-gates the three P5 m6-* build items; summary elevates as RFC-0064 notes.
-active  = [
-  {slug = "adopter-persona",            type = "research"},
-]
+# adopter-persona: COMPLETE (2026-08-02). Desk-research only; participant sessions
+# deferred. Two-segment hypothesis (FDE-mediated enterprise / solo engineer) confirmed
+# as a pathway framing complementary to the five-segment posture model. Five cross-
+# segment design requirements identified. Three P5 m6-* work items are now unblocked.
+# Brief: docs/product/research/adopter-persona-brief.md
+# Comparison matrix: docs/product/research/adopter-persona-comparison-matrix.md
+# Project (personal vault): efforts/research/2026-07-22-adopter-persona; phase=synthesize.
+active  = []
 backlog = [
   # Signal items — hand-authored by strategist; ongoing, non-graduating
   {slug = "ai-native-regulatory-watch", type = "signal"},


### PR DESCRIPTION
## Summary

- Closes the `adopter-persona` shaping-queue research item for ini-002 (P5 · Adopt). Desk-research only; participant sessions deferred.
- Two-segment adoption-pathway hypothesis confirmed (FDE-mediated enterprise / solo engineer). Five cross-segment design requirements identified. Third segment (unsupported mid-market enterprise) named as highest churn risk.
- `workspace.toml`: `adopter-persona` removed from `shaping_queue.active`; three `m6-*` work items are now unblocked.
- RFC-0064 P5 section: gate-cleared note added with brief links.

## Artifacts added

- `docs/product/research/adopter-persona-brief.md` — governance brief (BLUF, confidence-tagged, known-unknowns)
- `docs/product/research/adopter-persona-comparison-matrix.md` — full comparison across both segments and all 10 Level B packs

## Key findings

- FDE-mediated adoption fails at the handoff moment: vocabulary exposure, ~90-day credential expiry (atlassian/figma confirmed via official docs), governance maintenance.
- Solo adoption fails at the activation window: 60–80% drop-off; 68% cite too much setup time; sub-15 min TTFHW industry target.
- `product-strategy` confirmed standalone — no product-engineering dependency (`prerequisites = []`).
- One open confidence gap: governance-extras write-confidence under non-technical first use — flag as usability check AC in `m6-enterprise-rollout-playbook`.

## Deferred

Pilot sessions (architect, figma, governance-extras) preserved in personal vault as deferred artifacts; they do not block synthesis or the three P5 specs.