### PR TITLE
docs(agents): make packages/AGENTS.local.md a conditional load instruction

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -8,7 +8,7 @@ directly. To propagate changes to new adopters, also update `packs/core/seeds/AG
 - **Python package development** (install-test rules, Windows compatibility, test conventions):
   [`packages/AGENTS.md`](packages/AGENTS.md).
 - **Release coupling** (PyPI release requirements, version bump workflow, tagging):
-  [`packages/AGENTS.local.md`](packages/AGENTS.local.md).
+  **Read [`packages/AGENTS.local.md`](packages/AGENTS.local.md) before acting** whenever any file under `packages/` is in scope.
 - **Marketing site** (Astro build, Node.js deps, dev server, mobile viewport, link rules):
   [`web/AGENTS.md`](web/AGENTS.md).
 - **Catalogue CI** (portable commands, publication ordering, exit codes, responsibility boundary):


### PR DESCRIPTION
## Summary

- Rewrites the `packages/AGENTS.local.md` pointer in root `AGENTS.local.md` from an informational navigation hint into an imperative conditional load instruction
- Agents running from the repo root don't auto-load subdirectory AGENTS files; the pointer was silently ignored, leaving the two-step closeout rule invisible during work-loop runs that touch `packages/`

## Deferred

The two-step closeout rule itself stays in `packages/AGENTS.local.md` — no content moved.