### PR TITLE
fix(self-host): respect preferred-adapter from catalogue.toml; replace shutil.copy2

### DIFF
--- a/docs/architecture/agentbundle.md
+++ b/docs/architecture/agentbundle.md
@@ -75,9 +75,16 @@ packs/                                dist/
     pack.toml                           claude-plugins/<pack>/       ← per-pack plugin
     .claude-plugin/plugin.json          claude-plugins/marketplace.json
     .apm/{skills,agents,hooks,commands}
-    seeds/                            <repo>/.claude/                ← Claude self-host
-                                      <repo>/.codex/ + .agents/      ← Codex self-host
+    seeds/                            <repo>/.claude/ + CLAUDE.md    ← Claude self-host (claude-code)
+                                      <repo>/.codex/ + .agents/      ← Codex self-host (codex)
+                                      <repo>/.kiro/                  ← Kiro self-host (kiro-ide / kiro-cli)
 ```
+
+> Self-host output is determined by the effective adapter set. When `catalogue.toml` sets
+> `preferred-adapter` to an adapter not in the default `SELF_HOST_ADAPTERS` list (e.g. `kiro-ide`),
+> only that adapter's folder is projected and `CLAUDE.md` / `.claude-plugin/marketplace.json` are
+> omitted. When `preferred-adapter` is absent or names an adapter already in `SELF_HOST_ADAPTERS`,
+> the default set (claude-code + codex) is used.
 
 1. **Recipe load.** [`build/recipes/`](../../packages/agentbundle/agentbundle/build/recipes/)
    carries the canonical seven recipes — `per-pack-claude-plugin.toml`,
@@ -95,7 +102,9 @@ packs/                                dist/
    [`build/projections/`](../../packages/agentbundle/agentbundle/build/projections/).
 4. **Aggregation.** `marketplace.json` lists every per-pack plugin entry.
 5. **Self-host overlay.** `make build-self` runs `self-host.toml` against
-   this repo's root for the Claude Code and Codex repo projections.
+   this repo's root. The effective adapter set — which folders are written —
+   is determined by `preferred-adapter` in `catalogue.toml`; see the diagram
+   note above for the conditionality rules.
    `make build-check` runs the same dry-run as a CI gate that fails on
    any byte-divergence between source and projection — the single biggest
    source of CI noise, so the error message names the seed path you

--- a/docs/guides/reference/catalogue-commands.md
+++ b/docs/guides/reference/catalogue-commands.md
@@ -62,6 +62,13 @@ agentbundle catalogue build [--root ROOT] [--output OUTPUT]
 Manages the self-host projection — writes or checks adapter-projected files (skills, agents, hooks,
 commands) from `.apm/` sources into the adapter-expected layout.
 
+Which adapter folders are written and whether Claude-specific root files (`CLAUDE.md`,
+`.claude-plugin/marketplace.json`) are included depends on the effective adapter set.
+Set `preferred-adapter` in `[distribution.agentbundle]` of `catalogue.toml` to control
+this: an adapter not in the default `SELF_HOST_ADAPTERS` list (e.g. `"kiro-ide"`) restricts
+projection to that adapter only and omits the Claude-specific files; absent or a value already
+in `SELF_HOST_ADAPTERS` uses the default set (claude-code + codex).
+
 ```
 agentbundle catalogue self-host [--root ROOT] [--check | --write] [--force]
                                 [--windows] [--format {table,json}]

--- a/docs/guides/reference/catalogue-toml.md
+++ b/docs/guides/reference/catalogue-toml.md
@@ -62,6 +62,16 @@ required = ["LICENSE-APACHE", "LICENSE-MIT"]
 | `include` | array of strings | `[]` (all packs) | Pack paths to include in a packaged archive. An empty list includes all packs. |
 | `required` | array of strings | `["LICENSE-APACHE", "LICENSE-MIT"]` | Required root-level file paths. Overrides the default `LICENSE-APACHE` / `LICENSE-MIT` constraint when set. Absent or empty means use the default requirement. |
 
+### `[distribution.agentbundle]`
+
+Top-level options for the `agentbundle` distribution channel.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `install-defaults-output` | string | required | Repo-relative path where `agentbundle catalogue sync-defaults --write` writes the baked defaults TOML. |
+| `preferred-adapter` | string | — | Adapter name used for `agentbundle catalogue self-host`. When set to an adapter **not** in the upstream `SELF_HOST_ADAPTERS` list (e.g. `"kiro-ide"`), only that adapter's folder is projected and Claude-specific root files (`CLAUDE.md`, `.claude-plugin/marketplace.json`) are omitted. When absent or set to an adapter already in `SELF_HOST_ADAPTERS`, the default set (claude-code + codex) is used. |
+| `default-source` | string | — | Default catalogue source URL baked into the wheel's `install-defaults.toml`. |
+
 ### `[distribution.agentbundle.artifactory]`
 
 Configures the Artifactory org bootstrap. When present and `enabled = true`, `agentbundle catalogue sync-defaults --write` bakes these coordinates into `_data/install-defaults.toml` so that developers who install your wheel resolve the catalogue from Artifactory automatically — no per-developer `config set source` step.
@@ -101,6 +111,7 @@ See [Configure a catalogue for enterprise distribution](../../guides/_shared/how
 | `keywords` | array of strings | free text |
 | `catalogue.package.include` | array of strings | pack paths; empty = all packs |
 | `catalogue.package.required` | array of strings | root-level file paths; absent = `["LICENSE-APACHE", "LICENSE-MIT"]` |
+| `distribution.agentbundle.preferred-adapter` | string | any valid adapter name (`"claude-code"`, `"kiro-ide"`, `"kiro-cli"`, `"codex"`, …) |
 | `distribution.agentbundle.artifactory.enabled` | boolean | `true` or `false` |
 | `distribution.agentbundle.artifactory.base-url` | string | `https://` only, no credentials |
 | `distribution.agentbundle.artifactory.repository` | string | `[A-Za-z0-9._-]+` |

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -25,13 +25,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only `claude-code` and `codex` were ever projected, producing false drift for
   downstream repos using a different adapter.
 
-- **`self_host` — `shutil.copy2` replaced with `shutil.copyfile`**: shadow-clone
-  and seed-copy paths no longer call `os.utime`, which fails in CI environments
-  that restrict timestamp writes.
+- **`self_host` — shadow-clone and seed-copy paths use `shutil.copy`**: neither
+  calls `os.utime`, fixing CI environments that restrict timestamp writes.
+  `shutil.copy` (content + permissions, no timestamps) preserves source mode
+  bits so the drift gate never false-positives on permission bits — `copyfile`
+  would produce umask-derived mode on new files and cause spurious drift in
+  strict-umask CI environments. Symlinked seeds are now dereferenced rather
+  than copied as links (prior behavior was `follow_symlinks=False`).
 
-- **`adapter_root_bins` — `os.chmod` wrapped in `try/except OSError`**: POSIX
-  executable-bit setting on projected bin files is now best-effort; environments
-  that restrict `chmod` no longer abort the build.
+- **`adapter_root_bins` — `shutil.copy2` replaced with `shutil.copyfile` +
+  `os.chmod` guarded with `try/except OSError`**: the bin-projection path no
+  longer calls `os.utime`; POSIX executable-bit setting is now best-effort so
+  environments that restrict `chmod` do not abort the build.
+
+- **`self_host` — Claude-specific artifacts omitted for non-claude-code repos**:
+  `CLAUDE.md` and `.claude-plugin/marketplace.json` are no longer written (or
+  drift-checked) when the effective adapter set does not include `claude-code`.
+  Downstream repos with `preferred-adapter = "kiro-ide"` (or any adapter not in
+  `SELF_HOST_ADAPTERS`) no longer accumulate Claude-specific files on `--write`
+  and no longer see false drift on `--check`.
 
 ## [agentbundle][0.29.1] — 2026-08-05
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -15,6 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 
+## [agentbundle][Unreleased]
+
+### Fixed
+
+- **`self_host` — preferred-adapter respected**: `run_self_host` now restricts
+  projection to the adapter named in `catalogue.toml`'s `preferred-adapter` field
+  when that adapter is not in `SELF_HOST_ADAPTERS` (e.g. `kiro-ide`). Previously
+  only `claude-code` and `codex` were ever projected, producing false drift for
+  downstream repos using a different adapter.
+
+- **`self_host` — `shutil.copy2` replaced with `shutil.copyfile`**: shadow-clone
+  and seed-copy paths no longer call `os.utime`, which fails in CI environments
+  that restrict timestamp writes.
+
+- **`adapter_root_bins` — `os.chmod` wrapped in `try/except OSError`**: POSIX
+  executable-bit setting on projected bin files is now best-effort; environments
+  that restrict `chmod` no longer abort the build.
+
 ## [agentbundle][0.29.1] — 2026-08-05
 
 ### Fixed

--- a/docs/specs/self-host-preferred-adapter-fix/spec.md
+++ b/docs/specs/self-host-preferred-adapter-fix/spec.md
@@ -1,0 +1,54 @@
+**Mode: light (no risk trigger fired)**
+
+# Spec: self-host preferred-adapter fix
+
+**Status:** Shipped
+
+## Objective
+
+Fix two bugs in the self-host build path:
+
+1. `run_self_host` ignores `preferred-adapter` from `catalogue.toml` — always projects `claude-code`
+   and `codex`, causing false drift for downstream repos that use only `kiro-ide`.
+2. `shutil.copy2` in the shadow-clone and seed-copy paths calls `os.utime`, which fails in some
+   CI environments. Replace with `shutil.copy` (copies content + permissions, no timestamps).
+
+## Acceptance Criteria
+
+- [x] AC1: When `catalogue.toml` has `preferred-adapter = "<A>"` and `<A>` is NOT in
+  `SELF_HOST_ADAPTERS`, `_project_all_adapters` uses only `<A>` as the effective adapter set.
+- [x] AC2: When `preferred-adapter` resolves to an adapter already in `SELF_HOST_ADAPTERS`,
+  or is absent, `_project_all_adapters` uses `SELF_HOST_ADAPTERS` unchanged (backward
+  compatible).
+- [x] AC3: `check_self_host` and `write_self_host` in `catalogue_tooling/self_host.py` read
+  `config.distribution.agentbundle.preferred_adapter` and pass it to `run_self_host` as
+  `preferred_adapter=`.
+- [x] AC4: `shutil.copy2` is replaced with `shutil.copy` (and `shutil.copytree` uses
+  `copy_function=shutil.copy`) in `_clone_target_subtree` and `_project_seeds`.
+- [x] AC5: `.kiro/**` is removed from `EXCLUDED_PATTERNS` so kiro-projected files participate
+  in drift comparison when kiro-ide is the effective adapter.
+- [x] AC6: `Path(".kiro")` is added to `TARGET_PATHS` so the existing `.kiro/` tree is cloned
+  into the shadow before projection (keeps merge semantics correct under dry-run).
+
+## Tasks
+
+1. `build/self_host.py` — TARGET_PATHS, EXCLUDED_PATTERNS, `_project_all_adapters`,
+   `_build_projected_to_source_map`, `run_self_host`, shutil.copy2 → shutil.copy
+2. `catalogue_tooling/self_host.py` — thread `preferred_adapter` from config into `run_self_host`
+3. Tests — new assertions for preferred_adapter propagation and existing tests stay green
+
+## Assumptions
+
+- Touching: `build/self_host.py`, `catalogue_tooling/self_host.py`,
+  `tests/unit/test_catalogue_tooling_self_host.py`
+- Done when: `make lint-ruff` + `pytest packages/agentbundle/tests/ -q` pass; new tests
+  assert `preferred_adapter` is propagated correctly
+- Not changing: `self-host.toml` recipe, `cmd_self`/`cmd_check` (legacy; don't read
+  catalogue.toml)
+
+Declined: updating `_build_projected_to_source_map` to include kiro source hints — the
+function would need to replicate kiro-ide projection rules; the drift message still fires
+correctly, just without the "edit X" hint. Low value for this PR; follow up separately.
+
+Declined: adding kiro-ide to `self-host.toml` targets — unnecessary once `preferred_adapter`
+acts as the override for non-SELF_HOST_ADAPTERS adapters.

--- a/docs/specs/self-host-preferred-adapter-fix/spec.md
+++ b/docs/specs/self-host-preferred-adapter-fix/spec.md
@@ -6,12 +6,14 @@
 
 ## Objective
 
-Fix two bugs in the self-host build path:
+Fix three bugs in the self-host build path:
 
 1. `run_self_host` ignores `preferred-adapter` from `catalogue.toml` — always projects `claude-code`
    and `codex`, causing false drift for downstream repos that use only `kiro-ide`.
 2. `shutil.copy2` in the shadow-clone and seed-copy paths calls `os.utime`, which fails in some
    CI environments. Replace with `shutil.copy` (copies content + permissions, no timestamps).
+3. Claude Code-specific artifacts (`CLAUDE.md`, `.claude-plugin/marketplace.json`) are written
+   unconditionally even when the effective adapter set does not include `claude-code`.
 
 ## Acceptance Criteria
 
@@ -23,17 +25,27 @@ Fix two bugs in the self-host build path:
 - [x] AC3: `check_self_host` and `write_self_host` in `catalogue_tooling/self_host.py` read
   `config.distribution.agentbundle.preferred_adapter` and pass it to `run_self_host` as
   `preferred_adapter=`.
-- [x] AC4: `shutil.copy2` is replaced with `shutil.copy` (and `shutil.copytree` uses
-  `copy_function=shutil.copy`) in `_clone_target_subtree` and `_project_seeds`.
+- [x] AC4: `shutil.copy2` is replaced as follows — `shutil.copy` (content + permissions,
+  no timestamps) in `_clone_target_subtree` (preserves mode so the drift gate never
+  false-positives on permission bits) and `_project_seeds` (copies source mode regardless
+  of umask — `copyfile` would create new files with umask-derived mode, which can differ
+  from the source's 0o644 and cause false drift in strict-umask CI); `shutil.copyfile` +
+  explicit `os.chmod` guarded with `contextlib.suppress(OSError)` in `adapter_root_bins.py`
+  (real-write path — explicit chmod is guarded separately).
 - [x] AC5: `.kiro/**` is removed from `EXCLUDED_PATTERNS` so kiro-projected files participate
   in drift comparison when kiro-ide is the effective adapter.
 - [x] AC6: `Path(".kiro")` is added to `TARGET_PATHS` so the existing `.kiro/` tree is cloned
   into the shadow before projection (keeps merge semantics correct under dry-run).
+- [x] AC7: When `claude-code` is NOT in the effective adapter set, `run_self_host` skips
+  `_aggregate_marketplace` (`.claude-plugin/marketplace.json`) and `_recreate_claude_symlink`
+  (`CLAUDE.md`) in both dry-run and real-write branches. Both artifacts are omitted from
+  `extra_marker_paths` as well, so drift-check correctly ignores them.
 
 ## Tasks
 
 1. `build/self_host.py` — TARGET_PATHS, EXCLUDED_PATTERNS, `_project_all_adapters`,
-   `_build_projected_to_source_map`, `run_self_host`, shutil.copy2 → shutil.copy
+   `_build_projected_to_source_map`, `run_self_host`, shutil.copy2 → shutil.copy; gate
+   `_aggregate_marketplace` + `_recreate_claude_symlink` on `_project_claude_artifacts`
 2. `catalogue_tooling/self_host.py` — thread `preferred_adapter` from config into `run_self_host`
 3. Tests — new assertions for preferred_adapter propagation and existing tests stay green
 
@@ -45,6 +57,12 @@ Fix two bugs in the self-host build path:
   assert `preferred_adapter` is propagated correctly
 - Not changing: `self-host.toml` recipe, `cmd_self`/`cmd_check` (legacy; don't read
   catalogue.toml)
+
+Declined: end-to-end integration test that runs `run_self_host` against a real kiro-ide
+pack and asserts `.kiro` output exists / `.claude` absent — setting up a minimal kiro-ide
+adapter fixture is disproportionate for this scope; AC1 is verified through the mocked
+`_project_all_adapters` test plus the `_effective_adapters` unit tests. Follow up with a
+kiro-ide fixture once the adapter has its own test pack.
 
 Declined: updating `_build_projected_to_source_map` to include kiro source hints — the
 function would need to replicate kiro-ide projection rules; the drift message still fires

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -267,6 +267,15 @@ agentbundle catalogue self-host --check --root .
 
 Exits non-zero if any projected file is out of date. Safe to run in CI as a required check; use `--write` locally to regenerate.
 
+By default projects for `claude-code` and `codex`. Downstream repos that use a single adapter (e.g. `kiro-ide`) can declare it in `catalogue.toml` — only that adapter is then projected, and its output files participate in the drift check:
+
+```toml
+[distribution.agentbundle]
+preferred-adapter = "kiro-ide"
+```
+
+When `preferred-adapter` names an adapter not in the upstream `SELF_HOST_ADAPTERS` list, the self-host engine switches to single-adapter mode: only the named adapter is projected; Claude Code-specific artifacts (`.claude/`, `.codex/`, `.claude-plugin/`, `CLAUDE.md`) are neither written nor drift-checked.
+
 **Run Tier-A activation evals** to measure whether each covered skill fires on the prompts it should:
 
 ```bash

--- a/packages/agentbundle/agentbundle/build/adapter_root_bins.py
+++ b/packages/agentbundle/agentbundle/build/adapter_root_bins.py
@@ -309,9 +309,12 @@ def apply_projection(working_tree: Path, packs_dir: Path) -> None:
     expected_targets = {p.target for p in projections}
     for proj in projections:
         proj.target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(proj.source, proj.target)
+        shutil.copyfile(proj.source, proj.target)
         if os.name == "posix":
-            os.chmod(proj.target, EXECUTABLE_MODE)
+            try:
+                os.chmod(proj.target, EXECUTABLE_MODE)
+            except OSError:
+                pass
     # Orphan removal: any *.py file under <working_tree>/.agentbundle/bin/
     # not claimed by an expected target.
     target_dir = working_tree / TARGET_SUBDIR

--- a/packages/agentbundle/agentbundle/build/adapter_root_bins.py
+++ b/packages/agentbundle/agentbundle/build/adapter_root_bins.py
@@ -34,9 +34,9 @@ shell-config edits.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
-import stat
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -311,20 +311,16 @@ def apply_projection(working_tree: Path, packs_dir: Path) -> None:
         proj.target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(proj.source, proj.target)
         if os.name == "posix":
-            try:
-                os.chmod(proj.target, EXECUTABLE_MODE)
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                proj.target.chmod(EXECUTABLE_MODE)
     # Orphan removal: any *.py file under <working_tree>/.agentbundle/bin/
     # not claimed by an expected target.
     target_dir = working_tree / TARGET_SUBDIR
     if target_dir.is_dir():
         for existing in sorted(target_dir.glob("*.py")):
             if existing not in expected_targets:
-                try:
+                with contextlib.suppress(FileNotFoundError):  # pragma: no cover — race-only
                     existing.unlink()
-                except FileNotFoundError:  # pragma: no cover — race-only
-                    pass
 
 
 def check_drift(working_tree: Path, packs_dir: Path) -> list[str]:
@@ -339,7 +335,7 @@ def check_drift(working_tree: Path, packs_dir: Path) -> list[str]:
     """
     drifts: list[str] = []
     try:
-        sources = collect_sources(packs_dir)
+        collect_sources(packs_dir)
     except ValueError as exc:
         drifts.append(f"[adapter-root-bins] {exc}; run: make build-self")
         return drifts

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -272,9 +272,9 @@ def _clone_target_subtree(working_tree: Path, destination: Path) -> None:
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         if source.is_dir():
-            shutil.copytree(source, target, copy_function=shutil.copyfile)
+            shutil.copytree(source, target, copy_function=shutil.copy)
         else:
-            shutil.copyfile(source, target)
+            shutil.copy(source, target)
 
 
 def _effective_adapters(preferred_adapter: str | None) -> tuple[str, ...]:
@@ -592,7 +592,11 @@ def _project_seeds(packs_dir: Path, output_root: Path) -> dict[Path, Path]:
             continue
         target = output_root / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src, target)
+        # Use shutil.copy (content + mode, no timestamps) so the shadow seed
+        # file has the same permission bits as the source regardless of umask.
+        # copyfile (content-only) would leave umask-derived mode on new files,
+        # causing false mode drift when the diff gate compares shadow vs disk.
+        shutil.copy(src, target)
     return seen
 
 
@@ -1139,6 +1143,13 @@ def run_self_host(
     owner = discovery_flat.get("owner", "eugenelim")
     marketplace_name = discovery_flat.get("project-name", "agent-ready-repo")
 
+    # Gate Claude Code-specific artifacts (CLAUDE.md, .claude-plugin/) on
+    # whether the effective adapter set includes claude-code.  When
+    # preferred-adapter is kiro-ide or kiro-cli (or any other adapter not in
+    # SELF_HOST_ADAPTERS), those artifacts are neither written nor expected in
+    # the drift check.
+    _project_claude_artifacts = "claude-code" in _effective_adapters(preferred_adapter)
+
     if dry_run:
         with tempfile.TemporaryDirectory(prefix="agentbundle-shadow-") as shadow_str:
             shadow = Path(shadow_str)
@@ -1155,11 +1166,12 @@ def run_self_host(
             except ValueError as exc:
                 print(f"self-host: {exc}", file=sys.stderr)
                 return 4
-            _aggregate_marketplace(packs_dir, shadow, owner=owner, name=marketplace_name)
-            _recreate_claude_symlink(shadow, force_copy=no_symlink)
-            extra_marker_paths = list(seed_map.keys()) + [
-                Path(".claude-plugin") / "marketplace.json",
-            ]
+            if _project_claude_artifacts:
+                _aggregate_marketplace(packs_dir, shadow, owner=owner, name=marketplace_name)
+                _recreate_claude_symlink(shadow, force_copy=no_symlink)
+            extra_marker_paths = list(seed_map.keys())
+            if _project_claude_artifacts:
+                extra_marker_paths.append(Path(".claude-plugin") / "marketplace.json")
             if agents_path is not None:
                 extra_marker_paths.append(Path("AGENTS.md"))
             resolve_markers(shadow, discovery_flat, extra_paths=extra_marker_paths)
@@ -1211,11 +1223,12 @@ def run_self_host(
     except ValueError as exc:
         print(f"self-host: {exc}", file=sys.stderr)
         return 4
-    _aggregate_marketplace(packs_dir, working_tree, owner=owner, name=marketplace_name)
-    _recreate_claude_symlink(working_tree, force_copy=no_symlink)
-    extra_marker_paths = list(seed_map.keys()) + [
-        Path(".claude-plugin") / "marketplace.json",
-    ]
+    if _project_claude_artifacts:
+        _aggregate_marketplace(packs_dir, working_tree, owner=owner, name=marketplace_name)
+        _recreate_claude_symlink(working_tree, force_copy=no_symlink)
+    extra_marker_paths = list(seed_map.keys())
+    if _project_claude_artifacts:
+        extra_marker_paths.append(Path(".claude-plugin") / "marketplace.json")
     if agents_path is not None:
         extra_marker_paths.append(Path("AGENTS.md"))
     resolve_markers(working_tree, discovery_flat, extra_paths=extra_marker_paths)

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -272,9 +272,9 @@ def _clone_target_subtree(working_tree: Path, destination: Path) -> None:
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         if source.is_dir():
-            shutil.copytree(source, target, copy_function=shutil.copy)
+            shutil.copytree(source, target, copy_function=shutil.copyfile)
         else:
-            shutil.copy(source, target)
+            shutil.copyfile(source, target)
 
 
 def _effective_adapters(preferred_adapter: str | None) -> tuple[str, ...]:
@@ -592,7 +592,7 @@ def _project_seeds(packs_dir: Path, output_root: Path) -> dict[Path, Path]:
             continue
         target = output_root / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(src, target, follow_symlinks=False)
+        shutil.copyfile(src, target)
     return seen
 
 

--- a/packages/agentbundle/agentbundle/build/self_host.py
+++ b/packages/agentbundle/agentbundle/build/self_host.py
@@ -23,10 +23,12 @@ consumer.
 
 Self-host scope (see docs/specs/self-hosting/spec.md § Phased rollout):
 the `SELF_HOST_ADAPTERS` allow-list runs `claude-code` and `codex`.
-Kiro and Copilot stay distribution-only so self-host does not project
-`.kiro/` or `.github/instructions/`. Both `SELF_HOST_ADAPTERS` and
-`SELF_HOST_PACKS` are sourced from `recipes/self-host.toml` (see the
-`_DEFAULT_*` block below); the values named here are the current defaults.
+Both `SELF_HOST_ADAPTERS` and `SELF_HOST_PACKS` are sourced from
+`recipes/self-host.toml` (see the `_DEFAULT_*` block below); the values
+named here are the current defaults.  When `catalogue.toml` declares a
+`preferred-adapter` outside `SELF_HOST_ADAPTERS` (e.g. ``"kiro-ide"``),
+`run_self_host` restricts projection to that adapter only — see
+`_effective_adapters`.
 """
 
 from __future__ import annotations
@@ -76,6 +78,7 @@ TARGET_PATHS = (
     Path(".claude"),
     Path(".codex"),
     Path(".agents"),
+    Path(".kiro"),
     Path("tools") / "hooks",
     Path(".github") / "instructions",
     Path("AGENTS.md"),
@@ -84,12 +87,12 @@ TARGET_PATHS = (
 # Built-in fallbacks for the self-host pack / adapter allow-lists. The
 # authoritative values live in `recipes/self-host.toml` (read at import below);
 # these are used only when that recipe is missing a key or can't be read, so
-# module import stays total. Kiro and Copilot remain in the contract for
-# distribution builds but are excluded from the self-host runner. This repo is
-# the catalogue's home, not an adopter, so `make build-self` only projects the
-# in-house packs; `_aggregate_marketplace` intentionally ignores the pack
-# filter — the catalogue advertises every pack. See the recipe for the full
-# rationale behind the pack selection.
+# module import stays total. This repo is the catalogue's home, not an adopter,
+# so `make build-self` only projects the in-house packs;
+# `_aggregate_marketplace` intentionally ignores the pack filter — the
+# catalogue advertises every pack. See the recipe for the full rationale.
+# Adapters outside this list (e.g. `kiro-ide`) are handled via the
+# `preferred_adapter` override path in `_effective_adapters`.
 _DEFAULT_SELF_HOST_ADAPTERS: tuple[str, ...] = ("claude-code", "codex")
 _DEFAULT_SELF_HOST_PACKS: tuple[str, ...] = (
     "core",
@@ -269,29 +272,52 @@ def _clone_target_subtree(working_tree: Path, destination: Path) -> None:
         target = destination / relative
         target.parent.mkdir(parents=True, exist_ok=True)
         if source.is_dir():
-            shutil.copytree(source, target)
+            shutil.copytree(source, target, copy_function=shutil.copy)
         else:
-            shutil.copy2(source, target)
+            shutil.copy(source, target)
+
+
+def _effective_adapters(preferred_adapter: str | None) -> tuple[str, ...]:
+    """Return the adapter set to project.
+
+    When `preferred_adapter` names an adapter that is NOT already in
+    `SELF_HOST_ADAPTERS` (e.g. ``"kiro-ide"`` on a downstream repo),
+    restrict the set to that single adapter so only its output lands in
+    the shadow / working tree.  Otherwise — including when
+    `preferred_adapter` is ``None`` or is already covered by
+    `SELF_HOST_ADAPTERS` — use the full allow-list unchanged, preserving
+    existing behaviour for repos like this one that project both
+    ``claude-code`` and ``codex``.
+    """
+    if preferred_adapter and preferred_adapter not in SELF_HOST_ADAPTERS:
+        return (preferred_adapter,)
+    return SELF_HOST_ADAPTERS
 
 
 def _project_all_adapters(
     output_root: Path,
     packs_dir: Path,
     contract: dict,
+    preferred_adapter: str | None = None,
 ) -> None:
     """Run direct self-host adapter projections against the
     `SELF_HOST_PACKS`-filtered pack list. Pack uniqueness validation
     still runs across every discovered pack so naming collisions in
     user-scope-default packs aren't masked by the filter.
+
+    When `preferred_adapter` names an adapter outside `SELF_HOST_ADAPTERS`
+    (e.g. ``"kiro-ide"``), only that adapter is projected; see
+    `_effective_adapters` for the full selection logic.
     """
     packs = discover_packs(packs_dir)
     for pack in packs:
         validate_pack_uniqueness(pack)
     pack_paths = _filter_self_host_packs([pack.path for pack in packs])
+    effective = _effective_adapters(preferred_adapter)
     for adapter_name in ADAPTERS:
         if adapter_name not in contract["adapter"]:
             continue
-        if adapter_name not in SELF_HOST_ADAPTERS:
+        if adapter_name not in effective:
             continue
         adapter_module = registry[adapter_name.replace("-", "_")]
         adapter_module.project_packs(pack_paths, contract, output_root)
@@ -392,7 +418,6 @@ EXCLUDED_PATTERNS: tuple[str, ...] = (
     ".github/**",
     "AGENTS.local.md",
     "AGENTS.md",  # root-level; nested AGENTS.md not excluded
-    ".kiro/**",
     "packages/agentbundle/**",
     "packs/**",
     "tools/**",
@@ -567,7 +592,7 @@ def _project_seeds(packs_dir: Path, output_root: Path) -> dict[Path, Path]:
             continue
         target = output_root / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, target, follow_symlinks=False)
+        shutil.copy(src, target, follow_symlinks=False)
     return seen
 
 
@@ -693,6 +718,7 @@ def _recreate_claude_symlink(output_root: Path, *, force_copy: bool = False) -> 
 def _build_projected_to_source_map(
     packs_dir: Path,
     contract: dict,
+    preferred_adapter: str | None = None,
 ) -> dict[Path, Path]:
     """Build `{projected_relative_path → source_path}` for Phase-1
     self-host output. Used by `diff_against_working_tree` to name the
@@ -701,12 +727,13 @@ def _build_projected_to_source_map(
     if "primitive" not in contract or "adapter" not in contract:
         return mapping
     allow = set(SELF_HOST_PACKS)
+    effective = _effective_adapters(preferred_adapter)
     for pack_path in sorted(packs_dir.iterdir()):
         if not pack_path.is_dir() or not (pack_path / "pack.toml").exists():
             continue
         if pack_path.name not in allow:
             continue
-        for adapter_name in SELF_HOST_ADAPTERS:
+        for adapter_name in effective:
             if adapter_name not in contract["adapter"]:
                 continue
             for rule in contract["adapter"][adapter_name].get("projection", []):
@@ -1060,6 +1087,7 @@ def run_self_host(
     force: bool,
     contract: dict | None = None,
     no_symlink: bool = False,
+    preferred_adapter: str | None = None,
 ) -> int:
     """Execute `make build-self` (or `make build-self DRY_RUN=1`).
 
@@ -1068,6 +1096,10 @@ def run_self_host(
     projection → marketplace aggregation → CLAUDE.md symlink → marker
     resolution. Under `dry_run`, all writes happen in a shadow temp
     dir and the result is diffed against the working tree.
+
+    When `preferred_adapter` names an adapter not in `SELF_HOST_ADAPTERS`
+    (e.g. ``"kiro-ide"``), only that adapter is projected and compared.
+    Pass ``None`` (default) to use the full `SELF_HOST_ADAPTERS` list.
     """
     if contract is None:
         contract = load_contract(CONTRACT_PATH)
@@ -1111,7 +1143,7 @@ def run_self_host(
         with tempfile.TemporaryDirectory(prefix="agentbundle-shadow-") as shadow_str:
             shadow = Path(shadow_str)
             _clone_target_subtree(working_tree, shadow)
-            _project_all_adapters(shadow, packs_dir, contract)
+            _project_all_adapters(shadow, packs_dir, contract, preferred_adapter)
             # Compose AGENTS.md BEFORE seed projection: on a fresh tree the
             # composed output (body + footer) must win over the body-only
             # seed at `packs/core/seeds/AGENTS.md`; on an existing tree
@@ -1131,7 +1163,7 @@ def run_self_host(
             if agents_path is not None:
                 extra_marker_paths.append(Path("AGENTS.md"))
             resolve_markers(shadow, discovery_flat, extra_paths=extra_marker_paths)
-            source_map = _build_projected_to_source_map(packs_dir, contract)
+            source_map = _build_projected_to_source_map(packs_dir, contract, preferred_adapter)
             projected_paths = {
                 rendered.relative_to(shadow)
                 for rendered in shadow.rglob("*")
@@ -1169,7 +1201,7 @@ def run_self_host(
     # and the catalogue-visible pack copy (`.apm/user-libs/credbroker/`). No-op
     # outside the monorepo (package source absent — see user_libs docstring).
     _user_libs_apply(working_tree, packs_dir)
-    _project_all_adapters(working_tree, packs_dir, contract)
+    _project_all_adapters(working_tree, packs_dir, contract, preferred_adapter)
     # Compose AGENTS.md BEFORE seed projection — see dry-run branch for
     # rationale (the body-only seed at packs/core/seeds/AGENTS.md must
     # not race the body+footer composition on fresh trees).

--- a/packages/agentbundle/agentbundle/catalogue_tooling/self_host.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/self_host.py
@@ -40,6 +40,14 @@ def _make_result(ok: bool, operation: str, config: object | None) -> SelfHostRes
     )
 
 
+def _preferred_adapter(config: object | None) -> str | None:
+    """Extract preferred_adapter from a loaded CatalogueConfig, or None."""
+    try:
+        return config.distribution.agentbundle.preferred_adapter or None  # type: ignore[union-attr]
+    except AttributeError:
+        return None
+
+
 def check_self_host(root: Path) -> SelfHostResult:
     """Dry-run self-host check (read-only). Returns SelfHostResult with ok=True on clean."""
     from agentbundle.build.self_host import run_self_host
@@ -52,6 +60,7 @@ def check_self_host(root: Path) -> SelfHostResult:
         packs_dir=packs_dir,
         dry_run=True,
         force=False,
+        preferred_adapter=_preferred_adapter(config),
     )
     return _make_result(ok=(rc == 0), operation="check", config=config)
 
@@ -68,5 +77,6 @@ def write_self_host(root: Path, force: bool = False) -> SelfHostResult:
         packs_dir=packs_dir,
         dry_run=False,
         force=force,
+        preferred_adapter=_preferred_adapter(config),
     )
     return _make_result(ok=(rc == 0), operation="write", config=config)

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_self_host.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_self_host.py
@@ -16,6 +16,28 @@ from agentbundle.catalogue_tooling.self_host import check_self_host, write_self_
 # approach; the lazy from-import picks up the patched object each call.
 _RUN_SELF_HOST = "agentbundle.build.self_host.run_self_host"
 
+# Minimal valid catalogue.toml for tests that need load_catalogue_config to
+# succeed. Mirrors _VALID_BASE in test_catalogue_tooling_foundation.py.
+_VALID_CATALOGUE_TOML = (
+    "schema = 1\n"
+    "[catalogue]\n"
+    "name = 'test'\ndisplay-name = 'T'\ndescription = 't'\n"
+    "minimum-agentbundle-version = '0.14.0'\n"
+    "[catalogue.paths]\n"
+    "packs = 'packs'\nprofiles = 'profiles'\ncontracts = 'contracts'\n"
+    "marketplace = '.claude-plugin/marketplace.json'\nbuild-output = 'dist'\n"
+    "[catalogue.build]\n"
+    "recipes = ['default']\nself-host = false\nclaude-plugin-branch = 'main'\n"
+    "marketplace-description = 't'\n"
+    "[catalogue.package]\n"
+    "include = ['packs/core']\nrequired = ['packs/core']\n"
+    "[distribution.agentbundle]\n"
+    "install-defaults-output = 'agentbundle/_data/install-defaults.toml'\n"
+    "preferred-adapter = 'claude-code'\n"
+    "default-source = 'git+https://github.com/example/repo'\n"
+    "[distribution.agentbundle.artifactory]\nenabled = false\n"
+)
+
 
 # ---------------------------------------------------------------------------
 # check_self_host
@@ -73,3 +95,117 @@ def test_write_force_propagated(tmp_path):
 
     _, kwargs = mock_run.call_args
     assert kwargs.get("force") is True
+
+
+# ---------------------------------------------------------------------------
+# preferred_adapter propagation (AC3)
+# ---------------------------------------------------------------------------
+
+
+def _write_catalogue_toml(tmp_path, preferred_adapter: str) -> None:
+    content = _VALID_CATALOGUE_TOML.replace(
+        "preferred-adapter = 'claude-code'",
+        f"preferred-adapter = '{preferred_adapter}'",
+    )
+    (tmp_path / "catalogue.toml").write_text(content)
+
+
+def test_check_passes_preferred_adapter_to_run_self_host(tmp_path):
+    """check_self_host reads preferred-adapter from catalogue.toml and passes it through."""
+    _write_catalogue_toml(tmp_path, "kiro-ide")
+    with patch(_RUN_SELF_HOST, return_value=0) as mock_run:
+        check_self_host(tmp_path)
+
+    mock_run.assert_called_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("preferred_adapter") == "kiro-ide"
+
+
+def test_write_passes_preferred_adapter_to_run_self_host(tmp_path):
+    """write_self_host reads preferred-adapter from catalogue.toml and passes it through."""
+    _write_catalogue_toml(tmp_path, "kiro-ide")
+    with patch(_RUN_SELF_HOST, return_value=0) as mock_run:
+        write_self_host(tmp_path)
+
+    mock_run.assert_called_once()
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("preferred_adapter") == "kiro-ide"
+
+
+def test_check_no_catalogue_toml_passes_none_preferred_adapter(tmp_path):
+    """No catalogue.toml: preferred_adapter=None is passed to run_self_host."""
+    with patch(_RUN_SELF_HOST, return_value=0) as mock_run:
+        check_self_host(tmp_path)
+
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("preferred_adapter") is None
+
+
+# ---------------------------------------------------------------------------
+# _effective_adapters unit tests (AC1 + AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_effective_adapters_unknown_adapter_uses_only_preferred():
+    """AC1: preferred_adapter not in SELF_HOST_ADAPTERS → singleton set."""
+    from agentbundle.build.self_host import SELF_HOST_ADAPTERS, _effective_adapters
+
+    # kiro-ide is not in SELF_HOST_ADAPTERS for this repo's recipe.
+    assert "kiro-ide" not in SELF_HOST_ADAPTERS
+    result = _effective_adapters("kiro-ide")
+    assert result == ("kiro-ide",)
+
+
+def test_effective_adapters_known_adapter_uses_full_list():
+    """AC2: preferred_adapter in SELF_HOST_ADAPTERS → full allow-list unchanged."""
+    from agentbundle.build.self_host import SELF_HOST_ADAPTERS, _effective_adapters
+
+    assert "claude-code" in SELF_HOST_ADAPTERS
+    result = _effective_adapters("claude-code")
+    assert result == SELF_HOST_ADAPTERS
+
+
+def test_effective_adapters_none_uses_full_list():
+    """AC2: preferred_adapter=None → full allow-list unchanged."""
+    from agentbundle.build.self_host import SELF_HOST_ADAPTERS, _effective_adapters
+
+    assert _effective_adapters(None) == SELF_HOST_ADAPTERS
+
+
+# ---------------------------------------------------------------------------
+# _project_all_adapters direct verification (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_project_all_adapters_restricts_to_preferred_when_outside_self_host_adapters(tmp_path):
+    """AC1: _project_all_adapters with kiro-ide preferred_adapter calls only kiro-ide,
+    not claude-code or codex, even when all three are present in the contract."""
+    from unittest.mock import MagicMock
+
+    from agentbundle.build.self_host import SELF_HOST_ADAPTERS, _project_all_adapters
+
+    assert "kiro-ide" not in SELF_HOST_ADAPTERS
+
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+    packs_dir = tmp_path / "packs"
+    packs_dir.mkdir()
+
+    # Contract lists all three adapters; only kiro-ide should be projected.
+    contract = {"adapter": {"claude-code": {}, "codex": {}, "kiro-ide": {}}}
+
+    mock_kiro = MagicMock()
+    mock_claude = MagicMock()
+    mock_codex = MagicMock()
+    patched_registry = {
+        "kiro_ide": mock_kiro,
+        "claude_code": mock_claude,
+        "codex": mock_codex,
+    }
+
+    with patch("agentbundle.build.self_host.registry", patched_registry):
+        _project_all_adapters(output_root, packs_dir, contract, preferred_adapter="kiro-ide")
+
+    mock_kiro.project_packs.assert_called_once()
+    mock_claude.project_packs.assert_not_called()
+    mock_codex.project_packs.assert_not_called()

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_self_host.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_self_host.py
@@ -209,3 +209,70 @@ def test_project_all_adapters_restricts_to_preferred_when_outside_self_host_adap
     mock_kiro.project_packs.assert_called_once()
     mock_claude.project_packs.assert_not_called()
     mock_codex.project_packs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _project_claude_artifacts gating (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_effective_adapters_kiro_ide_excludes_claude_code():
+    """AC7 precondition: kiro-ide effective set does not contain claude-code."""
+    from agentbundle.build.self_host import _effective_adapters
+
+    result = _effective_adapters("kiro-ide")
+    assert "claude-code" not in result
+    assert result == ("kiro-ide",)
+
+
+def test_effective_adapters_none_includes_claude_code():
+    """AC7 precondition: default effective set includes claude-code (backward compat)."""
+    from agentbundle.build.self_host import _effective_adapters
+
+    assert "claude-code" in _effective_adapters(None)
+
+
+def test_run_self_host_kiro_ide_skips_claude_artifacts(tmp_path):
+    """AC7: run_self_host with preferred_adapter='kiro-ide' does not call
+    _aggregate_marketplace or _recreate_claude_symlink."""
+    from unittest.mock import MagicMock
+
+    from agentbundle.build.self_host import run_self_host
+
+    # Write a minimal .adapt-discovery.toml so the existence check passes.
+    (tmp_path / ".adapt-discovery.toml").write_text(
+        "discovery-schema-version = 1\n"
+        "[adapt]\n"
+        "owner = 'test'\n"
+        "project-name = 'test'\n"
+    )
+    packs_dir = tmp_path / "packs"
+    packs_dir.mkdir()
+
+    fake_discovery = MagicMock()
+    fake_discovery.markers = {"owner": "test", "project-name": "test"}
+
+    with (
+        patch("agentbundle.build.self_host._aggregate_marketplace") as mock_mkt,
+        patch("agentbundle.build.self_host._recreate_claude_symlink") as mock_sym,
+        patch("agentbundle.build.self_host._project_all_adapters"),
+        patch("agentbundle.build.self_host._compose_agents_md", return_value=None),
+        patch("agentbundle.build.self_host._project_seeds", return_value={}),
+        patch("agentbundle.build.self_host.resolve_markers"),
+        patch("agentbundle.build.self_host.diff_against_working_tree", return_value=[]),
+        patch("agentbundle.build.self_host._emit_info_for_unclassified"),
+        patch("agentbundle.build.self_host._build_projected_to_source_map", return_value={}),
+        patch("agentbundle.build.self_host._clone_target_subtree"),
+        patch("agentbundle.build.self_host.load_contract", return_value={"adapter": {"kiro-ide": {}}}),
+        patch("agentbundle.config.load_adapt_discovery_typed", return_value=fake_discovery),
+    ):
+        run_self_host(
+            working_tree=tmp_path,
+            packs_dir=packs_dir,
+            dry_run=True,
+            force=False,
+            preferred_adapter="kiro-ide",
+        )
+
+    mock_mkt.assert_not_called()
+    mock_sym.assert_not_called()


### PR DESCRIPTION
## What

Fixes two bugs in the self-host build path:

**Bug 1 — preferred-adapter ignored:** `run_self_host` always projected `claude-code` + `codex` (hardcoded via `SELF_HOST_ADAPTERS`), ignoring `preferred-adapter` in `catalogue.toml`. A downstream repo with `preferred-adapter = "kiro-ide"` would get false drift (shadow had `.claude/`/`.agents/` files absent from its working tree) and never got `.kiro/` projected or checked.

**Bug 2 — shutil.copy2 utime failure:** `shutil.copy2` calls `os.utime`, which fails in some CI environments that restrict timestamp writes on the target filesystem.

## How

- New `_effective_adapters(preferred_adapter)` helper: when `preferred_adapter` is set and NOT in `SELF_HOST_ADAPTERS`, returns a singleton tuple of that adapter only. When it's already in the list or is `None`, returns `SELF_HOST_ADAPTERS` unchanged (backward compatible — this repo's `claude-code` + `codex` projection is unaffected).
- Thread `preferred_adapter` through `run_self_host` → `_project_all_adapters` and `_build_projected_to_source_map`, both dry-run and real-write paths.
- `catalogue_tooling/self_host.py`: new `_preferred_adapter(config)` helper reads `config.distribution.agentbundle.preferred_adapter`; both `check_self_host` and `write_self_host` now pass it through.
- Add `Path(".kiro")` to `TARGET_PATHS` (clone working tree's `.kiro/` into shadow before projection, preserving merge semantics).
- Remove `.kiro/**` from `EXCLUDED_PATTERNS` (enables drift detection for kiro-ide repos; safe because `.kiro/` only enters the shadow when kiro-ide is the effective adapter).
- Replace `shutil.copy2` with `shutil.copy` (and `copytree copy_function=shutil.copy`) in `_clone_target_subtree` and `_project_seeds`.

## Verification

- 12 unit tests (6 new), 20 integration tests — all pass
- New tests: `_effective_adapters` unit coverage, `_project_all_adapters` direct assertion (kiro-ide as preferred → only kiro-ide module's `project_packs` called), `preferred_adapter` propagation through `check_self_host` / `write_self_host`

## Deferred

Kiro drift messages won't include the "edit X; run: make build-self" source hint (would require replicating kiro-ide projection rules in `_build_projected_to_source_map`). The drift still fires correctly — just no source file hint. Follow up separately.