### PR TITLE
fix(docs): correct install scope flags, stale pack count, and broken links

### DIFF
--- a/docs-site/src/content/docs/getting-started/index.mdx
+++ b/docs-site/src/content/docs/getting-started/index.mdx
@@ -55,7 +55,7 @@ The `agentbundle` CLI manages pack installation, upgrade, and discovery. One-tim
     agentbundle install --profile inception
     ```
 
-    Lands: `research` + `product-engineering` + `architect`
+    Lands: `desk-research` + `product-engineering` + `architect`
   </TabItem>
   <TabItem label="Solution architect">
     Design, research, and API contracts.
@@ -64,7 +64,7 @@ The `agentbundle` CLI manages pack installation, upgrade, and discovery. One-tim
     agentbundle install --profile solution-architect
     ```
 
-    Lands: `architect` + `research` + `contracts`
+    Lands: `architect` + `desk-research` + `contracts`
   </TabItem>
 </Tabs>
 

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -71,7 +71,7 @@ claude plugin install core@agent-ready-repo
 claude plugin install desk-research@agent-ready-repo
 ```
 
-Available for all 14 packs. Pack names match the directory names under `packs/`.
+Available for all 20 packs (catalogue-curation is an operator-only pack not published to the marketplace). Pack names match the directory names under `packs/`.
 
 ## Route 3: APM (Agent Package Manager)
 

--- a/packs/architect/README.md
+++ b/packs/architect/README.md
@@ -108,7 +108,7 @@ architect-diagram [C4 component view — billing service]
 ## Install
 
 ```bash
-agentbundle install --pack architect <catalogue>
+agentbundle install --pack architect --scope user <catalogue>
 ```
 
 Adapters: `claude-code`, `kiro-ide`, `codex`, `copilot`, `cursor`, `gemini`. Default scope: user.

--- a/packs/atlassian/README.md
+++ b/packs/atlassian/README.md
@@ -73,7 +73,7 @@ Each stage is optional. You can stop after the backlog review, improve only sele
 `atlassian` is **user-scope by default** — your Atlassian credentials are yours, not a project's.
 
 ```bash
-agentbundle install --pack atlassian <catalogue>
+agentbundle install --pack atlassian --scope user <catalogue>
 ```
 
 Or install via the Claude plugin registry:

--- a/packs/catalogue-curation/README.md
+++ b/packs/catalogue-curation/README.md
@@ -50,9 +50,8 @@ Returns a per-candidate verdict (in / out / reshape / defer) written to a resuma
 Say `propose-catalogue-pack` and describe the new pack's purpose.
 Tests whether the pack is additive (doesn't duplicate an existing pack) and fits the catalogue's charter, then scaffolds a pack shell and emits an RFC for human review. No RFC means no new pack.
 
-**Produce a redistributable derivative**
-Say `export-catalogue` and specify white-label or attributed mode and the target organization name.
-Produces a redistributable copy of the catalogue with upstream identity either stripped or credited. Runs a fail-closed leak check before writing any output — the command hard-fails if any identity signal would escape. Result is a local directory; you publish it.
+**Create a self-hosted catalogue**
+Run `agentbundle catalogue init --preset self-hosted` to scaffold a new catalogue from the managed template. No fork required.
 
 ---
 

--- a/packs/converters/README.md
+++ b/packs/converters/README.md
@@ -19,7 +19,7 @@ The Markdown → Office skills (`markdown-to-docx`, `markdown-to-pptx`, `markdow
 ## Install
 
 ```
-agentbundle install --pack converters <catalogue>
+agentbundle install --pack converters --scope user <catalogue>
 ```
 
 `converters` is user-scope by default — format conversion is a portable utility, not a project concern.

--- a/packs/credential-brokers/README.md
+++ b/packs/credential-brokers/README.md
@@ -22,7 +22,7 @@ user, not the project. The broker is written to `~/.agentbundle/bin/` behind
 the `.agentbundle/` user-prefix fence (RFC-0013).
 
 ```
-agentbundle install --pack credential-brokers <catalogue>
+agentbundle install --pack credential-brokers --scope user <catalogue>
 ```
 
 ## Set up credentials

--- a/packs/figma/README.md
+++ b/packs/figma/README.md
@@ -39,7 +39,7 @@ Do these once, top to bottom:
 1. **Install the figma pack** — user scope by default, so your token stays yours:
    ```
    # <catalogue> is your catalogue URI: a local clone path or a git+https://… URL.
-   agentbundle install --pack figma <catalogue>
+   agentbundle install --pack figma --scope user <catalogue>
    ```
 2. **Install the Python dependencies** — `python -m pip install credbroker httpx`
    (`httpx` is the HTTP client; `credbroker` resolves your token — step 3's pack

--- a/packs/github/README.md
+++ b/packs/github/README.md
@@ -11,7 +11,7 @@ GitHub integration for the agent-ready-repo catalogue. The pack ships one skill:
 `github` is **user-scope by default** (your GitHub access is yours, not a project's).
 
 ```
-agentbundle install --pack github <catalogue>
+agentbundle install --pack github --scope user <catalogue>
 ```
 
 ## Prerequisites

--- a/packs/governance-extras/JOURNEY.md
+++ b/packs/governance-extras/JOURNEY.md
@@ -5,7 +5,8 @@ start_state: read-only
 end_state: confirmed-write
 scope: repo
 tagline: "decisions committed, proposals structured, conventions tracked."
-prerequisitePacks: []
+prerequisitePacks:
+  - core
 contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."

--- a/packs/linear/README.md
+++ b/packs/linear/README.md
@@ -16,7 +16,7 @@ evolves.
 
 ```bash
 # <catalogue> is your catalogue URI: a local clone path or a git+https://… URL.
-agentbundle install --pack linear <catalogue>
+agentbundle install --pack linear --scope user <catalogue>
 ```
 
 Requires the `credential-brokers` pack for API key resolution. After install,

--- a/packs/product-strategy/JOURNEY.md
+++ b/packs/product-strategy/JOURNEY.md
@@ -5,8 +5,7 @@ start_state: read-only
 end_state: confirmed-write
 scope: user
 tagline: "Strategy seat upstream of every initiative — committed artifacts."
-prerequisitePacks:
-  - product-engineering
+prerequisitePacks: []
 contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."

--- a/web/src/components/marketing/BuildYourOrg.astro
+++ b/web/src/components/marketing/BuildYourOrg.astro
@@ -16,7 +16,7 @@ import { withBase } from '../../lib/paths';
       one catalogue every engineer installs in a single line — the loop, the reviewers,
       and the standards come out identical on every machine and in every agent.
     </p>
-    <a class="org__cta" href={withBase('/guides/_shared/how-to/build-an-org-stack-pack/')}>
+    <a class="org__cta" href={withBase('/docs/guides/_shared/how-to/build-an-org-stack-pack/')}>
       How to build your org's catalogue <span aria-hidden="true">→</span>
     </a>
   </div>

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -6,7 +6,8 @@ start_state: read-only
 end_state: confirmed-write
 scope: repo
 tagline: "decisions committed, proposals structured, conventions tracked."
-prerequisitePacks: []
+prerequisitePacks:
+  - core
 contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."

--- a/web/src/content/journeys/product-strategy.md
+++ b/web/src/content/journeys/product-strategy.md
@@ -6,8 +6,7 @@ start_state: read-only
 end_state: confirmed-write
 scope: user
 tagline: "Strategy seat upstream of every initiative — committed artifacts."
-prerequisitePacks:
-  - product-engineering
+prerequisitePacks: []
 contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."


### PR DESCRIPTION
## Summary

- **Sites (docs-site + web):** profile tab copy cited non-existent `` `research` `` pack (fixed to `` `desk-research` ``); Route 2 Claude Plugins count was stale at 14 (corrected to 20 — 21 packs minus `catalogue-curation` which is stripped by `publish_claude_plugins.py`); `BuildYourOrg.astro` CTA linked to `/guides/…` which doesn't exist on the marketing site (corrected to `/docs/guides/…`)
- **Pack READMEs (7 packs):** `architect`, `atlassian`, `converters`, `credential-brokers`, `figma`, `github`, `linear` — all had `agentbundle install --pack <name>` without `--scope user`, contradicting their `default-scope = "user"` in `pack.toml`
- **`catalogue-curation/README.md`:** removed `export-catalogue` section documenting a skill removed in v0.2.0; replaced with correct `agentbundle catalogue init --preset self-hosted` guidance
- **JOURNEY.md frontmatter:** `governance-extras` had `prerequisitePacks: []` despite a hard `core` dependency in `pack.toml`; `product-strategy` listed `product-engineering` as a prerequisite when `pack.toml` declares no dependencies

## Test plan

- [x] `SKIP_SAST=1 make build-check` passes (96 tests, 0 failures)
- [x] Codex review (`codex review -c model="gpt-5.6-sol" --base main`) confirmed all three site fixes and surfaced the `catalogue-curation` marketplace exclusion that refined the count from 21 → 20
- [ ] CI green