### PR TITLE
fix(web): correct broken reference links on pack and journey pages

### DIFF
--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -56,7 +56,7 @@ typicalSession:
   agentTurns: "6–10"
   humanTouches: 2
   wallClockMinutes: "30–60"
-docsUrl: /guides/architect/
+docsUrl: /docs/guides/architect/
 packUrl: /packs/architect/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -107,7 +107,7 @@ typicalSession:
   agentTurns: "6–10"
   humanTouches: 4
   wallClockMinutes: "20–40"
-docsUrl: /guides/atlassian/
+docsUrl: /docs/guides/atlassian/
 packUrl: /packs/atlassian/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/contracts.md
+++ b/web/src/content/journeys/contracts.md
@@ -36,7 +36,7 @@ typicalSession:
   agentTurns: "4–8"
   humanTouches: 1
   wallClockMinutes: "15–30"
-docsUrl: /guides/contracts/
+docsUrl: /docs/guides/contracts/
 packUrl: /packs/contracts/
 relatedJourneys:
   - architect

--- a/web/src/content/journeys/converters.md
+++ b/web/src/content/journeys/converters.md
@@ -53,7 +53,7 @@ typicalSession:
   agentTurns: "2–4"
   humanTouches: 1
   wallClockMinutes: "5–15"
-docsUrl: /guides/converters/
+docsUrl: /docs/guides/converters/
 packUrl: /packs/converters/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -83,7 +83,7 @@ typicalSession:
   agentTurns: "8–12"
   humanTouches: 2
   wallClockMinutes: "25–45"
-docsUrl: /guides/core/
+docsUrl: /docs/guides/core/
 packUrl: /packs/core/
 relatedJourneys:
   - release-engineering

--- a/web/src/content/journeys/credential-brokers.md
+++ b/web/src/content/journeys/credential-brokers.md
@@ -32,7 +32,7 @@ typicalSession:
   agentTurns: "2–4"
   humanTouches: 1
   wallClockMinutes: "5–15"
-docsUrl: /guides/credential-brokers/
+docsUrl: /docs/guides/credential-brokers/
 packUrl: /packs/credential-brokers/
 relatedJourneys:
   - figma

--- a/web/src/content/journeys/desk-research.md
+++ b/web/src/content/journeys/desk-research.md
@@ -83,7 +83,7 @@ typicalSession:
   agentTurns: "4–8"
   humanTouches: 2
   wallClockMinutes: "15–40"
-docsUrl: /guides/desk-research/
+docsUrl: /docs/guides/desk-research/
 packUrl: /packs/desk-research/
 relatedJourneys:
   - architect

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -121,7 +121,7 @@ typicalSession:
   agentTurns: "8–15"
   humanTouches: 3
   wallClockMinutes: "45–90"
-docsUrl: /guides/experience-design/
+docsUrl: /docs/guides/experience-design/
 packUrl: /packs/experience-design/
 relatedJourneys:
   - architect

--- a/web/src/content/journeys/figma.md
+++ b/web/src/content/journeys/figma.md
@@ -47,7 +47,7 @@ typicalSession:
   agentTurns: "3–6"
   humanTouches: 2
   wallClockMinutes: "10–25"
-docsUrl: /guides/figma/
+docsUrl: /docs/guides/figma/
 packUrl: /packs/figma/
 relatedJourneys:
   - experience-design

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -74,7 +74,7 @@ typicalSession:
   agentTurns: "6–10"
   humanTouches: 3
   wallClockMinutes: "20–45"
-docsUrl: /guides/governance-extras/
+docsUrl: /docs/guides/governance-extras/
 packUrl: /packs/governance-extras/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/iac-terraform.md
+++ b/web/src/content/journeys/iac-terraform.md
@@ -84,7 +84,7 @@ typicalSession:
   agentTurns: "12–20"
   humanTouches: 3
   wallClockMinutes: "45–90"
-docsUrl: /guides/iac-terraform/
+docsUrl: /docs/guides/iac-terraform/
 packUrl: /packs/iac-terraform/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/monorepo-extras.md
+++ b/web/src/content/journeys/monorepo-extras.md
@@ -32,7 +32,7 @@ typicalSession:
   agentTurns: "3–5"
   humanTouches: 1
   wallClockMinutes: "10–20"
-docsUrl: /guides/monorepo-extras/
+docsUrl: /docs/guides/monorepo-extras/
 packUrl: /packs/monorepo-extras/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/product-engineering.md
+++ b/web/src/content/journeys/product-engineering.md
@@ -115,7 +115,7 @@ typicalSession:
   agentTurns: "12–20"
   humanTouches: 4
   wallClockMinutes: "60–120"
-docsUrl: /guides/product-engineering/
+docsUrl: /docs/guides/product-engineering/
 packUrl: /packs/product-engineering/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/product-strategy.md
+++ b/web/src/content/journeys/product-strategy.md
@@ -88,7 +88,7 @@ typicalSession:
   agentTurns: "8–20"
   humanTouches: 3
   wallClockMinutes: "60–120"
-docsUrl: /guides/product-strategy/
+docsUrl: /docs/guides/product-strategy/
 packUrl: /packs/product-strategy/
 relatedJourneys:
   - experience-design

--- a/web/src/content/journeys/release-engineering.md
+++ b/web/src/content/journeys/release-engineering.md
@@ -40,7 +40,7 @@ typicalSession:
   agentTurns: "varies"
   humanTouches: 1
   wallClockMinutes: "15–30"
-docsUrl: /guides/release-engineering/
+docsUrl: /docs/guides/release-engineering/
 packUrl: /packs/release-engineering/
 relatedJourneys:
   - core

--- a/web/src/content/journeys/user-guide-diataxis.md
+++ b/web/src/content/journeys/user-guide-diataxis.md
@@ -39,7 +39,7 @@ typicalSession:
   agentTurns: "4–7"
   humanTouches: 2
   wallClockMinutes: "15–35"
-docsUrl: /guides/product-documentation/
+docsUrl: /docs/guides/product-documentation/
 packUrl: /packs/product-documentation/
 relatedJourneys:
   - core

--- a/web/src/content/packs/architect.md
+++ b/web/src/content/packs/architect.md
@@ -7,7 +7,7 @@ skills:
   - architect-diagram
   - architect-review
 installCommand: "agentbundle install --pack architect --scope user"
-docsUrl: /guides/architect/
+docsUrl: /docs/guides/architect/
 journeyUrl: /journeys/architect/
 ---
 

--- a/web/src/content/packs/atlassian.md
+++ b/web/src/content/packs/atlassian.md
@@ -15,7 +15,7 @@ skills:
   - confluence-publisher
   - ai-adoption-report
 installCommand: "agentbundle install --pack atlassian --scope user"
-docsUrl: /guides/atlassian/
+docsUrl: /docs/guides/atlassian/
 journeyUrl: /journeys/atlassian/
 ---
 

--- a/web/src/content/packs/catalogue-curation.md
+++ b/web/src/content/packs/catalogue-curation.md
@@ -7,7 +7,7 @@ skills:
   - assimilate-repo
   - propose-catalogue-pack
 installCommand: "agentbundle install --pack catalogue-curation"
-docsUrl: /guides/catalogue-curation/
+docsUrl: /docs/guides/catalogue-curation/
 ---
 
 Catalogue Curation is the operator's seat — meta-tooling for growing the catalogue, one meta-level above the skills themselves. `assimilate-primitive` folds an external skill or agent into a pack; `assimilate-repo` surveys a whole repo for reusable primitives; `propose-catalogue-pack` shapes a new pack proposal. To create a new or derived catalogue, use `agentbundle catalogue init`. Repo-only; no required dependencies.

--- a/web/src/content/packs/contracts.md
+++ b/web/src/content/packs/contracts.md
@@ -6,7 +6,7 @@ skills:
   - api-contract
   - event-contract
 installCommand: "agentbundle install --pack contracts --scope user"
-docsUrl: /guides/contracts/
+docsUrl: /docs/guides/contracts/
 journeyUrl: /journeys/contracts/
 ---
 

--- a/web/src/content/packs/converters.md
+++ b/web/src/content/packs/converters.md
@@ -12,7 +12,7 @@ skills:
   - markdown-to-xlsx
   - mermaid-renderer
 installCommand: "agentbundle install --pack converters --scope user"
-docsUrl: /guides/converters/
+docsUrl: /docs/guides/converters/
 journeyUrl: /journeys/converters/
 ---
 

--- a/web/src/content/packs/core.md
+++ b/web/src/content/packs/core.md
@@ -11,7 +11,7 @@ skills:
   - init-project
   - adapt-to-project
 installCommand: "agentbundle install --pack core"
-docsUrl: /guides/core/
+docsUrl: /docs/guides/core/
 journeyUrl: /journeys/core/
 ---
 

--- a/web/src/content/packs/credential-brokers.md
+++ b/web/src/content/packs/credential-brokers.md
@@ -5,7 +5,7 @@ tagline: "Credential resolution — env → OS keyring → dotfile. Never cleart
 skills:
   - credential-setup
 installCommand: "agentbundle install --pack credential-brokers --scope user"
-docsUrl: /guides/credential-brokers/
+docsUrl: /docs/guides/credential-brokers/
 journeyUrl: /journeys/credential-brokers/
 ---
 

--- a/web/src/content/packs/desk-research.md
+++ b/web/src/content/packs/desk-research.md
@@ -15,7 +15,7 @@ skills:
   - desk-research-project-digest
   - desk-research-project-synthesize
 installCommand: "agentbundle install --pack desk-research --scope user"
-docsUrl: /guides/desk-research/
+docsUrl: /docs/guides/desk-research/
 journeyUrl: /journeys/desk-research/
 ---
 

--- a/web/src/content/packs/experience-design.md
+++ b/web/src/content/packs/experience-design.md
@@ -23,7 +23,7 @@ skills:
   - informational-design
   - workspace-design
 installCommand: "agentbundle install --pack experience-design --scope user"
-docsUrl: /guides/experience-design/
+docsUrl: /docs/guides/experience-design/
 journeyUrl: /journeys/experience-design/
 ---
 

--- a/web/src/content/packs/figma.md
+++ b/web/src/content/packs/figma.md
@@ -5,7 +5,7 @@ tagline: "Read and render Figma designs — files, frames, variables."
 skills:
   - figma
 installCommand: "agentbundle install --pack figma --scope user"
-docsUrl: /guides/figma/
+docsUrl: /docs/guides/figma/
 journeyUrl: /journeys/figma/
 ---
 

--- a/web/src/content/packs/frontend-engineering.md
+++ b/web/src/content/packs/frontend-engineering.md
@@ -13,7 +13,7 @@ skills:
   - css-architecture
   - fe-status
 installCommand: "agentbundle install --pack frontend-engineering --scope user"
-docsUrl: /guides/frontend-engineering/
+docsUrl: /docs/guides/frontend-engineering/
 ---
 
 Frontend Engineering installs 9 skills covering the full build journey from design handoff to shipped component: the create/retrofit/audit/verify workflow (`frontend-engineering`), CSS token system architecture (`token-architecture`), deep accessibility engineering beyond automated tooling (`a11y-engineering`), Core Web Vitals measurement and remediation (`fe-performance`), rendering strategy selection (`rendering-strategy`), component API design (`component-contract`), responsive layout craft (`responsive-layout`), CSS architecture at scale (`css-architecture`), and surface orientation (`fe-status`). A forked-context `frontend-reviewer` agent provides a diff-level review for HTML/CSS/JS diffs covering CSS token drift, ARIA mutation completeness, state coverage regression, and the two WCAG 2.2 manual-verification items automated tooling misses.

--- a/web/src/content/packs/github.md
+++ b/web/src/content/packs/github.md
@@ -5,7 +5,7 @@ tagline: "Turn a GitHub Milestone into a product brief"
 skills:
   - github-brief-intake
 installCommand: "agentbundle install --pack github --scope user"
-docsUrl: /guides/github/
+docsUrl: /docs/guides/github/
 ---
 
 Reads a GitHub Milestone — title, description, and all linked issues — and

--- a/web/src/content/packs/governance-extras.md
+++ b/web/src/content/packs/governance-extras.md
@@ -7,7 +7,7 @@ skills:
   - new-adr
   - update-conventions
 installCommand: "agentbundle install --pack governance-extras"
-docsUrl: /guides/governance-extras/
+docsUrl: /docs/guides/governance-extras/
 journeyUrl: /journeys/governance-extras/
 ---
 

--- a/web/src/content/packs/iac-terraform.md
+++ b/web/src/content/packs/iac-terraform.md
@@ -6,7 +6,7 @@ skills:
   - generate-iac
   - reconcile-iac
 installCommand: "agentbundle install --pack iac-terraform"
-docsUrl: /guides/iac-terraform/
+docsUrl: /docs/guides/iac-terraform/
 journeyUrl: /journeys/iac-terraform/
 ---
 

--- a/web/src/content/packs/linear.md
+++ b/web/src/content/packs/linear.md
@@ -7,7 +7,7 @@ skills:
   - linear-brief-intake
   - linear-brief-sync
 installCommand: "agentbundle install --pack linear --scope user"
-docsUrl: /guides/linear/
+docsUrl: /docs/guides/linear/
 ---
 
 Turns a Linear Issue or Project into a structured product brief, then keeps

--- a/web/src/content/packs/monorepo-extras.md
+++ b/web/src/content/packs/monorepo-extras.md
@@ -5,7 +5,7 @@ tagline: "Package scaffolding for monorepos."
 skills:
   - new-package
 installCommand: "agentbundle install --pack monorepo-extras"
-docsUrl: /guides/monorepo-extras/
+docsUrl: /docs/guides/monorepo-extras/
 journeyUrl: /journeys/monorepo-extras/
 ---
 

--- a/web/src/content/packs/product-documentation.md
+++ b/web/src/content/packs/product-documentation.md
@@ -5,7 +5,7 @@ tagline: "Create, revise, audit, and verify catalogue-facing documentation."
 skills:
   - author-product-docs
 installCommand: "agentbundle install --pack product-documentation"
-docsUrl: /guides/product-documentation/
+docsUrl: /docs/guides/product-documentation/
 journeyUrl: /journeys/product-documentation/
 ---
 

--- a/web/src/content/packs/product-engineering.md
+++ b/web/src/content/packs/product-engineering.md
@@ -13,7 +13,7 @@ skills:
   - explore-options
   - plan-validation
 installCommand: "agentbundle install --pack product-engineering --scope user"
-docsUrl: /guides/product-engineering/
+docsUrl: /docs/guides/product-engineering/
 journeyUrl: /journeys/product-engineering/
 ---
 

--- a/web/src/content/packs/product-strategy.md
+++ b/web/src/content/packs/product-strategy.md
@@ -13,7 +13,7 @@ skills:
   - define-ux-strategy
   - define-content-strategy
 installCommand: "agentbundle install --pack product-strategy --scope user"
-docsUrl: /guides/product-strategy/
+docsUrl: /docs/guides/product-strategy/
 ---
 
 Start with the strategic question you're trying to answer — "Who should we serve first?", "Which problem should we commit to?", "Why would users switch?" — and the pack selects the method. Every run produces a committed artifact in `docs/product/shaping/` (a PRFAQ, situation picture, portfolio position, OKR cascade, or strategic narrative) that the `product-engineering` shaping queue or `experience-design` can act on directly. Methods include SWOT, Porter's Five Forces, PESTLE, BCG Matrix, OKR cascade, PRFAQ, stakeholder-research synthesis, UX strategy, and content strategy. No growth or marketing execution tooling.

--- a/web/src/content/packs/release-engineering.md
+++ b/web/src/content/packs/release-engineering.md
@@ -5,7 +5,7 @@ tagline: "Deploy. Verify. Converge. Then ship."
 skills:
   - release-loop
 installCommand: "agentbundle install --pack release-engineering"
-docsUrl: /guides/release-engineering/
+docsUrl: /docs/guides/release-engineering/
 journeyUrl: /journeys/release-engineering/
 ---
 

--- a/web/src/content/packs/user-guide-diataxis.md
+++ b/web/src/content/packs/user-guide-diataxis.md
@@ -5,7 +5,7 @@ tagline: "Superseded by product-documentation."
 skills:
   - new-guide
 installCommand: "agentbundle install --pack product-documentation"
-docsUrl: /guides/product-documentation/
+docsUrl: /docs/guides/product-documentation/
 journeyUrl: /journeys/product-documentation/
 ---
 


### PR DESCRIPTION
## Summary

- All 37 web content files (21 packs + 16 journeys) had `docsUrl: /guides/<pack>/` which resolved to a 404
- The Starlight docs site sits at `/docs/guides/<pack>/` — the `/docs` prefix was missing
- "Read the reference" and "Read the full reference" buttons on every pack and journey page were broken

## Changes

One-line fix per file: `docsUrl: /guides/` → `docsUrl: /docs/guides/` across `web/src/content/packs/` and `web/src/content/journeys/`.

## Test plan

- [ ] Verify a pack page (e.g. `/journeys/core/`) — "Read the reference" button should now route to `/agent-ready-repo/docs/guides/core/`
- [ ] Spot-check a journey page "Read the full reference" link at the bottom