### PR TITLE
docs(atlassian): spec jira check SSO auto-recovery in credbroker (RFC-0035/0013 errata)

### DIFF
--- a/docs/architecture/credentials.md
+++ b/docs/architecture/credentials.md
@@ -1,24 +1,111 @@
 # Credentials
 
-> **Updated for [RFC-0023](../rfc/0023-credential-manager-broker.md) (2026-06-09).**
-> For `auth: creds`, the resolver is the standalone, pip-installable
-> [`credbroker`](../rfc/0023-credential-manager-broker.md) library imported
-> in-process. It replaced the build-projected `credentials_shim`, which now
-> survives only as the `adapter-root-bins` companion shim for `sso-broker`.
-> This page describes the current (credbroker) model; the three-tier storage
-> contract below is unchanged from the shim.
+> **Refreshed 2026-08-05.** The `creds` resolver is the standalone,
+> pip-installable [`credbroker`](../rfc/0023-credential-manager-broker.md)
+> library imported in-process ([RFC-0023](../rfc/0023-credential-manager-broker.md)),
+> which replaced the build-projected `credentials_shim`. The `sso-cookie`
+> broker ([RFC-0035](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md)) now has
+> its own section. The convention lint moved from a shell script into
+> `agentbundle catalogue lint` (**CAT-L031**).
 
 The secret-handling subsystem for credentialed primitives in this
 catalogue. Defines how a credentialed primitive — a `jira`, `figma`,
-or `confluence-publisher` CLI — acquires a token at runtime without
+or `confluence-publisher` CLI — acquires a credential at runtime without
 ever putting it on argv, in env-var echoes, or in agent transcripts.
 Authoritative specs:
 [`docs/specs/credential-broker-contract/spec.md`](../specs/credential-broker-contract/spec.md)
-(current contract; four brokers); the predecessor
+(current contract); the predecessor
 [`docs/specs/skill-secrets/spec.md`](../specs/skill-secrets/spec.md)
 (historical, three-tier model). *Why*:
 [RFC-0013](../rfc/0013-credential-broker-contract.md) +
 [RFC-0006](../rfc/0006-skill-secrets-storage.md).
+
+## Threat model — what this subsystem does and does not defend against
+
+The tier model predates coding agents. It was built for a world where the
+adversary is *another user*, an accidental `echo`, a process list, a shell
+history file, or a `git add .`. Against those it works, and every control here
+earns its place.
+
+It was **not** built for an adversary running as the *same OS principal*, and it
+cannot be retrofitted to. If an agent executes as you, then by construction it
+can read `~/.agentbundle/credentials.env`, call the keychain with your
+credentials, edit `~/.agentbundle/sso-profiles/*.toml`, and invoke
+`~/.agentbundle/bin/sso-broker.py` directly. No tier, no `0600`, and no
+in-process guard changes that — they are all inside the boundary the adversary
+already occupies.
+
+**Defends against**
+
+- A secret reaching argv, a process list, a shell history, or a transcript.
+- A secret entering the agent's *context* — consumers receive a path or a
+  resolved value inside their own subprocess, never bytes the model sees.
+- A secret at rest being read by another user, or committed to git.
+- Silent degradation: resolution fails closed rather than falling through.
+
+**Does not defend against**
+
+- A same-principal process reading the store directly.
+- A same-principal process editing an adopter config that names a destination.
+- A same-principal process invoking the engine itself.
+
+That distinction matters because the dominant real failure mode is an agent that
+*misbehaves* — leaks a value into a log, echoes it into a transcript, pastes it
+into an issue — not one that is *adversarial*. This subsystem substantially
+closes the first and does not close the second. Documenting a stronger boundary
+than exists is how a design ends up resting on a control it never had.
+
+### The accepted profile, and the one carve-out
+
+This catalogue **accepts** the same-principal limit rather than pretending to
+close it. The accepted profile is:
+
+> **The subsystem defends against an agent that errs, not an agent that is
+> hostile.** A hostile same-principal process already has everything on the box.
+
+That acceptance is not new and not specific to SSO — it has always been true of
+the token path. An adversarial agent can read the Tier-3 dotfile, call the
+keychain, or invoke the engine directly. Any control we add *inside* that
+boundary is theatre, so we do not add it, and we do not claim it.
+
+**The consequence for feature design is liberating, with one exception.** Once
+the profile is accepted, a new capability is only worth arguing about if it gives
+a hostile agent something it *did not already have*. Most do not: a convenience
+verb that reads a store the agent could read anyway, or spawns an engine the
+agent could spawn anyway, adds no reachable capability. Those ship.
+
+The exception is **any flow that puts a human in front of a login page whose
+destination the agent could influence.** That is categorically different: it does
+not read what is already on the box, it *harvests a credential the agent cannot
+otherwise obtain* — the operator's IdP password and MFA, which unlock far more
+than the tool being configured. The blast radius leaves the machine.
+
+So the boundary is not a verb and not a subsystem. It is:
+
+| | Human types credentials? | Verdict |
+|---|---|---|
+| Automated re-auth against a warm browser session | no | ships — no marginal capability |
+| Any flow that renders a login page to a human | **yes** | the one place a real control is worth its cost |
+
+Where a control is warranted, it must satisfy the anchor test below — integrity
+protection for the destination fields specifically, not for the whole config.
+
+**What actually closes the same-principal case**, from a survey of comparable
+projects (see the references below), is always a trust anchor the agent's process
+cannot forge or reach:
+
+| Anchor | Example |
+|---|---|
+| Another machine / network boundary | credential-injecting egress proxies — the secret is never on the agent's host |
+| Another privilege level | `sudo`-gated wrappers; a root-owned config the agent cannot write |
+| OS-mediated human presence | biometric / WebAuthn approval prompts |
+| Platform attestation | SPIFFE/SPIRE — identity asserted by the kernel or orchestrator, not the caller |
+| Cryptographic binding at issuance | authorization bound into a token by a human, un-widenable at call time |
+
+Everything that fails does so the same way: it tries to enforce the boundary
+*inside* the process the adversary controls — validation, allowlists, config
+guards, prose rules, in-band confirmation. Any future control added here should
+be checked against that test first.
 
 ## Two-layer architecture
 
@@ -47,16 +134,77 @@ The repo distinguishes two things that often get conflated:
     *header-naming* flags (`--bearer-header`, `--auth-header`) but
     never value-shaped flags.
 
-The `auth:` field selects which broker the primitive uses. `creds` is
-the three-tier model documented below; `env` / `cli` / `sso-cookie`
-cover environment-variable, vendor-CLI delegation, and headed-browser
-SSO flows respectively. See the spec for the per-broker contracts.
+The `auth:` field selects which broker the primitive uses:
 
-`tools/lint-credentialed-skills.sh` enforces every rule: argv-ban,
-Don't-block presence, dotfile-read refusal, and per-broker AST walks
-(e.g. `auth: creds` requires a `credbroker` resolver import —
-`from credbroker import …`; the legacy `from .credentials_shim import …`
-is still recognized).
+| Broker | Credential | Section |
+| --- | --- | --- |
+| `creds` | a token resolved through three storage tiers | [The `creds` broker](#the-creds-broker) |
+| `sso-cookie` | a captured web session (cookie jar) | [The `sso-cookie` broker](#the-sso-cookie-broker) |
+| `env` | a value the environment already holds | see the contract spec |
+| `cli` | delegated to a vendor CLI's own login | see the contract spec |
+
+A primitive may declare a fallback. `jira` carries `auth: sso-cookie`
+with `auth-fallback: creds`, so the lint requires **both** brokers'
+Don't-block phrase sets in its Security section.
+
+### What the lint enforces
+
+`agentbundle catalogue lint` — **CAT-L031**, implemented as
+`_check_credentialed_skills` in
+[`agentbundle/catalogue_tooling/lint.py`](../../packages/agentbundle/agentbundle/catalogue_tooling/lint.py)
+and run by `make build-check`. It checks the argv ban, the presence of
+each declared broker's Don't-block phrases under the
+`### Security rules (non-negotiable)` heading (matched
+whitespace-normalised, so the phrases may wrap), refusal to read the
+dotfile, and per-broker AST walks over the primitive's scripts — e.g.
+`auth: creds` requires a `credbroker` resolver import, and `auth:
+sso-cookie` requires resolution via `load_sso_cookies`. A primitive that
+genuinely must read credentials directly opts out with the
+`# credentialed-primitive: reads-creds-directly` marker.
+
+## The three tiers
+
+| Tier | Storage | Use case |
+| --- | --- | --- |
+| **Tier 1** | `<NAMESPACE>_<KEY>` env var (`JIRA_API_TOKEN`, `JIRA_BASE_URL`, …) | CI runners, wrapper scripts that inject secrets per-command. |
+| **Tier 2** | OS keyring (macOS Keychain, Windows Credential Manager) | Interactive developer machine. The default. |
+| **Tier 3** | `~/.agentbundle/credentials.env`, mode `0600` + parent `0700` | Locked-down environments where Tier 2 isn't available; opt-in fallback. |
+
+`credbroker`'s Tier-2 dispatch is `sys.platform`-gated to `darwin` and
+`win32` only, so **Linux has no Tier 2** and falls through to Tier 3.
+libsecret support is deferred to a follow-up RFC.
+
+### Tier 2 backends — stdlib only
+
+- **macOS** (`credbroker`'s `_keychain_macos.py`) —
+  `subprocess.run(["/usr/bin/security", ...])`. The write path passes
+  the token via **child stdin**, never argv. Service =
+  `"agentbundle"`, account = `"<namespace>:<key>"`.
+- **Windows** (`credbroker`'s `_credman_windows.py`) —
+  `ctypes` against `advapi32.{CredReadW, CredWriteW, CredDeleteW,
+  CredFree}`. In-process, no subprocess. `CRED_TYPE_GENERIC`,
+  `CRED_PERSIST_LOCAL_MACHINE`, target-name
+  `agentbundle:<namespace>:<key>`.
+
+The backend label is selected at module-load time per `sys.platform`.
+A documented set of Win32 hard-fail codes raises `Tier2HardFailError`
+and does **not** fall through to Tier 3. Silent degradation is the
+security smell, not the dotfile.
+
+### Tier 3 — the dotfile
+
+A stdlib `.env` parser (`parse_env_file` in `credbroker`'s `_core`)
+handles `KEY=value`, quoted values, and `#` comments. It rejects
+`export ` prefix, variable expansion, and multi-line values — `.env`
+is not bash. POSIX: enforces mode `0600` on the file and `0700` on
+`~/.agentbundle/`. Windows: DACL-verified via `icacls`.
+`PermissiveAclError` on either failure.
+
+Where `credbroker[crypto]` is installed (a pip layer, never the stdlib
+floor), Tier 3 upgrades from the plaintext dotfile to an AEAD-encrypted
+**vault** (Argon2id → KEK → AES-256-GCM, `credbroker`'s `_vault`); the
+vendored floor stays stdlib-only and plaintext. See
+[RFC-0023](../rfc/0023-credential-manager-broker.md).
 
 ## The `creds` broker
 
@@ -103,7 +251,10 @@ two delivery layers (full author-facing detail in the
   credentialed skill appends to `sys.path` at **lowest** precedence — so a
   no-repo install resolves Tier-1/2/3 with no pip. The floor is drift-gated
   byte-for-byte against `packages/credbroker/credbroker/` — **one shared
-  copy**, not the N-per-skill projection the shim used.
+  copy**, not the N-per-skill projection the shim used. The projection is
+  performed by `agentbundle`'s build pipeline
+  ([`build/user_libs.py`](../../packages/agentbundle/agentbundle/build/user_libs.py)),
+  which copies *files*; it holds no knowledge of `credbroker`'s API.
 - **pip (corporate / PyPI).** A `pip install credbroker` (internal index,
   local wheel, or PyPI) lands in site-packages, which precedes the floor on
   `sys.path` — so it wins and unlocks the encrypted `[crypto]` vault.
@@ -114,105 +265,248 @@ but only as the companion shim that rides the `adapter-root-bins` →
 `~/.agentbundle/bin/` projection for `sso-broker.py`; no consumer skill
 imports it for `creds` resolution any more.
 
-## The three tiers
+## The `sso-cookie` broker
 
-| Tier | Storage | Use case |
-| --- | --- | --- |
-| **Tier 1** | `<NAMESPACE>_<KEY>` env var (`JIRA_API_TOKEN`, `JIRA_BASE_URL`, …) | CI runners, wrapper scripts that inject secrets per-command. |
-| **Tier 2** | OS keyring (macOS Keychain, Windows Credential Manager) | Interactive developer machine. The default. |
-| **Tier 3** | `~/.agentbundle/credentials.env`, mode `0600` + parent `0700` | Locked-down environments where Tier 2 isn't available; opt-in fallback. |
+> **Added by [RFC-0035](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md);
+> consumer resolution placed in `credbroker` by
+> [ADR-0026](../adr/0026-sso-consumer-resolution-in-credbroker.md);
+> recapture added by
+> [`docs/specs/jira-check-sso-auto-login/spec.md`](../specs/jira-check-sso-auto-login/spec.md).**
 
-Linux libsecret is deferred to a v2 RFC; the loader falls through to
-Tier 3 on Linux today.
+For a Data Center instance behind corporate SSO there is no token to
+resolve — the credential is a **captured web session**. The `sso-cookie`
+broker covers that case. It is the only broker whose acquisition step
+needs a human and a browser, which is what shapes everything below.
 
-### Tier 2 backends — stdlib only
+### Engine and library — the dependency direction
 
-- **macOS** (`credbroker`'s `_keychain_macos.py`) —
-  `subprocess.run(["/usr/bin/security", ...])`. The write path passes
-  the token via **child stdin**, never argv. Service =
-  `"agentbundle"`, account = `"<namespace>:<key>"`.
-- **Windows** (`credbroker`'s `_credman_windows.py`) —
-  `ctypes` against `advapi32.{CredReadW, CredWriteW, CredDeleteW,
-  CredFree}`. In-process, no subprocess. `CRED_TYPE_GENERIC`,
-  `CRED_PERSIST_LOCAL_MACHINE`, target-name
-  `agentbundle:<namespace>:<key>`.
+Two components, and the direction between them is load-bearing:
 
-The backend label is selected at module-load time per `sys.platform`.
-A documented set of Win32 hard-fail codes raises `Tier2HardFailError`
-and does **not** fall through to Tier 3. Silent degradation is the
-security smell, not the dotfile.
+- **`sso-broker.py`** — the *engine*. Ships via `adapter-root-bins` to
+  `~/.agentbundle/bin/`. Stdlib-only for `get-cookies` / `test` / `rm` /
+  `list-profiles`; `register` and `refresh` additionally require **playwright**
+  and exit non-zero when it is absent. `register` drives a **headed** Chromium
+  for interactive capture; `refresh` drives a **headless** one with a bounded
+  silent-completion window and returns a distinct exit code rather than showing a
+  login page, so an automated consumer can never put one in front of an operator.
+  Both store the jar (see below), and `get-cookies` answers with a **path, never
+  bytes**.
+- **`credbroker`** — the *library* consumers import. It **subprocesses**
+  the engine.
 
-### Tier 3 — the dotfile
+So `credbroker` → `sso-broker.py`, never the reverse. The engine cannot
+import `credbroker`; anything both need — notably the profile grammar
+below — is duplicated deliberately and pinned equal by test.
 
-A stdlib `.env` parser (`parse_env_file` in `credbroker`'s `_core`)
-handles `KEY=value`, quoted values, and `#` comments. It rejects
-`export ` prefix, variable expansion, and multi-line values — `.env`
-is not bash. POSIX: enforces mode `0600` on the file and `0700` on
-`~/.agentbundle/`. Windows: DACL-verified via `icacls`.
-`PermissiveAclError` on either failure.
+### Consumer API
 
-Where `credbroker[crypto]` is installed (a pip layer, never the stdlib
-floor), Tier 3 upgrades from the plaintext dotfile to an AEAD-encrypted
-**vault** (Argon2id → KEK → AES-256-GCM, `credbroker`'s `_vault`); the
-vendored floor stays stdlib-only and plaintext. See
-[RFC-0023](../rfc/0023-credential-manager-broker.md).
+Consumers never resolve the broker path, build its argv, or call
+`subprocess` themselves:
+
+> **Status:** `load_sso_cookies` ships today. `validate_sso_profile`,
+> `refresh_sso_session`, `register_sso_session` and `derive_sso_destination` are **planned** — specified by
+> [`jira-check-sso-auto-login`](../specs/jira-check-sso-auto-login/spec.md) and
+> landing with `credbroker` 0.5.0. This page is updated in that PR, not ahead of it.
+
+```python
+import credbroker
+
+credbroker.validate_sso_profile(profile)        # grammar guard
+jar_path = credbroker.load_sso_cookies(profile) # path, never bytes
+credbroker.refresh_sso_session(profile)         # re-capture an expired session
+credbroker.register_sso_session(profile, login_url=..., ...)  # first-time capture
+credbroker.derive_sso_destination(base_url, strategies=())     # ask the resource (first capture only)
+```
+
+`refresh_sso_session` takes **only a profile** — deliberately. That
+signature is how **destination pinning** is enforced: it is structurally
+incapable of forwarding a sign-in destination, so an automated recovery
+path cannot choose where the browser goes. The engine reads the
+destination from `~/.agentbundle/sso-profiles/<profile>.toml`, which only
+a completed, operator-authorised `register` writes.
+`register_sso_session` is the sole function that accepts a destination.
+**The guarantee is a property of this API, not of the system:** the engine binary
+is directly invokable by any process running as the operator, so a caller with
+shell access can hand it a destination regardless. Consumers are expected to
+reach `register_sso_session` only from an operator-typed action, which is a
+convention enforced by each consumer's own skill rules — not by this library.
+
+Keeping the spawn inside `credbroker` also keeps the cross-platform
+parts — timeout, process-tree kill (POSIX process groups vs Windows),
+and environment composition — in one type-checked, CI-exercised place
+rather than copied into each consumer skill.
+
+### Where the jar actually lives
+
+Two storage surfaces, and conflating them hides real bugs:
+
+- **Primary store.** On Tier-2-capable platforms (macOS, Windows)
+  `_store_cookie_jar` writes the jar into the **OS keychain**, chunked across
+  continuation credentials when it exceeds the per-credential blob limit. Where
+  Tier 2 is deferred by policy (Linux), it writes a `0600` file under
+  `~/.agentbundle/sso-cookies/`.
+- **Materialisation surface.** Consumers never receive bytes, so `get-cookies`
+  writes the jar it just loaded to `~/.agentbundle/sso-cookies/<profile>.jar`
+  and prints that path. On Linux the two surfaces are the same file; on
+  macOS/Windows they are not — which is why the materialisation must be
+  unconditional. A `get-cookies` that skips the rewrite when the file already
+  exists serves a stale jar after every keychain-backed re-capture.
+
+### Confinement controls
+
+The engine's captured jar is deliberately over-broad, so the library
+adds the controls above it — `validate_https_url`,
+`validate_root_relative_endpoint`, `domain_in_cookie_domains`,
+`filter_jar_to_domains`, `require_host_in_cookie_domains` — single-sourced
+in `credbroker` so they cannot drift between consumers. On top of those:
+
+- **Profile grammar.** `profile` is interpolated into filesystem paths
+  and a keychain target name, so it is confined to
+  `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` via `re.fullmatch` (**not**
+  `re.match`, whose `$` admits a trailing newline), excluding
+  case-insensitive Windows reserved device names (`CON`, `NUL`, …) —
+  on Windows `CON.toml` resolves to the console device regardless of
+  directory. The engine enforces the same grammar independently, plus
+  resolved-path containment (canonicalize-then-verify-parent).
+- **No secret on argv.** No cookie value, cookie name, or jar path ever
+  crosses a command line, in either direction.
+
+### Destination derivation — defence in depth, on first capture only
+
+The **automatic** recapture path takes no destination at all (see the Consumer
+API above), so it needs no derivation. Derivation exists for the one path that
+*does* accept one — an operator-typed first capture — where
+`credbroker.derive_sso_destination(base_url, *, strategies=())` asks the
+**resource server** where to authenticate, in a vendor-agnostic strategy chain,
+returning the first scheme+host it resolves:
+
+| Tier | Mechanism | Applies to |
+|---|---|---|
+| 1 | **RFC 9728** Protected Resource Metadata — `401` → `WWW-Authenticate: … resource_metadata` → `/.well-known/oauth-protected-resource` → authorization server metadata | modern OAuth resources (MCP adopted it) |
+| 2 | **OIDC Discovery / RFC 8414** — `/.well-known/openid-configuration` → `authorization_endpoint` | most OIDC-protected on-prem tools |
+| 3 | **Vendor probe** — a registered per-consumer strategy; Atlassian/Seraph is `GET {base_url}/login.jsp`, redirects unfollowed, read `Location` | Jira / Confluence / Bitbucket DC |
+| 4 | none | SAML-only SPs — their metadata names the SP, never the IdP |
+
+Tier 3 exists because SAML has no discovery equivalent; tier 4 is a real
+outcome, not a failure to handle. A consumer that cannot derive **refuses** and
+does not fall back to the configured value.
+
+**What derivation does not do.** It does **not** close config poisoning: the
+derivation target (`base_url`) lives in the same adopter- and agent-writable file
+as the value being attested, so one write moves both and the comparison passes.
+AWS's equivalent works only because its host suffix is hardcoded to
+`*.amazonaws.com`; there is no comparable invariant here. Where the configured
+sign-in host equals the base host — SP-initiated SAML, the majority Jira DC
+topology — derivation is bypassed by construction and attests nothing. Consent
+for first capture therefore rests on the operation being **operator-typed**, not
+on attestation. And attestation itself is **partial, not universal**: where the
+configured sign-in host equals the base host — SP-initiated SAML, the majority
+topology — derivation short-circuits and verifies nothing, so the re-register
+path attempts attestation but only achieves it on IdP-host topologies. A vendor's
+own setup helper performs none at all. Only scheme+host is compared; every tier's URL carries
+per-request `state` / `SAMLRequest` / `nonce`.
+
+**Bounds — this is an outbound fetch on the credential path.** Every hop is
+`https` only (including URLs read from a `resource_metadata` header or an
+`authorization_servers` list); redirects are not followed (hop cap 0); 5 s
+connect + 5 s read under a ≤15 s total budget; a 64 KiB body cap before parsing;
+strict certificate verification that never honours an `--insecure`-style flag and
+never reuses a consumer's own TLS context; and no `Authorization`, `Cookie`, or
+proxy-auth header on any derivation request.
+
+### Auto-recovery contract
+
+A consumer's `check` verb may self-heal an **expired** session: on a typed
+session-unavailable signal it calls `refresh_sso_session` once and re-probes.
+That call is **headless** — it succeeds only when the browser profile can
+complete the IdP flow unaided, and otherwise fails fast rather than presenting a
+login page. It must key on that typed signal, never on a generic auth
+error — a `403`, a failed confinement check, or a missing engine are
+terminal, and re-authenticating cannot fix them. First-time capture stays
+an explicit human action.
+
+### What this costs the operator
+
+Two very different experiences, and the split is the point — the path that runs
+unattended is the one that is structurally safe.
+
+| | Who acts | What they see | How often |
+|---|---|---|---|
+| **First capture** | operator, explicitly | a real sign-in page in a fresh browser context, and the destination host on stderr before it opens | **once per machine, per profile** |
+| **Silent refresh** | nobody | nothing — `refresh` is headless | whenever the app session expires and the IdP session is still valid |
+| **Re-registration prompt** | operator, unplanned | an exit-2 message, **not** a login page — headless `refresh` fails fast and names the consumer's *re-register* command, which is the path that attempts destination attestation | when the **IdP** session has also expired — typically first use of the day |
+
+The middle row is the common case and is safe by construction:
+`refresh_sso_session(profile)` accepts no destination, so an automated caller
+cannot choose where the browser goes. The first row accepts a destination and is
+therefore deliberately **not** automated — see the trust limits above.
+
+The third row is why `refresh` is headless. An unattended refresh that could open
+a headed browser would leave an agent-influenced login page in front of whoever
+happens to be at the machine — the one exposure whose blast radius leaves the box.
+A headless refresh instead fails fast and tells the caller a human is needed;
+interactive capture is reachable only from an operator-typed command.
 
 ## Setting up credentials
 
-The `credential-setup` skill (shipped by the `credential-brokers` pack
-and projected to `.claude/skills/credential-setup/`) replaces the
-prior `agentbundle creds setup <namespace>` CLI. The skill:
+The `credential-setup` skill — source at
+[`packs/credential-brokers/.apm/skills/credential-setup/`](../../packs/credential-brokers/.apm/skills/credential-setup/),
+installed into whichever adapter path the adopter's install targets —
+replaces the prior `agentbundle creds setup <namespace>` CLI. The skill:
 
 - Reads the consumer's `references/creds-schema.toml` to know which
   keys to prompt for.
-- Walks each key via `getpass` (token-shaped) or `input` (non-secret
+- Walks each key via `getpass` (secret) or `input` (non-secret
   sibling like `BASE_URL`).
 - Writes to the highest-available tier (Keychain → Credential Manager
   → dotfile), announces the chosen tier on stderr, and refuses to
   fall back to Tier 3 without `--allow-insecure-fallback`.
 
 There is no `get` verb. The LLM is never given a tool that returns
-cleartext. Anything that needs the token reads it via
+cleartext. Anything that needs the credential reads it via
 `load_credentials` inside the primitive's own subprocess and writes
 it to an outbound HTTP header.
 
-To verify resolution, invoke the consumer skill's own `check` verb —
-e.g. `python3 scripts/cli.py check` walks the same Tier 1 → 2 → 3
-ladder and exits 0 when every declared key resolves.
+To verify resolution, invoke the consumer primitive's own `check` verb —
+e.g. `python scripts/jira.py check` walks the same Tier 1 → 2 → 3
+ladder and exits 0 when every declared key resolves. On a primitive whose
+`auth:` is `sso-cookie`, `check` instead validates the captured session
+and may self-heal it per the auto-recovery contract above.
 
 ## Per-primitive schema declaration
 
-Every credentialed primitive ships
-`references/creds-schema.toml` declaring its namespace and required
-keys:
+Every credentialed primitive ships `references/creds-schema.toml`
+declaring its namespace and keys — a `[namespace]` table plus one
+`[[namespace.keys]]` entry per key:
 
 ```toml
-namespace = "JIRA"
+[namespace]
+name = "jira"
 
-[keys.API_TOKEN]
-secret = true
-description = "Atlassian API token"
-
-[keys.BASE_URL]
+[[namespace.keys]]
+name = "BASE_URL"
+label = "Jira base URL (Cloud: https://<site>.atlassian.net; Server: https://jira.corp.example.com)"
 secret = false
-description = "https://<your-org>.atlassian.net"
+
+[[namespace.keys]]
+name = "API_TOKEN"
+label = "Cloud API token or Server Personal Access Token"
+secret = true
 ```
 
-The schema is what the `credential-setup` skill reads to know which
-prompts to issue. Secret vs non-secret distinguishes which keys go
-to keyring storage (secret) vs which go to the dotfile / env var
-unconditionally (non-secret siblings like `BASE_URL`). A canonical
-reference is
-[`packs/atlassian/.apm/skills/jira/references/creds-schema.toml`](../../packs/atlassian/.apm/skills/jira/references/creds-schema.toml)
-(`API_TOKEN` secret; `BASE_URL` / `EMAIL` non-secret).
+The env-var shape is `<NAMESPACE>_<KEY>` — `JIRA_BASE_URL`,
+`JIRA_API_TOKEN`. `label` is the prompt text the `credential-setup` skill
+issues. `secret` distinguishes which keys go to keyring storage from
+non-secret siblings like `BASE_URL`. The canonical reference is
+[`packs/atlassian/.apm/skills/jira/references/creds-schema.toml`](../../packs/atlassian/.apm/skills/jira/references/creds-schema.toml).
 
 ## The substring trap
 
-Refuse-guards inside a primitive's `cli.py` that **literally name**
-the substring `.agentbundle/credentials.env` will trip the same
-`conventions-check` lint that catches credential *reads*. The lint is
-substring-shaped for backwards compatibility (a follow-up rewrites it
-as an AST walk per the `credential-broker-contract` ROADMAP entry).
+Refuse-guards inside a primitive's script that **literally name** the
+substring `.agentbundle/credentials.env` trip the same
+[`conventions-check`](../../.claude/commands/conventions-check.md) rule
+that catches credential *reads*, unless the script carries the
+`# credentialed-primitive: reads-creds-directly` opt-out marker.
 
 Compose path checks via basename + `Path.parts`, never the literal
 full string:
@@ -223,25 +517,69 @@ parts = Path(suspect).parts
 if "credentials.env" in parts and ".agentbundle" in parts:
     refuse(...)
 
-# Tripped by the lint
+# Tripped by the check
 if str(suspect) == ".agentbundle/credentials.env":
     refuse(...)
 ```
 
-This rule applies to any primitive script (`cli.py`) that mentions the
-dotfile defensively.
+This applies to any primitive script that mentions the dotfile
+defensively.
+
+## Prior art and threat references
+The controls above are shaped by these; each is cited where the reasoning depends
+on it rather than as a reading list.
+
+- **Confused deputy / designation with authority** — the 1988 confused-deputy paper;
+  [*Capability Myths Demolished*](https://papers.agoric.com/assets/pdf/papers/capability-myths-demolished.pdf).
+  Why the automatic path takes **no** destination parameter instead of validating
+  one.
+- **Config file as a trust boundary** —
+  [CVE-2024-52006 / GHSA-qm7j-c969-7j4q](https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q)
+  (Git credential helper): *"configuration-file-supplied URLs receive the same
+  credential access as explicitly user-provided URLs, despite having different
+  trustworthiness profiles."*
+- **Host pinning vs config-supplied tenant** — AWS CLI
+  [IAM Identity Center](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html):
+  `sso_start_url` is config-supplied, but the browser endpoint is derived from
+  `sso_region` and is always `*.amazonaws.com`.
+- **Resource-served destination discovery** —
+  [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.pdf) (Protected Resource
+  Metadata) and OIDC Discovery / RFC 8414, tiers 1–2 above. The
+  [MCP authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization/security-considerations)
+  adopts RFC 9728 and notes the residual limit: issuer validation *"provides no
+  protection if the expected issuer was obtained from an unvalidated source."*
+- **The approval channel must be one the agent cannot write** — OWASP Top 10 for
+  Agentic Applications 2026, **ASI09** (Human-Agent Trust Exploitation) and
+  **ASI02**; OWASP Agentic Skills **AST03**. Why an in-prompt or agent-owned-TTY
+  confirmation is not a control.
+- **Trust-on-first-use does not close first-contact poisoning** —   *Why TOFU Doesn't Work* (TOFU critique).
+- **Well-formed arguments defeat schema gating** —
+  [*Capability Gates Are Not Authorization*](https://arxiv.org/html/2606.28679v1)
+  (arXiv 2606.28679).
+- **Privilege separation is what actually protects an agent-editable config** —
+  *Locking down `gh`* (practitioner writeup):
+  the same failure shape for `gh auth setup-git`, mitigated with `sudo`-gated
+  wrappers rather than validation.
+- **Derive the destination from live browser state** — 1Password's extension
+  model injects only when the browser is already on the matching origin, with a
+  biometric approval prompt that is genuinely out of an agent's reach.
 
 ## Where to read next
 
 - [`docs/specs/credential-broker-contract/spec.md`](../specs/credential-broker-contract/spec.md) —
-  the four-broker contract.
+  the broker contract.
 - [`docs/rfc/0023-credential-manager-broker.md`](../rfc/0023-credential-manager-broker.md) —
   the `credbroker` library that replaced the projected shim for `auth: creds`
   (and its layered-delivery amendment); [`docs/specs/credbroker/spec.md`](../specs/credbroker/spec.md)
   + [`docs/specs/credbroker-user-scope/spec.md`](../specs/credbroker-user-scope/spec.md)
   are the implementing specs.
+- [`docs/rfc/0035-sso-cookie-auth-for-atlassian-pack.md`](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md) —
+  the `sso-cookie` broker; [`docs/adr/0026-sso-consumer-resolution-in-credbroker.md`](../adr/0026-sso-consumer-resolution-in-credbroker.md)
+  places consumer resolution in `credbroker`, and
+  [`docs/specs/jira-check-sso-auto-login/spec.md`](../specs/jira-check-sso-auto-login/spec.md)
+  extends it from resolution-only to resolution-plus-recapture.
 - [`docs/rfc/0013-credential-broker-contract.md`](../rfc/0013-credential-broker-contract.md) —
-  the four-broker design rationale (the predecessor shim model).
+  the broker design rationale (the predecessor shim model).
 - [`docs/specs/skill-secrets/spec.md`](../specs/skill-secrets/spec.md) —
   the predecessor spec (kept for historical context).
 - [`guides/credential-brokers/explanation/credentialed-skills.md`](../../guides/credential-brokers/explanation/credentialed-skills.md) —

--- a/docs/rfc/0013-credential-broker-contract.md
+++ b/docs/rfc/0013-credential-broker-contract.md
@@ -2076,3 +2076,46 @@ record. Corrections are appended here, Approver-signed.
   **Where this is recorded.** [ADR-0026](../adr/0026-sso-consumer-resolution-in-credbroker.md)
   (the architectural decision); `docs/specs/atlassian-sso-cookie/` (the
   implementation contract).
+
+- **2026-08-05 (Approver: eugenelim) — § Subcommands: `refresh` is no longer
+  "equivalent to `register`", and gains a distinct not-registered exit code.**
+  The verb table describes `refresh <profile>` as *"equivalent to `register` but
+  bypasses the 'already registered' check"* and pins `get-cookies` / `test` exit
+  semantics. Three corrections, found while specifying agent-triggered recapture:
+
+  0. **`refresh` is now headless and non-interactive.** It launches
+     `headless=True` and does not poll for sign-in: it succeeds when the warm
+     browser profile completes the IdP flow unaided, and waits up to 20 s for the flow to complete unaided, and otherwise closes the
+     headless context and returns exit **5** rather than presenting a login page.
+     Exit 5 is new and joins 3 and 4 in this verb's contract.
+     Interactive capture belongs solely to `register`. This is what allows an
+     automated consumer to re-authenticate without ever putting an
+     agent-influenced login page in front of an operator.
+  1. **`refresh` diverges from `register` on persistence.** `register` gains an
+     `--ephemeral` mode which captures in a throwaway browser context and seeds
+     `browser-state/<profile>` from the captured state; **plain `register`
+     remains persistent**, so an existing direct caller is unaffected.
+     `register_sso_session` always supplies the flag. `refresh` always uses the
+     persistent context and has no ephemeral mode. On first capture the persistent profile would
+     otherwise auto-complete the IdP flow sub-second with nothing for an operator
+     to observe.
+  2. **`refresh` rejects connection arguments.** `--login-url`,
+     `--success-url-pattern`, `--cookie-domain`, `--validation-endpoint`,
+     `--session-filename` and `--ttl-hint-minutes` are refused with exit 3, so an
+     automated refresh cannot supply a sign-in destination and takes it only from
+     the stored profile. Previously they were honoured whenever non-empty.
+  3. **`refresh` returns `4` when the profile is not registered.** Exit `3` is
+     returned from ten distinct engine sites — including playwright-absent and
+     success-pattern-not-matched — so a consumer could not distinguish the one
+     condition with a different remediation. `3` retains every other meaning.
+
+  Separately, `get-cookies` now rewrites the materialised jar unconditionally
+  rather than only when absent: on Tier-2-capable platforms the captured jar is
+  stored in the OS keychain, so the previous `if not exists` guard served a stale
+  file after every re-capture.
+
+  These are contract changes to this RFC's verb table, not to its decision. The
+  narrowing of RFC-0035's engine-unchanged non-goal is recorded in that RFC's own
+  [§ Errata](0035-sso-cookie-auth-for-atlassian-pack.md#errata). Implemented by
+  [`spec/jira-check-sso-auto-login`](../specs/jira-check-sso-auto-login/spec.md)
+  AC6a / AC6b / AC35.

--- a/docs/rfc/0035-sso-cookie-auth-for-atlassian-pack.md
+++ b/docs/rfc/0035-sso-cookie-auth-for-atlassian-pack.md
@@ -565,3 +565,54 @@ record. Corrections found while building it are appended here, Approver-signed.
   loaded jar to `cookie_domains` at load time, before attaching it
   (`atlassian-sso-cookie` AC4/AC5). The over-broad jar at rest is the broker's
   existing behavior, named honestly rather than claimed away.
+
+- **2026-08-05 (Approver: eugenelim) — the broker engine's non-goal is narrowed:
+  two engine contract changes are required for recapture to work at all.** This
+  RFC's non-goal preserved `sso-broker.py` unchanged, and the ADR-0026 erratum
+  above reaffirmed it by relocating consumer resolution into `credbroker`. Two
+  defects found while specifying agent-triggered recapture cannot be closed from
+  the consumer side, so the non-goal is narrowed here rather than silently
+  broken:
+
+  1. **`get-cookies` never refreshes the materialised jar.** It writes
+     `sso-cookies/<profile>.jar` only `if not materialised.exists()`, while on
+     Tier-2-capable platforms `_store_cookie_jar` writes the captured jar to the
+     **OS keychain**. So on macOS and Windows a successful re-capture updates the
+     keychain and the consumer keeps reading the stale file — recapture is a
+     silent no-op. It works only where Tier 2 is deferred by policy (Linux),
+     which is where CI runs, so no existing suite observes it. The guard is
+     removed; `get-cookies` rewrites the file unconditionally from the store it
+     just loaded.
+  2. **Exit `3` is overloaded across ten distinct sites**, including
+     playwright-absent and success-pattern-not-matched (the ordinary
+     "operator did not finish signing in" case). A consumer cannot distinguish
+     "profile not registered" — the one condition with a different remediation —
+     from the rest. `refresh` therefore returns **`4`** for not-registered,
+     leaving `3` for every other engine failure.
+
+  **`refresh` also becomes headless and non-interactive.** It launches
+  `headless=True`, waits up to 20 s for the flow to complete unaided, and
+  otherwise closes the context and returns the new exit **`5`** rather than
+  presenting a login page. That is what lets an automated consumer
+  re-authenticate without ever putting an agent-influenced login page in front of
+  an operator; interactive capture belongs solely to `register`. Adopter-visible:
+  exit `5` is new, and a `refresh` that previously prompted now fails fast.
+
+  Additionally, `register` gains an `--ephemeral` capture mode and `refresh`
+  **rejects** connection arguments (`--login-url`, `--success-url-pattern`,
+  `--cookie-domain`, `--validation-endpoint`, `--session-filename`,
+  `--ttl-hint-minutes`), so an automated refresh cannot supply a sign-in
+  destination and takes it only from the stored profile.
+
+  Recorded as an erratum rather than a new ADR because what this RFC owns — and
+  what is being changed here — is its **non-goal**, not the engine contract: the
+  broker's verb table and exit semantics belong to
+  [RFC-0013 § Subcommands](0013-credential-broker-contract.md), where a companion
+  Approver-signed erratum records the contract change itself. This entry narrows
+  "consumes the existing broker unchanged"; it does not reverse this RFC's
+  decision. Exit `3` → `4`, the new headless-`refresh` contract with its 20 s window and
+  exit `5`, and the `--ephemeral` / argument-rejection changes are all
+  adopter-visible; both ship with a `credential-brokers` minor bump and are
+  named in the changelog. Implemented by
+  [`spec/jira-check-sso-auto-login`](../specs/jira-check-sso-auto-login/spec.md)
+  AC6a / AC6b / AC35.

--- a/docs/specs/jira-check-sso-auto-login/agent-triggered-credential-capture-survey.md
+++ b/docs/specs/jira-check-sso-auto-login/agent-triggered-credential-capture-survey.md
@@ -1,0 +1,310 @@
+# Agent-triggered credential capture — secure alternatives to a reachable `--register`
+
+> Discipline: applied (practitioner-pattern survey)
+
+**Question.** A CLI invoked by an AI agent can trigger a headed-browser SSO login
+whose destination URL comes from a config file the same agent can edit. Is there
+a secure alternative to putting that capability on an agent-reachable flag?
+
+**Scope.** Prior art on binding/attesting the destination; out-of-band human
+confirmation for agent-triggered credential operations; confused-deputy
+mitigations. Feeds the `--register` decision in
+[`spec.md`](./spec.md) AC15 / AC32.
+
+---
+
+## Findings
+
+### F1. This is a textbook confused deputy, and the canonical fix is to remove the argument, not validate it `[high]`
+
+The classic 1988 formulation: a compiler with legitimate write authority to a
+billing directory was passed a billing-file *name* as its debug-output
+destination. The name and the right travelled separately — designation arrived
+without authority, and the deputy applied its own ambient authority to a target
+the caller chose.
+
+The capability-security answer is **"No Designation Without Authority"** (*Capability Myths Demolished*, property A): the caller passes an unforgeable
+reference that already carries the authority, never a name the deputy resolves
+against an ambient pool. Applied here — validating `login_url` after reading it
+is ACL-style thinking and fails the moment the allowlist itself lives in the
+file being guarded. The structural fix is that the automatic path must not
+*accept* a destination at all.
+
+This is precisely what `refresh_sso_session(profile)` already does. The gap is
+only first-run.
+
+Sources: Wikipedia *Confused deputy problem* (primary); *Capability Myths Demolished* (primary); *a capability-security retrospective* (primary). Two share an author, so they count as one under the practitioner-independence rule.
+
+### F2. AWS solved the identical problem by decoupling *which tenant* from *which host* `[high]`
+
+`aws sso login` reads `sso_start_url` from `~/.aws/config` — a plaintext file any
+process running as the user can edit. Structurally identical to our
+`sso-config.toml`.
+
+The mitigation is that **the browser's authorization endpoint is not derived from
+the config-supplied URL**. It is always `oidc.{sso_region}.amazonaws.com`
+(PKCE, default since CLI v2.22.0) or `device.sso.{sso_region}.amazonaws.com`
+(device flow) — i.e. always `*.amazonaws.com`, derived from `sso_region`.
+`sso_start_url` selects *which SSO portal on AWS's own back end*, not *which host
+the browser visits*. Poisoning it cannot redirect the browser to attacker
+infrastructure.
+
+The generalisable pattern: **let the config name the tenant; pin or derive the
+host.** Every major CLI surveyed does some version of this —
+`gcloud auth login` hardcodes `accounts.google.com`; `az login` hardcodes
+`login.microsoftonline.com` with only the tenant parameterised;
+`gh auth login` hardcodes `github.com` with `--hostname` as a *flag*, not a
+config read.
+
+Downgrade note: AWS docs are vendor-sourced and count as one source under
+practitioner-independence; corroborated by independent practitioner analysis
+(the independent practitioner analysis) which confirms no issuer validation exists but also confirms the host
+derivation.
+
+Sources: AWS CLI IAM Identity Center docs (primary, vendor);
+*MITMing AWS IAM Identity Center OIDC Authentication* (primary, practitioner);
+Google/Microsoft/GitHub CLI docs (primary, vendor).
+
+### F3. "Config file is a trust boundary" is a documented CVE class, not a hypothetical `[high]`
+
+**CVE-2024-52006 / CVE-2024-50349** (Git, Dec 2024): crafted URLs with encoded
+newlines injected via `.gitmodules` caused the credential helper to fetch
+credentials for one host and transmit them to an attacker's. The advisory
+(GHSA-qm7j-c969-7j4q) states the failure in exactly our terms —
+*"configuration-file-supplied URLs receive the same credential access as
+explicitly user-provided URLs, despite having different trustworthiness
+profiles."* **CVE-2025-23040** (GitHub Desktop) is the same class.
+
+Sources: git/git security advisory (primary); GitHub Desktop advisory (primary).
+
+### F4. In-prompt confirmation is the named anti-pattern; the approval channel must be one the agent cannot write `[high]`
+
+**OWASP Top 10 for Agentic Applications 2026, ASI09 — Human-Agent Trust
+Exploitation**: *"this risk targets the human approval step that other controls
+depend on"*, requiring *"forced, explicit confirmations that show the raw action
+rather than the agent's summary."* **ASI02 — Tool Misuse** is the framing for
+argument-supplied targeting. **OWASP Agentic Skills AST03 — Over-Privileged
+Skills** requires *"explicit operator consent for persistent state changes …
+must not be auto-applied from injected instructions."*
+
+The documented defeat: routing approval through a surface the agent controls.
+Auth0 states it plainly — *"the approval question reaches the user through the
+same chat surface that may already be compromised."* Slack/webhook approvals
+without message signing fail the same way.
+
+**This retroactively validates rejecting the TTY gate** — but for a reason
+different from the UX one: a TTY the agent owns is not out-of-band.
+
+Sources: OWASP ASI 2026 (primary); OWASP AST03 (primary); Auth0 (secondary,
+vendor); a practitioner CIBA writeup (secondary). Vendor-heavy — see *Known unknowns*.
+
+### F5. CIBA is the production out-of-band pattern, and it does not fit this case `[moderate]`
+
+Client-Initiated Backchannel Authentication (OpenID Connect) pushes approval to
+the user's separately-authenticated device; the agent cannot write that channel.
+Shipped by Auth0, Okta, MuleSoft; banking deployments under PSD2 SCA bind the
+approval cryptographically to the specific transaction. An IETF draft
+(`draft-klrc-aiagent-auth-01`, Ping/OpenAI/AWS/Zscaler, March 2026) extends it
+for agents.
+
+**It does not apply here.** CIBA presumes an authorization server issuing tokens
+to a registered client. Our flow captures a *browser session cookie jar* from a
+headed browser against an arbitrary corporate IdP — there is no authorization
+server in the loop and nothing to push. Recorded so the option is closed
+explicitly rather than silently.
+
+Downgrade: `[moderate]` — the pattern is well-evidenced, its
+*inapplicability here* is my inference, not a sourced claim.
+
+Sources: Auth0, WorkOS, a practitioner CIBA writeup, agentlair.dev (all secondary;
+three of four vendor-authored — counts as weak independence).
+
+### F6. TOFU fails exactly where we need it, confirming the rejection of a host-drift baseline `[high]`
+
+*Why Trust-On-First-Use Doesn't Work*: a MitM during first connection
+establishes false trust permanently, and subsequent change-warnings are
+routinely defeated by users deleting `known_hosts` on IT advice. Alert fatigue
+compounds it.
+
+This independently confirms the round-2 reasoning for deleting the host-drift
+control: its baseline would be recorded *after* the poisoned registration, so the
+attacker's host becomes the reference.
+
+Sources: the TOFU critique (primary); Wikipedia *Trust on first use* (secondary).
+
+### F7. Habituation degrades any confirmation control over time `[moderate]`
+
+Anthropic autonomy data cited in the intent-verification writeup shows users sliding from ~20%
+full-auto-approval to >40% after ~750 sessions — the agent analogue of MFA
+push-bombing fatigue. Relevant because a per-invocation confirmation on `check`
+would be trained away precisely on the machines that use it most.
+
+Downgrade: single secondary source citing the underlying data; not independently
+triangulated.
+
+Source: the intent-verification writeup (secondary).
+
+---
+
+## What this implies for `--register`
+
+Three options, ranked. All are structural (F1) rather than validation-based.
+
+### Option A — derive the destination from the server, don't read it from config
+
+> **Superseded 2026-08-05.** Two corrections, from the spike and round 4:
+> derivation works from `/login.jsp`, **not** `base_url`; and because `base_url`
+> lives in the same agent-writable file, derivation is **defence in depth**, not
+> a control. Consent for `--register` rests on it being operator-typed.
+> See spec AC15 + AC32.
+
+Follow F2's pattern: stop treating `login_url` as an input. An unauthenticated
+request to `base_url` on a DC instance behind SSO **302-redirects to the IdP** —
+so the *server* designates the destination, not the config. `base_url` is
+already confined by `cookie_domains` and the existing `credbroker` primitives.
+
+- **Strongest fix.** Removes the unbound designator entirely (F1), and mirrors
+  the mechanism every surveyed CLI uses (F2).
+- **Cost.** A behaviour change to the engine, and it inverts the deliberate
+  `follow_redirects=False` posture on the cookie path — which exists for a good
+  reason and would need care to relax safely for the *pre-auth, no-cookie* case
+  only. Not all DC + SSO topologies redirect predictably.
+- **Confidence in applicability:** `[moderate]` — the redirect behaviour is
+  standard but I could not verify it against a real DC instance (see gaps).
+
+### Option B — ephemeral browser context for `--register`
+
+The reason the sub-second auto-SSO makes disclosure useless is
+`launch_persistent_context(user_data_dir=…/browser-state/<profile>)`. For
+`register`, launch a **fresh context** instead: first-run then genuinely requires
+interactive sign-in on a visible page, restoring the URL bar as a real
+confirmation surface — the *only* out-of-band channel available here that the
+agent cannot write (F4).
+
+- **Cheap, local, no new dependency.** Persistence stays where it earns its keep
+  (`refresh`), and is removed where it destroys the confirmation surface
+  (`register`).
+- **Does not fix the destination**, only makes a poisoned one visible to a human
+  who is present. Subject to habituation (F7).
+
+### Option C — keep first-run out of agent reach
+
+`--register` requires an out-of-band signal the agent doesn't naturally produce,
+or first-run reverts to `setup_sso.py` only.
+
+- **Simplest and most certain.** Costs the one-command first run.
+- Consistent with AST03's "explicit operator consent … must not be auto-applied".
+
+---
+
+## Known unknowns
+
+- **CLOSED 2026-08-05 by research + live spike.** `GET base_url` does **not**
+  redirect — `/secure/Dashboard.jspa` returned `200`, confirming JRASERVER-66554
+  (SAML redirection fires only from `login.jsp`). The working derivation is
+  `GET {base_url}/login.jsp` with redirects unfollowed: observed
+  `302 → Location: https://auth.atlassian.com/authorize?…` on a live Seraph
+  instance. It returns `302` only in **forced-SSO** mode; in
+  SSO-with-local-fallback it returns `200` with a button. Option A is therefore
+  viable *with an explicit cannot-derive branch* — see spec AC32.
+- **Known-unknown:** does Playwright's non-persistent context reliably force a
+  visible interactive sign-in against an IdP that may itself hold a
+  Kerberos/desktop-SSO session? Would be closed by: one observed run on a
+  domain-joined machine. This gates Option B's core claim.
+- **Unknowable (as posed):** whether operators would actually *read* a disclosed
+  destination under Option B. The habituation data (F7) is from a different
+  interaction shape, and no public study measures destination-verification rates
+  in agent-triggered browser logins.
+- **Unknowable:** whether any adopter has been hit by this. Config-poisoning
+  incidents against SSO CLIs are not separately reported — the CVE class exists
+  (F3) but incident data does not.
+
+## Evidence quality caveats
+
+- The out-of-band-approval literature (F4, F5) is **vendor-dominated** — Auth0,
+  Okta, WorkOS, Teleport. Under the practitioner-independence rule these compress
+  toward one source. No independent post-mortem of a CIBA-protected agent
+  deployment being compromised exists publicly, which is itself a survivorship
+  signal.
+- The IETF agent-auth draft is ~7 months old and pre-RFC; treat as direction, not
+  standard.
+- F1, F3 and F6 rest on primary sources (capability literature, CVE advisories,
+  the TOFU critique) and are the load-bearing findings. F2 is vendor-primary but corroborated
+  by independent practitioner analysis.
+
+
+---
+
+## Addendum — prior-art sweep of agent-credential projects (2026-08-05)
+
+Three repos supplied by the owner, plus a wider sweep. **No project found solves
+this shape**: a *browser session capture* whose *destination comes from an
+agent-editable config file*.
+
+### F8. A shipping product has our exact unaddressed bug `[high]`
+
+`authsome` is a zero-knowledge credential proxy (SKILL.md only — no
+source visible, so implementation depth is unverified). Its agent-facing verb is
+`authsome login <provider>` — **the agent supplies the argument that selects the
+OAuth destination**, the identical confused-deputy shape, and their docs do not
+discuss it. Their stated human-in-the-loop is "the browser opens on their
+machine; they complete OAuth without touching the terminal" — the same
+confirmation-surface claim this survey already falsified for the warm-profile
+case (F2 rationale). Useful as evidence the problem is under-recognised, not as a
+solution.
+
+### F9. Proxy-injection removes the secret but not the destination choice `[high]`
+
+`agent-vault` (Infisical) (~2k stars, real code) runs a MITM proxy: the agent
+points `HTTPS_PROXY` at it and **never receives the credential** — it is injected
+into outbound requests by host-matching rules. That is genuinely stronger than
+handing over a value, and its egress filtering is the closest thing found to
+structural destination control. Two limits: it addresses **API egress, not
+browser session capture**, and the docs do not say who may write the service
+rules — if the agent can, the protection collapses the same way ours does.
+`agent-secrets` (real Go daemon, age-encrypted, TTL-bounded leases over
+a Unix socket) solves storage and leasing only; its `--client-id` is an audit
+label, not an access-control primitive, and it has no HITL and no browser flow.
+
+### F10. Two transferable ideas we do not currently have `[moderate]`
+
+1. **Derive the destination from the browser's live state, not from config.**
+   1Password's extension model injects a credential only when the browser is
+   *already on* the URL matching the saved item's origin, and approval is a
+   **Touch ID / biometric** prompt — a system-level channel that is genuinely
+   out of an agent's reach, unlike a TTY or a settings file. This is the only
+   out-of-band approval channel found that survives our threat model.
+2. **OS-level privilege separation is the only mechanism that actually protects
+   the config file.** a practitioner `gh` hardening writeup documents our exact problem
+   — `gh auth setup-git` writes the credential helper into an agent-writable git
+   config — and mitigates with `sudo`-gated wrapper scripts (zero-second cache),
+   *not* with validation. It corroborates directly: you cannot validate your way
+   out when the allowlist shares a trust boundary with the attacker.
+
+### F11. The literature confirms validation-moves-the-trust `[high]`
+
+*Capability Gates Are Not Authorization* (arXiv 2606.28679) tested LangChain /
+LangGraph, LlamaIndex and the Stripe Agent Toolkit: all ship capability gating
+only, so a **well-formed** argument naming an attacker destination passes. Its
+proposed ScopeGate assumes the policy file is protected from agent writes — the
+same limitation we hit, unresolved. MCP's RFC 9728 adoption moves the
+authorization-server URL from client config to server metadata, but the spec
+itself notes issuer validation *"provides no protection if the expected issuer
+was obtained from an unvalidated source"* — i.e. it moves the problem one hop,
+exactly what round 6 found about our `base_url`. HashiCorp Vault's Agent Registry
++ Rich Authorization Requests is the principled version — the permitted paths and
+parameter values are bound into the JWT **at issuance by a human**, so the agent
+cannot widen them at call time — but it is M2M only and does not reach browser
+sessions.
+
+**Net effect on this spec:** nothing found contradicts the design. Parameter
+elimination (our AC1) is the named correct fix; no source treats prompt-level
+confirmation as a real control, which is why AC15 records it as a non-control.
+The two ideas worth pursuing are F10's — recorded as
+*(deferred: sso-live-browser-destination-derivation)* and
+*(deferred: sso-privilege-separated-config)*.
+
+`ASM (Agent Skill Manager)` was also checked: it is an Agent Skill Manager with **no
+credential broker** — the comparison premise did not hold. Its one transferable
+idea is orthogonal: a pre-install scan of third-party skill files for embedded
+credentials, a supply-chain layer this spec does not address.

--- a/docs/specs/jira-check-sso-auto-login/plan.md
+++ b/docs/specs/jira-check-sso-auto-login/plan.md
@@ -1,0 +1,759 @@
+# Plan: jira-check-sso-auto-login
+
+- **Status:** Approved
+- **Spec:** [`spec.md`](./spec.md)
+- **Architecture:** [`docs/architecture/credentials.md § The `sso-cookie` broker`](../../architecture/credentials.md#the-sso-cookie-broker)
+- **Mode:** full (risk triggers: **security boundary** — auth, secrets, subprocess on the credential path; **public-interface change** — new `credbroker` API)
+
+> **Supersedes** the Shape A draft of this plan, which had `check` resolve the
+> broker path and call `subprocess.run` directly. That is now a spec *Never do*.
+> Nothing below routes a spawn through a skill script.
+
+## Approach
+
+Four layers change, bottom-up, and the dependency order is forced:
+
+1. **`credbroker`** gains the grammar validator, a cross-platform spawn helper,
+   and the two recapture verbs. Everything above consumes these.
+2. **`sso-broker.py`** (the engine) gains its own independent grammar guard plus
+   path containment, and two behaviour fixes the design review surfaced —
+   unconditional jar re-materialisation (with a unique temp name, since making the
+   write unconditional makes the shared-temp collision routine; **ordering between
+   concurrent materialisers is deliberately unspecified** — see AC6a and
+   `sso-materialisation-ordering`) and a distinct not-registered exit code.
+   It cannot import `credbroker`, so its grammar copy is pinned equal by test.
+3. **The `jira` skill** gains the typed discriminator, the `check` recovery
+   flow, `--register`, and the honest `--insecure` warnings.
+4. **Docs, CI wiring, bookkeeping, version bumps** — bumps strictly last, so
+   `make build-self` regenerates projections against settled content.
+
+Layer 2 has no dependency on layer 1 (separate implementations by design), so
+T5/T6 run in parallel with T1–T4. The parity test (T7) is the join. T5 and T6
+both edit `sso-broker.py`, so they serialise against **each other** — run T6
+first (it changes an exit code T5's tests assert).
+
+## Constraints
+
+- **Cross-platform is a hard requirement.** `start_new_session` / `os.killpg`
+  are POSIX-only; `Path.home()` reads `USERPROFILE` on Windows. Follow the
+  established pattern at `workspace_mcp.py:1069-1092` rather than inventing one.
+- **`credbroker` is published** (PyPI, 0.4.1). New API is additive, but the pip
+  layer *precedes* the vendored floor on `sys.path`, so an old pinned install
+  shadows the new floor — hence AC30's feature-detect guard.
+- **The engine cannot import `credbroker`** — `credbroker` subprocesses it.
+- **`catalogue_tooling/lint.py:439-459`** pins verbatim SKILL.md security phrases
+  for both `auth: sso-cookie` and `auth-fallback: creds`, matched after
+  whitespace normalisation. They cannot be reworded; only the unpinned lead-in
+  may be re-scoped.
+- **`tools/test-lint-sso-config.py:90-96`** pins `_sso_config.py`,
+  `setup_sso.py`, `test_sso_config.py`, `test_setup_sso.py`,
+  `test_auth_selector.py` byte-identical across `jira/` and
+  `confluence-crawler/`. Edit by copy, never retype.
+- **`jira.py` is not importable flat** — `import scripts.jira` is the only route
+  (verified). Tests must reach every symbol through `scripts.*` or the typed
+  `except` will not match.
+- **`.claude-plugin/marketplace.json`, `.agentbundle/bin/sso-broker.py`,
+  `.agentbundle/lib/credbroker/`** are generated. Regenerate with
+  `make build-self`; never hand-edit.
+- **Two version-shaped values in `packs/atlassian/pack.toml`** — only
+  `[pack].version` moves; `[pack.adapter-contract] version` does not.
+
+## Assumption trio
+
+**Files I will touch**
+
+| Layer | File | Change |
+|---|---|---|
+| credbroker | `packages/credbroker/credbroker/_sso.py` | grammar validator, spawn helper, two recapture verbs, new error types |
+| credbroker | `packages/credbroker/credbroker/__init__.py` | export the new public surface |
+| credbroker | `packages/credbroker/tests/unit/test_sso_recapture.py` | **new** — AC1–AC5, AC10 |
+| credbroker | `packages/credbroker/tests/unit/test_sso_broker_verbs.py` | AC6–AC9, AC6a, AC6b cases |
+| engine | `packs/credential-brokers/.apm/adapter-root-bins/sso-broker.py` | profile guard, containment, re-materialisation, exit 4, `_capture(persist=)` split + `--ephemeral`, `refresh` rejects connection args, `_write_profile` escaping |
+| jira | `packs/atlassian/.apm/skills/jira/scripts/_client.py` | typed subclass, guarded jar read, whoami guards |
+| jira | `…/jira/scripts/_sso_config.py` | validation delegation (+ mirror) |
+| jira | `…/jira/scripts/setup_sso.py` | refactor onto `register_sso_session` (+ mirror) |
+| jira | `…/jira/scripts/jira.py` | `_run` routing, `_probe`, recovery, `--register`, `--insecure`, version floor |
+| jira | `…/jira/scripts/test_check_sso_login.py` | **new** — AC11–AC20, AC30, AC31 |
+| credbroker | `packages/credbroker/tests/unit/test_sso_derivation.py` | **new** — AC32 chain + fetch bounds |
+| governance | `docs/rfc/0035-…md`, `docs/rfc/0013-credential-broker-contract.md` | Approver-signed `## Errata` entries — RFC-0035 narrows its non-goal, RFC-0013 records the verb-table/exit contract change (AC34) |
+| jira | `…/jira/scripts/test_setup_sso.py` | rewritten onto `register_sso_session` (+ mirror) |
+| release | `packs/figma/{pack.toml,.claude-plugin/plugin.json}`, `packs/linear/{pack.toml,.claude-plugin/plugin.json}`, `packs/credential-brokers/.claude-plugin/plugin.json` | dependency declaration + minor bump (`plugin.json` required — CAT_L009) |
+| jira | `…/confluence-crawler/requirements.txt` | `credbroker>=0.5.0` (AC30: both consuming skills) |
+| jira | `…/jira/requirements.txt` | `credbroker>=0.5.0` |
+| jira | `…/jira/SKILL.md`, `…/jira/evals/evals.json` | carve-out, pre-flight rule, exit table, negative eval |
+| mirror | `…/confluence-crawler/scripts/{_sso_config,setup_sso}.py` | byte-identical mirrors |
+| CI | `.github/workflows/build-check.yml` | wire the new jira suite |
+| CI | `packages/agentbundle/…/self_host_windows.py` | add credbroker suite + the new jira suite |
+| docs | `docs/architecture/credentials.md` | already landed; reconcile with shipped behaviour |
+| docs | `guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md`, `guides/_shared/reference/`, `docs/product/changelog.md` | AC21–AC24 |
+| bookkeeping | `workspace.toml` | queue entry + deferred slugs |
+| release | `packages/credbroker/pyproject.toml`, `packs/atlassian/{pack.toml,.claude-plugin/plugin.json}`, `packs/credential-brokers/pack.toml` | version bumps (**last**) |
+
+**Tests that demonstrate "done"** — canonical list; every task's `Done when:`
+references this block by number rather than restating commands.
+
+```bash
+# 1  credbroker
+cd packages/credbroker && python -m pytest
+# 2  both skills' script suites
+cd packs/atlassian/.apm/skills/jira/scripts && python -m pytest
+cd packs/atlassian/.apm/skills/confluence-crawler/scripts && python -m pytest
+# 3  byte-parity + schema parity
+python tools/test-lint-sso-config.py
+# 4  repo gates (SAST ON — this change adds subprocess on the credential path)
+make lint-ruff && python3 tools/lint-mypy.py && make build-check
+# 5  spec hygiene
+python .claude/skills/work-loop/scripts/lint-spec-status.py --root .
+# 6  manual QA — token path untouched, no browser
+cd packs/atlassian/.apm/skills/jira && python scripts/jira.py check
+cd packs/atlassian/.apm/skills/jira && python scripts/jira.py check --insecure
+```
+
+**What I am not changing**
+
+- The token path's credential resolution (only AC18's warning is added).
+- Any `jira.py` subcommand other than `check`.
+- `confluence-crawler`'s `check` behaviour (it *does* inherit the shared-file
+  changes — see spec scope; that is not "no change").
+- `[pack.adapter-contract] version`.
+- `catalogue.toml` / `install-defaults.toml` — deferred to the RFC-0074 addendum.
+
+## Declined patterns
+
+| Tempted to add | Why declined |
+|---|---|
+| Keeping the spawn in `jira.py` (Shape A) | Puts the platform split in an un-mypy-checked script and duplicates it into the next consumer. Rejected in the architect pass. |
+| A TTY/stdin confirmation gate | A TTY the agent owns is not out-of-band (survey F4 / OWASP ASI09). Replaced by destination pinning on the automatic path (AC1) + operator-typed `--register` (AC15), with derivation as defence in depth (AC32). |
+| Any CLI flag beyond `--register` | `--register` is earned by a real second caller (first-run vs steady-state trust). Nothing else has one. |
+| A retry loop around recapture | Exactly one attempt per process. A loop re-opens browsers against a broken profile. |
+| Making the engine import `credbroker` to share the grammar | Inverts the dependency — `credbroker` subprocesses the engine. Duplicate + pin by test instead. |
+| Fixing the non-JSON-2xx guard on *all* read paths | Every method calls `resp.json()`; widening beyond `whoami` changes subcommands the spec scopes out. Deferred with a slug. |
+| Hardening `browser-state` mode and the unfiltered at-rest jar | Real, but a different concern from recapture. Deferred with a slug. |
+| Bumping `[pack.adapter-contract]` alongside `[pack].version` | Different contract, unchanged here. |
+
+## Domain grounding
+
+Three claims about components outside the `jira` skill, each grounded by reading
+source or executing a probe — none recalled:
+
+1. *`_do_refresh` with no connection args reads the destination from the stored
+   profile TOML and returns non-zero when unregistered.* Read at source. This is
+   what makes destination pinning possible.
+2. *`_do_get_cookies` skips re-materialisation when the file exists, while
+   `_store_cookie_jar` writes to the keychain on Tier-2-capable platforms.* Read
+   at source — this is the bug AC6a fixes, and without it the whole feature is a
+   no-op on macOS/Windows.
+3. *`start_new_session` + `os.killpg` removes the grandchild on POSIX;
+   `os.killpg` is absent on Windows.* Executed probe, plus the repo's own
+   precedent at `workspace_mcp.py:1069-1092`.
+
+## Anchor-test sweep record
+
+Tests and lints that pin exact content of files this change edits:
+
+| Site | Pins | Disposition |
+|---|---|---|
+| `catalogue_tooling/lint.py:439-459` (via `make build-check`) | verbatim SKILL.md security phrases, both brokers | **keep** — carve-out is additive prose (T13) |
+| `tools/lint-catalogue-curation-guard.py` (`build-check.yml:478`) | hard-fails any change under `packs/credential-brokers/**` or engine code outside `build/recipes/` + `/tests/` | **exempt via trailer** — `Engine-Change-RFC: RFC-0035` on every commit (AC34) |
+| `tools/test-lint-sso-config.py:90-96` | byte-equality of five files across two skills | **change both sides** (T9) |
+| `packages/credbroker/tests/unit/test_sso_broker_verbs.py` | engine verb behaviour incl. `get-cookies` exit codes | **extend** — AC6b changes an exit code, so existing assertions on `3` must be re-read (T6) |
+| `jira/scripts/test_exit_codes.py:59-65,100-102` | source-index assertions over `jira.py` text | **verify** — re-run after every `jira.py` edit, not just at the end |
+| `jira/evals/evals.json:188-199` | eval 16 asserts the agent defers setup to the user | **extend** — token-path-scoped today; T13 adds the `setup_sso.py` negative case |
+| `make build-check` drift gates | `marketplace.json`, `.agentbundle/bin/`, `.agentbundle/lib/` | **regenerate** in T15 |
+
+## Resolve-vs-surface disposition record
+
+| Question | Disposition | Resolution |
+|---|---|---|
+| Where does the recapture operation belong? | **surfaced → resolved** | `credbroker` (Shape D). User ratified 2026-08-05. |
+| Does auto-recovery actually work on macOS/Windows? | **resolved** | No — sticky materialisation. AC6a fixes the engine. Found by design review, verified at source. |
+| Is exit `3` a usable "not registered" signal? | **resolved** | No — ten distinct sites. AC6b adds exit `4`. |
+| Can a stale session return exit 0? | **resolved** | Yes — parseable JSON without identity fields. AC11 site 5. |
+| Can `--register` be enforced outside the prose layer? | **resolved** | Partly. A pack-shipped `permissions.deny` does not exist as a mechanism; a `PreToolUse` hook is shippable but lands in an agent-writable repo file with uneven adapter coverage (deferred). An **operator-applied** user-scope deny rule is real but **Claude Code only** — the adapter contract has no permissions abstraction, and the other five adapters offer only coarse sandbox levels or tool-name allow-lists. Documented as adapter-specific hardening; nothing in the design depends on it. |
+| Is destination pinning airtight against a hostile agent? | **resolved** | No. TOFU was designed and rejected (baseline written after the poisoned register). Server-side derivation was then designed and **downgraded to defence in depth** — `base_url` sits in the same file, so one write defeats it. Consent rests on AC15 (operator-typed `--register`), not on attestation. |
+| Does the new API break old pinned installs? | **resolved** | Yes, silently. AC30 feature-detects + pins `>=0.5.0`. |
+| Bump `packs/credential-brokers`? | **surfaced → reversed** | Initially no (crash-fix precedent). AC6b changes an exit code = contract change → bump to 0.3.0. Reported to user. |
+| Materialise red stubs now? | **surfaced** | User said "no code". Stub bodies are specified below; each task writes its own immediately before implementing it. |
+| Windows `taskkill` arm | **surfaced** | Reasoned, not executed. Verified only when AC26's parity run is green; named limitation until then. |
+
+## Design (LLD)
+
+### credbroker surface
+
+```
+_sso.py
+  validate_sso_profile(profile)            -> None            (raises SsoConfigError)
+  derive_sso_destination(base_url, *, strategies=()) -> str | None  (public; AC32)
+  _spawn_broker(argv, *, timeout, env_profile, capture) -> CompletedProcess                      (private; tree-kill, env allowlist)
+  refresh_sso_session(profile)             -> None            (no destination parameter)
+  register_sso_session(profile, *, login_url, success_url_pattern,
+                       cookie_domains, validation_endpoint,
+                       session_filename=None, ttl_hint_minutes=None) -> None
+  SsoProfileNotRegisteredError(SsoSessionUnavailableError)     (refresh exit 4)
+  SsoRecaptureFailedError(SsoError)                            (refresh/register exit 3/unknown)
+  SsoInteractionRequiredError(SsoError)                        (refresh exit 5)
+  SsoBrokerUnavailableError(SsoError)                          (timeout / spawn /
+                                                                materialisation write /
+                                                                get-cookies 3)
+  # no lock error class: AC6a specifies no lock and no ordering protocol
+  # per-verb mapping is AC1's table — do not restate it here
+```
+
+### `check` control flow
+
+```
+_run(args)
+  └─ auth_path == "sso-cookie" and args.command == "check"     (AC31: BEFORE :717-725)
+       └─ _cmd_check_sso(sso_config, args)
+            1. warn if args.insecure                            (AC18)
+                        3. rc = await _probe(sso_config)      # whoami() direct, close in finally (AC13)
+                 └─ not SsoSessionUnavailable → return rc        (AC11: 403/config terminal)
+            5. stderr notice + log.info                          (AC16)
+            6. credbroker.refresh_sso_session(profile)           (AC1, AC9 destination-free)
+                 SsoProfileNotRegisteredError → exit 2, "ask the user … --register"
+                 SsoInteractionRequiredError  → exit 2, "run check --register"; NO browser
+               SsoRecaptureFailedError      → exit 2, engine stderr already shown
+            7. rc = await _probe(sso_config)      # exactly one retry (AC17)
+  └─ every other command / token path → today's construction, unchanged
+```
+
+### Failure matrix
+
+| Case | Behaviour |
+|---|---|
+| `403` on probe | plain `AuthError` → exit 2, **no** recapture |
+| cookie-domain confinement fails | `SsoConfigError` → exit 2, no recapture |
+| broker not installed | `SsoBrokerNotInstalledError` → exit 2 (credbroker's own remediation) |
+| profile not registered | engine exit 4 → exit 2 naming `check --register` |
+| headless refresh needs a human | engine exit **5** → exit 2 naming `check --register` (the attested path); no browser, no retry |
+| playwright absent / sign-in not completed | engine exit 3 → `SsoRecaptureFailedError` → exit 2, engine stderr surfaced |
+| refresh ok but jar unusable | post-recapture construction fails → exit 2, no second attempt |
+| spawn exceeds timeout | tree killed, exit 2 |
+| corrupt / wrong-shape jar | mapped to `SsoSessionUnavailable` → recovery runs (AC12) |
+| 2xx non-JSON, or JSON without identity | `SsoSessionUnavailable` → recovery runs (AC11 sites 4, 5) |
+| derived host ≠ configured `login_url` host (`--register` only) | exit 2, **no browser**, names both hosts + `setup_sso.py` (AC32) |
+| derivation cannot resolve (`--register` only) | exit 2 naming `setup_sso.py`; never falls back to the config value (AC32) |
+| old pinned credbroker | exit 2 with upgrade remediation (AC30) |
+| two concurrent `check`es | **undefined** — deferred slug |
+
+## Tasks
+
+> **Red stubs.** Each TDD task below carries a compilable body with a real
+> assertion that **fails against today's code** — not a comment-only body (which
+> raises `IndentationError`) and not an `...` body (which compiles and passes
+> green, giving a vacuous gate). No stub body is `...` — `packs/AGENTS.md:135` requires
+> `raise NotImplementedError  # STUB: ACn`, because a bare `...` is valid Python
+> that passes immediately and defeats the red-green cycle. Stubs are
+> materialised **per task, immediately before implementing that task** — not all
+> up front. Materialising every stub at once would put red tests from T1–T7 into
+> canonical suite 1 while each of those tasks independently requires that whole
+> suite to pass, so no intermediate gate could ever be green. Each task writes
+> its own stubs, observes them red, implements, then gates on the suite. Per the user's "no code" instruction, that materialisation has not
+> happened yet.
+>
+> **Fixture shape.** `test_sso_broker_verbs.py`'s `broker` fixture yields a
+> 2-tuple `(mod, backend)` and is parametrised over the pack-source and the
+> generated `.agentbundle/bin/` copies. Every engine stub below must unpack it
+> (`mod, _ = broker`) or it fails with `AttributeError` on a tuple — red for a
+> harness reason, which proves nothing. T7's parity test reads the **pack-source**
+> copy as canonical; the projected copy is covered by the existing drift gate.
+> AC6a's dual-store arms are the fixture's own `mod._tier2_backend` assignment
+> (a stub backend = keychain-backed, `None` = file-floor); the file-floor arm is
+> the **control**, not the regression guard, because store and materialisation
+> are the same file there.
+
+### T0 — Gate **and bookkeeping** (AC25)
+
+**Depends on:** none · **Mode:** goal-based · `no stub (gate)`
+Bookkeeping moves **first**, not last: `lint-spec-status.py`'s deferral-anchor
+invariant is status-independent and hard, so every `(deferred: <slug>)` in the
+spec must already resolve in `workspace.toml [backlog].open` or canonical 5 is
+red from here through T13. Add the queue entry under `["ini-002".work]` and **exactly** the
+`[backlog].open` slugs this spec's `(deferred: …)` anchors name — no more, no
+fewer. An anchor with no slug is a hard lint violation; a slug with no anchor is
+stale bookkeeping that exposes withdrawn work through backlog tooling. The
+current set is: `browser-state-lifetime`, `confluence-crawler-check-auto-login`, `insecure-warning-sibling-clis`, `lint-sso-config-profile-charset`, `nonjson-2xx-guard-all-read-paths`, `pack-config-catalogue-sso-defaults`, `sso-branch2-destination-attestation`, `sso-broker-at-rest-minimisation`, `sso-broker-register-concurrency`, `sso-cookie-lint-phrase-amendment`, `sso-destination-field-integrity`, `sso-live-browser-destination-derivation`, `sso-materialisation-ordering`, `sso-privilege-separated-config`, `sso-recapture-audit-sink`, `sso-recapture-cooldown`, `sso-register-pretooluse-hook`. Derive it, do not transcribe it:
+`grep -o '(deferred: [a-z0-9-]*)' spec.md | sort -u`.
+Then flip `spec.md` → `Implementing` and this plan → `Executing`, and run
+`loop-cohort approve-plan`. **Done when:** canonical 5 green (it now can be).
+
+### T1 — `credbroker.validate_sso_profile` (AC4)
+
+**Depends on:** none · **Mode:** TDD · `stub: true`
+```python
+def test_profile_grammar_rejects_newline():        # STUB: AC4
+    with pytest.raises(credbroker.SsoConfigError):
+        credbroker.validate_sso_profile("abc\n")   # re.match would accept this
+def test_profile_grammar_rejects_windows_device(): # STUB: AC4
+    for bad in ("CON", "con.toml", "NUL", "COM1"):
+        with pytest.raises(credbroker.SsoConfigError):
+            credbroker.validate_sso_profile(bad)
+def test_profile_grammar_rejects_non_str():        # STUB: AC4
+    with pytest.raises(credbroker.SsoConfigError):
+        credbroker.validate_sso_profile(5)
+def test_profile_grammar_accepts_ordinary():       # STUB: AC4
+    credbroker.validate_sso_profile("jira")
+```
+**Approach:** `re.fullmatch` + case-insensitive device-name denylist (stem
+compared, so `con.toml` is caught). **Done when:** canonical 1.
+
+### T2 — Cross-platform spawn helper (AC3)
+
+**Depends on:** none · **Mode:** TDD · `stub: true`
+```python
+def test_spawn_kills_process_tree(tmp_path):       # STUB: AC3
+    # fake broker forks a grandchild then sleeps past the timeout
+    cp = _spawn_broker([sys.executable, str(fake), "refresh", "p"],
+                       timeout=2, env_profile="browser", capture=False)
+    assert cp.returncode != 0
+    assert _no_survivors(pgid)                     # POSIX; skipped on Windows
+def test_probe_timeout_is_not_recoverable(tmp_path):       # STUB: AC3
+    raise NotImplementedError  # STUB: AC3 — fake get-cookies exceeds an injected short timeout ->
+         # SsoBrokerUnavailableError, exit 2, refresh_sso_session NEVER called
+def test_get_cookies_captures_stdout_but_not_stderr(tmp_path):  # STUB: AC3/F20
+    raise NotImplementedError  # STUB: AC3 — fake engine prints a jar path to stdout + a diagnostic to stderr;
+         # load_sso_cookies returns the path, the diagnostic stays visible
+def test_spawn_env_is_allowlisted(monkeypatch, tmp_path):  # STUB: AC3
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret-should-not-cross")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/etc/ssl/corp.pem")
+    env = _capture_child_env(tmp_path)
+    assert "JIRA_API_TOKEN" not in env
+    assert env["REQUESTS_CA_BUNDLE"] == "/etc/ssl/corp.pem"
+```
+**Approach:** `start_new_session=True`; `getattr(os, "killpg", None)` →
+SIGTERM/grace/SIGKILL on POSIX, `taskkill /T /F /PID` then
+`terminate()`/`kill()` on Windows; `_BROWSER_ENV_ALLOWLIST` split by platform.
+**Done when:** canonical 1 + 4 (mypy).
+
+### T3 — `refresh_sso_session` / `register_sso_session` + error taxonomy (AC1, AC2)
+
+**Depends on:** T1, T2, T5b · **Mode:** TDD · `stub: true`
+> Needs T5b: AC2 always passes `--ephemeral`, so the engine must accept it before
+> any real `register` invocation, or argparse rejects it.
+```python
+def test_per_operation_timeouts_match_ac3_table(fake_broker):  # STUB: AC3
+    raise NotImplementedError  # STUB: AC3 — assert the timeout each public
+                               # function passes: register 540 s, refresh 180 s,
+                               # load_sso_cookies 30 s. Lives here because T3 is
+                               # where all three callers exist.
+def test_refresh_argv_carries_no_destination(fake_broker):   # STUB: AC1
+    credbroker.refresh_sso_session("jira")
+    argv = fake_broker.last_argv
+    assert argv[-2:] == ["refresh", "jira"]
+    assert not any(a.startswith("--") for a in argv)
+def test_refresh_signature_has_no_destination_param():       # STUB: AC1
+    params = set(inspect.signature(credbroker.refresh_sso_session).parameters)
+    assert params == {"profile"}
+def test_exit4_is_not_registered(fake_broker):               # STUB: AC1
+    fake_broker.exit_code = 4
+    with pytest.raises(credbroker.SsoProfileNotRegisteredError):
+        raise NotImplementedError  # STUB: AC1
+@pytest.mark.parametrize("verb", ["refresh", "register"])
+def test_exit3_is_generic_failure(fake_broker, verb):        # STUB: AC1
+    #  drives the matching public function: refresh_sso_session / register_sso_session
+    fake_broker.exit_code = 3          # playwright absent / sign-in incomplete
+    with pytest.raises(credbroker.SsoRecaptureFailedError):
+        raise NotImplementedError  # STUB: AC1
+def test_exit5_maps_to_interaction_required(fake_broker):         # STUB: AC14a
+    fake_broker.exit_code = 5
+    with pytest.raises(credbroker.SsoInteractionRequiredError):
+        raise NotImplementedError  # STUB: AC14a
+def test_timeout_is_broker_unavailable(fake_broker):         # STUB: AC1
+    with pytest.raises(credbroker.SsoBrokerUnavailableError):
+        raise NotImplementedError  # STUB: AC1
+```
+**Done when:** canonical 1 + 4.
+
+### T4 — `load_sso_cookies` validates (AC5)
+
+**Depends on:** T1 · **Mode:** TDD · `stub: true`
+```python
+def test_load_sso_cookies_validates_profile():     # STUB: AC5
+    with pytest.raises(credbroker.SsoConfigError):
+        credbroker.load_sso_cookies("../../../../tmp/pwn")
+```
+**Done when:** canonical 1.
+
+### T5 — Engine: grammar guard, containment, `rm` carve-out (AC6, AC7, AC8, AC9)
+
+**Depends on:** none · **Mode:** TDD · `stub: true`
+```python
+@pytest.mark.parametrize("verb", ["register", "get-cookies", "test", "refresh"])
+@pytest.mark.parametrize("bad", ["../../../../tmp/pwn", "abc\n", "abc\r\n",
+                                 "x"*65, "café", "", ".", "..", "CON", "con.toml"])
+def test_profile_rejected_per_verb(broker, verb, bad, capsys):   # STUB: AC6/AC9
+    mod, _ = broker
+    assert mod.main([verb, bad]) == 3
+    assert "profile" in capsys.readouterr().err.lower()   # exit code alone is already green today
+def test_flag_shaped_via_double_dash_reaches_guard(broker):      # STUB: AC9
+    mod, _ = broker
+    assert mod.main(["get-cookies", "--", "-x"]) == 3            # `--` escape parses -x as the positional
+def test_bare_flag_is_argparse_exit(broker):                     # STUB: AC9
+    mod, _ = broker
+    with pytest.raises(SystemExit) as e: mod.main(["get-cookies", "-x"])
+    assert e.value.code == 2
+def test_rm_still_deletes_legacy_invalid_name(broker):           # STUB: AC8
+    mod, _ = broker
+    _seed_profile(mod, "legacy name")               # pre-change, grammar-invalid
+    assert mod.main(["rm", "legacy name"]) == 0
+    assert not mod._profile_path("legacy name").exists()   # rc==0 alone is green today
+    assert not mod._cookie_floor_path("legacy name").exists()
+```
+**Approach:** `_require_valid_profile` at each verb dispatch + resolved-parent
+containment assertion; `rm` gets containment only. **Done when:** canonical 1.
+
+### T6 — Engine: unconditional re-materialisation + exit 4 (AC6a, AC6b)
+
+**Depends on:** none · **Mode:** TDD · `stub: true`
+```python
+def test_write_uses_unique_temp_name(broker, tmp_path):          # STUB: AC6a
+    mod, _ = broker
+    raise NotImplementedError  # STUB: AC6a — two writes must use distinct *.tmp
+                               # names (pid+random), and leave none behind
+def test_get_cookies_rewrites_stale_materialised_jar(broker):    # STUB: AC6a
+    _store(broker, "jira", b'[{"name":"old"}]'); p1 = _get_cookies(broker, "jira")
+    _store(broker, "jira", b'[{"name":"new"}]'); p2 = _get_cookies(broker, "jira")
+    assert p1 == p2                                  # same path…
+    assert b"new" in p2.read_bytes()                 # …fresh bytes (fails today)
+def test_refresh_unregistered_returns_4(broker):                 # STUB: AC6b
+    mod, _ = broker
+    assert mod.main(["refresh", "never-registered"]) == 4
+
+
+```
+Run under **both** a keychain-backed and a file-floor-backed store — the bug is
+invisible on the file-floor (Linux/CI) path.
+**Approach:** drop the `if not materialised.exists()` guard; write via a
+**unique** temp name (pid + random suffix, not the shared `<profile>.jar.tmp`);
+use a **unique** temp name (pid + random suffix), removing the shared-path
+collision. Ordering between concurrent materialisers is **not** specified —
+see AC6a and `sso-materialisation-ordering`;
+`_do_refresh` returns 4 for `FileNotFoundError`. **Done when:** canonical 1.
+
+### T5b — Engine capture split + `refresh` argument rejection (AC35 engine half)
+
+**Depends on:** T6 · **Mode:** TDD · `stub: true`
+Split `_do_register` into `_capture(profile, args, *, persist, headless)`; add
+`--ephemeral` to the `register` verb (default `persist=True`); make `refresh`
+launch **`headless=True`** with a bounded **20 s** silent-completion window and
+return exit **`5`** when a login page is still displayed at the end of it (AC14a).
+`refresh`'s spawn timeout is **180 s** per AC3's per-operation table, not the
+540 s `register` bound — that code is what makes AC14a
+implementable, since an abort rule alone has no state in which the engine can
+report "needs a human" before a window is on screen; and make `refresh` reject
+every connection argument with exit 3. Serialises with T5/T6 on `sso-broker.py`.
+AC32's derivation stays in T11.
+
+> **T11b is the single regeneration point before the drift-gated tasks, and the
+> ordering is enforced by the dependency graph, not by this note.** T11b depends
+> on T4/T5/T5b/T6/T11 — every projection-source edit — and T12, T13 and T14a all
+> depend on T11b, so T14a's bump-regeneration necessarily follows it and T15
+> regenerates only the version-bump artifacts. No task before T11b runs
+> `make build-self`. **From T5 through T11, projection-source tasks substitute two
+> explicit commands** for canonical 1 and 4, because the projected copy is stale until
+> T11b regenerates it:
+> `cd packages/credbroker && python -m pytest -k 'source or not projected'`
+> — the `-k` filter must keep the non-parametrised suites (`test_sso_recapture.py`,
+> `test_sso_derivation.py`), which a bare `-k source` would silently drop — and
+> `SKIP_SAST=1 make lint-ruff && python3 tools/lint-mypy.py` (no `build-check`,
+> so no drift gate). **This substitution applies to T1–T4 as well**, not only the
+> engine tasks: T4 edits `credbroker`, whose vendored projections
+> (`.agentbundle/lib/credbroker/`, the pack copy) are drift-gated, so any task
+> after it that ran plain `build-check` before T11b would fail on that drift. T11b runs `make build-self` and from there every task uses
+> the unmodified canonical commands. The
+> `broker` fixture parametrises over the pack source *and* the generated
+> `.agentbundle/bin/` copy, and no task regenerates that copy before T11b — T14a
+> now depends on T11b — so the projected arm is stale only for T5 through T11.
+> From T11b onward every task, including T12/T13/T14a/T15, runs the full
+> source-plus-projected suite.
+```python
+def test_register_capture_is_ephemeral_then_seeds(broker):   # STUB: AC35
+    mod, _ = broker
+    calls = _record_playwright(mod)
+    mod.main(["register", "jira", "--ephemeral", "--login-url", "https://idp.example",
+              "--success-url-pattern", "https://jira.example/x"])
+    # capture must NOT use the persistent profile...
+    assert calls.capture.kind == "ephemeral"
+    assert calls.capture.headless is False        # interactive capture is HEADED
+    # ...but a second, headless persistent launch must seed it (AC35), so
+    # asserting launch_persistent_context is never called would reject a
+    # correct implementation.
+    assert calls.seed.kind == "persistent" and calls.seed.headless
+    assert calls.seed.user_data_dir.endswith("browser-state/jira")
+    assert calls.seed.add_cookies_called
+@pytest.mark.parametrize("verb,persist,headless", [
+    (["register", "jira"], True, False),                    # operator default
+    (["register", "jira", "--ephemeral"], False, False),     # register_sso_session
+    (["refresh", "jira"], True, True),                       # AC14a
+])
+def test_capture_mode_matrix(broker, verb, persist, headless):   # STUB: AC35
+    mod, _ = broker
+    raise NotImplementedError  # STUB: AC35 — pin all four rows of AC35's matrix
+                               # (the seeding launch is asserted above)
+@pytest.mark.parametrize("bad", ['a"b', "a" + chr(92) + "b", f"a{chr(1)}b", f"a{chr(0x7f)}b"])
+@pytest.mark.parametrize("field", ["login_url", "cookie_domains"])  # scalar AND list-valued
+def test_write_profile_rejects_toml_breaking_chars(broker, bad, field):  # STUB: AC6
+    raise NotImplementedError  # STUB: AC6 — reject or escape; then tomllib round-trips
+def test_refresh_silent_redirect_within_window_succeeds(broker):  # STUB: AC14a
+    mod, _ = broker
+    raise NotImplementedError  # STUB: AC14a — delayed unaided redirect inside 20 s -> 0
+def test_refresh_login_page_returns_5_and_closes(broker):         # STUB: AC14a
+    mod, _ = broker
+    raise NotImplementedError  # STUB: AC14a — login page still shown -> exit 5,
+                               # headless context closed, no browser left behind
+def test_refresh_rejects_login_url(broker):             # STUB: AC35
+    mod, _ = broker
+    assert mod.main(["refresh", "p", "--login-url", "https://evil.example"]) == 3
+```
+**Done when:** canonical 1.
+
+### T7 — Grammar parity test (AC10)
+
+**Depends on:** T1, T5 · **Mode:** TDD · `stub: true`
+```python
+def test_grammar_literal_matches_engine():         # STUB: AC10
+    assert _extract_pattern(BROKER_PY) == credbroker._sso._PROFILE_RE.pattern
+    assert _extract_denylist(BROKER_PY) == credbroker._sso._RESERVED_DEVICE_NAMES
+```
+**Done when:** canonical 1.
+
+### T8 — `_client.py`: typed discriminator + jar guards (AC11, AC12)
+
+**Depends on:** none · **Mode:** TDD · `stub: true`
+```python
+def test_session_unavailable_is_subclass_of_autherror():   # STUB: AC11
+    assert issubclass(SsoSessionUnavailable, AuthError)    # keeps exit band intact
+def test_403_is_not_session_unavailable():
+    raise NotImplementedError  # STUB: AC11
+def test_config_error_is_not_session_unavailable():
+    raise NotImplementedError  # STUB: AC11
+def test_401_on_cookie_path_is_session_unavailable():
+    raise NotImplementedError  # STUB: AC11
+def test_2xx_non_json_is_session_unavailable():
+    raise NotImplementedError  # STUB: AC11 site 4
+@pytest.mark.parametrize("field", ["displayName","name","emailAddress","key","accountId"])
+def test_identity_field_accepted_no_recapture(field):        # STUB: AC11 site 5
+    raise NotImplementedError  # STUB: AC11 — each must NOT raise and must NOT print "as ?" — pins raise site == _cmd_check set
+@pytest.mark.parametrize("body", [{"displayName": None}, {"name": ""}, {"key": 7}])
+def test_present_but_unusable_identity_is_session_unavailable(body):  # STUB: AC11 site 5
+    raise NotImplementedError  # STUB: AC11 — presence is not enough; selector is first NON-EMPTY str
+def test_falls_through_to_later_usable_field():                       # STUB: AC11 site 5
+    raise NotImplementedError  # STUB: AC11 — {"displayName": None, "accountId": "abc"} passes and displays "abc"
+def test_2xx_json_without_identity_is_session_unavailable():  # STUB: AC11 site 5
+    raise NotImplementedError  # STUB: AC11 — {"errorMessages": [...]} must NOT yield `ok: … as ?` / exit 0
+def test_corrupt_jar_is_session_unavailable():
+    raise NotImplementedError  # STUB: AC12
+def test_wrong_shape_jar_is_session_unavailable():
+    raise NotImplementedError  # STUB: AC12
+@pytest.mark.parametrize("bad", [{"domain": 1}, {"name": None}, {"path": 7}])
+def test_bad_cookie_record_field_is_session_unavailable(bad):  # STUB: AC12
+    raise NotImplementedError  # STUB: AC12 — each must raise SsoSessionUnavailable -> exit 2, never TypeError/exit 1
+def test_jar_error_message_does_not_interpolate_exc():     # STUB: AC12
+    raise NotImplementedError  # STUB: AC12 — a UnicodeDecodeError quotes cookie bytes; message must be fixed text
+```
+**Done when:** canonical 2 (incl. `test_exit_codes.py`).
+
+### T9 — `_sso_config.py` + `setup_sso.py`, both skills (AC20, AC2 consumer side)
+
+**Depends on:** T1, T3 · **Mode:** TDD · `stub: true`
+```python
+def test_profile_validated_before_str_coercion():  # STUB: AC20
+    cfg = _write_cfg(profile=5)                    # int, not str
+    with pytest.raises(SsoConfigError): load_sso_config(cfg)   # not TypeError
+def test_ttl_hint_minutes_must_be_int():
+    raise NotImplementedError  # STUB: AC20
+@pytest.mark.parametrize("bad", ['a"b', "a" + chr(92) + "b", f"a{chr(1)}b", f"a{chr(0x7f)}b"])
+@pytest.mark.parametrize("field", ["profile", "base_url", "login_url",
+                                   "success_url_pattern", "validation_endpoint",
+                                   "session_filename", "cookie_domains"])
+def test_control_chars_rejected_in_every_sso_field(field, bad):  # STUB: AC20
+    raise NotImplementedError  # STUB: AC20 — urlsplit() strips CR/LF, so validate_https_url cannot see them
+def test_setup_sso_uses_credbroker(monkeypatch):   # STUB: AC2
+    raise NotImplementedError  # STUB: AC2 — no subprocess / no broker-path resolution left in the skill
+```
+Copy both files verbatim into `confluence-crawler/scripts/`.
+**Done when:** canonical 2 + 3.
+
+### T10 — `jira.py`: routing, probe, recovery, `--register`, `--insecure`, version floor (AC13–AC20, AC30, AC31)
+
+**Depends on:** T3, T8, T9 · **Mode:** TDD · `stub: true`
+```python
+def test_automatic_path_aborts_rather_than_showing_login_page():  # STUB: AC14a
+    raise NotImplementedError  # STUB: AC14a — engine returns 5; check exits 2 with the
+                               # `check --register` remediation and NO login page
+def test_expired_session_refreshes_then_retries():
+    raise NotImplementedError  # STUB: AC14
+def test_refresh_called_with_profile_only():
+    raise NotImplementedError  # STUB: AC1/AC14
+def test_unregistered_names_check_register():
+    raise NotImplementedError  # STUB: AC14
+def test_403_does_not_recapture():
+    raise NotImplementedError  # STUB: AC11/AC19
+def test_recapture_invoked_at_most_once():
+    raise NotImplementedError  # STUB: AC17
+def test_non_check_subcommand_never_recaptures():
+    raise NotImplementedError  # STUB: AC19/AC31
+def test_probe_does_not_route_through_cmd_check():          # STUB: AC13
+    raise NotImplementedError  # STUB: AC13 — _cmd_check catches AuthError and returns int — would swallow the subclass
+def test_register_flag_discloses_host_on_stderr():
+    raise NotImplementedError  # STUB: AC15/AC16
+def test_bare_check_never_registers():
+    raise NotImplementedError  # STUB: AC15
+def test_insecure_warns_on_token_path():
+    raise NotImplementedError  # STUB: AC18
+def test_insecure_warns_ignored_on_sso_path():
+    raise NotImplementedError  # STUB: AC18
+def test_old_credbroker_exits_2_with_upgrade_hint():
+    raise NotImplementedError  # STUB: AC30
+def test_nothing_written_to_stdout_before_retry():
+    raise NotImplementedError  # STUB: AC16
+```
+Import via `sys.path.insert(0, <skill root>)` + `import scripts.jira`; reach
+every symbol through `scripts.*`; drive the SSO path via
+`scripts._sso_config._DEFAULT_CONFIG_PATH`; stub the two credbroker verbs at the
+`scripts.jira` binding. **Done when:** canonical 2 + 4.
+
+### T11 — Destination attestation + ephemeral register context (AC32, AC35)
+
+**Depends on:** T3, T5, T6, T10 · **Mode:** TDD · `stub: true`
+> Serialises against T5/T6 — all three edit `sso-broker.py`, and T11 refactors the
+> function they patch. Engine stubs take the `(mod, backend)` fixture.
+```python
+def test_derives_login_host_from_login_jsp(fake_jira):        # STUB: AC32
+    fake_jira.route("/login.jsp", status=302,
+                    location="https://idp.corp.example.com/authorize?state=abc")
+    assert _derive_login_host(fake_jira.base_url) == "https://idp.corp.example.com"
+def test_register_refuses_on_host_mismatch(fake_jira, capsys):  # STUB: AC32
+    fake_jira.route("/login.jsp", status=302,
+                    location="https://attacker.example.com/authorize")
+    rc = _cmd_check_sso(cfg_with_login_url("https://idp.corp.example.com/login"),
+                        register=True)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "idp.corp.example.com" in err and "attacker.example.com" in err
+    assert register_stub.call_count == 0        # no browser
+def test_cannot_derive_refuses_and_names_setup_sso(fake_jira):  # STUB: AC32
+    fake_jira.route("/login.jsp", status=200)   # SSO-with-fallback mode
+    assert _cmd_check_sso(cfg, register=True) == 2
+    assert register_stub.call_count == 0        # never falls back to the config value
+# AC35's capture/seed assertions live in T5b's
+# test_register_capture_is_ephemeral_then_seeds — not duplicated here.
+```
+Derivation is a plain unauthenticated GET with `follow_redirects=False` and no
+cookies — it must not reuse the SSO client. Compare **scheme+host only**; the
+query carries per-request `state` / `SAMLRequest`. `derive_sso_destination` is a
+**credbroker** function, bounded per AC32 (https-only, no redirects, 5 s/5 s,
+≤15 s total, 64 KiB cap, strict TLS, no auth headers).
+**Done when:** canonical 1 + 2 + 4.
+
+### T11b — Regenerate projections (before any drift-gated task)
+
+**Depends on:** T4, T5, T5b, T6, T11 · **Mode:** goal-based · `no stub (goal-based)`
+All projection-source edits are done by here, so run `make build-self` to bring
+`.agentbundle/bin/sso-broker.py` and the `.agentbundle/lib/credbroker/` +
+`packs/credential-brokers/.apm/user-libs/credbroker/` copies back in sync. T12
+and T13 both require canonical 4, which runs the drift gate, so regeneration
+must precede them; T15's regeneration then handles only the version-bump
+artifacts. From here the engine suites run **both** fixture arms again.
+**Done when:** `git status` clean after `build-self`; canonical 1 + 4.
+
+### T12 — CI wiring (AC26, AC27)
+
+**Depends on:** T6, T10, T11b · **Mode:** goal-based · `no stub (goal-based)`
+Add `test_check_sso_login.py` to `build-check.yml` and `self_host_windows.py`;
+add `packages/credbroker`'s suite to `self_host_windows.py` so the Windows kill
+arm is exercised on Windows. **Done when:** grep shows all three entries;
+canonical 4.
+
+### T13 — Docs (AC21–AC24)
+
+**Depends on:** T10, T11, T11b · **Mode:** goal-based · `no stub (goal-based)`
+SKILL.md carve-out as additive prose beside the pinned clause; `login_url`
+pre-flight rule; exit-table split; invocation budget; negative eval extended to
+`setup_sso.py`; how-to; reference guide; changelog; reconcile
+`credentials.md` with shipped behaviour and drop its "planned" note.
+**Done when:** all pinned phrases still pass `make build-check`; canonical 4 + 5.
+
+### T14a — Bump `credential-brokers` first (AC29 exception)
+
+**Depends on:** T11b · **Mode:** goal-based · `no stub (goal-based)`
+T14 declares `atlassian → ^0.3`, unsatisfiable while the pack ships `0.2.2`, and
+`verify.py`'s dependency step is a pass-through so nothing would catch it. Bump
+`[pack].version` **and** `.claude-plugin/plugin.json` together —
+`lint.py:1252-1258` (CAT_L009, ERROR) fails on a mismatch — **then run
+`make build-self`**, because `.claude-plugin/marketplace.json` carries the pack
+version and is drift-gated by the same `make build-check` this task's done-when
+runs. A bump without regeneration reddens canonical 4 for every later task. This pack is then **removed from
+T15's list**; AC29 carries the one-line exception.
+**Done when:** canonical 4.
+
+### T14 — Pack dependency declarations (AC33)
+
+**Depends on:** T14a · **Mode:** goal-based · `no stub (goal-based)`
+
+Add `[[pack.dependencies.required]]` on `credential-brokers` to `atlassian`
+(`^0.3`), `figma` (`^0.2`) and `linear` (`^0.2`). **Done when:** a fixture
+install of each pack without `credential-brokers` present fails the gate with a
+message naming it; a fixture install **with** `credential-brokers` at `0.3.0`
+succeeds for all three; canonical 4.
+
+### T15 — Version bumps + regeneration (AC29) — **last**
+
+**Depends on:** T11, T12, T13, T14 · **Mode:** goal-based · `no stub (goal-based)`
+`credbroker` → 0.5.0 in **both** `pyproject.toml` `[project].version` **and**
+`credbroker/__init__.py`'s `__version__`, plus the version assertion in
+`tests/unit/test_sso_resolver.py` — all three carry 0.4.1 today, and the package
+suite (canonical 1) runs **after** the bump so the drift is caught; and each of
+`packs/atlassian` → 0.8.0,
+`packs/figma` → 0.3.0, `packs/linear` → 0.2.0 — **`pack.toml` `[pack].version`
+plus that pack's `.claude-plugin/plugin.json`**, since `lint.py:1252-1258`
+(CAT_L009, ERROR) fails on a mismatch. `figma` and `linear` bump because T14
+changes their published contents (the `[[pack.dependencies.required]]` block),
+so leaving their versions stale ships changed packs under old numbers.
+`packs/credential-brokers` is **not** here — T14a already bumped it, and owning
+it twice is the contradiction AC29's exception line records. Then
+`make build-self`. **Done when:** `git status` clean after `build-self`;
+canonical **1** and 4; `[pack.adapter-contract]` unchanged; all five AC29 versions and
+their `plugin.json` files agree; and the engine suites pass on **both** fixture
+arms (source and projected) now that regeneration is final.
+
+## Rollout
+
+One PR. Releases `credbroker` 0.5.0 to PyPI and **four** packs through the
+marketplace aggregate — `atlassian` 0.8.0, `credential-brokers` 0.3.0,
+`figma` 0.3.0 and `linear` 0.2.0 — (`.apm` packs do not publish to PyPI — the bump PR *is*
+the release). No feature flag: the token path is inert, and the SSO-cookie path
+is dark until an enterprise pre-bakes `sso-config.toml`. Rollback is a revert; no
+migration and no new persisted state. **Upgrade-time refusal:** AC33's install
+gate turns a missing `credential-brokers` pack into an install failure for
+`atlassian` / `figma` / `linear`; the gate message names
+`agentbundle install credential-brokers --scope user` as the fix.
+
+Behaviour changes to watch after release: `refresh` is now headless with a 20 s
+silent-completion window and a new exit `5`, so a refresh that previously
+prompted fails fast; the engine rejects `profile` values it
+previously accepted and returns `4` where it returned `3`; `confluence-crawler`'s
+registration inherits the new spawn bounds and its loader rejects configs it
+previously accepted.
+
+## Risks
+
+- **The engine bug is the whole feature.** If AC6a regresses, recovery silently
+  no-ops on macOS/Windows and CI stays green. T6's dual-store test is the guard;
+  do not let it degrade to file-floor-only.
+- **Exit-code change is a contract change.** Any other caller reading `3` as
+  "not registered" breaks. T6 must re-read the existing engine assertions.
+- **The typed subclass could over-narrow** — five sites now; tests assert each
+  individually rather than asserting "recovery works".
+- **Parity lint half-satisfied** — a one-sided edit fails at GATES, not at edit
+  time. T9 ends with canonical 3.
+- **Windows arms unverified** until T12's parity run — `taskkill` and the
+  device-name behaviour are reasoned, not executed.
+
+## Changelog
+
+- 2026-08-05 — drafted (Shape A).
+- 2026-08-05 — rewritten onto Shape D (recapture in `credbroker`) after the
+  architect pass (5 spikes) and the design review's MAJOR REWRITE verdict;
+  absorbs AC6a/AC6b (engine re-materialisation + exit 4), AC11 site 5,
+  AC30–AC32, and the `packs/credential-brokers` bump reversal.

--- a/docs/specs/jira-check-sso-auto-login/spec.md
+++ b/docs/specs/jira-check-sso-auto-login/spec.md
@@ -1,0 +1,1215 @@
+# Spec: jira-check-sso-auto-login
+
+- **Status:** Approved
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](./plan.md)
+- **Constrained by:** [RFC-0035](../../rfc/0035-sso-cookie-auth-for-atlassian-pack.md) — pins the dual-auth selector and the fail-closed no-downgrade rule; [ADR-0026](../../adr/0026-sso-consumer-resolution-in-credbroker.md) — places SSO consumer resolution in `credbroker`, which this spec extends from resolution-only to resolution-plus-recapture.
+- **Architecture:** [`docs/architecture/credentials.md § The `sso-cookie` broker`](../../architecture/credentials.md#the-sso-cookie-broker) — the engine/library split, the consumer API, destination pinning, the profile grammar, and the auto-recovery contract live there. This spec does not restate them; it implements them.
+- **Contract:** none
+- **Brief:** none
+- **Shape:** integration
+
+Mode: full (risk triggers: **security boundary** — auth, secrets, subprocess invocation on the credential path; **public-interface change** — new `credbroker` API)
+
+> **Spec contract:** this document defines what "done" means. The implementing PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+`jira.py check` on the SSO-cookie path re-establishes an **expired** session
+without a second operator command, and `check --register` establishes a new one
+in a single command.
+
+The recapture operation lands in `credbroker`, per the architecture page's
+engine/library split. `jira.py` never resolves a broker path, builds an argv, or
+calls `subprocess`. Three consequences follow, and they are the reason for the
+placement:
+
+- **Destination pinning is structural — against implementer error, not malice.**
+  `refresh_sso_session(profile)` takes no destination parameter, so no *caller*
+  can choose where the browser goes; that is enforced by the signature rather
+  than by a rule an implementer can forget. It does **not** stop a hostile
+  same-principal process editing `~/.agentbundle/sso-profiles/<profile>.toml`,
+  which `_do_refresh` reads before launching. Per the accepted profile that is
+  conceded, not defended — see AC15 for the one exposure that is.
+- **The cross-platform parts are written once.** Timeout, process-tree kill, and
+  environment composition are where POSIX and Windows diverge. In `credbroker`
+  they are type-checked by `tools/lint-mypy.py` and exercised by CI; in a skill
+  script they would be neither, and would be copy-pasted into the next consumer.
+- **One broker-path resolver.** The probe path already resolves the broker via
+  `credbroker._sso._broker_path()` (`_client.py:204` → `_sso.py:100`).
+
+First-run establishment stays an explicit human act but costs **one** command:
+`check --register`. It is the ordinary first-run path and the **only** one that
+attests the destination (AC32). Bare `check` never registers. `setup_sso.py`
+remains, limited to exactly two cases — scripted pre-bake, and the AC32
+mismatch / cannot-derive escape where attestation is unavailable — because
+routing an ordinary first run through it would bypass attestation even when
+derivation would have succeeded.
+
+Recovery is keyed to a **typed** session-unavailable signal, not the collapsed
+`AuthError`.
+
+### Why automating this refresh does not weaken the "user runs it themselves" rule
+
+The rule — retained verbatim because `catalogue_tooling/lint.py:458` pins it,
+see AC21 — guards `credential-setup`, which reads a **secret on stdin**: a token
+typed into a prompt the agent owns is a token the agent can observe. The
+automated refresh passes no secret through the agent's stdio and no cookie value
+through argv.
+
+An earlier draft justified safety by claiming the browser's URL bar is the
+operator's confirmation surface. **That claim is false and is not used here.**
+`_do_register` launches with
+`launch_persistent_context(user_data_dir=~/.agentbundle/browser-state/<profile>)`,
+so on every run after the first the Chromium profile still holds the IdP
+session: `page.goto` auto-SSOs, the success pattern matches inside the first
+500 ms poll, and the window opens and closes sub-second with nothing for a human
+to read. Safety rests on destination pinning instead.
+
+## Boundaries
+
+### Always do
+
+- Perform recapture through `credbroker`, never by spawning the broker from a skill.
+- Key recovery on the typed session-unavailable signal, never on a bare `AuthError`.
+- Validate `[sso].profile` before it reaches argv, and again inside the engine before it reaches a path.
+- Assert resolved-path containment inside the engine, not just grammar.
+- Bound every broker spawn and kill its whole process tree on both platforms.
+- Emit a stderr warning whenever `--insecure` fires or is ignored.
+- Keep the lint-pinned SKILL.md security phrases byte-identical.
+
+### Ask first
+
+- Widening auto-recovery beyond `check`.
+- Adding any CLI flag to `check`.
+- Relaxing the profile grammar.
+- Calling `register_sso_session` from any path that is not explicitly operator-invoked.
+
+### Never do
+
+- Resolve the broker path, build a broker argv, or call `subprocess` from any skill script.
+- Invoke recapture from any `jira.py` path other than `check`, or more than once per process.
+- Give `refresh_sso_session` a parameter that could carry a sign-in destination.
+- Forward a cookie value, a jar path, or `--insecure` to the broker from any path.
+- Interpolate an exception's `str()` into a message on the jar path — it may carry cookie bytes.
+- Write a human-facing notice to **stdout** on any subcommand.
+- Edit `.claude-plugin/marketplace.json`, `.agentbundle/bin/sso-broker.py`, or `.agentbundle/lib/credbroker/` by hand — all are generated.
+- Read, print, or echo the cookie jar's contents.
+
+## Boundaries — scope
+
+**In scope**
+
+- `credbroker` 0.4.1 → 0.5.0: `refresh_sso_session`, `register_sso_session`,
+  `validate_sso_profile`, `derive_sso_destination`, and the cross-platform spawn
+  helper behind them.
+- `jira` skill: `check` auto-recovery, `setup_sso.py`, the typed
+  discriminator, and the token path's missing `--insecure` warning (a live
+  `docs/CONVENTIONS.md:1197,1214` violation in a file this change already edits).
+- `sso-broker.py`: independent profile guard plus path containment.
+- `packages/agentbundle`: add `packages/credbroker`'s suite to the Windows
+  parity list. This is the **only** agentbundle change, and it is warranted
+  because Shape D puts the cross-platform kill logic in credbroker, whose tests
+  run Linux-only today (`self_host_windows.py` lists agentbundle suites and the
+  two skill script dirs, not credbroker). No agentbundle version bump — the
+  single prior commit touching that file did not bump either.
+- `confluence-crawler`: the byte-parity mirror of the shared files
+  `tools/test-lint-sso-config.py` pins — which **does** carry behaviour. AC2
+  refactors `setup_sso.py` onto `register_sso_session`, so that skill's
+  registration gains the AC3 timeout, composed environment and tree-kill; AC20
+  adds control-character and `ttl_hint_minutes` validation, so its loader begins
+  rejecting configs it accepts today. Both are named in the atlassian changelog
+  entry. Its `test_sso_config.py` must pass unchanged after the mirror;
+  `test_setup_sso.py` **cannot** — all four of its tests bind symbols AC2
+  removes (`setup_sso.build_register_argv`, `setup_sso._broker_path`,
+  `setup_sso.subprocess`), so it is rewritten against a stubbed
+  `credbroker.register_sso_session` and mirrored byte-identically. AC2 also
+  fixes `setup_sso.main()`'s exit mapping, which returns
+  `subprocess.run(...).returncode` today and must map the raised `Sso*Error`
+  types onto the same `0` / `2` contract its tests assert.
+- `docs/architecture/credentials.md`: the `sso-cookie` broker section this spec
+  implements against (landed with this change; it was the one broker of four
+  with no section).
+
+**Out of scope**
+
+- The token path's credential resolution; every `jira.py` subcommand but `check`.
+- `confluence-crawler`'s `check` auto-recovery. See *Deferred*.
+- `tools/lint-sso-config.py` — a build-time grammar copy would be a further drift site.
+- Sourcing `auth_default` / `base_url` from `catalogue.toml`. See *Deferred*.
+**Reopened by AC6a/AC6b — `packs/credential-brokers` 0.2.2 → 0.3.0.** The
+earlier decision not to bump rested on precedent for *crash fixes*
+(7 of the last 8 `sso-broker.py` commits, including `81d53097`, did not bump).
+AC6b changes an **exit code** — `3` → `4` for not-registered-on-refresh — which
+is a contract change any other caller of the engine can observe, and AC6a
+changes what `get-cookies` writes. That is categorically different from a crash
+fix, so the pack bumps and the change is named in the changelog.
+
+## Acceptance Criteria
+
+### `credbroker` — the recapture API
+
+- [ ] **AC1 (`refresh_sso_session`).** `credbroker.refresh_sso_session(profile)`
+      resolves the broker via the module's existing `_broker_path()`, validates
+      *profile* per AC4, and runs `sso-broker refresh <profile>` with **no**
+      connection arguments. Its signature accepts no destination parameter.
+      Exit-code mapping: `0` → return; **`4`** → `SsoProfileNotRegisteredError`
+      (new, subclassing the existing `SsoSessionUnavailableError` so current
+      handlers still catch it); `refresh` exit `3` or unknown →
+      `SsoRecaptureFailedError`; timeout or spawn failure →
+      `SsoBrokerUnavailableError`; broker absent → the existing
+      `SsoBrokerNotInstalledError`. The full per-verb mapping is the table
+      below — exit `3` is **not** assigned two types; its meaning is
+      verb-dependent.
+
+      **The engine-exit taxonomy is defined once, here, per verb, and every other
+      AC defers to this table rather than restating it.** Exit `3` is not
+      assigned two types: its meaning is verb-dependent.
+
+      | Verb | Engine result | credbroker raises | Recoverable? |
+      |---|---|---|---|
+      | `get-cookies` | `2` (unregistered / no jar) | `SsoSessionUnavailableError` | **yes** |
+      | `get-cookies` | `3`, unknown, timeout, spawn failure | `SsoBrokerUnavailableError` | no |
+      | `refresh` | `4` (not registered) | `SsoProfileNotRegisteredError` | **yes** |
+      | `refresh` / `register` | `3`, unknown | `SsoRecaptureFailedError` | no |
+      | `refresh` | **`5`** — headless flow needs a human | `SsoInteractionRequiredError` | no |
+      | `refresh` / `register` | timeout, spawn failure | `SsoBrokerUnavailableError` | no |
+      | any | materialisation write failure | `SsoBrokerUnavailableError` | no |
+      | any | broker absent | `SsoBrokerNotInstalledError` | no |
+
+      Only the two rows marked recoverable reach AC11's recovery path. Without
+      that split, an internal broker or grammar failure would trigger a
+      browser recapture while the stored session is perfectly valid — the
+      behaviour AC3 exists to prevent. **`3` must not mean "not registered"**: the
+      engine returns it from ten distinct sites (verified), including
+      `_import_playwright` (playwright absent) and `_do_register`'s
+      success-pattern-not-matched — the *ordinary* "operator didn't finish
+      signing in" case. AC6a gives not-registered-on-refresh its own code. The
+      engine's stderr already reaches the operator via AC3's inherited stdio, so
+      `SsoRecaptureFailedError` surfaces that rather than substituting a guessed
+      remediation.
+
+- [ ] **AC2 (`register_sso_session`).** `credbroker.register_sso_session(profile,
+      *, login_url, success_url_pattern, cookie_domains, validation_endpoint,
+      session_filename=None, ttl_hint_minutes=None)` builds the `register` argv
+      and spawns it under **AC3's `register` bound**, always passing
+      **`--ephemeral`**. The engine's `register` keeps `persist=True` as its
+      default so a direct operator invocation is unaffected; `--ephemeral` is the
+      opt-in and `register_sso_session` is its only user. It is the **only**
+      function accepting a destination. No cookie value, cookie name, jar path, or
+      `Cookie:`-header shape may appear in the argv it constructs. `setup_sso.py`
+      is refactored onto it, so `build_register_argv` and the duplicate
+      `_broker_path` leave the skill scripts entirely.
+
+- [ ] **AC3 (bounded spawn, process tree killed, both platforms).** Both
+      functions spawn through one shared helper that:
+      - applies a **per-operation** wall-clock timeout — there is no single value
+        for "both functions", because their worst cases differ by an order of
+        magnitude:
+
+        | Operation | Timeout | Derivation |
+        |---|---|---|
+        | `register` (incl. `--ephemeral`) | **540 s** | 300 s sign-in poll + 30 s `page.goto` + ~90 s import/launch + ~60 s AC35 seeding launch + 60 s margin |
+        | `refresh` | **180 s** | ~90 s import/launch + 30 s `page.goto` navigation + AC14a's 20 s silent-completion window + 10 s context cleanup + 30 s margin — **no** sign-in poll |
+        | `get-cookies` | **30 s** | keychain unlock + read; see the probe note below |
+
+        The `register` derivation, spelled out:
+        300 s sign-in poll + 30 s default `page.goto` navigation + ~90 s for
+        `_import_playwright()` and `launch_persistent_context(headless=False)`
+        on a cold browser cache = 420 s; **plus ~60 s for AC35's second, headless
+        persistent launch and cookie seeding**, which happens *after* the poll
+        and was not in the original sum; plus a 60 s margin so the parent's
+        tree-kill does not race the engine's clean exit = **540 s**. Re-derive if
+        any component changes;
+      - passes `start_new_session=True` and, on timeout or `KeyboardInterrupt`,
+        kills the whole tree following the repo's established pattern at
+        `workspace_mcp.py:1069-1092` — `getattr(os, "killpg", None)`, SIGTERM →
+        bounded grace → SIGKILL on POSIX; on Windows (`os.killpg` absent)
+        `taskkill /T /F /PID` first, falling back to `proc.terminate()` then
+        `proc.kill()`. Without the tree kill, playwright's Chromium survives
+        holding a live corporate session and the `browser-state/<profile>` lock;
+      - passes an explicitly composed environment from a named
+        `_BROWSER_ENV_ALLOWLIST` constant, never a bare `os.environ`, so a headed
+        browser spawned from an agent session cannot inherit `JIRA_API_TOKEN` or
+        unrelated provider keys. The allowlist is enumerated in code and split by
+        platform, and must include — beyond the obvious `HTTP_PROXY` /
+        `HTTPS_PROXY` / `NO_PROXY` / `SSL_CERT_FILE` / `SSL_CERT_DIR` —
+        **`REQUESTS_CA_BUNDLE`** (`docs/CONVENTIONS.md:1210`, two lines from the
+        `:1214` AC18 cites), the **lowercase** `http_proxy` / `https_proxy` /
+        `no_proxy` forms Chromium and curl read, **`NODE_EXTRA_CA_CERTS`** (where
+        a corporate MITM CA must land for playwright's Node driver),
+        `PLAYWRIGHT_BROWSERS_PATH`, `PATH`, the platform home variables, the
+        POSIX display/session variables, and on Windows the minimum set without
+        which Chromium and CPython's TLS init fail to start (`SYSTEMROOT`,
+        `SYSTEMDRIVE`, `TEMP`, `TMP`, `APPDATA`, `LOCALAPPDATA`, `PROGRAMFILES`,
+        `WINDIR`, `PATHEXT`, `COMSPEC`). A test asserts each name is forwarded
+        when present in `os.environ`, and that `JIRA_API_TOKEN` is not;
+      - takes an explicit **output mode** rather than one fixed stdio posture,
+        because the three callers genuinely differ: `register` and `refresh` are
+        interactive and inherit **all** stdio; `get-cookies` must **capture
+        stdout** — the engine returns the materialised jar path on stdout and
+        `load_sso_cookies` parses it — while still letting stderr reach the
+        operator. The helper therefore returns a completed-process result, not an
+        `int`, so a captured stdout is available to the caller. A helper that
+        inherits stdout and returns only a status code would break every
+        SSO-cookie client construction even when `get-cookies` succeeds.
+
+      **A timeout is not an expired session.** `load_sso_cookies` maps every
+      unsuccessful engine access to `SsoSessionUnavailableError`, which AC11
+      site 1 makes *recoverable* — so a slow or locked keychain holding a
+      perfectly valid session would be killed by the 30 s probe timeout and then
+      trigger a browser recapture. Timeout, spawn failure and any unexpected
+      engine exit therefore map to a **non-recoverable** `SsoError` subtype
+      (`SsoBrokerUnavailableError`), leaving `SsoSessionUnavailableError` for a
+      genuinely missing or unusable session. A test drives a fake `get-cookies`
+      past an injected short timeout and asserts exit 2 with
+      `refresh_sso_session` never called.
+
+      **`load_sso_cookies` is refactored onto the same helper.** It runs
+      `get-cookies` with `env={**os.environ}` and **no timeout**
+      (`credbroker/_sso.py:113-119`) — the exact two properties this AC forbids,
+      in the same module, on the path AC14's post-recapture re-probe uses. So a
+      keychain-unlock prompt after a fresh capture blocks `check` with no
+      backstop, and `JIRA_API_TOKEN` crosses to the engine. It takes a short
+      (30 s) timeout and the allowlist minus the display/browser variables.
+
+- [ ] **AC4 (`validate_sso_profile`, canonical grammar).** Raises
+      `SsoConfigError` unless *profile* is a `str` matching **`re.fullmatch`** of
+      `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` and is not a case-insensitive Windows
+      reserved device name (`CON`, `PRN`, `AUX`, `NUL`, `COM1`–`COM9`,
+      `LPT1`–`LPT9`), with or without an extension. Rationale for `fullmatch` and
+      the denylist is in the architecture page; both were confirmed by spike. A
+      non-`str` raises `SsoConfigError` (exit 2), never `TypeError` (exit 1).
+
+- [ ] **AC5 (`load_sso_cookies` validates too).** The existing
+      `load_sso_cookies` calls `validate_sso_profile` before composing its argv,
+      so every credbroker entry point that reaches the engine is guarded.
+
+### `sso-broker.py` — the sink
+
+- [ ] **AC6 (independent guard).** The engine enforces the AC4 grammar on
+      `register`, `get-cookies`, `test` and `refresh` before any path is
+      composed — `:274` (jar), `:293` (`_profile_path`), `:376`
+      (`browser-state` user-data dir) and the keychain target name all
+      interpolate `profile` unguarded today — exiting `3` with a message naming
+      the constraint. It carries its own copy per the architecture page's
+      dependency direction.
+
+      **`_write_profile` is guarded independently too.** It interpolates
+      `f'{key} = "{value}"'` unescaped (`sso-broker.py:308-324`), and
+      `_do_refresh` reads the stored table then re-writes every value back
+      through it — so AC20's consumer-side guard only covers *newly supplied*
+      values, and a profile poisoned before this change is re-injected on every
+      automatic refresh. `_write_profile` either **TOML-escapes** every written string or
+      rejects **every character a TOML basic string forbids literally** — `"`,
+      `\`, and the whole `U+0000`–`U+001F` / `U+007F` control range, not the
+      four-character subset. A subset is not enough: TOML input can encode
+      `U+0001` as `\u0001`, so after parsing the value holds a bare control
+      character with no literal backslash, passes a quote/backslash/CR/LF check,
+      and is interpolated straight into the quoted string — producing a profile
+      that `tomllib` can no longer read, which breaks every later `check`,
+      `refresh` and `rm`. Guarded independently of the consumer.
+
+- [ ] **AC6a (the refreshed jar must actually reach the consumer).**
+      `_do_get_cookies` materialises the jar to
+      `sso-cookies/<profile>.jar` **only** `if not materialised.exists()`
+      (`sso-broker.py:467-469`), while on Tier-2-capable platforms
+      `_store_cookie_jar` writes the refreshed jar to the **keychain**. So after a
+      successful `refresh` on macOS or Windows the re-probe reads the *stale*
+      file the pre-refresh probe wrote, the retry 401s, and `check` exits 2
+      having opened a browser for nothing. It works only where `_tier2_capable()`
+      is false (Linux) — which is where CI runs, so no existing rung would catch
+      it. The guard is removed: `_do_get_cookies` rewrites the materialised file
+      unconditionally from the store it just loaded.
+
+      **Making the write unconditional makes an existing race routine — and that
+      race is deferred, not specified here.** `_file_floor_write` composes a
+      **shared** temp path (`path.with_suffix(path.suffix + ".tmp")`) and
+      previously fired at most once per profile; every `check` now rewrites, so
+      two concurrent `check`es for one profile can collide, and a stale snapshot
+      can replace a fresher one. AC6a requires exactly one thing about it: a
+      **unique temp name per write** (pid + random suffix), which removes the
+      shared-path collision.
+
+      It deliberately specifies **no ordering guarantee** between concurrent
+      materialisers. Seventeen review rounds established that the ordering
+      protocol cannot be pinned down in prose here: a write-only guard permits
+      generation reversal; a lock and a generation check cannot be distinguished
+      by any single deterministic test; and a generation check is itself racy
+      unless compare-and-replace is atomic. Each formulation admitted the next
+      hole. That is a concurrency protocol needing its own design and its own
+      tests, not an acceptance criterion bolted onto a jar-materialisation fix.
+      The Risks section already records concurrent `check` behaviour as
+      undefined; materialisation ordering is explicitly part of that deferral, so
+      this AC claims only what it can defend.
+      *(deferred: sso-materialisation-ordering)*
+
+      A test asserts two sequential `get-cookies` calls straddling a store change
+      return different bytes, under both a keychain-backed and a
+      file-floor-backed store — the AC6a regression, which is deterministic.
+
+- [ ] **AC6b (distinct not-registered code).** `_do_refresh` returns **`4`** when
+      the profile is not registered, leaving `3` for every other engine failure.
+      Pinned by AC10's parity test so credbroker's mapping and the engine agree.
+
+- [ ] **AC7 (containment, not just grammar).** Each guarded verb additionally
+      asserts that the **resolved** profile and jar paths have the engine's store
+      directories as their direct parent (canonicalize-then-verify-parent, the
+      CWE-73 depth), independent of the grammar, and case-insensitively on
+      Windows. Grammar alone is not the control: it is a denylist of shapes,
+      while containment is an allowlist of locations.
+
+- [ ] **AC8 (`rm` stays usable).** `rm` is gated on **containment only**, not the
+      AC4 grammar. A profile registered before this change under a now-invalid
+      name must remain deletable — `list-profiles` enumerates the filesystem
+      directly (`sso-broker.py:591-602`) and would otherwise keep showing a live
+      corporate cookie jar the operator cannot remove.
+
+- [ ] **AC9 (traversal proven closed, per verb).** For each guarded verb a test
+      asserts exit `3` **and** that stderr names the constraint. An
+      exit-code-only assertion would already be green for most cases today
+      (`get-cookies` and `test` return 2 for an unregistered profile; `register`
+      returns 3 before `mkdir` when `--login-url` is absent), so it would not be
+      a red stub. Vectors: `"../../../../tmp/pwn"`, `"abc\n"`, `"abc\r\n"`, a
+      65-character name, a non-ASCII name, `""`, `"."`, `".."`, `"CON"`,
+      `"con.toml"`, and a non-`str`. Two argv shapes are asserted separately
+      because they behave differently: a bare flag-shaped value (`-x`) is
+      `SystemExit(2)` from argparse before any guard runs, while
+      **`-- -x` parses `profile="-x"` successfully and must reach the guard**
+      (verified by spike — the `--` escape is why the grammar's leading-`-`
+      rejection is load-bearing rather than cosmetic).
+
+- [ ] **AC10 (grammar cannot drift).** A test under `packages/credbroker/tests/unit/`
+      extracts the pattern literal and the device-name denylist from
+      `sso-broker.py` and from `credbroker` and asserts equality — the same
+      byte-equivalence shape as `test_sso_broker_verbs.py`'s existing
+      sibling-parity tests. Drift is a fail-open: `load_sso_cookies` maps every
+      non-zero engine exit to a session error, so a name credbroker accepts and
+      the engine rejects would make `check` attempt recapture on every
+      invocation. Under AC1's taxonomy a grammar rejection is a
+      **non-recoverable** `SsoBrokerUnavailableError`, so the drift surfaces as a
+      hard exit 2 rather than a recapture loop — but the parity test is what stops
+      it arising at all.
+
+### `jira` skill — `check` recovery
+
+- [ ] **AC11 (typed discriminator).** A typed `SsoSessionUnavailable(AuthError)`
+      subclass in `_client.py` marks "no usable session", raised at exactly **five**
+      sites and nowhere else:
+      1. `from_sso_cookies` — `credbroker.SsoSessionUnavailableError` from `load_sso_cookies`;
+      2. `from_sso_cookies` — jar read, parse, or **shape** failure (AC12);
+      3. `_request` — `401`, or an unfollowed `3xx`, on the SSO-cookie path only;
+      4. `whoami` — a `2xx` whose body is not parseable JSON, on the SSO-cookie
+         path only. Required because an SSO reverse proxy commonly answers an
+         expired session with `200` plus the IdP login page, and `resp.json()`
+         (`_client.py:397`) then raises `JSONDecodeError`, which is neither
+         `AuthError` nor `JiraError` — today that escapes to `main`'s catch-all
+         as exit 1, outside the exit-2 credential band, and no recovery fires.
+      5. `whoami` — a `2xx` whose body **parses** but carries no identity, on the
+         SSO-cookie path only. The predicate is one **shared selector**: *the
+         first non-empty `str`* among `displayName`, `name`, `emailAddress`,
+         `key`, `accountId`. Presence alone is not enough — `{"displayName":
+         null}` or `{"name": ""}` satisfies a presence test while
+         `_cmd_check`'s truthiness `or` chain still falls through to `as ?` at
+         exit 0, which is the failure this site exists to stop. **`_cmd_check`
+         uses the identical selector** for its display fallback
+         (`jira.py:405-410` reads only the first three, by truthiness, today), so
+         `{"displayName": null, "accountId": "abc"}` both passes and displays
+         `abc`. Both halves are required: listing a field the raise
+         site accepts but `_cmd_check` does not still prints `as ?` at exit 0,
+         and omitting `displayName` from the raise site would reject a valid
+         `{"displayName": …}` response and open a spurious browser. Without site
+         5 at all, an SSO proxy answering an expired session with a parseable
+         non-identity body returns **exit 0** — an expired session reported as
+         success, worse than a missed recovery.
+
+      `SsoConfigError`, `SsoBrokerNotInstalledError`, the construction-time https
+      guard, and `403` stay plain `AuthError` → exit 2 with **no** recapture.
+      Because the subclass *is* an `AuthError`, every existing handler and exit
+      code is unchanged.
+
+- [ ] **AC12 (jar failures are in the contract, without leaking bytes).**
+      `from_sso_cookies` reads, parses **and shape-checks** the jar inside the
+      guarded block. A list-of-dicts check is **not** sufficient: `filter_jar_to_domains`
+      calls `.lstrip()` on `domain` and indexes `c["name"]`, so
+      `[{"domain": 1, "name": "sid"}]` raises `AttributeError` and a record
+      missing `name` raises `KeyError` — both escaping as exit 1, the very band
+      AC12 exists to close. Validate **each record**: `raw` is a `list`, every
+      entry a `dict`, `name` / `domain` / `value` present and `str`, **and a
+      supplied non-null `path` also `str`** — `_client.py` passes
+      `c.get("path") or "/"` straight to `httpx.Cookies.set`, so
+      `{"path": 7}` reaches the cookie jar and raises `TypeError` mid-request,
+      escaping as exit 1 exactly like the cases above. Map `OSError` / `JSONDecodeError` / `UnicodeDecodeError` / shape
+      mismatch to the AC11 type. Today the read at `_client.py:210` sits outside
+      the `except credbroker.SsoError` block, and a valid-JSON-wrong-shape jar
+      additionally reaches `filter_jar_to_domains` and raises `AttributeError`;
+      both escape as exit 1. The raised message is a **fixed** remediation string
+      naming only the profile, cause chained via `from exc` and never
+      interpolated — a `UnicodeDecodeError`'s text quotes the offending bytes of
+      a cookie jar, which `jira.py:798-800` already refuses to echo.
+
+- [ ] **AC13 (`_probe` preserves the discriminator).** The probe helper
+      constructs the client, calls `client.whoami()` **directly**, and closes it
+      in a `finally`. It must not route through `_cmd_check`, which catches
+      `AuthError` (`jira.py:399-401`) and returns an `int` — that would swallow
+      the subclass at raise sites 3 and 4, the primary expired-session cases.
+
+- [ ] **AC14 (automatic path).** On `SsoSessionUnavailable`, `check` calls
+      `refresh_sso_session(profile)` and re-probes **once**.
+      `SsoProfileNotRegisteredError` yields exit 2 with a remediation addressed
+      to the **user** — `ask the user to run: python scripts/jira.py check --register` — with no retry and no registration. Any other recapture
+      failure yields exit 2 with no retry. A post-recapture **construction**
+      failure is equally terminal: `refresh` shares `_capture` with
+      `register` (AC35) and returns 0 whenever the success-URL pattern matched, so
+      it can succeed while leaving nothing resolvable. It does **not** delegate to
+      the headed interactive path — AC14a fixes `refresh` at
+      `headless=True`. The post-recapture probe, not the exit code, is
+      the success criterion.
+
+- [ ] **AC14a (the automatic path never renders a login page to a human).**
+      Automatic refresh may re-establish a session **only without human
+      interaction.** If the recapture would require a person to type credentials
+      — the IdP session has also expired, so the warm browser profile cannot
+      complete the flow silently — the automatic path **aborts** with exit 2 and
+      the **`check --register`** remediation — the only first-capture path that
+      *attempts* destination attestation — and does **not** leave a login page in
+      front of the operator. The qualifier matters: AC32 verifies the destination
+      only where derivation succeeds; on **branch 2** (configured sign-in host ==
+      `base_url` host, i.e. SP-initiated SAML, the majority topology) derivation
+      short-circuits and attests nothing. So `check --register` is strictly better
+      than `setup_sso.py`, which attempts no attestation at all — but it is not
+      universally attested, and this AC does not claim it is.
+
+      This closes the gap between this spec's own threat analysis and its ACs.
+      The spec identifies "a human types credentials into a page whose
+      destination the agent could influence" as the single exposure whose blast
+      radius leaves the machine, and AC15 defers the destination-integrity
+      control that would contain it — yet bare `check` reached exactly that state
+      whenever the IdP session had expired too, using destination fields from the
+      agent-writable `~/.agentbundle/sso-profiles/<profile>.toml`. Deferring the
+      control while shipping the flow it was meant to contain is not a defensible
+      order of operations.
+
+      So the harvest surface is removed from the automatic path entirely rather
+      than guarded: silent re-auth ships (it is the common case and involves no
+      human), interactive capture is reachable **only** from an operator-typed
+      command. `sso-destination-field-integrity` remains the prerequisite for ever
+      relaxing this — until it lands, no automated path may render a login page.
+
+      **The enforceable engine contract: `refresh` is universally headless.**
+      An abort rule alone is unimplementable — `_do_refresh` delegates to
+      `_do_register`, which launches `headless=False` and polls for 300 s, so
+      there is no state in which the engine can report "this would need a human"
+      before a window is already on screen. Therefore `refresh` launches
+      `headless=True` and never polls for sign-in: if the warm browser profile
+      completes the IdP flow, capture succeeds silently; if it cannot, the launch
+      fails with engine exit **`5`**, which `credbroker` maps to
+      `SsoInteractionRequiredError` (non-recoverable), and which `check` surfaces
+      as exit 2 plus the **`check --register`** remediation without retrying.
+
+      **"Never polls" is too blunt: the contract is a bounded silent-completion
+      window.** A warm IdP session still redirects asynchronously, so a zero-wait
+      launch would fail flows that would have succeeded. `refresh` therefore waits
+      up to **20 s** for the success-URL pattern to appear *unaided* — long enough
+      for a redirect chain, far short of a human sign-in — then, if a login page is
+      still displayed, closes the headless context and returns `5`. The engine
+      distinguishes the two by URL, not by timing out silently.
+
+      `refresh` also carries its **own** spawn timeout, not AC3's 540 s: with no
+      human-duration poll its worst case is import + launch + navigation + the
+      20 s window + cleanup + margin, so **180 s** — the derivation is AC3's
+      per-operation table, which is the single source for all three values.
+      Interactive capture belongs solely to `register` / `setup_sso.py`, which
+      keep `headless=False`. Added to AC1's taxonomy table and to the
+      RFC-0013 erratum, since it changes the verb's contract.
+
+- [ ] **AC15 (`check --register`, under the accepted threat profile).**
+      `check --register` performs first capture from `sso-config.toml` and then
+      completes the check — one command, not two. Accepted on `check` only.
+
+      **Why it ships, having once been withdrawn.** The withdrawal argued that a
+      registration flag on the agent's own command surface is reachable by
+      prompt injection. Under the accepted profile
+      (`credentials.md § Threat model`) that argument does not hold up: a hostile
+      same-principal agent can already invoke
+      `sso-broker.py register <profile> --login-url …` directly, so the flag
+      confers **no capability it did not have**. Removing it amputated the UX
+      without closing the path.
+
+      **What the real boundary is.** Not a verb and not a subsystem, but: *does a
+      human type credentials into a page whose destination the agent could
+      influence?* That catches `--register` **and** an interactive refresh when
+      the IdP session has also expired — both harvest the operator's IdP password
+      and MFA, which reach far beyond this tool. That is the one exposure in this
+      design whose blast radius leaves the machine, and it is the only one that
+      earns a control.
+
+      **The control, narrowed to fit.** Integrity-protect the two destination
+      fields — `login_url` and `success_url_pattern` — rather than the whole
+      config or the whole flow. Everything else in `sso-config.toml` stays
+      adopter-editable. *(deferred: sso-destination-field-integrity)*
+
+      AC21 still puts `--register` under the SKILL.md rule that the agent relays
+      the command rather than running it, and AC21's negative eval still asserts
+      that. That is belt, not the boundary: it reduces accidental invocation by an
+      erring agent, which is exactly the threat the accepted profile *does* cover.
+
+- [ ] **AC16 (disclosure and record).** Before any recapture, `check` writes one
+      stderr line naming the profile. The wording is **path-specific**: on
+      `--register` it states that a headed browser will open and names the
+      resolved `login_url` host; on the **automatic** path it states that recapture
+      is headless, that no browser will be shown, and that the destination comes
+      from the engine's stored profile rather than from `sso-config.toml`. The
+      automatic notice must not mention a headed browser, because AC14a forbids
+      one. The profile and the outcome are
+      echoed via `log.info`. **This is not an audit record:** `jira.py:780-783`
+      calls `logging.basicConfig` with no `filename` and no handler, so the line
+      goes to the stderr of a process the agent spawns and may discard. It makes
+      the attempt visible in the invoking session; an unattended
+      re-authentication remains repudiable. A durable sink is
+      *(deferred: sso-recapture-audit-sink)*. `check` itself writes
+      nothing to stdout before the retry probe; inherited stdio means the
+      engine's child may write to the shared streams, which is noted rather than
+      claimed away.
+
+- [ ] **AC17 (exactly one attempt).** `check` invokes recapture at most once per
+      process, on either path.
+
+- [ ] **AC18 (`--insecure` is honest on both paths).** On the **token** path it
+      emits a stderr warning whenever it fires — `docs/CONVENTIONS.md:1197` and
+      `:1214` require it and `jira.py:722` is silent today. On the **SSO-cookie**
+      path the flag is inert (`from_sso_cookies` hardcodes `_sso_ssl_context()`);
+      `check` warns that it is ignored, scoped to `check` so no other subcommand
+      changes, and it is never forwarded to the engine.
+
+- [ ] **AC19 (blast radius).** No `jira.py` path other than `check` invokes
+      recapture. On the token path `check` behaves exactly as today apart from
+      AC18's warning. A malformed `sso-config.toml` — non-`https` URL, unknown or
+      missing `[sso]` key, over-broad `cookie_domains`, `base_url` host outside
+      `cookie_domains`, path-bearing `session_filename`, an AC4-rejected
+      `profile`, or a wrong-typed `ttl_hint_minutes` (AC20) — fails at the
+      selector with exit 2 and no recapture; `auth_default = "creds"` and an
+      absent file run the token path unchanged.
+
+- [ ] **AC20 (forwarded-field validation).** `_sso_config.load_sso_config`
+      delegates `profile` to `validate_sso_profile` **before any `str()`
+      coercion** — `_sso_config.py:155` currently does
+      `profile=str(sso["profile"])`, which would turn an int `5` into `"5"` and
+      make AC4's non-`str` rejection unreachable from this path — type-checks
+      `ttl_hint_minutes` as an integer (`_sso_config.py:162` passes it through
+      untyped today despite its `int | None` annotation), and rejects `"`, `\` and **every**
+      `U+0000`–`U+001F` / `U+007F` control character (not just `\n` / `\r` /
+      `\t` — a TOML source can encode any of them as `\uXXXX`, so the parsed
+      value carries a bare control char) in every `[sso]` string field that
+      can reach an argv or the engine's profile writer. Control characters matter
+      because `validate_https_url` cannot see them — `urlsplit` strips CR/LF
+      before parsing (verified by spike) — while `sso-broker.py:308-324`
+      interpolates values into `f'{key} = "{value}"'` unescaped, injecting lines
+      into the profile store. AC1 removes this exposure from the automatic path;
+      AC2's `register` path retains it, which is why the guard lives at load.
+
+- [ ] **AC30 (credbroker version floor).** The pip layer **precedes** the
+      vendored floor on `sys.path`, so an adopter pinned to `credbroker==0.4.1` (or earlier)
+      with atlassian 0.8.0 gets the old library. The failure differs by call
+      site, and the guard is scoped to match: `_sso_config.py:85` uses
+      `from credbroker import (…)`, so a missing name raises **`ImportError`** —
+      not `AttributeError` — inside `load_sso_config`, which `_run`'s handler at
+      `jira.py:713` already turns into **exit 2**; and it is unreachable on the
+      token path because `load_sso_config` returns `None` at `:80-81` before that
+      import. Only `credbroker.refresh_sso_session`, a module attribute
+      referenced in `jira.py`, produces the uncaught-`AttributeError` exit-1
+      path, and only on `check` + sso-cookie.
+      So the guard is a feature-detect (`hasattr(credbroker,
+      "refresh_sso_session")`) placed **in the sso-cookie branch of `_run`,
+      before `_cmd_check_sso`** — never in the shared bootstrap, which would
+      break every token-path subcommand and contradict AC19. It exits 2 with an
+      upgrade remediation naming the required version. `requirements.txt` pins
+      `credbroker>=0.5.0` in **both** consuming skills (`confluence-crawler` is
+      at `>=0.1.0` today and inherits the mirrored files); a test asserts the
+      guard fires against a stub 0.4.1 module.
+
+- [ ] **AC31 (`_run` routing is pinned).** Today `from_sso_cookies` is called at
+      `jira.py:719` for **every** subcommand before dispatch, and its `AuthError`
+      is caught at `:723` — so AC11 sites 1–2 raise from a block shared by all
+      commands, and the obvious implementation would violate AC19. `_run` routes
+      `auth_path == "sso-cookie" and args.command == "check"` to a dedicated
+      handler **before** the shared construction at `:717-725`; every other
+      command keeps today's construction path byte-for-byte. A test asserts the
+      recapture stub is never called for `whoami` or `get-issue`.
+
+- [ ] **AC32 (server-attested destination on `--register`).** The automatic
+      path already accepts no destination (AC1). `--register` does, so it
+      attests it against the instance itself rather than trusting the config.
+
+      **Mechanism — a vendor-agnostic strategy chain, not a Jira probe.**
+      `credbroker` owns
+      `derive_sso_destination(base_url, *, strategies: Sequence[str] = ()) -> str | None`
+      — the keying parameter is explicit, because
+      the broker is meant to serve any vendor with this shape (an on-prem
+      Confluent admin console, any corporate tool behind SSO), not just
+      Atlassian. It tries, in order, and returns the first **scheme+host** it
+      resolves:
+
+      1. **RFC 9728 — OAuth 2.0 Protected Resource Metadata.** Unauthenticated
+         request → `401` carrying `WWW-Authenticate: … resource_metadata="…"` →
+         fetch `/.well-known/oauth-protected-resource` → `authorization_servers`
+         → fetch that AS's metadata → `authorization_endpoint`. The modern
+         standard; adopted by MCP.
+      2. **OIDC Discovery / RFC 8414.** `GET {base_url}/.well-known/openid-configuration`
+         → `authorization_endpoint`. Older, far more widely deployed today.
+      3. **Vendor probe (Atlassian/Seraph).** `GET {base_url}/login.jsp` with
+         redirects **not** followed and no cookies → `302` whose `Location` is
+         the IdP authorization URL. **Verified by live spike 2026-08-05:**
+         `GET https://jira.atlassian.com/login.jsp` → `302`,
+         `Location: https://auth.atlassian.com/authorize?…`. Registered as a
+         named strategy in a module-level registry, requested by the caller as
+         `strategies=("atlassian-seraph",)`, so `confluence-crawler` and
+         `bitbucket` opt in (same Seraph framework) and a non-Atlassian consumer
+         never runs it. Default `strategies=()` runs tiers 1–2 only.
+
+      **The comparison lives in `jira.py`'s `--register` path, not in
+      `register_sso_session`.** So `setup_sso.py` and `confluence-crawler` —
+      which AC2 refactors onto the same function — get **no** attestation; only
+      `check --register` attests. The `credbroker` placement buys reusability,
+      not coverage. AC32's mismatch and cannot-derive tests therefore drive
+      `check --register`, and `setup_sso.py` is documented as the unattested
+      operator escape (AC23).
+      4. **None** → cannot-derive.
+
+      Only the **scheme+host** is compared; every tier's URL carries per-request
+      `state` / `SAMLRequest` / `nonce` values that change on each call.
+
+      The same spike recorded that `jira.atlassian.com` answers its REST `401`
+      with the **legacy** `WWW-Authenticate: OAuth realm="…"` form, *not* RFC
+      9728's `resource_metadata` — so tier 1 is the right thing to try first and
+      the wrong thing to depend on. SAML-only SPs expose no discovery at all
+      (their SP metadata names the SP, never the IdP), which is why tiers 3 and 4
+      exist.
+
+      **This is defence in depth, not the control.** It closes
+      *`login_url`-poisoned-alone*. It does **not** close config poisoning,
+      because `base_url` — the derivation target — lives in the same
+      agent-writable file: one write changes both, the attacker serves the `302`
+      themselves, and the comparison passes. AWS's equivalent works only because
+      its host suffix is hardcoded to `*.amazonaws.com`; there is no comparable
+      invariant here, since everything we could compare against is also in the
+      file. Consent for `--register` therefore rests on AC15 (operator-typed),
+      not on this. `credentials.md` states the same limit (AC22).
+
+      Comparison is **topology-aware**, not one string — plain host equality
+      would refuse the *majority* Jira DC configuration. In SP-initiated SAML
+      (the default for most DC SSO plugins) `login_url` sits on the **SP** host
+      (`{base_url}/plugins/servlet/samlsso`) while tier 3's `302` names the
+      **IdP** host. Accept when the derived host equals the `login_url` host
+      (**branch 1**) **or** the `login_url` host equals the `base_url` host
+      (**branch 2**).
+
+      **Branch 2 attests nothing, and that is recorded rather than dressed up.**
+      `require_host_in_cookie_domains` compares a host against the
+      *config-supplied* `cookie_domains` and is called on the request base host
+      (`_client.py:203`), never on `login_url` — so an attacker writing
+      `base_url`, `cookie_domains` and `login_url` to the same host satisfies
+      branch 2, derivation is never consulted, and within-host path/query is
+      unconstrained (an on-host open redirector passes). Since branch 2 is the
+      majority topology, **derivation is effective only on IdP-host topologies.**
+      This is accepted rather than fixed: requiring derivation in branch 2 would
+      refuse every SSO-with-local-fallback adopter, and derivation is explicitly
+      not the control — AC15 is. Recorded as
+      *(deferred: sso-branch2-destination-attestation)*.
+
+      **Branch 2 is evaluated first and short-circuits.** Where `login_url`'s host
+      equals `base_url`'s host, **no derivation request is made** and the
+      cannot-derive outcome does not apply — otherwise `setup_sso.py` would
+      refuse the majority topology whenever `/login.jsp` returns 200, defeating
+      the one-command objective. Derivation runs only when the hosts differ.
+
+      Outcomes: **accept** → proceed; **mismatch** → exit 2, **no browser**,
+      naming both hosts *and* the `setup_sso.py` escape — which performs **no**
+      attestation, and is safe only because it too is operator-typed, the same
+      basis as AC15 (a refusal with no remedy gets worked around by editing the
+      config); **cannot derive** → exit 2
+      naming `setup_sso.py`. It **never** falls back to the configured value.
+
+      **Derivation is bounded — it is an outbound fetch on the credential path.**
+      `credbroker` has no dependencies, so this is `urllib`, which follows
+      redirects, honours `file://` and `ftp://`, and has no default timeout;
+      tier 1 fetches a URL taken from a *response header* and then a second from
+      that document, i.e. two attacker-influenceable targets. Required:
+      `https` only at every hop (reject `http`/`file`/`ftp`, including inside
+      `resource_metadata` and `authorization_servers`); redirects **not**
+      followed, hop cap 0; 5 s connect + 5 s read and a ≤15 s total derivation
+      budget; a 64 KiB body cap before `json.loads`; strict certificate
+      verification that never honours `--insecure` and never reuses the token
+      path's SSL context; no `Authorization`, `Cookie`, or proxy-auth header on
+      any derivation request. The same bounds are recorded in
+      `credentials.md`'s derivation table.
+
+      **Named degradation, verified for the Atlassian tier.** Derivation is
+      configuration-dependent
+      and this is a *material* limitation, not a caveat: `/secure/Dashboard.jspa`
+      returned `200`, confirming JRASERVER-66554 — SAML redirection fires only
+      from `login.jsp`, never from the base URL or dashboard, so deriving from
+      `base_url` (the design's first draft) does **not** work. `login.jsp` itself
+      returns `302` only in forced-SSO mode; in SSO-with-local-fallback it
+      returns `200` with a sign-in button and no `Location`. Those adopters land
+      on the cannot-derive branch and register via `setup_sso.py`.
+
+      **The engine is directly invokable, and no control here closes that.**
+      `~/.agentbundle/bin/sso-broker.py` is an executable on disk; any process
+      running as the operator — including the agent, with shell access — can call
+      `sso-broker.py register <profile> --login-url https://evil…` with no
+      `credbroker`, no AC15, no AC31 and no derivation in the path. Destination
+      pinning is a property of the **library API**, not of the system. The
+      *Never do* rules are constraints on skill authors, not on the agent. Stated
+      so no reader mistakes the library boundary for a system boundary.
+
+      **Threat model, stated plainly.** `sso-config.toml` is a skill-tree file
+      the agent can edit, and `~/.agentbundle/sso-profiles/<profile>.toml` is
+      protected by file permissions against *other users*, not against the
+      principal the agent runs as. Attestation closes config poisoning **only
+      where derivation succeeds**; where it does not, first-run is
+      operator-driven and the agent-reachable path is closed by refusing rather
+      than by trusting. A trust-on-first-use record was designed and rejected:
+      its baseline would be written after the poisoned registration, so the
+      attacker's host would become the reference.
+
+- [ ] **AC33 (declare the pack dependency, don't imply it).** Every pack
+      shipping a `credentialed: true` skill declares
+      `[[pack.dependencies.required]]` on `credential-brokers` — **`atlassian`,
+      `figma`, `linear`** — i.e. every credentialed pack *other than the broker pack*
+      itself, which ships `credential-setup` (`credentialed: true`) and cannot
+      depend on itself. `github` is excluded because it shells out to `gh`, which
+      owns its own credential chain, and declares no `credentialed:` frontmatter.
+      The literal block, per `pack.schema.json:143` (`catalogue` / `pack` /
+      `version` required, `additionalProperties: false`):
+
+      ```toml
+      [[pack.dependencies.required]]
+      catalogue = "agent-ready-repo"
+      pack = "credential-brokers"
+      version = "^0.3"        # atlassian; figma and linear use "^0.2"
+      ```
+
+      `install.py:493-505` gates required dependencies **before any write**,
+      resolving against the union of repo + user state; five packs already use the
+      mechanism but no credentialed pack does, so today
+      `agentbundle install atlassian --scope user` succeeds while the credbroker
+      floor and `sso-broker.py` are absent, failing at runtime with no
+      remediation. Ranges are per-need — the grammar is caret-minor and `^0.2` is
+      satisfied by `0.3.0` (`install.py:4374-4381` — `^X.Y` means
+      `>= X.Y.0, < (X+1).0.0`), so `atlassian` takes `^0.3` (it needs AC6b's exit-4
+      engine) while `figma` and `linear` take `^0.2`.
+
+      **Breaking-change note:** the gate resolves installed *packs*, not module
+      importability, so an adopter who `pip install credbroker`-ed without
+      installing the pack has a working `creds` install today and will be refused
+      at upgrade. The gate message names the fix. This makes `figma` and `linear`
+      minor bumps.
+
+- [ ] **AC34 (engine-change governance — RFC-0035, amended).** The changeset
+      edits `packs/credential-brokers/**` (AC6, AC6a, AC6b, AC35) and
+      `packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py`
+      (AC26), both protected by `tools/lint-catalogue-curation-guard.py` —
+      `CREDBROKER_PREFIX` is the whole pack with **no carve-out**, and the engine
+      prefix carves out only `build/recipes/` and `/tests/`. `build-check.yml:478`
+      runs it against `origin/main`, so **this cannot merge** without an
+      `Engine-Change-RFC:` trailer on its commits. `has_exemption` is a substring
+      check validating neither the RFC's existence nor its scope, so the trailer
+      is a governance speed bump, not a resolver.
+
+      Commits carry `Engine-Change-RFC: RFC-0035` — the RFC that introduced
+      `sso-broker.py` and owns the `sso-cookie` broker. **No new RFC.**
+
+      **The instrument is an Approver-signed `## Errata` entry, not an
+      amendment.** Verified: RFC-0035 is `Status: Accepted` → Frozen, and already
+      carries `## Errata` with four signed entries and **no** `## Amendments`
+      section; the `new-rfc` convention reserves amendments for in-flight Open
+      RFCs and states the two headings never coexist. The entry follows the
+      existing form — `- **YYYY-MM-DD (Approver: <handle>) — …**` — recording
+      (i) `refresh`'s not-registered exit `3` → `4` (AC6b), (ii) the
+      `register --ephemeral` CLI-surface addition plus `refresh`'s rejection of
+      connection arguments (AC35), and (iii) **`refresh` becoming headless with a
+      bounded 20 s silent-completion window and the new exit `5`** (AC14a) — the
+      break that turns a previously-prompting `refresh` into a fast failure. The RFC body is not edited.
+
+      **Settled 2026-08-05.** The Approver signed the erratum (`eugenelim`) and
+      chose the erratum alone — **no ADR**. Recorded in the entry itself: it
+      narrows an existing non-goal and corrects engine behaviour this RFC already
+      governs, rather than reversing the decision. **Two** entries are appended, because two RFCs are
+      implicated: RFC-0035's `## Errata` records the narrowing of its
+      engine-unchanged **non-goal**, and **RFC-0013 § Subcommands owns the verb
+      table and exit semantics actually being changed** — `refresh` is no longer
+      "equivalent to `register`" — so a companion Approver-signed entry lands
+      there too. Neither RFC body is edited and no `## Amendments` section is
+      introduced. Verification is the AC34 Testing Strategy row.
+
+- [ ] **AC35 (`register` captures in an ephemeral context, and still seeds the
+      persistent one).** `_do_refresh` currently *is* `_do_register`
+      (`sso-broker.py:583` → `return _do_register(profile, args)`), with
+      `launch_persistent_context(user_data_dir=…/browser-state/<profile>)`
+      hardcoded — so there is no branch to make ephemeral. The engine splits into
+      `_capture(profile, args, *, persist: bool, headless: bool)` — both flags,
+      because persistence and headedness vary independently:
+
+      | Caller | `persist` | `headless` |
+      |---|---|---|
+      | `register` (operator, default) | `True` | `False` |
+      | `register --ephemeral` (via `register_sso_session`) | `False` | `False` |
+      | the AC35 seeding launch | `True` | `True` |
+      | `refresh` (AC14a) | `True` | `True` |
+
+      `register` selects
+      `persist=False` **only when `--ephemeral` is passed** — the verb's default
+      stays `True`, so a direct operator invocation is unchanged — and `refresh`
+      is always `persist=True` **and always `headless=True`** per AC14a — it never
+      polls for sign-in, so it cannot put a login page in front of an operator.
+      The flag is added to AC2's argv contract.
+
+      **The adopter-visible break is the persistence change, not the flag.** A
+      caller relying on `register` leaving a reusable `browser-state/<profile>`
+      now gets a *seeded* profile rather than the capture context itself; the
+      errata name that, not the flag. Asserted in `test_sso_broker_verbs.py` — **not** the skill suite,
+      which cannot observe a Playwright call inside a subprocessed engine.
+
+      Note this interacts with AC14a: because `refresh` is headless, the seeded
+      profile is what lets the *first* automatic refresh complete silently. If
+      seeding fails, that refresh returns `5` and the operator re-registers — it
+      does **not** open a browser.
+
+      **The ephemeral capture must seed the persistent profile.**
+      `launch_persistent_context` takes **no** `storage_state` argument — a
+      persistent context owns its own state directory — so seeding is: export
+      `storage_state` from the ephemeral context, then launch a second,
+      *headless* persistent context on `browser-state/<profile>` and
+      `add_cookies(state["cookies"])`. **`localStorage` / `sessionStorage` cannot
+      be seeded this way**; if the IdP session depends on either, the seed
+      silently fails and the first automatic `refresh` requires an operator. That
+      is a named limitation, not a solved case — no probe has been run against
+      Playwright's persistent-context model, unlike every other mechanism claim
+      in this spec. Otherwise the first automatic `refresh` after first capture
+      finds no usable browser session and — because `refresh` is headless with a
+      bounded window (AC14a) — returns exit `5` rather than opening a browser, so
+      the operator must re-register. That is a UX cost, not a security exposure:
+      the automatic path never renders a login page.
+
+      **Named non-control:** on a domain-joined machine where the IdP uses
+      Negotiate/Kerberos, IWA, or a machine certificate, an ephemeral context
+      still authenticates silently from the OS credential store, so no visible
+      sign-in occurs. AC35 is a confirmation surface only where the IdP relies
+      on a browser-resident session. This is recorded rather than assumed —
+      the survey lists it as an open known-unknown.
+
+      **`refresh` also stops accepting a destination.** `sso-broker.py:570-581`
+      currently back-fills `args.login_url` from the stored table only `if not
+      args.login_url` — so `--login-url` on `refresh` is honoured today. The verb
+      now **rejects** any connection argument (`--login-url`,
+      `--success-url-pattern`, `--cookie-domain`, `--validation-endpoint`,
+      `--session-filename`, `--ttl-hint-minutes`) with exit 3; destinations come
+      only from the stored profile. Asserted in `test_sso_broker_verbs.py`.
+      Without this, AC1's "enforced by the signature" holds at the library layer
+      only — which the Objective now says explicitly.
+
+      These engine CLI-surface changes are a second reason
+      `packs/credential-brokers` bumps.
+
+### Docs
+
+- [ ] **AC21 (SKILL.md matches behavior, and still lints).** The phrases
+      `catalogue_tooling/lint.py:439-459` pins for `auth: sso-cookie` **and**
+      `auth-fallback: creds` (jira declares both) survive in the
+      `### Security rules (non-negotiable)` section, matched after
+      `_cs_normalize_whitespace` — the pinned clause is line-wrapped in the file
+      today (`SKILL.md:106-107`), so verification is `make build-check`, never a
+      single-line literal grep. The **unpinned** lead-in sentence is re-scoped
+      (it currently tells the agent to hand every SSO recovery to the user, which
+      the new `check` contradicts); the pinned clause is not reworded. The
+      carve-out declares its own boundary — applies to `jira.py check` only; the
+      agent never passes `--register` itself and never invokes `setup_sso.py` or
+      `credential-setup` on the user's behalf. `check --register` is the
+      **canonical** first-run path, and AC14's remediation, AC23's how-to, the
+      plan's failure matrix and this section all name it. `setup_sso.py` is
+      reserved for exactly two cases and named only there: scripted pre-bake, and
+      AC32's mismatch / cannot-derive escape where attestation is unavailable —
+      routing an ordinary unregistered first run through it would bypass AC32's
+      attestation even when derivation would have succeeded. And **two** negative eval cases are
+      added: (i) the agent still refuses to run `credential-setup` or
+      `setup_sso.py`; (ii) driven by a prompt in which `check` has already emitted
+      AC14's `ask the user to run: python scripts/jira.py check --register`
+      remediation, the agent **relays that command as text and does not invoke it
+      via Bash** — the assertion AC15's consent story actually depends on, and
+      which no existing eval covers (`evals.json:188-199` is token-path scoped) — the latter is the helper the pinned phrase actually names,
+      and that phrase's literal meaning is now false for `jira.py check`, so its
+      amendment is recorded as a deferred slug rather than left unremarked. Additionally: a `login_url`
+      agent pre-flight rule mirroring the `JIRA_BASE_URL` rule
+      (`SKILL.md:81-91`); the exit-code table's exit-2 row split by auth path;
+      and Step 1 stating that bare `check` **never** blocks for browser sign-in
+      (AC14a: `refresh` is headless, worst case 180 s) while `check --register`
+      does, with an
+      invocation budget derived from AC3's **540 s** backstop — the post-margin
+      value including AC35's seeding launch, not the 420 s pre-margin sum — plus two worst-case
+      probes (`MAX_RETRIES` × `DEFAULT_TIMEOUT_S` plus backoff).
+
+- [ ] **AC22 (architecture page).** `docs/architecture/credentials.md` carries a
+      `## The sso-cookie broker` section covering the engine/library split, the
+      consumer API, destination pinning, the confinement controls, and the
+      auto-recovery contract; the `auth:` paragraph routes to it instead of
+      deflecting to the spec; and *Where to read next* links RFC-0035, ADR-0026
+      and this spec. The destination-pinning paragraph states the AC32 trust
+      boundary verbatim — the signature blocks implementer error, **not** an
+      agent that can edit `sso-config.toml` — so the durable architecture doc
+      does not outlive this spec carrying an unqualified security claim. The
+      shipped behavior matches that page.
+
+- [ ] **AC36 (the authoring how-to stops teaching the banned pattern).**
+      `guides/credential-brokers/how-to/add-a-credentialed-skill.md:139-151`
+      instructs new `auth: sso-cookie` skills to build
+      `Path.home() / ".agentbundle" / "bin" / "sso-broker.py"` and
+      `subprocess.run([...], env={**os.environ})` — verbatim this spec's first
+      *Never do*, and the scaffold every future SSO skill copies. It is replaced
+      with `credbroker.load_sso_cookies(profile)` and the recapture verbs, and
+      its re-auth exit-code note (`:220`) records AC6b's `4` alongside `2`.
+
+- [ ] **AC23 (adopter how-to).**
+      `guides/atlassian/how-to/authenticate-jira-confluence-with-sso-cookies.md`
+      states that `check` self-heals an expired session, that **`check --register`
+      is the ordinary one-command first run** and the only path that attests the
+      destination (AC32), that `setup_sso.py` is limited to scripted pre-bake and
+      to the AC32 mismatch / cannot-derive escape where attestation is
+      unavailable, that a **Claude Code** adopter may add a
+      user-scope deny rule per AC15 — with the literal rule text, the reason it
+      must live in `~/.claude/settings.json` rather than the repo, and an
+      explicit statement that `kiro-ide`, `codex`, `copilot`, `cursor` and
+      `gemini` have no equivalent per-command control. The how-to must describe
+      that rule as **belt-only: protection against accidental invocation, not a
+      boundary.** It does not put first capture out of agent reach, because an
+      agent with shell access can invoke `~/.agentbundle/bin/sso-broker.py
+      register` directly, bypassing every command-level rule. Only privilege
+      separation would support an out-of-reach claim, and none is shipped. Also
+      the profile grammar constraint.
+
+- [ ] **AC24 (changelog + API reference).** `docs/product/changelog.md` gains
+      `## [credbroker][0.5.0]`, `## [atlassian][0.8.0]`,
+      `## [credential-brokers][0.3.0]`, `## [figma][0.3.0]` and
+      `## [linear][0.2.0]` — each `— <YYYY-MM-DD>` in the file's existing heading
+      form. The bodies name the two adopter-visible breaks: the engine's exit-`3`→`4`
+      change (AC6b), the **new `refresh` contract** — headless, with a bounded
+      silent-completion window and a new exit `5`, so a `refresh` that previously
+      prompted now fails fast (AC14a) — `refresh`'s rejection of connection
+      arguments and `register`'s persistence change (AC35), and AC33's new install
+      gate,
+      and `guides/_shared/reference/` documents **all four** new `credbroker`
+      functions alongside the existing SSO entries — `validate_sso_profile`,
+      `refresh_sso_session`, `register_sso_session` and `derive_sso_destination`,
+      the last of which AC32 requires be publicly exported from
+      `credbroker/__init__.py` on the same additive-compatibility basis as the
+      other three.
+
+- [ ] **AC25 (deferred work recorded, with its constraint).**
+      `workspace.toml [backlog].open` carries a slug per *Deferred* entry. The
+      `pack-config-catalogue-sso-defaults` entry additionally records the
+      destination-pinning constraint this spec discovered: a projected
+      `~/.agentbundle/<pack>/defaults.toml` is **not** trusted merely because the
+      installer wrote it — if it can supply `auth_default` or a sign-in
+      destination it becomes a second adopter-writable source for an automated
+      launch, so the addendum must keep the automatic path pinned to
+      engine-written state exactly as AC1 does.
+
+### Tests and release
+
+- [ ] **AC26 (credbroker suites, and they run on Windows).** `packages/credbroker/tests/unit/`
+      covers AC1–AC5, AC10 and AC32 (the last in `test_sso_derivation.py`) with a
+      **fake broker executable** in `tmp_path`,
+      giving real argv, real exit codes and no browser. The single test seam is a
+      redirected home: `monkeypatch.setenv` for **both** `HOME` and `USERPROFILE`
+      — `Path.home()` reads `USERPROFILE` on Windows — following
+      `test_sso_broker_verbs.py:69-77`, which additionally rebinds the engine
+      module's `_AGENTBUNDLE_HOME` because `sso-broker.py:106` computes it at
+      **import** time while credbroker's `_broker_path()` resolves at **call**
+      time (verified by spike). `packages/credbroker`'s suite is added to
+      `self_host_windows.py`'s parity list so the Windows kill arm is actually
+      exercised on Windows; until that run is green the `taskkill` arm is a
+      named limitation, not a verified control.
+
+- [ ] **AC27 (jira skill suite).** A new `test_check_sso_login.py` covers
+      AC11–AC20. It imports via `sys.path.insert(0, <skill root>)` +
+      `import scripts.jira` — flat `import jira` raises `ImportError: attempted
+      relative import with no known parent package` because the bootstrap block
+      at `jira.py:54` is gated on `__spec__ is None` while the relative imports
+      below it are unconditional. It reaches **every** symbol through `scripts.*`,
+      never a flat `import _client` / `import _sso_config`: **verified by spike
+      that `flat._client.AuthError is scripts._client.AuthError` → `False`**, so
+      `jira.py`'s `except SsoSessionUnavailable` — bound to the `scripts.` copy —
+      would not catch an exception raised from the flat copy, and sibling suites
+      in the same pytest session load the flat copies. It drives the SSO path by
+      pointing `scripts._sso_config._DEFAULT_CONFIG_PATH` at a `tmp_path` config
+      (verified by spike to route the real loader to `sso-cookie`), not by
+      patching `_select_auth_path`, which would bypass the loader AC19 verifies.
+      It stubs the two `credbroker` recapture functions at the `scripts.jira`
+      binding to assert call count, arguments, and that no destination reaches
+      the refresh call. Wired into `.github/workflows/build-check.yml` and
+      `self_host_windows.py`.
+
+- [ ] **AC28 (existing suites green).** `test_sso_config.py`,
+      `test_sso_client.py`, `test_setup_sso.py`, `test_auth_selector.py` and
+      `test_exit_codes.py` pass in **both** skills' `scripts/`;
+      `python tools/test-lint-sso-config.py` passes; `pytest packages/credbroker`
+      passes; `make build-check` passes **with SAST enabled** — the change adds
+      subprocess spawning on the credential path, which is what the SAST leg
+      exists to inspect.
+
+- [ ] **AC29 (version bump lands last).** After code, tests and docs are settled:
+      `packages/credbroker` `[project].version` → `0.5.0` (**minor** — new public
+      API, and the engine now rejects input it previously accepted);
+      `packs/atlassian` → `0.8.0`, `packs/credential-brokers` → `0.3.0`,
+      `packs/figma` → `0.3.0`, `packs/linear` → `0.2.0` — each `[pack].version`
+      **plus that pack's `.claude-plugin/plugin.json`**, because
+      `catalogue_tooling/lint.py:1252-1258` fails on any mismatch between the
+      two; then `make build-self` regenerates
+      `.claude-plugin/marketplace.json`, `.agentbundle/bin/sso-broker.py`, and the
+      `.agentbundle/lib/credbroker/` + `packs/credential-brokers/.apm/user-libs/credbroker/`
+      projections. `[pack.adapter-contract] version` is unchanged.
+
+## Testing Strategy
+
+| AC | Mode | Mechanism |
+|---|---|---|
+| AC1–AC5, AC10 | TDD | `packages/credbroker/tests/unit/` — fake broker executable, dual-env home redirect, real subprocess. Type-checked by `tools/lint-mypy.py`. |
+| AC3 (tree kill) | TDD | POSIX: a fake broker that forks a grandchild; assert no survivors after timeout (spiked green). Windows: asserted on the parity runner per AC26. |
+| AC6–AC9 | TDD | `test_sso_broker_verbs.py` — its `importlib` harness (`:24-41`) loads the engine from its real path; drive each verb per vector, assert exit 3 **and** stderr text, plus the `--` escape case. |
+| AC11–AC20 | TDD | `test_check_sso_login.py` per AC27. |
+| AC30, AC31 | TDD | `test_check_sso_login.py` per AC27 — version-floor guard against a stub 0.4.1 module; recapture stub never called for `whoami` / `get-issue`. |
+| AC33 | Goal-based | fixture install of `atlassian` / `figma` / `linear` with and without `credential-brokers`; grep the three `[[pack.dependencies.required]]` blocks. |
+| AC36 | Goal-based | grep the authoring how-to for `credbroker.load_sso_cookies` and the **absence** of `subprocess` / a hand-built broker path. |
+| AC32 | TDD | `packages/credbroker/tests/unit/test_sso_derivation.py` — a fake resource server per tier, plus bounds assertions: non-`https` at any hop rejected, redirect not followed, connect/read timeouts, ≤15 s budget, 64 KiB cap, no auth headers on the wire. |
+| AC35 | TDD | `test_sso_broker_verbs.py` — `register` ephemeral / `refresh` persistent; `refresh` rejects every connection argument; the seeding step. |
+| AC34 | Goal-based | `git log --format=%B` on the branch contains `Engine-Change-RFC:`; grep **both** RFC-0035's and RFC-0013's `## Errata` for the `2026-08-05 (Approver: eugenelim)` entries; confirm neither file has an `## Amendments` heading. |
+| AC21 | Goal-based | `make build-check` (runs the normalized pinned-phrase lint); both negative eval cases in `evals.json`. |
+| AC22–AC25 | Goal-based | grep the new heading + anchor in `credentials.md`; grep `--register` in the how-to; grep both bracketed changelog headings; grep all four function names in the reference guide; grep each slug in `workspace.toml`; `lint-spec-status.py --root .`. |
+| AC26, AC27 | Goal-based | grep the new filenames in `build-check.yml` and `self_host_windows.py`. |
+| AC28 | Goal-based | the plan's canonical command block. |
+| AC29 | Goal-based | `make build-self` then `make build-check` (drift-gated); version grep across every site. |
+| whole change | Visual / manual QA | `python scripts/jira.py check` against the shipped `sso-config.toml` (`auth_default = "creds"`) — token path untouched, no browser. Then `check --insecure` on the token path to observe AC18's warning. Record observed stdout, stderr and exit code for both. |
+
+**Named limitation.** A live corporate SSO sign-in is not reachable in this loop
+— no Data Center instance and no identity provider. The fake-broker rung proves
+argv, exit-code routing, destination pinning, timeout and retry bounds; it does
+not prove what Chromium emits during a real redirect chain, nor Seraph's actual
+status codes. AC4's Windows device-name behavior and AC3's `taskkill` arm are
+reasoned from Win32 semantics and are only verified once AC26's parity run is
+green.
+
+## Assumptions
+
+Every entry was established by reading source or executing a probe on
+2026-08-05, not recalled.
+
+- `_do_refresh` with no connection arguments reads the destination fields from
+  the stored profile TOML and returns `3` when the profile is absent — this is
+  what makes destination pinning possible. (source: `sso-broker.py` `_do_refresh`)
+- `re.match` admits a trailing newline where `re.fullmatch` does not; `CON` and
+  `NUL` satisfy the grammar. (source: executed spike)
+- `sso-broker get-cookies -- -x` parses `profile="-x"` successfully, while bare
+  `-x` is `SystemExit(2)` from argparse. (source: executed spike)
+- `flat._client.AuthError is scripts._client.AuthError` → `False`. (source: executed spike)
+- Patching `_DEFAULT_CONFIG_PATH` routes the real loader to the SSO-cookie path,
+  and `profile = "../../../../tmp/pwn"` is **accepted today**. (source: executed spike)
+- `start_new_session=True` + `os.killpg` removes the grandchild on POSIX;
+  `os.killpg` is absent on Windows and `Path.home()` reads `USERPROFILE` there.
+  (source: executed spike + `workspace_mcp.py:1069-1092`)
+- `_cmd_check` catches `AuthError` and returns an `int`, so routing the probe
+  through it would swallow the typed subclass. (source: `jira.py:396-404`)
+- The probe path resolves the engine through `credbroker._sso._broker_path()`,
+  not any skill-side resolver. (source: `_client.py:204` → `_sso.py:100`)
+- agentbundle's knowledge of credbroker is a **file-copy** relationship
+  (`build/user_libs.py` vendors the package source to three targets), never an
+  API one — so new credbroker functions add no agentbundle coupling.
+  (source: `build/user_libs.py:1-17,66-67`)
+- `packs/credential-brokers` **is** bumped to 0.3.0. The initial no-bump call
+  followed the crash-fix precedent (7 of the last 8 `sso-broker.py` commits did
+  not bump), but AC6b changes an exit code and AC35 changes the engine CLI
+  surface — both observable contract changes. (source: git history; user
+  confirmation 2026-08-05, reversed same day on the AC6b finding)
+- No TTY gate — it fails closed in exactly the agent-driven case this spec
+  serves; destination pinning replaces it. (source: user confirmation 2026-08-05)
+
+## Risks
+
+- **Concurrent `check` invocations are undefined.** Two processes collide on
+  Chromium's singleton lock in the shared `browser-state/<profile>` dir, and
+  materialisation ordering is likewise unspecified (`sso-materialisation-ordering`);
+  concurrent processes can race the jar write. `jira-defect-flow`'s evals mandate a `check` pre-flight, so it
+  is plausible. AC17's bound is per-process; AC3's tree kill removes the
+  orphan-lock case but not the race. Deferred with a slug.
+- **The Windows tree kill is reasoned, not executed**, until AC26's parity run.
+  If disproved, the fallback leaves the Chromium grandchild alive.
+- **The persistent browser profile becomes an agent-triggered credential.**
+  `~/.agentbundle/browser-state/<profile>` holds a standing, silently-replayable
+  corporate SSO session — that is *why* the sub-second auto-SSO happens, and this
+  change converts replaying it from operator-triggered to agent-triggered. The
+  `sso-broker-at-rest-minimisation` slug covers the directory mode and the
+  unfiltered jar, not its lifetime. *(deferred: browser-state-lifetime)*
+- **The typed subclass could over-narrow.** If a real expired-DC-session shape is
+  none of AC11's five sites, recovery silently never fires. Mitigation: tests
+  assert each site individually rather than asserting "recovery works".
+- **The grammar is enforced in two implementations** — AC10's literal-equality
+  test is the drift guard; the engine cannot import credbroker.
+- **credbroker is published.** New public API is a compatibility surface for
+  other consumers; all four functions are additive and
+  `SsoProfileNotRegisteredError` subclasses the existing
+  `SsoSessionUnavailableError`, so current handlers keep working.
+
+## Deferred
+
+- `auth_default` / `base_url` from `catalogue.toml [pack-defaults.atlassian]`,
+  via an installer-side projection so skill scripts stay stdlib-only. The
+  RFC-0074 cascade is Shipped but has no consumer, and its baked layer lives
+  inside the `agentbundle` package at
+  `packages/agentbundle/agentbundle/_data/install-defaults.toml`, unreachable
+  from stdlib-only scripts. Needs an RFC-0074 addendum plus an ADR extending
+  ADR-0059, and must carry AC25's destination-pinning constraint.
+  *(deferred: pack-config-catalogue-sso-defaults)*
+- Auto-recovery for `confluence-crawler`'s CLI — now a small change, since the
+  operation lives in `credbroker`. *(deferred: confluence-crawler-check-auto-login)*
+- Serialising concurrent *browser launches* — two recaptures collide on
+  Chromium's singleton lock in the shared `browser-state/<profile>` dir. Scoped to
+  the browser launch only; it makes no claim about materialisation.
+  *(deferred: sso-broker-register-concurrency)*
+- Residual engine exposures: `browser-state/<profile>` is created with
+  umask-default mode, and `_do_register` stores `context.cookies()` unfiltered,
+  so IdP cookies are retained at rest even though the consumer filters at load.
+  *(deferred: sso-broker-at-rest-minimisation)*
+- The non-JSON-2xx guard on read paths other than `whoami` — every method calls
+  `resp.json()`, so the same login-page body still exits 1 elsewhere.
+  *(deferred: nonjson-2xx-guard-all-read-paths)*
+- Attestation for SP-initiated topologies, where `login_url` and `base_url`
+  share a host and AC32's branch 2 consults no server.
+  *(deferred: sso-branch2-destination-attestation)*
+- A pack-shipped `PreToolUse` hook denying **both** agent-facing capture
+  commands — `jira.py check --register` and `setup_sso.py` — while allowing bare
+  `check`. Explicitly **belt-only, not a boundary**: it lands in
+  `.claude/settings.local.json`, an agent-writable repo file; adapter coverage is
+  uneven (`kiro-ide` drops hook-wiring); and it cannot stop a direct
+  `sso-broker.py register`. A real boundary needs privilege separation.
+  *(deferred: sso-register-pretooluse-hook)*
+- Deriving the sign-in destination from the **browser's live state** rather than
+  config, after 1Password's extension model (inject only when the browser is
+  already on the matching origin; approve via a biometric prompt the agent cannot
+  reach). *(deferred: sso-live-browser-destination-derivation)*
+- Privilege-separating `sso-config.toml` so the agent cannot write it, after
+  a practitioner writeup's `sudo`-gated `gh` wrappers — the only mechanism found in the
+  prior-art sweep that actually protects an agent-editable credential config.
+  *(deferred: sso-privilege-separated-config)*
+- The profile grammar in `tools/lint-sso-config.py`, so a pre-baked traversal
+  value fails at build time as well as at runtime.
+  *(deferred: lint-sso-config-profile-charset)*
+- A cross-process recapture cooldown. AC17's bound is per-process and each agent
+  turn is a new process, so a retry loop can spawn a **headless** recapture on
+  every invocation — no browser is shown (AC14a), but each spawn still costs up to
+  `refresh`'s 180 s and re-exercises the engine.
+  *(deferred: sso-recapture-cooldown)*
+- Amending the lint-pinned phrase `do not run any setup helper for them`
+  (`catalogue_tooling/lint.py:458`), whose literal meaning the `check` carve-out
+  inverts. *(deferred: sso-cookie-lint-phrase-amendment)*
+- The `--insecure` stderr warning in the four sibling credentialed CLIs
+  (`jira-align`, `confluence-crawler`, `confluence-publisher`, `figma`).
+  *(deferred: insecure-warning-sibling-clis)*

--- a/workspace.toml
+++ b/workspace.toml
@@ -139,6 +139,7 @@ queue   = [
 
   # Backlog-graduated specs — Approved, independent of RFC-0064
   "spec/catalogue-curation-qa-coverage",                 # consumes the 4 catalogue-curation-* QA backlog items
+  "spec/jira-check-sso-auto-login",                      # jira check SSO auto-recovery in credbroker; engine errata RFC-0035/0013
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -438,6 +439,92 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+    # ~/.agentbundle/browser-state/<profile> holds a standing, silently-replayable corporate
+    # IdP session; this change makes replaying it agent-triggered. No lifetime management
+    # today. Fix: bound/expire it in sso-broker.py. Unblocks: after
+    # jira-check-sso-auto-login ships.
+  {slug = "browser-state-lifetime", source = "spec/jira-check-sso-auto-login"},
+    # confluence-crawler inherits the shared _sso_config/setup_sso files but not check
+    # auto-recovery. Fix: adopt the same _probe/recapture flow now that it lives in
+    # credbroker. Unblocks: after credbroker 0.5.0.
+  {slug = "confluence-crawler-check-auto-login", source = "spec/jira-check-sso-auto-login"},
+    # docs/CONVENTIONS.md:1197 requires --insecure to emit a stderr warning; jira-align,
+    # confluence-crawler, confluence-publisher and figma are silent. Fix: add the warning in
+    # each _client/CLI. Unblocks: now.
+  {slug = "insecure-warning-sibling-clis", source = "spec/jira-check-sso-auto-login"},
+    # tools/lint-sso-config.py validates the [sso] key set but not the profile charset, so a
+    # pre-baked traversal value only fails at runtime. Fix: add the AC4 grammar as a
+    # build-time check. Unblocks: after AC4 lands.
+  {slug = "lint-sso-config-profile-charset", source = "spec/jira-check-sso-auto-login"},
+    # AC11 site 4/5 guards only whoami; every other read method calls resp.json(), so an SSO
+    # login-page body still exits 1 there. Fix: move the guard to a shared _json helper.
+    # Unblocks: after AC11.
+  {slug = "nonjson-2xx-guard-all-read-paths", source = "spec/jira-check-sso-auto-login"},
+    # RFC-0074's catalogue pack-defaults cascade is Shipped but has no consumer, and its
+    # baked layer sits inside the agentbundle package, unreachable from stdlib-only skill
+    # scripts. Fix: installer projects [pack-defaults.<pack>] to
+    # ~/.agentbundle/<pack>/defaults.toml; needs an RFC-0074 addendum plus an ADR extending
+    # ADR-0059. CONSTRAINT (AC25): a projected defaults.toml is NOT trusted merely because
+    # the installer wrote it — its contents come from catalogue.toml, so if it can supply
+    # auth_default or a sign-in destination it becomes a second adopter-writable source for
+    # an automated launch; the addendum must keep the automatic path pinned to
+    # broker-written state exactly as AC1 does. Unblocks: after the addendum is Accepted.
+  {slug = "pack-config-catalogue-sso-defaults", source = "spec/jira-check-sso-auto-login"},
+    # AC32 branch 2 (login_url host == base_url host, the majority SP-initiated SAML
+    # topology) consults no server, so derivation attests nothing there. Fix: an attestation
+    # that works when SP and IdP share a host. Unblocks: needs design.
+  {slug = "sso-branch2-destination-attestation", source = "spec/jira-check-sso-auto-login"},
+    # sso-broker.py creates browser-state/<profile> with umask-default mode and stores
+    # context.cookies() unfiltered, so IdP cookies persist at rest though the consumer
+    # filters at load. Fix: 0700 mode + capture-time domain filter. Unblocks: now.
+  {slug = "sso-broker-at-rest-minimisation", source = "spec/jira-check-sso-auto-login"},
+    # Two concurrent recaptures collide on Chromium's singleton lock in the shared
+    # browser-state/<profile> dir. Scoped to the browser launch only; materialisation
+    # ordering is separately deferred as sso-materialisation-ordering. Fix: per-profile
+    # launch lockfile. Unblocks: now.
+  {slug = "sso-broker-register-concurrency", source = "spec/jira-check-sso-auto-login"},
+    # catalogue_tooling/lint.py:458 pins the phrase 'do not run any setup helper for them',
+    # whose literal meaning the check carve-out inverts. Fix: amend the pinned phrase set.
+    # Unblocks: needs a lint-contract change.
+  {slug = "sso-cookie-lint-phrase-amendment", source = "spec/jira-check-sso-auto-login"},
+    # Derive the destination from the browser's live state rather than config, after
+    # 1Password's extension model (inject only when already on the matching origin). Fix:
+    # design a live-state derivation. Unblocks: needs design.
+  {slug = "sso-live-browser-destination-derivation", source = "spec/jira-check-sso-auto-login"},
+    # login_url and success_url_pattern are the only fields that can point a human at a
+    # login page; everything else in sso-config.toml can stay adopter-editable. Fix:
+    # integrity-protect just those two (root-owned or signed). Unblocks: now — this is the
+    # one control the accepted threat profile says earns its cost.
+  {slug = "sso-destination-field-integrity", source = "spec/jira-check-sso-auto-login"},
+    # sso-config.toml is agent-writable, so no validation closes poisoning; a practitioner writeup's
+    # sudo-gated gh wrappers are the only mechanism found that actually protects such a
+    # file. Fix: privilege-separate the config at install. Unblocks: needs an install-path
+    # decision.
+  {slug = "sso-privilege-separated-config", source = "spec/jira-check-sso-auto-login"},
+    # AC16 logs recapture via log.info, but jira.py:780-783 configures logging with no filename,
+    # so the record goes to stderr the agent may discard - an unattended re-auth stays repudiable.
+    # Fix: append-only 0600 log under ~/.agentbundle/logs/. Unblocks: now.
+  {slug = "sso-recapture-audit-sink", source = "spec/jira-check-sso-auto-login"},
+    # AC16 logs recapture via log.info, but jira.py:780-783 configures logging with no
+    # filename, so the record goes to stderr the agent may discard — an unattended re-auth
+    # stays repudiable. Fix: append-only 0600 log under ~/.agentbundle/logs/. Unblocks: now.
+    # Making get-cookies materialisation unconditional (AC6a) makes an existing shared-temp race
+    # routine; ordering between concurrent materialisers is deliberately unspecified - a write-guard
+    # permits reversal, lock vs generation-check is not distinguishable by any single test, and a
+    # generation check is racy unless compare-and-replace is atomic. Fix: design an ordering protocol
+    # with its own tests. Unblocks: needs design.
+  {slug = "sso-materialisation-ordering", source = "spec/jira-check-sso-auto-login"},
+    # AC17's at-most-once bound is per-process and each agent turn is a new process, so a retry
+    # loop can spawn a HEADLESS recapture on every invocation - no browser is shown (AC14a),
+    # but each spawn still costs up to refresh's 180 s and re-exercises the engine.
+    # Fix: persist a last-attempt timestamp per profile and refuse inside a cooldown. Unblocks: now.
+  {slug = "sso-recapture-cooldown", source = "spec/jira-check-sso-auto-login"},
+    # A pack-shipped PreToolUse hook denying BOTH agent-facing capture commands (jira.py
+    # check --register and setup_sso.py) while allowing bare check. Belt-only, not a
+    # boundary: lands in .claude/settings.local.json, an agent-writable repo file; uneven
+    # adapter coverage (kiro-ide drops hook-wiring); cannot stop direct sso-broker.py
+    # register. Fix: only if an adopter wants it knowing the limits. Unblocks: on request.
+  {slug = "sso-register-pretooluse-hook", source = "spec/jira-check-sso-auto-login"},
 
   # Two ADR-0055 / v0.13 stragglers found while reconciling docs/architecture/
   # against the real agentbundle surface. Both are engine-or-tooling edits, so


### PR DESCRIPTION
## What changed and why

`jira.py check` on the SSO-cookie path dead-ends when the captured session is stale: it exits 2 and tells the operator to run a second command. This is the approved spec and plan for making it self-heal, plus the architecture and governance records the design rests on.

The recapture operation lands in **`credbroker`**, not the skill. `refresh_sso_session(profile)` takes only a profile, so an automated caller is structurally incapable of choosing where the browser goes — and the cross-platform parts (timeout, process-tree kill, environment composition) are written once in the one package `tools/lint-mypy.py` type-checks and CI exercises on both platforms, rather than copy-pasted into each consumer skill.

**No implementation in this PR.** Spec and plan are `Approved`; the build follows separately.

## Two engine defects found while specifying it

Both are recorded as Approver-signed errata, because they change contracts the RFCs own rather than anything this spec introduces:

- **`get-cookies` never refreshes the materialised jar.** It writes `sso-cookies/<profile>.jar` only when the file is absent, while on Tier-2-capable platforms the refreshed jar goes to the **OS keychain**. So a successful recapture on macOS or Windows updates the keychain and the consumer keeps reading the stale file — recapture is a silent no-op. It works only where Tier 2 is deferred by policy (Linux), which is where CI runs, so no existing suite would have caught it.
- **Exit `3` is returned from ten distinct engine sites,** including playwright-absent and success-pattern-not-matched. A consumer cannot distinguish "profile not registered" — the one condition with a different remediation — from the rest. `refresh` now returns `4` for that case.

## The security shape

`refresh` also becomes **headless**, with a bounded 20 s silent-completion window and a new exit `5`. The automatic path can re-authenticate silently or fail fast, but never renders a login page to a human.

That closes the one exposure whose blast radius leaves the machine — a human typing credentials into a page whose destination the agent could influence — rather than deferring the control meant to contain it. First capture, which does accept a destination, is reachable only from an operator-typed `check --register`.

## Threat model, written down

`docs/architecture/credentials.md` gains an explicit statement of what this subsystem does and does not defend against: **an agent that errs, not one that is hostile.** A same-principal process can already read the Tier-3 dotfile, call the keychain, edit the profile store, and invoke the engine directly — so controls inside that boundary are not claimed. The page also documents the `sso-cookie` broker, which was the only one of four brokers with no section, and consolidates the prior-art references the design leans on.

The doc was also reordered for readability: threat model first, the three tiers before the broker that references them, references at the end.

## Review

Reviewed to convergence by two independent adversarial passes plus 29 rounds of an independent reviewer against the spec and plan. 42 findings raised: 38 resolved, 1 rejected with a recorded code-based rationale, 3 documentation-consistency items outstanding and listed below.

Findings that changed the design rather than the prose:

- automatic refresh would have rendered a login page whenever the IdP session had also expired — the exposure the spec itself names as the only one leaving the machine, while the containing control was deferred
- a probe timeout mapped to a *recoverable* error, so a slow keychain holding a valid session would have triggered a browser recapture
- the shared spawn helper could not return `get-cookies`' stdout, which would have broken every SSO client construction
- a `2xx` whose JSON parses but carries no identity returned **exit 0** — an expired session reported as success
- destination attestation is **partial**: on SP-initiated SAML, the majority Data Center topology, derivation short-circuits and verifies nothing. Stated rather than papered over.

## Verification

- `lint-spec-status.py --root .` — clean
- 39 acceptance criteria, 19 tasks; 12 Python fences in `plan.md`, all parse
- 17 deferral anchors, set-equal with `workspace.toml [backlog].open`, each with a cold-start comment
- `workspace.toml` parses; no broken relative links; privacy sweep clean per `AGENTS.md § Privacy`
- No source code modified, so no test suites apply

## Outstanding (documentation consistency)

Three items from the final review round, all single-source-of-truth wording rather than design:

1. Architecture page's re-registration row wording versus the spec's exit-5 remediation
2. RFC-0035's changelog sentence and the rollout watch list omit exit `5`
3. `check --register` described as attested without the branch-2 qualifier

Prose cannot hold an invariant across nine documents; a test can. These close during implementation, when the behaviour is pinned in code.

## Note for the implementation PR

It touches `packs/credential-brokers/` and `packages/agentbundle/`, both protected by `tools/lint-catalogue-curation-guard.py` with no carve-out, so **every commit there needs an `Engine-Change-RFC: RFC-0035` trailer**. This PR touches neither, so the trailer does not apply here.
