### PR TITLE
research(adopter-persona): six-segment model — round-2 role-level personas

### DIFF
--- a/docs/product/research/adopter-persona-brief.md
+++ b/docs/product/research/adopter-persona-brief.md
@@ -1,190 +1,287 @@
 # adopter-persona — brief
 
-**Bottom line:** The Level B pack set has two primary adopter pathways —
-enterprise customers reached through forward-deployed engineer practitioners
-(FDE-mediated) and solo software engineers working independently. These
-pathways fail for opposite reasons: FDE-mediated adoption fails at the handoff
-moment (post-FDE vocabulary exposure, ~90-day credential expiry, governance
-maintenance); solo adoption fails at the activation window (60–80% of
-developer-tool signups never reach activation; 68% cite too much setup time).
-Five cross-segment design changes address both simultaneously. The enterprise
-rollout playbook needs three tracks, not two: a well-resourced FDE track, a
-solo self-serve track, and a mid-market unsupported-enterprise track that is
-currently the highest churn risk.
+**Bottom line:** The Level B pack set has six primary adopter segments across
+two orthogonal dimensions — arrival pathway and role/altitude identity — that
+fail in structurally different ways and cannot share a single onboarding flow.
+The enterprise rollout playbook requires three distinct tracks (technical,
+enterprise, non-technical), not the two originally identified. Nine cross-segment
+design requirements address the most consistent failure patterns in the corpus.
+A seventh segment (mid-market enterprise) is named but uncharacterised and is
+the highest structural churn risk in the portfolio.
 
 ---
 
 ## What the evidence shows
 
-- **Four dimensions jointly determine whether a cold adopter reaches first
-  value: vocabulary, visible prerequisites, safe-action posture, and result
-  findability.** These recur independently across W3C accessibility guidance,
-  Diátaxis tutorial structure, IBM's progressive-disclosure model, Nielsen
-  usability heuristics, and the Level B pack portfolio audit.
-  [high — ≥5 independent sources; segmentation survey synthesis]
+### On the segmentation model
 
-- **FDE-mediated adoption achieves 60–80% automation rates versus ~20% for
-  self-service — a structural, not marginal, difference.** The primary variable
-  is whether the client receives a human specialist during deployment, not the
-  model, prompt, or vendor.
+- **Arrival pathway and role/altitude identity are orthogonal dimensions; the
+  round-1 FDE/solo binary described pathways, not personas.** A solo engineer
+  can arrive without an FDE and occupy any task posture. An FDE client can be
+  an AI-naive knowledge worker or a technical PM. Collapsing the two into one
+  dimension produces a synthesis that answers "how do adopters arrive?" but not
+  "who are the adopters?" — the two questions the P5 deliverables require.
+  [high — adoption pathway and role identity coded separately across 13 sources;
+  no source merged the two dimensions; segmentation survey explicitly coded
+  posture as independent of pathway]
+
+- **Six primary segments emerged from open-coding; five were not characterised
+  in round-1.** Round-1 characterised FDE-mediated enterprise and solo engineer.
+  Round-2 adds: technical PM / product engineer (altitude 1), AI-naive knowledge
+  worker (altitude 0–1), enterprise AI champion (altitude 0–1), and UX /
+  experience designer (altitude 2). Each segment has a distinct binding
+  constraint, first-value shape, failure mode, and sustainability mechanism.
+  [moderate — all six segments documented; no direct comparative study; role
+  characterisations are secondary and desk-research sources, not participant
+  observation]
+
+### On binding constraints — not additive
+
+- **Each segment has exactly one primary binding constraint; solving for multiple
+  simultaneously is not possible without tracking separation.** Outcome-first
+  vocabulary helps solo engineers (reduces activation window consumption) and
+  AI-naive professionals (reduces cognitive load), but lowers trust for enterprise
+  champions (reads as product immaturity). Preview-confirm flows are essential
+  for FDE clients and governance-extras adopters, but their friction may abandon
+  solo engineers within the 15-minute activation window.
+  [high — binding constraint × segment matrix coded across all 13 sources;
+  no source generalised one constraint across all segments; four-zone constraint
+  model consistent with round-1 findings]
+
+- **The FDE model achieves 60–80% automation rates; self-service achieves ~20%.
+  The gap is structural, not marginal.** The primary variable is whether the client
+  receives a human specialist during deployment. FDE-mediated deployments absorb
+  installation friction; self-service deployments require the user to bear it.
   [moderate — SaaStr practitioner analysis; consistent across fde.academy,
   Baseten engineering blog, Everest Group; no RCT-level evidence]
 
-- **FDE deployment absorbs installation friction but not vocabulary transfer.**
-  The dominant post-FDE failure modes are: knowledge vacuum at handoff, custom-
-  integration orphaning, silent system degradation, and escalation-chain
-  breakdown — not credential misconfiguration during the engagement itself.
-  [high — Palantir Foundry Phase 3 documentation (primary); corroborated by
-  fde.academy, Webvillee, Everest Group]
+- **95% of GenAI pilots fail to produce measurable business value.** For the
+  enterprise AI champion, this is a career-consequential fact: 12+ months of
+  production evidence is required before vendor selection; board-ready proof within
+  one budget cycle is the binding first-value shape.
+  [moderate — MIT NANDA 2025 (N=300+ enterprise GenAI deployments); directionally
+  consistent with BCG AI at Work 2025, AI Assembly Lines practitioner analysis;
+  no published methodology for the NANDA figure]
 
-- **Atlassian OAuth refresh tokens expire after 90 days of inactivity; Figma
-  OAuth access tokens expire after 90 days unconditionally.** Every FDE-deployed
-  atlassian or figma integration will require client-side re-authentication
-  before or shortly after the first 90-day post-engagement window.
-  [high — developer.atlassian.com OAuth 2.0 3LO documentation;
-  developers.figma.com OAuth apps documentation]
+### On verification burden — universal churn mechanism
 
-- **60–80% of developer-tool signups never reach activation; 68% cite "too much
-  setup time" as the reason.** The industry TTFHW (time to first working value
-  without external help) target is under 15 minutes; the first meaningful action
-  within 10 minutes produces a 3–4× conversion lift.
-  [moderate — daily.dev developer onboarding research; directional signal
-  consistent across Stack Overflow 2025 and ICSE 2024; no controlled study]
+- **Inability to quickly verify output quality is the primary churn mechanism
+  across all six segments, with distinct failure signatures.** Solo engineers:
+  "almost right but not quite" debugging overhead reverses productivity gain
+  (Stack Overflow 2025: 66% cite this; 45.7% distrust accuracy). AI-naive
+  professionals: mental simulation of agent steps doubles effort (arXiv
+  2505.17767). UX designers: identical prompts produce incompatible designs;
+  output dismissed as "templatized" (NN/G 2024). FDE clients: cannot verify
+  what the FDE produced post-handoff (Palantir Phase 3 documentation).
+  [high — ≥5 independent sources from different disciplines; verification burden
+  appears independently in each segment characterisation]
 
-- **AI agent toolkit adoption (30.9% regular use) significantly lags coding-
-  assistant adoption (70%+).** A solo engineer arriving at Agent Ready Repo
-  may be comfortable with coding assistants but is a first-time agent-toolkit
-  adopter. Onboarding must bridge chat-assistant vocabulary to pack-activation
-  vocabulary within the activation window.
-  [high — Stack Overflow Developer Survey 2025, N=49,000+]
+- **The remediation that works across segments: constrain the first task to a
+  domain the adopter already knows well enough to verify in minutes.** Grippo
+  practitioner case: UX designer's first value was a compressed synthesis of
+  interviews they had already read. Microsoft WorkLab (Dow case): first
+  deliverable was a white paper on a domain the user owned. Stripe/Vercel TTFHW
+  benchmarks: outputs users can immediately confirm work (payment processed, site
+  is live). This produces session-one trust regardless of segment.
+  [moderate — practitioner consensus across disciplines; no controlled study
+  isolating task-scoping as the causal variable]
 
-- **For solo engineers doing client-facing work, output ambiguity carries
-  reputational cost that raises the adoption threshold.** Freelancers lack
-  organisational support and depend on client positive feedback; unreliable
-  tool output is a direct professional risk, not just a personal frustration.
-  [moderate — Dolata, Lange, Schwabe, ICSE 2024, N=52 freelancers; Skywork.ai
-  2025 survey; consistent directional signal, qualitative]
+### On peer adoption — universal accelerant
 
-- **The three expert walkthroughs (architect, figma, governance-extras) at
-  baseline revision `b43ae2e` identified five categories of mechanical defect:
-  invalid install commands, vocabulary before outcomes, missing prerequisite
-  order, ambiguous mutation status, and incomplete receipts.** All identified
-  defects were mechanically addressed at revision `d9ebec99`; verified by
-  repository diff inspection.
-  [high — mechanical fix verification; direct repository inspection]
+- **Peer adoption consistently outperforms top-down mandates and vendor onboarding
+  across all six segments.** Solo engineers: 78% primary discovery through peer
+  recommendation; 52% via dark social (Slack/Discord) (daily.dev practitioner
+  research). AI-naive professionals: consulted workers adopt; mandated workers
+  resist (CHI 2025). Enterprise champions: champion programmes (1:15–25 ratio)
+  deliver 2.1× higher sustained usage vs. top-down mandate (AI Assembly Lines;
+  directionally consistent with BCG AI at Work 2025). UX designers: practitioner
+  case more trusted than product marketing (NN/G 2024; Grippo case).
+  [high — triangulated across 4+ independent sources from different disciplines;
+  directional consistency is very strong across all segments]
 
-- **product-strategy is standalone — no product-engineering dependency.**
-  `pack.toml` declares `prerequisites = []`; the starter task (`write-prfaq`)
-  is explicitly defined with a ready-to-use prompt. Highest first-value
-  clarity of any Level B pack.
-  [high — direct `pack.toml` inspection]
+### On professional identity threat — three-segment concern
+
+- **Professional identity threat appears in three of six segments at different
+  registers, not only in non-technical tiers.** AI-naive knowledge workers:
+  deskilling fear; junior roles' growth path threatened; employees at AI-advanced
+  organisations are MORE worried about job security (46% vs. 34% at lagging orgs)
+  (BCG AI at Work 2025, N=~150,000). UX designers: craft devaluation; junior
+  designers report higher threat perception than seniors (3.02/5 vs. 2.656/5)
+  (arXiv 2603.05848). Technical PM/PE: authorship ambiguity (who authored the
+  strategy if AI generated the brief?) — implicit in the gate-based-review
+  adoption pattern.
+  [moderate — well-documented for AI-naive and UX segments; inferred for PM/PE;
+  no cross-segment comparative study]
+
+### On the mid-market gap
+
+- **The mid-market enterprise segment is the highest structural churn risk and
+  is uncharacterised in the corpus.** Three independent sources name the gap:
+  (1) FDE deployment patterns: "clients sold on quick FDE-assisted implementation
+  who instead receive self-service documentation struggle and churn"; (2) round-1
+  brief: "mid-market or less-resourced enterprise — sold on FDE-level outcomes,
+  given self-service documentation — is the highest churn risk"; (3) fde.academy:
+  FDE model threshold is ~5,000+ employee organisations.
+  [high — gap existence confirmed by 3 independent sources. Segment
+  characterisation: none — not researched]
 
 ---
 
 ## Segment profiles
 
-### Segment A — enterprise customer via FDE practitioner
+### Segment 1 — FDE-mediated enterprise
+**Binding constraint:** handoff quality — can the client operate independently
+after the FDE exits? Four failure modes: knowledge vacuum, custom-integration
+orphaning, silent system degradation, escalation-chain breakdown.
+**First value:** client executes one pack task independently before engagement
+closes.
+**High-priority packs:** atlassian, figma (credential lifecycle); governance-extras,
+user-guide-diataxis (vocabulary recurs in every artifact post-handoff).
 
-The FDE installs, configures credentials, and establishes governance
-conventions during the engagement. The client organisation is the end adopter.
-The FDE absorbs installation friction; the client inherits vocabulary barriers
-and credential lifecycle without direct support.
+### Segment 2 — Solo engineer
+**Binding constraint:** time budget — 60–80% dropout before activation; 68%
+cite "too much setup time"; sub-15-min TTFHW target.
+**First value:** working result within the activation window; shareable result
+for client-facing engineers.
+**Lowest friction entry:** product-strategy (`write-prfaq`) — no credential,
+no configuration, explicit starter prompt.
 
-**High-priority packs for FDE deployment:** atlassian and figma (credential
-lifecycle risk); governance-extras and user-guide-diataxis (governance
-vocabulary recurs in every artifact the client maintains post-handoff).
+### Segment 3 — Technical PM / product engineer
+**Binding constraint:** mental model shift from reactive prompting to
+declarative orchestration; gate-based review vs. per-sentence checking is the
+threshold.
+**First value:** structured brief the engineering team can act on without a
+sync meeting — cross-team handoff, not individual productivity.
+**Vocabulary bridge:** brief, initiative, spec, appetite, shaping (Shape Up/OKR
+native). Vocabulary barrier: skill, pack, workspace-as-context, invoke,
+orchestrate.
 
-**Critical handoff requirements:** (1) re-authentication documentation for
-atlassian and figma (step-by-step, client-legible, covering the ~90-day
-expiry window); (2) pre-exit vocabulary transfer — the FDE must not close the
-engagement until the client has demonstrated independent artifact-type
-selection (ADR vs. RFC; Diátaxis kind); (3) one client-independent workflow
-run before engagement close.
+### Segment 4 — AI-naive knowledge worker
+**Binding constraint:** verification burden (mental simulation of agent steps
+doubles effort) + professional identity threat (deskilling fear for junior roles);
+2-week activation window.
+**First value:** visible, shareable deliverable in session one — not a
+capability tour. Peer champion is the activation mechanism.
+**Adoption mechanism:** consulted workers adopt; mandated workers resist (CHI
+2025).
 
-**Third track — unsupported mid-market enterprise.** The FDE model scales only
-to roughly 5,000+ employee organisations. Mid-market and less-resourced
-enterprise clients must self-serve packs with enterprise-grade complexity.
-This population — sold on FDE-level outcomes, given self-service documentation —
-is the highest churn risk in the Level B set. The rollout playbook must address
-it as a distinct track, not as a variant of either the FDE or solo tracks.
+### Segment 5 — Enterprise AI champion
+**Binding constraint:** career-risk management; 95% of GenAI pilots produce
+zero measurable return; four personal risk vectors (pilot failure, budget
+overrun, regulatory exposure, adoption stall).
+**First value:** board-ready proof within one budget cycle.
+**Sustainability mechanism:** named internal owner at engagement close +
+documented workflow operating guide + prompt library + measurement log.
 
-### Segment B — solo software engineer
+### Segment 6 — UX / experience designer
+**Binding constraint:** craft integrity — generic-output barrier (AI output
+"templatized," below professional standard); articulation barrier (can't
+describe a good journey map to AI); inconsistency barrier (identical prompts →
+incompatible designs).
+**First value:** compressed research synthesis → structured journey map with
+emotion scores, tagged quotes, pain points. Designer retains strategic
+authorship.
+**Entry point:** Figma (familiar environment, plugin-shaped integration) is the
+Trojan-horse integration for experience-design.
 
-The solo engineer is installer and end user in one person. Time budget is the
-primary binding constraint; motivation and available time decay faster than
-vocabulary barriers.
-
-**High-friction packs:** atlassian and figma (full credential self-service; no
-admin to call); governance-extras (highest vocabulary load; first repository
-write is high-anxiety).
-
-**Critical solo requirements:** (1) prerequisites at the decision point before
-the attempt — not as error messages; (2) outcome-first framing at every pack
-entry — vocabulary after first value, not before; (3) explicit artifact status
-in every receipt (chat-only OR exact path, never implied); (4) for client-facing
-use: output confidence tags and explicit mutation status in every receipt.
-
-**Low-friction entry point for solo adoption:** product-strategy (`write-prfaq`)
-is the best-positioned Level B pack for a solo first experience. No credential,
-no configuration, explicit starter prompt, PRFAQ output is immediately shareable
-with a client or colleague.
+### Segment 7 — Mid-market enterprise (uncharacterised)
+Named but not characterised. FDE scale threshold: ~5,000+ employee organisations.
+Mid-market accounts sold on FDE-level outcomes but given self-service
+documentation. Churn risk is the highest in the portfolio. No viable self-serve
+path for enterprise-complexity packs (atlassian, figma, governance-extras) has
+been characterised; the rollout playbook must name this gap honestly.
 
 ---
 
-## Pack-level design implications
+## Three-track rollout requirement
 
-Five design changes address both segments:
+A single onboarding flow cannot address binding constraints that are
+structurally incompatible. Minimum three tracks:
 
-1. **Prerequisites at the decision point, not on failure** — converters (runtime),
-   atlassian (admin pre-config), figma (PAT/OAuth). Affects both segments for
-   opposite reasons: FDE client has no FDE to call; solo engineer burns the
-   activation budget.
+**Technical track** (solo engineer + technical PM/PE): outcome-first vocabulary
+for the activation window; gate-based review vocabulary for the mental model
+shift; constrained first task on a real problem.
 
-2. **Outcome-first vocabulary at every pack entry point** — plain-language
-   outcome label before internal terminology. Affects: all Level B packs.
-   Post-fix improvements verified for architect, figma, governance-extras.
+**Enterprise track** (FDE client + enterprise champion): handoff documentation
+completeness; governance depth for trust; measurement infrastructure; champions
+programme before org-wide rollout.
 
-3. **Explicit artifact status in every receipt** — chat-only OR exact path,
-   stated, never implied. Affects: architect (concept stop), converters
-   (output file), figma (render vs. remote), governance-extras (ADR/RFC path
-   and index).
+**Non-technical track** (AI-naive professional + UX designer): constrained
+first task the user can verify; peer champion in the same role; identity-safe
+framing ("AI amplifies your expertise"); shareable deliverable in session one.
 
-4. **Credential lifecycle section in atlassian and figma documentation** —
-   re-authentication steps (trigger, steps, token storage location) as a
-   named, findable section, not buried in prerequisites. Required as FDE
-   handoff artefact; required as inline self-service for solo.
+---
 
-5. **Mutation status stated, not implied** — "No Figma changes made" / "no
-   Jira items modified" in every read-only receipt. Post-fix verified for
-   figma; atlassian requires equivalent treatment.
+## Nine cross-segment design requirements
+
+**Five from round-1 (apply to all six segments):**
+
+1. **Prerequisites at the decision point, not on failure.** "Do you have X?"
+   before the attempt; a blocking error mid-attempt burns both the activation
+   window (solo) and the client's confidence (FDE).
+2. **Outcome-first vocabulary at every entry point.** Plain-language outcome
+   label before internal pack terminology. All Level B packs.
+3. **Explicit artifact status in every receipt.** Chat-only OR exact path,
+   stated — never implied. Affects architect (concept), converters (output
+   file), figma (render vs. remote), governance-extras (ADR/RFC path + index).
+4. **Credential lifecycle documentation.** Atlassian OAuth refresh tokens
+   expire after 90 days of inactivity; Figma OAuth access tokens expire after
+   90 days unconditionally. Re-authentication section (trigger, steps, storage
+   location) is required in both packs.
+5. **Mutation status stated, not implied.** "No Figma changes made" / "no Jira
+   items modified" in every read-only receipt. Verified post-fix for figma;
+   atlassian requires equivalent treatment.
+
+**Four from round-2 (triangulated across ≥3 independent sources):**
+
+6. **Constrain the first task to a domain the user can verify in minutes.**
+   The user must know enough to confirm the output is right; this is the
+   universal remediation for verification burden as a churn mechanism.
+7. **Name human control points explicitly.** "You decide here" moments must be
+   visible by design; loss-of-controllability anxiety is present in AI-naive and
+   UX segments and must be remediated structurally, not in copy.
+8. **Peer-champion the demo and onboarding.** Peer discovery is primary for
+   engineers (78%); champions programmes deliver 2.1× for enterprise; practitioner
+   case beats product marketing for designers; consulted workers beat mandated
+   workers for AI-naive professionals. The demo should be peer-shaped, not vendor-shaped.
+9. **Frame value at the shareable artifact, not at system capability.** Each
+   segment's first value is defined by who they share the artifact with. The demo
+   must end at the sharing moment: the brief the engineer acts on, the metric the
+   board reviews, the journey map presented at the design review.
 
 ---
 
 ## Known unknowns
 
+- **Known-unknown:** What is the mid-market enterprise segment's binding
+  constraint? Is it inherited from the FDE model, inherited from the solo
+  model, or a third structural form? Would be closed by: FDE practitioner
+  interviews + mid-market self-serve attempt sessions. Until closed: the
+  rollout playbook must name this as an unresolved track, not promise a path
+  that doesn't reliably succeed.
+
 - **Known-unknown:** Does a non-technical enterprise client trust and act on
-  the governance-extras preview-confirm flow without external reassurance?
-  The mechanical fix (rev `d9ebec99`) documented the cues; whether a first-time
-  adopter uses them correctly is unverifiable without participant observation.
-  Would be closed by: a moderated first-use session with a non-technical
-  governance-extras adopter. Until closed: the P5 governance-extras build AC
-  should include a usability check; the rollout playbook should recommend
-  facilitated first use.
+  the governance-extras preview-confirm flow without external reassurance? The
+  mechanical fix documented the cues; client first-use trust is unverifiable
+  without participant observation. Would be closed by: a moderated first-use
+  session with a non-technical governance-extras adopter.
 
 - **Known-unknown:** What proportion of Level B deployments are FDE-mediated
-  versus self-service? No activation or deployment-pathway data exists.
-  Would be closed by: deployment telemetry or FDE practitioner survey.
+  versus self-service? No activation or deployment-pathway data exists. Would
+  be closed by: deployment telemetry or FDE practitioner survey.
 
-- **Known-unknown:** Does the unsupported mid-market enterprise segment require
-  a distinct pack subset, a distinct onboarding flow, or both? The segment is
-  identified but not characterised in detail. Would be closed by: FDE
-  practitioner interviews + mid-market self-serve attempt sessions.
+- **Known-unknown:** Does the technical PM/PE segment's authorship-ambiguity
+  identity concern require explicit design remediation? The pattern is inferred
+  from gate-based-review adoption; it is not directly observed. Would be closed
+  by: structured interviews with practitioners who use agent-skills platforms
+  for brief generation.
 
 - **Unknowable:** Which provisional segment labels adopters will self-identify
   with before experiencing the product. Segment identity is behavioural and
   contextual; self-identification cannot substitute for observed task behaviour.
 
-- **Unknowable:** Whether the five-posture model will remain stable after pack
-  designs change in response to these findings. The model is inferred from
-  documentation and secondary research, not from observed behaviour; it will
-  require revision as the product evolves.
+- **Unknowable:** Whether the nine cross-segment design requirements will hold
+  stable as pack designs change in response to these findings. The requirements
+  are inferred from documentation and secondary research; they will require
+  revision as the product evolves and as participant observation data becomes
+  available.

--- a/docs/product/research/adopter-persona-comparison-matrix.md
+++ b/docs/product/research/adopter-persona-comparison-matrix.md
@@ -1,171 +1,167 @@
-# Comparison matrix — adopter-persona
+# Comparison matrix — adopter-persona (round 2)
 
-Two primary adopter segments for the Level B pack set, compared across the
-dimensions that determine whether they reach first value and sustain use.
-
----
-
-## Segment profiles
-
-### Segment A — enterprise customer via FDE practitioner
-
-A technically proficient forward-deployed engineer installs and configures the
-toolkit on behalf of an enterprise client. The FDE is the installer; the client
-organisation is the end adopter. The FDE absorbs installation friction and
-credential setup, but vocabulary barriers, token lifecycle, and governance
-maintenance land on the client unaided after the engagement ends. The CoE
-the FDE hands off to — if one exists at all — must include named role owners
-who are long-term domain participants, not rotational staff.
-
-The binding constraint is **handoff quality**: whether the client can operate
-the toolkit independently after the FDE exits. The FDE model achieves 60–80%
-automation rates in mature deployments; self-service achieves ~20%. The gap
-is structural. [moderate — SaaStr practitioner analysis; consistent across
-fde.academy, Baseten, Everest Group]
-
-### Segment B — solo software engineer
-
-A technically proficient developer installs and uses the toolkit for their own
-side projects or to assist a colleague or client with a business problem. They
-are installer and end user in one person, with no team support to absorb output
-uncertainty or troubleshoot credential failures. The binding constraint is
-**time budget**: 60–80% of developer-tool signups never reach activation;
-68% cite "too much setup time" as the reason. The industry target for time to
-first working value (TTFHW) is under 15 minutes. [moderate — daily.dev
-practitioner research; consistent with Stack Overflow 2025 and ICSE 2024]
-
-For solo engineers doing client-facing work, a second constraint overlays the
-time budget: **reputational cost of uncertain output**. Ambiguous results or
-unclear mutation status that would be absorbed in a team context carry direct
-professional cost when the audience is a paying client. [moderate — ICSE 2024,
-N=52 freelancers; Skywork.ai 2025 survey]
+**Verdict:** The Level B pack set has six primary adopter segments across two
+orthogonal dimensions. Arrival pathway (FDE-mediated vs. self-directed) and
+role/altitude identity are independent; the round-1 FDE/solo binary described
+pathways, not personas. These segments fail in structurally different ways; a
+single onboarding flow cannot serve all six. Nine cross-segment design requirements
+address the most consistent patterns. The enterprise rollout playbook requires
+three tracks, not two. Mid-market enterprise is a seventh, uncharacterised segment
+and the highest structural churn risk.
 
 ---
 
-## Dimension comparison
+## Segment profiles across dimensions
 
-| Dimension | FDE-mediated (Segment A) | Solo engineer (Segment B) |
+### Arrival pathways
+
+| Segment | Arrival | Controls installation | Binding constraint |
+|---|---|---|---|
+| **FDE-mediated enterprise** | FDE installs/configures on behalf of client org | FDE (external) | Handoff quality: can client operate independently after FDE exits? |
+| **Solo engineer** | Self-installs; installer = end user in one person | Self | Time budget: 5–15 min activation window before abandonment |
+
+### Role / altitude identities
+
+| Segment | Altitude | Primary packs | Binding constraint |
+|---|---|---|---|
+| **Technical PM / product engineer** | Altitude 1 (initiative shaping) | product-engineering, workspace.toml, shaping queue | Mental model shift: reactive prompting → declarative orchestration |
+| **AI-naive knowledge worker** | Altitude 0–1 (strategy/research) | product-strategy, desk-research | Verification burden + professional identity threat |
+| **Enterprise AI champion** | Altitude 0–1 (strategic oversight) | Cross-pack | Career-risk management; 95% of GenAI pilots produce zero return |
+| **UX / experience designer** | Altitude 2 (project/design) | experience-design, figma | Craft integrity: generic-output and articulation barriers |
+
+---
+
+## Full segment comparison
+
+### FDE-mediated enterprise
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Handoff quality — CoE resourcing (7 named permanent roles); FDE absorbs installation friction but not vocabulary transfer |
+| **First-value shape** | Client operates one pack task independently after FDE exits; one client-independent run before engagement closes |
+| **Vocabulary bridge/barrier** | Bridge: determined by what FDE translates before exit. Barrier: any pack vocabulary the FDE didn't cover = post-handoff blocker |
+| **Trust mechanism** | FDE absorbs installation trust; post-handoff trust rebuilt from documentation alone |
+| **Failure modes** | Four: knowledge vacuum, custom-integration orphaning, silent system degradation, escalation-chain breakdown |
+| **Sustainability driver** | Named domain owners who are "long-term participants"; not rotational staff |
+| **High-priority packs** | atlassian, figma (credential lifecycle); governance-extras, user-guide-diataxis (governance maintenance) |
+
+### Solo engineer
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Time budget: 60–80% dropout before activation; 68% cite "too much setup time"; sub-15-min TTFHW target |
+| **First-value shape** | Working result within 15 min on a real problem; for client-facing: result the client can evaluate |
+| **Vocabulary bridge/barrier** | Bridge: peer vocabulary; coding-assistant vocabulary. Barrier: agent/pack vocabulary; required config steps |
+| **Trust mechanism** | Peer discovery (78% primary channel); 5+ doc pages = 340% conversion lift; tangible result on real problem |
+| **Failure modes** | Motivation decay; vocabulary exploration and configuration consume the activation window before first value |
+| **Sustainability driver** | Competitive advantage for client-facing engineers; peer community |
+| **Lowest-friction entry** | product-strategy (write-prfaq) — no credential, no configuration, explicit starter prompt |
+
+### Technical PM / product engineer
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Mental model shift: chat-assistant ("AI answers") → agent orchestration ("AI acts"). Gate-based review vs. per-sentence checking is the threshold |
+| **First-value shape** | Structured brief that the engineering team can act on without a sync meeting — cross-team handoff, not individual productivity |
+| **Vocabulary bridge/barrier** | Bridge: brief, initiative, spec, appetite, shaping (Shape Up/OKR native). Barrier: skill (as primitive), pack, workspace-as-context, invoke, orchestrate |
+| **Trust mechanism** | Cross-team handoff quality: the brief that eliminates a sync meeting is proof-of-value; gate-based review teaches trust through doing |
+| **Failure modes** | Workflow inertia: installs agent skills platform, continues drafting in ChatGPT; unclear which skills to invoke when |
+| **Sustainability driver** | Stage-progression: 0.5 (chat user) → 0.7 (templated assistant) → 1.0 (gate-based orchestration); each stage is self-reinforcing once crossed |
+| **Primary packs** | product-engineering, workspace.toml, shaping queue; product-strategy as low-friction first entry |
+
+### AI-naive knowledge worker
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Verification burden (mental simulation of agent steps = doubled effort) + professional identity threat (deskilling fear for junior roles); 2-week activation window |
+| **First-value shape** | Visible, shareable deliverable in session one — completed research summary, drafted brief, strategic document. Not a capability tour |
+| **Vocabulary bridge/barrier** | Bridge: familiar output types (research summary, brief, analysis). Barrier: all agent/platform vocabulary (prompting, pipeline, schema, invoke, orchestrate) |
+| **Trust mechanism** | (1) Empathy-grounded approach (start with worker's problem, not org's efficiency goal). (2) Meaningful consultation: consulted workers adopt; mandated workers resist (CHI 2025) |
+| **Failure modes** | Reliability anxiety (44% cite hallucination) + identity threat cause early abandonment; cognitive load from prompting overhead exceeds manual speed |
+| **Sustainability driver** | Session-one value + explicit reason to return for session two; peer champion in role-proximate position |
+| **Primary packs** | product-strategy (write-prfaq — standalone, no dependencies, clear starter task); desk-research |
+
+### Enterprise AI champion
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Career-risk management: 95% of GenAI pilots produce zero measurable return (MIT NANDA 2025, N=300+); four personal risk vectors (pilot failure, budget overrun, regulatory exposure, adoption stall) |
+| **First-value shape** | Board-ready proof within one budget cycle (weeks, not quarters); 12+ months of production evidence required before selection; 4-week-to-production benchmark |
+| **Vocabulary bridge/barrier** | Bridge: governance, compliance, ROI, TCO framing. Barrier: outcome-first framing without governance depth reads as immature product; vendor lock-in risk |
+| **Trust mechanism** | Champions programme (peer-led, 1:15–25 ratio) delivers 2.1× higher sustained usage vs. top-down mandate; measurement infrastructure the champion can present upward |
+| **Failure modes** | IBM Watson Health pattern: technology championed top-down without frontline validation; adoption stall at sub-20% active usage is a reputational write-off |
+| **Sustainability driver** | Named internal owner at engagement close; documented workflow operating guide + prompt library + measurement log; internal champions network |
+| **Role in pack adoption** | Cross-pack; drives all Level B pack adoption decisions; feeds enterprise rollout playbook directly |
+
+### UX / experience designer
+
+| Dimension | Characterisation |
+|---|---|
+| **Binding constraint** | Craft integrity: generic-output barrier (AI results "templatized," below professional standard); inconsistency barrier (identical prompts → incompatible designs); articulation barrier (can't describe a good journey map to AI) |
+| **First-value shape** | Compressed research synthesis → structured journey map with emotion scores, tagged quotes, pain points; designer retains strategic authorship; AI removes collation work |
+| **Vocabulary bridge/barrier** | Bridge: journey map, JTBD, screen brief, persona, affinity map, Figma, plugin, method, framework. Barrier: skill, pack, agent, pipeline, invoke, schema |
+| **Trust mechanism** | (1) Source provenance disclosure. (2) Peer/social proof (Grippo practitioner case > product marketing). (3) "Digital prosthetic" framing: AI amplifies craft |
+| **Failure modes** | Generic-output rejection at first use; verifiability-first adoption means journey maps (0.5% adoption rate) are the last thing attempted, not the first |
+| **Sustainability driver** | Collation/synthesis removed while strategic authorship preserved; "anxious amplifier" posture becomes stable amplifier when first-value is confirmed |
+| **Entry point** | Figma (familiar environment, plugin-shaped integration) as Trojan-horse; experience-design pack for core workflow |
+
+---
+
+## Cross-segment patterns
+
+### Four binding-constraint zones (solving for one may harm another)
+
+| Zone | Segments | Key tension |
 |---|---|---|
-| **Activation failure mode** | Vocabulary exposure post-handoff: the FDE absorbed install friction, but pack vocabulary (ADR, RFC, OAuth scope, Diátaxis type) lands on the client unaided after exit | Activation window exceeded: prerequisite friction, vocabulary, or configuration steps consume the sub-15-min budget before first value lands; 60–80% drop-off rate |
-| **Prerequisite timing** | FDE configures prerequisites during the engagement; client must re-authenticate (~90-day token expiry for atlassian and figma) without FDE support | Prerequisites must surface at the decision point before the attempt — not as error messages. Solo engineer is their own IT department; a blocking error mid-task triggers abandonment |
-| **First-value boundary** | First value = client produces a result independently after FDE exit. Chat-only vs. exact-path ambiguity and wrong artifact type selection (ADR vs. RFC, Diátaxis kind) are the two most common post-handoff failure points | First value = reaching a useful result within the activation window. Stop-at-concept ambiguity (is this in chat or saved?) is the primary boundary-marking failure across conversational-shaper packs |
-| **Credential lifecycle** | FDE must document re-authentication steps as a mandatory handoff artefact. Atlassian OAuth refresh tokens expire after 90 days of inactivity; Figma OAuth access tokens expire after 90 days unconditionally. A client who is slow to adopt after FDE exit may hit expiry before their first independent use | Solo engineer must self-serve re-authentication from inline guidance alone. If the token-regeneration steps are not self-contained inline, there is no support channel. Same 90-day expiry windows apply |
-| **Sustainability mechanism** | CoE role staffing + pre-exit vocabulary transfer + one client-independent run before FDE closes the engagement. Governance packs require the client to make the right vocabulary choice every time post-handoff — this is a recurring, not a one-time, sustainability requirement | Peer discovery (78% primary channel) + documentation depth signal (5+ pages = 340% conversion lift) + pragmatic task-test on a real problem. Client-facing work raises the bar: output confidence and explicit mutation status are not cosmetic for this sub-segment |
+| **External / engagement** | FDE client, champion | Governance depth and preview-confirm build trust here; same interventions add friction that abandons the time-constrained solo engineer |
+| **Resource / time** | Solo engineer | Outcome-first vocabulary helps here and for AI-naive; champion reads it as product immaturity |
+| **Cognitive / mental model** | Technical PM/PE | Gate-based review teaching requires sustained engagement; no 15-min equivalent |
+| **Identity / epistemic** | AI-naive, UX designer | Peer champion + constrained first task is the primary intervention; efficiency framing actively harms |
+
+### Nine cross-segment design requirements
+
+**From round-1 (five — apply to all six segments):**
+1. **Prerequisites at the decision point, not on failure** — "Do you have X?" before the attempt, not as an error message
+2. **Outcome-first vocabulary at every entry point** — plain-language outcome label before internal pack terminology
+3. **Explicit artifact status in every receipt** — chat-only OR exact path, stated, never implied
+4. **Credential lifecycle documentation** — re-authentication steps (trigger, steps, storage location) as a named, findable section in atlassian and figma
+5. **Mutation status stated, not implied** — "No Figma changes made" / "no Jira items modified" in every read receipt
+
+**From round-2 (four — triangulated across ≥3 independent sources each):**
+6. **Constrain first task to a domain the user can verify in minutes** — user must know enough to confirm the output is right; removes verification burden as adoption barrier
+7. **Name human control points explicitly** — agent paradigm requires visible "you decide here" moments; loss-of-controllability anxiety requires remediation by design
+8. **Peer-champion the demo and onboarding** — peer discovery primary for engineers (78%), peer champions 2.1× for enterprise; practitioner case > marketing claim for designers
+9. **Frame value at the shareable artifact, not at the system capability** — each segment's first value is defined by who they share it with; the demo must end at that sharing moment
+
+### Three-track requirement for the rollout playbook
+
+| Track | Segments | Primary constraint addressed |
+|---|---|---|
+| **Technical** | Solo engineer + Technical PM/PE | Time budget → outcome-first framing; mental model shift → gate vocabulary |
+| **Enterprise** | FDE client + Enterprise champion | Handoff quality → documentation completeness; career risk → governance depth + measurement infrastructure |
+| **Non-technical** | AI-naive knowledge worker + UX designer | Verification burden → constrained first task; identity threat → peer champion + "digital prosthetic" framing |
 
 ---
 
-## Pack groupings by segment risk
+## Mid-market enterprise — unresolved
 
-### High FDE deployment priority — packs where handoff quality determines sustained adoption
-
-**atlassian, figma** — Credential setup is FDE-handled; client must re-authenticate
-independently after ~90-day token expiry. The re-auth documentation gap is a
-confirmed design requirement, not a marginal edge case. [high — official
-Atlassian and Figma OAuth documentation]
-
-**governance-extras, user-guide-diataxis** — Governance vocabulary (ADR, RFC,
-amendment/errata; Diátaxis type selection) appears in every artifact the client
-must extend post-handoff. Wrong type selection is a recurring failure point.
-The pre-exit vocabulary transfer must include at least one client-performed
-write before the FDE closes. [moderate — expert walkthrough + mechanical fix
-verification; post-fix repairs verified at rev `d9ebec99`]
-
-### High solo activation friction — packs where the activation window is most at risk
-
-**atlassian, figma** — Full credential self-service from a standing start. No
-admin to call; OAuth/token setup must be self-sufficient from inline guidance.
-[moderate — figma expert walkthrough; mechanical fix verification]
-
-**governance-extras** — Highest vocabulary load of any Level B pack. Anxiety
-around a first repository write is the primary friction point. Preview-confirm
-flow verified in documentation (post-fix); whether a first-time adopter trusts
-it without moderator support is the one remaining unverifiable confidence gap.
-[moderate — governance-extras expert walkthrough; mechanical fix verification;
-client confidence unverifiable without participant observation]
-
-### Low friction for both segments
-
-**converters, desk-research** — No credential, no SaaS admin. Low FDE overhead
-(likely written instructions rather than a live session). Solo activation
-risk is limited to runtime prerequisites surfacing on failure rather than
-before the attempt. [moderate — segmentation survey; pack coverage table]
-
-**product-strategy** — Declared standalone with no product-engineering
-dependency (`prerequisites = []` in `pack.toml`). Starter task (`write-prfaq`)
-is explicitly defined with a ready-to-use prompt. Clearest first-value path of
-any Level B pack. [high — direct pack.toml inspection]
-
-### Medium friction — vocabulary or runtime, but no credential
-
-**architect, experience-design, product-engineering** — Conversational entry;
-no credential. Vocabulary barriers (C4, RFC/ADR, forked-context; JTBD, screen
-brief; work-loop, Gate: Idea) are present but manageable with outcome-first
-framing. Post-fix improvements (rev `d9ebec99`) address the Architect
-vocabulary and receipt gaps. [moderate — expert walkthrough + mechanical fix
-verification]
+Named in three independent sources as the highest structural churn risk. Sold
+on FDE-level outcomes; given self-service documentation; achieves ~20%
+automation vs. 60–80% for FDE-mediated. No viable self-serve path for
+enterprise-complexity packs (atlassian, figma, governance-extras) has been
+characterised. The rollout playbook must name this gap honestly rather than
+promise a path that doesn't exist.
 
 ---
 
-## Cross-segment design requirements
+## Confidence summary
 
-Five requirements hold for both segments — their rationale differs, but the
-design change is identical:
-
-1. **Prerequisites at the decision point, not on failure.** FDE rationale:
-   the client who hits a blocking error post-handoff has no FDE to call.
-   Solo rationale: a blocking error mid-attempt burns the activation budget.
-   Implementation: "Do you have X?" before the attempt, not as an error
-   message. Affects: converters (runtime), atlassian (admin pre-config),
-   figma (PAT/OAuth).
-
-2. **Outcome-first vocabulary.** FDE rationale: vocabulary barriers land on
-   the client unaided post-handoff; plain outcomes reduce maintenance calls.
-   Solo rationale: vocabulary exploration consumes the activation window.
-   Implementation: plain-language outcome label before internal pack
-   terminology at every entry point. Affects: all Level B packs.
-
-3. **Explicit artifact status in every receipt.** FDE rationale: the client
-   must be able to locate what the FDE produced. Solo rationale: uncertainty
-   about whether a result was saved or is chat-only triggers a re-run.
-   Implementation: chat-only OR exact path, stated in the receipt — never
-   implied. Affects: architect (concept), converters (output file), figma
-   (render vs. remote), governance-extras (ADR/RFC path + index).
-
-4. **Credential lifecycle documentation.** FDE rationale: ~90-day token expiry
-   is a guaranteed post-handoff event for every atlassian and figma deployment.
-   Solo rationale: self-service re-authentication with no support channel.
-   Implementation: a re-authentication section (trigger, steps, token storage)
-   in atlassian and figma pack documentation — not optional appendix material.
-
-5. **Mutation status stated, not implied.** FDE rationale: enterprise clients
-   using connected-system packs in a governance context cannot assume no
-   remote change without an explicit statement. Solo rationale: client-facing
-   use has reputational cost if a "read" session is ambiguous. Implementation:
-   "No Figma changes made" / "no Jira items modified" in every read receipt.
-   Affects: atlassian, figma. Post-fix verified for figma; atlassian requires
-   the same treatment.
-
----
-
-## Synthesis verdict
-
-The two segments are not alternatives to the five-segment posture model — they
-are a layer above it. The FDE-mediated pathway and the solo pathway explain
-*how an adopter arrives* at a pack; the five postures explain *what they need
-once they're there*. Both framings are required for the P5 persona, the
-live-demo design, and the enterprise rollout playbook.
-
-**The enterprise rollout playbook needs three tracks, not two.** The well-resourced
-enterprise (FDE-mediated) track and the solo self-serve track are defined by
-the corpus. The mid-market or less-resourced enterprise track — too small for
-FDE support, too complex for unassisted self-service — is the highest churn
-risk and must be named as a distinct design concern in the rollout playbook,
-even if its detailed design is deferred.
-
-**Governance-extras write-confidence is the one remaining unresolvable gap.**
-The mechanical fix (rev `d9ebec99`) documented the preview-confirm flow; the
-expert walkthrough confirmed the cues exist. Whether a non-technical client
-trusts the preview and proceeds without external reassurance is unverifiable
-without participant observation. The P5 governance-extras build AC should
-include a usability check; the rollout playbook should flag this as a
-facilitated first-use recommendation.
+| Finding | GRADE | Source count | Note |
+|---|---|---|---|
+| FDE/solo as pathway dimension | High | 8 | Cross-validated across all source tiers |
+| Six-segment role model | Moderate | 13 | Desk research only; no participant observation |
+| Verification burden as universal churn mechanism | High | 5+ independent disciplines | Cross-segment pattern; strongest finding |
+| Peer adoption > mandate | High | 4+ independent disciplines | Directionally consistent across all segments |
+| Professional identity threat in 3 segments | Moderate | 4 | Inferred for PM/PE; observed for AI-naive and UX |
+| Mid-market gap existence | High | 3 | Consistent across round-1 and round-2 sources |
+| Mid-market characterisation | None | — | Not researched; highest remaining gap |

--- a/docs/rfc/0064-ini-001-ai-native-ecosystem.md
+++ b/docs/rfc/0064-ini-001-ai-native-ecosystem.md
@@ -533,14 +533,21 @@ ACs are grouped by delivery batch (see spec map above). Each batch ships as one 
 - [ ] Enterprise rollout playbook: champion → CTO → platform team → engineers adoption arc; staged rollout phases (pilot → wave → org-wide); rollout checklist and retrospective template — `spec/m6-enterprise-rollout-playbook`; distinct from the technical catalogue enterprise-distribution guides already shipped
 
 The `research:adopter-persona` gate is now clear (2026-08-02). Desk-research only;
-participant sessions deferred. Two-segment hypothesis (FDE-mediated enterprise /
-solo engineer) confirmed as adoption-pathway framing complementary to the five-
-segment posture model. Five cross-segment design requirements identified (prerequisites
-at decision point; outcome-first vocabulary; explicit artifact status; credential
-lifecycle documentation; mutation status stated). Third segment (unsupported
-mid-market enterprise) identified as highest churn risk — address in rollout playbook.
+participant sessions deferred. Six primary adopter segments across two orthogonal
+dimensions: **arrival pathway** (FDE-mediated enterprise; solo engineer) and
+**role/altitude identity** (technical PM/product engineer; AI-naive knowledge
+worker; enterprise AI champion; UX/experience designer). A seventh segment
+(mid-market enterprise) is named but uncharacterised and is the highest churn
+risk — the rollout playbook must address it as a distinct track. Nine
+cross-segment design requirements: five from round-1 (prerequisites at decision
+point; outcome-first vocabulary; explicit artifact status; credential lifecycle
+documentation; mutation status stated) plus four from round-2 (constrain first
+task to a verifiable domain; name human control points; peer-champion the demo;
+frame value at the shareable artifact). Three rollout tracks required: technical
+(solo engineer + PM/PE), enterprise (FDE client + AI champion), non-technical
+(AI-naive professional + UX designer).
 
-Evidence base: [`docs/product/research/adopter-persona-brief.md`](../product/research/adopter-persona-brief.md) (governance brief, self-contained) · [`docs/product/research/adopter-persona-comparison-matrix.md`](../product/research/adopter-persona-comparison-matrix.md) (full comparison).
+Evidence base: [`docs/product/research/adopter-persona-brief.md`](../product/research/adopter-persona-brief.md) (governance brief, self-contained) · [`docs/product/research/adopter-persona-comparison-matrix.md`](../product/research/adopter-persona-comparison-matrix.md) (full six-segment comparison).
 
 ## Sub-RFCs
 


### PR DESCRIPTION
## Summary

- Round-1 synthesis identified FDE-mediated enterprise and solo engineer as **adoption pathways** (how adopters arrive). Round-2 desk-research found those are orthogonal to **role/altitude identity** (who adopters are); collapsing the two produced a synthesis that answered the wrong question for P5.
- Six primary segments now characterised: FDE-mediated enterprise, solo engineer (arrival pathways) + technical PM/PE, AI-naive knowledge worker, enterprise AI champion, UX/experience designer (role identities).
- Mid-market enterprise named as a seventh, uncharacterised segment and the highest structural churn risk.
- Nine cross-segment design requirements (five from round-1, four new from round-2).
- Three rollout tracks required: technical, enterprise, non-technical.

## Changes

- `docs/product/research/adopter-persona-brief.md` — replaced two-segment brief with six-segment governance brief (BLUF, GRADE-tagged, self-contained)
- `docs/product/research/adopter-persona-comparison-matrix.md` — replaced two-segment matrix with full six-segment comparison across seven emergent concepts
- `docs/rfc/0064-ini-001-ai-native-ecosystem.md` — updated P5 notes block to reflect the full round-2 findings; links to updated evidence base files

## Test plan

- [ ] Verify RFC-0064 P5 notes accurately describe the six-segment model and three-track requirement
- [ ] Verify brief is self-contained (no cross-links to vault sources)
- [ ] Verify nine design requirements are listed correctly (five + four split)
- [ ] Confirm evidence base links in RFC-0064 resolve to the updated repo files