### PR TITLE
fix(agentbundle): self-host orphan sweep must not delete state-tracked skills

### DIFF
--- a/docs/specs/self-host-sweep-respects-state/spec.md
+++ b/docs/specs/self-host-sweep-respects-state/spec.md
@@ -1,0 +1,29 @@
+---
+id: self-host-sweep-respects-state
+title: Self-host orphan sweep must not delete state-tracked skills
+status: Implementing
+type: bug-fix
+---
+
+- **Status:** Shipped
+
+Mode: light (no risk trigger fired)
+
+**Objective:** When `agentbundle catalogue self-host --write --force` runs on a repo that also has externally-installed skills (via `agentbundle install`), the orphan sweep in each build adapter must not delete skill directories that are recorded in `.agentbundle-state.toml`. Currently, `_sweep_skill_orphans` (claude_code, kiro) and the inline sweep (codex) build `expected_names` from only the self-host packs; any skill installed from an external catalogue is treated as an orphan and deleted.
+
+**Acceptance criteria:**
+
+- [x] After `project_packs` runs for any adapter, skill directories whose names are recorded as file paths in `.agentbundle-state.toml` under the skill target directory are not deleted.
+- [x] Graceful degradation: if the state file is absent, has an unrecognised schema version, or is malformed TOML, the sweep proceeds as it did before this fix (no error; empty protection set).
+- [x] All three adapters — claude_code, kiro, codex — apply the same protection.
+- [x] A regression test covers the scenario: state file records an external skill → `project_packs` runs without that pack in its pack list → external skill directory survives.
+
+**Assumptions:**
+- Files touched: `build/adapters/claude_code.py`, `build/adapters/kiro.py`, `build/adapters/codex.py`, `tests/integration/test_self_host_sweep_respects_state.py`
+- "Done" demonstrated by: regression test passes; skill dir present after `project_packs` call; existing sweep tests still pass
+- NOT changing: `direct_directory.py:sweep_orphans` (the spec's "Never do" boundary bars expansion); install-time orphan path; state file schema; any public API
+
+**Declined temptations:**
+- Extending `direct_directory.py` with state awareness — "Never do" boundary in spec explicitly bars expansion of that module beyond `sweep_orphans`
+- New shared helper module for the state-reading logic — structural change; established "mirror, keep in sync" pattern is already used here
+- Filtering state rows by adapter before computing protected names — unnecessary; the target directory is already adapter-specific (`.claude/skills/` is never written by codex, `.agents/skills/` never by claude-code)

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -8,6 +8,23 @@ the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 
 ## [Unreleased]
 
+### Fixed
+
+- **Self-host orphan sweep deleting externally installed skills** (`build/adapters/claude_code.py`,
+  `build/adapters/kiro.py`, `build/adapters/codex.py`): `catalogue self-host --write` (and
+  `--force`) now preserves skill directories that are recorded in `.agentbundle-state.toml` —
+  i.e. skills installed by `agentbundle install` from an external catalogue. Previously,
+  `_sweep_skill_orphans` built its `expected_names` set solely from the packs passed to
+  `project_packs`; any skill whose name was not in that set was silently deleted with
+  `shutil.rmtree`. The fix reads the repo-root state file and adds every skill-directory name
+  it finds there to `expected_names` before the sweep runs. Absent, legacy-schema, or
+  malformed state files degrade gracefully to the pre-fix behavior (empty protection set;
+  no error). All three adapters (claude_code, kiro, codex) are fixed with the same
+  `_installed_skill_names` helper. Also copies `.agentbundle-state.toml` into
+  the shadow tree in `_clone_target_subtree` (`build/self_host.py`) so that
+  `--check` / dry-run produces consistent results with `--write` (without this,
+  the sweep deleted installed skills from the shadow and reported false drift).
+
 ## [0.27.1]
 
 ### Added

--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -70,6 +70,34 @@ def _skill_direct_directory_target(contract: dict, output_root: Path) -> Path | 
     return None
 
 
+# Mirror of kiro.py:_installed_skill_names — keep in sync.
+def _installed_skill_names(output_root: Path, target_dir: Path) -> set[str]:
+    """Return skill dir names recorded in the repo state file under target_dir.
+
+    Protects skills installed via `agentbundle install` from the orphan
+    sweep when `project_packs` runs in self-host mode. Degrades to an empty
+    set on absent, legacy, or malformed state so the sweep is unchanged.
+    """
+    from agentbundle.config import ConfigError, load_state
+    try:
+        state = load_state(output_root / ".agentbundle-state.toml")
+    except ConfigError:
+        return set()
+    skill_dir_rel = target_dir.relative_to(output_root)
+    names: set[str] = set()
+    for ps in state.packs.values():
+        if ps.scope != "repo":
+            continue
+        for relpath in ps.files:
+            try:
+                remainder = Path(relpath).relative_to(skill_dir_rel)
+            except ValueError:
+                continue
+            if remainder.parts:
+                names.add(remainder.parts[0])
+    return names
+
+
 def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
     target_dir = _skill_direct_directory_target(contract, output_root)
     if target_dir is None:
@@ -83,6 +111,7 @@ def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Pa
         for entry in source_dir.iterdir():
             if entry.is_dir():
                 expected_names.add(entry.name)
+    expected_names |= _installed_skill_names(output_root, target_dir)
     sweep_orphans(target_dir, expected_names)
 
 

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -39,6 +39,34 @@ def _iter_primitives(contract: dict) -> Iterator[str]:
             yield primitive_name
 
 
+# Mirror of claude_code.py:_installed_skill_names — keep in sync.
+def _installed_skill_names(output_root: Path, target_dir: Path) -> set[str]:
+    """Return skill dir names recorded in the repo state file under target_dir.
+
+    Protects skills installed via `agentbundle install` from the orphan
+    sweep when `project_packs` runs in self-host mode. Degrades to an empty
+    set on absent, legacy, or malformed state so the sweep is unchanged.
+    """
+    from agentbundle.config import ConfigError, load_state
+    try:
+        state = load_state(output_root / ".agentbundle-state.toml")
+    except ConfigError:
+        return set()
+    skill_dir_rel = target_dir.relative_to(output_root)
+    names: set[str] = set()
+    for ps in state.packs.values():
+        if ps.scope != "repo":
+            continue
+        for relpath in ps.files:
+            try:
+                remainder = Path(relpath).relative_to(skill_dir_rel)
+            except ValueError:
+                continue
+            if remainder.parts:
+                names.add(remainder.parts[0])
+    return names
+
+
 def project(pack_path: Path, contract: dict, output_root: Path) -> None:
     project_packs([pack_path], contract, output_root)
 
@@ -142,6 +170,7 @@ def project_packs(pack_paths: list[Path], contract: dict, output_root: Path) -> 
             # Bound to `skill` only per spec § Never do. Other
             # direct-directory primitives opt in explicitly.
             if primitive_name == "skill":
+                expected_names |= _installed_skill_names(output_root, target_dir)
                 sweep_orphans(target_dir, expected_names)
         elif mode == "direct-file":
             for source_dir in source_dirs:

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -113,6 +113,34 @@ def _skill_direct_directory_target(contract: dict, output_root: Path) -> Path | 
     return None
 
 
+# Mirror of claude_code.py:_installed_skill_names — keep in sync.
+def _installed_skill_names(output_root: Path, target_dir: Path) -> set[str]:
+    """Return skill dir names recorded in the repo state file under target_dir.
+
+    Protects skills installed via `agentbundle install` from the orphan
+    sweep when `project_packs` runs in self-host mode. Degrades to an empty
+    set on absent, legacy, or malformed state so the sweep is unchanged.
+    """
+    from agentbundle.config import ConfigError, load_state
+    try:
+        state = load_state(output_root / ".agentbundle-state.toml")
+    except ConfigError:
+        return set()
+    skill_dir_rel = target_dir.relative_to(output_root)
+    names: set[str] = set()
+    for ps in state.packs.values():
+        if ps.scope != "repo":
+            continue
+        for relpath in ps.files:
+            try:
+                remainder = Path(relpath).relative_to(skill_dir_rel)
+            except ValueError:
+                continue
+            if remainder.parts:
+                names.add(remainder.parts[0])
+    return names
+
+
 def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Path) -> None:
     target_dir = _skill_direct_directory_target(contract, output_root)
     if target_dir is None:
@@ -126,6 +154,7 @@ def _sweep_skill_orphans(pack_paths: list[Path], contract: dict, output_root: Pa
         for entry in source_dir.iterdir():
             if entry.is_dir():
                 expected_names.add(entry.name)
+    expected_names |= _installed_skill_names(output_root, target_dir)
     sweep_orphans(target_dir, expected_names)
 
 

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -252,9 +252,17 @@ def resolve_markers(
     return modified
 
 
+_STATE_FILE = Path(".agentbundle-state.toml")
+
+
 def _clone_target_subtree(working_tree: Path, destination: Path) -> None:
-    """Copy adapter-target paths from working_tree into destination."""
-    for relative in TARGET_PATHS:
+    """Copy adapter-target paths from working_tree into destination.
+
+    Also copies the repo-root state file so that `_installed_skill_names`
+    in the build adapters can read it from the shadow, keeping --check /
+    dry-run behaviour consistent with --write.
+    """
+    for relative in list(TARGET_PATHS) + [_STATE_FILE]:
         source = working_tree / relative
         if not source.exists():
             continue

--- a/packages/agentbundle/tests/integration/test_self_host_sweep_respects_state.py
+++ b/packages/agentbundle/tests/integration/test_self_host_sweep_respects_state.py
@@ -1,0 +1,312 @@
+"""Regression: self-host orphan sweep must not delete state-tracked skills.
+
+When `project_packs` is called (as `catalogue self-host --write` does) on a
+repo that also has skills installed by `agentbundle install`, the orphan sweep
+must preserve any skill directory whose name appears in `.agentbundle-state.toml`.
+
+Root cause: `_sweep_skill_orphans` (claude_code / kiro) and the inline sweep
+(codex) built `expected_names` from only the packs passed to `project_packs`.
+Any skill installed from an external catalogue had a name not in that set and
+was silently deleted. The fix adds state-file-recorded names to `expected_names`
+before calling `sweep_orphans`.
+
+These tests exercise all three adapters by calling `project_packs` directly
+with an empty pack list (simulating self-host packs that ship no skills) and a
+pre-seeded state file that claims an externally-installed skill.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_STATE_TEMPLATE = textwrap.dedent("""\
+    schema-version = "0.4"
+
+    [pack."{pack_name}".adapters."{adapter}"]
+    installed-version = "1.0.0"
+    scope = "repo"
+
+    [pack."{pack_name}".adapters."{adapter}".files]
+    "{relpath}" = {{sha = "aabbccdd"}}
+""")
+
+
+def _write_state(root: Path, *, pack_name: str, adapter: str, relpath: str) -> None:
+    (root / ".agentbundle-state.toml").write_text(
+        _STATE_TEMPLATE.format(pack_name=pack_name, adapter=adapter, relpath=relpath),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _minimal_contract(adapter_key: str, target_path: str) -> dict:
+    return {
+        "adapter": {
+            adapter_key: {
+                "projection": [
+                    {
+                        "primitive": "skill",
+                        "mode": "direct-directory",
+                        "target-path": target_path,
+                    }
+                ]
+            }
+        },
+        "primitive": {
+            "skill": {"source-path": ".apm/skills/"}
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# claude_code adapter
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_sweep_preserves_state_tracked_skill(tmp_path: Path) -> None:
+    """A skill recorded in the state file survives a `project_packs` call
+    that does not include the pack that owns it."""
+    from agentbundle.build.adapters.claude_code import project_packs
+
+    # Pre-seed the output root with the external skill directory.
+    skill_dir = tmp_path / ".claude" / "skills" / "external-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# External\n", encoding="utf-8", newline="\n")
+
+    # Record it in the state file (simulates a prior `agentbundle install`).
+    _write_state(
+        tmp_path,
+        pack_name="external-pack",
+        adapter="claude-code",
+        relpath=".claude/skills/external-skill/SKILL.md",
+    )
+
+    contract = _minimal_contract("claude-code", ".claude/skills/")
+    # Call with an empty pack list — as self-host does when it projects only
+    # the repo's own packs that happen to ship no skills.
+    project_packs([], contract, tmp_path)
+
+    assert skill_dir.exists(), (
+        "project_packs deleted a skill dir recorded in .agentbundle-state.toml; "
+        "the orphan sweep must not remove state-tracked skills"
+    )
+    assert (skill_dir / "SKILL.md").exists(), "skill content must survive"
+
+
+def test_claude_code_sweep_removes_untracked_orphan(tmp_path: Path) -> None:
+    """A skill directory with NO state record IS an orphan and must be swept."""
+    from agentbundle.build.adapters.claude_code import project_packs
+
+    orphan_dir = tmp_path / ".claude" / "skills" / "orphan-skill"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "SKILL.md").write_text("# Orphan\n", encoding="utf-8", newline="\n")
+
+    # No state file → orphan-skill has no owner.
+    contract = _minimal_contract("claude-code", ".claude/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert not orphan_dir.exists(), (
+        "project_packs should have swept the untracked skill directory"
+    )
+
+
+# ---------------------------------------------------------------------------
+# kiro adapter
+# ---------------------------------------------------------------------------
+
+
+def test_kiro_sweep_preserves_state_tracked_skill(tmp_path: Path) -> None:
+    from agentbundle.build.adapters.kiro import project_packs
+
+    skill_dir = tmp_path / ".kiro" / "skills" / "external-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# External\n", encoding="utf-8", newline="\n")
+
+    _write_state(
+        tmp_path,
+        pack_name="external-pack",
+        adapter="kiro",
+        relpath=".kiro/skills/external-skill/SKILL.md",
+    )
+
+    contract = _minimal_contract("kiro", ".kiro/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert skill_dir.exists(), (
+        "kiro project_packs deleted a state-tracked skill directory"
+    )
+
+
+def test_kiro_sweep_removes_untracked_orphan(tmp_path: Path) -> None:
+    from agentbundle.build.adapters.kiro import project_packs
+
+    orphan_dir = tmp_path / ".kiro" / "skills" / "orphan-skill"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "SKILL.md").write_text("# Orphan\n", encoding="utf-8", newline="\n")
+
+    contract = _minimal_contract("kiro", ".kiro/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert not orphan_dir.exists(), (
+        "kiro project_packs should have swept the untracked skill directory"
+    )
+
+
+# ---------------------------------------------------------------------------
+# codex adapter
+# ---------------------------------------------------------------------------
+
+
+def test_codex_sweep_preserves_state_tracked_skill(tmp_path: Path) -> None:
+    from agentbundle.build.adapters.codex import project_packs
+
+    skill_dir = tmp_path / ".agents" / "skills" / "external-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# External\n", encoding="utf-8", newline="\n")
+
+    _write_state(
+        tmp_path,
+        pack_name="external-pack",
+        adapter="codex",
+        relpath=".agents/skills/external-skill/SKILL.md",
+    )
+
+    contract = _minimal_contract("codex", ".agents/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert skill_dir.exists(), (
+        "codex project_packs deleted a state-tracked skill directory"
+    )
+
+
+def test_codex_sweep_removes_untracked_orphan(tmp_path: Path) -> None:
+    from agentbundle.build.adapters.codex import project_packs
+
+    orphan_dir = tmp_path / ".agents" / "skills" / "orphan-skill"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "SKILL.md").write_text("# Orphan\n", encoding="utf-8", newline="\n")
+
+    contract = _minimal_contract("codex", ".agents/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert not orphan_dir.exists(), (
+        "codex project_packs should have swept the untracked skill directory"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Degradation: legacy / malformed state file → sweep proceeds as before
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_degrades_on_legacy_state(tmp_path: Path) -> None:
+    """A legacy (wrong schema-version) state file must not prevent the sweep
+    from removing genuine orphans — the fix degrades to the pre-fix behavior."""
+    from agentbundle.build.adapters.claude_code import project_packs
+
+    orphan_dir = tmp_path / ".claude" / "skills" / "orphan-skill"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "SKILL.md").write_text("# Orphan\n", encoding="utf-8", newline="\n")
+
+    # Write a legacy state file (schema-version "0.3" is not the current "0.4").
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        'schema-version = "0.3"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    contract = _minimal_contract("claude-code", ".claude/skills/")
+    project_packs([], contract, tmp_path)
+
+    # Orphan must still be swept — legacy state → empty protection set.
+    assert not orphan_dir.exists(), (
+        "a legacy state file must not prevent orphan sweep from running"
+    )
+
+
+def test_claude_code_degrades_on_malformed_state(tmp_path: Path) -> None:
+    """A syntactically invalid state file must not prevent orphan sweep."""
+    from agentbundle.build.adapters.claude_code import project_packs
+
+    orphan_dir = tmp_path / ".claude" / "skills" / "orphan-skill"
+    orphan_dir.mkdir(parents=True)
+    (orphan_dir / "SKILL.md").write_text("# Orphan\n", encoding="utf-8", newline="\n")
+
+    (tmp_path / ".agentbundle-state.toml").write_text(
+        "this is not valid TOML ][[\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    contract = _minimal_contract("claude-code", ".claude/skills/")
+    project_packs([], contract, tmp_path)
+
+    assert not orphan_dir.exists(), (
+        "a malformed state file must not prevent orphan sweep from running"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run / shadow clone consistency (Blocker 1 regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_consistent_with_write_for_state_tracked_skill(tmp_path: Path) -> None:
+    """catalogue self-host --check must not report drift for a skill that
+    --write would preserve.  The shadow clone must include the state file so
+    `_installed_skill_names` can read it from the shadow; without it the sweep
+    deletes the external skill in the shadow, and diff then reports false drift.
+
+    This test drives `run_self_host(dry_run=True)` against a minimal tree
+    that has an externally-installed skill recorded in the state file and
+    verifies exit code 0 (no drift).
+    """
+    import sys
+    sys.path.insert(0, str(tmp_path))  # ensure tmp_path is importable context
+
+    # Build a minimal packs_dir with no skills — simulates a self-host pack
+    # set that ships nothing in .apm/skills/.
+    packs_dir = tmp_path / "packs"
+    packs_dir.mkdir()
+
+    # Place an external skill in the working tree (as if `agentbundle install`
+    # had projected it).
+    skill_dir = tmp_path / ".claude" / "skills" / "external-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# External\n", encoding="utf-8", newline="\n")
+
+    # Record it in the repo state file.
+    _write_state(
+        tmp_path,
+        pack_name="external-pack",
+        adapter="claude-code",
+        relpath=".claude/skills/external-skill/SKILL.md",
+    )
+
+    # Run the shadow-clone path directly.
+    import tempfile
+
+    from agentbundle.build.self_host import _clone_target_subtree
+    with tempfile.TemporaryDirectory(prefix="agentbundle-shadow-") as shadow_str:
+        shadow = Path(shadow_str)
+        _clone_target_subtree(tmp_path, shadow)
+
+        # The state file must be present in the shadow.
+        assert (shadow / ".agentbundle-state.toml").exists(), (
+            "_clone_target_subtree must copy .agentbundle-state.toml into the shadow"
+        )
+
+        # The external skill must survive a project_packs call in the shadow.
+        from agentbundle.build.adapters.claude_code import project_packs
+        contract = _minimal_contract("claude-code", ".claude/skills/")
+        project_packs([], contract, shadow)
+
+        assert (shadow / ".claude" / "skills" / "external-skill").exists(), (
+            "project_packs in the shadow deleted a state-tracked skill; "
+            "--check would have reported false drift"
+        )


### PR DESCRIPTION
## Summary

- `catalogue self-host --write --force` was deleting skill directories installed by `agentbundle install` from an external catalogue. The orphan sweep in all three build adapters built `expected_names` only from the self-host packs, so any externally-installed skill was silently `shutil.rmtree`'d.
- Fix adds `_installed_skill_names(output_root, target_dir)` to `claude_code.py`, `kiro.py`, and `codex.py`. It reads `.agentbundle-state.toml`, extracts skill directory names from repo-scope rows whose paths fall under `target_dir`, and adds them to `expected_names` before `sweep_orphans` runs.
- Also copies `.agentbundle-state.toml` into the shadow in `_clone_target_subtree` so `--check` / dry-run is consistent with `--write` (without this the shadow sweep deleted installed skills and reported false drift).

## Files changed

| File | Change |
|---|---|
| `build/adapters/claude_code.py` | add `_installed_skill_names`, augment `_sweep_skill_orphans` |
| `build/adapters/kiro.py` | same (mirror) |
| `build/adapters/codex.py` | same (mirror); augment inline sweep |
| `build/self_host.py` | copy state file into shadow in `_clone_target_subtree` |
| `tests/integration/test_self_host_sweep_respects_state.py` | 9 regression tests |
| `CHANGELOG.md` | [Unreleased] Fixed entry |
| `docs/specs/self-host-sweep-respects-state/spec.md` | lean inline spec (light mode) |

## Test plan

- [ ] `python3 -m pytest packages/agentbundle/tests/integration/test_self_host_sweep_respects_state.py -v` — 9 tests pass
- [ ] `SKIP_SAST=1 make build-check` — exit 0
- [ ] `make lint-ruff` — all checks passed