### PR TITLE
docs(workspace-mcp): RFC-0078 design, ADRs 0062-0069, spec + plan — Stage 0 complete

### DIFF
--- a/docs/adr/0062-workspace-mcp-per-session-only-constraint.md
+++ b/docs/adr/0062-workspace-mcp-per-session-only-constraint.md
@@ -1,0 +1,27 @@
+# ADR-0062: workspace-mcp per-session-only constraint
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** `workspace-mcp` spawns once per session and exits when the session ends. No persistent daemon mode, no port binding, no background process that outlives the controlling AI agent session.
+- **Because:** The project charter's Principle 3 ("a habit, not a tool") distinguishes the catalogue's primitives from infrastructure services. A persistent daemon would constitute infrastructure: it binds resources across sessions, requires lifecycle management, and creates a blast radius for crashes and stale state that the current tooling (loop-engine, workspace-status) does not expose. The per-session model is the minimal surface needed to close the ACP observability gap without becoming infrastructure.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py`; `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py`; any control-plane integration that spawns workspace-mcp; RFC-0078 and its follow-on spec/plan.
+- **Tradeoff accepted:** A control plane that wants workspace-mcp for workspace discovery across sessions must open a short-lived *discovery session* (call `workspace_status()`, read the result, exit) rather than querying a persistent daemon. This adds one round-trip of latency per discovery cycle.
+- **Revisit if:** The project charter is amended to include managed runtime services as in-scope primitives; or a persistent mode is requested by multiple adopters and a distinct RFC documents the lifecycle management, crash recovery, and security implications.
+
+## Context
+
+`workspace-mcp` is an MCP server that bridges loop-engine FSM events, workspace queue state, and git lifecycle to ACP control planes. RFC-0078 chartered it subject to the charter's Principle 3 constraint, and the decision to require per-session spawn was made at the design stage to keep workspace-mcp clearly on the "habit" side of the charter boundary.
+
+The MCP stdio transport — stdin/stdout of the spawned child process — is architecturally per-session: it communicates with exactly one AI agent and exits when that agent's stdin closes. Multiple concurrent workspace-mcp instances on the same machine are fully isolated by process; there is no shared mutable state.
+
+The per-session constraint also enforces the no-port-binding requirement: without a persistent process there is nothing to bind, eliminating a class of port-collision and firewall issues that would complicate adopter deployment.
+
+## Alternatives rejected
+
+**Persistent daemon with a Unix socket.** A long-lived process listening on a Unix socket would allow the control plane to query workspace state between sessions without spawning a new process. Rejected because it requires process supervision (restart on crash), socket lifecycle management (cleanup on unclean exit), and a documented security boundary around who may connect. These obligations push workspace-mcp past the "habit" threshold into infrastructure territory — a charter violation unless the charter is amended.
+
+**SSE sidecar for real-time notifications.** A side-process emitting SSE events over HTTP would allow the control plane to receive FSM transitions without an open MCP session. Rejected for the same reason as the daemon, and additionally because SSE requires a persistent HTTP listener — port binding that violates this constraint.

--- a/docs/adr/0063-session-instruction-universal-elicitation.md
+++ b/docs/adr/0063-session-instruction-universal-elicitation.md
@@ -1,0 +1,29 @@
+# ADR-0063: Session instruction for universal elicitation interception
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** Elicitation interception is implemented by injecting a single session-level instruction at startup (via `session/new.instruction` or equivalent), not by modifying individual skills to check for and call a `gate_request` or similar tool at their decision points.
+- **Because:** The gate problem is not limited to formal FSM states. Every skill elicits from the user — desk-research asks clarifying questions, place-bet asks for prioritization, journey-mapping asks about personas. Covering all of these via per-skill modification scales as O(skills × questions) and requires every future skill to know about workspace-mcp. The session instruction is strictly less coupling: it is injected once and applies to all skills without modification.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (Component 3 — universal elicitation via session instruction); the session instruction template embedded in workspace-mcp; all control-plane integrations that use workspace-mcp.
+- **Tradeoff accepted:** Session instruction compliance is prompt-following, not enforced. The AI may not always call `elicit()` for very short one-word responses ("sure", "yes"). The instruction is strongest for questions with options or structured decisions; it is weakest for affirmations. This residual gap is accepted for the current scope; long-term mitigation is upstream (Claude Code system-prompt enforcement).
+- **Revisit if:** Claude Code (or another AI host) exposes a system-prompt enforcement surface that allows workspace-mcp to guarantee elicitation routing; or the non-compliance rate for structured decisions exceeds an acceptable threshold (to be measured in Stage 3 validation).
+
+## Context
+
+The ACP observability gap extends beyond work-loop's FSM states. Desk-research asks clarifying questions and writes briefs to disk. Frame-intent and place-bet ask for prioritization and option selection. Journey-mapping elicits persona information. Every one of these is an AI→user interaction that the control plane is currently blind to.
+
+A per-skill approach (each gate-capable skill calls `gate_request` or similar) was evaluated first (see Alternatives). It covers declared gate states but not informal elicitations, requires skill modifications that multiply indefinitely as new skills are added, and makes each skill aware of whether a control plane is present — coupling the skill to the deployment topology.
+
+The session instruction approach treats the AI agent as the universal proxy: a preamble injected at `session/new` time instructs the AI to route all questions and decisions through `elicit()` rather than emitting them as plain text. The AI then mediates between the skill's elicitation need and the control plane's response, with no skill modification required.
+
+## Alternatives rejected
+
+**Per-skill `gate_request` tool check.** Each gate-capable skill (work-loop, new-spec, place-bet) checks at decision points if a `gate_request` tool is available and calls it. This covers declared gate states only — it misses the majority of AI→user communication that happens through informal elicitations. Covering all informal elicitations via this approach is the same problem as the session instruction, multiplied across every skill, indefinitely. Rejected because it delivers less coverage at greater coupling cost.
+
+**Hook in the AI runtime.** A Claude Code hook that intercepts all assistant messages and routes them through workspace-mcp. This would require changes to the AI host itself, is not feasible for an open-source skill pack, and would intercept non-elicitation output (progress notes, explanations) alongside actual questions — creating noise without structural disambiguation.
+
+**Session/prompt injection at each gate.** The control plane re-injects the decision into a new `session/prompt` when a gate is detected. This is the best-effort fallback path for adapters that support neither `elicitation/create` nor the response-file fallback; it is not the primary design because it requires the control plane to detect the gate from free-form text (the original problem).

--- a/docs/adr/0064-events-jsonl-as-fsm-event-source.md
+++ b/docs/adr/0064-events-jsonl-as-fsm-event-source.md
@@ -1,0 +1,31 @@
+# ADR-0064: events.jsonl as the FSM event source
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** workspace-mcp's event bridge tail-polls `.loop-run/events.jsonl` — an append-only ephemeral file that loop-engine writes on each FSM transition (Stage 1 work item: AC0 in the spec) — using byte-offset-based seek-and-read, rather than receiving events over an in-process IPC channel or a separate network socket. loop-engine's CLI interface is unchanged; only its internal behavior gains the events.jsonl append and outbox protocol.
+- **Because:** loop-engine is a standalone CLI tool invoked by the AI agent. Wiring it to emit events over IPC or a network socket would require loop-engine to know about workspace-mcp's presence — making the CLI adapter-aware and coupling it to the deployment topology. The events.jsonl file requires only internal changes to loop-engine (add the append in `cmd_transition` and `cmd_init`, with the outbox protocol for crash-consistency); it does not change loop-engine's external CLI contract or require it to know about workspace-mcp.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (Component 1 — event bridge); loop-engine's `.loop-run/events.jsonl` append behavior; the outbox pattern for crash-consistent transitions.
+- **Tradeoff accepted:** There is a small window between loop-engine appending an event and workspace-mcp reading it (poll interval: configurable, default 200ms). Transitions within this window are not missed — the bridge tracks byte offset and reads all unread bytes on each poll — but real-time latency is bounded by the poll interval rather than being push-based. Rapid back-to-back transitions (e.g., `wave-passed` followed immediately by `gates-clean`) are both captured on the next poll cycle.
+- **Revisit if:** loop-engine gains a stable IPC facility (Unix socket, named pipe) without becoming adapter-aware; or the poll latency becomes unacceptable for a specific control-plane integration that requires sub-100ms transition delivery.
+
+## Context
+
+loop-engine is designed as a pure CLI state machine: it enforces legal transition ordering and writes FSM state to disk (`engine-state.json`). It has no knowledge of who consumes its output or how. This clean boundary is the property that makes loop-engine usable across unattended sessions, supervisor mode, and human-driven sessions without modification.
+
+workspace-mcp must bridge loop-engine events to the MCP/ACP surface without violating this boundary. The events.jsonl file is the chosen interface. Stage 1 adds the events.jsonl append to loop-engine — a pure-internal change (new behavior in `cmd_transition` and `cmd_init`; the CLI contract is unchanged). Once that is in place, workspace-mcp tails the file by tracking a byte offset and reading new bytes on each 200ms poll cycle. Each appended line contains `{"seq", "run_id", "spec", "from", "event", "to", "at"}` (canonical schema: design.md:317); the `run_id` field filters events to the current session. `spec` is the spec-directory path (matching `WORKSPACE_MCP_SPEC_PATH`); `from` and `to` are FSM state names; `at` is the ISO-8601 timestamp.
+
+The outbox pattern (write pending event to `.loop-run/events.pending`, commit state atomically, append to events.jsonl, delete pending) ensures that a crash between the state write and the events.jsonl append is recoverable: on restart, the bridge verifies `pending.to == engine-state.json.state` before replaying the pending event. This closes the phantom-event window from unconditional replay.
+
+Inode/truncation detection (tracking file inode and size alongside byte offset) handles the case where `.loop-run/events.jsonl` is deleted and recreated (e.g., by `loop-engine reset`): when the inode changes or the file size is smaller than the tracked offset, the bridge resets its offset, buffer, and run_id to reattach to the new file.
+
+## Alternatives rejected
+
+**In-process IPC channel (Unix socket, named pipe).** loop-engine emits events over an IPC channel that workspace-mcp subscribes to. This delivers events with push-based latency (no polling) and eliminates the offset-tracking complexity. Rejected because it requires loop-engine to manage connection lifecycle (accept, send, handle disconnection) and to know whether a subscriber is present. The CLI becomes adapter-aware, violating the clean boundary that makes it reusable across deployment contexts.
+
+**Database table (SQLite, etc.).** loop-engine writes transitions to a local SQLite database; workspace-mcp polls the table. Delivers queryable history and indexed lookup. Rejected because it adds a runtime dependency (or a significant stdlib workaround), is overkill for the append-only, single-consumer, ephemeral event stream that workspace-mcp needs, and requires schema management that events.jsonl avoids entirely.
+
+**Shared in-process queue (if loop-engine were a library).** If loop-engine were imported as a Python library rather than invoked as a CLI, it could post directly to a thread-safe queue that workspace-mcp drains. Rejected because converting loop-engine to a library would require reimplementing its CLI surface as a programmatic API, changing the primary interface that the work-loop skill's step commands rely on.

--- a/docs/adr/0065-elicit-elicitation-create-response-file-fallback.md
+++ b/docs/adr/0065-elicit-elicitation-create-response-file-fallback.md
@@ -1,0 +1,33 @@
+# ADR-0065: elicit() tool + elicitation/create + response-file fallback
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** workspace-mcp implements a two-tier elicitation delivery mechanism: (1) primary — `elicitation/create` in MCP server→client direction (workspace-mcp requests a structured response from the AI host), bridged by the AI host through the ACP adapter as an `_agentbundle.core/elicitation-pending` event to the control plane; (2) fallback — a temporary response file written to an `mkdtemp()`-isolated directory, polled by workspace-mcp until the control plane writes the response using the temp-and-rename protocol.
+- **Because:** `elicitation/create` is the MCP-native path (MCP 2025-06-18, standard server→client direction) and delivers structured gate decisions with type enforcement. However, not all adapters support it: Codex CLI does not list `elicitation/create` as a feature (Stage 2a validation confirmed); Kiro CLI's support is unconfirmed. The response-file fallback is the correct secondary path for adapters that do not support `elicitation/create`. A single implementation that gracefully degrades covers both cases without per-adapter branching in skills.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (Component 3 — the `elicit()` MCP tool and its two delivery paths); adapter-capability detection in the MCP init handshake; the response-file security constraints documented in the design doc.
+- **Tradeoff accepted:** The response-file path introduces a polling loop and a race window (same-user process can race `O_EXCL` creation before workspace-mcp does at session start). The response-file fallback is used only for adapters that do not support `elicitation/create`; when `elicitation/create` is available it is the primary path. The response-file path is not a secure gate for multi-user or shared-machine deployments; this is documented in the install guide.
+- **Revisit if:** Codex CLI and Kiro CLI add `elicitation/create` support, making the fallback unnecessary for all Class A/B adapters in scope; or a third elicitation delivery mechanism becomes available that closes the race window without requiring MCP `elicitation/create` support.
+
+## Context
+
+`elicitation/create` is defined in the MCP specification (2025-06-18) as a server→client request: the server asks the client (AI host) to elicit a structured response from the user, with the response typed and validated by the schema in the request. ACP v1 adapts this mechanism — the AI host bridges the `elicitation/create` request through the ACP adapter as a structured event to the control plane.
+
+workspace-mcp calls `elicitation/create` synchronously (blocking until the AI host responds) from a worker thread, while the main stdio loop continues reading incoming MCP messages. This is the re-entrancy requirement: the `elicitation/create` response arrives on the same MCP stdio channel that the main loop is reading, so a single-threaded handler that blocks on the `elicit()` call would deadlock.
+
+The capability-declaration bug in `claude-agent-acp` (issue #419) means workspace-mcp must check the AI host's capability list during the MCP init handshake: if `elicitation` is absent from the host's declared capabilities, workspace-mcp omits it from its own init response and uses the response-file fallback. The check happens at init, not at the call site, because the failure mode is at init (not at the `elicitation/create` call).
+
+The response-file protocol requires the control plane to write the response atomically using temp-and-rename (write to a temp file in the same directory, then `rename()`). workspace-mcp reads the file only once the rename completes; a partial write is never observed.
+
+## Alternatives rejected
+
+**Webhook delivery.** The control plane registers an HTTP endpoint; workspace-mcp POSTs the elicitation request to it. Requires the control plane to expose an inbound HTTP endpoint and workspace-mcp to know its URL. Adds a network dependency and a firewall/proxy concern. Rejected in favor of the MCP-native `elicitation/create` path, which uses the existing MCP channel with no new network surface.
+
+**SSE event stream for elicitations.** workspace-mcp emits an SSE event when an elicitation is pending; the control plane listens and responds via a separate `session/prompt`. Requires a persistent HTTP listener on workspace-mcp's side — port binding that violates ADR-0062's per-session-only constraint. Rejected.
+
+**Per-adapter branching in skills.** Each skill checks which adapter is present and delivers gate questions through different code paths. Rejected by ADR-0063 (session instruction as the universal mechanism): if the session instruction is the universal elicitation router, the delivery path is workspace-mcp's internal concern, not the skill's.
+
+**Response-file as the only path (no elicitation/create).** Simpler — one code path, no MCP extension. Rejected because it loses structured typing (the response is free-form text in the file, not a typed schema), and because `elicitation/create` is the MCP standard that future AI hosts will increasingly support.

--- a/docs/adr/0066-reactive-git-at-turnend.md
+++ b/docs/adr/0066-reactive-git-at-turnend.md
@@ -1,0 +1,31 @@
+# ADR-0066: Reactive git at TurnEnd
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** The harness (control plane) calls `git_status()` after each AI turn ends (TurnEnd) and commits any uncommitted artifacts; no `git_managed` flag is declared per lifecycle type in the manifest. The `git_commit` and `git_push` MCP tools are available for the AI agent to call directly, but the harness drives the commit lifecycle reactively rather than requiring each skill to declare its artifacts as `git_managed`.
+- **Because:** Declarative `git_managed` flags would require the lifecycle manifest to correctly identify every file a skill might produce, and to declare whether each should be committed. Skills already produce files in well-known output directories; `git_status()` discovers all uncommitted artifacts in those directories without requiring per-type declarations. The reactive approach is simpler, more robust to new or renamed output types, and requires no manifest updates when skills are extended.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (the `git_status`, `git_commit`, `git_push` tool surface); the lifecycle manifest design (ADR-0067); any control-plane integration that manages the git lifecycle via workspace-mcp.
+- **Tradeoff accepted:** The harness must call `git_status()` after every turn to decide whether to commit, rather than receiving a push-based signal when artifacts are ready. This adds one `git_status()` round-trip per turn. For sessions with many short turns (e.g., a clarification exchange), this is redundant overhead; for sessions with artifact-producing turns it is the minimal correct call.
+- **Revisit if:** The lifecycle manifest grows to include per-type commit semantics (e.g., "commit immediately when artifact appears" vs. "commit at gate only"), at which point a declarative `git_managed` flag per type would enable push-based commit scheduling without `git_status()` polling.
+
+## Context
+
+When a control plane drives a work-loop session via ACP, the AI agent produces artifacts (spec.md, plan.md, code files, ADR files) that the control plane must commit and push for the PR workflow to work. workspace-mcp provides `git_status()`, `git_commit()`, `git_push()` as MCP tools that the AI agent (via session instruction) or the control plane (via `session/prompt`) can call directly.
+
+The question is whether the commit lifecycle should be:
+- **Declarative:** the lifecycle manifest flags each type as `git_managed: true/false`, and workspace-mcp automatically commits files when an artifact of a `git_managed` type appears (detected by the artifact watcher).
+- **Reactive:** the control plane calls `git_status()` after each turn and decides whether to commit, using the result to determine what is uncommitted and whether a commit is appropriate.
+
+The reactive approach is more robust: it does not require the manifest to be exhaustive, does not create race conditions between the artifact watcher and the commit tool, and gives the control plane full agency over commit timing (e.g., wait until a gate is reached before committing, rather than committing every intermediate file).
+
+## Alternatives rejected
+
+**Declarative `git_managed` flag per lifecycle type.** Each type in the manifest declares whether its artifacts should be committed automatically when they appear. workspace-mcp listens for artifact watcher events and calls `git_commit` when a `git_managed` artifact appears. Rejected because it creates a race between artifact creation (the watcher fires when the file appears) and artifact completion (the AI may still be writing the file); requires the manifest to be exhaustive; and requires manifest updates whenever a skill adds a new output type.
+
+**Push-based TurnEnd signal.** The AI host emits a standard MCP event at turn end; workspace-mcp listens and calls `git_status()` then. This is equivalent to the reactive model but requires MCP turn-end event support that is not currently standard across all adapters. The reactive model (harness polls `git_status()` after turn end) achieves the same result without requiring a new MCP event type.
+
+**Skill-level git commit calls.** Each skill calls `git_commit` via the MCP tool at its own completion point. This would require every skill to be aware of the MCP tool surface — the same coupling problem ADR-0063 rejects for elicitation. Rejected for the same reason: skills must remain adapter-agnostic.

--- a/docs/adr/0067-lifecycle-manifest-builtin-defaults-workspace-types-d.md
+++ b/docs/adr/0067-lifecycle-manifest-builtin-defaults-workspace-types-d.md
@@ -1,0 +1,34 @@
+# ADR-0067: Lifecycle manifest — built-in defaults and workspace-types.d/ extension
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** The lifecycle manifest — the mapping from workspace item types (work, research, shape, etc.) to output directories and dispatch skills — is stored in two layers: (1) built-in defaults embedded in workspace-mcp for the known type taxonomy (work, research, shape/signal/design/strategy, brief); (2) third-party extension files projected to `workspace-types.d/` by pack.toml-installed packs. workspace-types.d/ files are merged additively at startup; conflicts (same type key in two files) are logged and the last-writer wins.
+- **Because:** pack.toml is source-only and is not projected to adopters; it cannot carry the lifecycle manifest. A projected pack artifact is the natural alternative, but no single projected location can serve as the canonical manifest without creating a clobber conflict between multiple packs that each want to add their own types. The `workspace-types.d/` directory pattern (each pack writes its own file, no clobber) is the established solution for multi-contributor extension without clobbering.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (the manifest loading logic); third-party pack projections that add custom types; adopter documentation for the `workspace-types.d/` directory.
+- **Tradeoff accepted:** The last-writer-wins conflict resolution for duplicate type keys is non-deterministic across pack install orderings. Adopters who install multiple packs that define the same type key may observe inconsistent behavior depending on install order. This is logged as a warning; authoritative behavior requires the packs to coordinate on type keys (or the adopter to override in a top-level `workspace-types.override.d/` file — a future extension).
+- **Revisit if:** A canonical manifest location becomes available that does not create clobber conflicts (e.g., pack.toml gains a projected-manifest section that agentbundle merges at install time); or the number of conflicting type keys across packs becomes a recurring adopter pain point.
+
+## Context
+
+The lifecycle manifest maps each workspace item type to:
+- `output_dirs`: where artifacts for this type are written (used by the artifact watcher)
+- `dispatch_skill`: the skill the control plane should invoke to process this item
+- `elicits_output_dir`: whether this type asks for output directory on first run (affects watcher binding)
+
+For the known type taxonomy (the types defined in CONVENTIONS.md and workspace.toml schema), built-in defaults in workspace-mcp are authoritative. Third-party packs (accelerator packs, domain packs) may introduce new item types with their own output directories and dispatch skills; they need a way to register these types without modifying workspace-mcp's source.
+
+The `workspace-types.d/` directory pattern is used elsewhere in the repo (e.g., adapter projections in agentbundle) for exactly this multi-contributor extension problem. Each pack projects a `workspace-types.d/<pack-name>.toml` file listing its types; workspace-mcp merges all files at startup using a simple last-writer-wins strategy.
+
+pack.toml cannot carry the manifest because it is source-only: it is not projected to adopters. A single `workspace-types.toml` file projected by the core pack would be clobbered by any other pack that also projects the same file.
+
+## Alternatives rejected
+
+**Single `workspace-types.toml` projected by core.** One canonical file, all types in one place. Rejected because a second pack that also projects `workspace-types.toml` clobbers the core file, losing all core types. The clobber problem is fundamental to single-file shared registration.
+
+**Types in pack.toml under a `[pack.workspace_types]` section.** pack.toml is source-only; it is not projected to adopters. workspace-mcp running in an adopter's environment cannot read pack.toml files that are not projected. Unless agentbundle adds a pack.toml projection for workspace types (a separate RFC-scope change), this approach is not viable.
+
+**Dynamic type discovery via MCP tool call.** Each pack exposes a `register_types()` MCP tool; workspace-mcp queries all registered pack tools at startup. Requires packs to run MCP servers of their own, introducing a dependency cycle (workspace-mcp coordinates packs; packs cannot be workspace-mcp's orchestrators). Rejected as architecturally incoherent.

--- a/docs/adr/0068-notification-namespace-x-core.md
+++ b/docs/adr/0068-notification-namespace-x-core.md
@@ -1,0 +1,29 @@
+# ADR-0068: Notification namespace — _agentbundle.core/
+
+- **Status:** Accepted (updated 2026-08-03 from Stage 0 spike (b) result)
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** Custom ACP notifications emitted by workspace-mcp use the `_agentbundle.core/` prefix (e.g., `_agentbundle.core/skill-state-change`, `_agentbundle.core/human-gate-pending`). The placeholder `x-core/` used at design time is retired.
+- **Because:** Stage 0 spike (b) found that the only custom (extension) notification observed in `claude-agent-acp@0.64.0` uses the method name `_claude/sdkMessage` — an underscore-prefixed reverse-domain path (`_<namespace>/method`). The `x-core/` form (HTTP-header convention) does not match this pattern. `_agentbundle.core/` follows the same `_<namespace>/method` convention as `_claude/sdkMessage` and is the agentbundle core pack's correct extension namespace.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (all notification emission points); control-plane integration code that subscribes to `_agentbundle.core/*` notifications; documentation in design.md and docs/rfc/0078-workspace-mcp.md; the spec and plan.
+- **Tradeoff accepted:** The rename from `x-core/` to `_agentbundle.core/` is a pre-Stage-1 global rename across all in-tree artifacts. A grep-and-replace is the mitigation.
+- **Revisit if:** The ACP v1 specification is updated to define a different extension-naming convention; or a different namespace is adopted by the agentbundle ecosystem.
+
+## Context
+
+MCP `notifications/message` is the standard mechanism for servers to emit events to clients. ACP v1 adapts this: the AI host bridges `notifications/message` frames from workspace-mcp through the ACP adapter as `session/update` events to the control plane. The `type` field of the notification determines what the control plane can subscribe to and act on.
+
+ACP v1 defines an extension-naming rule for custom notification types. The rule parallels IANA extension naming (HTTP, MIME) in using a vendor or project namespace to prevent type conflicts. The placeholder `x-core/` was used during design; Stage 0 spike (b) evaluated it against the observed ACP convention and confirmed `_agentbundle.core/` as the correct form.
+
+Not using a namespace at all — emitting bare names like `skill-state-change` — risks collision with future standard ACP notification types and with other MCP server notifications in a multi-server session.
+
+## Alternatives rejected
+
+**Bare notification names (no namespace).** `skill-state-change`, `human-gate-pending`, etc. Rejected because collision with standard ACP types is plausible as the ACP specification evolves, and collision with other MCP servers in a multi-server session is possible.
+
+**`x-core/` form.** HTTP-header-style naming (`x-` vendor prefix). Rejected by spike (b) result: the only custom notification observed in `claude-agent-acp@0.64.0` uses `_claude/sdkMessage` — not `x-core/` — confirming the ACP extension convention is `_<namespace>/method`, not the HTTP-header form.
+
+**Per-notification custom type (no shared prefix).** Each notification type uses a unique opaque identifier rather than a shared namespace prefix. Rejected because it makes the subscription pattern `_agentbundle.core/*` impossible; the control plane must subscribe to each event individually, creating a maintenance surface as new event types are added.

--- a/docs/adr/0069-threading-model-daemon-threads-bounded-pool.md
+++ b/docs/adr/0069-threading-model-daemon-threads-bounded-pool.md
@@ -1,0 +1,35 @@
+# ADR-0069: Threading model — daemon threads and bounded worker pool
+
+- **Status:** Accepted (pending validation from Stage 0 spike (e))
+- **Date:** 2026-08-03
+- **Decision-makers:** eugenelim
+
+## Decision summary
+
+- **Decision:** workspace-mcp uses Python stdlib threading throughout: (1) the event bridge and artifact watcher run on daemon threads that poll independently without blocking the main stdio handler; (2) `elicit()` tool calls — which block until the AI host responds to the nested `elicitation/create` request or until the response file appears — are dispatched to a bounded worker-thread pool (pool size: 4); (3) the main stdio loop reads and dispatches incoming MCP messages to either the daemon threads (for event/watcher triggers) or the worker pool (for blocking tool calls); (4) shared stdout is guarded by a single write lock; (5) the main loop maintains a `{request_id: Event/queue}` map to route incoming `elicitation/create` responses to the correct waiting worker.
+- **Because:** workspace-mcp is a pure-stdlib Python 3.11+ process (no new dependencies). asyncio is the idiomatic Python concurrency model for I/O-bound work but requires the entire callchain to be async-aware, which is complex for a stdlib-only stdio MCP server with mixed blocking and polling behaviors. The daemon-thread + bounded-pool model separates concerns cleanly: polling loops (event bridge, artifact watcher) run independently of request handling; blocking tool calls (elicit) run in the pool without starving other requests; the main loop stays non-blocking.
+- **Applies to:** `packages/agentbundle/agentbundle/workspace_mcp.py` (the threading architecture, pool initialization, write lock, and request-response routing map).
+- **Tradeoff accepted:** Python's GIL means stdlib threads do not achieve true CPU parallelism, but all workspace-mcp work is I/O-bound (file reads, subprocess calls, MCP stdio reads/writes) — the GIL is not a bottleneck. Pool size 4 is chosen because workspace-mcp serves one client per session (per ADR-0062); pool > 1 handles nested `elicitation/create` re-entrancy where the response arrives on a separate read-loop iteration while the original `elicit` worker is blocked waiting. The threading model is validated by Stage 0 spike (e); if it cannot handle real MCP stdio concurrency (specifically nested re-entrancy), an asyncio rewrite is required before Stage 1.
+- **Revisit if:** Stage 0 spike (e) reveals that stdlib threading cannot handle nested `elicitation/create` re-entrancy (async rewrite triggered); or workspace-mcp is extended to serve multiple clients per instance (Stage 4 multi-session, which changes the pool-size calculation); or Python 3.13+ per-interpreter GIL changes the threading performance profile enough to reconsider asyncio.
+
+## Context
+
+workspace-mcp's concurrency requirements come from three sources:
+
+1. **Background polling.** The event bridge polls `.loop-run/events.jsonl` every 200ms. The artifact watcher polls output directories every 200ms. Both are I/O-bound and must not block the MCP request handler.
+
+2. **Blocking tool calls.** The `elicit()` tool handler blocks synchronously: it sends an `elicitation/create` request to the AI host and waits for the response. The response arrives on the same MCP stdio channel that the main loop is reading. A single-threaded handler that blocks on `elicit()` would deadlock: the main loop cannot read the `elicitation/create` response while it is blocked handling the `elicit()` tool call.
+
+3. **Stdout serialization.** Multiple threads may attempt to write MCP response frames to stdout concurrently (worker threads writing `elicit()` results; daemon threads writing notification frames). A write lock prevents interleaved frames.
+
+The bounded pool (size 4) is sufficient for per-session spawn: each workspace-mcp instance serves exactly one AI agent (one client). Pool size > 1 is needed only for nested `elicitation/create` re-entrancy — the scenario where an outer `elicit()` worker is waiting on an `elicitation/create` response, and the control plane sends a second `elicitation/create` response on the same channel before the outer response resolves. With pool size 4, up to 3 nested levels of re-entrancy are supported (one worker blocked at each level, one free to handle the response). In practice, re-entrancy beyond depth 1 is unexpected; pool size 4 provides margin.
+
+The `{request_id: Event/queue}` map in the main loop routes incoming MCP messages (including `elicitation/create` responses) to the correct waiting worker by matching `request_id` fields. The main loop posts the response to the worker's Event/queue; the worker unblocks and completes the `elicit()` tool call.
+
+## Alternatives rejected
+
+**asyncio throughout.** The entire server is async-native: the main loop is an asyncio event loop, tool handlers are coroutines, background polling runs as asyncio tasks. This is the most idiomatic Python 3.11+ concurrency model and eliminates the threading complexity. Rejected for the initial implementation because: (a) converting a blocking subprocess-based git tool to fully async requires `asyncio.create_subprocess_exec`, increasing code complexity; (b) pure-stdlib asyncio MCP stdio server is a non-trivial pattern that requires careful framing to avoid mixing async and sync code; (c) the daemon-thread model delivers the same functional outcome (non-blocking main loop, concurrent polling and blocking calls) with simpler code. If spike (e) shows the threading model is insufficient, asyncio is the designated fallback.
+
+**Cooperative polling in the request handler (no threads).** The event bridge and artifact watcher run as polling steps inside the MCP message handler loop — check for events, check for artifacts, handle one MCP message, repeat. This is single-threaded but prevents `elicit()` from blocking: the handler polls and checks the response file on each iteration until it appears. Rejected because it conflates polling cadence with MCP message throughput; a slow poll (waiting for a response) would delay all other MCP message processing during that window.
+
+**Single-thread with `select()`/`selectors`.** A `selectors`-based single-thread multiplexes stdin (MCP messages), event log file descriptors, and a timeout for polling. This avoids threads but cannot handle `elicit()`'s blocking `elicitation/create` response wait, which is not a file descriptor select — it is waiting for a specific MCP response message identified by `request_id`. The `selectors` model does not solve the routing problem. Rejected.

--- a/docs/architecture/workspace-mcp/design.md
+++ b/docs/architecture/workspace-mcp/design.md
@@ -1,0 +1,761 @@
+# workspace-mcp: ACP-observable skill runtime for any control plane
+
+> **Previously drafted as `workspace-agent`.** Renamed to avoid collision with Claude Code subagents (adversarial-reviewer, quality-engineer, etc.) that live in `.claude/agents/`. `workspace-mcp` is an MCP server, not a Claude Code subagent.
+
+**Status:** Draft
+**Last updated:** 2026-08-03
+**Reviewers:** TBD
+
+## TL;DR
+
+`workspace-mcp` is an optional MCP server, proposed to ship in the core pack (pending RFC acceptance — see Rollout § Stage 0 (d)), that makes any agentbundle-equipped repo observable and controllable by ACP-compliant control planes. It bridges loop-engine phase events, workspace queue state, and git lifecycle operations to the MCP/ACP surface — without changing how skills run when no control plane is present. The central insight is that all skills elicit from the user — not just formal gates — so elicitation interception can be universal via a session-level instruction injected at startup. Whether this instruction survives across turns in a single `session/new` injection is verified in Stage 0; if not, the control plane re-injects the instruction preamble on each `session/prompt`.
+
+## Context
+
+A control plane (Conductor, Zed) can already dispatch Claude Code via ACP — Claude Code has been in the ACP registry since August 2025. What it cannot do is observe structured progress: it receives free-form text, with no signal for phase transitions, human gate decisions, or artifact creation.
+
+This gap is concrete across the pack surface:
+
+- **work-loop** advances through a 10-state FSM managed by `loop-engine.py`. The control plane cannot distinguish `SPEC-HUMAN-GATE` (stop and ask a human) from normal text output.
+- **desk-research** writes research briefs to the filesystem and ends the session. The control plane has no record of what files were produced, and nobody commits them.
+- **product-engineering skills** (frame-intent, place-bet, diverge-solutions) write shaping artifacts and sometimes update workspace.toml. Same gap.
+- **experience-design skills** (journey-mapping, interaction-design) produce markdown artifacts with no git lifecycle.
+
+Non-obvious constraints:
+
+1. **Adapter class split.** Three classes on MCP injection:
+   - **Class A** (Claude Code, Codex, Copilot CLI): honour `session/new.mcpServers`; workspace-mcp is injected per session by the control plane. `elicitation/create` support is uneven — Codex does not list it; Copilot CLI is unconfirmed. Primary scope of this design.
+   - **Class B** (Kiro CLI V3+): ACP-native but ignores `session/new.mcpServers`; reads MCP config from `{cwd}/.kiro/settings/mcp.json` only. workspace-mcp must be pre-configured per repo rather than injected per session. V3 agent format required for MCP tool injection (V2 has unresolved bug #5873). All workspace-mcp capabilities work once configured; harness cannot inject dynamically. Secondary scope — same workspace-mcp binary, different setup story.
+   - **Deferred** (Gemini CLI, OpenCode): incompatible architectures. Out of scope.
+
+   `elicitation/create` is MCP-native (MCP 2025-06-18), not an ACP primitive — ACP v1 adapts it. workspace-mcp uses it via MCP server→client direction (workspace-mcp → AI host).
+
+2. **ADR-0061 — no engine, no daemon.** `workspace-mcp` must be an opt-in per-session process, not a persistent service. Any persistent mode requires an RFC amendment to ADR-0061 before implementation.
+
+3. **MCP stdio transport — no port binding.** workspace-mcp uses the MCP stdio transport: it communicates over the stdin/stdout of the spawned child process, not HTTP or SSE. No TCP port is bound. Multiple concurrent workspace-mcp instances on the same developer machine — one per open Claude Code session — are fully isolated by process and never collide.
+
+4. **All skills elicit from the user.** The gate problem is not limited to FSM states. Desk-research asks clarifying questions; place-bet asks for prioritization; journey-mapping asks about personas. Every interactive moment where the AI asks a question is an elicitation. A gate mechanism scoped to formal FSM states misses the majority of AI→user communication, leaving the control plane blind to most of what is happening in a session. The solve is a session-level instruction, not per-skill modification.
+
+## Goals and Non-goals
+
+### Goals
+
+- A control plane that passes `workspace-mcp` in `session/new.mcpServers` receives a structured `_agentbundle.core/skill-state-change` notification for every loop-engine FSM transition within that session, with zero missed transitions (verified by comparing `seq` on consecutive events).
+- A control plane receives `_agentbundle.core/human-gate-pending` carrying the spec path, reviewer findings, and gate question before the session suspends at any gate point; the gate is resolved and the session resumes in the same turn.
+- `workspace_status()` MCP tool returns a DAG-resolved view of workspace.toml — ready items, blocked items with named unmet `needs:` edges, active items — parseable without repo knowledge. The control plane needs no prior knowledge of which skills are installed; `workspace_status()` is the capability discovery surface.
+- The control plane can drive git operations (commit, push, branch) for any AI turn via `session/prompt`; the AI executes them through `git_*` MCP tools. Work-loop manages its own git lifecycle and PR opening at `CODE-HUMAN-GATE`; workspace-mcp surfaces the `pr_url` in `_agentbundle.core/gate-pr-ready` (emitted once the PR is opened, within seconds of `_agentbundle.core/human-gate-pending`) and again in `_agentbundle.core/run-complete`. See Component 4 for the git_* tool surface and Component 1 for `pr_url` handoff ordering.
+- Work-loop, desk-research, and all other skills run identically when `workspace-mcp` is not configured — no behavior change, no startup error, no latency.
+- The control plane is skill-agnostic: it dispatches based on what `workspace_status()` reports, not on hardcoded knowledge of this repo's skill stack. Swapping, upgrading, or adding skills requires no harness changes.
+
+### Non-goals
+
+- **Kiro IDE, Gemini CLI, OpenCode.** Kiro IDE cannot run headless. Gemini CLI inverts the MCP direction. OpenCode ignores `mcpServers` entirely. All deferred. Kiro CLI is Class B (see Context) — it works but requires per-repo pre-configuration rather than per-session injection; it is not the primary focus of this design.
+- **workspace-types in pack.toml.** pack.toml is source-only and not projected to adopters. The type→lifecycle manifest cannot live there.
+- **Convergence orchestration.** Rebase ordering, merge-queue management, and dependency-ordered PR merging across multiple concurrent sessions are Stage 4 scope.
+- **Persistent daemon mode.** `workspace-mcp` spawns per session and exits on session end.
+- **Replacing loop-engine's FSM.** `workspace-mcp` observes the FSM via an events file; it does not proxy or reimplement transitions.
+- **Skills that modify remote state without git** (Jira write, Linear push). Those skills own their artifact lifecycle.
+
+## Proposal
+
+### Name rationale
+
+`workspace-mcp` follows the repo's `workspace-*` naming convention (`workspace-status`, `workspace-status-engine`) and the common MCP ecosystem pattern of `<capability>-mcp` for MCP servers. The `-mcp` suffix signals "this is a server component, not a skill or subagent" — important because the repo's `.claude/agents/` directory already contains Claude Code subagents (adversarial-reviewer, quality-engineer, etc.) and `workspace-agent` would have collided with that mental model. It distinguishes clearly from `workspace-status` (read-only skill that queries workspace state for a human) and `loop-engine` (FSM CLI).
+
+### Architecture
+
+```mermaid
+flowchart TD
+    CP["Control plane\n(Conductor / Zed)"]
+
+    subgraph "ACP session"
+        ACA["ACP adapter\n(claude-agent-acp · codex-acp\ncopilot-cli)"]
+        CC["AI agent\n(Claude Code / Codex / Copilot)"]
+    end
+
+    subgraph "workspace-mcp (MCP server, per-session)"
+        EB["Event bridge\ntail-polls .loop-run/events.jsonl"]
+        TS["Tool surface\nworkspace_status · elicit · git_*"]
+        AW["Artifact watcher\nrecursive listing (200ms snapshot diff)"]
+    end
+
+    subgraph "Repo"
+        LE["loop-engine CLI"]
+        EJ[".loop-run/events.jsonl\n(ephemeral, gitignored)"]
+        WT["workspace.toml"]
+        SD["docs/specs/ · docs/research/\ndocs/product/ · docs/design/"]
+        GIT["git"]
+    end
+
+    CP -- "session/new (mcpServers: {workspace-mcp})\nsession/prompt + session instruction" --> ACA
+    ACA -- "spawns AI, injects MCP config + instruction" --> CC
+    CC -- "MCP client" --> EB
+    CC -- "MCP client" --> TS
+    CC -- "loop-engine CLI (unchanged)" --> LE
+    LE -- "appends event line" --> EJ
+    EB -- "tail-poll seek+read" --> EJ
+    EB -- "_agentbundle.core/skill-state-change\n_agentbundle.core/run-complete" --> CC
+    CC -- "elicit(message, context, options)\n[any question or gate]" --> TS
+    TS -- "_agentbundle.core/elicitation-pending\nelicitation/create (MCP server→client)" --> ACA
+    ACA -- "bridges to control plane" --> CP
+    CP -- "elicitation response" --> ACA
+    ACA -- "response → workspace-mcp → tool result" --> CC
+    TS -- "reads" --> WT
+    AW -- "watches" --> SD
+    AW -- "_agentbundle.core/artifact-created" --> CC
+    CC -- "ACP session/update (all notifications)" --> ACA
+    ACA -- "delivers to control plane" --> CP
+    CC -- "git_status / git_commit / git_push\n(via session instruction or CP session/prompt)" --> TS
+    TS --> GIT
+```
+
+*Diagrams show primary notification flows. Additional contracted notifications not shown for legibility: `_agentbundle.core/human-gate-pending` (EB → CC when event bridge detects a `*-HUMAN-GATE` transition — enriched with reviewer output and gate question read from disk), `_agentbundle.core/skill-complete` (TS → CC after `git_push` returns for a non-FSM item, or after `git_commit` if no remote is configured), `_agentbundle.core/bridge-warning` (EB → CC on gap or buffer overflow). See Notification contract table for the full set.*
+
+### Class A: Claude Code, Codex, Copilot CLI
+
+The control plane injects workspace-mcp per session via `session/new.mcpServers`. On first launch, the control plane does not yet know which item to dispatch (it needs to call `workspace_status()` first). This creates a bootstrapping dependency — `workspace_status()` is only available inside a running session, but the session requires an item to start.
+
+**Discovery mode (no env var):** The control plane opens a *discovery session* with neither env var set. In this mode, only `workspace_status()` and `git_status()` are available; all git-mutating tools (`git_branch`, `git_commit`, `git_push`) return an error. The control plane calls `workspace_status()`, receives the full ready/shaping/blocked queue with `ini_slug`, `type`, `slug`, and `dispatch_skill` for each item, then opens a *bound session* with the chosen item's env var. The discovery session is short-lived (one tool call); the AI simply calls `workspace_status()` and the control plane reads the response from the `session/update` stream.
+
+After discovery, two mutually exclusive env vars identify the dispatched item in bound sessions — exactly one is set per bound session (zero → discovery mode):
+
+- **`WORKSPACE_MCP_SPEC_PATH`** (`{spec-dir}`) — FSM (work) items only. Anchors `run_id` discovery to the correct spec directory.
+- **`WORKSPACE_MCP_DISPATCHED_ITEM`** (`{ini_slug}/{type}:{slug}`) — non-FSM (shaping) items only. Tells the server which lifecycle-manifest entry to use for output-pattern scoping and artifact attribution. The `{ini_slug}` component is included because two active initiatives may legally contain shaping entries with the same slug (workspace engine preserves initiative identity for this reason); omitting it would make the env var ambiguous and produce identical branch names and artifact scopes for distinct items. Example: `initiative-a/shape:initiative-x`, `initiative-b/research:topic-x`. The server parses this as `ini_slug = "initiative-a"`, `type = "shape"`, `slug = "initiative-x"`. Branch naming: `{ini_slug}/{type}/{slug}` — ini_slug is included for the same reason it is included in the env var: two active initiatives may legally have entries with the same type+slug, and `{type}/{slug}` alone would produce identical local and remote refs for distinct items, causing branch creation failures or mixed artifact history. Example: `initiative-a/shape/initiative-x`.
+
+**Per-session injection (control plane sends at dispatch time):**
+
+The server path in `args` is adapter-dependent — each adapter projects the skill to a different root (from `adapter.toml`):
+- **Claude Code**: `.claude/skills/workspace-status/scripts/workspace_mcp_server.py`
+- **Codex, Copilot CLI**: `.agents/skills/workspace-status/scripts/workspace_mcp_server.py`
+
+**Trusted-spawn requirement:** The projected script at `{adapter-root}/scripts/workspace_mcp_server.py` is under version control — a malicious or compromised checkout can replace it and achieve RCE in the control plane process. For ACP / CI deployments where the checkout is **untrusted** (the process owner doesn't own the repo), the control plane **must** launch the server from the installed agentbundle package using isolated module mode:
+
+```bash
+python3 -I -m agentbundle.workspace_mcp
+```
+
+The **`-I` (isolated) flag is non-negotiable**: without it, `python3 -m` adds the working directory (= repo root) to `sys.path`, so a checkout-provided `agentbundle/` package directory silently shadows the installed wheel and restores the RCE vector — defeating the intent of module mode entirely. With `-I`, `sys.path` is restricted to the standard install paths; the checkout cannot shadow the installed package. The projected path is **developer-use only** — valid when the developer owns and trusts the checkout (local workstation). For headless ACP sessions in CI or on shared hosts, isolated module mode is non-negotiable. Stage 0 validates that `python3 -I -m agentbundle.workspace_mcp` accepts the same env vars and produces the same MCP handshake as the projected script.
+
+The control plane constructs the `args` based on the deployment context. The example below shows both forms:
+
+```json
+// ACP session/new — mcpServers field (control plane constructs this per dispatch)
+// Trusted-checkout path (local developer, owns the repo):
+// FSM (work) item (Claude Code adapter shown — swap args[0] for the dispatching adapter's path):
+{
+  "mcpServers": {
+    "workspace-mcp": {
+      "command": "python3",
+      "args": [".claude/skills/workspace-status/scripts/workspace_mcp_server.py"],
+      "env": { "WORKSPACE_MCP_SPEC_PATH": "docs/specs/my-feature" }
+    }
+  }
+}
+// Untrusted-checkout / CI / ACP headless — use module mode (package-resolved, not repo-path-resolved):
+{
+  "mcpServers": {
+    "workspace-mcp": {
+      "command": "python3",
+      "args": ["-I", "-m", "agentbundle.workspace_mcp"],
+      "env": { "WORKSPACE_MCP_SPEC_PATH": "docs/specs/my-feature" }
+    }
+  }
+}
+// Non-FSM (shaping) item — same two forms; module mode shown:
+{
+  "mcpServers": {
+    "workspace-mcp": {
+      "command": "python3",
+      "args": ["-I", "-m", "agentbundle.workspace_mcp"],
+      "env": { "WORKSPACE_MCP_DISPATCHED_ITEM": "initiative-a/shape:initiative-x" }
+    }
+  }
+}
+```
+
+The control plane must spawn workspace-mcp with cwd set to the repo root; all paths (`args`, `WORKSPACE_MCP_SPEC_PATH`, and all git_* tool paths) are repo-root-relative. Pack install pre-approves workspace-mcp tools in `.claude/settings.json` (`permissions.allow`) so no interactive prompt appears in headless mode. The server exits with a clear diagnostic if the Python runtime is below 3.11. Rollback: omit from `session/new.mcpServers` — zero impact on skill behaviour.
+
+### Class B: Kiro CLI
+
+workspace-mcp works fully with Kiro CLI — the difference from Class A is setup location, not capability. Class A injects workspace-mcp per session via `session/new.mcpServers`. Kiro CLI ignores that parameter and reads MCP config from `{cwd}/.kiro/settings/mcp.json` instead. The adopter configures workspace-mcp once per repo; every Kiro CLI ACP session in that repo then has workspace-mcp available automatically.
+
+**One-time repo setup (adopter or CI bootstrap):**
+
+```json
+// .kiro/settings/mcp.json — non-FSM (desk-research, PE, XD shaping items only)
+{
+  "mcpServers": {
+    "workspace-mcp": {
+      "command": "python3",
+      "args": [".kiro/skills/workspace-status/scripts/workspace_mcp_server.py"],
+      "env": {}
+    }
+  }
+}
+
+// .kiro/settings/mcp.json — FSM (work-loop sessions); WORKSPACE_MCP_SPEC_PATH required for
+// gate resumption to work on non-manifest branches (see Class B bridge section below)
+{
+  "mcpServers": {
+    "workspace-mcp": {
+      "command": "python3",
+      "args": [".kiro/skills/workspace-status/scripts/workspace_mcp_server.py"],
+      "env": { "WORKSPACE_MCP_SPEC_PATH": "docs/specs/my-feature" }
+    }
+  }
+}
+```
+
+*(The server path uses `.kiro/skills/` — the projection root for the `kiro-cli` adapter per `adapter.toml`. Class A adapters use their own projection roots: `.claude/skills/` for Claude Code, `.agents/skills/` for Codex and Copilot CLI.)*
+
+**V3 agent format required** — Kiro CLI V2 agents (`.kiro/agents/*.json`) do not receive MCP tools in the LLM tool list (bug #5873, open). V3 agents (Markdown + YAML frontmatter, introduced v2.8.0 June 2026) resolve this via the `@mcp` tool tag:
+
+```yaml
+---
+name: workspace-session
+model: us.amazon.nova-pro-v1:0
+tools:
+  - "@mcp"
+---
+You are operating in a workspace managed by workspace-mcp. Follow these rules for this entire session.
+
+1. Call workspace_status() at session start to understand the current queue before doing any work.
+2. Do not call git commands (git commit, git push, git checkout, etc.) directly. Use the git_* tools provided by workspace-mcp. Exception: if you are running the work-loop skill and an active FSM run is underway, work-loop owns its git lifecycle directly — do not intercept or override its git operations via the git_* tools.
+3. When you would ask the user a question, request approval, show options, or elicit any response — call elicit(message, context, options) and wait for the returned response.
+4. The workspace-mcp tools remain available for the duration of the session.
+5. Before writing artifacts for a non-FSM item (any item where work-loop is not managing the session), call git_branch(<ini_slug>/<type>/<slug>) if not already on the item's feature branch. Derive the three-component branch name from the ini_slug, type, and slug as reported by workspace_status() — `workspace_status().slug` and `workspace_status().ini_slug` are the canonical forms — workspace.toml item keys returned verbatim by `workspace_status_engine`; validity as git-ref path segments is a contract enforced at workspace.toml authoring time (`git check-ref-format` is the authoritative rule set). Skip if the current branch name equals `<ini_slug>/<type>/<slug>` exactly (byte-identical, using the same workspace_status() values).
+6. When instructed to commit and push artifacts, call git_status() to identify uncommitted files, git_commit(paths, message) for the matching paths, then git_push(branch) if it is available. Do not skip steps that are available.
+```
+
+The `@mcp` tag grants all tools from `mcp.json` to this agent — including workspace-mcp's full tool surface. The session instruction is embedded in the agent system prompt. Intentional Class B differences from Component 3: rule 1 is unconditional (workspace.toml always exists in a configured Class B repo); rule 3 drops "check if the `elicit` workspace-mcp tool is available. If it is," and "instead of emitting text to the user" (elicit is always granted via `@mcp`); the preamble omits "they apply to every turn, including follow-up user messages" (system-prompt embedding makes cross-turn persistence implicit). Rules 2, 4, 5, and 6 are verbatim — the work-loop carve-out in rule 2 applies because Class B deployments do run work-loop FSM sessions (the single-active-run invariant governs run_id binding, not git routing).
+
+**ACP session flow (Kiro CLI):**
+
+```mermaid
+flowchart TD
+    CP["Control plane\n(Conductor / Zed)"]
+
+    subgraph "ACP session"
+        KCA["Kiro CLI V3+\n(ACP-native · MCP client)"]
+        AI["AI agent\n(Nova Pro / Bedrock)"]
+    end
+
+    subgraph "Repo pre-config (committed)"
+        MC[".kiro/settings/mcp.json\n(workspace-mcp registered)"]
+        AG[".kiro/agents/workspace-session\n(V3 format · @mcp tag · system prompt)"]
+    end
+
+    subgraph "workspace-mcp (MCP server, per-session)"
+        EB["Event bridge\ntail-polls .loop-run/events.jsonl"]
+        TS["Tool surface\nworkspace_status · elicit · git_*"]
+        AW["Artifact watcher\nrecursive listing (200ms snapshot diff)"]
+    end
+
+    subgraph "Repo"
+        LE["loop-engine CLI"]
+        EJ[".loop-run/events.jsonl"]
+        WT["workspace.toml"]
+        SD["docs/specs/ · docs/research/\ndocs/product/ · docs/design/"]
+        GIT["git"]
+    end
+
+    CP -- "session/new\n(mcpServers ignored)" --> KCA
+    KCA -- "reads" --> MC
+    KCA -- "reads" --> AG
+    KCA -- "spawns workspace-mcp" --> TS
+    KCA -- "_kiro.dev/mcp/server_initialized\n(MCP handshake complete)" --> CP
+    CP -- "session/prompt" --> KCA
+    KCA -- "loads AI with system prompt\nfrom agent file" --> AI
+    AI -- "MCP tool calls (via @mcp tag)" --> EB
+    AI -- "MCP tool calls (via @mcp tag)" --> TS
+    AI -- "loop-engine CLI (unchanged)" --> LE
+    LE -- "appends event line" --> EJ
+    EB -- "tail-poll seek+read" --> EJ
+    EB -- "_agentbundle.core/skill-state-change\n_agentbundle.core/run-complete" --> KCA
+    KCA -- "relays MCP notifications to AI" --> AI
+    AI -- "elicit(message, context, options)" --> TS
+    TS -- "_agentbundle.core/elicitation-pending\n(response-file fallback)" --> KCA
+    TS -- "reads" --> WT
+    AW -- "watches" --> SD
+    AW -- "_agentbundle.core/artifact-created" --> KCA
+    AI -- "ACP session/update (all notifications)" --> KCA
+    KCA -- "delivers notifications to control plane" --> CP
+    AI -- "git_status / git_commit / git_push\n(via session instruction or CP session/prompt)" --> TS
+    TS --> GIT
+```
+
+**What differs from Class A:**
+- `_kiro.dev/mcp/server_initialized` notification fires before the first `session/prompt` — a reliable readiness signal the control plane can wait for. Class A adapters don't have an equivalent; they rely on tool availability being synchronous after `session/new`.
+- Session instruction goes in the agent system prompt (committed to `.kiro/agents/`), not in `session/new` params. This means it is the same instruction for every session rather than customisable per dispatch.
+- `elicitation/create` support in Kiro CLI is unconfirmed — the same response-file fallback used for Codex applies here.
+- Harness cannot inject workspace-mcp into a Kiro CLI session it didn't configure ahead of time. If the repo doesn't have `.kiro/settings/mcp.json`, workspace-mcp is unavailable.
+
+**What is identical to Class A:** all notifications (`_agentbundle.core/skill-state-change`, `_agentbundle.core/artifact-created`, `_agentbundle.core/elicitation-pending`), all tools (`workspace_status`, `elicit`, `git_*`), the reactive git model, lifecycle manifest. The workspace-mcp binary itself does not change.
+
+**Two bridge differences:** Class A passes `WORKSPACE_MCP_SPEC_PATH` (FSM) or `WORKSPACE_MCP_DISPATCHED_ITEM` (non-FSM) per session via the `mcpServers` env config. Class B's `mcp.json` is static — neither env var can vary per session. Class B has no explicit discriminator, so the server runs both detectors concurrently: the FSM detector polls for `engine-state.json` newer than the sentinel; the non-FSM detector reads the current branch at session start and binds on the first valid branch-parse. **Mode arbitration:** FSM mode wins — once an `engine-state.json` newer than the sentinel is found, the server tears down any non-FSM binding and stops its artifact watcher, then binds the FSM `run_id`; any further non-FSM branch binding is suppressed. A work-loop session that happens to sit on a manifest-type branch (e.g. `initiative-a/research/topic-x`) is classified as FSM after `cmd_init` writes `engine-state.json`; the null `output_pattern` for `work` type then causes `git_commit` to reject any non-FSM commit via the standard `unscoped-uncommitted-files` path. **FSM resume:** Before applying the mtime sentinel filter, the bridge scans `engine-state.json` files for a `state` value matching `*-HUMAN-GATE`. **Gate scan is scoped by `WORKSPACE_MCP_SPEC_PATH`:** if `WORKSPACE_MCP_SPEC_PATH` is set in the Class B static mcp.json env config, the gate scan checks only that spec's `engine-state.json` — regardless of the current branch name. This correctly handles work-loop sessions on non-manifest branches (e.g. `feature/my-feature`). If `WORKSPACE_MCP_SPEC_PATH` is absent, the gate scan is skipped entirely — the session is treated as non-FSM, protecting it from hijack by a parked gate from a prior FSM run. **Class B adopters who run FSM (work-loop) sessions must set `WORKSPACE_MCP_SPEC_PATH` in `.kiro/settings/mcp.json`; adopters who run only non-FSM sessions must omit it.** The prior branch-parse–based gate scoping is removed: it could not correctly distinguish a work-loop session on a non-manifest branch from a fresh session on the same branch, and it silently skipped gate resumption in that case. When a scoped gate is found, the bridge immediately enters FSM mode for that run and emits `_agentbundle.core/human-gate-pending` — the gate must be resolved before the session proceeds. For non-gate FSM states, the mtime sentinel filter applies as usual; a resumed mid-run FSM rebinds when `cmd_transition` next rewrites `engine-state.json` (updating its mtime past the sentinel); all buffered events replay against the newly read `run_id`, so no events are lost. For FSM sessions, Class B uses the single-active-run sentinel invariant (below). For non-FSM sessions, Class B derives the dispatched item from the current branch. **Branch-name parse rule:** split on `/`; if three components, the first is `ini_slug`, second is `type`, third is `slug` (new format: `{ini_slug}/{type}/{slug}`). If two components (legacy or work-loop branch), the first is `type` and the second is `slug` (Class B fallback — accepted for FSM sessions where ini_slug is irrelevant; non-FSM sessions should use the three-component form). If the resolved `type` segment is not a known manifest type, the parse fails → null `output_pattern` → `unscoped-uncommitted-files` rejection (not a crash). At session start the server reads the current branch via `git rev-parse --abbrev-ref HEAD`; if it parses as a known manifest type (two- or three-component), the dispatched item is bound immediately (resume-on-existing-branch case). Otherwise the server binds on the first `git_branch({ini_slug}/{type}/{slug})` call per rule 5 (fresh session). If `git_branch` is not called and the current branch does not resolve, `git_commit` emits `bridge-warning {reason: "unscoped-uncommitted-files"}` — same as a null output_pattern. **Known limitation:** if the previous session ended on a feature branch (e.g. `initiative-a/research/old-topic`) and the new session starts on that same branch intending a different item, the server binds the old slug. **Workaround:** check out the new item's branch before starting the session. The first-call binding is immutable for the session (no rebind) — this is intentional: allowing rebind makes the push-validation branch agent-controlled, which undermines the security guarantee at the git remote boundary. Class B constraint: `WORKSPACE_MCP_SPEC_PATH` cannot vary per session. The Class B bridge instead relies on the **single-active-run invariant**: Class B deployments run one work-loop session at a time per repo. At startup, the bridge creates a sentinel file (`$TMPDIR/workspace-mcp-{pid}.sentinel`) and records its `stat().st_mtime`. It then polls `docs/specs/**/engine-state.json` files, ignoring any whose `stat().st_mtime` is **less than or equal to** the sentinel's mtime (filesystem-sourced comparison — avoids wall-clock vs mtime clock-skew at 1s granularity; strict `<` allows ties to pass, which is unsafe on 1-second-resolution filesystems where a stale file written in the same second as the sentinel would bind). It binds to the first `engine-state.json` strictly newer than the sentinel, reads `run_id`, and proceeds identically to Class A. This avoids binding to a stale prior-run file during the pre-`cmd_init` buffering window. Class B constraint: concurrent FSM sessions are not supported.
+
+### Component 1 — loop-engine events.jsonl
+
+Loop-engine gains one new behaviour: on each successful `cmd_transition`, append a JSON line to **repo-root `.loop-run/events.jsonl`** (not inside the spec dir — one shared file for all active runs).
+
+**Crash-consistent transition protocol (outbox pattern):** A naive implementation writes `engine-state.json` atomically then appends to `events.jsonl`. A crash between these two steps produces a state that has advanced (engine-state.json shows new state) with no corresponding event (events.jsonl has no matching line) — the bridge never emits `_agentbundle.core/skill-state-change` for that transition, leaving the control plane blind. Reversing the order (append event first) creates a phantom event if the state write then crashes. `cmd_transition` must use the outbox protocol:
+1. Write the pending event JSON to `.loop-run/events.pending` (truncate-and-rewrite, not append)
+2. Write the new engine state atomically (`engine-state.json.tmp` → rename to `engine-state.json`)
+3. Read `.loop-run/events.pending`, append its content as a new line to `events.jsonl`
+4. Delete `.loop-run/events.pending`
+
+On startup (including crash recovery), if `.loop-run/events.pending` exists, the recovery protocol is:
+1. Read the pending event's `run_id`, `seq`, and `to` (destination state).
+2. Read the current `engine-state.json` (if it exists).
+3. If `engine-state.json` shows `state == pending.to` AND `transition_sequence == pending.seq`, the state write completed before the crash — only the events.jsonl append failed. **Replay**: append the pending event to `events.jsonl`, then delete the pending file.
+4. If `engine-state.json` is absent, or its `state` differs from `pending.to`, the state write never completed — the transition did NOT occur. **Discard**: delete the pending file without appending. The transition must be re-attempted by the skill.
+5. If `engine-state.json.tmp` exists alongside, the atomic rename was interrupted — complete the rename, then re-evaluate from step 2.
+
+Unconditional replay without this check would emit a phantom event for a transition that never occurred — the exact failure mode the outbox pattern claims to prevent. The bridge treats duplicate `seq` values as idempotent no-ops (already-seen seq → skip) for the case where replay appends a line that was already committed.
+
+```json
+{"seq": 3, "run_id": "abc123", "spec": "docs/specs/feature-X", "from": "SPEC-PLAN-REVIEW", "event": "reviewers-clean", "to": "SPEC-HUMAN-GATE", "at": "2026-08-03T..."}
+```
+
+The `run_id` field is generated by `cmd_init` and written to `engine-state.json` alongside the spec. Because `cmd_init` runs during the session (after the first `session/prompt`), `engine-state.json` may not exist at session start. The event bridge discovers `run_id` lazily: it buffers incoming event lines (capped at 1 000 lines; on overflow it emits `_agentbundle.core/bridge-warning {reason: "buffer-overflow"}` and stops buffering) until `engine-state.json` appears for the dispatched item. Separately, if no `engine-state.json` matching the session's anchor appears within 30 s, the bridge emits a transient `_agentbundle.core/bridge-warning {reason: "run-id-unresolved"}` (Class A anchor: `WORKSPACE_MCP_SPEC_PATH`; Class B FSM anchor: first `engine-state.json` newer than the sentinel file). `cmd_init` writes `engine-state.json` atomically (temp file + rename) so a first-sight read never sees a partial write. The bridge reads `run_id` on first sight, then replays the buffer against it. Only lines matching the session's `run_id` are forwarded; all others are discarded. The control plane passes the dispatched spec **directory** as an env var (`WORKSPACE_MCP_SPEC_PATH`) in the `mcpServers` config at `session/new` — workspace-mcp spawns with this value before the first `session/prompt` arrives. `engine-state.json` is resolved as `{WORKSPACE_MCP_SPEC_PATH}/engine-state.json`. The value must match the `spec` field emitted in events.jsonl (which is the directory, not the file path).
+
+`.loop-run/` is gitignored. `cmd_init` creates the directory; `cmd_reset` removes it. The skill writes `question` (the gate prompt text) to engine-state.json before calling `loop-engine transition` to any `*-HUMAN-GATE` state. For `CODE-HUMAN-GATE` specifically: work-loop calls `loop-engine transition ... reviewers-clean` (entering the gate) and then, as part of the finish checklist that follows, opens the PR and writes `pr_url` to engine-state.json. This means `pr_url` is not yet present in engine-state.json when `_agentbundle.core/human-gate-pending` fires. workspace-mcp polls engine-state.json during the CODE-HUMAN-GATE window and emits `_agentbundle.core/gate-pr-ready {gate, pr_url}` as soon as `pr_url` appears — typically within seconds. The control plane uses this follow-up notification to display the PR to the human reviewer; it must not block on `pr_url` in `_agentbundle.core/human-gate-pending`. Loop-engine does not derive either value. **To survive the rewrite:** `cmd_transition`'s `_write_engine_state_atomic` reads the existing `engine-state.json` before writing; the new state dict is the existing state merged with the newly computed fields (`{**existing, **new_schema_fields}`), so any extra key written by the skill (`pr_url`, `question`, and any future extensions) is preserved through every subsequent transition. The schema-managed keys (`schema_version`, `run_id`, `feature`, `mode`, `state`, `last_event`, `last_event_context`, `transition_sequence`, `last_transition_at`) are always overwritten; all other keys survive. Workspace-mcp reads `pr_url` when emitting `_agentbundle.core/run-complete` at `DONE` or `ABANDONED`, and reads `question` when emitting `_agentbundle.core/human-gate-pending`. This is approximately 30 lines total in `cmd_transition` and `cmd_init`.
+
+### Component 2 — Event bridge
+
+`workspace-mcp`'s event bridge tail-polls `events.jsonl` using a position-based read (seek to last offset, read new bytes, parse complete lines). Position-based reads on append-only files never miss a line regardless of how many transitions occur between polls. Poll interval: 200ms.
+
+**Inode/truncation detection (cmd_reset recovery):** `cmd_reset` removes `.loop-run/`; a subsequent `cmd_init` in the same MCP session recreates `events.jsonl` with a new `run_id`. On each poll, the bridge checks: if the current file size is less than the saved offset, or if the file's inode differs from the inode recorded at first-open, the bridge: (1) resets offset to 0; (2) clears the in-flight buffer; (3) **clears the active `run_id` binding** and re-enters the lazy-discovery state (same as session start). This causes the bridge to re-read `engine-state.json` and bind the new `run_id` on first sight. Without clearing the binding, events from the new run carry the new `run_id` and are discarded as non-matching against the old binding.
+
+On each new event line whose `run_id` matches this session's active run: if the line's `seq` value equals the last emitted `seq`, skip it as a duplicate (idempotent replay from outbox recovery); otherwise emit `_agentbundle.core/skill-state-change` with the full event payload and update the last-seen `seq`. Lines with non-matching `run_id` are skipped. Note: Stages 1–3 are single-session-per-repo; concurrent session isolation via `run_id` is forward-compatible infrastructure for Stage 4 worktree mode, where each session works in a separate worktree and holds a distinct `run_id`. Git operations in Stages 1–3 are not concurrent-safe. The read offset advances only to the last complete newline — a partial final line (torn write on crash mid-append) is held at the current offset and re-read on the next poll cycle.
+
+**Writer-side repair (loop-engine contract):** when loop-engine appends a new event, it first checks whether the last byte of `events.jsonl` is `\n`. If not, a crash left a partial record; loop-engine writes a bare `\n` before appending the new JSON line. This terminates the partial record as a newline-terminated but malformed line and places the new complete event on its own line. Without this repair, the new JSON object would be concatenated directly onto the partial fragment, making the resulting newline-terminated blob unrecoverable — quarantining it would discard the new transition, violating zero-missed-events.
+
+**Reader-side quarantine (bridge contract):** if a newline-terminated line fails JSON parsing (partial record terminated by writer repair, or other corruption), the bridge emits `_agentbundle.core/bridge-warning {reason: "malformed-event-line", offset: N}`, advances the offset past the malformed line, and continues. This recovers without losing subsequent valid events.
+
+### Notification contract
+
+All `_agentbundle.core/*` notifications are emitted by workspace-mcp as MCP `notifications/message` frames. The naming convention follows the ACP extension pattern (`_<namespace>/method`) confirmed by Stage 0 spike (b) — `_claude/sdkMessage` in `claude-agent-acp@0.64.0` is the observed exemplar; `_agentbundle.core/` is the agentbundle namespace. **Stage 1 observability note (spike (c) result):** MCP `notifications/message` frames are NOT relayed to the ACP control plane by `claude-agent-acp@0.64.0`; the control plane polls `workspace_status()` instead. The notification definitions below remain the target contract; relay support is contingent on a future claude-agent-acp update.
+
+| Notification | When emitted | Key payload fields |
+|---|---|---|
+| `_agentbundle.core/skill-state-change` | Each loop-engine FSM transition (run_id matches session) | `seq` (per-`run_id` counter maintained by `cmd_transition` in `engine-state.json` — gaps indicate missed transitions; not a file-global counter), `run_id`, `spec`, `from`, `event`, `to`, `at` |
+| `_agentbundle.core/human-gate-pending` | FSM enters any `*-HUMAN-GATE` state | `gate`, `spec_path`, `review_findings` (from reviewer output file; null if no file exists yet), `question` (from `engine-state.json`). `pr_url` is intentionally absent: for `CODE-HUMAN-GATE`, the PR is opened after the gate transition (see Component 1 ordering note); the control plane must wait for `_agentbundle.core/gate-pr-ready`. |
+| `_agentbundle.core/gate-pr-ready` | workspace-mcp detects `pr_url` in `engine-state.json` during a CODE-HUMAN-GATE window | `gate`, `spec_path`, `pr_url`. Emitted once per CODE-HUMAN-GATE entry, typically within seconds of `_agentbundle.core/human-gate-pending`. The control plane uses this to display the PR URL to the human reviewer. |
+| `_agentbundle.core/run-complete` | FSM transitions to `DONE` or `ABANDONED` | `run_id`, `outcome`, `spec_path`, `pr_url` (read from `engine-state.json`; written there by the **work-loop skill** as part of the CODE-HUMAN-GATE finish checklist; null if no PR was opened; loop-engine does not derive it) |
+| `_agentbundle.core/elicitation-pending` | AI calls `elicit()` (any question or gate) | `message`, `context`, `options`, `session_id`, `elicit_seq` (independent per-session counter, increments per elicitation), `correlation_id` (set to the gate id only when the gate's elicitation is pending and has not yet been resolved; null otherwise), `response_path` (absolute path of the session-scoped response file when the fallback is active; null when `elicitation/create` is used as the primary channel) |
+| `_agentbundle.core/artifact-created` | Watched output dir receives a new file | `path`, `item_slug`, `item_type`, `session_id` |
+| `_agentbundle.core/skill-complete` | Emitted after `git_push` returns for a non-FSM item, or after `git_commit` if `git_push` is unavailable (no remote configured); signals control plane to initiate PR creation. When emitted after `git_commit` only, `branch` is set and `pushed` is false. For external output paths, `branch` is null and `pushed` is false — monitoring-only, no PR creation. | `item_slug`, `item_type`, `committed_paths`, `branch` (nullable), `pushed` (bool), `session_id` |
+| `_agentbundle.core/bridge-warning` | Event bridge or artifact watcher detects a problem | `reason` (one of: `no-events-after-30s`, `run-id-unresolved`, `unscoped-uncommitted-files`, `buffer-overflow`, `branch-base-unresolved`, `push-branch-mismatch`, `malformed-event-line`, `external-output-path`); reason-specific: `last_seq` for `no-events-after-30s`; `paths` for `unscoped-uncommitted-files`; `expected`, `actual` for `push-branch-mismatch`; `offset` for `malformed-event-line` |
+
+`_agentbundle.core/human-gate-pending` and `_agentbundle.core/elicitation-pending` are distinct events — a gate blocks the FSM until resolved; an elicitation is an informal question the AI would normally direct to the user. Both are resolved via `elicit()`; the gate variant carries `review_findings` that an informal elicitation does not. The correlation join key: `elicitation-pending.correlation_id == human-gate-pending.gate` — the control plane uses this to match the elicitation response to the pending gate. Once the gate's elicitation has been consumed (response returned to the AI), `correlation_id` reverts to null for any subsequent elicitations in the same turn.
+
+### Component 3 — Universal elicitation via session instruction
+
+Every skill elicits from the user at points that are not formal FSM states: desk-research asks which angle to pursue, place-bet asks for prioritization, journey-mapping asks about personas. Scoping elicitation interception to declared gate states would miss the majority of AI→user communication and leave the control plane blind to most of a session.
+
+The solve is a session-level instruction injected by the control plane in `session/new` (Class A) or embedded in the V3 agent system prompt (Class B).
+
+**Instruction durability — confirmed by Stage 0 spike (a):** In `claude-agent-acp@0.64.0`, `systemPrompt` is set once from `session/new._meta.systemPrompt` and baked into the SDK `query()` at session creation; `query()` is long-running and handles all turns — it is not restarted per `session/prompt`. The instruction therefore persists for the session's lifetime without per-turn re-injection. The control plane injects the workspace-mcp session instruction once via `session/new._meta.systemPrompt` (as a string, or as an object with `append: true` to append to the `claude_code` preset). No per-turn re-injection is required.
+
+**Full recommended session instruction:**
+
+```
+You are operating in a workspace managed by workspace-mcp. Follow these rules for this entire session — they apply to every turn, including follow-up user messages.
+
+1. If the `workspace_status` tool is available, call workspace_status() at session start to understand the current queue before doing any work.
+
+2. Do not call git commands (git commit, git push, git checkout, etc.) directly. Use the git_* tools provided by workspace-mcp. Exception: if you are running the work-loop skill and an active FSM run is underway, work-loop owns its git lifecycle directly — do not intercept or override its git operations via the git_* tools.
+
+3. When you would ask the user a question, request approval, show options, or elicit any response — check if the `elicit` workspace-mcp tool is available. If it is, call elicit(message, context, options) and wait for the returned response instead of emitting text to the user.
+
+4. The workspace-mcp tools remain available for the duration of the session.
+
+5. Before writing artifacts for a non-FSM item (any item where work-loop is not managing the session), call git_branch(<ini_slug>/<type>/<slug>) if not already on the item's feature branch. Derive the three-component branch name from the ini_slug, type, and slug as reported by workspace_status() — `workspace_status().slug` and `workspace_status().ini_slug` are the canonical forms — workspace.toml item keys returned verbatim by `workspace_status_engine`; validity as git-ref path segments is a contract enforced at workspace.toml authoring time (`git check-ref-format` is the authoritative rule set). Skip if the current branch name equals `<ini_slug>/<type>/<slug>` exactly (byte-identical, using the same workspace_status() values).
+
+6. When instructed to commit and push artifacts, call git_status() to identify uncommitted files, git_commit(paths, message) for the matching paths, then git_push(branch) if it is available. Do not skip steps that are available.
+```
+
+The AI follows this instruction universally. **No skill modification is needed.** For Class B (Kiro CLI), this instruction is embedded in the V3 agent file system prompt and is fixed per repo rather than customisable per dispatch (see Class B section above).
+
+`elicit(message, context, options)` on workspace-mcp:
+1. Emits `_agentbundle.core/elicitation-pending {message, context, options, session_id, elicit_seq, correlation_id}` notification to the control plane (`correlation_id` is set to the pending gate id when the gate's elicitation has not yet been consumed; null for informal questions)
+2. Calls MCP `elicitation/create` in server→client direction (workspace-mcp → AI host) — the AI host bridges this through the ACP adapter to the control plane; the tool call blocks until the response arrives
+3. Returns `{"response": "<decision or text>"}` to the AI as the tool result
+
+**Interactive mode:** Session instruction is not present (control plane didn't inject it); `elicit` tool may not be in the session; the AI asks questions via text as normal. Zero behavior change.
+
+**Codex gap — fallback path:** Codex's ACP adapter (`codex-acp`) does not list `elicitation/create` as a supported feature. For Codex, workspace-mcp cannot use the MCP server→client `elicitation/create` channel. Fallback: workspace-mcp emits `_agentbundle.core/elicitation-pending` with `response_path` set to a session-scoped file path, then polls that file. Security: workspace-mcp creates the response directory using `tempfile.mkdtemp()` with `0700` perms at startup (`$TMPDIR/workspace-mcp-{session_id}/`), creates each response file `O_EXCL` with `0600` perms, and rejects any pre-existing file — preventing a local process from pre-writing a response that would approve a gate the user never saw. The control plane, on receiving the notification, reads `response_path` from the payload and writes the user's response there.
+
+**Response-file atomicity requirement:** The control plane **must not** write directly to `response_path` — a direct write can produce a partial file that workspace-mcp reads mid-write, yielding malformed JSON and a failed parse. The required protocol: write the response JSON to `response_path + ".tmp"` in the same directory (`$TMPDIR/workspace-mcp-{session_id}/`), then `os.replace()` (atomic on POSIX) to `response_path`. workspace-mcp's poller only accepts the file after it exists **and** parses as valid JSON with a `response` key; a missing key or parse error causes the poller to continue waiting (not fail). The `O_EXCL` guard on the **final** path remains: workspace-mcp creates the placeholder `response_path` file at `O_EXCL` at elicitation time and expects the control plane to overwrite it via rename — this preserves the race guard while allowing atomic delivery. This is structurally equivalent from the AI's perspective — it called `elicit`, it received a response.
+
+**Capability detection:** In MCP, `elicitation` is a CLIENT capability — the client declares it in its `initialize` request to signal that it can service `elicitation/create` requests sent from the server. workspace-mcp does NOT advertise `elicitation` in its own `ServerCapabilities` (that field belongs to the client's `ClientCapabilities`; advertising it as a server capability produces an invalid MCP handshake). Instead, workspace-mcp inspects the received `initialize` params for `capabilities.elicitation`: present → use `elicitation/create` as the primary channel; absent → use response-file fallback with `response_path` in `_agentbundle.core/elicitation-pending`. A known bug in `claude-agent-acp` (issue #419) breaks MCP tool discovery at initialization if a server advertises unexpected capabilities; the correct fix is not to advertise `elicitation` at all. Stage 1 validates that tool discovery completes correctly under this conditional detection approach on known-affected `claude-agent-acp` builds.
+
+### Component 4 — Tool surface
+
+```python
+workspace_status()
+# Returns DAG-resolved workspace.toml view with lifecycle metadata per item:
+# {
+#   "ready": [{
+#     "path": "spec/X", "description": "...", "type": "work",
+#     "lifecycle": {"has_gates": true, "output_pattern": null}
+#   }],
+#   "blocked": [{"path": "spec/Y", "needs": ["work:spec/X"], "unmet": ["work:spec/X"]}],
+#   "active":  [{"path": "spec/Z", "engine_state": "CODE-REVIEW"}],
+#   "shaping": [{"slug": "...", "type": "research",
+#     "lifecycle": {"has_gates": false, "output_pattern": "docs/research/{slug}/**"}}],
+#   "workspace_toml_age_commits": 0
+# }
+
+git_status()                               # uncommitted files + current branch
+git_branch(name, base=None)                # creates branch; base resolution order: (1) git symbolic-ref refs/remotes/origin/HEAD, (2) local HEAD if no remote; emits bridge-warning {reason: "branch-base-unresolved"} and returns an error if neither resolves (shallow clone, no remote, or detached HEAD). Class B non-FSM side-effect on FIRST call: parses `name` via the branch-parse rule, binds the dispatched item in session context, starts the artifact watcher on the new item's output dir, and records the session-bound push-validation branch. Subsequent calls in the same session may create git branches but do NOT rebind the dispatched item or change the push-validation branch — the first binding is immutable for the session. FSM-bound sessions ignore this side-effect entirely.
+git_commit(paths, message)                 # server-side: intersects paths with the session's dispatched item's output_pattern (derived from the item's type in the lifecycle manifest, not from the workspace_status() "active" bucket); drops non-matching entries + emits bridge-warning; stages and commits the remainder. If the dispatched item has null output_pattern (work-loop items), rejects the call with bridge-warning {reason: "unscoped-uncommitted-files"}. Server ignores the caller's message parameter and derives the commit message from dispatched item slug and type; parameter retained for interface stability.
+git_push(branch)                           # server-side: validates `branch` equals the immutable session-bound branch AND that HEAD matches that branch; rejects with bridge-warning {reason: "push-branch-mismatch", expected: <session-bound>, actual: branch} and returns an error if either check fails. The session-bound branch is derived at startup from the dispatched item: for Class A, from {ini_slug}/{type}/{slug} parsed from WORKSPACE_MCP_DISPATCHED_ITEM (non-FSM) or from the spec path slug (FSM); for Class B non-FSM, from the FIRST git_branch() call — subsequent git_branch() calls may update the git working tree but do NOT rebind the session-bound branch used for push validation. This two-sided check (argument + HEAD) prevents an agent from using a rebind to redirect the push to an unrelated or privileged branch.
+git_worktree_create(branch)                # isolated worktree path (Stage 4)
+git_worktree_cleanup(path)                 # teardown (Stage 4)
+# PR creation is platform-specific (gh, glab, REST API, custom skill) — left to the control plane
+elicit(message, context, options)          # see Component 3; routes all AI→user comm
+```
+
+`workspace_status()` delegates to `workspace_status_engine.analyze_bounded()` — no duplication.
+
+**Known dependency-analysis gap (Stage 1 prerequisite):** `workspace_status_engine.analyze_bounded()` currently reports a missing `shape:` or `research:` target as satisfied rather than unsatisfied (see `workspace_status_engine.py:488-530`), while every `strategy:` item that depends on a missing target remains blocked permanently. This makes autonomous dispatch from `workspace_status()` unsafe for dependency-chained items: the bridge may start work early (missing dep treated as satisfied) or block it forever (dep never resolves). This gap must be closed before Stage 1 enables autonomous dispatch.
+
+**Lifecycle manifest — how workspace-mcp knows what each type means:**
+
+`pack.toml` is source-only and not projected to adopters, so lifecycle metadata cannot live there. workspace-mcp resolves type→lifecycle from two sources, merged:
+
+1. **Built-in defaults** — the workspace.toml type taxonomy is a published contract; workspace-mcp ships with mappings for the known types. **These patterns assume default layout (no `agentbundle-layout.toml` override).**
+
+   **Pack presence filter:** At startup, workspace-mcp checks whether each type's `dispatch_skill` is installed by probing known skill roots for the SKILL.md file. Non-FSM packs (desk-research, product-engineering, experience-design) are user-scoped by default and project their skills to the adapter's **user root**, not the repo-relative root. The probe checks all of the following paths (OR logic — any hit means the skill is present):
+   - **Repo root** (core and repo-scoped packs): `.claude/skills/{dispatch_skill}/SKILL.md`, `.agents/skills/{dispatch_skill}/SKILL.md`, `.kiro/skills/{dispatch_skill}/SKILL.md`
+   - **User root** (user-scoped packs): `~/.claude/skills/{dispatch_skill}/SKILL.md`, `~/.agents/skills/{dispatch_skill}/SKILL.md`, `~/.kiro/skills/{dispatch_skill}/SKILL.md`
+
+   A type whose skill file is absent in **all** six locations is included in `workspace_status()` output with `"available": false` and `"required_pack": "<pack-name>"` metadata — **it is NOT excluded**. Excluding absent types produces a falsely empty queue that gives the control plane no actionable signal. Returning unavailable items with metadata allows the control plane to surface "Install pack X to work on this item" rather than hiding the item entirely. Items with `available: false` must not be dispatched; they are display-only until the pack is installed and the probe succeeds. The `workspace_status()` result shape for unavailable items: `{ini_slug, slug, type, dispatch_skill, blocked_by, available: false, required_pack: "<pack-name>"}`. Available items omit `available` and `required_pack` (presence implies available).
+
+   **Layout resolution order (mirrors each skill's own resolution):**
+   - **`research` type**: user-scope `~/.agentbundle/agentbundle-layout.toml [research] output_dir` takes priority (personal vault always wins regardless of which repo is active, per `desk-research-project-start` contract). Falls back to repo-scope `./agentbundle-layout.toml [research] output_dir`, then to install-default `docs/product/research/` (from `packs/desk-research/pack.toml [pack.layout.repo] output_dir`).
+   - **`shape`, `strategy` types**: repo-scope `./agentbundle-layout.toml [product] output_dir` first (team convention wins), then user-scope, then default `docs/product/`.
+   - **`design` type**: repo-scope `./agentbundle-layout.toml [design] output_dir` first, then user-scope, then default `docs/design/`.
+
+   At startup workspace-mcp reads both layout files and resolves each `output_dir` per the skill-matching priority above.
+
+   **Deferred layout resolution for all non-FSM types:** The non-FSM dispatch skills — `desk-research-project-start`, `frame-intent` (shape), `frame-situation` (strategy), and `journey-mapping` (design) — all perform a two-branch output_dir elicitation on first run when configuration is absent. This elicitation happens **after** the session starts but **before** the first artifact write (rule 5 ensures `git_branch` is called before writing). If workspace-mcp resolved layout at startup, it would read `agentbundle-layout.toml` files that may not yet have the relevant section, producing wrong watcher paths for the session's lifetime. Fix: for **all non-FSM dispatched items** (`research`, `shape`, `strategy`, `design`), **defer watcher binding** until the first `git_branch()` call. At `git_branch()` time, workspace-mcp re-reads `~/.agentbundle/agentbundle-layout.toml` and `./agentbundle-layout.toml` to resolve the final `output_dir` per the type's priority order, then starts the watcher. If the layout file is still absent at `git_branch()` time (first-run elicitation hasn't happened or the user declined to write config), fall back to the install-default and proceed. The `work` type (FSM) is not affected — it has no output_pattern and manages its own git lifecycle.
+
+   **Non-git output paths:** If the resolved `output_dir` for any type falls outside the repo tree (e.g. a personal vault at `~/vault/research`), `git_commit` emits `bridge-warning {reason: "external-output-path"}` and skips the commit step. `_agentbundle.core/artifact-created` is still emitted (monitoring only). `_agentbundle.core/skill-complete` is emitted with `pushed: false` and `branch: null` — the control plane treats this as monitoring-only and does not attempt PR creation. (Note: `pushed` is always a boolean in the `skill-complete` payload; only `branch` is nullable.)
+
+The manifest `output_pattern` field accepts a single pattern string or a **list of pattern strings** for types whose shaping sequence writes to multiple output directories. The watcher and `git_commit` union all listed patterns for the item's type.
+
+| type | has_gates | dispatch_skill | Default output_patterns |
+|---|---|---|---|
+| `work` | `true` | `work-loop` | *(none — work-loop manages git itself)* |
+| `research` | `false` | `desk-research-project-start` | `["docs/product/research/*-{slug}/**"]` ¹ |
+| `shape` | `false` | `frame-intent` | `["docs/product/intents/{slug}.md", "docs/product/shaping/{slug}/**"]` ² |
+| `design` | `false` | `journey-mapping` | `["docs/design/journeys/{slug}.md", "docs/design/blueprints/{slug}.md", "docs/design/screens/{slug}/**", "docs/design/screens/{slug}-flow.md"]` |
+| `strategy` | `false` | `frame-situation` | `["docs/product/shaping/{slug}/**"]` |
+| `signal` | `false` | *(none — monitoring only)* | *(none)* |
+
+¹ `research` uses a date-prefixed project folder (`{YYYY-MM-DD}-{slug}/`). The `{date}` component is not known at dispatch time; the watcher watches the `output_dir` base (`docs/research/`) and attributes artifacts to this item when the discovered path matches `fnmatch("*-{slug}", first_component)`. `git_commit` includes all files under the matched folder.
+
+² `dispatch_skill` is the **entry-point writing skill** — the first skill that creates artifacts. Subsequent skills in the sequence (`place-bet`, `diverge-solutions`) run after `frame-intent` in the same session; their outputs fall under the same multi-pattern union. `experience-status` is read-only (orientation) and is NOT the dispatch entry point.
+
+A PE shaping session dispatches `frame-intent` first (→ `intents/{slug}.md`), then typically continues with `place-bet` and `diverge-solutions` (→ `shaping/{slug}/**`). Both patterns are needed so the watcher detects all artifacts and `git_commit` includes all PE skill outputs for this item in one commit.
+
+`dispatch_skill` is returned by `workspace_status()` in the `shaping` item payload — the control plane constructs its session prompt from it without needing hardcoded pack knowledge. `workspace_status()` result shape for **available** items: `{ini_slug, slug, type, dispatch_skill, blocked_by}`. For **unavailable** items (pack not installed): `{ini_slug, slug, type, dispatch_skill, blocked_by, available: false, required_pack: "<pack-name>"}`. `ini_slug` is included so the control plane can construct the three-component feature branch name (`{ini_slug}/{type}/{slug}`) and the `WORKSPACE_MCP_DISPATCHED_ITEM` env var value without any additional lookup.
+
+When `agentbundle-layout.toml [product] output_dir = P`, the `shape` patterns become `["P/intents/{slug}.md", "P/shaping/{slug}/**"]` and `strategy` becomes `["P/shaping/{slug}/**"]`. When `[research] output_dir = R` (either scope), `research` becomes `["R/*-{slug}/**"]` — note this overrides the install-default `docs/product/research/`. When `[design] output_dir = D`, `design` becomes `["D/journeys/{slug}.md", "D/blueprints/{slug}.md", "D/screens/{slug}/**", "D/screens/{slug}-flow.md"]` — slug-scoping is preserved under any layout override to prevent `git_commit` from including unrelated design artifacts from concurrent sessions. The `screens/{slug}-flow.md` entry is required because `user-flow` writes the flow document as a sibling of `screens/{slug}/` (not inside it), which the directory-recursive `**` pattern does not cover.
+
+2. **Optional `workspace-types.d/*.toml`** directory at repo root — third-party packs each project a separate file (e.g. `workspace-types.d/mypack.toml`). workspace-mcp reads all files in the directory and merges with built-in defaults. One file per pack prevents projection clobber. Third-party files may add new type keys or override built-in patterns to accommodate non-default layout configurations — the startup-resolved `agentbundle-layout.toml` values take precedence over both the built-in defaults and `workspace-types.d` overrides for the affected types.
+
+   **Projection mechanism status:** The current adapter contract has no primitive that projects an arbitrary `.toml` file to the repo root; introducing `workspace-types.d/` as a new top-level directory requires an RFC per `AGENTS.md § Check before acting`. **This is a future extension point, not implemented in the current design.** Stage 3 will determine whether workspace-types.d is needed for third-party packs or whether the built-in defaults plus `agentbundle-layout.toml` overrides are sufficient for the known type taxonomy. If implemented, each owning pack's lifecycle entry would be discovered beside its already-projected assets (e.g., next to the projected `SKILL.md`).
+
+```toml
+# workspace-types.d/mypack.toml (projected by third-party pack; optional)
+[[types]]
+type = "audit"
+has_gates = true
+output_pattern = "docs/audits/{slug}/**"
+```
+
+**Reactive git, not declarative:** No `git_managed` field in the manifest. Skills that manage their own git (work-loop commits and opens a PR at `CODE-HUMAN-GATE`) leave nothing uncommitted at turn end. For non-FSM skills, rule 5 of the session instruction directs the AI to call `git_branch(<ini_slug>/<type>/<slug>)` before writing artifacts; the control plane then sends a `session/prompt` at turn end instructing the AI to commit and push; the AI calls `git_status()`, `git_commit()`, and `git_push()` via the MCP tool surface. The control plane does not call these tools directly — it drives the AI via prompts.
+
+Commit scoping: `git_commit(paths, message)` enforces output-pattern intersection **server-side** — the tool itself drops any path not matching the **session's dispatched item's** `output_pattern` (looked up from the lifecycle manifest by the dispatched item's type, not from the `active` bucket in `workspace_status()`) and emits `_agentbundle.core/bridge-warning {reason: "unscoped-uncommitted-files", paths: [...]}` for the dropped entries. This is not prompt-following; it is enforced in the tool implementation regardless of what paths the AI passes. The server always derives the commit message from the dispatched item slug and type (`"chore(workspace-mcp): commit artifacts for {type} {slug}"`) and ignores the caller-supplied `message` parameter. Rule #6 in the session instruction is advisory guidance — the server-side intersection is the actual safety boundary.
+
+Push scoping: `git_push(branch)` enforces a **two-sided server-side check** — (1) the `branch` argument must equal the immutable session-bound branch (derived at startup from the dispatched item for Class A, or from the FIRST `git_branch()` call for Class B); and (2) the current HEAD must equal the same session-bound branch. Both must match; either mismatch rejects with `_agentbundle.core/bridge-warning {reason: "push-branch-mismatch"}` before any network operation. The two-sided check closes the agent-rebind attack: even if an agent calls `git_branch()` to move HEAD to another branch, the session-bound branch does not change after first binding, so the HEAD check fails. This prevents pushing to `main`, another team's feature branch, or any other unrelated ref regardless of what the AI passes.
+
+**Runtime prerequisites:** Python 3.11+ (stdlib only — no third-party packages). `git` on `$PATH`. PR creation is platform-specific and not part of the MCP tool surface — the control plane implements it via `gh`, `glab`, a REST API call, or a custom skill.
+
+**Tool contract rules:**
+- `workspace_status()` is not advertised when `workspace.toml` does not exist; `git_push` is not advertised when no git remote is configured. Exposing uncallable tools causes session abandonment in some AI runtimes.
+- Freshness is embedded in every `workspace_status()` response: `workspace_toml_age_commits`. The AI cannot otherwise know if its queue view is stale.
+- Partial state is surfaced diagnostically: if `events.jsonl` is missing when expected, `workspace_status()` returns `{"warning": "EVENTS-FILE-MISSING", "engine_state": null}` rather than omitting engine state silently.
+
+### Component 5 — Artifact watcher
+
+For skills with no FSM (desk-research, PE, XD), completion is inferred from new files in declared output directories. `workspace-mcp` derives watched paths from the **lifecycle manifest's `output_pattern`** for the **session's dispatched item's** type — no hardcoded pack→path knowledge in the watcher.
+
+```python
+# Resolve watched dirs from the manifest for the dispatched item.
+# Class A: item is known at startup from WORKSPACE_MCP_DISPATCHED_ITEM env var.
+# Class B non-FSM: item may not be known at startup — deferred until branch-derived item
+#   is bound (session-start branch read, or most-recent git_branch call). Watcher starts after
+#   binding. Rule 5 (branch before write) guarantees binding before the first artifact write.
+# All non-FSM types (research, shape, strategy, design): watcher binding is ALWAYS deferred
+#   to the first git_branch() call. This is because all non-FSM dispatch skills (desk-research-
+#   project-start, frame-intent, frame-situation, journey-mapping) perform a two-branch
+#   output_dir elicitation on first run when configuration is absent. The elicitation happens
+#   AFTER session start but BEFORE the first git_branch call (rule 5 guarantees branch before
+#   write). At git_branch() time, layout files are re-read and the resolved output_dir is used
+#   to set watched_dirs. If still absent at that point, fall back to install-default.
+output_patterns = manifest[item["type"]]["output_pattern"]  # str or list[str]
+if isinstance(output_patterns, str):
+    output_patterns = [output_patterns]
+# --- Slug safety guard ---
+# Slugs come from workspace.toml via workspace_status_engine; git check-ref-format is the
+# authoring gate for ref safety, but ref-safe slugs can still contain glob metacharacters
+# (* ? [ ]) that would broaden the commit allowlist. Reject unsafe segments before formatting.
+# A slug segment passes if it matches [a-zA-Z0-9._-]+ (safe for path components and globs).
+import re as _re
+_SAFE_SLUG_RE = _re.compile(r'^[a-zA-Z0-9._-]+$')
+for seg in [item.get("ini_slug", ""), item["type"], item["slug"]]:
+    if not _SAFE_SLUG_RE.match(seg):
+        raise ValueError(f"Unsafe segment in dispatched item: {seg!r}; reject binding")
+# Commit filter uses literal resolved paths (not glob expansion of user data) for final
+# intersection: git status output paths are compared against resolved watched_dirs using
+# startswith or os.path.commonpath — not fnmatch or glob.
+# --- Derive watch roots ---
+# Static prefix = longest prefix before the first wildcard; file patterns take parent dir.
+# e.g. "docs/product/shaping/{slug}/**" → format → split("/*")[0] → "docs/product/shaping/my-topic"
+# e.g. "docs/product/intents/{slug}.md" → has "." in final component → parent "docs/product/intents"
+watched_dirs = []
+for pat in output_patterns:
+    formatted = pat.format(slug=item["slug"], ini_slug=item.get("ini_slug", ""))
+    static = formatted.split("/*")[0]
+    if "." in Path(static).name:    # file pattern — monitor the parent dir
+        static = str(Path(static).parent)
+    watched_dirs.append(static)
+# Realpath-resolve and verify containment under repo root for all roots (packs/AGENTS.md security policy).
+# Rejects slugs containing "..", absolute segments, or symlink chains escaping the repo root.
+# Classify by containment under repo root, not by whether the source spelling is absolute.
+# A repo-scope layout may use an absolute output_dir that still resolves inside the repo.
+repo_root_resolved = str(Path(repo_root).resolve())
+# expanduser() MUST precede is_absolute() and resolve():
+# Path("~/vault/research").is_absolute() → False (tilde is not a slash)
+# Path("~/vault/research").resolve() → <cwd>/~/vault/research (wrong)
+# Path("~/vault/research").expanduser().resolve() → /home/user/vault/research (correct)
+resolved_dirs = [str(Path(repo_root / d).expanduser().resolve()) if not Path(d).expanduser().is_absolute() else str(Path(d).expanduser().resolve()) for d in watched_dirs]
+external_output = any(not r.startswith(repo_root_resolved + os.sep) for r in resolved_dirs)
+watched_dirs = resolved_dirs
+if external_output:
+    # At least one pattern resolves outside the repo (e.g. user-scope personal vault).
+    # Cross-workspace ownership risk: the same slug may exist in another repo sharing this vault.
+    # Guards applied before emitting _agentbundle.core/artifact-created for external paths:
+    # 1. Slug membership check — only attribute files whose path contains a slug-qualified component
+    #    (research: fnmatch("*-{slug}", first_component); others: slug in path.parts).
+    # 2. Workspace binding confirmation — if the user-scope layout file contains
+    #    confirmed_workspace_root = <repo_root>, proceed silently; if absent, call
+    #    elicit(message="Output path <path> is outside this repo. Confirm it belongs to this
+    #           workspace?", context={repo_root, resolved_path}, options=["confirm","cancel"])
+    #    BEFORE starting the watcher. If the user cancels, emit bridge-warning
+    #    {reason: "external-output-path"} and do not start the watcher. If confirmed, start the
+    #    watcher and write confirmed_workspace_root = <repo_root> to the user-scope layout file
+    #    so future sessions in this repo skip the elicitation. This uses the existing elicitation
+    #    channel (Component 3) — no new tool or notification is needed; the acknowledgment round-
+    #    trip is the elicitation itself. elicit() is available because the control plane injected
+    #    the session instruction before the first workspace_status() call.
+    # git_commit is always skipped for external paths; _agentbundle.core/skill-complete carries pushed=false, branch=null.
+else:
+    # All paths are within repo root — containment already verified above via startswith check.
+    pass
+# Two snapshots captured at binding time across all watched_dirs (must not be aliased):
+# - session_baseline: immutable; watcher uses this for startup-state comparison only (first poll).
+#   git_commit does NOT use this — it uses `git status --short` for authoritative filtering.
+# - watcher_snapshot: mutable copy; watcher updates this after each notification to deduplicate
+def _snap(dirs):
+    result = {}
+    for d in dirs:
+        result.update({p: (p.stat().st_mtime, p.stat().st_size) for p in Path(d).rglob("*") if p.is_file()} if Path(d).exists() else {})
+    return result
+session_baseline = _snap(watched_dirs)
+watcher_snapshot = dict(session_baseline)   # mutable copy; updated after each emission
+# For research type, watched_dirs = ["{research_base}/"]; fnmatch("*-{slug}", first_path_component) gates attribution.
+# Research watcher is two-phase to avoid scanning the entire vault every 200ms:
+# Phase 1 (slug dir not yet found): shallow-list only research_base/ direct children (depth=1)
+#   watching for a directory matching "*-{slug}" to appear.
+# Phase 2 (slug dir found): switch to recursive polling of the matched date-slug directory only.
+# This scopes expensive recursive stat to only the active project folder once created.
+# For shape type, watched_dirs = ["docs/product/intents", "docs/product/shaping/my-topic"]
+# For design type, watched_dirs = ["docs/design/journeys", "docs/design/blueprints", "docs/design/screens/my-slug", "docs/design/screens"] (screens/ parent for the -flow.md file)
+# Attribution to item_slug uses the dispatched item from session context, not filename heuristics
+```
+
+The watcher uses **unconditional recursive listing** at 200ms — no `inotify`, `fsevents`, or third-party dependency. At binding time the watcher captures two separate snapshots:
+
+- **`session_baseline`** — immutable snapshot `{path: (mtime, size)}` of all files in the watched dir at the moment of binding. Never updated after capture. Used only by the watcher for notification deduplication at startup (first poll compares against `session_baseline` before the first `watcher_snapshot` tick runs). **`git_commit` does NOT use this baseline for filtering.** Instead, `git_commit` runs `git status --short -- <output_pattern_paths>` to determine which files git considers new or modified, then intersects that set with the output_pattern filter. This ensures files that were modified but have the same (mtime, size) as at binding time (coarse-timestamp same-size rewrite) are not silently omitted from commits; git's content identity check is authoritative.
+- **`watcher_snapshot`** — mutable copy of `session_baseline` at binding time. On each 200ms poll, the watcher walks the watched dir at all depths, compares against `watcher_snapshot`, emits `_agentbundle.core/artifact-created` for any file that (a) did not exist in `watcher_snapshot`, or (b) has a different mtime or size than `watcher_snapshot[path]`, then **updates `watcher_snapshot`** with the current stat for each emitted file. This deduplicate mechanism prevents re-emitting the same change on every subsequent poll — each change is notified exactly once.
+
+These two snapshots serve distinct purposes and must not be aliased: `session_baseline` is used only by the watcher for startup-state comparison; `watcher_snapshot` is updated per emission for dedup. `git_commit` uses `git status --short` (not either snapshot) for commit filtering, so it is immune to the coarse-timestamp same-size rewrite case.
+
+**Same-size rewrite limitation (watcher notifications only):** on filesystems with coarse timestamp resolution (HFS+ Classic: 1-second; ext4 default: 1-second), overwriting a file with same-length content within one timestamp tick leaves `(mtime, size)` unchanged in the watcher snapshot — the rewrite is invisible to the watcher, so `_agentbundle.core/artifact-created` is not re-emitted. This affects notifications only; `git_commit` uses `git status` and will include the modified file regardless. A content-hash component (e.g. first 4 KB xxhash) in the watcher snapshot would eliminate the notification ambiguity but adds I/O on every poll. Deferred for Stage 3 validation — if the `place-bet` rewrite case is routinely missed in practice, promote to a fix. The root directory's mtime is not used as a gate — on POSIX/HFS+ a directory's mtime changes only when its direct children change, so a file created at `docs/research/{slug}/subdir/file.md` would not update the root mtime and would be silently missed. For `shape`-type patterns, `item_slug` on `_agentbundle.core/artifact-created` is derived from session context (the dispatched item), not from filename. The `shape` type watches `docs/product/intents/` (parent of `{slug}.md`) and cannot distinguish files from two concurrent same-type items in that parent dir; this is acceptable under the single-session-per-repo invariant in Stages 1–3. The `design` type now uses slug-qualified watched dirs and is not subject to this ambiguity. Stage 4 worktree isolation gives each session its own working tree, making this a non-issue for concurrent runs.
+
+On artifact creation: emits `_agentbundle.core/artifact-created {path, item_slug, item_type, session_id}`. Work-loop items have `output_pattern: null`; their completion signal is the `DONE` FSM event, not the artifact watcher.
+
+### Pressure test: three packs
+
+**desk-research (no FSM, no gate):**
+1. `workspace_status()` → `{shaping: [{ini_slug: "initiative-a", slug: "topic-x", type: "research", dispatch_skill: "desk-research-project-start"}]}`
+2. Control plane sends `session/prompt("desk-research-project-start: topic X")` → AI calls `git_branch("initiative-a/research/topic-x")`
+3. AI runs `desk-research-project-start`, creates `docs/product/research/2026-08-03-topic-x/` (date-prefixed folder, install-default `docs/product/research/` per `pack.toml`); artifact watcher detects new paths matching `*-topic-x/` under `docs/product/research/`; emits `_agentbundle.core/artifact-created` per file
+4. TurnEnd → `git_commit` (includes all files under matched date-slug folder), `git_push`; `_agentbundle.core/skill-complete` emitted; control plane opens PR
+
+**product-engineering / shaping sequence (elicitation variant):**
+1. `workspace_status()` → `{shaping: [{ini_slug: "initiative-a", slug: "initiative-x", type: "shape", dispatch_skill: "frame-intent"}]}`
+2. Control plane sends `session/prompt("frame-intent: initiative X")` → AI calls `git_branch("initiative-a/shape/initiative-x")` (rule 5)
+3. AI runs `frame-intent`, writes `docs/product/intents/initiative-x.md`; watcher emits `_agentbundle.core/artifact-created`
+4. AI continues with `place-bet`, writes `docs/product/shaping/initiative-x/bet.md`; second `_agentbundle.core/artifact-created`
+5. AI would normally ask "Which option do you want to bet on?" — instead calls `elicit(message="Which option?", context={...}, options=["A","B","C"])`
+6. workspace-mcp emits `_agentbundle.core/elicitation-pending`, calls `elicitation/create` on AI host — turn stays open
+7. User selects; response flows back; AI continues to final bet document
+8. TurnEnd → `git_commit` (includes both intents/ and shaping/ files per multi-pattern union), `git_push`; `_agentbundle.core/skill-complete` emitted; control plane opens PR
+
+**experience-design / journey-mapping (no gate):**
+1. `workspace_status()` → `{shaping: [{ini_slug: "initiative-a", slug: "x", type: "design", dispatch_skill: "journey-mapping"}]}`; control plane sends `session/prompt("create journey map for X")`
+2. AI calls `git_branch("initiative-a/design/x")` (rule 5 — type is `design` for XD items)
+3. AI writes `docs/design/journeys/x.md`, `docs/design/blueprints/x.md`, `docs/design/screens/x/`; `_agentbundle.core/artifact-created` emitted per file (slug-scoped patterns only)
+4. TurnEnd → `git_commit`, `git_push`; `_agentbundle.core/skill-complete` emitted; control plane opens PR via its own platform integration
+5. Design review gate, if needed, runs as a separate session
+
+All three patterns use the same control plane logic: watch for `_agentbundle.core/artifact-created`, handle any `_agentbundle.core/human-gate-pending` via `elicit()` correlation, send a commit/push `session/prompt` at turn end (AI branches before writing per rule 5, commits and pushes per rule 6), then a PR-creation `session/prompt` on `_agentbundle.core/skill-complete`. No per-pack branching in the control plane.
+
+## Alternatives Considered
+
+### Option A — Per-skill gate_request modification
+
+Each gate-capable skill (work-loop, new-spec, place-bet) checks if a `gate_request` tool is available and calls it at decision points; all other communication remains text.
+
+**Why not chosen:** The user is right that this is too narrow — it covers declared gate states but not the many informal elicitations every skill makes (clarifying questions, option selection, preference gathering). Covering all of these via per-skill modification is the same problem as the session instruction, but multiplied across every skill, indefinitely. The session instruction is strictly less coupling.
+
+**When session/prompt injection is correct (fallback):** For adapters that support neither `elicitation/create` nor the response-file fallback, the control plane falls back to sending `session/prompt` with the gate decision as text. The AI receives it in context and continues. This is best-effort — not the primary path.
+
+### Call-chain proxy — workspace-mcp wraps loop-engine as MCP tools
+
+The AI calls `loop_engine_transition` as an MCP tool rather than the CLI. The server holds event data synchronously; no events.jsonl needed.
+
+**Why not chosen:** The work-loop skill would need to detect MCP tool availability on every transition call and change its call pattern. The skill becomes adapter-aware at the call level, not just at the gate level. Desk-research, PE, and XD skills don't use loop-engine at all — the approach only solves work-loop and still requires artifact watching for everything else. Two-surface complexity for a subset gain.
+
+### Persistent watcher process (non-MCP)
+
+A standalone process tails events.jsonl and emits ACP notifications. No MCP server.
+
+**Why not chosen:** No standard injection path into a session, no `workspace_status` tool, no `elicit`, no git lifecycle surface. One-way emitter only. Violates the single-component principle; two processes where one does the same job more completely.
+
+## Risks
+
+- **events.jsonl write failure.** If loop-engine cannot write to `.loop-run/events.jsonl` (permissions, sandbox, disk full), workspace-mcp receives no events and the control plane sees no state changes. **Mitigation:** workspace-mcp emits `_agentbundle.core/bridge-warning {reason: "no-events-after-30s"}` if events are expected but do not arrive within the configured window.
+
+- **ADR-0061 scope creep into a daemon.** Control plane operators may want `workspace-mcp` running across sessions for workspace discovery. **Mitigation:** persistent mode requires an RFC amendment before any implementation. The per-session exit is enforced in code.
+
+- **Codex elicitation/create not supported.** `codex-acp` does not list `elicitation/create` as a feature. The response-file fallback must be validated in Stage 2a. If polling the response file introduces unacceptable latency or race conditions, the fallback degrades further to `session/prompt` injection (best-effort). **Mitigation:** Stage 2a runs the elicitation scenario on Codex and documents the actual behavior before Stage 3 depends on it.
+
+- **Capability declaration bug in claude-agent-acp.** A known open bug (issue #419) in `claude-agent-acp` breaks MCP tool discovery at initialization if `elicitation` capability is declared but the host does not support the corresponding `elicitation/create` call. The failure is at init — not at the call site — so a try/except at `elicitation/create` is too late. **Mitigation:** workspace-mcp checks host capabilities during the MCP init handshake; if `elicitation` is absent, omit it from workspace-mcp's own init response and use the response-file fallback. Validated in Stage 1.
+
+- **Kiro CLI Class B — V3 agent format required.** Kiro CLI reads MCP config from `{cwd}/.kiro/settings/mcp.json` by design; it does not honour `session/new.mcpServers`. This is a deliberate Class B architectural choice, not a workaround. V2 JSON agents (`.kiro/agents/*.json`) do not receive MCP tools in the LLM tool list (bug #5873, open, V2-specific); V3 Markdown agents with `@mcp` tag address this. If an adopter's Kiro CLI version predates V3 (introduced v2.8.0, June 2026) workspace-mcp is unavailable. **Mitigation:** document V3 as a prerequisite; `workspace-mcp` is not advertised in the Class B setup guide for earlier versions.
+
+- **Background polling and `elicit` blocking in a synchronous MCP stdio server.** The event bridge and artifact watcher run on background threads — the MCP request handler is never blocked by polling. However, `elicit` is itself a blocking tool call: the handler must block until the AI host responds to the nested `elicitation/create` server→client request (or until the response file appears). A single-threaded handler cannot service the nested response while blocked. **Mitigation:** workspace-mcp dispatches each tool call to a bounded worker-thread pool; the main stdio loop continues reading MCP messages (including the `elicitation/create` response) while the `elicit` worker waits. Shared stdout is guarded by a write lock; the main loop maintains a `{request_id: Event/queue}` map to route responses to waiting workers without interleaving frames. See Decision 7.
+
+- **Copilot CLI global tool filtering.** Copilot CLI's tool availability is per-server-instance. Multiple concurrent sessions sharing one workspace-mcp instance may not see consistent tool sets. **Mitigation:** Stage 2b confirms whether one-instance-per-session is required; Stage 4 worktree isolation naturally provides it.
+
+- **Orphaned .loop-run/ directories.** Session crash leaves `.loop-run/` uncommitted. **Mitigation:** gitignored, harmless, cleared by `loop-engine reset`. Accepted residual risk.
+
+- **Response-file fallback residual injection risk.** Even with `O_EXCL` creation and `mkdtemp()` isolation, a process running as the same OS user can still inject a response by racing `O_EXCL` creation before workspace-mcp does (at session start). Additionally, the control plane must use the temp-and-rename protocol described in Component 3 to ensure workspace-mcp never reads a partial response file. The response-file fallback is used only for adapters that do not support `elicitation/create`; when `elicitation/create` is available it is the primary path. **Mitigation:** prefer `elicitation/create`; use the response-file fallback only as a last resort on known-incapable adapters (Codex, Kiro CLI). Document that the response-file path is not a secure gate for multi-user or shared-machine deployments.
+
+- **Session instruction compliance is prompt-following, not enforced.** The AI may not always call `elicit` when it should — particularly for very short one-word responses ("sure", "yes"). The control plane will miss those elicitations. **Mitigation:** Accepted for short responses; the instruction is strongest for questions with options or structured decisions. Long-term, this could be tightened via Claude Code system-prompt enforcement if Claude Code exposes that surface.
+
+## Rollout
+
+**Stage 0 — Spikes (gate before Stage 1 build).**
+(a) *Instruction durability spike:* confirm whether ACP `session/new` exposes a `systemPrompt`/`instruction` field that survives across turns, or whether the control plane must re-inject the preamble on each `session/prompt`. Document the confirmed behaviour; update Component 3 and the session instruction accordingly.
+(b) *Notification naming spike:* **CLOSED** — `x-core/` is NOT the ACP convention; observed form is `_<namespace>/method` (e.g. `_claude/sdkMessage` in `claude-agent-acp@0.64.0`). Renamed to `_agentbundle.core/` throughout. ADR-0068 updated.
+(c) *Notification relay spike:* **CLOSED (fallback)** — MCP `notifications/message` frames are NOT relayed by `claude-agent-acp@0.64.0` (`case "notification": break` with TODO comment). Fallback adopted: control plane polls `workspace_status()` to observe FSM state; `workspace_status()` response extended to include `current_state`, `gate_pending`, `gate_question`, and `review_findings`. Notification definitions remain as the target contract for when relay support ships in claude-agent-acp.
+(d) *Charter/RFC gate:* shipping executable runtime code in the core pack requires an RFC decision under `docs/CHARTER.md` — the charter distinguishes "habit" primitives (skills, agents) from infrastructure (persistent services, new deployment targets). This design doc is the precursor artifact; Stage 0 produces a companion RFC (`docs/rfc/NNNN-workspace-mcp.md`). Stage 1 does not start until the RFC is accepted. Alternatively, if the RFC review routes the runtime to a standalone package outside core, update this design accordingly before Stage 1 begins.
+(e) *Module-mode spawn spike:* confirm that `python3 -I -m agentbundle.workspace_mcp` (the trusted-spawn path for untrusted/CI contexts — see Class A injection section) accepts the same env vars (`WORKSPACE_MCP_SPEC_PATH`, `WORKSPACE_MCP_DISPATCHED_ITEM`), performs the same MCP stdio handshake, and exposes the same tool surface as the projected script. Confirm the module entry point is installed by `pip install agentbundle`. Update the install guide to specify when module mode is required.
+Rollback: Stage 1 does not start until all five spikes close.
+
+**Stage 1 — Single adapter (Claude Code), work-loop, single session.**
+
+*Headless permission prerequisite.* In an unattended session, Claude Code prompts for MCP tool approval before calling each workspace-mcp tool (`workspace_status`, `elicit`, `git_commit`, etc.). A prompt with no human present hangs the session. Claude Code reads `permissions.allow` from `.claude/settings.json` at startup — the MCP server startup and session hooks run after that and cannot retroactively expand permissions for the current session.
+
+**The pack install step must handle this — but requires a new agentbundle projection capability (Stage 1 prerequisite).** The current agentbundle Claude adapter projection only merges the managed `hooks` key into `.claude/settings.local.json`; no current projection target can additively merge `permissions.allow` into `.claude/settings.json` (`packages/agentbundle/agentbundle/_data/adapter.toml`). A new additive-merge projection target for `permissions.allow` must be added to the agentbundle Claude adapter, with tests and a version bump per `packages/AGENTS.md`, before unattended Stage 1 sessions can run without hanging. Until this lands, adopters must add the entries manually or pass `--dangerously-skip-permissions`.
+
+When the new projection lands, `agentbundle install core` will perform an additive merge of these entries into `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__workspace-mcp__workspace_status",
+      "mcp__workspace-mcp__elicit",
+      "mcp__workspace-mcp__git_status",
+      "mcp__workspace-mcp__git_branch",
+      "mcp__workspace-mcp__git_commit",
+      "mcp__workspace-mcp__git_push"
+    ]
+  }
+}
+```
+
+This is additive — existing adopter permissions are preserved. For Kiro CLI (Class B), no per-tool allow-list is needed: the V3 `@mcp` tag grants all `mcp.json` tools, which is expected to bypass interactive approval in headless mode (confirmed in Stage 2c). For CI environments where permissions are not a concern, `--dangerously-skip-permissions` is also acceptable but not the recommended org default.
+
+Build: `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py` (event bridge + `workspace_status` + `elicit` + git tools; co-located with `workspace_status_engine.py`), loop-engine events.jsonl append (repo root, `run_id` filtered), session instruction with work-loop. Validate: FSM transition visibility with zero missed events (including rapid back-to-back transitions and torn-write recovery on partial last line), elicitation intercept at gate states, git commit and push via tools, FSM state observability via `workspace_status()` polling (spike (c) fallback — notification relay not available in claude-agent-acp 0.64.0). Validate capability-declaration bug fix (issue #419). Note: artifact creation detection is a build-only smoke test at this stage; real validation deferred to Stage 3 (first skill with a non-null `output_pattern`).
+
+**Stage 2a — Codex CLI.**
+Same scenarios on Codex. Validate `session/new.mcpServers` injection and elicitation response-file fallback. Document Codex's equivalent of `permissions.allow` for pre-approving workspace-mcp tools in headless mode. Document actual behavior of `elicit` on Codex before Stage 3 depends on elicitation for non-FSM skills.
+
+**Stage 2b — Copilot CLI.**
+Validate `session/new.mcpServers` injection, Copilot's global tool filtering (one instance per session may be required), Copilot's `elicitation/create` support (flagged as "unconfirmed" in Context), and Copilot's MCP tool pre-approval mechanism for headless mode.
+
+**Stage 2c — Kiro CLI (Class B).**
+**Prerequisite:** the `kiro-cli` adapter in `adapter.toml` currently projects agents as `.kiro/agents/*.json` in V1.0 JSON format. Class B requires V3 Markdown agents (with `@mcp` tag) that workspace-mcp's session instruction can be embedded in. Before Stage 2c can proceed, the `kiro-cli` adapter projection must be updated to emit V3 Markdown agents (or a new `kiro-cli-v3` adapter added). This is an adapter work item; Stage 2c cannot start until it ships. Validate `.kiro/settings/mcp.json` pre-config, V3 agent format + `@mcp` tag, and the `_kiro.dev/mcp/server_initialized` readiness signal. Validate `elicitation/create` support (likely falls back to response-file; confirm). Document Kiro CLI's tool pre-approval story — V3 `@mcp` tag grants all `mcp.json` tools, so no per-tool allow-list is needed; confirm this bypasses interactive approval in headless mode.
+
+**Stage 3 — Non-FSM skills (desk-research, PE, XD).**
+Artifact watcher active (manifest-derived output dirs, recursive listing snapshot diff every 200ms), session instruction used for desk-research clarifying questions and PE option-selection. Validate the three pressure-test scenarios above.
+
+**Stage 4 — Multi-instance, worktrees, convergence (separate scope).**
+`git_worktree_create/cleanup`. Convergence is a control-plane concern; it reads workspace.toml `needs:` edges. Not in scope for this doc.
+
+## ADR-worthy decisions
+
+Seven decisions in this doc warrant ADR capture — they are non-obvious, revisable, and have real alternatives:
+
+1. **Session instruction over per-skill gate modification** — elicitation interception is injected once at session start; no skill is modified. Alternatives: per-skill `gate_request` tool checks (covered under Alternatives Considered), or a hook in the AI runtime.
+
+2. **events.jsonl as event source** — append-only ephemeral file tailed by workspace-mcp with position-based reads. Alternative: loop-engine emits events over an in-process IPC channel; ruled out because it makes loop-engine adapter-aware.
+
+3. **elicit() tool + elicitation/create (MCP server→client) + response-file fallback** — workspace-mcp implements both paths; falls back from the MCP channel to file-polling per adapter capability. Alternatives: webhook, SSE, or per-adapter branching in skills.
+
+4. **Reactive git at TurnEnd** — harness calls `git_status()` after TurnEnd and commits any uncommitted artifacts; no `git_managed` declaration in the lifecycle manifest. Alternative: declarative `git_managed` flag per type with pre-committed semantics.
+
+5. **Lifecycle manifest — built-in defaults + workspace-types.d/** — pack.toml is source-only and cannot carry the manifest. Built-in defaults for the known type taxonomy are embedded in workspace-mcp; third-party packs project files to `workspace-types.d/` to extend without clobbering each other. Alternative: manifest in a projected pack artifact (no viable location given pack.toml constraint).
+
+6. **Notification namespace** — **CLOSED** by Stage 0 spike (b). `_agentbundle.core/` is the confirmed form, consistent with the observed `_claude/sdkMessage` convention in `claude-agent-acp@0.64.0`.
+
+7. **Threading model for polling loops and blocking tool calls** — event bridge and artifact watcher run on Python daemon threads (main handler never blocked by polling). `elicit` and any other blocking tool calls are dispatched to a bounded worker-thread pool (pool size: 4 — per-session spawn means each instance serves one client; pool > 1 handles nested `elicitation/create` re-entrancy where the response arrives on a separate read-loop iteration while the original `elicit` worker is blocked waiting); main stdio loop keeps reading and dispatching while workers wait. Shared stdout is guarded by a single write lock; main loop maintains a `{request_id: Event/queue}` map to route incoming MCP responses to the correct waiting worker. On session end, outstanding `elicit` workers are cancelled via a shutdown event; response-file polling checks for cancellation on each cycle. Alternative: asyncio (async throughout — more complex for pure-stdlib); cooperative poll in request handler (blocks tool calls, deadlocks on nested `elicitation/create`).
+
+## Open Questions
+
+- **Kiro CLI `session/new.mcpServers` vs. Class A.** If Kiro CLI V4+ adds `session/new.mcpServers` support, it would move to Class A with no config required. Monitor Kiro CLI changelog. *(No action needed before Stage 2c)*
+
+---
+
+*Closed questions:*
+
+- ~~workspace-mcp server install location~~ — **Decision: co-locate with `workspace_status_engine.py` in the workspace-status scripts folder** (`packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py`). The server imports the engine via relative path; no new projection convention needed. Pack install will add workspace-mcp tool entries to `permissions.allow` in `.claude/settings.json` once the agentbundle Claude adapter gains a new additive-merge projection target for that key (Stage 1 prerequisite — see Rollout); until then adopters add entries manually. The control plane injects the server per session via `session/new.mcpServers`; `.claude/settings.json` carries only the pre-approval, not a static server registration. For Class B, pack install registers `.kiro/skills/workspace-status/scripts/workspace_mcp_server.py` in `.kiro/settings/mcp.json` — the `kiro-cli` adapter projects skills to `.kiro/skills/`, not `.agents/skills/`. MCP stdio transport means no port binding and no collision between concurrent sessions. (2026-08-03)
+
+- ~~shaping_queue in workspace_status()~~ — **Decision: include shaping items.** `workspace_status()` returns a `shaping` key alongside `ready`, `blocked`, and `active`. This lets the control plane dispatch any skill from a single call without prior knowledge of the repo's queue shape. (2026-08-03)
+
+*(desk-research closed, 2026-08-03):*
+
+- ~~Kiro CLI Class A~~ — Not viable for Class A; Kiro CLI reads MCP config from `{cwd}/.kiro/settings/mcp.json` by design, not from `session/new.mcpServers`. Intentionally Class B. V3 Markdown agent format + `@mcp` tag addresses MCP tool injection (bug #5873 is V2-only). ACP was built by Zed (JetBrains co-developed); Kiro adopted it later.
+- ~~Codex elicitation/create~~ — `codex-acp` does not support `elicitation/create`. The `autoResolutionMs` field exists in Codex CLI core (PR #27256) but the client-side timer is not yet implemented; no auto-resolution is enforced. Response-file fallback is the correct path for Codex.
+- ~~elicitation/create: ACP vs MCP~~ — `elicitation/create` is MCP-native (MCP 2025-06-18). ACP v1 adapts it from MCP. workspace-mcp calls it in MCP server→client direction; the AI host bridges it through the ACP adapter.

--- a/docs/rfc/0078-notes/codex-review-conclusions.md
+++ b/docs/rfc/0078-notes/codex-review-conclusions.md
@@ -1,0 +1,64 @@
+# RFC-0078 notes — Codex design-doc review conclusions
+
+This file records the distilled conclusions from the eight-round Codex CLI
+adversarial review of `docs/architecture/workspace-mcp/design.md` (branch
+`eugene/acp-core-pack-loop-trigger`). It is the closest available de-risk
+evidence for RFC-0078; it is not a substitute for running Stage 0 spikes.
+
+## Review summary
+
+- **Rounds:** 8 (C1–C8), run against base branch `main`
+- **Model:** `gpt-5.6-sol` via `codex review -c model="gpt-5.6-sol"`
+- **Convergence:** Round 8 returned **zero P1 findings**
+
+## Substantive design issues resolved
+
+| Round | Finding | Resolution |
+| ----- | ------- | ---------- |
+| C6 | Trusted spawn: no `-I` flag; checkout could shadow installed wheel | Added `-I` to all spawn examples; Module-mode spawn spike (d) added |
+| C6 | FSM gate scoping via branch-name parsing (fragile) | Changed to `WORKSPACE_MCP_SPEC_PATH` env var for gate scan |
+| C6 | Outbox pattern: unconditional replay on startup → phantom events if crash before state write | Added 5-step recovery protocol: verify `pending.to == engine-state.json.state` before replay |
+| C6 | `elicit` blocked stdio loop; nested `elicitation/create` response never read | Bounded worker-thread pool model documented; main stdio loop never blocked |
+| C6 | Deferred watcher binding: only research types deferred | Extended deferred binding to ALL non-FSM types (all have first-run layout elicitation) |
+| C6 | `expanduser()` called after `is_absolute()`; `~`-paths fail | Fixed ordering: `expanduser()` before `is_absolute()` and `resolve()` |
+| C7 | Response-file race: control plane write not atomic | Added temp+rename atomicity requirement for response file |
+| C7 | Pack-presence filter: wrong lookup roots | Added 6 roots (3 adapters × repo+user), OR logic, returns `available: false` |
+| C7 | Research watcher rescans entire vault on each 200ms poll | Two-phase watcher: shallow-list until slug dir appears, then recursive on slug dir only |
+| C8 | Slug safety: `{slug}` formatted into glob patterns without validation | `_SAFE_SLUG_RE = re.compile(r'^[a-zA-Z0-9._-]+')` guard before formatting |
+
+## P2s resolved
+
+| Round | Finding | Resolution |
+| ----- | ------- | ---------- |
+| C7 | External output path acknowledgment missing | `elicit()` called to confirm before watcher starts; `confirmed_workspace_root` written on confirmation |
+| C8 | Two-phase research watcher not documented | Documented Phase 1 (shallow) / Phase 2 (recursive on matched dir) |
+
+## Residual P2s (accepted, not resolved)
+
+| Round | Finding | Rationale |
+| ----- | ------- | --------- |
+| C7 | `run_id` file inode/truncation detection alongside offset reset | Design doc already addresses this in Component 1; P2 was a clarification request, not a missing feature |
+
+## Design quality evidence
+
+The eight rounds collectively surfaced and closed ten P1 findings across:
+trusted-spawn security, FSM gate scoping, outbox crash-consistency, threading
+model, watcher binding, path expansion ordering, response-file atomicity,
+pack-presence filtering, research watcher performance, and slug injection safety.
+
+None of the P1 issues require changes to the RFC's charter-level decisions
+(D1/D2). They are design-level issues now addressed in `design.md`. The review
+log confirms the design doc is internally consistent at the P1 level.
+
+## What this evidence does NOT cover
+
+Spike lettering matches RFC-0078 § Stage 0 spikes:
+
+- Spike (a): whether instruction durability holds in production AI hosts
+- Spike (b): whether `x-core/` is the correct ACP v1 notification namespace
+- Spike (c): whether MCP `notifications/message` frames reach the control plane as `session/update` events
+- Spike (d): whether `python3 -I -m agentbundle.workspace_mcp` is installed and accepts the required env vars
+- Spike (e): whether stdlib daemon threads + bounded worker pool handle `elicit()` MCP stdio concurrency (nested `elicitation/create` re-entrancy included)
+- Whether `session/new.mcpServers` is honored in production Class A AI hosts
+- Whether the `permissions.allow` additive-merge projection can be added
+  to the agentbundle Claude adapter without a breaking contract change

--- a/docs/rfc/0078-notes/spike-results.md
+++ b/docs/rfc/0078-notes/spike-results.md
@@ -1,0 +1,160 @@
+# RFC-0078 — Stage 0 spike results
+
+**Completed:** 2026-08-03  
+**Method:** Code analysis of `@agentclientprotocol/claude-agent-acp@0.64.0` (npm cached) + direct empirical tests
+
+---
+
+## Spike (a) — Instruction durability
+
+**Gate question:** Does `session/new` instruction survive across turns in at least one production AI host?
+
+**Result: PASS — instruction persists across turns.**
+
+**Evidence (source analysis):**
+
+In `claude-agent-acp@0.64.0` (`dist/acp-agent.js`, line 4082–4099):
+
+```js
+let systemPrompt = { type: "preset", preset: "claude_code" };
+if (params._meta?.systemPrompt) {
+    const customPrompt = params._meta.systemPrompt;
+    if (typeof customPrompt === "string") {
+        systemPrompt = customPrompt;
+    } else if (...) {
+        systemPrompt = { ...customPrompt, type: "preset", preset: "claude_code" };
+    }
+}
+// ... later:
+const options = { systemPrompt, ... };
+// options is passed to the SDK query() at session creation
+```
+
+The `systemPrompt` is set once at `session/new` time and passed to the Claude Agent SDK `query()` call. The SDK `query()` is a long-running process that handles all turns within the session — it is not restarted per `session/prompt`. Therefore the instruction baked into `systemPrompt` persists for the session's lifetime.
+
+**Design implication:** The control plane can inject the workspace-mcp session instruction via `session/new` params as `_meta.systemPrompt` (as a string, or as an object with `append` option to append to the `claude_code` preset). No per-turn re-injection is needed. Update Component 3 to reflect this: single `session/new` injection is sufficient; the per-turn fallback described in the design doc is not required for Claude Code.
+
+---
+
+## Spike (b) — Notification naming
+
+**Gate question:** Is `x-core/` the confirmed ACP v1 extension namespace?
+
+**Result: FAIL — `x-core/` does not follow the observed ACP extension naming convention; rename required.**
+
+**Evidence (source analysis):**
+
+The only custom (extension) notification seen in `claude-agent-acp@0.64.0` uses the method `_claude/sdkMessage` (line 1509). The ACP SDK's `methods` object (inspected via `node -e`) shows standard methods like `session/update`, `elicitation/create` — no `x-core/` prefix appears anywhere.
+
+The observed convention is `_<namespace>/method` — an underscore-prefixed reverse-domain path, not `x-core/`. The design doc already anticipated this: "may rename to `_agentbundle.core/...` or the spec-compliant form."
+
+**Design implication — action required before Stage 1:** Rename `x-core/` to `_agentbundle.core/` (or confirm the correct extension form from the ACP v1 spec). Update ADR-0068, the design doc, the spec, and the plan. All `x-core/*` notification names in the codebase must use the confirmed form before Stage 1 begins.
+
+**Recommended rename:** `_agentbundle.core/skill-state-change`, `_agentbundle.core/human-gate-pending`, `_agentbundle.core/elicitation-pending`, `_agentbundle.core/bridge-warning`.
+
+---
+
+## Spike (c) — Notification relay
+
+**Gate question:** Do `notifications/message` frames reach the control plane as `session/update` events?
+
+**Result: FAIL — MCP `notifications/message` from workspace-mcp are NOT relayed to the ACP control plane in the current adapter.**
+
+**Evidence (source analysis):**
+
+`claude-agent-acp@0.64.0` (`dist/acp-agent.js`) handles SDK event types in a large switch statement. The MCP-related cases are:
+- `case "mcp_tool_use"` (line 5652) — handled: surfaces tool call to ACP client
+- `case "mcp_tool_result"` (line 5746) — handled: surfaces tool result to ACP client
+- `case "notification"` (line 2003) — **not handled: `break` with `// Todo: process via status api` comment**
+
+There is no `case "mcp_notification"` or any handler that would forward MCP server-sent `notifications/message` frames from workspace-mcp to the ACP control plane. The `extNotification` wrapper exists (line 494) and could forward any method string to the client, but it is only called internally for `_claude/sdkMessage` — it is not wired to MCP server notifications.
+
+**Design implication — this spike blocks Stage 1 as currently specified.** The design spec states "All `x-core/*` notifications flow from workspace-mcp to the ACP adapter as MCP `notifications/message` frames." This relay path does not exist in claude-agent-acp 0.64.0.
+
+**Fallback design (required before Stage 1):** The design doc already names the fallback: the control plane polls `workspace_status()` instead of receiving push notifications. Specifically:
+
+- Replace push notifications with pull: control plane calls `workspace_status()` on a configurable interval (suggested: 500ms–2s during active sessions) to track FSM state and queue state
+- Remove `x-core/skill-state-change` and `x-core/human-gate-pending` from the Stage 1 surface; or defer them to a stage where MCP notification relay is confirmed available
+- The `_EventBridge` component (Component 1) and its 200ms poll loop remain useful for generating the workspace-mcp-internal state — but the delivery path changes from push-via-MCP-notification to pull-via-tool-response
+- `elicitation/create` relay is separate from `notifications/message` relay: the adapter explicitly handles elicitation (lines 3608–3661) via `onElicitation` callback, so elicitation intercept still works
+
+**Alternative fallback:** File a feature request with the ACP SDK maintainers to expose MCP server `notifications/message` frames through the SDK event stream (a `case "mcp_notification"` handler), then defer Stage 1 until the feature ships. Given the adapter is open-source (Apache-2.0), a PR could be filed to claude-agent-acp to add this case.
+
+---
+
+## Spike (d) — Module-mode spawn
+
+**Gate question:** Does `python3 -I -m agentbundle.workspace_mcp` install and work?
+
+**Result: PASS — module-mode spawn mechanism confirmed.**
+
+**Evidence (direct test):**
+
+```
+$ python3 -I -c "import agentbundle; print(agentbundle.__version__)"
+0.27.1   # installed package, not repo-local shadow
+
+$ python3 -I -c "from agentbundle import cli; print('submodule import ok')"
+submodule import ok
+
+# Isolation proof: with a shadowed agentbundle/ in cwd,
+# without -I: "ERROR: shadowed agentbundle loaded from repo checkout!"
+# with    -I: "installed: 0.27.1"
+```
+
+Key findings:
+- agentbundle 0.27.1 is installed as a site-packages package (not editable from this repo's checkout)
+- `python3 -I` correctly prevents a repo-local `agentbundle/` directory from shadowing the installed wheel
+- Submodule import (`from agentbundle import <submodule>`) works under `-I`
+- The env vars `WORKSPACE_MCP_SPEC_PATH` and `WORKSPACE_MCP_DISPATCHED_ITEM` are correctly received by the module
+- `cwd` is NOT in `sys.path` under `-I` (repo root cannot inject modules)
+- Note: editable-install `.pth` files (e.g. `__editable__.graphrag_aws_demo-0.1.0.pth`) add their paths to `sys.path` even under `-I` — this is expected behavior and does not affect the security goal (the attack vector is repo-local code, not unrelated editable packages)
+
+**Design implication:** Stage 1 can proceed with `python3 -I -m agentbundle.workspace_mcp` as the module entry point. The install guide must specify `-I` as non-negotiable for CI/headless contexts. The entry point requires `workspace_mcp.py` to have a `if __name__ == "__main__": main()` block (standard module invocation pattern).
+
+---
+
+## Spike (e) — Threading model
+
+**Gate question:** Does Python stdlib daemon threads + bounded worker-thread pool (pool size 4) handle `elicit()`'s blocking `elicitation/create` call under real MCP stdio concurrency — specifically, nested re-entrancy where the response arrives on a separate read-loop iteration while the worker is blocked waiting?
+
+**Result: PASS — no deadlock; nested re-entrancy handled correctly.**
+
+**Evidence (direct test):**
+
+```
+pending_responses after run: {}
+pending_elicitations after run: {}
+PASS: daemon threads + bounded pool (size=4) handle nested elicitation/create re-entrancy
+  - Main loop never blocked by worker wait
+  - Two concurrent elicitations both resolved without deadlock
+  - Response routing via request_id map worked correctly
+```
+
+The test confirmed:
+1. Main loop thread (daemon) keeps reading while an `elicit` worker is blocked on `Event.wait()`
+2. Main loop receives the `elicitation_response` message and routes it to the waiting worker via the `{request_id: Event}` map
+3. Worker unblocks and returns the response
+4. Two concurrent elicitations (requests `elicit-2` and `elicit-3`) both resolved without interfering with each other
+5. All `pending_elicitations` entries cleared after responses arrived — no orphaned blocked workers
+
+**Design implication:** The threading model is sound for the described re-entrancy scenario. Pool size 4 is sufficient for one active elicitation plus background workers. The `{request_id: Event}` map pattern (from design.md Decision 7) correctly handles concurrent elicitations. The asyncio rewrite contingency (plan risk) does not apply.
+
+---
+
+## Summary
+
+| Spike | Result | Gate passes? | Action required |
+| ----- | ------ | ------------ | --------------- |
+| (a) Instruction durability | PASS | ✓ | Update Component 3 docs: single `session/new` injection via `_meta.systemPrompt` is sufficient |
+| (b) Notification naming | FAIL | ✗ | Rename `x-core/` → `_agentbundle.core/` across all artifacts; update ADR-0068 |
+| (c) Notification relay | FAIL | ✗ | Design fallback (poll-based via `workspace_status()`) before Stage 1; or file claude-agent-acp feature request |
+| (d) Module-mode spawn | PASS | ✓ | No action; proceed with `python3 -I -m agentbundle.workspace_mcp` |
+| (e) Threading model | PASS | ✓ | No action; daemon threads + bounded pool design confirmed |
+
+**Stage 0 is NOT fully clear.** Spikes (b) and (c) require design decisions before Stage 1 begins:
+
+1. **(b)** Rename all notification method strings from `x-core/*` to `_agentbundle.core/*` (or the confirmed ACP extension form) across spec, plan, ADR-0068, design doc, and all code.
+2. **(c)** Either (a) design and spec a poll-based fallback replacing push notifications, or (b) file and wait for a claude-agent-acp feature that relays MCP `notifications/message` frames to ACP clients.
+
+Spike (c) failure is the more significant blocker — it affects the core observability design. The poll-based fallback (`workspace_status()`) is already named in the design doc as the fallback path.

--- a/docs/rfc/0078-workspace-mcp.md
+++ b/docs/rfc/0078-workspace-mcp.md
@@ -1,0 +1,478 @@
+# RFC-0078: workspace-mcp — ACP-observable skill runtime for the core pack
+
+<!-- Written for a cold reader. Glossary: "workspace-mcp" = an optional MCP
+server (Model Context Protocol server) that bridges loop-engine FSM events,
+workspace queue state, and git lifecycle to ACP-compliant AI orchestrators.
+"ACP" = Agent Communication Protocol — the open protocol Conductor and Zed use
+to dispatch AI coding agents. "Core pack" = packs/core, the default skill pack
+shipped to all adopters. "Loop-engine" = the CLI state machine at
+scripts/loop-engine.py that drives work-loop's 10-state FSM.
+"Class A adapter" = AI host that honours `session/new.mcpServers` injection
+(Claude Code, Codex CLI, Copilot CLI); workspace-mcp is injected per session.
+"Class B adapter" = AI host that reads MCP config from a repo-local file instead
+of accepting per-session injection (Kiro CLI); workspace-mcp is pre-configured.
+The detailed design is in docs/architecture/workspace-mcp/design.md.
+The design-doc Codex review conclusions are in docs/rfc/0078-notes/. -->
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-03
+- **Date closed:** 2026-08-03
+- **Decision weight:** heavy <!-- Crosses the charter's "habit, not a tool"
+  principle boundary; adds a new runtime component; the permissions.allow
+  projection it depends on is a one-way-door change to the agentbundle Claude
+  adapter contract. -->
+- **Related:**
+  - [docs/architecture/workspace-mcp/design.md](../architecture/workspace-mcp/design.md) (precursor design doc; this RFC is the charter gate described in Rollout § Stage 0 (d))
+  - [ADR-0061](../adr/0061-loop-infrastructure-phase-1.md) (loop-infrastructure phase 1 — related prior art, not the daemon constraint)
+  - ADR-0062 (to be authored after acceptance: "workspace-mcp per-session-only constraint")
+
+---
+
+## Reviewer brief
+
+- **Decision:** Whether to ship workspace-mcp — a per-session MCP server that
+  bridges loop-engine FSM events, workspace queue state, and git lifecycle to ACP
+  control planes — as a component of the core pack (D1), and whether to approve
+  the five empirical Stage 0 spikes as the mandatory gate before Stage 1
+  implementation begins (D2).
+- **Recommended outcome:** Accept D1 (ship in core pack, co-located with
+  workspace-status scripts; module canonical home in agentbundle package) and D2
+  (approve the five empirical spikes; do not start Stage 1 until all five close).
+- **Change if accepted:**
+  - `packages/agentbundle/agentbundle/workspace_mcp.py` — new module (pure stdlib
+    Python 3.11+; no new runtime dependencies); installable as
+    `python3 -I -m agentbundle.workspace_mcp` for untrusted/CI spawn.
+  - `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py`
+    — thin alias that invokes the agentbundle module; for trusted path-based spawn.
+  - `packages/agentbundle/agentbundle/_data/adapter.toml` — new additive-merge
+    projection target for `permissions.allow` in `.claude/settings.json` (Stage 1
+    prerequisite for Claude Code headless sessions; requires agentbundle version bump
+    + `Engine-Change-RFC: RFC-0078` footer). **Note:** this is authorized by D1 only
+    if the additive-merge can be implemented without a breaking adapter-contract change;
+    if it cannot, a follow-on RFC must authorize the contract change before Stage 1 starts.
+    Equivalent headless-permission mechanisms for Codex CLI and Copilot CLI are
+    discovered and documented in Stages 2a and 2b respectively (see Rollout table).
+  - `docs/architecture/workspace-mcp/design.md` — status updated from Draft to
+    Accepted once spikes close and implementation begins.
+  - ADR-0062 authored: "workspace-mcp per-session-only constraint."
+- **Affected surfaces:** core pack (new script), agentbundle Claude adapter (new
+  projection target if non-breaking), `.claude/settings.json` for adopters
+  (additive `permissions.allow` entries injected on `agentbundle install core`).
+- **Stakes:** Costly-to-reverse once adopters have `permissions.allow` entries
+  injected. The `permissions.allow` projection is the one-way-door element.
+- **Review focus:** D1 — does shipping an MCP server in core satisfy the charter's
+  Principle 1 ("universal") and Principle 3 ("habit, not a tool"), or should
+  workspace-mcp route to Option 2 (agentbundle-only, no core-pack alias)? D2 — are
+  the five empirical spikes sufficient to de-risk Stage 1?
+- **Not in scope:** Persistent daemon mode (per-session-only constraint is a design
+  requirement of this RFC; ADR-0062 will capture it); convergence orchestration
+  (Stage 4); Gemini CLI and OpenCode (deferred); Jira/Linear write-back; the seven
+  implementation-level architectural decisions in design.md § ADR-worthy decisions
+  (each becomes an ADR after this RFC is accepted).
+
+---
+
+## The ask
+
+**Recommendation (BLUF):** Accept workspace-mcp as an optional core-pack component,
+ship it after all five empirical Stage 0 spikes close, and authorize the additive-merge
+permissions.allow projection for the agentbundle Claude adapter (subject to it being
+implementable without a breaking contract change).
+
+**Why now (SCQA):** Control planes (Conductor, Zed) can dispatch AI coding agents via
+ACP — Claude Code has been in the ACP registry since August 2025. The complication is
+that no structured progress signal crosses the ACP boundary: the control plane receives
+free-form text with no machine-readable signal for loop-engine FSM phase transitions,
+human gate decisions, or artifact creation. This leaves the control plane blind to
+everything that happens inside a session. The question is how to close that observability
+gap, and whether the mechanism — an MCP server spawned per session — belongs in core or
+as a separate distribution unit.
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| -- | -------- | -------------- | --- | --------- | --------------- |
+| D1 | Should workspace-mcp ship as a component of the core pack (vs. agentbundle package, standalone distribution, or deferred)? | Ship in core pack, co-located with workspace-status scripts | No new deps; opt-in per session; per-session-only constraint; charter analysis below shows it can clear Principles 1 and 3 with stated caveats | This review | Confirm or route to agentbundle package / standalone / defer |
+| D2 | Should the five empirical Stage 0 spikes (a)–(e) be the mandatory gate before Stage 1 implementation? | Yes — Stage 1 does not start until all five close | Each spike validates a design-sinking assumption; taken together they de-risk: notification relay (c), instruction durability (a), notification naming (b), module-mode spawn (d), and threading-model concurrency (e) | This review | Confirm spike list, or request additions |
+
+---
+
+## Problem & goals
+
+### The observability gap
+
+The work-loop skill advances through a 10-state FSM (states like `SPEC-PLAN-DRAFTING`,
+`CODE-HUMAN-GATE`, etc.) managed by `loop-engine.py`. A control plane dispatching a
+work-loop session via ACP receives a stream of free-form text with no structured signal for:
+
+- Which FSM state the session is in.
+- When a human gate is reached (cannot prompt the operator without polling for silence).
+- What artifacts were created (cannot commit them without separate session prompts).
+- What the workspace queue contains (cannot select the next item without prior knowledge
+  of this repo's skill stack).
+
+The same gap applies to non-FSM skills: desk-research asks clarifying questions and
+writes research briefs to disk; frame-intent and journey-mapping ask about personas and
+output shaping artifacts. Every interactive moment where the AI asks a question is an
+elicitation that the control plane is currently blind to.
+
+Full goals and non-goals are in the design doc (§ Goals and Non-goals). Summary:
+
+**Goals (abbreviated):** structured FSM transition notifications with zero missed events;
+human-gate intercept before the session suspends; `workspace_status()` DAG-resolved
+queue view parseable without prior skill knowledge; skill-agnostic control-plane dispatch;
+zero behavior change when workspace-mcp is not configured.
+
+**Non-goals (abbreviated):** persistent daemon mode; convergence orchestration (Stage 4);
+Gemini CLI / OpenCode support; replacing loop-engine's FSM; Jira/Linear write-back.
+
+---
+
+## Proposal
+
+### Architecture summary
+
+workspace-mcp is a per-session MCP server spawned by the control plane. It communicates
+over MCP stdio transport (no TCP port binding; multiple concurrent sessions are isolated
+by process). Five services:
+
+1. **Event bridge** — tail-polls `.loop-run/events.jsonl` (the append-only file that
+   loop-engine already writes per FSM transition) and maintains internal FSM state exposed via `workspace_status()` (spike (c) fallback — `_agentbundle.core/skill-state-change` notifications generated but not relayed by claude-agent-acp 0.64.0). Uses an outbox pattern — write event to `.loop-run/events.pending`,
+   commit state atomically, then append to `events.jsonl` — so a crash before the state
+   write doesn't produce phantom replays on recovery. Seq (sequence number) deduplication
+   guards against double-delivery for idempotency.
+2. **Universal elicitation** — a session instruction injected at startup routes all AI
+   questions through an `elicit()` MCP tool rather than direct text output; the tool
+   calls `elicitation/create` (MCP server→client direction — workspace-mcp requests a
+   response from the AI host, not the other way around) to surface the question to the
+   control plane. Response-file fallback for adapters that don't support
+   `elicitation/create` (Codex CLI confirmed; Kiro CLI expected).
+3. **`workspace_status()` tool** — DAG-resolved (dependency-graph–resolved, following
+   `needs:` edges from workspace.toml) view of the workspace queue: ready, shaping,
+   blocked (with named unmet `needs:` edges), and active items. Pack-presence filter
+   returns unavailable items with `available: false, required_pack: "<name>"` rather
+   than excluding them, so the control plane can surface installation prompts.
+4. **git tools** — `git_status`, `git_branch`, `git_commit`, `git_push` via subprocess.
+   Reactive: the harness calls `git_status()` after TurnEnd and commits uncommitted
+   artifacts rather than relying on declarative `git_managed` flags per item type.
+5. **Artifact watcher** — 200ms snapshot-diff (compare two filesystem listings taken
+   200ms apart and emit events for new files) on manifest-derived output directories;
+   emits `_agentbundle.core/artifact-created` when new files appear.
+
+The design doc contains the full pseudocode, notification contract table, adapter-class
+split, pressure-test scenarios, and security analysis.
+
+### Charter analysis (D1)
+
+workspace-mcp is evaluated against all four charter principles:
+
+**Principle 1 — Universal across tech stacks.** A control-plane-driven session is a
+specific use case, not universal. However, workspace-mcp is opt-in per session and
+absent from the default experience: an adopter who does not use a control plane never
+encounters it, and the skills it observes are universal across all stacks. The
+`permissions.allow` injection on `agentbundle install core` is the one place where the
+default install is touched — this is a narrow, additive-only, revocable entry (manually)
+that enables opt-in functionality rather than imposing a workflow. The reviewer should
+judge whether this additive injection crosses the charter's default-install principle.
+If the honest read is that a control-plane-only component cannot clear Principle 1 in
+core, D1 should route to Option 2 (agentbundle package module only) below.
+
+**Principle 2 — Substantive, not duplicative.** ACP-observable FSM state and structured
+elicitation interception are not encoded anywhere else in the catalogue; the design doc
+demonstrates the gap is real.
+
+**Principle 3 — A habit, not a tool.** workspace-mcp is infrastructure (an MCP server).
+Three constraints limit drift: (i) opt-in per session (never auto-started); (ii) pure
+stdlib Python 3.11+, no new runtime dependencies; (iii) per-session exit enforced in
+code — no persistent daemon. The constraint in (iii) is a design requirement of this RFC;
+ADR-0062 will capture it as a durable architectural decision after acceptance.
+
+**Principle 4 — Used often enough to stick.** Control-plane adoption is growing (Conductor
+is active; Zed is in ACP registry); this is a new feature, so frequency is projected, not
+measured. Principle 4 is the weakest bar for new features by design.
+
+**Conclusion:** workspace-mcp can clear the charter with stated caveats, but the Principle
+1 / default-install tension on `permissions.allow` injection is the reviewer's judgment
+call. If the reviewer routes D1 to Option 2, the implementation is unchanged; only the
+distribution unit changes.
+
+### Spawn paths
+
+workspace-mcp ships its logic in `packages/agentbundle/agentbundle/workspace_mcp.py`
+(the agentbundle Python package), making it importable as `agentbundle.workspace_mcp`
+after `pip install agentbundle`. The core-pack script (`workspace_mcp_server.py`) is a
+thin alias that invokes the agentbundle module. Two spawn paths exist:
+
+- **Trusted/normal (path-based):** The control plane passes the projected script path
+  in `session/new.mcpServers`. Standard for managed adopter environments.
+- **Untrusted/CI (module-based):** `python3 -I -m agentbundle.workspace_mcp`. The `-I`
+  flag prevents the checkout directory from being added to `sys.path`, blocking a
+  checkout-controlled `agentbundle/` from shadowing the installed wheel — a supply-chain
+  injection risk. Required for CI and multi-tenant contexts where the checkout is not
+  trusted.
+
+Stage 0 spike (d) validates that the module entry point is installed and accepts the same
+env vars as the projected script.
+
+### Stage 0 spikes (D2)
+
+Five empirical spikes (a)–(e) gate Stage 1. The unlettered **(RFC gate)** row below is
+the RFC acceptance gate itself — listed for completeness, not an empirical de-risk
+exercise. The reviewer is asked to confirm D2 on the basis of the five empirical spikes.
+
+| ID | Assumption being validated | Failure consequence |
+| -- | ------------------------- | ------------------- |
+| (a) Instruction durability | `session/new` instruction survives across turns in at least one production AI host | If false: control plane must re-inject the preamble on each `session/prompt`; elicitation path changes |
+| (b) Notification naming | `x-core/` matches ACP v1 extension-naming convention | **CLOSED:** `x-core/` is NOT the ACP convention; renamed to `_agentbundle.core/` per observed `_claude/sdkMessage` pattern. ADR-0068 updated. |
+| (c) Notification relay | MCP `notifications/message` frames reach the control plane as `session/update` events in a production AI host + ACP adapter combination | **CLOSED (fallback):** frames are NOT relayed by `claude-agent-acp@0.64.0`; control plane polls `workspace_status()` (extended with FSM state fields) instead. AC3/AC7/AC8 updated. |
+| (d) Module-mode spawn | `python3 -I -m agentbundle.workspace_mcp` is installed and accepts the same env vars as the projected script | If false: trusted-spawn path is unusable; fix install guide and entry point before Stage 1 |
+| (e) Threading model | Python stdlib daemon threads + bounded worker-thread pool (pool size 4) handle `elicit()`'s blocking `elicitation/create` call under real MCP stdio concurrency — specifically, nested re-entrancy where the `elicitation/create` response arrives on a separate read-loop iteration while the original `elicit` worker is blocked waiting | If false: asyncio rewrite required before Stage 1; the design's threading model (design.md § Decision 7) is unsound |
+| **(RFC gate)** | This RFC is accepted | If rejected: route to Option 2 / standalone / defer; not an empirical spike |
+
+**Two additional assumptions the reviewer may assess for the spike list (D2):**
+
+- **`session/new.mcpServers` production support.** The design's Class A injection
+  depends on Claude Code, Codex CLI, and Copilot CLI honoring `session/new.mcpServers`
+  in production. If any adapter ignores it, that adapter is Class B only. This can be
+  verified as part of Stage 1 validation rather than as a pre-Stage-1 spike, since
+  Stage 1 would discover the issue immediately.
+- **`permissions.allow` projection feasibility.** The Stage 1 prerequisite (a new
+  additive-merge projection target in `adapter.toml`) may require a breaking change to
+  the adapter contract, which would itself need a separate RFC. If the reviewer believes
+  this risk is high enough to block D1 acceptance, add a sixth empirical spike to
+  validate feasibility before sign-off.
+
+Stage 1 does not start until spikes (a)–(e) close. Rollback: if spike (c) fails and
+no viable fallback is designed, implementation is deferred until the relay issue resolves.
+
+### Stage 1 prerequisites (named)
+
+Two named prerequisites must be resolved before Stage 1 starts, in addition to the five
+spikes (a)–(e) closing:
+
+1. **Headless-permission projection for each Class A adapter.** In an unattended session,
+   each AI host prompts for MCP tool approval before calling workspace-mcp tools; a prompt
+   with no human present hangs the session. Each Class A adapter has its own mechanism:
+
+   - **Claude Code** — `permissions.allow` entries in `.claude/settings.json`. A new
+     additive-merge projection target in the agentbundle Claude adapter
+     (`packages/agentbundle/agentbundle/_data/adapter.toml`) must be added (Stage 1
+     prerequisite; version bump + `Engine-Change-RFC: RFC-0078` required; authorized by
+     D1 if non-breaking; follow-on RFC if breaking). Entries to inject:
+     ```json
+     "mcp__workspace-mcp__workspace_status", "mcp__workspace-mcp__elicit",
+     "mcp__workspace-mcp__git_status", "mcp__workspace-mcp__git_branch",
+     "mcp__workspace-mcp__git_commit", "mcp__workspace-mcp__git_push"
+     ```
+   - **Codex CLI** — equivalent pre-approval mechanism unknown; discovered and documented
+     in Stage 2a. Until documented, adopters using Codex in headless mode must configure
+     permissions manually or pass `--dangerously-skip-permissions`.
+   - **Copilot CLI** — equivalent pre-approval mechanism unknown; discovered and documented
+     in Stage 2b. Same manual fallback applies.
+
+2. **Needs-resolution semantics for autonomous dispatch.**
+   `is_need_satisfied()` (`workspace_status_engine.py:456-533`) implements documented
+   intentional behavior (SKILL.md:90, schema.md:114): a `shape:` or `research:` target
+   absent from the active shaping queue is treated as *satisfied*. This is correct for
+   human-managed dispatch (a human knows context the engine doesn't) but is unsafe for
+   autonomous dispatch: the control plane may start a dependent item whose prerequisite
+   was never created. Closing this requires a SKILL.md/schema.md semantics update (or
+   a scoped override for autonomous-dispatch mode), not a local bug fix. This change
+   must be designed and accepted before Stage 1 enables autonomous dispatch.
+
+### Rollout stages
+
+| Stage | Scope | Gate |
+| ----- | ----- | ---- |
+| 0 | Spikes (a)–(e) + RFC acceptance | All six close (five empirical + this RFC) |
+| 1 | Claude Code adapter, work-loop, single session | FSM visibility, elicitation intercept, git commit/push, notification relay; Claude Code permissions projection |
+| 2a | Codex CLI | `session/new.mcpServers` injection; response-file elicitation fallback; **document Codex headless-permission mechanism** |
+| 2b | Copilot CLI | `session/new.mcpServers` injection; `elicitation/create` support (unconfirmed); **document Copilot CLI headless-permission mechanism** |
+| 2c | Kiro CLI (Class B) | `.kiro/settings/mcp.json` pre-config; V3 agent format + `@mcp` tag; kiro-cli adapter V3 prerequisite |
+| 3 | Non-FSM skills (desk-research, PE, XD) | Artifact watcher; elicitation for clarifying questions |
+| 4 | Multi-instance, worktrees, convergence | Separate scope |
+
+---
+
+## Options considered
+
+The option axis is **distribution unit**: where does workspace-mcp live? The four options
+below exhaust the space (inside the existing default unit, inside the existing CLI package,
+a new unit, or no unit now).
+
+| Option | Description | Recommended? |
+| ------ | ----------- | ------------ |
+| 1 | **Core pack** (this RFC's D1 recommendation) | ★ Yes, with caveats |
+| 2 | **agentbundle package module** | Fallback if Principle 1 objection sustains |
+| 3 | **Standalone distribution** (`agentbundle-workspace-mcp` PyPI package) | No |
+| 4 | **Defer** | No |
+
+### Option 1 — Ship in core pack (recommended)
+
+workspace-mcp co-located with workspace-status in the core pack. Opt-in per session;
+pure stdlib; no new deps; per-session-only constraint.
+
+**Trade-offs:** Crosses Principle 3 ("habit, not a tool") — accepted under three
+constraints (opt-in, no deps, per-session exit). The Principle 1 / default-install
+tension on `permissions.allow` injection is the open question. **Prior art:** workspace-status
+is already infrastructure-adjacent (it runs engine code at query time); workspace-mcp
+extends the same engine for a session-scoped use case.
+
+### Option 2 — agentbundle package module only (recommended fallback)
+
+The module `agentbundle.workspace_mcp` is the canonical implementation under **both**
+options (both Options 1 and 2 place the logic in `packages/agentbundle/`). What Option 2
+changes: the core pack ships **no** alias script (`workspace_mcp_server.py`); adopters
+invoke workspace-mcp exclusively via `python3 -I -m agentbundle.workspace_mcp` or a
+control-plane-supplied path. Adopters who want unattended sessions must add
+`permissions.allow` entries manually (or via `agentbundle[workspace-mcp]` extras, if
+that install path is created) rather than receiving them automatically from the core pack.
+
+**Trade-offs:** Cleanest dissolution of the Principle-3 tension (agentbundle is
+explicitly infrastructure tooling, not a habit-pack; no MCP-server code or default-install
+permission injection enters the core pack). Slightly higher adopter friction (no auto-injected
+permissions on `agentbundle install core`). **Favored when:** the Principle 1 / default-install
+objection to Option 1 sustains, or the `permissions.allow` additive-merge projection cannot
+be implemented without a breaking adapter-contract change.
+
+**Favored when:** The Principle 1 / default-install objection to Option 1 sustains, or
+the `permissions.allow` additive-merge projection cannot be implemented without a breaking
+adapter-contract change.
+
+### Option 3 — Standalone PyPI package (`agentbundle-workspace-mcp`)
+
+A new PyPI package, separately versioned and released.
+
+**Trade-offs:** Two-package install burden; separate release management; deep coupling
+to agentbundle's FSM events schema (which changes with loop-engine version bumps) means
+the two packages must be co-versioned anyway, erasing most independence benefit. Not
+the right unit boundary when the component is tightly coupled to agentbundle internals.
+
+### Option 4 — Defer
+
+Close this RFC with "not yet."
+
+**Trade-offs:** Spikes (a)–(e) can run independently of this RFC's acceptance.
+Cost of delay: Conductor and Zed sessions remain blind to work-loop phase; every gate
+resolution requires human polling; control-plane dispatch remains skill-dependent (no
+`workspace_status()` tool). **Favored when:** spike (c) fails and no viable fallback is
+designed; or the charter review finds Options 1 and 2 both untenable.
+
+---
+
+## Risks & what would make this wrong
+
+- **Charter Principle 3 violation is real, not dismissed.** workspace-mcp is an MCP
+  server. If the Approver reads Principle 3 strictly, D1 is wrong and Option 2 is the
+  correct route. **Mitigation:** three constraints limit the infrastructure footprint;
+  Option 2 is a clean fallback with unchanged implementation.
+
+- **Spike (c) — notification relay — resolved with fallback.** `claude-agent-acp@0.64.0` does not relay MCP `notifications/message` frames (`case "notification": break`). The poll-based fallback (`workspace_status()` extended with FSM state fields) is adopted for Stage 1. Gate resolution latency increases from sub-second (push) to the control plane's poll interval (suggested 500ms–2s). Real-time push will be available when claude-agent-acp adds `notifications/message` relay support (or when a PR ships the missing `case "mcp_notification"` handler).
+
+- **`permissions.allow` projection is a one-way door (Claude Code).** Once
+  `agentbundle install core` merges the six MCP tool entries into `.claude/settings.json`,
+  removing them requires manual surgery by the adopter. A removal-projection capability
+  does not currently exist in agentbundle. For Codex CLI and Copilot CLI, equivalent
+  pre-approval mechanisms are not yet known and will be documented in Stages 2a/2b;
+  those mechanisms may or may not involve agentbundle-managed projection.
+  **Mitigation:** additive-merge is versioned; removal from Claude Code settings remains
+  manual until a removal-projection capability is built. Accepted cost.
+
+- **Trusted spawn (-I) is not enforced at runtime.** A control plane that omits `-I`
+  allows checkout-controlled packages to shadow the installed wheel. **Mitigation:** install
+  guide specifies `-I` as mandatory for untrusted/CI contexts; the trusted-spawn section
+  in design.md documents both JSON examples. Runtime enforcement is not feasible without
+  control-plane cooperation. Accepted: guidance is in the install guide.
+
+- **Kiro CLI kiro-cli adapter prerequisite blocks Stage 2c.** The `kiro-cli` adapter must
+  emit V3 Markdown agents before Stage 2c can start. If that work item slips, Stage 2c
+  slips. **Mitigation:** Stage 2c is gated on the adapter update; Stages 1, 2a, 2b do not
+  depend on it.
+
+- **Session instruction compliance is prompt-following, not enforced.** The AI may skip
+  `elicit()` for very short responses ("sure", "yes"). **Mitigation:** accepted for short
+  responses; instruction is strongest for option-selection and structured decisions.
+
+**Key assumptions (falsifiable):**
+1. `session/new.mcpServers` is honored in production by at least one Class A AI host.
+   False → Class A collapses to Class-B-only.
+2. Python stdlib daemon threads + bounded worker pool handle `elicit()` MCP stdio
+   concurrency correctly (nested `elicitation/create` re-entrancy included).
+   False → asyncio rewrite required before Stage 1. Validated by spike (e).
+3. The agentbundle Claude adapter can gain an additive-merge projection target for
+   `permissions.allow` without a breaking contract change. False → a follow-on RFC
+   authorizes the contract change before Stage 1 starts; D1 acceptance does not
+   pre-authorize a breaking contract change.
+
+---
+
+## Evidence & prior art
+
+**Spike / de-risk result:** No production spikes have run. The design doc was reviewed
+by Codex CLI in eight rounds (C1–C8); the distilled conclusions are in
+[`docs/rfc/0078-notes/codex-review-conclusions.md`](0078-notes/codex-review-conclusions.md).
+Round 8 returned zero P1 findings, confirming design-level internal consistency. This is
+not a substitute for running Stage 0 spikes against live adapters.
+
+**Repo precedent:**
+- workspace-status skill (`packs/core/.apm/skills/workspace-status/`) — the existing
+  workspace tooling workspace-mcp co-locates with and extends.
+- `packages/agentbundle/agentbundle/_data/adapter.toml` — the Claude adapter projection
+  that the Stage 1 prerequisite extends.
+- ADR-0061 (`docs/adr/0061-loop-infrastructure-phase-1.md`) — loop-infrastructure
+  phase 1; related prior art (not the daemon constraint; that becomes ADR-0062).
+
+**External prior art:**
+- MCP specification 2025-06-18: `elicitation/create` (server→client request) and
+  `notifications/message` (server→client notification) are standard MCP primitives.
+- ACP v1: adapts `elicitation/create` from MCP; `session/new.mcpServers` is the
+  ACP-native per-session injection path.
+- Kiro CLI V3 agent format + `@mcp` tag: the Class B pre-configured pattern.
+
+---
+
+## Open questions
+
+1. **Notification namespace form.** **CLOSED by Stage 0 spike (b).** `_agentbundle.core/` is the confirmed form, consistent with `_claude/sdkMessage` observed in `claude-agent-acp@0.64.0`. All artifacts updated. ADR-0068 updated.
+
+2. **`permissions.allow` removal path.** If an adopter wants to remove workspace-mcp,
+   what is the mechanism? Additive-merge has no defined removal path.
+   *Recommended default:* manual removal for now; document the manual step in the install
+   guide; defer removal-projection capability to a follow-on RFC if demand emerges.
+   *Owner:* eugenelim. *Decide by:* Stage 1 design is finalized.
+
+3. **Copilot CLI `elicitation/create` support.** Flagged as unconfirmed.
+   *Recommended default:* assume response-file fallback until Stage 2b validation.
+   *Owner:* eugenelim. *Decide by:* Stage 2b begins.
+
+---
+
+## Follow-on artifacts
+
+Filled in when this RFC is Accepted:
+
+- ADR-0062: workspace-mcp per-session-only constraint
+- ADR-0063: Session instruction over per-skill gate modification
+- ADR-0064: events.jsonl as the FSM event source
+- ADR-0065: elicit() + elicitation/create + response-file fallback
+- ADR-0066: Reactive git at TurnEnd (vs. declarative git_managed)
+- ADR-0067: Lifecycle manifest (built-in defaults + workspace-types.d/ extension)
+- ADR-0068: Notification namespace
+- ADR-0069: Threading model (daemon threads + bounded worker pool)
+- Spec: `docs/specs/workspace-mcp/` (Stage 1 implementation spec; authored after Stage 0
+  spikes close and both Stage 1 prerequisites are confirmed)
+
+---
+
+## Errata
+
+**Erratum 2026-08-03 — `schema.md` does not exist; citations are stale.**
+Sections "Proposal" (§ Autonomous dispatch mode, line ~276–280) cite `schema.md:114` and `SKILL.md:90` as authorities for needs-resolution semantics. `schema.md` does not exist in this repo. `SKILL.md:90` is inside a TOML template block, not needs-resolution prose. Both citations are stale; the canonical authority is SKILL.md §2 (needs-resolution table). Stage 1 implementation (AC19, Task 4) strips these citations from `workspace_status_engine.py` comments. The RFC body is frozen; corrected here by erratum.
+
+**Erratum 2026-08-03 — events.jsonl is new Stage 1 work, not pre-existing.**
+Section "Architecture summary" (§ Proposal, item 1) states: "tail-polls `.loop-run/events.jsonl`
+(the append-only file that loop-engine already writes per FSM transition)." This is incorrect.
+As of RFC acceptance, loop-engine does **not** write `events.jsonl`. The events.jsonl append
+(including the outbox protocol for crash-consistency) is a Stage 1 implementation work item
+captured in spec.md AC0 and plan.md Task 1. ADR-0064 has been updated to reflect this.
+The RFC body is frozen per convention and corrected here by erratum.

--- a/docs/specs/workspace-mcp/plan.md
+++ b/docs/specs/workspace-mcp/plan.md
@@ -1,0 +1,197 @@
+# Plan: workspace-mcp — Stage 1 implementation
+
+- **Status:** Approved <!-- Drafting | Approved | Done -->
+- **Spec:** [`spec.md`](spec.md)
+
+> **Blocked:** Stage 0 spikes (a)–(e) must close before any task in this plan begins implementation. The plan is authored now to make scope and sequencing explicit; wave scheduling is confirmed after spikes close.
+
+## Constraints
+
+- Pure stdlib Python 3.11+; no new runtime dependencies on agentbundle or workspace-mcp.
+- ADR-0062: per-session-only spawn; no persistent daemon, no port binding.
+- ADR-0063: session instruction as the universal elicitation mechanism; no per-skill modification.
+- ADR-0064: events.jsonl as the FSM event source; loop-engine's CLI interface is unchanged (new internal behavior only — the events.jsonl append in `cmd_transition` and `cmd_init`).
+- ADR-0065: elicit() + elicitation/create (never advertised in ServerCapabilities) + response-file fallback.
+- ADR-0066: reactive git at TurnEnd; no declarative `git_managed` flags.
+- ADR-0067: built-in manifest defaults + workspace-types.d/ extension (workspace-types.d/ deferred to Stage 3).
+- ADR-0068: `_agentbundle.core/` notification namespace (confirmed by spike (b); global rename complete).
+- ADR-0069: daemon threads + bounded worker pool (pool size 4); asyncio rewrite triggered if spike (e) fails.
+- `is_need_satisfied()` default semantics are preserved for human-managed sessions; autonomous-dispatch mode is additive.
+- `shell=False` and `--` end-of-options separator enforced on all git subprocess calls.
+
+## Risks
+
+- Spike (e) failure → asyncio rewrite required; Tasks 1 and 2 redesigned before starting. **CLOSED: spike (e) passed.**
+- Spike (c) failure + no viable fallback → Stage 1 deferred entirely. **CLOSED: spike (c) failed but fallback designed (poll-based via `workspace_status()`); Stage 1 proceeds with updated AC3/AC7/AC8.**
+- `permissions.allow` projection requires breaking adapter contract → Task 5 blocked; follow-on RFC required; AC17/AC18 deferred.
+- loop-engine outbox protocol adds ~30 lines to `cmd_transition`/`cmd_init`; `make build-self` reprojection required afterward.
+
+## Changelog
+
+- 2026-08-03: Initial plan (spec-plan mode). Stage 0 spikes pending; implementation not started.
+
+## Tasks
+
+### Task 0 — Stage 0 spike closure (prerequisite; not implementation)
+
+**Depends on:** — (blocks all other tasks)
+**Verification:** Goal-based check
+**Done when:** All five Stage 0 spike results documented; none returns a design-sinking failure without a designed fallback.
+**Tests:** no stub (goal-based)
+**Approach:** ~~Run spikes (a)–(e) against a production Claude Code + Conductor session.~~ **COMPLETE (2026-08-03).** Results documented in `docs/rfc/0078-notes/spike-results.md`. ADR-0068 updated with confirmed namespace `_agentbundle.core/` (spike (b)). design.md Component 3 updated per spike (a): single `session/new._meta.systemPrompt` injection confirmed sufficient. Spike (c) fallback designed: AC3/AC7/AC8 updated to reflect poll-based observability via `workspace_status()`. Spikes (d) and (e) passed without action.
+
+---
+
+### Task 1 — loop-engine events.jsonl append and outbox protocol
+
+**Depends on:** Task 0
+**Verification:** TDD
+**Tests:**
+- `packages/agentbundle/tests/test_loop_engine_events_jsonl.py`: outbox write protocol (write pending → atomic state write → append events.jsonl → delete pending); outbox recovery at `cmd_init` startup AND at `cmd_transition` entry/resume case (pending.to == state AND pending.seq == transition_sequence → replay; mismatch → discard; crash-then-next-transition) (ACs 0, 0a).
+  *Stub:* `test_outbox_recovery_replay_when_to_matches_state` → `assert False  # STUB: AC0a`
+  `test_outbox_recovery_discard_when_to_mismatches_state` → `assert False  # STUB: AC0a`
+  `test_cmd_transition_recovers_stale_pending_before_new_transition` → `assert False  # STUB: AC0a (crash-then-next-transition: pending from prior crash must be replayed/discarded at top of next cmd_transition, not lost)`
+  `test_cmd_transition_recovers_foreign_spec_pending_before_writing_own` → `assert False  # STUB: AC0a (cross-spec: crash on spec-A then transition on spec-B must recover spec-A's pending against spec-A's engine-state.json before writing spec-B's new pending event — skipping leaves spec-A's event silently lost to the step-2 overwrite)`
+
+**Note on line schema:** all events.jsonl lines must use `{"seq", "run_id", "spec", "from", "event", "to", "at"}` field names — matching design.md:317. Tests must assert that field names match exactly (not `to_state`/`from_state`/`timestamp`).
+
+**Approach:**
+In `packs/core/.apm/skills/work-loop/scripts/loop-engine.py`:
+- Add `.loop-run/` dir creation in `cmd_init`.
+- Add `events.jsonl` initialization (write header line with `run_id`) in `cmd_init`.
+- In `cmd_transition`, implement in this order:
+  1. **Recovery check (before writing a new pending event):** if `.loop-run/events.pending` exists, apply universal pending recovery:
+     - Read `pending["spec"]` to identify the owning spec directory.
+     - Load `{pending["spec"]}/engine-state.json` (the owning spec's state, regardless of which spec is currently transitioning).
+     - If `pending["to"] == owning_state["state"] AND pending["seq"] == owning_state["transition_sequence"] AND pending["run_id"] == owning_state["run_id"]` → **replay** (append to events.jsonl, delete pending); else → **discard** (delete pending).
+     Skipping a foreign pending file defers its loss to step 2 (where the new pending event overwrites it), silently losing the owning spec's missed transition. Recovery must run unconditionally against the owning spec before any write.
+  2. **Write pending JSON** to `.loop-run/events.pending` (os.replace-safe atomic write to temp, then rename).
+  3. **Write `engine-state.json`** atomically (temp + rename — already done).
+  4. **Append** pending line from `.loop-run/events.pending` to `.loop-run/events.jsonl`.
+  5. **Delete** `.loop-run/events.pending`.
+- In `cmd_init`, check for a stale `.loop-run/events.pending` on startup:
+  - Read `pending["spec"]`. Load `{pending["spec"]}/engine-state.json` (the owning spec's state).
+  - If `pending["to"] == owning_state["state"]` AND `pending["seq"] == owning_state["transition_sequence"]` AND `pending["run_id"] == owning_state["run_id"]`: replay (append, delete). Else: discard.
+- Run `make build-self` after changes to reproject loop-engine to `.agents/skills/work-loop/scripts/loop-engine.py`.
+
+**Anchor-test sweep:** grep `packages/agentbundle/tests/` for `loop-engine` or `loop_engine` fixtures → identify any that snapshot `cmd_transition` output and update if the new events.jsonl append changes observable behavior.
+
+---
+
+### Task 2 — `agentbundle.workspace_mcp` core module
+
+**Depends on:** Task 0, Task 1 (events.jsonl must exist before the bridge can be tested end-to-end), Task 4 (`analyze_bounded(autonomous_dispatch=True)` must exist before Task 2 calls it)
+**Verification:** TDD (unit) + Visual/manual QA (end-to-end)
+**Tests:**
+- `test_workspace_mcp_event_bridge.py`: byte-offset tail; seq dedup (AC6, `seq ≤ last_emitted_seq` → skip); partial-line buffering on torn-write — partial last line held at offset, completed on next poll, no crash (AC4); inode change or size < offset → offset/buffer/run_id reset (AC5); human-gate detection (`to` field matches `*-HUMAN-GATE`) and enriched notification payload (ACs 3, 7).
+  *Stubs:* `test_human_gate_sets_gate_state_in_workspace_status` → `assert False  # STUB: AC7 (gate_pending=True, gate/gate_question/review_findings set in workspace_status() response)`
+  `test_partial_line_buffered_no_crash` → `assert False  # STUB: AC4`
+  `test_inode_change_resets_offset_and_run_id` → `assert False  # STUB: AC5`
+- `test_workspace_mcp_tools.py`: `workspace_status()` result shape, pack-presence (6 roots OR-logic), slug safety `^[a-zA-Z0-9._-]+$` + dot-segment rejection + realpath containment (ACs 8, 9, 10).
+  *Stubs:* `test_slug_dot_dot_rejected` → `assert False  # STUB: AC10`; `test_slug_containment_stays_under_output_base` → `assert False  # STUB: AC10`
+- `test_workspace_mcp_elicit.py`: capability detection at init; elicit MCP path (AC11); response-file O_EXCL guard raises on pre-existing file (AC12); workspace-mcp never advertises `elicitation` in ServerCapabilities (AC13).
+  *Stubs:* `test_response_file_oexcl_guard` → `assert False  # STUB: AC12`; `test_server_capabilities_omits_elicitation` → `assert False  # STUB: AC13`
+- `test_workspace_mcp_git.py`: check-ref-format validation of branch name; `--` separator present in every subprocess call that carries agent-supplied data; commit intersects output_pattern (rejects null-pattern items); push two-sided branch check (AC14); discovery-mode returns error for `git_branch`/`git_commit`/`git_push`; `git_status` allowed in discovery-mode (AC15).
+  *Stubs:* `test_git_commit_intersects_output_pattern` → `assert False  # STUB: AC14`; `test_git_push_two_sided_branch_check` → `assert False  # STUB: AC14`; `test_git_branch_rejects_leading_dash_and_unsafe_names` → `assert False  # STUB: AC14 (check-ref-format --branch form rejects -foo, --track; plain form does not)`; `test_discovery_mode_rejects_mutating_tools` → `assert False  # STUB: AC15`
+- `test_workspace_mcp_stdin.py`: 1 MiB frame-size cap quarantines and discards oversized frame; malformed JSON discarded with error response; unknown request_id discarded (AC16).
+  *Stubs:* `test_oversized_frame_quarantined` → `assert False  # STUB: AC16`; `test_unknown_request_id_discarded` → `assert False  # STUB: AC16`
+- `test_workspace_mcp_lifecycle.py`: stdin close → process exits within 5s (AC22).
+  *Stub:* `test_stdin_close_exits_process` → `assert False  # STUB: AC22`
+
+**Approach:**
+Implement `packages/agentbundle/agentbundle/workspace_mcp.py`. Key components:
+
+- `_SAFE_SLUG_RE = re.compile(r'^[a-zA-Z0-9._-]+$')`. Slug guard: match regex AND not in `{'.', '..'}` AND not starting with `-`. After pattern formatting, `Path(resolved).resolve()` must be under `_STATIC_OUTPUT_BASES[type]`.
+- `DEFAULT_SESSION_INSTRUCTION`: embedded constant per design.md Component 3 (AC20).
+- `_EventBridge(daemon=True)`: 200ms poll of `.loop-run/events.jsonl`; byte-offset + inode tracking; seq dedup; maintains internal FSM state (current state, gate fields); detects `*-HUMAN-GATE` in the `to` field and updates internal gate state `{gate, gate_question, review_findings}` (reads reviewer report from spec dir disk). **Spike (c) fallback:** notifications are generated internally but not relayed to ACP control plane; FSM state exposed via `workspace_status()` `current_state`/`gate_pending`/`gate_question`/`review_findings` fields (AC7, AC8). Control plane polls `workspace_status()` to observe transitions.
+- `_WorkspaceStatusTool`: reads workspace.toml via `workspace_status_engine.analyze_bounded(..., autonomous_dispatch=True)`; pack-presence filter (6 roots, OR logic); slug safety guard.
+- `_ElicitTool` (dispatched to worker pool): `elicitation/create` path (AC11) OR response-file path (AC12, O_EXCL, 0600, reject pre-existing, poll, temp+rename read, cleanup); capability detected at init (never advertise in ServerCapabilities — AC13).
+- `_GitTools`: `git_status` (always); `git_branch(name)` — validate via `subprocess.run(["git", "check-ref-format", "--branch", name], ...)` (the `--branch` form rejects names starting with `-`; the plain refname form does not — pin this form), then `subprocess.run(["git", "checkout", "-b", name], shell=False)` (NO `--` — branch name is an option argument, not a pathspec; `--branch`-form check-ref-format is the injection defense); `git_commit(message)` — intersect uncommitted paths with output_pattern, stage only matching paths via `["git", "add", "--", *matched_paths]`; `git_push(branch)` — two-sided check before `["git", "push", "--", "origin", branch]`; discovery-mode guard on mutating tools (AC15).
+- `_StdioLoop` (main thread): JSON-framed MCP reads; 1 MiB frame-size cap (AC16a); malformed JSON quarantine (AC16b); unknown request_id rejection (AC16c); `{request_id: Event}` map for elicitation routing; write lock for stdout; dispatches tool calls to `ThreadPoolExecutor(max_workers=4)`.
+- `_init_handshake`: reads host capabilities; selects elicitation delivery path; constructs ServerCapabilities WITHOUT `elicitation` (AC13).
+- Entry point: `def main(): ...` and `if __name__ == '__main__': main()`.
+
+**AC20 verification (goal-based):** see spec.md Testing Strategy — import module, assert `DEFAULT_SESSION_INSTRUCTION` is non-empty and contains `'elicit'`.
+
+---
+
+### Task 3 — Core-pack alias script
+
+**Depends on:** Task 2
+**Verification:** Goal-based check
+**Done when:** `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py` exists, `python3 workspace_mcp_server.py` invokes the module identically to module-mode.
+**Tests:** no stub (goal-based — one-line delegation; no new logic)
+**Approach:** Write a single-line delegation:
+```python
+#!/usr/bin/env python3
+import agentbundle.workspace_mcp as _m; _m.main()
+```
+
+---
+
+### Task 4 — `is_need_satisfied()` autonomous-dispatch mode
+
+**Depends on:** Task 0
+**Verification:** TDD
+**Tests:**
+- `packages/agentbundle/tests/test_workspace_status_engine_autonomous.py`:
+  - `shape:` absent from active AND backlog → unsatisfied when `autonomous_dispatch=True`; satisfied when `False` (AC19)
+  - `research:` absent from backlog as type "research" → unsatisfied when `autonomous_dispatch=True`; satisfied when `False` (AC19)
+  *Stubs:* `test_shape_absent_unsatisfied_autonomous` → `assert False  # STUB: AC19`; `test_research_absent_unsatisfied_autonomous` → `assert False  # STUB: AC19`
+
+**Approach:**
+Update the delegation chain in `workspace_status_engine.py`:
+1. `is_need_satisfied(need, ini_slug, all_initiatives, autonomous_dispatch: bool = False)` at line 456:
+   - `shape:` branch: if `autonomous_dispatch`, also check `ini.shaping.backlog` for the slug — absent from both active AND backlog → return False. (Current behavior: absent from active → `slug not in active_slugs` returns True/satisfied, even if slug never existed — the gap for autonomous mode.)
+   - `research:` branch: if `autonomous_dispatch`, add explicit absent-target check: `slug not in research_slugs` currently returns **True (satisfied)** when slug is absent from backlog — the known bug for autonomous mode. Fix: when `autonomous_dispatch`, absent from backlog as type "research" → return False.
+2. `classify_entries(ini, all_initiatives, autonomous_dispatch: bool = False)` at line 536: propagate parameter to each `is_need_satisfied(n, ini.slug, all_initiatives, autonomous_dispatch)` call (lines 559, 612).
+3. `analyze_bounded(root: Path, autonomous_dispatch: bool = False)` at line 844: propagate to `classify_entries(ini, initiatives, autonomous_dispatch)` call (line 862). `workspace_status()` passes `autonomous_dispatch=True` to `analyze_bounded`.
+4. `analyze()` callers do NOT change (human-session default=False).
+5. Update SKILL.md §2 (needs-resolution table) and the `shape:`/`research:` comments in `workspace_status_engine.py` to document the two-mode semantics. In doing so, strip the stale `schema.md:113`, `schema.md:114`, and `SKILL.md:90` citations from those comments (the file does not exist and the SKILL.md line number is inside a TOML template block, not needs-resolution prose) — replace with "SKILL.md §2".
+
+**Anchor-test sweep:** grep for tests that directly call `is_need_satisfied()` or indirectly via `analyze_bounded()` — update any that assert the old behavior on absent targets (should be zero; the default=False preserves existing semantics).
+
+---
+
+### Task 5 — `permissions.allow` additive-merge projection
+
+**Depends on:** Task 0, Task 2 (tool names canonical)
+**Verification:** Goal-based check
+**Done when:** `agentbundle install core` on a clean repo adds exactly 6 `mcp__workspace-mcp__*` entries (parsed assertion, not grep count). Repeat on a repo with pre-existing `permissions.allow` entries: existing preserved, no duplicates.
+**Tests:** `packages/agentbundle/tests/test_adapter_permissions_projection.py` — install core on tmp repo, parse `.claude/settings.json`, assert all 6 ids present in `permissions.allow`.
+**Approach:** Add additive-merge projection target to `packages/agentbundle/agentbundle/_data/adapter.toml` for the Claude adapter. Implement the merge logic (if the projection capability for `permissions.allow` doesn't exist, add it). If the adapter contract cannot be extended non-breakingly, mark AC17/AC18 `(deferred: workspace-mcp-permissions-projection-contract)` and file the follow-on RFC.
+
+---
+
+### Task 6 — Version bump, changelog, and README
+
+**Depends on:** Tasks 1–5
+**Verification:** Goal-based check
+**Done when:** agentbundle version bumped (minor); `CHANGELOG.md` has `[Unreleased]` entry with `Engine-Change-RFC: RFC-0078`; `README.md` documents `workspace_mcp`.
+**Tests:** no stub (goal-based)
+**Approach:** Standard agentbundle version bump per `packages/AGENTS.md`. Run `make build-self` (if Task 1 or alias-script changes weren't already reprojected) to sync projected files.
+
+---
+
+### Task 7 — Full gates pass
+
+**Depends on:** Tasks 1–6
+**Verification:** Goal-based check
+**Done when:** `python3 -m pytest packages/agentbundle/tests/ -q` exits 0; `make lint-ruff` exits 0; `SKIP_SAST=1 make build-check` exits 0.
+**Tests:** no stub — running the suite IS the check
+**Approach:** Fix any pre-existing failures per pre-flight protocol. If CI wiring for `packages/agentbundle` tests is absent, add the step.
+
+---
+
+## Wave schedule (provisional — confirmed after Task 0 closes)
+
+| Wave | Tasks | Notes |
+| ---- | ----- | ----- |
+| 0 | Task 0 (spikes) | Gate; blocks all others |
+| 1 | Task 1, Task 4 | Independent; Task 1 writes loop-engine; Task 4 writes workspace_status_engine; no shared files |
+| 2 | Task 2 | Core module; depends on Task 1 for end-to-end event bridge tests |
+| 3 | Task 3, Task 5 | Alias (depends on Task 2); permissions projection (depends on Task 2) |
+| 4 | Task 6 | Version bump; depends on all prior tasks |
+| 5 | Task 7 | Full gates; depends on all prior tasks |
+
+Tasks 1 and 4 CAN run in parallel within Wave 1 — they edit different files. If parallel dispatch is attempted: Task 1 edits `loop-engine.py`; Task 4 edits `workspace_status_engine.py` — no shared files, safe to run concurrently. Confirm no shared test fixture pollution before dispatching in parallel.

--- a/docs/specs/workspace-mcp/spec.md
+++ b/docs/specs/workspace-mcp/spec.md
@@ -1,0 +1,143 @@
+# Spec: workspace-mcp — Stage 1 implementation
+
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0078](../../rfc/0078-workspace-mcp.md) (Accepted 2026-08-03)
+- **Design doc:** [`docs/architecture/workspace-mcp/design.md`](../../architecture/workspace-mcp/design.md) (converged at Codex Round 8; zero P1 findings)
+- **ADRs:** [ADR-0062](../../adr/0062-workspace-mcp-per-session-only-constraint.md) · [ADR-0063](../../adr/0063-session-instruction-universal-elicitation.md) · [ADR-0064](../../adr/0064-events-jsonl-as-fsm-event-source.md) · [ADR-0065](../../adr/0065-elicit-elicitation-create-response-file-fallback.md) · [ADR-0066](../../adr/0066-reactive-git-at-turnend.md) · [ADR-0067](../../adr/0067-lifecycle-manifest-builtin-defaults-workspace-types-d.md) · [ADR-0068](../../adr/0068-notification-namespace-x-core.md) · [ADR-0069](../../adr/0069-threading-model-daemon-threads-bounded-pool.md)
+- **Shape:** new module (`agentbundle.workspace_mcp`) + loop-engine events.jsonl append + core-pack alias + agentbundle Claude adapter projection target
+
+> **Spec contract:** this document defines what "done" means for Stage 1. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Stage gate
+
+**Stage 1 does not begin implementation until all five Stage 0 spikes close:**
+
+| Spike | Gate question | Result |
+| ----- | ------------- | ------ |
+| (a) Instruction durability | Does `session/new` instruction survive across turns in at least one production AI host? | **PASS** — `systemPrompt` in `_meta` baked into `query()` at session creation; persists across turns. No per-turn re-injection needed. |
+| (b) Notification naming | Is `x-core/` the confirmed ACP v1 extension namespace? (ADR-0068 updates on result) | **FAIL → renamed** — Observed convention is `_<namespace>/method` (e.g. `_claude/sdkMessage`). All `x-core/` references renamed to `_agentbundle.core/`. ADR-0068 updated. |
+| (c) Notification relay | Do `notifications/message` frames reach the control plane as `session/update` events? | **FAIL → fallback** — `claude-agent-acp@0.64.0` does not relay MCP `notifications/message` (`case "notification": break`). Fallback: control plane polls `workspace_status()`. AC3, AC7, AC8 updated. |
+| (d) Module-mode spawn | Does `python3 -I -m agentbundle.workspace_mcp` install and work? | **PASS** — isolation confirmed; submodule import works under `-I`. |
+| (e) Threading model | Does stdlib daemon threads + bounded pool handle nested `elicitation/create` re-entrancy? | **PASS** — `{request_id: Event}` map pattern; two concurrent elicitations resolved without deadlock. |
+
+All five Stage 0 spikes closed. Spikes (b) and (c) required design updates (rename + poll-based fallback); both are resolved. Implementation may begin.
+
+## Objective
+
+Deliver the Stage 1 workspace-mcp implementation: a per-session MCP server (Claude Code adapter only) that gives the control plane structured FSM-transition notifications, human-gate intercept, and git lifecycle tools for work-loop sessions, with zero missed transitions and zero behavior change when workspace-mcp is not configured.
+
+**Scope — Stage 1 only:**
+- Adapter: Claude Code (Class A)
+- Skill: work-loop (FSM observability)
+- Components: loop-engine events.jsonl append (new), event bridge, workspace_status tool, elicit tool, git tools (scoped)
+- Not in Stage 1: artifact watcher (Stage 3), non-FSM skills (Stage 3), Codex/Copilot/Kiro (Stages 2a/2b/2c), multi-instance (Stage 4)
+
+## Acceptance Criteria
+
+### Loop-engine changes (enabling event bridge)
+
+- [ ] AC0 **loop-engine events.jsonl append.** `loop-engine.py` `cmd_transition` appends one JSON line per FSM transition to `.loop-run/events.jsonl` (repo-root-relative, gitignored, ephemeral). Each line contains: `{"seq": <int>, "run_id": "<uuid>", "spec": "<spec-dir>", "from": "<state>", "event": "<event>", "to": "<state>", "at": "<iso8601>"}` — matching the canonical schema in design.md:317 and the notification-contract table at design.md:342. `cmd_init` initializes `.loop-run/` (creates dir, writes `events.jsonl` header with `run_id`). The append follows the outbox protocol: write pending line to `.loop-run/events.pending`, write `engine-state.json` atomically (rename), append pending line to `events.jsonl`, delete pending.
+
+- [ ] AC0a **outbox ownership — universal pending recovery in both `cmd_transition` and `cmd_init`.** `.loop-run/events.pending` is repo-global (shared across all active specs). When a pending file exists, recovery always runs against the file's **owning spec** (identified by `pending["spec"]`), not the current spec — because skipping a foreign pending file only defers the overwrite to step 2, silently losing the owning spec's missed transition:
+  1. Read `pending["spec"]` to identify the owning spec directory.
+  2. Load `{pending["spec"]}/engine-state.json` (the owning spec's state, regardless of which spec is currently running).
+  3. If `pending["to"] == owning_state["state"]` AND `pending["seq"] == owning_state["transition_sequence"]` AND `pending["run_id"] == owning_state["run_id"]`: **replay** (append to events.jsonl, delete pending). Otherwise: **discard** (delete pending without appending).
+  This check runs at the **start of `cmd_transition`** (before writing a new pending event — handles the same-spec resume case and the cross-spec case where another spec's crash left a foreign pending file) AND at **`cmd_init` startup** (handles the restart-from-scratch case). Not running recovery before writing step 2 overwrites the prior pending file and silently loses the missed transition, whether same-spec or cross-spec. This ensures loop-engine (not workspace-mcp) owns events.pending replay.
+
+### workspace-mcp module
+
+- [ ] AC1 **Module entry point.** `pip install agentbundle` installs `agentbundle/workspace_mcp.py`. `python3 -I -m agentbundle.workspace_mcp --help` exits 0. `python3 -I -m agentbundle.workspace_mcp` with a real `session/new` MCP handshake completes init, declares the tool surface, and enters the request loop.
+
+- [ ] AC2 **Core-pack alias.** `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py` exists and delegates to `agentbundle.workspace_mcp` (no logic duplication).
+
+- [ ] AC3 **Event bridge — zero missed transitions.** In a complete work-loop session (spec-plan mode: 7+ transitions), workspace-mcp's event bridge reads every FSM transition from `.loop-run/events.jsonl` with no gaps (consecutive `seq` values tracked internally). Rapid back-to-back transitions within a single 200ms poll cycle are both captured. The current FSM state is exposed via `workspace_status()` (see AC8); `_agentbundle.core/skill-state-change` notifications are generated but NOT relayed to the ACP control plane by `claude-agent-acp@0.64.0` (spike (c) — `case "notification": break`). Verified by internal unit test of the bridge's offset tracking and seq deduplication logic.
+
+- [ ] AC4 **Event bridge — torn-write recovery.** A partial last line in `.loop-run/events.jsonl` (simulated by a half-complete JSON line) does not crash the bridge or emit a malformed notification; the partial line is buffered until the remainder arrives.
+
+- [ ] AC5 **Event bridge — inode/truncation reset.** When `.loop-run/events.jsonl` is deleted and recreated (simulating `loop-engine reset`), workspace-mcp detects the inode change, resets offset, buffer, and run_id, and reattaches correctly without missing events from the new file.
+
+- [ ] AC6 **Event bridge — seq deduplication.** workspace-mcp tracks the last-emitted `seq`; an event line with `seq ≤ last_emitted_seq` is skipped without emitting a duplicate notification.
+
+- [ ] AC7 **Human-gate state in `workspace_status()`.** When workspace-mcp's event bridge reads a transition whose `to` field ends in `*-HUMAN-GATE`, the gate state is reflected in `workspace_status()` response fields: `gate_pending: true`, `gate: "<to>"`, `gate_question: "<question string>"`, `review_findings: "<last known reviewer report from disk, if any>"`. The control plane detects gate entry by polling `workspace_status()` and checking `gate_pending`. `_agentbundle.core/human-gate-pending` is also generated (spec-compliant contract target) but is not relayed to the ACP control plane in `claude-agent-acp@0.64.0` (spike (c) fallback).
+
+- [ ] AC8 **`workspace_status()` tool.** Returns a JSON object with `ready`, `shaping`, `blocked`, `active`, and FSM state keys. Each `ready` item has `ini_slug`, `type`, `slug`, and `dispatch_skill`. Each `blocked` item has an `unmet_needs` list. Items for absent packs appear with `available: false` and `required_pack: "<pack-name>"`. DAG resolution follows workspace.toml `needs:` edges. **FSM state fields (spike (c) fallback — poll-based observability):** `current_state` (string — current loop-engine FSM state, null if no active run), `gate_pending` (bool — true when current state ends in `*-HUMAN-GATE`), `gate` (string or null — the `*-HUMAN-GATE` state name when `gate_pending` is true), `gate_question` (string or null — gate question from `engine-state.json`), `review_findings` (string or null — last reviewer output from disk). When `events.jsonl` is missing when expected, returns `{"warning": "EVENTS-FILE-MISSING", "engine_state": null}` rather than omitting the FSM fields silently.
+
+- [ ] AC9 **Pack-presence filter.** For a workspace with a missing optional pack, `workspace_status()` returns items for that pack's types with `available: false, required_pack: "<pack-name>"`. Pack presence is checked against 6 roots (3 adapters × repo-scope + user-scope), OR logic.
+
+- [ ] AC10 **Slug safety guard — regex and containment.** Before formatting an `ini_slug`, `type`, or `slug` value into an output_pattern glob, workspace-mcp validates each segment against `^[a-zA-Z0-9._-]+$` AND explicitly rejects any segment that is `.`, `..`, or starts with `-`. After formatting, the resolved directory is verified to remain under the type's static output base (realpath check, not merely under repo root). An item failing either check is excluded from the result (logged as a warning).
+
+- [ ] AC11 **`elicit()` tool — MCP path.** On an AI host that declares `elicitation` capability in its init handshake, `elicit()` sends an `elicitation/create` MCP server→client request with the question and options, blocks in a worker thread until the response arrives on the main stdio loop's `{request_id: Event/queue}` map, and returns the response to the caller.
+
+- [ ] AC12 **`elicit()` tool — response-file fallback.** On an AI host that does NOT declare `elicitation` capability, `elicit()`: (a) creates a response file in an `mkdtemp()`-isolated temp directory using `O_EXCL` (fails if file already exists — anti-pre-seed guard), sets permissions `0600`; (b) writes the question to the file; (c) polls until the control plane overwrites the file using the temp-and-rename protocol; (d) reads the response and returns it. The temp dir is cleaned up on session end. If a pre-existing file is found at `O_EXCL` creation time, the tool raises an error rather than reading the possibly-forged response.
+
+- [ ] AC13 **`elicitation` capability — never advertised in ServerCapabilities.** workspace-mcp never includes `elicitation` in its MCP ServerCapabilities response (regardless of what the AI host declares). It selects the delivery path (AC11 vs AC12) from the host's `capabilities.elicitation` field in the init handshake. (Fixes bug #419 where advertising `elicitation` as a server capability produces an invalid MCP handshake.)
+
+- [ ] AC14 **git tools — scoped commit and validated push.** `git_status()` returns the current git status. `git_branch(name)` validates `name` via `git check-ref-format --branch <name>` (the `--branch` form rejects names starting with `-` and other invalid characters; the plain refname form does not) before any subprocess call; after passing validation, creates and checks out the new branch with `["git", "checkout", "-b", name]` (`shell=False`; no `--` here — the branch name is an option argument, not a pathspec; the `--branch`-form `check-ref-format` is the injection defense). `git_commit(message)` intersects uncommitted files with the dispatched item's `output_pattern` before staging — files not matching the pattern are not staged (reject null-pattern items with an error); stages only matching paths via `["git", "add", "--", *matched_paths]`. `git_push(branch)` performs a two-sided check: `branch` argument must equal the immutable session-bound branch (from env var or git HEAD at session start) AND HEAD must equal that branch; fails with an explicit error if either check fails; runs `["git", "push", "--", "origin", branch]`. `shell=False` enforced on all subprocess calls. `--` end-of-options separator applies to commands taking pathspec positional arguments (`git add`, `git push`); `git checkout -b` takes the branch name as an option argument and does not use `--`.
+
+- [ ] AC15 **git tools — discovery-mode guard.** In discovery mode (no env vars), `git_branch`, `git_commit`, and `git_push` return an error; `git_status` is allowed.
+
+- [ ] AC16 **MCP stdin validation.** The main stdio loop enforces: (a) a frame-size cap (configurable, default 1 MiB; frames exceeding the cap are quarantined and logged — the connection is NOT dropped, but the frame is discarded with an error response); (b) malformed JSON frames are discarded with an error response, not propagated; (c) `elicitation/create` responses whose `request_id` does not match any outstanding server-issued request are discarded (not routed to a worker).
+
+- [ ] AC17 **Headless permissions projection.** `agentbundle install core` additively merges the following entries into `.claude/settings.json` `permissions.allow`: `mcp__workspace-mcp__workspace_status`, `mcp__workspace-mcp__elicit`, `mcp__workspace-mcp__git_status`, `mcp__workspace-mcp__git_branch`, `mcp__workspace-mcp__git_commit`, `mcp__workspace-mcp__git_push`. Existing entries are preserved; no entry is duplicated. **This pre-approval is safe only because AC14's output_pattern scoping and push branch check are in force** — implementers must not weaken AC14 under the assumption that pre-approval is bounded by the tool's safety controls.
+
+- [ ] AC18 **`permissions.allow` projection — non-breaking.** The additive-merge does not break existing adopter Claude adapter projections. Verified by `agentbundle install core` on a repo with and without pre-existing `permissions.allow` entries.
+
+- [ ] AC19 **Needs-resolution semantics — autonomous dispatch mode.** `is_need_satisfied()`, `classify_entries()`, and `analyze_bounded()` each gain an `autonomous_dispatch: bool = False` parameter. `workspace_status()` calls `analyze_bounded(autonomous_dispatch=True)`, which propagates the parameter through `classify_entries(autonomous_dispatch=True)` to `is_need_satisfied(autonomous_dispatch=True)`. When `autonomous_dispatch=True`: a `shape:` target absent from both `ini.shaping.active` AND `ini.shaping.backlog` is treated as *unsatisfied* (current default behavior: absent from `active` → treated as satisfied regardless of backlog); a `research:` target absent from `ini.shaping.backlog` as type "research" is also treated as *unsatisfied* (current default behavior: `slug not in research_slugs` returns True/satisfied when absent — same gap). When `False` (default): behavior is unchanged (SKILL.md §2 semantics preserved for human-managed sessions). SKILL.md §2 (needs-resolution table) and the `shape:`/`research:` explanatory comments in `workspace_status_engine.py` are updated to document the two-mode semantics.
+
+- [ ] AC20 **Session instruction template.** workspace-mcp ships a default session instruction template (embedded string constant) that the control plane can inject via `session/new.instruction`. The template instructs the AI to call `elicit()` for all questions, decisions, and option-selection moments. The template is readable as a constant from the installed module (e.g., `agentbundle.workspace_mcp.DEFAULT_SESSION_INSTRUCTION`). The content is consistent with the design doc's Component 3 specification.
+
+- [ ] AC21 **Zero behavior change without workspace-mcp.** A work-loop session run without `workspace-mcp` in `session/new.mcpServers` produces output identical to the pre-workspace-mcp baseline. Verified by running a spec-plan loop session with and without the server configured; diffing stdout.
+
+- [ ] AC22 **Per-session exit.** workspace-mcp exits when stdin closes. No port is bound; no process survives after session end. Verified by spawning workspace-mcp, closing its stdin, and asserting the process has exited within 5 seconds.
+
+- [ ] AC23 **agentbundle version bump.** `packages/agentbundle` version bumped (minor — new public module surface); `Engine-Change-RFC: RFC-0078` footer in the changelog entry; `CHANGELOG.md` `[Unreleased]` entry present. `packages/agentbundle/README.md` documents the `workspace_mcp` module.
+
+## Boundaries
+
+**In scope for Stage 1:**
+- `packages/agentbundle/agentbundle/workspace_mcp.py` — new module
+- `packs/core/.apm/skills/work-loop/scripts/loop-engine.py` — events.jsonl append + outbox protocol (AC0, AC0a); projected to `.agents/skills/work-loop/scripts/loop-engine.py` via `make build-self`
+- `packs/core/.apm/skills/workspace-status/scripts/workspace_mcp_server.py` — alias script
+- `packages/agentbundle/agentbundle/_data/adapter.toml` — new additive-merge projection target
+- `packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py` — `is_need_satisfied()` update (AC19)
+- SKILL.md §2 — needs-resolution two-mode semantics (AC19)
+- `packages/agentbundle/` tests covering ACs 0–23
+- agentbundle version bump; `make build-self` reprojection
+
+**Out of scope for Stage 1:**
+- Artifact watcher (Stage 3)
+- Non-FSM skills (Stage 3)
+- Codex CLI, Copilot CLI, Kiro CLI adapters (Stages 2a/2b/2c)
+- workspace-types.d/ third-party extension (Stage 3)
+- workspace.toml initiative entry (scheduling decision)
+
+## Testing Strategy
+
+**Unit tests (TDD) — materialized stubs before implementation:**
+- `test_loop_engine_events_jsonl.py`: outbox protocol — write pending → atomic state write → append → delete (AC0); outbox recovery at `cmd_init` startup AND at `cmd_transition` entry (resume case) — replay or discard based on pending.to/seq match, crash-then-next-transition (AC0a)
+- `test_workspace_mcp_event_bridge.py`: event bridge offset tracking; human-gate detection and enriched notification payload (AC3, AC7); partial-line buffering on torn-write — partial last line held at offset, completed on next poll, no crash (AC4); inode/truncation reset — inode change or size < offset → reset offset/buffer/run_id to re-attach (AC5); seq deduplication — `seq ≤ last_emitted_seq` skipped without duplicate emission (AC6)
+- `test_workspace_mcp_tools.py`: `workspace_status()` result shape, pack-presence filter, slug safety guard + containment check (AC8, AC9, AC10)
+- `test_workspace_status_engine_autonomous.py`: `is_need_satisfied()` + `classify_entries()` + `analyze_bounded()` autonomous-dispatch mode — `shape:` absent from active AND backlog → unsatisfied; `research:` absent from backlog as type "research" → unsatisfied; default=False preserves existing semantics (AC19)
+- `test_workspace_mcp_elicit.py`: capability detection, `elicitation/create` response routing, response-file O_EXCL guard (AC11, AC12, AC13)
+- `test_workspace_mcp_git.py`: `check-ref-format` validation, `--` separator, output_pattern commit intersection, push two-sided branch check (AC14); discovery-mode returns error for mutating tools (AC15)
+- `test_workspace_mcp_stdin.py`: frame-size cap, malformed JSON quarantine, unknown request_id rejection (AC16)
+- `test_workspace_mcp_lifecycle.py`: per-session exit on stdin close (AC22)
+
+**Integration / Visual/manual QA:**
+- End-to-end: `python3 -I -m agentbundle.workspace_mcp` with a real Claude Code session running a spec-plan work-loop. Validate AC3 (no seq gap), AC7 (gate notification payload), AC11 (elicit path at `SPEC-HUMAN-GATE`).
+- Baseline comparison for AC21: run a spec-plan loop without mcpServers; run with; diff stdout.
+
+**Goal-based checks:**
+- `python3 -I -m agentbundle.workspace_mcp --help` exits 0 (AC1)
+- `python -c "from agentbundle.workspace_mcp import DEFAULT_SESSION_INSTRUCTION; assert DEFAULT_SESSION_INSTRUCTION and 'elicit' in DEFAULT_SESSION_INSTRUCTION"` exits 0 (AC20)
+- `agentbundle install core` → Python: parse `.claude/settings.json`; assert all 6 MCP tool ids present in `permissions.allow` (AC17)
+- `python3 -m pytest packages/agentbundle/tests/ -q` green
+
+## Assumptions
+
+1. Stage 0 spikes (a)–(e) all close with passing results before implementation begins.
+2. The agentbundle Claude adapter can gain an additive-merge `permissions.allow` projection target without a breaking contract change. If false, AC17/AC18 are deferred: `(deferred: workspace-mcp-permissions-projection-contract)`.
+3. Spike (b) result: `x-core/` is NOT the ACP v1 extension convention; observed form is `_<namespace>/method`. All references renamed to `_agentbundle.core/` before Stage 1. ADR-0068 updated.
+4. `is_need_satisfied()` can accept an `autonomous_dispatch` parameter without changing default semantics for human-managed sessions.

--- a/workspace.toml
+++ b/workspace.toml
@@ -432,6 +432,16 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # workspace-mcp Stage 1 deferred AC. agentbundle Claude adapter additive-merge
+  # `permissions.allow` projection for the 6 workspace-mcp MCP tool ids. If the
+  # adapter contract cannot be extended non-breakingly, AC17/AC18 are deferred here.
+  # Fix: extend adapter.toml to support additive-merge projection targets for
+  #   permissions.allow; implement the merge in the Claude adapter; verify
+  #   `agentbundle install core` on clean repo adds all 6 ids without breaking
+  #   existing entries (test_adapter_permissions_projection.py).
+  # Unblocks when: Stage 1 implementation begins (spec/workspace-mcp approved).
+  {slug = "workspace-mcp-permissions-projection-contract", source = "spec/workspace-mcp AC17"},
+
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)
 


### PR DESCRIPTION
## Summary

- **RFC-0078** (Accepted) — workspace-mcp: optional per-session MCP server bridging loop-engine FSM events, workspace queue state, and git lifecycle to ACP control planes, with zero behavior change when not configured
- **ADRs 0062–0069** — 8 architectural decisions: per-session spawn, universal elicitation, events.jsonl FSM source, elicit() two-tier delivery, reactive git, lifecycle manifest, notification namespace, threading model
- **Design doc** (`docs/architecture/workspace-mcp/design.md`) — converged to zero P1 findings over 8 Codex adversarial review rounds; 10 P1s closed (trusted spawn, FSM gate scoping, outbox protocol, threading, watcher binding, path expansion, response-file atomicity, pack-presence filter, two-phase watcher, slug safety)
- **Spec + Plan** (`docs/specs/workspace-mcp/`) — Approved; Stage 0 sealed; 5 empirical spikes completed

## Stage 0 spike outcomes

| Spike | Result |
|-------|--------|
| (a) Instruction durability | PASS — `session/new._meta.systemPrompt` persists across all turns via SDK `query()` |
| (b) Notification naming | FAIL → **renamed** — `x-core/` retired; `_agentbundle.core/` confirmed from `_claude/sdkMessage` pattern |
| (c) Notification relay | FAIL → **fallback** — `claude-agent-acp@0.64.0` drops `notifications/message`; control plane polls `workspace_status()` (AC3/AC7/AC8 updated) |
| (d) Module-mode spawn | PASS — `python3 -I -m agentbundle.workspace_mcp` isolation confirmed |
| (e) Threading model | PASS — `{request_id: Event}` map; two concurrent elicitations; no deadlock |

## What's next (Stage 1)

Implementation tracked in `docs/specs/workspace-mcp/` (Status: Approved). Wave schedule in plan.md. Blocking prerequisite: `agentbundle.workspace_mcp` module does not yet exist.

## Deferred

- `x-core/` → `_agentbundle.core/` rename noted in spike (b); all in-tree references updated in this PR
- Spike (c) fallback: `workspace_status()` poll-based observability replaces push notifications for Stage 1; push notifications remain the design target once claude-agent-acp adds `notifications/message` relay