### PR TITLE
fix(web): correct broken journey index links for product-engineering and release-engineering

### DIFF
--- a/web/src/pages/journeys/index.astro
+++ b/web/src/pages/journeys/index.astro
@@ -7,8 +7,8 @@ import { withBase } from '../../lib/paths';
 // Display order: three supervised loops first, then alpha by slug.
 const displayOrder = [
   { slug: 'core', name: 'Core' },
-  { slug: 'discovery', name: 'Discovery (Product Engineering)' },
-  { slug: 'release', name: 'Release Engineering' },
+  { slug: 'product-engineering', name: 'Discovery (Product Engineering)' },
+  { slug: 'release-engineering', name: 'Release Engineering' },
   { slug: 'architect', name: 'Architect' },
   { slug: 'atlassian', name: 'Atlassian' },
   { slug: 'contracts', name: 'Contracts' },


### PR DESCRIPTION
## Problem

Two links on the journeys index page ([/journeys/](https://eugenelim.github.io/agent-ready-repo/journeys/)) were 404ing:

- **Discovery (Product Engineering)** linked to `/journeys/discovery/` — no such page
- **Release Engineering** linked to `/journeys/release/` — no such page

The actual content files are `product-engineering.md` and `release-engineering.md`, which generate URLs `/journeys/product-engineering/` and `/journeys/release-engineering/` respectively.

## Fix

Corrected the two slug entries in the `displayOrder` array in `web/src/pages/journeys/index.astro`.

## Verification

`python3 tools/lint-web-journey-parity.py` passes: all 16 journeys in parity.