### PR TITLE
docs(agents-local): surface projected-adapter lint command

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -12,6 +12,12 @@ directly. To propagate changes to new adopters, also update `packs/core/seeds/AG
 - **Catalogue CI** (portable commands, publication ordering, exit codes, responsibility boundary):
   [`guides/_shared/reference/catalogue-ci-contract.md`](guides/_shared/reference/catalogue-ci-contract.md).
 
+## Commands
+
+```bash
+python tools/lint-agent-artifacts.py     # projected adapter lint — not in make build-check; run for .apm/ changes
+```
+
 ## Catalogue authoring scaffold — release-impact policy
 
 The catalogue authoring scaffold is bundled into the `agentbundle` wheel as package data under


### PR DESCRIPTION
Adds a `## Commands` section to `AGENTS.local.md` with the one command that isn't covered by `make build-check`: `python tools/lint-agent-artifacts.py` (projected adapter output lint).

This knowledge was previously only in agent memory — moving it into the repo so any contributor sees it.

Deferred: remaining memory-to-repo migrations (CI package wiring, agentbundle test roots, traceability marker form, deferred-marker spec, etc.) tracked separately.