### PR TITLE
docs(agents): convert subdirectory AGENTS.local.md pointers to conditional load instructions

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -4,11 +4,11 @@ Repo-local addendum for maintainers of this checkout. `AGENTS.md` is adopter-own
 directly. To propagate changes to new adopters, also update `packs/core/seeds/AGENTS.md`.
 
 - **Pack and skill development** (version bumps, projection, skill authoring, eval coverage, plugin format):
-  [`packs/AGENTS.md`](packs/AGENTS.md).
+  [`packs/AGENTS.md`](packs/AGENTS.md). **Read [`packs/AGENTS.local.md`](packs/AGENTS.local.md) before acting** whenever any file under `packs/` is in scope.
 - **Python package development** (install-test rules, Windows compatibility, test conventions):
   [`packages/AGENTS.md`](packages/AGENTS.md).
 - **Release coupling** (PyPI release requirements, version bump workflow, tagging):
-  [`packages/AGENTS.local.md`](packages/AGENTS.local.md).
+  **Read [`packages/AGENTS.local.md`](packages/AGENTS.local.md) before acting** whenever any file under `packages/` is in scope.
 - **Marketing site** (Astro build, Node.js deps, dev server, mobile viewport, link rules):
   [`web/AGENTS.md`](web/AGENTS.md).
 - **Catalogue CI** (portable commands, publication ordering, exit codes, responsibility boundary):


### PR DESCRIPTION
## Summary

- `packs/AGENTS.local.md` and `packages/AGENTS.local.md` were listed as informational navigation hints in root `AGENTS.local.md` — agents running from the repo root silently ignored them
- Rewrites both as imperative conditional load instructions ("Read X before acting whenever any file under Y is in scope")
- Ensures rules like the two-step spec closeout and self-hosting projection quirks are actually read before the agent acts on changes in those directories