### PR TITLE
docs(rfc-0080 + local-scope-install): RFC, spec, plan, ADR for --scope local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ docs-site/src/sidebar-config.json
 .workspace-repair.lock
 .workspace.toml.*.tmp
 .plan.*.tmp
+.loop-run/

--- a/docs/adr/0070-local-scope-install-decisions.md
+++ b/docs/adr/0070-local-scope-install-decisions.md
@@ -63,12 +63,14 @@ across all clones, and appear in `git diff --stat` until committed — the oppos
 what a local-scope install requires.
 
 The path is resolved via `git rev-parse --git-path info/exclude` rather than
-hard-coded as `.git/info/exclude`. This one-liner handles linked worktrees
-(which have their own `.git` file pointing to the common `.git` dir under
-`.git/worktrees/<name>/`) and submodules, both of which have non-standard `.git`
-directory layouts. In the primary worktree the path resolves to `.git/info/exclude`;
-in linked worktrees it resolves to `.git/worktrees/<name>/info/exclude` (which is a
-separate per-worktree file, not the common one — a subtlety covered in D3 below).
+hard-coded as `.git/info/exclude`. In both primary and linked worktrees, this
+command resolves to the **common-dir** exclude file (i.e. `.git/info/exclude`
+under the main repository's `.git/` directory), not a per-worktree variant.
+This is because git routes `--git-path` for `info/exclude` through the common
+directory even when run from a linked worktree, making the resolved path
+identical from any worktree. The command also handles submodules correctly.
+The per-worktree discriminant needed for block attribution is provided by D3's
+keyed-block design, not by writing to separate files.
 
 The file is created on first write if absent (it is optional in a fresh repo).
 Writes are always atomic: read → modify in memory → write to a temp file in the same
@@ -129,12 +131,18 @@ Block format (canonical):
 
 Rules:
 - Leading `/` anchors patterns to the repo root (same behaviour as `.gitignore`).
+- Each path is gitignore-metacharacter-escaped before writing (`[`, `]`, `*`, `?`,
+  `\` are backslash-escaped; `#` and `!` only when at line start) so that projected
+  filenames containing gitignore pattern syntax are matched literally.
 - If a block for this `(pack, worktree-id)` already exists, it is replaced in place
   (no duplicate accumulation).
 - Blocks from different worktrees coexist; each is stripped only by its own
   `(pack, worktree-id)` uninstall.
-- Stale blocks (from deleted worktrees) accumulate harmlessly — git treats the paths
-  as unmatchable when the files don't exist.
+- Stale blocks (from deleted worktrees) accumulate in `info/exclude`. They are **not**
+  harmless: their patterns continue to apply in all linked worktrees that share the
+  common-dir `info/exclude`. A stale block can silently hide a tracked or committed
+  file in another worktree. Pruning deferred to a follow-on `agentbundle local prune`
+  CLI; risk must be documented in the `write_exclude_block` docstring.
 
 ### D4 — Defer file locking on `.git/info/exclude` to a follow-on release
 
@@ -193,8 +201,11 @@ actual platform mix of agentbundle users.
 **Negative:**
 
 - Stale blocks accumulate in `.git/info/exclude` when worktrees are deleted without
-  uninstalling. They are harmless but untidy. A future `agentbundle local prune`
-  command could clean them; deferred.
+  uninstalling. They are **not** harmless: their patterns continue excluding same-path
+  files in all linked worktrees sharing the common-dir `info/exclude`, potentially
+  hiding a tracked or committed file added later in another worktree. A future
+  `agentbundle local prune` command could clean them; deferred. The risk is documented
+  in the `write_exclude_block` docstring (AC26/AC27).
 - The lost-update race (D4) can result in one process's block being silently overwritten
   by another. Users running parallel `agentbundle install` processes will need to
   re-run the losing install. Unlikely in practice; documented.

--- a/docs/adr/0070-local-scope-install-decisions.md
+++ b/docs/adr/0070-local-scope-install-decisions.md
@@ -1,0 +1,285 @@
+# ADR-0070: Local scope install — `.git/info/exclude` exclusion, whole-install abort, per-worktree keyed blocks, and deferred concurrent-write lock
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Decision-makers:** eugenelim
+- **Consulted:** adversarial-reviewer (25 passes on RFC-0080)
+- **Supersedes:** none
+- **Related:** RFC-0080, ADR-0002 (install scope per pack), ADR-0039 (install identity and footprint)
+
+## Decision summary
+
+- **Decision:** We will implement `--scope local` using `.git/info/exclude` for git
+  exclusion (not `.gitignore`), abort the whole install on any tracked-file collision,
+  key exclude blocks to `(pack, worktree-id)` pairs for multi-worktree safety, and
+  defer file-locking to a follow-on release.
+- **Because:** `.git/info/exclude` is never committed, is per-clone, and is the only
+  exclusion mechanism that satisfies the "no git-visible side-effect" invariant for a
+  local-scope install.
+- **Applies to:** `agentbundle install --scope local`, `uninstall --scope local`, and
+  any future subcommands that read or modify local-scope state.
+- **Tradeoff accepted:** Concurrent writes by two agentbundle processes share a
+  whole-file replacement strategy with no lock; the last writer wins (lost-update
+  race documented but not prevented in v1).
+- **Revisit if:** A user report demonstrates real data loss from the concurrent-write
+  race; or a subcommand needs to accept `--scope local` alongside `--profile` (current
+  guard already refuses this, but a future spec amendment could reopen the question).
+
+## Context
+
+RFC-0080 introduced `--scope local`: install pack files at the same working-tree
+paths as `--scope repo`, but keep them invisible to git so they never appear in
+`git status`, are never committed, and leave no trace after uninstall. The primary
+use case is trialling a pack in a repo you don't own or haven't permanently adopted.
+
+Implementing this requires four distinct architectural decisions, each with at least
+two plausible alternatives. RFC-0080 researched and modelled each one before
+implementation began. This ADR records the chosen options and their rationale.
+
+Key constraints that shaped all four decisions:
+
+- **No committed file.** Nothing written by `--scope local` may appear in
+  `git status` or be committable. Corollary: the exclusion mechanism itself must
+  not be a committed file.
+- **Per-clone isolation.** Local installs are per-clone, not per-user. They must
+  survive branch switches and `git stash` without becoming visible.
+- **Atomic writes.** `os.replace` (POSIX-atomic, near-atomic on NTFS) is the only
+  safe write mechanism for files that another process might read concurrently.
+- **Multi-worktree correctness.** `git worktree add` creates linked worktrees that
+  share the same `.git/info/exclude` file. An exclude block that doesn't identify its
+  source worktree would be ambiguous and impossible to strip correctly on uninstall.
+
+## Decision
+
+### D1 — Use `.git/info/exclude`, not `.gitignore`, for per-file git exclusion
+
+> We will resolve the exclude-file path via `git rev-parse --git-path info/exclude`
+> and write all local-scope exclusions there. We will never write to `.gitignore`.
+
+`.git/info/exclude` is the per-clone, per-working-tree exclusion file. It is never
+committed, is not shared between clones, and is ignored by `git status` itself (its
+own path is outside the working tree). `.gitignore` entries are committed, shared
+across all clones, and appear in `git diff --stat` until committed — the opposite of
+what a local-scope install requires.
+
+The path is resolved via `git rev-parse --git-path info/exclude` rather than
+hard-coded as `.git/info/exclude`. This one-liner handles linked worktrees
+(which have their own `.git` file pointing to the common `.git` dir under
+`.git/worktrees/<name>/`) and submodules, both of which have non-standard `.git`
+directory layouts. In the primary worktree the path resolves to `.git/info/exclude`;
+in linked worktrees it resolves to `.git/worktrees/<name>/info/exclude` (which is a
+separate per-worktree file, not the common one — a subtlety covered in D3 below).
+
+The file is created on first write if absent (it is optional in a fresh repo).
+Writes are always atomic: read → modify in memory → write to a temp file in the same
+directory → `os.replace`.
+
+### D2 — Abort the whole install when any target file is already tracked by git
+
+> We will check every target file for git-tracked status before writing any of them.
+> If any file is tracked, the whole install aborts with no partial writes.
+
+A partial install (some files written, some refused) is worse than no install:
+it is hard to reason about, hard to undo, and can leave the repo in a state where
+`git status` shows unexpected deletions or modifications. An atomic "all or nothing"
+contract is simpler to communicate and to implement.
+
+The check runs as a pre-flight step using
+`git ls-files --error-unmatch <path>` on every target path. Exit 0 → tracked;
+exit non-zero → untracked. On any tracked file, the install is refused before any
+files are written.
+
+The refusal message names all tracked files (not just the first) so the user can
+decide whether to `git rm --cached` them before retrying.
+
+### D3 — Key exclude blocks to `(pack-name, worktree-id)` pairs
+
+> We will write exclude blocks with a structured comment key:
+> `# agentbundle:local:<pack>:<worktree-id>:{begin,end}`.
+> The worktree-id is derived at install time and stored only in the block key itself.
+
+`.git/info/exclude` is shared across all linked worktrees of the same repository
+(the primary worktree and all `git worktree add` clones share the same common-dir
+`info/exclude`). Without a worktree discriminant, two different worktrees installing
+the same pack would write overlapping blocks, and uninstall in one worktree would
+strip the other's block.
+
+The worktree-id is derived by comparing `git rev-parse --git-dir` and
+`git rev-parse --git-common-dir`:
+- Equal → primary worktree; use a stable sentinel derived from the common-dir path
+  (e.g. a short hash of the absolute path) so the key is deterministic.
+- Unequal → linked worktree; use the last component of `--git-dir` (the name git
+  assigned under `.git/worktrees/`).
+
+Sanitization: the id must not contain `:` (the block-key delimiter). Any `:` is
+replaced with `_`.
+
+The block key is the only identity mechanism: no external registry, no state-file
+field, no cross-file reference. Pack names are `[a-z0-9-]+` per `pack.schema.json`;
+the worktree-id after sanitization is also URL-safe. Together they are sufficient to
+identify, locate, and strip a block without ambiguity.
+
+Block format (canonical):
+```
+# agentbundle:local:<pack-name>:<worktree-id>:begin
+/.agentbundle-local-state.toml
+/.claude/skills/<pack-slug>/SKILL.md
+# agentbundle:local:<pack-name>:<worktree-id>:end
+```
+
+Rules:
+- Leading `/` anchors patterns to the repo root (same behaviour as `.gitignore`).
+- If a block for this `(pack, worktree-id)` already exists, it is replaced in place
+  (no duplicate accumulation).
+- Blocks from different worktrees coexist; each is stripped only by its own
+  `(pack, worktree-id)` uninstall.
+- Stale blocks (from deleted worktrees) accumulate harmlessly — git treats the paths
+  as unmatchable when the files don't exist.
+
+### D4 — Defer file locking on `.git/info/exclude` to a follow-on release
+
+> We will not add a file lock in v1. Concurrent writes use whole-file atomic
+> replacement (`os.replace`); a lost-update race is possible when two agentbundle
+> processes write simultaneously. This is documented and accepted as a v1 limitation.
+
+A POSIX advisory lock (`fcntl.flock`) would serialize concurrent writers.
+The cost: complexity in the write path, platform divergence (Windows `msvcrt.locking`
+vs. POSIX `flock`), and a non-trivial test surface.
+
+The lost-update scenario requires two agentbundle processes to simultaneously write
+to the same `.git/info/exclude`. In practice this is rare: `agentbundle install`
+is a CLI command typically run by one developer at a time. The risk-adjusted cost
+of the race is low relative to the implementation cost of a correct cross-platform
+lock in v1.
+
+`os.replace` is POSIX-atomic (the kernel guarantees the rename is atomic) and
+near-atomic on NTFS (the replacement is visible to other processes either before or
+after, never as a torn write). This eliminates the corruption scenario; only the
+lost-update scenario remains.
+
+The follow-on specification for concurrent-write locking should evaluate whether
+`filelock` (a small, cross-platform advisory-lock library) is an appropriate
+dependency, or whether the POSIX `fcntl`-based approach is sufficient given the
+actual platform mix of agentbundle users.
+
+## Decision drivers
+
+- **No committed file.** The exclusion mechanism must not appear in `git status`.
+  Eliminates `.gitignore` for D1.
+- **Atomic writes.** File writes must be resilient to concurrent reads.
+  Drives `os.replace` for all writes; drives D4's deferred-lock acceptance.
+- **Multi-worktree correctness.** Blocks must be attributable to a specific
+  worktree so uninstall strips only the correct block.
+  Drives the keyed-block design in D3.
+- **Simplicity over completeness.** v1 should ship a correct, tested, minimal
+  implementation. Concurrency handling beyond `os.replace` is deferred.
+  Drives D4.
+- **User experience.** A partial install is harder to recover from than a clean
+  refusal. Drives the abort-on-any-collision policy in D2.
+
+## Consequences
+
+**Positive:**
+
+- Local-scope installs leave no git-visible trace; `git status` is clean before
+  and after install/uninstall cycles.
+- Multi-worktree safety is guaranteed at the data-model level (block keys), not by
+  runtime coordination.
+- Whole-install atomicity (D2) means the repo is always either fully installed or
+  unmodified.
+- The `os.replace` write path is already used by agentbundle for `.agentbundle-state.toml`;
+  no new platform abstraction is needed.
+
+**Negative:**
+
+- Stale blocks accumulate in `.git/info/exclude` when worktrees are deleted without
+  uninstalling. They are harmless but untidy. A future `agentbundle local prune`
+  command could clean them; deferred.
+- The lost-update race (D4) can result in one process's block being silently overwritten
+  by another. Users running parallel `agentbundle install` processes will need to
+  re-run the losing install. Unlikely in practice; documented.
+- `.git/info/exclude` is not visible to `git status` itself, so users cannot
+  directly inspect it via normal git UX. They can read the file, or run
+  `agentbundle list-installed --scope local` for the agentbundle-managed view.
+
+**Revisit if:**
+
+- A user report demonstrates real data loss (not just inconvenience) from the
+  concurrent-write race in D4.
+- A future subcommand needs `--scope local` alongside `--profile`; the current
+  pre-flight guard (`:162-165`) would need amending.
+- `git rev-parse --git-path info/exclude` begins resolving differently for linked
+  worktrees in a future git version (currently stable across git ≥2.5).
+
+## Confirmation
+
+- **Mode:** architecture fitness test + reviewer-checked
+- **Signal:**
+  - `python3 -m pytest packages/agentbundle/tests/ -q` green with the
+    integration test (T11 in `plan.md`) exercising the full install/uninstall cycle.
+  - The integration test asserts: (a) specific files exist on disk after install,
+    (b) `git status --short` is empty, (c) the keyed block is in `info/exclude`,
+    (d) `git status --short` is empty after uninstall, (e) the block is gone.
+  - Adversarial reviewer confirms no new site in `install.py` uses a
+    `plan.scope == "repo" else` ternary without being documented in RFC-0080's
+    threading section.
+- **Owner:** eugenelim
+
+## Alternatives considered
+
+### D1 alternatives
+
+- **`.gitignore`** — Rejected. `.gitignore` is a committed file; adding entries to it
+  via `agentbundle install` would produce `git status` output (the modified
+  `.gitignore`), directly violating the no-visible-trace requirement.
+- **`git update-index --assume-unchanged`** — Rejected. This marks a tracked file
+  as unchanged, not an untracked file as ignored. It is the wrong primitive for
+  new files that should never be tracked at all. It also has surprising interactions
+  with `git stash` and `git checkout`.
+- **`git update-index --skip-worktree`** — Rejected for the same reason as
+  `--assume-unchanged`; both operate on already-tracked files.
+
+### D2 alternatives
+
+- **Partial install (skip tracked files, write the rest)** — Rejected. Leaves the
+  repo in an inconsistent state. The user's intent was to install the full pack; a
+  silently partial install is harder to diagnose than an explicit refusal.
+- **Overwrite tracked files** — Rejected. Would produce visible modifications in
+  `git status` (the tracked files would show as modified), violating the invariant.
+- **Warn and continue** — Rejected. Same problem as partial install; the risk of
+  undetected inconsistency outweighs the convenience.
+
+### D3 alternatives
+
+- **Single-worktree assumption (no worktree-id in block key)** — Rejected. Any repo
+  with `git worktree add` would accumulate overlapping blocks from different
+  worktrees; uninstall from one would silently break the other's exclusion.
+- **External registry (a separate file mapping worktree-id to block ranges)** —
+  Rejected. Introduces a second file to keep in sync with `info/exclude`, a second
+  failure mode (registry and exclude diverge), and a second write requiring
+  coordination. The block key is self-describing.
+- **Per-worktree state only (no shared exclude file)** — Rejected. The `info/exclude`
+  in a linked worktree under `.git/worktrees/<name>/` is a separate file from the
+  primary worktree's `info/exclude`. Writing only to the per-worktree file would
+  mean local installs in linked worktrees are invisible from the primary worktree's
+  perspective. The shared common-dir `info/exclude` is the correct single location;
+  the block key is the per-worktree discriminant.
+
+### D4 alternatives
+
+- **`fcntl.flock` (POSIX advisory lock)** — Deferred, not rejected. Correct and
+  efficient on POSIX; not available on Windows (`fcntl` is POSIX-only). A
+  cross-platform lock would need `msvcrt.locking` on Windows or a third-party
+  library such as `filelock`. Cost is real; defer until a user report justifies it.
+- **`filelock` library (cross-platform)** — Deferred. Would be the preferred
+  approach if locking is added in a follow-on release; avoids platform branches.
+  Not added in v1 to avoid a new dependency (per the repo's Dependencies are
+  forever constraint in `AGENTS.md`).
+
+## References
+
+- RFC-0080 — canonical authority for all design decisions recorded here
+- ADR-0002 — install-scope is a per-pack default + allowance
+- ADR-0039 — install identity is the content-addressed footprint
+- `docs/specs/local-scope-install/spec.md` — acceptance criteria and boundaries
+- `docs/specs/local-scope-install/plan.md` — implementation tasks and rollout

--- a/docs/adr/0070-local-scope-install-decisions.md
+++ b/docs/adr/0070-local-scope-install-decisions.md
@@ -87,7 +87,9 @@ it is hard to reason about, hard to undo, and can leave the repo in a state wher
 contract is simpler to communicate and to implement.
 
 The check runs as a pre-flight step using
-`git ls-files --error-unmatch <path>` on every target path. Exit 0 → tracked;
+`git --literal-pathspecs ls-files --error-unmatch <path>` on every target path
+(`--literal-pathspecs` prevents pathspec syntax in filenames from matching
+unrelated tracked files). Exit 0 → tracked;
 exit non-zero → untracked. On any tracked file, the install is refused before any
 files are written.
 
@@ -132,8 +134,9 @@ Block format (canonical):
 Rules:
 - Leading `/` anchors patterns to the repo root (same behaviour as `.gitignore`).
 - Each path is gitignore-metacharacter-escaped before writing (`[`, `]`, `*`, `?`,
-  `\` are backslash-escaped; `#` and `!` only when at line start) so that projected
-  filenames containing gitignore pattern syntax are matched literally.
+  and `\` are backslash-escaped; `#`/`!` need not be escaped because the leading `/`
+  anchor prevents them from appearing at line start) so that projected filenames
+  containing gitignore pattern syntax are matched literally.
 - If a block for this `(pack, worktree-id)` already exists, it is replaced in place
   (no duplicate accumulation).
 - Blocks from different worktrees coexist; each is stripped only by its own

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,15 @@
 | 0058 | [Per-pack config root (`user-root`) stored as an optional field on `PackState` adapter rows in user-scope `state.toml`](0058-per-pack-config-root-in-packstate-adapter-rows.md) | Accepted |
 | 0059 | [Pack config uses a three-source cascade baked into `_data/install-defaults.toml` at catalogue build time](0059-pack-config-cascade-via-install-defaults-baking.md) | Accepted |
 | 0061 | [Phase-1 loop infrastructure uses Option A — pure phase tracker with hard engine/cohort boundary](0061-loop-infrastructure-phase-1.md) | Accepted |
+| 0062 | [workspace-mcp is per-session only — no persistent daemon, no lifecycle management across sessions](0062-workspace-mcp-per-session-only-constraint.md) | Accepted |
+| 0063 | [Session instruction for universal elicitation interception](0063-session-instruction-universal-elicitation.md) | Accepted |
+| 0064 | [events.jsonl as the FSM event source](0064-events-jsonl-as-fsm-event-source.md) | Accepted |
+| 0065 | [elicit() tool + elicitation/create + response-file fallback](0065-elicit-elicitation-create-response-file-fallback.md) | Accepted |
+| 0066 | [Reactive git at TurnEnd](0066-reactive-git-at-turnend.md) | Accepted |
+| 0067 | [Lifecycle manifest — built-in defaults and workspace-types.d/ extension](0067-lifecycle-manifest-builtin-defaults-workspace-types-d.md) | Accepted |
+| 0068 | [Notification namespace — _agentbundle.core/](0068-notification-namespace-x-core.md) | Accepted |
+| 0069 | [Threading model — daemon threads and bounded worker pool](0069-threading-model-daemon-threads-bounded-pool.md) | Accepted |
+| 0070 | [Local scope install — `.git/info/exclude` exclusion, whole-install abort, per-worktree keyed blocks, and deferred concurrent-write lock](0070-local-scope-install-decisions.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/rfc/0080-local-scope-install.md
+++ b/docs/rfc/0080-local-scope-install.md
@@ -1,0 +1,782 @@
+# RFC-0080: Local scope install
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-04
+- **Date closed:**
+- **Decision weight:** standard
+- **Related:** [RFC-0004](0004-install-scope-per-pack.md) (install-scope per pack),
+  [RFC-0005](0005-user-scope-hook-support.md) (user-scope hook support; defines force-merge as user-scope-only),
+  [RFC-0008](0008-claude-plugins-install-route-parity.md) (Claude-plugins install-route parity),
+  [RFC-0012](0012-repo-scope-per-adapter-projection.md) (repo-scope per-adapter projection; defines allowed-prefixes.repo)
+
+## Reviewer brief
+
+- **Decision:** Add `--scope local` to `agentbundle install`
+  (agentbundle — the CLI that installs and manages packs; a pack is a bundle of
+  agent skill files projected into a repo) — files land in the working tree
+  (identical placement to `--scope repo`) but are excluded from git via
+  `.git/info/exclude`, so a pack is usable in a session without touching any
+  committed file.
+- **Recommended outcome:** Accept.
+- **Change if accepted:**
+  - `LEGAL_SCOPES` in `scope.py` gains `"local"`; `allowed-scopes` pack schema
+    gains `"local"` as a valid value; `"local"` is auto-allowed for any pack that
+    allows `"repo"` (no existing `pack.toml` changes needed).
+  - Install refuses if not inside a git working tree; resolves the exclude path
+    via `git rev-parse --git-path info/exclude`; refuses if any target file is
+    already tracked; appends a comment-delimited block to the exclude file.
+    Uninstall removes working-tree files and strips the block.
+  - New per-repo state file `.agentbundle-local-state.toml`, gitignored via the
+    same block.
+  - `_parse_adapter_row` in `config.py` is widened to source its scope allowlist
+    from `LEGAL_SCOPES` rather than a hardcoded tuple, so `scope = "local"` rows
+    are read correctly by the new binary.
+- **Affected surface:** `agentbundle install`/`uninstall` CLI; `scope.py`
+  (`LEGAL_SCOPES` + `resolve()` default-scope guard); `config.py`
+  (`_parse_adapter_row` guard); `commands/_common.py` (`resolve_state_path`
+  routing); `commands/list_installed.py` (three-scope default list; inline
+  `if/else` routing must gain an explicit `local` branch); `commands/install.py`
+  (substantial: new `local` branch in `_ScopePlan`-building loop at line 759;
+  full site-by-site audit — see "install.py write-path threading" in Proposal
+  for the complete fork-family enumeration including carve-outs and key sites; `--emit-install-routes + --scope local` refusal at
+  `install.py:390`; `emit_install_routes` inference at line 258 — `cli_scope !=
+  "user"` must become `cli_scope == "repo"` so local never infers the
+  plugins-route producer); `cli.py` (six hardcoded
+  `choices=("repo","user")` sites at `cli.py` lines 261, 390, 525, 581, 630, 678);
+  `pack.schema.json` (`allowed-scopes` `allOf` if/then constraint);
+  `config.py:860` (`Literal["repo","user"]` type annotation on
+  `load_adapt_discovery_typed` — a follow-on concern; not on the primary local
+  write path, but must be widened if profile/adapt support is added later).
+  `adapter.toml` does not change — local reuses the repo resolution path
+  (`allowed_prefixes_repo` via the widened upstream gate at `install.py:513`);
+  `safety.py:337` guards only `scope="user"`. No `pack.toml` changes needed for
+  existing packs. Note: the `resolve()` local⇒repo invariant for the
+  explicit-allowed-list case (when a pack names `["user","local"]` without
+  `"repo"`) rests solely on the schema `allOf` gate — `resolve()` itself does
+  not re-check it. Schema validation must precede `resolve()`; this ordering
+  is the current behavior and must be preserved.
+- **Stakes:** Reversible — `--scope local` installs can be undone; the scope can
+  be deprecated without touching existing `repo`/`user` behaviour.
+- **Review focus:** (1) The `.git/info/exclude` append/uninstall contract and
+  its shared-across-worktrees behaviour. (2) The tracked-file collision detection
+  and partial-overlap edge case.
+- **Not in scope:** `.gitignore` writes; changes to pack content rules; user-scope
+  equivalents; cross-clone persistence; per-pack ability to exclude `"local"` scope;
+  `--scope local` for the claude-plugins adapter route (which uses
+  `settings.local.json` as its target, not the working tree — a separate, untriggered
+  problem).
+
+## The ask
+
+**Recommendation (BLUF — Bottom Line Up Front):** Accept a `--scope local`
+install mode that installs pack files into the repo working tree and excludes
+them from git via `.git/info/exclude`, so skills (Claude Code instruction files
+installed to `.claude/skills/`) like `work-loop` (the implementation-loop skill)
+can be used in any repo session without appearing in `git status` or being
+committable.
+
+**Why now (SCQA — Situation, Complication, Question, Answer):** Agent-ready-repo
+(the open-source repo that publishes these packs) packs are useful in repos that haven't
+permanently adopted them. Today's workarounds are `--scope user` (globally
+persistent across all repos — wrong lifetime), `--scope repo` plus a manual
+`.gitignore` entry (fragile; easy to forget; creates a diff), or
+install-then-uninstall (files remain visible in `git status` during the session,
+risking an accidental commit). A first-class local scope removes the last
+friction on "try this in any repo without polluting its git history."
+
+**Decisions requested:**
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+|----|----------|----------------|-----|-----------|-----------------|
+| D1 | What does `--scope local` mean? | Working-tree files + `.git/info/exclude` exclusion | Same placement as `repo`; semantically consistent with RFC-0008's "not committed, per clone" use of `local` | This review | Confirm scope definition |
+| D2 | Git exclusion mechanism? | Append to `.git/info/exclude` via `git rev-parse --git-path` (comment-delimited; never duplicate) | Not committed; creates no working-tree diff; stdlib-only | This review | Confirm mechanism |
+| D3 | State file location? | `<repo>/.agentbundle-local-state.toml`, itself gitignored via same block | Transparent; mirrors `.agentbundle-state.toml`; separate file means old agentbundle never reads it | This review | Confirm location |
+| D4 | Must packs opt in via `allowed-scopes`? | No — auto-allowed for any pack that allows `"repo"`, unconditionally | `local` is a visibility modifier on `repo`, same content rules; no pack author burden; no per-pack exclusion in v1 | This review | Confirm or require opt-in |
+
+## Problem & goals
+
+**Problem.** Pack skills are most useful precisely in repos that haven't adopted
+them — one-off sessions in an unfamiliar codebase, a contractor repo without
+the `core` pack, a quick audit. The two existing scopes don't cover this:
+
+- `--scope repo` makes pack files visible in `git status` and committable. Fine
+  for long-term adoption; wrong for a session.
+- `--scope user` installs to `~/.claude/` and follows the user globally. Wrong
+  lifetime (the skill shows up in every repo, forever).
+
+The manual workaround — install, add paths to `.gitignore`, work, uninstall,
+restore `.gitignore` — is fragile and error-prone.
+
+**Goals.**
+
+- One flag (`--scope local`) installs a pack into the working tree, fully
+  functional for the session, with no git footprint.
+- Uninstall is clean: working-tree files removed, no residue in
+  `.git/info/exclude`, no stale state file.
+
+**Non-goals.**
+
+- Changing what adapter-projected files a pack projects (local scope projects
+  the same adapter-overlay files as repo scope — i.e. the files listed in
+  `allowed-prefixes.repo`). Seeds (repo-root `AGENTS.md`/`docs/CHARTER.md`,
+  written at `install.py:1254`), the install marker (`_append_install_marker`
+  at `:1447`), and the layout section (`_append_layout_section` at `:1456`) are
+  **not** delivered in `--scope local` installs: they land at the repo root
+  outside `allowed_prefixes_repo`, which would surface them in `git status` and
+  defeat the no-footprint goal. `:1254` is already gated by `plan.scope ==
+  "repo"` and can be left unchanged; `:1447` and `:1456` are **unconditional
+  calls** that require an explicit `if plan.scope != "local":` guard (see
+  Proposal, Carve-outs).
+- Supporting `.gitignore` writes (`.git/info/exclude` is the right mechanism;
+  see Options considered).
+- A `--scope local` equivalent for user scope.
+- Cross-clone persistence: local-scope installs are intentionally per-clone.
+- Per-pack ability to exclude `"local"` scope (no v1 denylist; see D4).
+- `--profile … --scope local`: profile installs (`install.py:4331`, `:4357`)
+  have their own scope-routing and an `opposite` scope computation that breaks
+  for `local`. No new refusal guard is needed in v1 — `install.py:162-165`
+  already refuses any `--scope` flag alongside `--profile`; once `cli.py:390`
+  adds `"local"` as a valid choice, `--profile --scope local` hits that existing
+  guard unchanged, and the `scope_value` computations at `:4331`/`:4357` are
+  only reachable when no `--scope` was passed. Follow-on deferred.
+
+## Proposal
+
+### Scope definition (D1)
+
+`--scope local` installs pack files to the same working-tree paths as
+`--scope repo` (governed by the adapter's `allowed-prefixes.repo` list — the
+adapter is the per-target-tool integration layer, e.g. `claude-code` or
+`cursor`; `allowed-prefixes.repo` is its declared list of permitted filesystem
+path prefixes for repo-scope writes) and additionally appends a
+comment-delimited exclusion block to the repo's per-clone `.git/info/exclude`
+file (not a `.gitignore`; uses gitignore syntax but is never committed). From
+git's perspective the files don't exist.
+
+**Naming note.** RFC-0008 (Accepted) uses the `local` token in the context of
+the Claude-plugins install route to mean "listed in `settings.local.json`
+(a gitignored Claude Code settings file not committed to the repo), not
+committed." The semantics are consistent — both uses mean "visible to this
+clone, not committed, not shared" — but the mechanisms differ. No CLI conflict
+exists: RFC-0008's `local` is a keyword in the Claude-plugins adapter's own
+scope taxonomy, distinct from the `agentbundle install --scope` flag.
+
+### Git exclusion contract (D2)
+
+**Pre-flight check.** Before any file write, agentbundle verifies it is inside
+a git working tree:
+
+```bash
+git rev-parse --is-inside-work-tree
+```
+
+If this fails or returns `false`, install aborts with:
+```
+error: --scope local requires a git working tree; use --scope repo instead.
+```
+
+**Exclude path resolution.** agentbundle resolves the exclude file path via:
+
+```bash
+git rev-parse --git-path info/exclude
+```
+
+This returns the correct path for all repo configurations. Verified spike:
+in a linked worktree (`philadelphia-v1`), the command returns the main repo's
+`.git/info/exclude` — `info/exclude` is shared across all worktrees of the
+same repo, not per-worktree. This is the expected git behaviour (only a subset
+of `.git/` paths are per-worktree; `info/exclude` is not one of them). In a
+submodule, `git rev-parse --git-path` resolves relative to the submodule's own
+gitdir.
+
+**Block format.** agentbundle derives a worktree identifier by comparing
+`git rev-parse --git-dir` and `git rev-parse --git-common-dir` (equal →
+primary worktree; the implementation spec must choose a reserved sentinel that
+cannot be a user-assigned worktree name, such as a hash of the common-dir
+path; unequal → linked worktree, id taken from the last component of
+`--git-dir`). agentbundle appends a keyed block to the resolved file (creating
+it if absent):
+
+```
+# agentbundle:local:<pack-name>:<worktree-id>:begin
+/.agentbundle-local-state.toml
+/.claude/skills/work-loop/SKILL.md
+# agentbundle:local:<pack-name>:<worktree-id>:end
+```
+
+Paths are anchored with a leading `/` to match at repo root only, following
+gitignore semantics for absolute paths. Because gitignore deduplicates
+equivalent patterns, multiple worktrees having overlapping path entries is
+harmless.
+
+**Block rules.**
+
+- **Append-or-replace-in-place, never duplicate a `(pack-name, worktree-id)`
+  block.** agentbundle reads the file first; if a block keyed to this pack name
+  and worktree id already exists, it replaces it in place (e.g. on reinstall).
+  Otherwise it appends. Two different worktrees installing the same pack will
+  have path entries that overlap — gitignore deduplicates patterns at match time;
+  this is not a violation of the "no duplicate block" rule, which is
+  per-`(pack-name, worktree-id)` pair.
+- **One block per `(pack-name, worktree-id)` pair.** Multiple packs write
+  independent named blocks; the same pack in different worktrees writes
+  independent worktree-keyed blocks.
+- **Uninstall strips only this worktree's block and removes its working-tree
+  files.** Uninstall: (1) removes installed working-tree files (same as `repo`
+  scope uninstall); (2) reads the exclude file, strips the `(pack-name,
+  worktree-id)` block inclusive of markers, and writes back atomically via
+  `os.replace` (write to a temp file in the same directory, then rename);
+  (3) removes this pack's rows from `.agentbundle-local-state.toml`; deletes
+  the file only when it becomes empty (mirrors how `repo`-scope uninstall
+  removes rows rather than the whole state file). Install uses the same atomic
+  mechanism (read → modify in memory → write to temp file → `os.replace`) so
+  that all writes to `info/exclude` are full-file replacements, not in-place
+  appends.
+- **Stale blocks from deleted worktrees accumulate and are harmless.** When a
+  worktree is deleted without uninstalling (e.g. Conductor deleting an ephemeral
+  workspace), its block remains in `info/exclude`. The paths it references no
+  longer exist, so git treats them as unmatchable — no observable effect.
+  Cleanup is manual; the exact CLI surface (`agentbundle uninstall --scope local
+  --worktree <id>` or equivalent) is specified in the follow-on spec
+  (`docs/specs/local-scope-install/`).
+
+**Tracked-file collision check.** Before writing any file, agentbundle runs
+`git ls-files --error-unmatch <path>` for each target path. If any path is
+already tracked, the install aborts with:
+```
+error: <path> is already tracked by git; --scope local cannot shadow a
+       committed file. Use --scope repo or remove the tracked file first.
+```
+The whole install aborts (no partial writes). This is conservative — see Risks
+for the partial-overlap trade-off.
+
+**Repo/local conflict detection.** If the same pack is already installed at
+`--scope repo` in this working tree, `--scope local` refuses:
+```
+error: <pack> is already installed at --scope repo; uninstall it first or
+       use --scope repo to upgrade.
+```
+The reverse direction — `--scope repo` install when a local install already
+exists — is also refused:
+```
+error: <pack> is already installed at --scope local; uninstall it first or
+       use --scope local to upgrade.
+```
+This prevents a `--scope repo` install from writing files that the local
+exclude block hides from `git status`, which would make a committed install
+invisible to `git add`/`git commit`. `--scope user` installs land in
+`~/.claude/` (outside the working tree) and are unaffected by the exclude
+block, so user/local coexistence is allowed.
+
+Both directions are **hard refusals, immune to `--force`**. The existing
+cross-scope machinery at `install.py:668-684` is binary and `--force`-bypassable
+(`if other_already and not force:`). Wiring `installed_at_local` into that path
+would let `--scope repo --force` dual-install over a local install, writing
+committed files hidden by the exclude block. The local cross-scope refusal must
+be enforced before the `--force` check, outside the `scopes_to_install`
+computation.
+
+**Same-scope local reinstall.** The upgrade-offer guard at `install.py:631` is
+`(requested_scope=="repo" and installed_at_repo) or (requested_scope=="user" and
+installed_at_user)`. A `--scope local` reinstall of an already-local pack
+matches neither disjunct and bypasses the upgrade-offer. The `install.py:631`
+branch must gain `(requested_scope=="local" and installed_at_local)` so local
+reinstall routes to the upgrade-offer flow.
+
+**Multi-worktree support.** Because blocks are keyed per `(pack-name,
+worktree-id)`, multiple worktrees can hold independent `--scope local` installs
+of the same pack simultaneously, and each worktree's uninstall strips only its
+own block. Ephemeral worktrees (e.g. Conductor workspaces) may be deleted without
+uninstalling; their stale blocks accumulate but are harmless (see Block rules
+above).
+
+**Important: exclusion patterns are repo-global.** The keyed blocks scope only
+bookkeeping and uninstall — not git exclusion. A leading-`/` pattern in the
+shared `info/exclude` file anchors to each worktree's own root, so worktree A's
+install also suppresses those paths in worktree B. Consequence: the tracked-file
+collision check (see above) only protects the installing worktree; if worktree B
+has an untracked file at the same path that it intends to commit, A's
+local-install block will silently git-ignore it in B. Users with multiple
+active worktrees should be aware that `--scope local` affects git visibility
+across all worktrees of the same repo.
+
+**Concurrent-write limitation.** agentbundle does not hold a file lock on
+`.git/info/exclude` during install or uninstall. Because both install and
+uninstall use full-file atomic writes (`os.replace`), two simultaneous
+operations produce a *lost update*: one writer's full-file replacement clobbers
+the other's block, silently removing those pack files from the exclusion list
+and making them git-visible and committable. The same race applies to
+`.agentbundle-local-state.toml`. This is a known limitation; the implementation
+must document it prominently. Locking is out of scope for v1.
+
+### `_parse_adapter_row` guard (Blocker addressed)
+
+`config.py:524-529` currently contains a hardcoded tuple `("repo", "user")` that
+silently coerces unknown scope values to `default_scope` (the fallback scope
+recorded in the state row when no valid scope is found). The new binary must
+widen this guard to source from `LEGAL_SCOPES` (the frozenset in `scope.py`
+listing all valid scope values; after this RFC it becomes `{"repo", "user",
+"local"}`), so `scope = "local"` rows read from `.agentbundle-local-state.toml`
+are preserved correctly. Concretely:
+
+```python
+# Before:
+raw_scope if isinstance(raw_scope, str) and raw_scope in ("repo", "user") else default_scope
+# After (single-source from LEGAL_SCOPES):
+raw_scope if isinstance(raw_scope, str) and raw_scope in LEGAL_SCOPES else default_scope
+```
+
+This is a one-line change but is load-bearing for `list-installed` and any path
+that reads the local state file.
+
+### State file (D3)
+
+Local-scope state lives in `<repo>/.agentbundle-local-state.toml`. Its schema is
+identical to `.agentbundle-state.toml` (same `PackState` shape — the dataclass
+recording which files a pack installed and their content hashes — same
+`schema-version = "0.4"`) except all rows carry `scope = "local"`. The file is
+included in the pack's exclusion block at install time and removed at uninstall.
+
+**Backward compatibility.** Old agentbundle never enumerates
+`.agentbundle-local-state.toml` — `resolve_state_path` in
+`commands/_common.py` (the function that returns the canonical state-file path
+for a given scope) currently routes any non-`user` scope to
+`<root>/.agentbundle-state.toml`. This must be extended to route `"local"` to
+`<root>/.agentbundle-local-state.toml`. A team member on an older binary sees
+no effect (the new state file doesn't exist for them). No schema-version bump
+is needed.
+
+### `allowed-scopes` auto-promotion (D4)
+
+`scope.resolve()` (the function that checks whether the requested scope is
+permitted for a given pack) treats `"local"` as in-scope for any pack whose
+`allowed-scopes` contains `"repo"`. No per-pack exclusion mechanism exists in
+v1 — unconditional. The pack schema's `allowed-scopes` enum gains `"local"` as a valid explicit
+value so a pack may enumerate it (e.g. `allowed-scopes = ["repo", "local"]`);
+`default-scope` retains the `["repo", "user"]` enum and `"local"` is rejected
+there. No existing pack needs to change.
+
+`LEGAL_SCOPES` in `scope.py` is extended from `{"repo", "user"}` to
+`{"repo", "user", "local"}`.
+
+**Standalone `"local"` without `"repo"` is rejected.** A pack declaring
+`allowed-scopes = ["local"]` (without `"repo"`) is invalid — `"local"` is a
+visibility modifier on `"repo"` and has no meaning without it. Two enforcement
+points are required:
+
+1. **Schema rule.** `pack.schema.json`'s `[pack.install]` object already uses a
+   single `if/then/else` block (default-scope=user ⇒ contains user; else
+   contains repo). JSON Schema permits only one bare `if` per object; the new
+   local⇒repo constraint must be added as an `allOf` sibling:
+   `allOf: [{ if: { contains "local" }, then: { must also contain "repo" } }]`.
+   Without this, `allowed-scopes = ["user", "local"]` passes existing schema
+   validation and the auto-promote guard.
+
+2. **`resolve()` guard.** Adding `"local"` to `LEGAL_SCOPES` would otherwise
+   loosen the existing `pack_default not in LEGAL_SCOPES` check in `scope.py`,
+   allowing `default-scope = "local"` to pass runtime validation. `resolve()`
+   must gain an explicit check that runs **before** D4 auto-promotion:
+   ```python
+   # Illustrative — exact exception args/message to be determined by the spec
+   if pack_default == "local":
+       raise ScopeRefused(pack_name, "local", allowed_scopes)
+   ```
+   The `default-scope = "local"` reject must precede auto-promotion so a
+   hand-edited pack.toml with `default-scope = "local"` and no `--scope` flag
+   is caught before `"repo" in allowed` is evaluated.
+
+**Claude-plugins install-route guard.** `claude-plugins` is an install-route
+(not an adapter name); it is selected via the `--emit-install-routes` flag on
+`agentbundle install`, which writes `settings.local.json` entries for the
+`claude-code` adapter (see `contracts/adapter.toml:185`, `adapter.schema.json:240`).
+`commands/install.py:390` currently binds the plugins route to
+`requested_scope == "user"`; this check must also reject `scope = "local"` so
+`--emit-install-routes --scope local` is refused at install time with a
+scope-specific message (branched from the existing `--scope repo` error):
+```
+error: --scope local is not supported with --emit-install-routes.
+       See RFC-0008 for the plugins route's own local-scope behavior.
+```
+The existing guard at `install.py:390-393` emits a single shared string;
+widening it to cover `local` requires branching so the `local` path emits the
+message above rather than the repo-scoped one. Uninstall, diff, upgrade,
+list-installed, and init-state operate on state rows whose adapter is
+`claude-code` (never a separate `claude-plugins` entry), so no additional guard
+is needed in those subcommands. `commands/install.py` is the sole enforcement
+point. This is a v1 decision; a future RFC may define the interaction.
+
+### install.py write-path threading
+
+`commands/install.py` is the most complex change in this RFC — it is a
+two-valued `repo`/`user` machine at every level, and local must be threaded
+through each layer:
+
+1. **Upstream resolution gates.** `install.py:513` gates resolution of
+   `allowed_prefixes_repo`, `repo_target_adapter`, and the repo projection
+   on `requested_scope == "repo" and not emit_install_routes`. For a local
+   request `requested_scope == "local"`, this block is skipped and
+   `allowed_prefixes_repo` stays `None` — breaking the write-jail fence.
+   This gate must become `requested_scope in ("repo", "local") and not
+   emit_install_routes`. Similarly, `install.py:929` (`if any(p.scope ==
+   "repo" ...)`) and `:950` (`any(p.scope == "user" ...)`) gate projection
+   rendering; the repo aggregate must become `any(p.scope in ("repo",
+   "local") ...)` so local plans produce a projection.
+
+2. **`_ScopePlan`-building loop.** A new `local` branch at `install.py:759`
+   must produce `_ScopePlan(scope="local", root=repo_root, state_path=
+   <repo>/.agentbundle-local-state.toml, allowed_prefixes=allowed_prefixes_repo)`.
+
+3. **Downstream fork audit.** `install.py` has six families of
+   scope-branching sites — all must be audited:
+   - **`requested_scope == "repo"/"user"` equality comparisons** (e.g. lines
+     390, 397, 432, 486, 513, 577, 631, 663, 668, 739). Line 486
+     (`repo_state if requested_scope == "repo" else user_state`) routes
+     source-conflict checks; the `local` path must route to the new local
+     state file. Lines 631 and 668 drive the "already installed" and
+     cross-scope conflict checks — these currently only load
+     `installed_at_repo`/`installed_at_user`; a new `local_state` load and
+     `installed_at_local` flag must be derived so that the D4 repo/local
+     refusal is actually enforced.
+   - **`!= "user"` negation comparisons** — two sites, each needing different
+     treatment:
+     - `install.py:258` (`cli_scope != "user"`) — must become `cli_scope ==
+       "repo"` to stop local from entering the plugins-route producer. Handled
+       by point 4 below; only protects the test-fixture fallback.
+     - `install.py:377` (`if force_merge and requested_scope != "user":`) —
+       correctly refuses force-merge for every non-user scope; force-merge is
+       user-scope-only (RFC-0005). This guard works for local as-is. **Do not
+       change `!= "user"` to `== "repo"` here** — that would let
+       `--force-merge --scope local` slip through and execute undefined
+       behavior. If the implementer wants to be explicit, use
+       `requested_scope in ("repo", "local")` to make the intent legible, but
+       the behavior of the existing `!= "user"` is already correct.
+   - **`scope_value == "repo"/"user"` comparisons** in the profile-install
+     path (lines 760, 4331, 4357). All three are guarded by the v1 profile
+     refusal (see Non-goals), but must be explicitly skipped or wired if
+     profile support is added in a follow-on.
+   - **`plan.scope == "repo"/"user"` and `p.scope == "repo"/"user"` forks**
+     throughout the `_ScopePlan` processing loop (grep both variants).
+   - **`X if plan.scope == "repo" else <user-variant>` ternaries** — the
+     "else-implies-user" hazard, symmetric to the negation hazard above.
+     These are the load-bearing sites that select which projection is actually
+     written to disk: `install.py:1018`, `:1045`, `:1086` select
+     `repo_projection if plan.scope == "repo" else user_projection`; `:859`
+     and `:1093` select the adapter. For a `local` plan, all five default to
+     the user branch. When a user-only install is not present `user_projection` is
+     `None`; `install.py:1087-1088` coerces `None → {}`, so a missed ternary
+     site yields a **silent zero-file install that reports success**. These
+     five sites must use `plan.scope in ("repo", "local")` rather than a plain
+     equality check. This silent-`{}` failure mode makes a missed ternary site
+     undetectable without an integration test that asserts files were written.
+   - **`any(p.scope == ...)` aggregates**: the `:929` repo aggregate is widened
+     in point 1 (`any(p.scope in ("repo","local") ...)`); the `:950` user
+     aggregate (`any(p.scope == "user" ...)`) must **stay user-only** — local
+     plans must not enter user-projection rendering.
+   **Carve-outs** — sites that must be adjusted so local scope is *excluded*,
+   not widened:
+   - `install.py:1060` — dry-run seed preview, gated by `plan.scope ==
+     "repo"` — leave as-is (twin of `:1254`; correctly excludes local).
+   - `install.py:1254` — seed delivery (root `AGENTS.md`/`docs/CHARTER.md`);
+     already gated by `plan.scope == "repo"` — leave it as-is.
+   - `install.py:1447` (`_append_install_marker`) and `:1456`
+     (`_append_layout_section`) — **both are unconditional calls** (no
+     existing `plan.scope == "repo"` guard). For a local plan both write
+     root-level files outside `allowed_prefixes_repo`; `write_jailed` raises
+     `PathJailError`, and the loop's `except` at `:1463` returns 1 — the local
+     install cannot complete. The implementer must add an explicit scope guard
+     wrapping both calls (e.g. `if plan.scope != "local":`) so they are skipped
+     for local installs. Do *not* widen the per-prefix skip at `:2716`/`:2851`
+     (those are `scope == "repo"` only by design).
+
+   **Additional key sites** (add to the spec's individual enumeration):
+   - `install.py:814` — `if plan.scope == "repo" and not plan.already_installed:`
+     reloads state in `for_write=True` mode to fire the v0.1-format refusal.
+     Leave repo-only; `.agentbundle-local-state.toml` is always new so the
+     v0.1 reload is moot for local. Mark it explicitly "intentionally
+     repo-only" so the spec's implementer doesn't treat it as a missed site.
+   - `install.py:859` — `repo_target_adapter if plan.scope == "repo" else
+     user_target_adapter` adapter-selection ternary (also counted in the fifth
+     "else-implies-user ternary" fork family above; listed here for the `:863`
+     warning-suppression detail). For a local plan resolves to
+     `user_target_adapter` (None), suppressing the `_maybe_emit_dropped_warning`
+     call at `:863`. Widen to `plan.scope in ("repo","local")`.
+   - `install.py:1334` — `elif plan.scope == "repo" and repo_target_adapter is
+     not None:` sets `new_pack_state.adapter`. A local plan matches neither
+     this branch nor the user branch at `:1305`, so the local state row's
+     `adapter` field is never populated — diverging from an equivalent repo
+     install and causing `_parse_adapter_row`/`list-installed` to read back an
+     empty adapter. Widen the condition to
+     `plan.scope in ("repo","local") and repo_target_adapter is not None:`
+     (the adapter is already resolved via the `:1093` / `:859` fix).
+   - `install.py:1356` — compound condition `plan.scope == "repo" and
+     state_relpath == ".agentbundle-state.toml"` skips the RFC-0012 prefix
+     check so the root-level state write isn't blocked. The second conjunct does
+     not match `.agentbundle-local-state.toml`, so the local state write would
+     be blocked by the prefix check. Both conjuncts must be updated to accept
+     the local state filename.
+   - `install.py:1493-1543` (Step 13 emission loop) — has no `local` branch;
+     a `local` plan falls through to a bare `installed: core @ local` without
+     the mandated exclude-path suffix. A `local` branch must be added to emit
+     `installed: <pack> @ local (excluded via <git-resolved exclude path>)`.
+   - `install.py:1471-1477` (Step 12 `_chain_adapt`) — runs unconditionally;
+     for `local` scope, chain-adapt should be **skipped** (local installs are
+     ephemeral; adapt-discovery re-running would apply to files the user
+     considers invisible). The comment at `install.py:1468` records AC19b as
+     "invoke … regardless of the install scope (markers are repo-only)";
+     skipping for local is a deliberate amendment to AC19b — the derived spec
+     must record this change explicitly rather than silently diverging from it.
+
+4. **`emit_install_routes` inference.** `install.py:258` (`emit_install_routes
+   = cli_scope != "user"`) must become `cli_scope == "repo"` so local never
+   silently enters the plugins-route producer. Note: this only protects the
+   attribute-absent test-fixture fallback (real CLI invocations always have
+   `args.emit_install_routes`); the primary guard is the explicit refusal at
+   `install.py:390-393`.
+
+### CLI surface
+
+`cli.py` currently hardcodes `choices=("repo","user")` at six argparse sites.
+Three accept `local` in v1; three refuse it:
+
+| `cli.py` line | Subcommand | v1 treatment |
+|---|---|---|
+| 261 | `list-installed` | add `"local"` |
+| 390 | `install` | add `"local"` |
+| 525 | `diff` | **leave as `("repo","user")`** — argparse-native rejection |
+| 581 | `upgrade` | **leave as `("repo","user")`** — argparse-native rejection |
+| 630 | `uninstall` | add `"local"` |
+| 678 | `init-state` | **leave as `("repo","user")`** — argparse-native rejection |
+
+For the three that accept `local`, source `choices` from
+`tuple(sorted(LEGAL_SCOPES))` rather than duplicating the tuple, resolving
+the pre-existing single-sourcing drift the `scope.py:44-45` comment notes but
+does not enforce. The sorted-tuple form (not the bare frozenset) is required so
+`--help` and error messages render in stable, deterministic order across Python
+versions and `PYTHONHASHSEED` values — consistent with how
+`shipped_adapters_from_contract()` returns a sorted tuple at `scope.py:247-256`.
+The three refused sites **retain** `("repo","user")` so argparse rejects
+`--scope local` natively, giving users a consistent error without a runtime guard.
+
+Per-subcommand behavior for `--scope local` (v1):
+
+| Subcommand | Accepts `local`? | Notes |
+|---|---|---|
+| `install` | Yes | Primary use case |
+| `uninstall` | Yes | Removes local-scope install |
+| `list-installed` | Yes | Filters output to local scope |
+| `diff` | **No — refused** | `diff.py` has its own `== "user"` routing; follow-on |
+| `upgrade` | **No — refused** | `upgrade.py` has its own state-routing; follow-on |
+| `init-state` | **No — refused** | `init_state.py` hardcodes `.agentbundle-state.toml`; follow-on |
+
+`diff`, `upgrade`, and `init-state` each have their own inline scope-routing that
+does not go through `resolve_state_path` and would silently misroute a `local`
+request to the repo state file. v1 refuses `--scope local` on these three
+subcommands with:
+```
+error: --scope local is not yet supported for this subcommand.
+       Install, uninstall, and list-installed are fully supported.
+```
+Threading `local` through `diff.py` (`:85,102,183`), `upgrade.py`
+(`:524,601,843,958,994`), `init_state.py` (`:122,141,169`), and the
+`uninstall.py:105`/`:87` disambiguator is deferred to the follow-on spec.
+
+```
+agentbundle install --pack core --scope local
+agentbundle uninstall --pack core --scope local
+agentbundle list-installed   # local-scope rows shown with scope = local
+                             # and a note: "not committed; per-clone only"
+```
+
+The install success line must report both the scope and the actual
+exclude-file path written (resolved via `git rev-parse --git-path info/exclude`,
+which may point to the main repo's `.git/info/exclude` for a linked worktree
+or `.git/modules/<name>/info/exclude` for a submodule), e.g.:
+```
+installed: core @ local (excluded via /path/to/repo/.git/info/exclude)
+```
+
+## Options considered
+
+Axis: *what is the install target, and what git mechanism provides per-clone
+exclusion without a committed diff?*
+
+The option space is exhausted along two dimensions: (A) where files land
+(working-tree vs. out-of-tree); (B) for working-tree options, how they are
+excluded from git. Do-nothing is included.
+
+| Option | Files land in | Git-hidden? | Committed diff? | Verdict |
+|--------|--------------|-------------|-----------------|---------|
+| **A. Working-tree + `.git/info/exclude`** *(proposed)* | `<repo>/` | Yes — per-clone exclude | No | ✓ Recommended |
+| **B. `--scope user` alias** | `~/.claude/` | N/A — never in repo | No | ✗ Wrong lifetime: global, not per-session |
+| **C. Working-tree + `.gitignore` write** | `<repo>/` | Yes | Yes — `.gitignore` change creates a diff | ✗ Defeats the purpose |
+| **D. Working-tree + `--skip-worktree`** | `<repo>/` | Yes — index flag | No | ✗ Requires files to be previously committed; irrelevant for new installs |
+| **E. Temp-dir install** | System temp | N/A | No | ✗ Fixed discovery paths in harness (the Claude Code runtime that loads skills from fixed locations); requires harness changes out of scope |
+| **F. No automation (do-nothing)** | N/A | User-managed | Varies | ✗ Cost of delay: every user rediscovers the workaround; risk of accidental commits stays; per-session onboarding friction persists |
+
+A is the only option that satisfies "working-tree visible to Claude Code,
+excluded from git without a committed diff, stdlib-only."
+
+## Risks & what would make this wrong
+
+**Pre-mortem.**
+
+- *User runs `--scope local` and the pack's files are already tracked in the
+  repo.* The install aborts with a clear error; no partial write. This is the
+  correct conservative behaviour, but it means `--scope local` cannot be used
+  in repos that already track a colliding path (e.g. a repo that already commits
+  `.claude/skills/work-loop/`). This is an intentional non-goal: `--scope repo`
+  is the right scope for repos that track pack files.
+- *Multi-worktree installs of the same pack.* Per-worktree keyed blocks allow
+  independent simultaneous installs. Stale blocks from deleted worktrees
+  accumulate in `info/exclude` but are harmless (paths no longer exist).
+- *Concurrent agentbundle calls on the same repo.* Without a file lock, two
+  simultaneous `--scope local` installs produce a lost update: one writer's
+  atomic full-file replace clobbers the other's block, silently making those
+  files git-visible and committable. Same applies to the state file. Known
+  limitation; locking is deferred to v2.
+- *User deletes the repo and re-clones.* The exclude file and state file are
+  machine-local; a fresh clone has neither. Pack files also don't transfer.
+  Correct behaviour for local scope.
+
+**Key assumptions (falsifiable).**
+
+- `git rev-parse --git-path info/exclude` is available in all git versions users
+  are likely to have (introduced git ≥2.5.0, 2015).
+- `info/exclude` (or its submodule equivalent) is writable by the process that
+  owns the working tree.
+- `git ls-files --error-unmatch` correctly identifies tracked paths before the
+  install writes any file.
+
+**Drawbacks.**
+
+- Adds a third scope to a two-scope system; `scope.resolve()` logic grows.
+- `.git/info/exclude` is per-clone: CI pipelines and teammates on a fresh clone
+  do not have the exclusions. Correct for local scope but may surprise users who
+  expect the pack to "just work" in CI.
+- The whole-install abort on any tracked-file collision is conservative: a repo
+  that already tracks `.claude/skills/work-loop/SKILL.md` for some other reason
+  cannot use `--scope local` for the `core` pack at all. This is by design
+  (shadowing a tracked file is git-breaking) but limits the feature for partially
+  pre-configured repos.
+- No per-pack ability to restrict `--scope local` in v1.
+
+## Evidence & prior art
+
+**Spike / de-risk result.** Verified in the current working directory, which is
+itself a git linked worktree (a checkout that shares git history with the main
+repo but has its own working directory):
+
+1. `git rev-parse --git-path info/exclude` → returns main repo's
+   `.git/info/exclude` (not a per-worktree path). `info/exclude` is shared
+   across all worktrees; the command resolves correctly in all repo configurations
+   via the git-path abstraction.
+2. `echo "test-entry" >> .git/info/exclude && git status` — the entry is
+   honoured immediately, no git process restart required.
+3. Atomic replace (`os.replace`) is standard POSIX/Windows stdlib; no third-party
+   dependency.
+
+**Repo precedent.**
+- RFC-0004 (`0004-install-scope-per-pack.md`) — canonical scope RFC; established
+  `"repo"` and `"user"`, explicitly noted that adding scopes later is "a one-line
+  schema bump"; rejected `"global"` (system-wide), not `"local"`.
+- RFC-0008 (`0008-claude-plugins-install-route-parity.md:202`) — uses the
+  `local` token to mean "project-local, not committed" in the Claude-plugins
+  install route. Semantically aligned with this RFC's `--scope local`.
+- `scope.py:46` — `LEGAL_SCOPES = frozenset({"repo", "user"})` — the extension
+  point this RFC expands.
+- `config.py:524-529` — `_parse_adapter_row` hardcoded tuple; widening to
+  `LEGAL_SCOPES` is a one-line fix required by this RFC.
+
+**External prior art.**
+- [git-scm.com/docs/gitignore](https://git-scm.com/docs/gitignore) — documents
+  `.git/info/exclude` as the per-clone, user-private, never-committed exclusion
+  mechanism. Pattern syntax identical to `.gitignore`.
+- `git config --local / --global / --system` — canonical three-tier scope
+  hierarchy; the `local` naming here is intentionally aligned.
+- Ansible `blockinfile` module — documents the comment-delimited
+  `# BEGIN ANSIBLE MANAGED BLOCK` / `# END ANSIBLE MANAGED BLOCK` managed-section
+  pattern that this RFC's `:begin`/`:end` markers follow.
+  ([docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html))
+
+## Follow-on artifacts
+
+- Spec: `docs/specs/local-scope-install/` — implementation plan covering:
+  - `scope.py` (`LEGAL_SCOPES`; `resolve()` default-scope reject-before-promote
+    guard)
+  - `config.py` (`_parse_adapter_row` widen to `LEGAL_SCOPES`)
+  - `commands/_common.py` (`resolve_state_path` local branch)
+  - `commands/list_installed.py` (three-scope default list; explicit `local`
+    branch in inline `if/else` at lines 477-486 — the existing else-user
+    fallthrough misroutes `local` to `~/.agentbundle/state.toml`)
+  - `commands/install.py` — the largest change: (1) widen upstream resolution
+    gate at line 513 (`requested_scope in ("repo","local") and not
+    emit_install_routes`) and the repo projection-rendering aggregate at line 929
+    (`any(p.scope in ("repo","local") ...)`); the `:950` user aggregate stays
+    user-only — see fork-family 6 in the Proposal;
+    (2) new `local` branch in `_ScopePlan`-building loop at line 759; (3) full
+    site-by-site audit per the Proposal's "install.py write-path threading"
+    section — grep patterns:
+    `requested_scope == "repo"`, `requested_scope == "user"`,
+    `scope_value == "repo"`, `scope_value == "user"`,
+    `plan.scope == "repo"`, `plan.scope == "user"`,
+    `p.scope == "repo"`, `p.scope == "user"`; **IMPORTANT**: some key sites
+    are grep-invisible and must be handled by line number from the Proposal
+    rather than via grep hits:
+    - Truly grep-invisible (no `plan.scope ==` comparison): `:1447`/`:1456`
+      (unconditional carve-out calls — see Proposal "Carve-outs"), `:1471-1477`
+      (`_chain_adapt`), `:1493-1543` (Step-13 emission loop). Also: `:258`
+      (`cli_scope != "user"`) and `:377` (`requested_scope != "user"`) use
+      `!=` and are invisible to all `==` grep patterns — `:258` handled per
+      Proposal point 4; `:377` handled per Proposal fork-family 2 (the
+      force-merge "do not change to `== "repo"`" warning).
+    - Grep-surfaced but needing site-specific treatment (see Proposal
+      "Additional key sites"): `:814` (intentionally leave repo-only), `:859`
+      (widen to `in ("repo","local")`), `:1334` (widen adapter recording),
+      `:1356` (update both conjuncts).
+    Key grep results to resolve: `:486` (state-file routing for source-conflict
+    check), `:631`/`:668` (add `local_state`/`installed_at_local` for conflict
+    checks);
+    (4) `--emit-install-routes + --scope local` refusal at line 390, branching
+    the error message for `local` vs. `repo`; (5) `emit_install_routes`
+    inference at line 258 changed from `cli_scope != "user"` to
+    `cli_scope == "repo"` (protects test-fixture fallback)
+  - `cli.py` (six `choices=` sites; source from `tuple(sorted(LEGAL_SCOPES))`
+    — sorted tuple required for stable `--help` output)
+  - `install.py` (`.git/info/exclude` write path; worktree-id derivation)
+  - `uninstall.py` (block-strip path; worktree-id matching; also fix
+    `uninstall.py:105`/`:87` disambiguator which has no `local` branch)
+  - `diff.py`, `upgrade.py`, `init_state.py`: v1 retains `("repo","user")` at
+    their argparse `choices=` sites (argparse-native rejection); a follow-on
+    spec threads full `--scope local` support through each subcommand's inline
+    state routing
+  - `install.py` profile path (`:4331`/`:4357`): no new guard needed —
+    `install.py:162-165` already refuses any `--scope` alongside `--profile`;
+    audit only (verify the guard covers `"local"` once it is a valid choice at
+    `cli.py:390`); follow-on deferred for full profile support
+  - `pack.schema.json` (`allOf` if/then: local⇒repo) — this file exists as two
+    byte-identical copies: `contracts/pack.schema.json` and
+    `packages/agentbundle/agentbundle/_data/pack.schema.json`. **Both must be
+    edited by hand to remain byte-identical.** `check_contract_parity.py` is
+    the CI gate (verify-only — no `--write` flag); run it locally after editing
+    both files to confirm parity before committing.
+  - Block-key encoding: both `<pack-name>` and `<worktree-id>` fields in the
+    `# agentbundle:local:<pack-name>:<worktree-id>:begin/end` markers are
+    `:`-delimited positionally. Pack names follow the existing `[a-z0-9-]+`
+    identifier convention (enforced by `pack.schema.json`) and never contain
+    `:` — assert this invariant at parse time. Worktree-id (last component of
+    `git rev-parse --git-dir`) must be sanitized to replace or reject `:` so
+    the key is unambiguously parseable.
+- ADR: record the decision to use `.git/info/exclude` over `.gitignore`, the
+  whole-install-abort policy for tracked-file collisions, the per-worktree
+  keyed-block design (blocks keyed by `(pack-name, worktree-id)`), and the
+  deferred concurrent-write locking.
+
+## Open questions
+
+None. All decisions are resolved in the D1–D4 table (each row carries a
+recommendation and `decide-by: This review`). Implementation-detail deferrals
+(stale-block cleanup CLI surface, worktree-id sanitization encoding, and the
+sentinel choice for the block-key delimiter) are tracked in the follow-on spec
+(`docs/specs/local-scope-install/`), not left as open questions here.

--- a/docs/rfc/0080-local-scope-install.md
+++ b/docs/rfc/0080-local-scope-install.md
@@ -42,8 +42,9 @@
   full site-by-site audit — see "install.py write-path threading" in Proposal
   for the complete fork-family enumeration including carve-outs and key sites; `--emit-install-routes + --scope local` refusal at
   `install.py:390`; `emit_install_routes` inference at line 258 — `cli_scope !=
-  "user"` must become `cli_scope == "repo"` so local never infers the
-  plugins-route producer); `cli.py` (six hardcoded
+  "user"` must become `cli_scope not in ("user", "local")` so local never infers the
+  plugins-route producer; see implementation erratum in §4 of Proposal for the
+  corrected form vs. the original `== "repo"` specification); `cli.py` (six hardcoded
   `choices=("repo","user")` sites at `cli.py` lines 261, 390, 525, 581, 630, 678);
   `pack.schema.json` (`allowed-scopes` `allOf` if/then constraint);
   `config.py:860` (`Literal["repo","user"]` type annotation on
@@ -208,10 +209,11 @@ it if absent):
 
 Paths are anchored with a leading `/` to match at repo root only, following
 gitignore semantics for absolute paths. Each path is gitignore-metacharacter-escaped
-before writing: `[`, `]`, `*`, `?`, and `\` are backslash-escaped; `#` and `!` are
-escaped only when they appear at the start of a line. This ensures that projected
-filenames containing gitignore pattern syntax (e.g. `references/[draft].md`) are
-matched literally and are not interpreted as character-class or glob patterns.
+before writing: `[`, `]`, `*`, `?`, and `\` are backslash-escaped. (`#` and `!`
+need not be escaped because the leading `/` anchor ensures they can never appear at
+line start.) This ensures that projected filenames containing gitignore pattern
+syntax (e.g. `references/[draft].md`) are matched literally rather than as
+character-class or glob patterns.
 Because gitignore deduplicates equivalent patterns, multiple worktrees having
 overlapping path entries is harmless.
 
@@ -303,8 +305,9 @@ to the multi-adapter union-write path (AC14b).
 worktree-id)`, multiple worktrees can hold independent `--scope local` installs
 of the same pack simultaneously, and each worktree's uninstall strips only its
 own block. Ephemeral worktrees (e.g. Conductor workspaces) may be deleted without
-uninstalling; their stale blocks accumulate but are harmless (see Block rules
-above).
+uninstalling; their stale blocks accumulate. Stale blocks are **not harmless**:
+see Block rules above for the data-loss risk (stale patterns continuing to hide
+files in other worktrees).
 
 **Important: exclusion patterns are repo-global.** The keyed blocks scope only
 bookkeeping and uninstall — not git exclusion. A leading-`/` pattern in the
@@ -455,9 +458,10 @@ through each layer:
      refusal is actually enforced.
    - **`!= "user"` negation comparisons** — two sites, each needing different
      treatment:
-     - `install.py:258` (`cli_scope != "user"`) — must become `cli_scope ==
-       "repo"` to stop local from entering the plugins-route producer. Handled
-       by point 4 below; only protects the test-fixture fallback.
+     - `install.py:258` (`cli_scope != "user"`) — must become
+       `cli_scope not in ("user", "local")` (see implementation erratum in
+       point 4 — the originally-specified `== "repo"` breaks `None`-scope callers).
+       Handled by point 4 below; only protects the test-fixture fallback.
      - `install.py:377` (`if force_merge and requested_scope != "user":`) —
        correctly refuses force-merge for every non-user scope; force-merge is
        user-scope-only (RFC-0005). This guard works for local as-is. **Do not
@@ -543,10 +547,14 @@ through each layer:
      must record this change explicitly rather than silently diverging from it.
 
 4. **`emit_install_routes` inference.** `install.py:258` (`emit_install_routes
-   = cli_scope != "user"`) must become `cli_scope == "repo"` so local never
-   silently enters the plugins-route producer. Note: this only protects the
-   attribute-absent test-fixture fallback (real CLI invocations always have
-   `args.emit_install_routes`); the primary guard is the explicit refusal at
+   = cli_scope != "user"`) must become `cli_scope not in ("user", "local")` so
+   local never silently enters the plugins-route producer. **Implementation
+   erratum:** the RFC originally specified `cli_scope == "repo"` here, but that
+   value breaks programmatic/legacy callers that pass a `Namespace` without an
+   explicit `scope` attribute (`None == "repo"` is `False`, misrouting them from
+   the repo-dist-tree path to adapter projection). The correct expression is
+   `cli_scope not in ("user", "local")` so that `None` is treated as repo-like,
+   matching the historical behavior. The primary guard is the explicit refusal at
    `install.py:390-393`.
 
 ### CLI surface
@@ -649,7 +657,10 @@ excluded from git without a committed diff, stdlib-only."
   is the right scope for repos that track pack files.
 - *Multi-worktree installs of the same pack.* Per-worktree keyed blocks allow
   independent simultaneous installs. Stale blocks from deleted worktrees
-  accumulate in `info/exclude` but are harmless (paths no longer exist).
+  accumulate in `info/exclude` and are **not harmless**: their patterns continue
+  excluding same-path files in all linked worktrees; a committed file added later
+  at that path is silently invisible to `git status`. Pruning via
+  `agentbundle local prune` is deferred; documented in `write_exclude_block` docstring.
 - *Concurrent agentbundle calls on the same repo.* Without a file lock, two
   simultaneous `--scope local` installs produce a lost update: one writer's
   atomic full-file replace clobbers the other's block, silently making those

--- a/docs/rfc/0080-local-scope-install.md
+++ b/docs/rfc/0080-local-scope-install.md
@@ -207,16 +207,21 @@ it if absent):
 ```
 
 Paths are anchored with a leading `/` to match at repo root only, following
-gitignore semantics for absolute paths. Because gitignore deduplicates
-equivalent patterns, multiple worktrees having overlapping path entries is
-harmless.
+gitignore semantics for absolute paths. Each path is gitignore-metacharacter-escaped
+before writing: `[`, `]`, `*`, `?`, and `\` are backslash-escaped; `#` and `!` are
+escaped only when they appear at the start of a line. This ensures that projected
+filenames containing gitignore pattern syntax (e.g. `references/[draft].md`) are
+matched literally and are not interpreted as character-class or glob patterns.
+Because gitignore deduplicates equivalent patterns, multiple worktrees having
+overlapping path entries is harmless.
 
 **Block rules.**
 
 - **Append-or-replace-in-place, never duplicate a `(pack-name, worktree-id)`
   block.** agentbundle reads the file first; if a block keyed to this pack name
-  and worktree id already exists, it replaces it in place (e.g. on reinstall).
-  Otherwise it appends. Two different worktrees installing the same pack will
+  and worktree id already exists, it replaces it in place (e.g. when a second
+  adapter is installed for the same pack — the block is rewritten with the union
+  of both adapters' patterns). Otherwise it appends. Two different worktrees installing the same pack will
   have path entries that overlap — gitignore deduplicates patterns at match time;
   this is not a violation of the "no duplicate block" rule, which is
   per-`(pack-name, worktree-id)` pair.
@@ -234,17 +239,22 @@ harmless.
   mechanism (read → modify in memory → write to temp file → `os.replace`) so
   that all writes to `info/exclude` are full-file replacements, not in-place
   appends.
-- **Stale blocks from deleted worktrees accumulate and are harmless.** When a
-  worktree is deleted without uninstalling (e.g. Conductor deleting an ephemeral
-  workspace), its block remains in `info/exclude`. The paths it references no
-  longer exist, so git treats them as unmatchable — no observable effect.
-  Cleanup is manual; the exact CLI surface (`agentbundle uninstall --scope local
-  --worktree <id>` or equivalent) is specified in the follow-on spec
-  (`docs/specs/local-scope-install/`).
+- **Stale blocks from deleted worktrees accumulate and require pruning.**
+  When a worktree is deleted without uninstalling (e.g. Conductor deleting an
+  ephemeral workspace), its block remains in `info/exclude`. The patterns in that
+  block continue excluding same-path files in **all** linked worktrees that share
+  the common-dir `info/exclude`. If a tracked or committed file is later created
+  at that path in another worktree, git silently hides it — `git status` and
+  `git add` do not see it. Cleanup is manual; the exact CLI surface
+  (`agentbundle local prune` or equivalent) is deferred to a follow-on spec.
+  The implementation must document this risk in a user-visible location
+  (spec AC26/AC27; see `write_exclude_block` docstring).
 
 **Tracked-file collision check.** Before writing any file, agentbundle runs
-`git ls-files --error-unmatch <path>` for each target path. If any path is
-already tracked, the install aborts with:
+`git --literal-pathspecs ls-files --error-unmatch <path>` for each target path
+(the `--literal-pathspecs` flag prevents pathspec syntax in filenames —
+e.g. `foo[bar].md` — from being interpreted as a pattern and matching unrelated
+tracked files). If any path is already tracked, the install aborts with:
 ```
 error: <path> is already tracked by git; --scope local cannot shadow a
        committed file. Use --scope repo or remove the tracked file first.
@@ -261,8 +271,8 @@ error: <pack> is already installed at --scope repo; uninstall it first or
 The reverse direction — `--scope repo` install when a local install already
 exists — is also refused:
 ```
-error: <pack> is already installed at --scope local; uninstall it first or
-       use --scope local to upgrade.
+error: <pack> is already installed at --scope local; uninstall it first
+       (agentbundle uninstall --scope local), then reinstall.
 ```
 This prevents a `--scope repo` install from writing files that the local
 exclude block hides from `git status`, which would make a committed install
@@ -281,9 +291,13 @@ computation.
 **Same-scope local reinstall.** The upgrade-offer guard at `install.py:631` is
 `(requested_scope=="repo" and installed_at_repo) or (requested_scope=="user" and
 installed_at_user)`. A `--scope local` reinstall of an already-local pack
-matches neither disjunct and bypasses the upgrade-offer. The `install.py:631`
-branch must gain `(requested_scope=="local" and installed_at_local)` so local
-reinstall routes to the upgrade-offer flow.
+matches neither disjunct. **Implementation erratum (see spec AC21b):** routing
+through `upgrade.run` is incorrect for v1 because `upgrade.run` has no local-scope
+support. Instead, `install.py:631` must refuse (adapter-identity check: refuse only
+when the requested adapter row already exists in `local_state`) with a message
+naming `agentbundle uninstall --scope local` then `install --scope local` as the
+v1 refresh path. A second *different* adapter for the same pack must fall through
+to the multi-adapter union-write path (AC14b).
 
 **Multi-worktree support.** Because blocks are keyed per `(pack-name,
 worktree-id)`, multiple worktrees can hold independent `--scope local` installs
@@ -578,6 +592,11 @@ subcommands with:
 error: --scope local is not yet supported for this subcommand.
        Install, uninstall, and list-installed are fully supported.
 ```
+**Implementation erratum (see spec AC25):** the argparse-native `invalid choice:
+'local'` mechanism (retaining `("repo","user")` as the choices list) is the v1
+refusal; the friendly message above is reserved for a future custom argparse action
+if the UX is revisited. The net user-visible behavior is the same, but the error text
+in v1 will be argparse's own wording, not the string above.
 Threading `local` through `diff.py` (`:85,102,183`), `upgrade.py`
 (`:524,601,843,958,994`), `init_state.py` (`:122,141,169`), and the
 `uninstall.py:105`/`:87` disambiguator is deferred to the follow-on spec.

--- a/docs/rfc/0080-local-scope-install.md
+++ b/docs/rfc/0080-local-scope-install.md
@@ -676,8 +676,8 @@ excluded from git without a committed diff, stdlib-only."
   are likely to have (introduced git ≥2.5.0, 2015).
 - `info/exclude` (or its submodule equivalent) is writable by the process that
   owns the working tree.
-- `git ls-files --error-unmatch` correctly identifies tracked paths before the
-  install writes any file.
+- `git --literal-pathspecs ls-files --error-unmatch` correctly identifies tracked
+  paths before the install writes any file.
 
 **Drawbacks.**
 
@@ -771,7 +771,8 @@ repo but has its own working directory):
     (4) `--emit-install-routes + --scope local` refusal at line 390, branching
     the error message for `local` vs. `repo`; (5) `emit_install_routes`
     inference at line 258 changed from `cli_scope != "user"` to
-    `cli_scope == "repo"` (protects test-fixture fallback)
+    `cli_scope not in ("user", "local")` (preserves `None`-scope repo-like
+    behavior for legacy callers; see implementation erratum in §4)
   - `cli.py` (six `choices=` sites; source from `tuple(sorted(LEGAL_SCOPES))`
     — sorted tuple required for stable `--help` output)
   - `install.py` (`.git/info/exclude` write path; worktree-id derivation)

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -81,6 +81,7 @@
 | [0073](0073-slo-authoring-and-error-budget.md) | SLO-authoring capability and error-budget PRR integration — new `define-slo` skill in `release-engineering` pack (OpenSLO v1 format), four-state PRR `error-budget` field resolution, `error_budget_policy` block, query-at-gate-time instruction. Settles RFC-0049 § Follow-on provisional scope call. | Accepted | 2026-07-27 | 2026-07-27 |
 | [0074](0074-pack-config-and-oplog.md) | Pack config and operation log — per-pack user config (`pack_dir`, `load_pack_config`), three-source cascade via `install-defaults.toml` baking, atomic JSONL oplog (`write_entry`), new `catalogue.toml` `[pack-defaults.*]` and `user-dir`, two new CLI subcommand groups. | Accepted | 2026-07-27 | 2026-07-28 |
 | [0079](0079-codebase-context-pack.md) | `codebase-context` pack — optional user-scope pack wrapping `codebase-memory-mcp` (C/tree-sitter, stdio subprocess) and `serena` (Python/LSP) as semantic graph MCP backends; `CBM_ALLOWED_ROOT` path confinement; three-tier freshness (file watcher / git hook `touch` / PLAN-time check); `agentbundle install` only. | Draft | 2026-08-03 | — |
+| [0080](0080-local-scope-install.md) | Local scope install — `--scope local` installs pack files into the working tree and excludes them via `.git/info/exclude` so they never appear in `git status` or get committed. | Accepted | 2026-08-04 | 2026-08-04 |
 
 ## Adding a new RFC
 

--- a/docs/specs/local-scope-install/plan.md
+++ b/docs/specs/local-scope-install/plan.md
@@ -1,0 +1,533 @@
+# Plan: Local scope install (`--scope local`)
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting <!-- Drafting | Approved | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially,
+> note why in the changelog at the bottom.
+
+## Approach
+
+Thread `"local"` through agentbundle bottom-up: schema and scope engine first
+(T1–T3), then state-file routing (T4), then the two simpler read-path commands
+(T5, T6), then the CLI choices (T7), then the install write-path (T8 — the
+largest task, covering all six fork families plus carve-outs and key sites),
+then the `.git/info/exclude` write and worktree-id logic (T9), then the uninstall
+strip (T10), and finally a full integration test (T11). Each task is a coherent
+commit. T8 and T9 share install.py but can be separated by landing T9's
+helper functions before T8 calls them. All prior tasks must be green before T8
+begins — the install write path touches every earlier layer.
+
+The riskiest part is T8 (install.py): it has six scope-branching fork families,
+carve-outs that must NOT be widened, and five "else-implies-user" ternary sites
+that silently produce a zero-file install if missed. An integration test (T11)
+that asserts specific files were actually written is the primary safety net
+against silent misses.
+
+## Constraints
+
+- RFC-0080 — canonical authority for all design decisions.
+- ADR-0070 — records the four implementation decisions (exclude mechanism,
+  abort policy, keyed-block design, deferred locking).
+- RFC-0004 — install-scope per pack; `allowed-scopes` schema precedent.
+- RFC-0005 — user-scope hook support; force-merge is user-scope-only.
+- RFC-0008 — claude-plugins install-route; `--emit-install-routes` guard.
+- RFC-0012 — repo-scope per-adapter projection; `allowed-prefixes.repo` contract.
+- ADR-0006 — doc drift prevention; spec and plan must stay in sync.
+
+## Construction tests
+
+**Integration tests:** T11 covers the full install / uninstall cycle across all
+three phases: write, verify git-invisible, uninstall-clean. This is the primary
+defence against the silent-zero-file hazard in T8.
+
+**Manual verification:** After T11 is green, run `agentbundle install --pack core
+--scope local` in a test repo and confirm: (a) files appear in the working tree,
+(b) `git status` shows nothing, (c) `list-installed` shows `scope = local` row,
+(d) `agentbundle uninstall --pack core --scope local` produces a clean `git status`.
+
+## Design (LLD)
+
+### Design decisions
+
+*(Detailed rationale in ADR-0070 and RFC-0080; brief design notes here.)*
+
+- **`LEGAL_SCOPES` is the single source of truth** for argparse `choices` at the
+  three accepting `cli.py` sites — sourced as `tuple(sorted(LEGAL_SCOPES))` so
+  `--help` order is stable. The three refusing sites retain `("repo","user")` to
+  give argparse-native rejection (no runtime guard needed).
+- **Separate state file** (`.agentbundle-local-state.toml`) means older agentbundle
+  binaries see no effect; no schema-version bump required.
+- **`_chain_adapt` skipped for local** — local installs are ephemeral; adapt-discovery
+  re-running would apply to files the user considers git-invisible. This is a
+  deliberate amendment to AC19b (the existing spec comment at `install.py:1468`
+  that reads "invoke regardless of the install scope (markers are repo-only)");
+  the PR description must record this deviation explicitly.
+- **`install.py:377` stays `!= "user"`** — the force-merge guard correctly covers
+  local scope; changing to `== "repo"` would introduce a security regression by
+  letting `--force-merge --scope local` through.
+- **`install.py:950` user aggregate stays unchanged** — local plans must not enter
+  user-projection rendering; only the `:929` repo aggregate widens.
+
+### Data & schema
+
+State-file schema: identical `PackState` shape to `.agentbundle-state.toml`,
+`schema-version = "0.4"`, all rows `scope = "local"`. Path:
+`<repo>/.agentbundle-local-state.toml`. Included in the exclude block at install;
+removed row-by-row at uninstall; file deleted when empty.
+
+Block format in `.git/info/exclude`:
+```
+# agentbundle:local:<pack-name>:<worktree-id>:begin
+/.agentbundle-local-state.toml
+/.claude/skills/<pack-slug>/SKILL.md
+# agentbundle:local:<pack-name>:<worktree-id>:end
+```
+Worktree-id: derived by comparing `git rev-parse --git-dir` and
+`git rev-parse --git-common-dir` (equal → primary worktree, use a reserved
+sentinel such as a hash of the common-dir path; unequal → last component of
+`--git-dir`). The id must be sanitized to replace or reject `:` to preserve
+the `:` -delimited block-key. Pack names are `[a-z0-9-]+` per schema; assert
+the invariant at parse time.
+
+### Component / module decomposition
+
+| Module | Change |
+|---|---|
+| `pack.schema.json` (×2) | Add `"local"` to enum; add `allOf` if/then constraint |
+| `scope.py` | Extend `LEGAL_SCOPES`; add `default-scope="local"` reject in `resolve()` |
+| `config.py` | Widen `_parse_adapter_row` to `LEGAL_SCOPES` |
+| `commands/_common.py` | Add `"local"` branch in `resolve_state_path` |
+| `commands/list_installed.py` | Three-scope default; explicit `local` branch in inline if/else |
+| `cli.py` | 3 sites gain `"local"`; 3 sites retain `("repo","user")` |
+| `commands/install.py` | Substantial — see T8 task for full site list |
+| New helper (install.py or a new module) | `write_exclude_block`, `strip_exclude_block`, `derive_worktree_id` |
+| `commands/uninstall.py` | Block-strip path; worktree-id matching; `:105`/`:87` disambiguator |
+
+### Failure, edge cases & resilience
+
+- `git` not in PATH or not a git repo: pre-flight fails fast; clear error.
+- `info/exclude` does not exist: created on first write.
+- Block already exists for this `(pack, worktree-id)`: replaced in place (no duplicate).
+- Target file already tracked: whole install aborts; no partial writes.
+- Concurrent write (two processes writing simultaneously): lost-update race
+  documented in ADR-0070; no lock in v1.
+- Worktree deleted without uninstall: stale block accumulates in `info/exclude`;
+  paths don't exist, git treats them as unmatchable — harmless.
+
+## Tasks
+
+### T1: Schema — add `"local"` to `pack.schema.json`
+
+**Depends on:** none
+
+**Tests:**
+- `check_contract_parity.py` exits 0 (both copies byte-identical). Goal-based.
+- `python3 -m pytest packages/agentbundle/tests/ -q` — any existing schema-
+  validation tests still pass. Goal-based.
+- A pack with `allowed-scopes = ["local"]` (no `"repo"`) fails schema validation.
+  TDD.
+- A pack with `allowed-scopes = ["user", "local"]` (has `"local"` but not `"repo"`)
+  fails schema validation — this is the key case the `allOf` constraint closes. TDD.
+- A pack with `allowed-scopes = ["repo", "local"]` passes. TDD.
+
+**Approach:**
+- Edit **both** `contracts/pack.schema.json` AND
+  `packages/agentbundle/agentbundle/_data/pack.schema.json` byte-identically.
+- In the `allowed-scopes` array enum, add `"local"` alongside `"repo"` and `"user"`.
+- Add a new `allOf` sibling to the existing `if/then/else` block:
+  `if allowed-scopes contains "local" then allowed-scopes must also contain "repo"`.
+- Run `python3 tools/catalogue/check_contract_parity.py` to verify byte-identity.
+
+**Done when:** `check_contract_parity.py` exits 0; the `allOf` constraint test is green.
+
+---
+
+### T2: `scope.py` — extend `LEGAL_SCOPES` and `resolve()` guard
+
+**Depends on:** T1
+
+**Tests:**
+- `LEGAL_SCOPES == {"repo", "user", "local"}`. TDD.
+- `resolve(pack, requested="local", default="repo", allowed=["repo"])` returns
+  `"local"` (D4 auto-promote). TDD.
+- `resolve(pack, requested=None, default="local", allowed=["repo", "local"])`
+  raises `ScopeRefused`. TDD (default-scope reject precedes auto-promote).
+- `resolve(pack, requested="local", default="repo", allowed=["user"])` raises
+  `ScopeRefused` (repo not in allowed). TDD.
+
+**Approach:**
+- Add `"local"` to `LEGAL_SCOPES` in `scope.py`.
+- In `resolve()`, add an explicit check: if the resolved default is `"local"`,
+  raise `ScopeRefused` before the D4 auto-promote logic.
+- In the auto-promote path: if `requested == "local"` (or resolved to `"local"`),
+  allow if `"repo" in allowed_scopes` (the pack's allowed-scopes list).
+
+**Done when:** all four new unit tests green; `python3 -m pytest packages/agentbundle/tests/ -q` still green.
+
+---
+
+### T3: `config.py` — widen `_parse_adapter_row`
+
+**Depends on:** T2
+
+**Tests:**
+- `_parse_adapter_row(row_with_scope="local")` preserves `scope="local"` (not
+  coerced to `default_scope`). TDD.
+- `_parse_adapter_row(row_with_scope="unknown")` still coerces to `default_scope`.
+  TDD.
+
+**Approach:**
+- In `config.py:524-529`, replace hardcoded `("repo", "user")` with `LEGAL_SCOPES`
+  (imported from `scope.py`).
+
+**Done when:** both new tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T4: `commands/_common.py` — `resolve_state_path` local branch
+
+**Depends on:** T2
+
+**Tests:**
+- `resolve_state_path("local", root=Path("/repo"))` returns
+  `Path("/repo/.agentbundle-local-state.toml")`. TDD.
+- `resolve_state_path("repo", root=Path("/repo"))` returns
+  `Path("/repo/.agentbundle-state.toml")` (unchanged). TDD.
+- `resolve_state_path("user", root=...)` returns the user-scoped path (unchanged). TDD.
+
+**Approach:**
+- Add an `elif scope == "local":` branch in `resolve_state_path` returning
+  `root / ".agentbundle-local-state.toml"`.
+
+**Done when:** all three routing tests green.
+
+---
+
+### T5: `commands/list_installed.py` — three-scope default + `local` branch
+
+**Depends on:** T4
+
+**Tests:**
+- `list-installed` without `--scope` lists all three scopes (repo, user, local).
+  TDD / goal-based against a fixture state.
+- `list-installed --scope local` shows rows with `scope = local` and the
+  `(not committed; per-clone only)` annotation. TDD.
+- The existing else-user fallthrough is replaced by an explicit `local` branch;
+  no `local` rows are silently routed to the user state file. TDD.
+
+**Approach:**
+- Update the hardcoded `["user", "repo"]` scope list to `["user", "repo", "local"]`
+  (or derive from `LEGAL_SCOPES`).
+- Replace the inline `if sc == "repo": … else: # user` routing at lines 477–486
+  with an explicit three-way branch that handles `"local"` explicitly.
+
+**Done when:** fixture-based tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T6: `cli.py` — update `choices=` at the three accepting sites
+
+**Depends on:** T2
+
+**Tests:**
+- `agentbundle install --scope local --help` lists `{local,repo,user}` (or sorted
+  equivalent). Goal-based (run actual CLI).
+- `agentbundle diff --scope local` is rejected by argparse with a "invalid choice"
+  error (not a runtime guard). Goal-based.
+- Same argparse-native rejection for `upgrade --scope local` and
+  `init-state --scope local`. Goal-based.
+
+**Approach:**
+- At `cli.py` lines **261** (`list-installed`), **390** (`install`), **630**
+  (`uninstall`): change `choices=("repo","user")` to
+  `choices=tuple(sorted(LEGAL_SCOPES))` (import from `scope.py`).
+- Lines **525** (`diff`), **581** (`upgrade`), **678** (`init-state`): leave as
+  `("repo","user")` — argparse-native rejection is the v1 refusal mechanism.
+
+**Done when:** all three goal-based CLI tests pass.
+
+---
+
+### T7: `commands/install.py` — upstream gates, `_ScopePlan` branch, `emit_install_routes` inference
+
+**Depends on:** T4, T6
+
+**Tests:**
+- `agentbundle install --scope local --emit-install-routes` is refused with the
+  RFC-0008-referencing error message. TDD.
+- `emit_install_routes` inference at line 258: `cli_scope == "repo"` (not
+  `!= "user"`). Unit test for the fixture-fallback path. TDD.
+- Upstream gate at line 513: `requested_scope in ("repo", "local")` resolves
+  `allowed_prefixes_repo` correctly for a local request. TDD.
+- `any(p.scope in ("repo", "local"))` aggregate at line 929 gates projection
+  rendering for a local plan. TDD.
+- `any(p.scope == "user")` at line 950 does NOT include local plans. TDD.
+- A new `_ScopePlan(scope="local", ...)` is produced for a local request. TDD.
+
+**Approach:**
+- `install.py:258`: change `cli_scope != "user"` to `cli_scope == "repo"`.
+- `install.py:390-393`: branch the `--emit-install-routes` guard to emit the
+  RFC-0008-referencing message when `requested_scope == "local"`.
+- `install.py:513`: widen gate to `requested_scope in ("repo", "local") and not
+  emit_install_routes`.
+- `install.py:759`: add a `local` branch producing
+  `_ScopePlan(scope="local", root=output_root,
+  state_path=output_root / ".agentbundle-local-state.toml",
+  allowed_prefixes=allowed_prefixes_repo)`
+  (`output_root` is the function-level variable; `repo_root` is not defined here).
+- `install.py:929`: widen to `any(p.scope in ("repo", "local") ...)`.
+- (`:950` is unchanged — user-only.)
+
+**Done when:** all six unit tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T8: `commands/install.py` — full six-family fork audit
+
+**Depends on:** T7, T9
+
+*This is the largest task. Proceed site-by-site per the six families below.
+Use `git diff` after each sub-group to confirm no unintended changes.*
+
+> **Line-number caveat:** all absolute line references in this task reflect
+> pre-T7 `install.py`. T7 inserts a `_ScopePlan` local branch at ~`:759`, shifting
+> every line below it. In this task, always **locate sites by symbol name or
+> surrounding comment text** (as noted per site below), not by the raw number.
+> The "~:" prefix signals a pre-T7 estimate; treat it as a grep hint, not a
+> go-to-line instruction.
+
+**Tests:**
+- Projection write: `repo_projection if plan.scope in ("repo","local") else user_projection`
+  at lines 1018, 1045, 1086 — TDD: a local plan selects repo_projection (non-None). TDD.
+- Adapter selection: `:859` and `:1093` widen to `plan.scope in ("repo","local")` —
+  TDD: local plan selects `repo_target_adapter`. TDD.
+- `:486` state-file routing for source-conflict check routes local to
+  `.agentbundle-local-state.toml`. TDD.
+- `:631` upgrade-offer guard gains `(requested_scope=="local" and installed_at_local)`
+  — TDD: local reinstall routes to upgrade-offer. TDD.
+- `:668` cross-scope conflict loads `installed_at_local`; repo refusal is
+  `--force`-immune. TDD.
+- `:377` force-merge guard: `agentbundle install --force-merge --scope local` is
+  refused; this is the AC11b behavioral test. TDD (assert non-zero exit and error
+  message; do NOT change `:377` to `== "repo"`).
+- `:814` left repo-only (v0.1 reload moot for new local state file) — no test
+  change needed; assert it is unchanged.
+- `:1334` adapter recording: `plan.scope in ("repo","local") and repo_target_adapter
+  is not None` — TDD: local state row has adapter field set. TDD.
+- `:1356` compound condition: both conjuncts accept `.agentbundle-local-state.toml`
+  — TDD: local state write not blocked by prefix check. TDD.
+- `:1447` and `:1456` wrapped in `if plan.scope != "local":` — TDD: no marker/
+  layout writes for local scope. TDD.
+- `:1471-1477` `_chain_adapt` skipped for local — TDD: adapt not invoked. TDD.
+- `:1493-1543` Step-13 emission: local branch emits
+  `installed: <pack> @ local (excluded via <path>)` — TDD / visual QA via CLI. TDD.
+- Silent-zero-file guard: integration test (T11) asserts specific files were
+  written to disk for a local install.
+
+**Approach:**
+
+**Family 1 — `requested_scope ==` equality comparisons (grep: `requested_scope == "repo"`, `requested_scope == "user"`):**
+- `:486`: `repo_state if requested_scope in ("repo","local") else user_state`.
+- `:631`: add `(requested_scope=="local" and installed_at_local)` to upgrade-offer guard.
+- `:668`: add `installed_at_local` derivation; enforce repo/local refusal before
+  `--force` check (outside `scopes_to_install` computation).
+- Other sites (`390`, `397`, `432`, `513`, `577`, `663`, `739`): review each;
+  widen or leave as-is per their individual semantics.
+
+**Family 2 — `!= "user"` negation comparisons:**
+- `:258`: already handled in T7 (change to `== "repo"`).
+- `:377`: **leave unchanged** — `requested_scope != "user"` correctly refuses
+  force-merge for local; do NOT change to `== "repo"`.
+
+**Family 3 — `scope_value ==` (profile path, lines 760, 4331, 4357):**
+- Guarded by `install.py:162-165` which already refuses `--scope` alongside
+  `--profile` once `"local"` is a valid CLI choice. Audit that the guard fires
+  correctly; no code change to `:4331`/`:4357` needed.
+
+**Family 4 — `plan.scope ==` and `p.scope ==` forks (grep both):**
+- Review each site; apply `in ("repo","local")` where the site drives a repo-path
+  operation; leave user-branch sites unchanged.
+- Carve-outs (leave as repo-only): `:1060`, `:1254`.
+- Unconditional carve-outs (add guard): wrap `:1447` and `:1456` in
+  `if plan.scope != "local":`.
+
+**Family 5 — else-implies-user ternaries (`X if plan.scope == "repo" else <user>`):**
+- `:1018`, `:1045`, `:1086`: `repo_projection if plan.scope in ("repo","local") else user_projection`.
+- `:859`, `:1093`: `repo_target_adapter if plan.scope in ("repo","local") else user_target_adapter`.
+
+**Additional key sites** (locate by symbol — absolute line numbers shift after T7
+inserts a `_ScopePlan` branch; use grep on function name or comment text):
+- `_reload_state` call (currently ~`:814`): leave repo-only (v0.1 reload moot for
+  the new local state file; add a one-line comment to mark it intentional).
+- Adapter ternary `repo_target_adapter`/`user_target_adapter` selection (~`:859`):
+  widened in Family 5; ensures the adjacent warning (~`:863`) fires for local too.
+- Adapter recording condition `repo_target_adapter is not None …` (~`:1334`):
+  widen to `plan.scope in ("repo","local") and repo_target_adapter is not None`.
+- Compound condition guarding state write (~`:1356`): update both conjuncts to
+  accept `.agentbundle-local-state.toml`.
+- `_chain_adapt` call site (locate via `_chain_adapt` symbol; ~`:1471-1477`):
+  wrap the Step-12 block in `if requested_scope != "local":` (not `continue` —
+  the call site is not inside a loop; use a conditional guard wrapping the block).
+  **Also** update the adjacent comment (~`:1468`) to record the local-scope
+  exception. **Also** add erratum notes to `docs/specs/adapt-to-project/spec.md`
+  AC19b ("regardless of install scope" → "except local scope, which is ephemeral")
+  and a clarifying note to AC19a ("every successful install" → "every successful
+  repo/user install — local is ephemeral and writes no marker").
+- Step-13 emission loop (locate via `# Step 13` comment or `"installed:"` string;
+  ~`:1493-1543`): add `local` branch emitting exclude-path suffix.
+
+**Family 6 — `any(p.scope == ...)` aggregates:**
+- `:929`: already widened in T7.
+- `:950`: unchanged (user-only; leave as-is).
+
+**Done when:** all family-audit tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green; no new `plan.scope == "repo" else` sites in the diff that aren't documented.
+
+---
+
+### T9: exclude-file write path and worktree-id derivation
+
+**Depends on:** T4
+
+*Can be authored in parallel with T7 since T9 provides helpers that T8 calls.
+Land T9 first — T9 and T7 are DAG-independent (both depend on T4 only) but
+both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7.*
+
+**Tests:**
+- `derive_worktree_id()` returns the sentinel for the primary worktree (same
+  `--git-dir` and `--git-common-dir`). TDD.
+- `derive_worktree_id()` returns the last component of `--git-dir` for a linked
+  worktree. TDD.
+- Worktree-id containing `:` is sanitized (replaced or rejected). TDD.
+- `write_exclude_block(path, pack, worktree_id, patterns)` appends a new block
+  when none exists. TDD.
+- `write_exclude_block` replaces an existing block for the same `(pack, worktree_id)`
+  pair in place. TDD.
+- Two different worktree-ids coexist in the file. TDD.
+- `strip_exclude_block(path, pack, worktree_id)` removes the block and leaves
+  sibling blocks intact. TDD.
+- Write is atomic: a temp-file `os.replace` is used (not in-place append). TDD.
+- `git ls-files --error-unmatch <path>` exits non-zero for a tracked file → install
+  aborts with clear error. TDD.
+- Pre-flight `git rev-parse --is-inside-work-tree` failure → install aborts. TDD.
+
+**Approach:**
+- Implement `derive_worktree_id()` using `subprocess.run(["git", "rev-parse",
+  "--git-dir"])` and `--git-common-dir`, compare; sanitize with `re.sub(r":", "_", id)`.
+- Implement `write_exclude_block(exclude_path, pack, worktree_id, patterns)`:
+  read file (create if absent), find existing block by marker, replace or append,
+  write atomically via `tempfile.NamedTemporaryFile` + `os.replace`.
+- Implement `strip_exclude_block(exclude_path, pack, worktree_id)`: read file,
+  find and remove the `begin`/`end` block (inclusive), write atomically.
+- Wire into `commands/install.py` pre-flight and write path.
+- In the `write_exclude_block` docstring, document: (a) the concurrent-write
+  lost-update limitation (two processes writing simultaneously; last writer wins)
+  and (b) the cross-worktree side-effect (a leading-`/` pattern in the shared
+  `info/exclude` silently git-ignores same-path untracked files in *all* linked
+  worktrees, not only the installing one). This satisfies AC26 and AC27.
+
+**Done when:** all ten new tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T10: `commands/uninstall.py` — block-strip and worktree-id matching
+
+**Depends on:** T9
+
+**Tests:**
+- `agentbundle uninstall --scope local` removes installed files. TDD.
+- `agentbundle uninstall --scope local` strips only the correct worktree's block
+  (sibling blocks untouched). TDD.
+- Uninstall removes pack rows from `.agentbundle-local-state.toml`; file deleted
+  when empty. TDD.
+- `uninstall.py:105`/`:87` disambiguator explicitly handles `"local"` scope (no
+  else-fallthrough to repo). TDD.
+- `git status` is clean after uninstall. Goal-based.
+
+**Approach:**
+- In `uninstall.py`, add a `"local"` branch in the `:105`/`:87` disambiguator.
+- Call `strip_exclude_block` with the current worktree-id.
+- Update state-file rows via `resolve_state_path("local", root)`.
+
+**Done when:** all five tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T11: Integration test — full install / uninstall cycle
+
+**Depends on:** T8, T10
+
+**Tests:**
+- Install `core` pack with `--scope local` in a temp git repo:
+  - Specific files appear in the working tree (assert at least one skill file
+    exists at the expected path — guards against the silent-zero-file hazard).
+  - `git status --short` output is empty (files not visible to git).
+  - `git rev-parse --git-path info/exclude` target file contains the keyed block.
+  - `agentbundle list-installed --scope local` output includes a row for `core`
+    with `scope = local`.
+  - Install success line contains `@ local (excluded via`.
+  - `.agentbundle-local-state.toml` contains `schema-version = "0.4"` (AC7).
+  - Neither `AGENTS.md` nor `docs/CHARTER.md` was written (seed absence; AC17).
+  - `write_exclude_block` docstring references the lost-update limitation (AC26).
+  - `write_exclude_block` docstring contains the cross-worktree side-effect text
+    (AC27) — assert a key phrase (e.g. "linked worktrees") is present in the
+    docstring body.
+- Uninstall `core` pack with `--scope local`:
+  - Working-tree files removed.
+  - Exclude block stripped.
+  - `git status --short` output is empty.
+  - `.agentbundle-local-state.toml` deleted (was the only pack).
+- Conflict (repo↔local): installing `core` at `--scope local` when already
+  installed at `--scope repo` is refused, and vice versa; both refusals survive
+  `--force`. (`--scope user` coexists with local — no refusal expected; assert
+  user/local install succeeds.)
+- Reinstall (same-scope local → local): routes to upgrade-offer flow.
+
+**Approach:**
+- Add an integration test under `packages/agentbundle/tests/` (or
+  `packages/agentbundle/build/tests/` — check both test roots; add to whichever
+  pattern the CI already picks up).
+- Set up a temporary git repo (`tempfile.mkdtemp` + `git init`), install a real
+  or fixture pack, assert the above behaviours, clean up.
+- This test may require a real git binary; gate behind `pytest.mark.integration`
+  or equivalent if the CI environment doesn't guarantee one.
+
+**Done when:** integration test green; all prior task tests still green.
+
+## Rollout
+
+Pure Python library change; no infra, no external services. Shipped as a new
+`agentbundle` wheel version. The `--scope local` flag is additive and backwards-
+compatible: old binaries ignore `.agentbundle-local-state.toml` (they never
+enumerate it). Reversible: `--scope local` installs can be fully uninstalled;
+the scope can be deprecated without touching `repo`/`user` behaviour.
+
+## Risks
+
+- **Silent-zero-file install** from a missed ternary in T8 — mitigated by T11's
+  file-presence assertion.
+- **`os.replace` not atomic on Windows across volumes** — blocked by existing
+  constraint (temp file must be in the same directory as the target). Already
+  the pattern used for `.agentbundle-state.toml`; no new risk.
+- **Concurrent write lost-update** — documented in ADR-0070; no mitigation in v1.
+- **Stale worktree blocks** — documented and declared harmless; manual cleanup
+  CLI deferred to the follow-on spec.
+- **`install.py` fork-family audit incomplete** — mitigated by the six-family
+  taxonomy in RFC-0080 and the explicit grep patterns in T8.
+
+## Changelog
+
+- 2026-08-04: initial plan, derived from RFC-0080 (Accepted).
+- 2026-08-04: adversarial review pass 1 — added `["user","local"]` rejection
+  test to T1; added AC11b force-merge behavioral test to T8; added `_chain_adapt`
+  erratum sub-step and symbol-based key-site location guidance to T8; added
+  schema-version and seed-absence assertions to T11; added AC26/AC27 documentation
+  requirement to T9.
+- 2026-08-04: adversarial review pass 2 — corrected AC12 (user/local coexistence
+  allowed per RFC); extended AC19 erratum to cover AC19a marker-write universal;
+  fixed T8 `_chain_adapt` skip mechanism (conditional guard, not `continue`);
+  added AC27 docstring verification to T11; hoisted line-number caveat to T8 header;
+  clarified T11 conflict test removes user/local refusal; added T9/T7 ordering note.
+- 2026-08-04: adversarial review pass 3 — corrected T7 `_ScopePlan` illustrative
+  branch from `repo_root` to `output_root` (the actual function-level variable).

--- a/docs/specs/local-scope-install/plan.md
+++ b/docs/specs/local-scope-install/plan.md
@@ -1,7 +1,7 @@
 # Plan: Local scope install (`--scope local`)
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Drafting <!-- Drafting | Approved | Executing | Done -->
+- **Status:** Approved <!-- Drafting | Approved | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially,

--- a/docs/specs/local-scope-install/plan.md
+++ b/docs/specs/local-scope-install/plan.md
@@ -326,8 +326,10 @@ Use `git diff` after each sub-group to confirm no unintended changes.*
   local requests to `local_state` (not `repo_state`). TDD.
 - `:631` upgrade-offer guard: local reinstall of same adapter refuses with
   "already installed" message (AC21b) — does NOT route through `upgrade.run`. TDD.
-- Tier-2 refusal for local: if a target exists as an untracked file with different
-  content, the install is refused (AC10b). TDD.
+- Unowned pre-existing file refusal (AC10b): if a target path exists as an untracked
+  file with **no ownership record** in any agentbundle state (repo, user, or local)
+  — regardless of content — the install is refused. TDD: assert refusal for both the
+  different-content case AND the identical-content case with no state ownership.
 - Path-level cross-scope collision: if incoming paths overlap with any path in the
   other scope's footprint, refuse with `--force`-immune error (AC12b). TDD.
 - `:668` cross-scope conflict loads `installed_at_local`; repo refusal is
@@ -356,12 +358,13 @@ Use `git diff` after each sub-group to confirm no unintended changes.*
 - `:631`: replace upgrade-offer guard with an adapter-identity check: refuse only when the requested adapter row (not just the pack) already exists in `local_state`; a second *different* adapter for the same pack must fall through to the union-write path (AC14b). The guard looks up the specific adapter row, not the pack-level `installed_at_local` boolean alone (AC21b).
 - `:668`: add `installed_at_local` derivation; enforce repo/local refusal before
   `--force` check; also add path-level cross-scope overlap check for AC12b.
-- Tier-2 (different-content untracked) refusal: before any write, check `_classify_for_install()` results for Tier-2 paths; for local scope, refuse rather than write a companion file.
+- Unowned pre-existing file refusal (AC10b): before any write, check each target path for existence as an untracked file. If the path exists and has NO ownership record in any agentbundle state (repo, user, or local), refuse the whole install with a clear error — regardless of whether the file content matches. This is a superset of Tier-2 (different-content) classification; do NOT rely solely on `_classify_for_install()` Tier-2 detection, which would pass same-content unowned files through to installation and subsequent deletion-on-uninstall.
 - Other sites (`390`, `397`, `432`, `513`, `577`, `663`, `739`): review each;
   widen or leave as-is per their individual semantics.
 
 **Family 2 — `!= "user"` negation comparisons:**
-- `:258`: already handled in T7 (change to `== "repo"`).
+- `:258`: already handled in T7 (change to `not in ("user", "local")` — see T7
+  approach note; do NOT use `== "repo"` as the RFC originally specified).
 - `:377`: **leave unchanged** — `requested_scope != "user"` correctly refuses
   force-merge for local; do NOT change to `== "repo"`.
 
@@ -446,21 +449,18 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
 **Approach:**
 - Implement `derive_worktree_id(repo_root)` using `subprocess.run(["git", "-C",
   str(repo_root), "rev-parse", "--git-dir"])` and `--git-common-dir`, compare;
-  sanitize with `re.sub(r":", "_", id)`. All git probes pass `-C <repo_root>` (or
-  equivalent `cwd=repo_root`) so they operate on the target repository, not the
-  process CWD (which differs when `--output` or `--root` names another repo).
-- Implement `derive_worktree_id()` using `subprocess.run(["git", "-C", str(repo_root),
-  "rev-parse", "--git-dir"])` and `--git-common-dir` (always pass `-C <repo_root>`
-  or `cwd=repo_root` to every git subprocess call so they probe the correct repo when
-  `--output` or `--root` names a directory other than the process CWD).
+  sanitize with `re.sub(r":", "_", id)`. All git subprocess calls pass `-C
+  <repo_root>` (or equivalent `cwd=repo_root`) so they probe the target repository,
+  not the process CWD (which differs when `--output` or `--root` names another repo).
 - Implement `write_exclude_block(exclude_path, pack, worktree_id, patterns)`:
   read file (create if absent), find existing block by marker, replace or append,
   write atomically via `tempfile.NamedTemporaryFile` + `os.replace`. The caller
   passes the **union** of all adapter patterns for this pack + worktree-id pair
   (not just the current adapter's patterns), so the block always reflects all
   remaining installed adapters. Before writing each path into the block, apply
-  gitignore metacharacter escaping: backslash-escape `[`, `]`, `*`, `?`, `\`;
-  backslash-escape `#` and `!` only when they appear at the start of a line.
+  gitignore metacharacter escaping: backslash-escape `[`, `]`, `*`, `?`, and `\`
+  (the leading `/` anchor means `#`/`!` can never appear at line start, so no
+  escaping of those is needed).
   Pre-flight tracked-file checks use `git --literal-pathspecs ls-files --error-unmatch <path>`
   (not bare `git ls-files`) to prevent pathspec pattern interpretation.
 - Implement `strip_exclude_block(exclude_path, pack, worktree_id)`: read file,
@@ -472,9 +472,12 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
 - Define the commit order for install: (1) read and snapshot prior exclude content,
   (2) write the exclude block first (files are git-invisible before they exist —
   satisfies the no-footprint guarantee even across abrupt process death), (3) write
-  projected files, (4) write state row. If any step after (1) fails, roll back:
-  call `rollback_exclude_block` to restore exclude content, then delete any projected
-  files written so far, then discard uncommitted state.
+  projected files, (4) write state row. If any step after (1) fails, roll back in
+  this order: (a) delete any projected files written so far, (b) call
+  `rollback_exclude_block` to restore exclude content, (c) discard uncommitted state.
+  Deleting files BEFORE restoring the block is critical: restoring the block while
+  files still exist creates a transient window where the files are git-visible and
+  non-excluded, violating the no-footprint guarantee during rollback.
 - Wire into `commands/install.py` pre-flight and write path.
 - In the `write_exclude_block` docstring, document: (a) the concurrent-write
   lost-update limitation (two processes writing simultaneously; last writer wins)
@@ -482,7 +485,7 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
   `info/exclude` silently git-ignores same-path untracked files in *all* linked
   worktrees, not only the installing one). This satisfies AC26 and AC27.
 
-**Done when:** all ten new tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+**Done when:** all new tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
 
 ---
 
@@ -684,3 +687,16 @@ the scope can be deprecated without touching `repo`/`user` behaviour.
   F8 (show scope field): AC23c + T12 tests narrowed to `source: installed-state`
   (no scope field assertion); F9 (parametrize over all adapters): T11 tests updated;
   F10 (version bump): added T13; F11 (pack schema contract): spec Contract field updated.
+- 2026-08-04: adversarial review round 2 (post-Codex-round-1 pass) — B1 (AC10/T8
+  inconsistency): T8 Family-1 approach now uses ownership-record check (not Tier-2
+  classification) and adds same-content test case; B2 (rollback order): AC21 and T9
+  corrected to delete-files THEN restore-block (inverse order prevents transient
+  git-visible window); B3 (T8 Family-2 stale `== "repo"`): updated to
+  `not in ("user","local")`; B4 (RFC missing F7 erratum): added implementation erratum
+  to RFC §4 emit_install_routes; B5 (RFC §Multi-worktree and §Risks still "harmless"):
+  corrected in both sections; M6 (ADR D2 missing --literal-pathspecs): added; M7
+  (stale test count in T9 "Done when"): dropped count; M8 (Testing Strategy Tier-2
+  label): renamed to "unowned pre-existing target refusal"; M9 (AC27 stale-block
+  risk): AC27 extended to cover deleted-worktree stale-block risk; A10 (#/! escaping
+  unreachable): dropped dead #/! escaping from spec/RFC/ADR/plan; A11 (duplicate
+  derive_worktree_id bullet): collapsed to one bullet.

--- a/docs/specs/local-scope-install/plan.md
+++ b/docs/specs/local-scope-install/plan.md
@@ -14,10 +14,11 @@ Thread `"local"` through agentbundle bottom-up: schema and scope engine first
 (T5, T6), then the CLI choices (T7), then the install write-path (T8 — the
 largest task, covering all six fork families plus carve-outs and key sites),
 then the `.git/info/exclude` write and worktree-id logic (T9), then the uninstall
-strip (T10), and finally a full integration test (T11). Each task is a coherent
-commit. T8 and T9 share install.py but can be separated by landing T9's
-helper functions before T8 calls them. All prior tasks must be green before T8
-begins — the install write path touches every earlier layer.
+strip (T10), then a full integration test (T11), then `show.py` state loading
+(T12), and finally the version bump (T13). Each task is a coherent commit.
+T8 and T9 share install.py but can be separated by landing T9's helper functions
+before T8 calls them. All prior tasks must be green before T8 begins — the
+install write path touches every earlier layer.
 
 The riskiest part is T8 (install.py): it has six scope-branching fork families,
 carve-outs that must NOT be widened, and five "else-implies-user" ternary sites
@@ -102,8 +103,9 @@ the invariant at parse time.
 | `commands/list_installed.py` | Three-scope default; explicit `local` branch in inline if/else |
 | `cli.py` | 3 sites gain `"local"`; 3 sites retain `("repo","user")` |
 | `commands/install.py` | Substantial — see T8 task for full site list |
-| New helper (install.py or a new module) | `write_exclude_block`, `strip_exclude_block`, `derive_worktree_id` |
-| `commands/uninstall.py` | Block-strip path; worktree-id matching; `:105`/`:87` disambiguator |
+| New helper (install.py or a new module) | `write_exclude_block`, `strip_exclude_block`, `rollback_exclude_block`, `derive_worktree_id` |
+| `commands/uninstall.py` | Block recompute or strip; worktree-id matching; `:105`/`:87` disambiguator |
+| `commands/show.py` | `_load_states()` local branch (T12) |
 
 ### Failure, edge cases & resilience
 
@@ -113,8 +115,13 @@ the invariant at parse time.
 - Target file already tracked: whole install aborts; no partial writes.
 - Concurrent write (two processes writing simultaneously): lost-update race
   documented in ADR-0070; no lock in v1.
-- Worktree deleted without uninstall: stale block accumulates in `info/exclude`;
-  paths don't exist, git treats them as unmatchable — harmless.
+- Worktree deleted without uninstall: stale block accumulates in `info/exclude`.
+  **Not harmless if same-path files exist in other worktrees**: a stale block's
+  patterns continue excluding those paths in ALL linked worktrees that share the
+  common-dir `info/exclude`. If a tracked/committed file lands at that path in
+  another worktree later, it is silently hidden from `git status`. Mitigation:
+  recommend `agentbundle local prune` (deferred CLI); document the risk in the
+  `write_exclude_block` docstring (AC26/AC27).
 
 ## Tasks
 
@@ -257,17 +264,25 @@ the invariant at parse time.
 **Tests:**
 - `agentbundle install --scope local --emit-install-routes` is refused with the
   RFC-0008-referencing error message. TDD.
-- `emit_install_routes` inference at line 258: `cli_scope == "repo"` (not
-  `!= "user"`). Unit test for the fixture-fallback path. TDD.
+- `emit_install_routes` inference at line 258: `cli_scope not in ("user", "local")`
+  (preserves `None`-scope legacy-caller behavior; `None not in ("user", "local")` is
+  `True`, keeping the historical repo-dist-tree path). Unit test for the fixture-fallback
+  path and `None`-scope case. TDD.
 - Upstream gate at line 513: `requested_scope in ("repo", "local")` resolves
   `allowed_prefixes_repo` correctly for a local request. TDD.
 - `any(p.scope in ("repo", "local"))` aggregate at line 929 gates projection
   rendering for a local plan. TDD.
 - `any(p.scope == "user")` at line 950 does NOT include local plans. TDD.
 - A new `_ScopePlan(scope="local", ...)` is produced for a local request. TDD.
+- A required dependency installed only at local scope satisfies
+  `validate_dependencies_required()` for a local install (AC23b). TDD.
 
 **Approach:**
-- `install.py:258`: change `cli_scope != "user"` to `cli_scope == "repo"`.
+- `install.py:258`: change `cli_scope != "user"` to `cli_scope not in ("user", "local")`.
+  (`cli_scope == "repo"` would break legacy/programmatic callers that pass a Namespace
+  without an explicit `scope` field — `None not in ("user", "local")` is `True`,
+  preserving the historical repo-dist-tree path for `None`; `None == "repo"` is `False`,
+  which would silently switch legacy callers to adapter projection.)
 - `install.py:390-393`: branch the `--emit-install-routes` guard to emit the
   RFC-0008-referencing message when `requested_scope == "local"`.
 - `install.py:513`: widen gate to `requested_scope in ("repo", "local") and not
@@ -280,7 +295,11 @@ the invariant at parse time.
 - `install.py:929`: widen to `any(p.scope in ("repo", "local") ...)`.
 - (`:950` is unchanged — user-only.)
 
-**Done when:** all six unit tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+- `install.py`: update `validate_dependencies_required()` call to pass `local_state`
+  alongside `repo_state` and `user_state` when `requested_scope == "local"` (AC23b).
+  If the function signature doesn't accept a third state, extend it.
+
+**Done when:** all unit tests (plus AC23b dependency test) green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
 
 ---
 
@@ -303,10 +322,14 @@ Use `git diff` after each sub-group to confirm no unintended changes.*
   at lines 1018, 1045, 1086 — TDD: a local plan selects repo_projection (non-None). TDD.
 - Adapter selection: `:859` and `:1093` widen to `plan.scope in ("repo","local")` —
   TDD: local plan selects `repo_target_adapter`. TDD.
-- `:486` state-file routing for source-conflict check routes local to
-  `.agentbundle-local-state.toml`. TDD.
-- `:631` upgrade-offer guard gains `(requested_scope=="local" and installed_at_local)`
-  — TDD: local reinstall routes to upgrade-offer. TDD.
+- `:486` state-file routing for source-conflict check: three-way selection routes
+  local requests to `local_state` (not `repo_state`). TDD.
+- `:631` upgrade-offer guard: local reinstall of same adapter refuses with
+  "already installed" message (AC21b) — does NOT route through `upgrade.run`. TDD.
+- Tier-2 refusal for local: if a target exists as an untracked file with different
+  content, the install is refused (AC10b). TDD.
+- Path-level cross-scope collision: if incoming paths overlap with any path in the
+  other scope's footprint, refuse with `--force`-immune error (AC12b). TDD.
 - `:668` cross-scope conflict loads `installed_at_local`; repo refusal is
   `--force`-immune. TDD.
 - `:377` force-merge guard: `agentbundle install --force-merge --scope local` is
@@ -329,10 +352,11 @@ Use `git diff` after each sub-group to confirm no unintended changes.*
 **Approach:**
 
 **Family 1 — `requested_scope ==` equality comparisons (grep: `requested_scope == "repo"`, `requested_scope == "user"`):**
-- `:486`: `repo_state if requested_scope in ("repo","local") else user_state`.
-- `:631`: add `(requested_scope=="local" and installed_at_local)` to upgrade-offer guard.
+- `:486`: **three-way selection** — `local_state if requested_scope == "local" else (repo_state if requested_scope == "repo" else user_state)`. This ensures source-conflict checking reads the correct state file for each scope; routing local to `repo_state` (binary expression) would miss local provenance rows.
+- `:631`: replace upgrade-offer guard with an adapter-identity check: refuse only when the requested adapter row (not just the pack) already exists in `local_state`; a second *different* adapter for the same pack must fall through to the union-write path (AC14b). The guard looks up the specific adapter row, not the pack-level `installed_at_local` boolean alone (AC21b).
 - `:668`: add `installed_at_local` derivation; enforce repo/local refusal before
-  `--force` check (outside `scopes_to_install` computation).
+  `--force` check; also add path-level cross-scope overlap check for AC12b.
+- Tier-2 (different-content untracked) refusal: before any write, check `_classify_for_install()` results for Tier-2 paths; for local scope, refuse rather than write a companion file.
 - Other sites (`390`, `397`, `432`, `513`, `577`, `663`, `739`): review each;
   widen or leave as-is per their individual semantics.
 
@@ -404,22 +428,53 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
   when none exists. TDD.
 - `write_exclude_block` replaces an existing block for the same `(pack, worktree_id)`
   pair in place. TDD.
+- `write_exclude_block` with a superset of patterns (union of two adapter rows)
+  replaces the block with the union. TDD.
 - Two different worktree-ids coexist in the file. TDD.
 - `strip_exclude_block(path, pack, worktree_id)` removes the block and leaves
   sibling blocks intact. TDD.
 - Write is atomic: a temp-file `os.replace` is used (not in-place append). TDD.
-- `git ls-files --error-unmatch <path>` exits non-zero for a tracked file → install
-  aborts with clear error. TDD.
+- `rollback_exclude_block(path, prior_content)` restores the prior file content
+  atomically. TDD (used when a subsequent write fails after the block was written).
+- `git --literal-pathspecs ls-files --error-unmatch <path>` exits non-zero for a
+  tracked file → install aborts with clear error. TDD.
 - Pre-flight `git rev-parse --is-inside-work-tree` failure → install aborts. TDD.
+- A path containing gitignore metacharacters (e.g. `references/[draft].md`) is
+  correctly escaped in the exclude block as `references/\[draft\].md`; the unescaped
+  path does NOT appear in the block. TDD.
 
 **Approach:**
-- Implement `derive_worktree_id()` using `subprocess.run(["git", "rev-parse",
-  "--git-dir"])` and `--git-common-dir`, compare; sanitize with `re.sub(r":", "_", id)`.
+- Implement `derive_worktree_id(repo_root)` using `subprocess.run(["git", "-C",
+  str(repo_root), "rev-parse", "--git-dir"])` and `--git-common-dir`, compare;
+  sanitize with `re.sub(r":", "_", id)`. All git probes pass `-C <repo_root>` (or
+  equivalent `cwd=repo_root`) so they operate on the target repository, not the
+  process CWD (which differs when `--output` or `--root` names another repo).
+- Implement `derive_worktree_id()` using `subprocess.run(["git", "-C", str(repo_root),
+  "rev-parse", "--git-dir"])` and `--git-common-dir` (always pass `-C <repo_root>`
+  or `cwd=repo_root` to every git subprocess call so they probe the correct repo when
+  `--output` or `--root` names a directory other than the process CWD).
 - Implement `write_exclude_block(exclude_path, pack, worktree_id, patterns)`:
   read file (create if absent), find existing block by marker, replace or append,
-  write atomically via `tempfile.NamedTemporaryFile` + `os.replace`.
+  write atomically via `tempfile.NamedTemporaryFile` + `os.replace`. The caller
+  passes the **union** of all adapter patterns for this pack + worktree-id pair
+  (not just the current adapter's patterns), so the block always reflects all
+  remaining installed adapters. Before writing each path into the block, apply
+  gitignore metacharacter escaping: backslash-escape `[`, `]`, `*`, `?`, `\`;
+  backslash-escape `#` and `!` only when they appear at the start of a line.
+  Pre-flight tracked-file checks use `git --literal-pathspecs ls-files --error-unmatch <path>`
+  (not bare `git ls-files`) to prevent pathspec pattern interpretation.
 - Implement `strip_exclude_block(exclude_path, pack, worktree_id)`: read file,
-  find and remove the `begin`/`end` block (inclusive), write atomically.
+  find and remove the `begin`/`end` block (inclusive), write atomically. Use only
+  when the last adapter row for this pack is being removed; otherwise call
+  `write_exclude_block` with the remaining adapters' union.
+- Implement `rollback_exclude_block(exclude_path, prior_content)`: write
+  `prior_content` atomically, restoring the file to its pre-write state.
+- Define the commit order for install: (1) read and snapshot prior exclude content,
+  (2) write the exclude block first (files are git-invisible before they exist —
+  satisfies the no-footprint guarantee even across abrupt process death), (3) write
+  projected files, (4) write state row. If any step after (1) fails, roll back:
+  call `rollback_exclude_block` to restore exclude content, then delete any projected
+  files written so far, then discard uncommitted state.
 - Wire into `commands/install.py` pre-flight and write path.
 - In the `write_exclude_block` docstring, document: (a) the concurrent-write
   lost-update limitation (two processes writing simultaneously; last writer wins)
@@ -439,15 +494,20 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
 - `agentbundle uninstall --scope local` removes installed files. TDD.
 - `agentbundle uninstall --scope local` strips only the correct worktree's block
   (sibling blocks untouched). TDD.
-- Uninstall removes pack rows from `.agentbundle-local-state.toml`; file deleted
-  when empty. TDD.
+- Uninstalling one of two adapter rows recomputes the block from the remaining row's
+  patterns (AC14b); the remaining row's files stay excluded. TDD.
+- Uninstalling the last adapter row strips the block entirely. TDD.
+- Uninstall removes only the specified adapter row from `.agentbundle-local-state.toml`;
+  sibling adapter rows remain. File deleted when empty. TDD.
 - `uninstall.py:105`/`:87` disambiguator explicitly handles `"local"` scope (no
   else-fallthrough to repo). TDD.
 - `git status` is clean after uninstall. Goal-based.
 
 **Approach:**
 - In `uninstall.py`, add a `"local"` branch in the `:105`/`:87` disambiguator.
-- Call `strip_exclude_block` with the current worktree-id.
+- Load all local rows for this pack from `local_state`. Remove the target adapter row.
+  If remaining rows exist, call `write_exclude_block` with the union of remaining
+  rows' patterns. If no rows remain, call `strip_exclude_block`.
 - Update state-file rows via `resolve_state_path("local", root)`.
 
 **Done when:** all five tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
@@ -459,7 +519,14 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
 **Depends on:** T8, T10
 
 **Tests:**
-- Install `core` pack with `--scope local` in a temp git repo:
+- **Parametrize over all shipped adapters** (per `packages/AGENTS.md:13-24`
+  install-test-coverage-rule). Derive `_SHIPPED_ADAPTERS` from
+  `packages/agentbundle/agentbundle/_data/adapter.toml` via
+  `scope.shipped_adapters_from_contract()`. For each adapter, run the full
+  install/uninstall cycle in a fresh temp git repo. Each adapter projects to
+  a different directory layout; parametrizing ensures local-scope exclusion
+  works for every adapter, not just the default.
+- Install `core` pack (and each adapter per above) with `--scope local` in a temp git repo:
   - Specific files appear in the working tree (assert at least one skill file
     exists at the expected path — guards against the silent-zero-file hazard).
   - `git status --short` output is empty (files not visible to git).
@@ -482,7 +549,20 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
   installed at `--scope repo` is refused, and vice versa; both refusals survive
   `--force`. (`--scope user` coexists with local — no refusal expected; assert
   user/local install succeeds.)
-- Reinstall (same-scope local → local): routes to upgrade-offer flow.
+- Same-scope reinstall (local → local, same adapter): refuses with "already installed"
+  message; does NOT call `upgrade.run`; state is unchanged (AC21b).
+- Rollback: monkeypatch the state-write helper to raise on the first call; assert
+  the working tree, exclude file, and local state all match pre-install values after
+  the exception propagates (AC21).
+- Path-overlap cross-scope (symmetric, AC12b): install pack A locally (adapter A's
+  paths) then attempt a repo install of pack B that projects the same path; assert
+  `--force`-immune refusal. Then install pack A at repo scope first, and attempt
+  local install of pack B with an overlapping path; assert same refusal.
+- Multi-adapter: install pack for adapter A locally, then adapter B locally; assert
+  both adapters' files are excluded and block contains union of both; uninstall A;
+  assert B's files still excluded; uninstall B; assert block stripped (AC14b, AC22).
+- Tier-2 target: place a file at a projected path with different content; assert
+  local install refuses (AC10b).
 
 **Approach:**
 - Add an integration test under `packages/agentbundle/tests/` (or
@@ -494,6 +574,47 @@ both edit `install.py`; to avoid merge conflicts, complete T9 before starting T7
   or equivalent if the CI environment doesn't guarantee one.
 
 **Done when:** integration test green; all prior task tests still green.
+
+---
+
+### T12: `commands/show.py` — include local state in `_load_states()`
+
+**Depends on:** T4
+
+**Tests:**
+- Create only a `.agentbundle-local-state.toml` row; force catalogue resolution to
+  fail; assert `agentbundle show <pack>` reports `source: installed-state` (the pack
+  is found and reported as installed). TDD / goal-based.
+  Note: `show` currently emits `inventory` and `source` fields but not a top-level
+  `scope` field; do NOT assert `scope = local` in this test. If the scope field is
+  needed for observability, extend `show`'s output contract in a follow-on spec.
+- `_load_states()` returns local-state candidates alongside repo and user. TDD.
+
+**Approach:**
+- In `commands/show.py`, update `_load_states()` to include
+  `resolve_state_path("local", root)` alongside the existing repo and user paths.
+
+**Done when:** both tests green; `python3 -m pytest packages/agentbundle/tests/ -q` green.
+
+---
+
+### T13: Version bump — `version.py` and `pyproject.toml`
+
+**Depends on:** T12
+
+**Tests:**
+- `agentbundle --version` reports the bumped version string. Goal-based.
+- `packages/agentbundle/pyproject.toml` `version` field matches `version.py`. Goal-based.
+
+**Approach:**
+- Per `packages/AGENTS.md` version-bump-rule: any new CLI behavior ships under a
+  new version. `--scope local` adds substantial new CLI behavior.
+- Increment the patch (or minor) version in `packages/agentbundle/agentbundle/version.py`
+  and the matching `version` field in `packages/agentbundle/pyproject.toml`.
+- This PR IS the release artifact: tag → PyPI is the follow-on step per the
+  repo's release convention.
+
+**Done when:** both goal-based checks pass; `python3 -m pytest packages/agentbundle/tests/ -q` green.
 
 ## Rollout
 
@@ -511,8 +632,11 @@ the scope can be deprecated without touching `repo`/`user` behaviour.
   constraint (temp file must be in the same directory as the target). Already
   the pattern used for `.agentbundle-state.toml`; no new risk.
 - **Concurrent write lost-update** — documented in ADR-0070; no mitigation in v1.
-- **Stale worktree blocks** — documented and declared harmless; manual cleanup
-  CLI deferred to the follow-on spec.
+- **Stale worktree blocks** — NOT harmless: a stale block's patterns continue
+  excluding same-path files in all other linked worktrees; a committed file at
+  that path would be invisible to `git status` in those worktrees. Documented
+  in the `write_exclude_block` docstring (AC26/AC27); `agentbundle local prune`
+  CLI deferred to a follow-on spec.
 - **`install.py` fork-family audit incomplete** — mitigated by the six-family
   taxonomy in RFC-0080 and the explicit grep patterns in T8.
 
@@ -531,3 +655,32 @@ the scope can be deprecated without touching `repo`/`user` behaviour.
   clarified T11 conflict test removes user/local refusal; added T9/T7 ordering note.
 - 2026-08-04: adversarial review pass 3 — corrected T7 `_ScopePlan` illustrative
   branch from `repo_root` to `output_root` (the actual function-level variable).
+- 2026-08-04: adversarial review pass 5 — fixed RFC-0080 §Same-scope local reinstall
+  (erratum + correct adapter-identity refusal); fixed RFC cross-scope message to name
+  uninstall/reinstall; fixed RFC `:218` "e.g. on reinstall" phrasing; collapsed
+  redundant T11 path-overlap bullet.
+- 2026-08-04: adversarial review pass 4 — reconciled AC15 vs AC21b (AC15 now
+  scoped to multi-adapter union path only); added adapter-identity guard spec to T8
+  `:631`; added AC23b test bullet to T7; added T12 to approach narrative and
+  decomposition table; updated Testing Strategy TDD enumeration; added symmetric
+  AC12b and rollback injection point to T11.
+- 2026-08-04: Codex Sol review round 0 (10 findings) — F1: removed upgrade-offer
+  routing for local reinstall (AC21b); F2: added dependency validation update to T7
+  (AC23b); F3: fixed `:486` to three-way state selection; F4: added multi-adapter
+  block union to T9/T10 (AC14b, AC22); F5: added tier-2 refusal for local (AC10b);
+  F6: added path-level cross-scope collision check (AC12b); F7: defined commit order +
+  rollback in T9 (AC21); F8: pre-existing deferred design (invalid — already in
+  ADR-0070); F9: added T12 for show.py `_load_states()` (AC23c); F10: fixed ADR D1
+  linked-worktree path description.
+- 2026-08-04: Codex Sol review round 1 (11 findings) — F1 (git probes against output
+  root): T9 adds `-C <root>` to all git subprocess calls; F2 (equal-content
+  pre-existing file deleted on uninstall): AC10 extended to refuse ALL unowned
+  pre-existing targets regardless of content; F3 (gitignore metacharacter escaping):
+  AC14 + T9 + RFC + ADR D3 all specify backslash-escaping; F4 (stale blocks not
+  harmless): corrected in plan §Failure, §Risks, RFC §Stale blocks, ADR D3;
+  F5 (write block BEFORE files): AC21 + T9 commit order corrected to
+  block→files→state; F6 (--literal-pathspecs): T9 + RFC §tracked-file check updated;
+  F7 (None-scope legacy caller): T7 `:258` corrected to `not in ("user","local")`;
+  F8 (show scope field): AC23c + T12 tests narrowed to `source: installed-state`
+  (no scope field assertion); F9 (parametrize over all adapters): T11 tests updated;
+  F10 (version bump): added T13; F11 (pack schema contract): spec Contract field updated.

--- a/docs/specs/local-scope-install/spec.md
+++ b/docs/specs/local-scope-install/spec.md
@@ -1,6 +1,6 @@
 # Spec: Local scope install (`--scope local`)
 
-- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Approved <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0080, ADR-0070, RFC-0004, RFC-0005, RFC-0008, RFC-0012

--- a/docs/specs/local-scope-install/spec.md
+++ b/docs/specs/local-scope-install/spec.md
@@ -1,0 +1,218 @@
+# Spec: Local scope install (`--scope local`)
+
+- **Status:** Draft <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** RFC-0080, ADR-0070, RFC-0004, RFC-0005, RFC-0008, RFC-0012
+- **Brief:** none
+- **Discovery:** none
+- **Contract:** none (CLI-only; no new API or event surface)
+- **Shape:** integration
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+`agentbundle install --scope local` installs pack files into the working tree at
+the same paths as `--scope repo`, but excludes every installed file from git via a
+comment-delimited block in `.git/info/exclude` (the per-clone, never-committed
+exclusion file). The result: a pack is fully functional for the session — skills
+load, agents use them — and `git status` never shows any trace. Uninstall removes
+the working-tree files and strips the block, leaving the repo in exactly the state
+it was in before. The primary user is anyone who wants to trial a pack in a repo
+they don't own or haven't permanently adopted it.
+
+## Boundaries
+
+### Always do
+
+- Verify `git rev-parse --is-inside-work-tree` succeeds before any write.
+- Resolve the exclude path via `git rev-parse --git-path info/exclude` (handles
+  linked worktrees and submodules automatically).
+- Write to `.git/info/exclude` atomically: read → modify in memory → write to a
+  temp file in the same directory → `os.replace` (never in-place append).
+- Abort the whole install (no partial writes) when any target file is already
+  tracked by git.
+- Enforce the repo/local cross-scope refusal as a hard, `--force`-immune check.
+- Leave `:1060` and `:1254` (seed gates) unchanged — both are already gated
+  `plan.scope == "repo"` and correctly exclude local; no new code needed there.
+- Add explicit `if plan.scope != "local":` guards around `:1447` (install marker)
+  and `:1456` (layout section) — these are unconditional calls with no existing guard.
+- Skip `_chain_adapt` (Step 12) for `scope="local"` installs; update the
+  `install.py:1468` comment and add an erratum note to `adapt-to-project/spec.md`
+  AC19b in the implementing PR.
+- Record adapter in the local state row (widen `install.py:1334`).
+
+### Ask first
+
+- Any change to the block-key format `# agentbundle:local:<pack>:<worktree-id>:{begin,end}`.
+- Any change that causes `diff`, `upgrade`, or `init-state` to accept `--scope local`
+  (deferred to a follow-on spec per RFC-0080).
+- Any file lock added to `.git/info/exclude` or `.agentbundle-local-state.toml`.
+
+### Never do
+
+- Write to `.gitignore` (use `.git/info/exclude` only).
+- Allow `--scope local` alongside `--profile` (existing `install.py:162-165` guard
+  already covers this once `"local"` is a valid choice at `cli.py:390`).
+- Allow `--scope local` alongside `--emit-install-routes`.
+- Allow `default-scope = "local"` in a pack manifest.
+- Allow `allowed-scopes = ["local"]` without `"repo"` (schema `allOf` constraint).
+- Deliver seeds, install markers, or layout sections for local-scope installs.
+- Widen `:950` user-aggregate beyond `any(p.scope == "user" ...)`; local plans
+  must not enter user-projection rendering.
+- Add any new guard around `:1060` or `:1254` — both are already correctly gated
+  `plan.scope == "repo"` and that logic must not change.
+- Change `install.py:377` `!= "user"` to `== "repo"` — the existing negation
+  correctly refuses force-merge for every non-user scope.
+
+## Testing Strategy
+
+- **TDD** — for all logic with a compressible invariant: `resolve()` auto-promote
+  rule, `_parse_adapter_row` scope coercion, `resolve_state_path` routing,
+  block-key parse/strip round-trip, tracked-file collision check, `installed_at_*`
+  flag derivation, repo/local cross-scope refusal (including `--force` immunity),
+  `--force-merge --scope local` refusal.
+- **Goal-based check** — schema validation: `python3 tools/lint-ruff.py` passes;
+  `python3 -m pytest packages/agentbundle/tests/ -q` green; `check_contract_parity.py`
+  exits 0 (both schema copies byte-identical).
+- **Visual / manual QA** — full install / uninstall cycle exercised via the real
+  `agentbundle` CLI in an integration test: files appear in working tree, do NOT
+  appear in `git status`, `list-installed` shows `scope = local`, uninstall removes
+  files and the exclude block, `git status` clean after.
+
+## Acceptance Criteria
+
+### Schema and scope engine
+
+- [ ] AC1: `pack.schema.json` `allowed-scopes` enum includes `"local"`; an
+  `allOf` constraint rejects `allowed-scopes` that contain `"local"` but not `"repo"`.
+  Both copies (`contracts/pack.schema.json` and
+  `packages/agentbundle/agentbundle/_data/pack.schema.json`) are byte-identical;
+  `check_contract_parity.py` exits 0.
+- [ ] AC2: `scope.py` `LEGAL_SCOPES` equals `{"repo", "user", "local"}`.
+- [ ] AC3: `scope.resolve()` raises `ScopeRefused` when `default-scope == "local"`,
+  before the D4 auto-promote check.
+- [ ] AC4: `scope.resolve()` permits `scope="local"` for any pack whose
+  `allowed-scopes` contains `"repo"`, without requiring explicit `"local"` in the
+  pack's `allowed-scopes`.
+- [ ] AC5: `config.py` `_parse_adapter_row` sources its allowlist from `LEGAL_SCOPES`
+  (not a hardcoded tuple); `scope = "local"` rows in `.agentbundle-local-state.toml`
+  are preserved correctly.
+
+### State file routing
+
+- [ ] AC6: `commands/_common.py` `resolve_state_path("local", root)` returns
+  `root / ".agentbundle-local-state.toml"`.
+- [ ] AC7: `.agentbundle-local-state.toml` uses `schema-version = "0.4"` and the
+  same `PackState` shape as `.agentbundle-state.toml`; all rows carry `scope = "local"`.
+  The T11 integration test reads the written file and asserts `schema-version = "0.4"`.
+
+### Install — pre-flight
+
+- [ ] AC8: `agentbundle install --scope local` fails with a clear error when run
+  outside a git working tree.
+- [ ] AC9: `agentbundle install --scope local --emit-install-routes` is refused with
+  an error that references RFC-0008 for the plugins route's own local-scope behaviour.
+- [ ] AC10: `agentbundle install --scope local` fails when any target file is already
+  tracked by git; the whole install aborts (no partial writes).
+- [ ] AC11: `agentbundle install --scope local` fails when the pack is already
+  installed at `--scope repo`; the refusal is `--force`-immune.
+- [ ] AC11b: `agentbundle install --force-merge --scope local` is refused; the
+  force-merge guard (`install.py:377` `!= "user"` negation) covers local scope
+  and must not be changed to `== "repo"`.
+- [ ] AC12: `agentbundle install --scope repo` fails when the pack is already
+  installed at `--scope local`; the cross-scope refusal is `--force`-immune.
+  (`--scope user` coexists with a local install — user-scope files land in `~/.claude/`
+  outside the working tree and are unaffected by the exclude block; user/local
+  coexistence is explicitly permitted by RFC-0080.)
+
+### Install — write path
+
+- [ ] AC13: Installed files appear in the working tree at the same paths as
+  `--scope repo`; they do NOT appear in `git status` output.
+- [ ] AC14: A comment-delimited block keyed to `(pack-name, worktree-id)` is appended
+  to the file returned by `git rev-parse --git-path info/exclude`. Block format:
+  `# agentbundle:local:<pack>:<worktree-id>:begin / [paths] / …:end`.
+- [ ] AC15: Reinstalling an already-local pack replaces the existing block in place
+  (no duplicate blocks).
+- [ ] AC16: Two different worktrees installing the same pack each write their own
+  keyed block; the blocks coexist in the shared `info/exclude` file.
+- [ ] AC17: Seeds (`AGENTS.md`/`docs/CHARTER.md`), install markers, and layout
+  sections are NOT written for `--scope local` installs.
+- [ ] AC18: The local state row includes the adapter field (populated from
+  `repo_target_adapter`).
+- [ ] AC19: `_chain_adapt` (Step 12) is skipped for `--scope local` installs.
+  Amends `adapt-to-project/spec.md` AC19b ("regardless of install scope"); the
+  implementing PR adds an erratum note to AC19b and updates the adjacent
+  `install.py` comment to record the local-scope exception. Also addresses AC19a
+  (the "every successful install" universal is now scoped to repo/user installs
+  only — local installs are ephemeral and do not write install markers); the PR
+  adds a clarifying note to AC19a as well.
+- [ ] AC20: The install success line reports both the scope and the actual
+  exclude-file path: `installed: <pack> @ local (excluded via <exclude-path>)`.
+
+### Install — same-scope reinstall
+
+- [ ] AC21: `agentbundle install --scope local` on an already-local pack routes to
+  the upgrade-offer flow (same as `--scope repo` reinstall behaviour).
+
+### Uninstall
+
+- [ ] AC22: `agentbundle uninstall --scope local` removes installed working-tree
+  files, strips the `(pack-name, worktree-id)` block from the exclude file, and
+  removes the pack's rows from `.agentbundle-local-state.toml` (deletes the state
+  file only when it becomes empty). `git status` is clean after.
+
+### List-installed
+
+- [ ] AC23: `agentbundle list-installed` includes local-scope rows with
+  `scope = local` and a note `(not committed; per-clone only)`.
+
+### CLI surface
+
+- [ ] AC24: `agentbundle install --scope local`, `uninstall --scope local`, and
+  `list-installed --scope local` are accepted by argparse. `diff --scope local`,
+  `upgrade --scope local`, and `init-state --scope local` are rejected by argparse
+  (choices list does not include `"local"` on those three subcommands).
+- [ ] AC25: `agentbundle diff --scope local`, `upgrade --scope local`, and
+  `init-state --scope local` produce an argparse-native `invalid choice: 'local'`
+  error (not a runtime guard). The argparse rejection is the v1 "not yet supported"
+  mechanism; the friendly RFC-0080 message at lines 577-580 is reserved for a future
+  custom action if the UX is revisited.
+
+### Documentation
+
+- [ ] AC26: The concurrent-write lost-update limitation (two `agentbundle` processes
+  writing simultaneously; last writer wins) is documented in at least one user-visible
+  location: a docstring on `write_exclude_block`, a note in the `--scope local` entry
+  of the guides, or an inline `# WARNING:` comment in the write helper. The location
+  is named in the PR description.
+- [ ] AC27: The cross-worktree exclusion side-effect is documented in a user-visible
+  location: a leading-`/` pattern in `info/exclude` git-ignores same-path untracked
+  files in *all* linked worktrees, not just the installing one. Document in the same
+  location as AC26 (docstring, guide note, or inline comment). Verified by a T11
+  assertion that the documented text is present in the chosen location (docstring
+  content check or guide file existence check).
+
+## Assumptions
+
+- Technical: `.git/info/exclude` is shared across all linked worktrees of the same
+  repo — verified by spike in the philadelphia-v1 worktree (source: RFC-0080
+  §Git exclusion contract).
+- Technical: `os.replace` is atomic on POSIX and near-atomic on Windows (NTFS);
+  sufficient for the v1 lost-update tolerance documented in ADR-0070
+  (source: RFC-0080 §Concurrent-write limitation).
+- Technical: `git rev-parse --git-path info/exclude` resolves correctly for
+  standard repos, linked worktrees, and submodules (source: RFC-0080 spike).
+- Technical: `install.py:162-165` already refuses `--scope <anything>` alongside
+  `--profile`; no new guard needed once `"local"` is a valid choice (source:
+  RFC-0080 pass-19 adversarial reviewer).
+- Process: `check_contract_parity.py` is the CI gate for `pack.schema.json` parity;
+  no `--write` flag exists — both copies must be hand-edited (source: RFC-0080
+  §Follow-on artifacts).
+- Process: `install.py:377` (`requested_scope != "user"` negation) must NOT be
+  changed to `== "repo"` — the existing negation correctly excludes force-merge
+  for local scope; changing it would introduce a security regression (source:
+  RFC-0080 adversarial pass-20).

--- a/docs/specs/local-scope-install/spec.md
+++ b/docs/specs/local-scope-install/spec.md
@@ -73,8 +73,9 @@ they don't own or haven't permanently adopted it.
   rule, `_parse_adapter_row` scope coercion, `resolve_state_path` routing,
   block-key parse/strip round-trip, tracked-file collision check, `installed_at_*`
   flag derivation (adapter-level), repo/local cross-scope refusal (including
-  `--force` immunity), `--force-merge --scope local` refusal, Tier-2 file refusal
-  (AC10b), path-level cross-scope overlap refusal (AC12b, both directions),
+  `--force` immunity), `--force-merge --scope local` refusal, unowned pre-existing
+  target refusal (AC10b — both same-content and different-content unowned cases),
+  path-level cross-scope overlap refusal (AC12b, both directions),
   rollback round-trip (AC21), dependency validation with local state (AC23b),
   show-state loading (AC23c).
 - **Goal-based check** — schema validation: `python3 tools/lint-ruff.py` passes;
@@ -152,9 +153,10 @@ they don't own or haven't permanently adopted it.
   the common-dir `info/exclude` from both primary and linked worktrees). Block format:
   `# agentbundle:local:<pack>:<worktree-id>:begin / [paths] / …:end`. Each path
   written into the block is gitignore-metacharacter-escaped before writing: the
-  characters `[`, `]`, `*`, `?`, and `\` are backslash-escaped; `#` and `!` are
-  escaped only when they appear at the start of a line. This ensures filenames
-  containing gitignore pattern syntax are matched literally and not as globs.
+  characters `[`, `]`, `*`, `?`, and `\` are backslash-escaped. (All paths are
+  written with a leading `/` anchor, so `#` and `!` can never appear at line start
+  and need no escaping.) This ensures filenames containing gitignore pattern syntax
+  are matched literally and not as globs.
 - [ ] AC14b: The exclude block for a pack represents the **union** of all adapter rows
   installed locally for that pack. Installing a second adapter replaces the block with
   a block containing all paths from both adapters. Uninstalling one adapter recomputes
@@ -185,12 +187,15 @@ they don't own or haven't permanently adopted it.
 - [ ] AC21: The write path follows the order: (1) snapshot prior exclude-file content,
   (2) write the exclude block (so installed files are git-invisible from the moment
   they exist), (3) write projected files, (4) write state row. If any step fails after
-  step 1, the install rolls back: the exclude block is restored to the snapshotted
-  content, any projected files written so far are deleted, and no state row is
-  persisted. The working tree, exclude file, and local state are identical to their
-  pre-install values after rollback. Writing the block before the files guarantees
-  that no background git tooling (IDE integrations, `git status` watchers) can
-  observe the files in a non-excluded state.
+  step 1, the install rolls back in the inverse order: (a) delete any projected files
+  written so far, THEN (b) restore the exclude block to its snapshotted content, THEN
+  (c) discard any uncommitted state row. Deleting files before restoring the block
+  ensures that the exclude file is never restored while the installed files still
+  exist on disk (which would create a transient window where files are git-visible
+  and unexcluded). The working tree, exclude file, and local state are identical to
+  their pre-install values after rollback. Writing the block before the files
+  guarantees that no background git tooling can observe the files in a non-excluded
+  state.
 
 ### Install — same-scope reinstall
 
@@ -255,12 +260,16 @@ they don't own or haven't permanently adopted it.
   location: a docstring on `write_exclude_block`, a note in the `--scope local` entry
   of the guides, or an inline `# WARNING:` comment in the write helper. The location
   is named in the PR description.
-- [ ] AC27: The cross-worktree exclusion side-effect is documented in a user-visible
-  location: a leading-`/` pattern in `info/exclude` git-ignores same-path untracked
-  files in *all* linked worktrees, not just the installing one. Document in the same
-  location as AC26 (docstring, guide note, or inline comment). Verified by a T11
-  assertion that the documented text is present in the chosen location (docstring
-  content check or guide file existence check).
+- [ ] AC27: The cross-worktree exclusion side-effects are documented in a user-visible
+  location (same as AC26 — docstring, guide note, or inline comment):
+  (a) **Live-worktree side-effect:** a leading-`/` pattern in `info/exclude` excludes
+  same-path untracked files in *all* linked worktrees, not just the installing one.
+  (b) **Stale-block risk:** when a worktree is deleted without uninstalling, its block
+  remains in `info/exclude` and continues excluding same-path files in all remaining
+  worktrees — including tracked or committed files added later. The documentation must
+  name `agentbundle local prune` (deferred) as the cleanup path and record this as a
+  known v1 limitation. Verified by a T11 assertion that the documented text is present
+  in the chosen location (docstring content check or guide file existence check).
 
 ## Assumptions
 

--- a/docs/specs/local-scope-install/spec.md
+++ b/docs/specs/local-scope-install/spec.md
@@ -6,7 +6,7 @@
 - **Constrained by:** RFC-0080, ADR-0070, RFC-0004, RFC-0005, RFC-0008, RFC-0012
 - **Brief:** none
 - **Discovery:** none
-- **Contract:** none (CLI-only; no new API or event surface)
+- **Contract:** `contracts/pack.schema.json` (and parity copy `packages/agentbundle/agentbundle/_data/pack.schema.json`) — AC1 modifies `allowed-scopes` in both copies
 - **Shape:** integration
 
 > **Spec contract:** this document defines what "done" means. The implementing
@@ -72,8 +72,11 @@ they don't own or haven't permanently adopted it.
 - **TDD** — for all logic with a compressible invariant: `resolve()` auto-promote
   rule, `_parse_adapter_row` scope coercion, `resolve_state_path` routing,
   block-key parse/strip round-trip, tracked-file collision check, `installed_at_*`
-  flag derivation, repo/local cross-scope refusal (including `--force` immunity),
-  `--force-merge --scope local` refusal.
+  flag derivation (adapter-level), repo/local cross-scope refusal (including
+  `--force` immunity), `--force-merge --scope local` refusal, Tier-2 file refusal
+  (AC10b), path-level cross-scope overlap refusal (AC12b, both directions),
+  rollback round-trip (AC21), dependency validation with local state (AC23b),
+  show-state loading (AC23c).
 - **Goal-based check** — schema validation: `python3 tools/lint-ruff.py` passes;
   `python3 -m pytest packages/agentbundle/tests/ -q` green; `check_contract_parity.py`
   exits 0 (both schema copies byte-identical).
@@ -115,8 +118,16 @@ they don't own or haven't permanently adopted it.
   outside a git working tree.
 - [ ] AC9: `agentbundle install --scope local --emit-install-routes` is refused with
   an error that references RFC-0008 for the plugins route's own local-scope behaviour.
-- [ ] AC10: `agentbundle install --scope local` fails when any target file is already
-  tracked by git; the whole install aborts (no partial writes).
+- [ ] AC10: `agentbundle install --scope local` fails (no partial writes) when:
+  (a) any target file is already tracked by git (checked via
+  `git --literal-pathspecs ls-files --error-unmatch <path>`); or
+  (b) any target file exists as an untracked file that has **no ownership record**
+  in any agentbundle state (repo, user, or local) — regardless of content match.
+  Matching content does not grant ownership: a pre-existing unowned file with
+  identical content would be deleted on uninstall, violating the exact-restoration
+  guarantee. For local scope, a conflicting untracked file must not be silently
+  bypassed via companion-file routing (Tier-2 classification applies to unowned
+  untracked files with different content, but the ownership check is broader).
 - [ ] AC11: `agentbundle install --scope local` fails when the pack is already
   installed at `--scope repo`; the refusal is `--force`-immune.
 - [ ] AC11b: `agentbundle install --force-merge --scope local` is refused; the
@@ -127,16 +138,32 @@ they don't own or haven't permanently adopted it.
   (`--scope user` coexists with a local install — user-scope files land in `~/.claude/`
   outside the working tree and are unaffected by the exclude block; user/local
   coexistence is explicitly permitted by RFC-0080.)
+- [ ] AC12b: Cross-scope path collision (not just same-pack) is detected and refused:
+  if a local install's projected paths overlap with any path owned by a repo-scope
+  pack (or vice versa), the install is refused with a `--force`-immune error naming
+  the colliding path and its owner.
 
 ### Install — write path
 
 - [ ] AC13: Installed files appear in the working tree at the same paths as
   `--scope repo`; they do NOT appear in `git status` output.
 - [ ] AC14: A comment-delimited block keyed to `(pack-name, worktree-id)` is appended
-  to the file returned by `git rev-parse --git-path info/exclude`. Block format:
-  `# agentbundle:local:<pack>:<worktree-id>:begin / [paths] / …:end`.
-- [ ] AC15: Reinstalling an already-local pack replaces the existing block in place
-  (no duplicate blocks).
+  to the file returned by `git rev-parse --git-path info/exclude` (which resolves to
+  the common-dir `info/exclude` from both primary and linked worktrees). Block format:
+  `# agentbundle:local:<pack>:<worktree-id>:begin / [paths] / …:end`. Each path
+  written into the block is gitignore-metacharacter-escaped before writing: the
+  characters `[`, `]`, `*`, `?`, and `\` are backslash-escaped; `#` and `!` are
+  escaped only when they appear at the start of a line. This ensures filenames
+  containing gitignore pattern syntax are matched literally and not as globs.
+- [ ] AC14b: The exclude block for a pack represents the **union** of all adapter rows
+  installed locally for that pack. Installing a second adapter replaces the block with
+  a block containing all paths from both adapters. Uninstalling one adapter recomputes
+  the block from the remaining rows; the block is stripped only when the last row is
+  removed.
+- [ ] AC15: When a second adapter is installed locally for the same pack
+  (multi-adapter union path per AC14b), the block is replaced in place with the
+  union of both adapters' patterns — no duplicate blocks. Same-adapter reinstall
+  is governed by AC21b's refusal (not this AC).
 - [ ] AC16: Two different worktrees installing the same pack each write their own
   keyed block; the blocks coexist in the shared `info/exclude` file.
 - [ ] AC17: Seeds (`AGENTS.md`/`docs/CHARTER.md`), install markers, and layout
@@ -153,22 +180,61 @@ they don't own or haven't permanently adopted it.
 - [ ] AC20: The install success line reports both the scope and the actual
   exclude-file path: `installed: <pack> @ local (excluded via <exclude-path>)`.
 
+### Install — rollback on failure
+
+- [ ] AC21: The write path follows the order: (1) snapshot prior exclude-file content,
+  (2) write the exclude block (so installed files are git-invisible from the moment
+  they exist), (3) write projected files, (4) write state row. If any step fails after
+  step 1, the install rolls back: the exclude block is restored to the snapshotted
+  content, any projected files written so far are deleted, and no state row is
+  persisted. The working tree, exclude file, and local state are identical to their
+  pre-install values after rollback. Writing the block before the files guarantees
+  that no background git tooling (IDE integrations, `git status` watchers) can
+  observe the files in a non-excluded state.
+
 ### Install — same-scope reinstall
 
-- [ ] AC21: `agentbundle install --scope local` on an already-local pack routes to
-  the upgrade-offer flow (same as `--scope repo` reinstall behaviour).
+- [ ] AC21b: `agentbundle install --scope local` on an already-local pack, **same
+  adapter**, same scope, is refused with a clear "already installed" message. The
+  guard fires only when the requested adapter row already exists in `local_state`
+  (adapter-identity check, not a pack-level boolean). The install does not route
+  through `upgrade.run` (which does not support local scope in v1) and does not
+  modify any state. The v1 message names `uninstall --scope local` then
+  `install --scope local` as the refresh path. Amends RFC-0080 §"Same-scope local
+  reinstall" (which mandated upgrade-offer routing — that routing fails because
+  `upgrade.run` has no local support); this amendment is recorded in the
+  implementing PR description.
 
 ### Uninstall
 
 - [ ] AC22: `agentbundle uninstall --scope local` removes installed working-tree
-  files, strips the `(pack-name, worktree-id)` block from the exclude file, and
-  removes the pack's rows from `.agentbundle-local-state.toml` (deletes the state
-  file only when it becomes empty). `git status` is clean after.
+  files for the specified adapter row, recomputes the exclude block from the remaining
+  local rows for this pack (strips the block if no local rows remain), and removes
+  the specified adapter row from `.agentbundle-local-state.toml` (deletes the state
+  file only when it becomes empty). `git status` is clean after. When multiple
+  adapter rows exist for the same pack, uninstalling one adapter leaves the other
+  adapter's files excluded and in-place.
 
 ### List-installed
 
 - [ ] AC23: `agentbundle list-installed` includes local-scope rows with
   `scope = local` and a note `(not committed; per-clone only)`.
+
+### Dependency validation
+
+- [ ] AC23b: `validate_dependencies_required()` (called during install pre-flight)
+  receives the local state in addition to repo and user state when `requested_scope ==
+  "local"`. A required dependency installed only at local scope satisfies the
+  dependency check for a local install.
+
+### Show command
+
+- [ ] AC23c: `agentbundle show <pack>` includes `.agentbundle-local-state.toml` in
+  its `_load_states()` fallback. After a local-only install with the catalogue
+  unavailable, `show` correctly reports the pack as installed (`source:
+  installed-state`). The current `show` output format does not include a top-level
+  scope field; extending the output contract to expose scope is deferred to a
+  follow-on spec.
 
 ### CLI surface
 
@@ -179,7 +245,7 @@ they don't own or haven't permanently adopted it.
 - [ ] AC25: `agentbundle diff --scope local`, `upgrade --scope local`, and
   `init-state --scope local` produce an argparse-native `invalid choice: 'local'`
   error (not a runtime guard). The argparse rejection is the v1 "not yet supported"
-  mechanism; the friendly RFC-0080 message at lines 577-580 is reserved for a future
+  mechanism; the friendly RFC-0080 message at lines 582-585 is reserved for a future
   custom action if the UX is revisited.
 
 ### Documentation


### PR DESCRIPTION
## Summary

Adds all governance and planning artifacts for RFC-0080 (local-scope install):

- **RFC-0080** — Accepted; defines `--scope local` for `agentbundle install`
- **ADR-0070** — Records 4 architecture decisions (exclude mechanism, abort policy, keyed blocks, deferred locking)
- **Spec** — 27 acceptance criteria (Approved); includes 3 rounds of Codex Sol + adversarial review
- **Plan** — 13 tasks T1–T13, dependency-ordered (Approved)

## What this is not

This PR contains **no code**. Implementation follows in a separate PR.

## Review highlights

Two Codex Sol review rounds and two adversarial passes were applied before approval. Key design decisions resolved:

- Write exclude block **before** projected files (not after) — prevents background git tooling observing files in a non-excluded window
- Rollback: delete files **first**, then restore block — same invariant applies during rollback
- `--literal-pathspecs` on all `git ls-files` calls — prevents pathspec interpretation of metacharacters in filenames
- Gitignore metacharacter escaping for paths written into `info/exclude`
- Stale blocks from deleted worktrees are **not harmless** — documented risk with deferred `agentbundle local prune` CLI
- `cli_scope not in ("user", "local")` (not `== "repo"`) to preserve `None`-scope legacy-caller behavior
- T11 integration test parametrized over all shipped adapters per `packages/AGENTS.md:13-24`

## Files changed

- `docs/rfc/0080-local-scope-install.md` — new (Accepted)
- `docs/specs/local-scope-install/spec.md` — new (Approved, 27 ACs)
- `docs/specs/local-scope-install/plan.md` — new (Approved, 13 tasks)
- `docs/adr/0070-local-scope-install-decisions.md` — new (Accepted, 4 decisions)
- `docs/adr/README.md` — rows 0062–0070 added
- `docs/rfc/README.md` — RFC-0080 row status → Accepted
- `.gitignore` — `.loop-run/` entry

## Deferred (follow-on)

- Implementation code (PR follows)
- `agentbundle local prune` CLI for stale-block cleanup
- `show` output contract extension for scope field
- Concurrent-write locking (ADR-0070 D4)