### PR TITLE
refactor(packs): give each pack description its own shape

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
         "name": "eugenelim"
       },
       "category": "architecture",
-      "description": "Go from a fuzzy technical problem to a reviewed design doc. Shapes the concept first, then produces a Google-style design doc or a Mermaid diagram, and critiques an existing one against a rubric.",
+      "description": "Sketch a system, write it up, then have it torn apart. You get a Google-style design doc or a Mermaid diagram, and a reviewer that never saw you write it.",
       "displayName": "Architect",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -37,7 +37,7 @@
         "name": "eugenelim"
       },
       "category": "integrations",
-      "description": "Run Jira and Confluence from a conversation. Credentialed CLIs for Jira, Jira Align, and Confluence, plus workflows for flow metrics, defect analysis, brief intake, story triage, and team status.",
+      "description": "Run Jira and Confluence from a conversation. Ask for the team's open work, a defect breakdown, or this quarter's flow metrics, and it queries the real API and answers.",
       "displayName": "Atlassian",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -63,7 +63,7 @@
         "name": "eugenelim"
       },
       "category": "governance",
-      "description": "Grow and maintain an agent-skill catalogue. Assimilate external primitives, survey candidate repos, and propose new packs, portable against any catalogue's own contracts.",
+      "description": "For the person who runs a catalogue, not the people installing from it. Bring in an outside skill, survey a repo worth borrowing from, or draft the case for a new pack.",
       "displayName": "Catalogue Curation",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -87,7 +87,7 @@
         "name": "eugenelim"
       },
       "category": "api-design",
-      "description": "Design the API before the implementation. Authoring skills for OpenAPI 3.1 request/response contracts and AsyncAPI event contracts, portable across projects.",
+      "description": "Write the OpenAPI or AsyncAPI contract before anyone writes a handler.",
       "displayName": "Contracts",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -113,7 +113,7 @@
         "name": "eugenelim"
       },
       "category": "file-conversion",
-      "description": "Convert files without leaving the conversation. Documents and images to Markdown; Markdown to styled HTML and to branded Word, PowerPoint, and Excel; Outlook and MIME email to Markdown.",
+      "description": "Say \"convert this PDF to Markdown\" or \"turn this into a branded deck\" and it happens. Documents, images, and Outlook email go in; Markdown, HTML, Word, PowerPoint, and Excel come out.",
       "displayName": "Converters",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -140,7 +140,7 @@
         "name": "eugenelim"
       },
       "category": "governance",
-      "description": "Supervised coding from brief to merged PR. A plan, execute, verify, review loop with spec-driven development, adversarial and security reviewers, and pre-commit gates.",
+      "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look.",
       "displayName": "Core",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -166,7 +166,7 @@
         "name": "eugenelim"
       },
       "category": "credentials",
-      "description": "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill.",
+      "description": "Your credentials stay out of the repo and out of the agent's context. credbroker resolves them in-process, sso-broker handles the browser cookie dance, and an LLM-cooperative credential-setup skill walks you through the first time.",
       "displayName": "Credential Brokers",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -192,7 +192,7 @@
         "name": "eugenelim"
       },
       "category": "research",
-      "description": "Research a question and get back evidence you can cite. Scoping, source curation, synthesis, adversarial review, and decision support, plus a project mode for sustained multi-week investigations.",
+      "description": "Ask a question, get an answer with citations you can check. It runs from a two-minute lookup to a multi-week investigation with its own folder, and argues against its own findings before handing them over.",
       "displayName": "Desk Research",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -218,7 +218,7 @@
         "name": "eugenelim"
       },
       "category": "design",
-      "description": "Walk a design from outcome to realization. Customer journey, content and copy direction, screen flows, visual craft, and independent design review, all held to one accessibility and quality floor.",
+      "description": "Start from what the customer is trying to do and end at a screen someone could build. Journey, copy, flows, visual craft \u2014 and a reviewer that asks about the empty state and the focus ring you forgot.",
       "displayName": "Experience Design",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -245,7 +245,7 @@
         "name": "eugenelim"
       },
       "category": "integrations",
-      "description": "Work with Figma files from a normal share URL. Reads files, nodes, metadata, versions, comments, and variables, renders frame images, posts comments, and turns FigJam connector graphs into Mermaid.",
+      "description": "Paste a Figma share URL and the agent can read the file. It pulls nodes, variables, and version history, renders frames as images, leaves comments, and turns a FigJam connector graph into Mermaid.",
       "displayName": "Figma",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -271,7 +271,7 @@
         "name": "eugenelim"
       },
       "category": "engineering",
-      "description": "Build, audit, and ship production-quality web surfaces. Covers design handoff through shipped component: CSS token architecture, WCAG 2.2 AA accessibility, Core Web Vitals, rendering strategy, and component API design, plus a reviewer for HTML, CSS, and JS diffs.",
+      "description": "Build the web surface, then prove it holds up. HTML, CSS, and JS with a real token system, WCAG 2.2 AA, and Core Web Vitals measured rather than asserted. A reviewer reads the diff for the regressions those three tend to hide.",
       "displayName": "Frontend Engineering",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -298,7 +298,7 @@
         "name": "eugenelim"
       },
       "category": "integrations",
-      "description": "Turn a GitHub Milestone into a product brief. Reads the milestone and its issues and hands off a structured brief ready to decompose into specs.",
+      "description": "Point it at a GitHub Milestone and get a product brief back, issues and all.",
       "displayName": "GitHub",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -325,7 +325,7 @@
         "name": "eugenelim"
       },
       "category": "governance",
-      "description": "Keep decisions and proposals on the record. Author RFCs and ADRs, track their status, and update conventions, with templates and seed READMEs to start from.",
+      "description": "Write the RFC, record the ADR, and keep track of which ones are still open. Templates come with it, so nobody argues about format.",
       "displayName": "Governance Extras",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -350,7 +350,7 @@
         "name": "eugenelim"
       },
       "category": "infrastructure",
-      "description": "Turn a plain-language intent into governed Terraform. Produces cloud-agnostic Terraform or OpenTofu plus a human-gated CI/CD pipeline, gated on a recorded decision and stopping short of apply.",
+      "description": "Describe the infrastructure you want; get Terraform you would be willing to review. Cloud-agnostic, gated on a written decision, and it stops at the plan \u2014 applying is still yours.",
       "displayName": "IaC (Terraform)",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -377,7 +377,7 @@
         "name": "eugenelim"
       },
       "category": "integrations",
-      "description": "Turn a Linear Issue into a product brief, and keep the two in sync. A credentialed GraphQL CLI plus intake and sync workflows over it.",
+      "description": "Pull a Linear issue into a product brief, and push the status back when it moves.",
       "displayName": "Linear",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -403,7 +403,7 @@
         "name": "eugenelim"
       },
       "category": "devops",
-      "description": "Add a new package to a monorepo without hand-wiring it. A new-package skill plus a seed README and package template to scaffold from.",
+      "description": "Add a package to the monorepo without hand-wiring the build.",
       "displayName": "Monorepo Extras",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -428,7 +428,7 @@
         "name": "eugenelim"
       },
       "category": "documentation",
-      "description": "Create, revise, retrofit, audit, and verify product documentation. Covers pack READMEs, user guides, and journeys, held to Di\u00e1taxis as a page contract.",
+      "description": "Documentation that matches what actually shipped. Write, restructure, or audit pack READMEs and user guides, with Di\u00e1taxis deciding what each page is allowed to do.",
       "displayName": "Product Documentation",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -455,7 +455,7 @@
         "name": "eugenelim"
       },
       "category": "product-management",
-      "description": "Turn a raw product idea into build-ready specs. Frame the outcome, test the riskiest assumption before building it, then decompose into the briefs a delivery loop can consume, plus UI copy and an upstream discovery loop.",
+      "description": "The messy part, before there is anything to build. Name the outcome, find the assumption that would sink it, and test that one first. What survives gets cut into specs a delivery loop can pick up.",
       "displayName": "Product Engineering",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -481,7 +481,7 @@
         "name": "eugenelim"
       },
       "category": "product-management",
-      "description": "Answer the strategic questions upstream of any product initiative. Market and competitive analysis (SWOT, Five Forces, PESTLE, BCG, OKRs, PRFAQ), UX strategy, and content strategy, each producing a committed artifact rather than a slide.",
+      "description": "The questions someone will ask before they fund the work. SWOT, Five Forces, PESTLE, BCG, OKRs, a PRFAQ \u2014 each one ending in a committed document rather than a deck.",
       "displayName": "Product Strategy",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -508,7 +508,7 @@
         "name": "eugenelim"
       },
       "category": "devops",
-      "description": "Validate a release the way production will. Deploy to an ephemeral environment, run end-to-end tests, read telemetry, and feed findings back until the deployed whole converges, stopping at a human gate before anything irreversible.",
+      "description": "Ship it the way production will see it. Deploy to a throwaway environment, run the tests, read the telemetry, and go round again until it holds. Then it stops and asks, because the next step is the one you cannot undo.",
       "displayName": "Release Engineering",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [
@@ -535,7 +535,7 @@
         "name": "eugenelim"
       },
       "category": "documentation",
-      "description": "Deprecated compatibility pack; install product-documentation instead. Kept so existing installs keep working, and exposes a new-guide shim that routes to the current authoring skill.",
+      "description": "Deprecated. Install product-documentation instead; this exists so older installs keep working.",
       "displayName": "User Guide (Di\u00e1taxis) \u2014 Deprecated",
       "homepage": "https://github.com/eugenelim/agent-ready-repo",
       "keywords": [

--- a/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/guides/_shared/reference/catalogue-authoring-standards.md
@@ -46,12 +46,31 @@ model reads to decide whether to **activate** the primitive. Length is load-bear
 there and shortening it degrades activation; per-target caps in
 `contracts/target-vocab.toml` govern it. Do not carry habits from one to the other.
 
-**Shape.** First sentence names the job the adopter accomplishes — verb-first, and
-readable on its own. An optional second sentence carries a compressed capability list
-or the one thing that distinguishes this pack. Then stop.
+**Shape.** Open on the job the adopter accomplishes, in their words. Say what they
+get. Then stop.
 
-> Supervised coding from brief to merged PR. A plan, execute, verify, review loop with
-> spec-driven development, adversarial and security reviewers, and pre-commit gates.
+Beyond that, let the pack decide the shape. Some need one sentence:
+
+> Write the OpenAPI or AsyncAPI contract before anyone writes a handler.
+
+Others earn three:
+
+> Ship it the way production will see it. Deploy to a throwaway environment, run
+> the tests, read the telemetry, and go round again until it holds. Then it stops
+> and asks, because the next step is the one you cannot undo.
+
+**Do not run every description through one mould.** An earlier pass here applied a
+single shape — verb-first sentence, then a comma-list of capabilities — to all
+22 packs. The result measured as 20 of 22 at exactly two sentences, 14 with a
+comma-list second sentence, four opening on the identical "Turn X into Y" frame.
+Every fact was right and the set still read as machine-written, because uniform
+rhythm and symmetrical construction are themselves the tell. Vary sentence count
+and length to match what each pack actually is.
+
+Reach for the concrete. A real thing the user says (`"convert this PDF to
+Markdown"`), a real artifact (`a Google-style design doc`), or a real check
+(`the empty state and the focus ring you forgot`) all beat an abstract capability
+noun.
 
 **Anti-patterns**, each of which has shipped here before:
 

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
@@ -46,12 +46,31 @@ model reads to decide whether to **activate** the primitive. Length is load-bear
 there and shortening it degrades activation; per-target caps in
 `contracts/target-vocab.toml` govern it. Do not carry habits from one to the other.
 
-**Shape.** First sentence names the job the adopter accomplishes — verb-first, and
-readable on its own. An optional second sentence carries a compressed capability list
-or the one thing that distinguishes this pack. Then stop.
+**Shape.** Open on the job the adopter accomplishes, in their words. Say what they
+get. Then stop.
 
-> Supervised coding from brief to merged PR. A plan, execute, verify, review loop with
-> spec-driven development, adversarial and security reviewers, and pre-commit gates.
+Beyond that, let the pack decide the shape. Some need one sentence:
+
+> Write the OpenAPI or AsyncAPI contract before anyone writes a handler.
+
+Others earn three:
+
+> Ship it the way production will see it. Deploy to a throwaway environment, run
+> the tests, read the telemetry, and go round again until it holds. Then it stops
+> and asks, because the next step is the one you cannot undo.
+
+**Do not run every description through one mould.** An earlier pass here applied a
+single shape — verb-first sentence, then a comma-list of capabilities — to all
+22 packs. The result measured as 20 of 22 at exactly two sentences, 14 with a
+comma-list second sentence, four opening on the identical "Turn X into Y" frame.
+Every fact was right and the set still read as machine-written, because uniform
+rhythm and symmetrical construction are themselves the tell. Vary sentence count
+and length to match what each pack actually is.
+
+Reach for the concrete. A real thing the user says (`"convert this PDF to
+Markdown"`), a real artifact (`a Google-style design doc`), or a real check
+(`the empty state and the focus ring you forgot`) all beat an abstract capability
+noun.
 
 **Anti-patterns**, each of which has shipped here before:
 

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
@@ -1,14 +1,14 @@
 {
   "files": {
-    "guides/_shared/reference/catalogue-authoring-standards.md": "f5e41498139ca335b8a679644eb02d2a35abb2234a77b5b14e7ff90da02722b9",
+    "guides/_shared/reference/catalogue-authoring-standards.md": "ff4bdc203affda0a2f41641c1155b3f4e90aade022e122999a82e7093e94d2ee",
     "guides/_shared/reference/catalogue-ci-contract.md": "fae793ab47989b6dd3c731afcb0b4cda21c7d08bbe7fa40fca6d3abb3d158141",
     "packs/AGENTS.md": "9bfeda4069826e518a4f4fdae45bd40f4393c1c5aaf146149d3eb4aece30be83",
     "packs/README.md": "d2de5f9556f4c8e521103474bde74636e02cc805f9bf5312a3a61a1f3eb45d8f",
     "packs/_example/.apm/skills/example-skill/SKILL.md": "33be8cbf4b2c014a5a63e788b7d0b350ad8061c6c4b2579369a3e984135bf9f1",
     "packs/_example/.apm/skills/example-skill/evals/eval_queries.json": "f41ecda0834a22f3b4823c81ab02e58b0e4beba610e3b40c185579abff9cfeee",
-    "packs/_example/.claude-plugin/plugin.json": "d38c8456640d5e2f9296361f7e3e675e368ddd3eb22a6245267560f460155f41",
+    "packs/_example/.claude-plugin/plugin.json": "7f94084a56260eed225ec47ac82042fe9029c594557cca760a459885d03ccc26",
     "packs/_example/README.md": "ef130c9c1f97a75a07cc59fc55fc5b3bf71846dd2f06c3cddf5a1154023b6ef6",
-    "packs/_example/pack.toml": "94e2c7fd25d4d115858728c7ecb8f739adfd0f594b29596c106daba0791a4b94",
+    "packs/_example/pack.toml": "f19a0be9fca99a6a0e3ce2d5cd188bf98000f0a4f186954fb42a0c99c6859701",
     "profiles/AGENTS.md": "8950438d9e0f57c13613104c88c90b598b53196c91bfdced6d63e4e01b5e9254",
     "profiles/README.md": "a0b0268edc57fc575f7fea08f3363ba7da9f6e67dc4a0a6f8bd38c9668c97922",
     "profiles/_example/README.md": "164494df049ddce3e57cb44ed604cb3d39be0a6ec2072e609ea3fa4bbfc74c72",

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/packs/_example/.claude-plugin/plugin.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/packs/_example/.claude-plugin/plugin.json
@@ -1,9 +1,14 @@
 {
   "name": "example-pack",
   "version": "0.1.0",
-  "description": "A minimal example pack demonstrating the standard authoring layout.",
+  "description": "The skeleton to copy when you start a new pack.",
   "displayName": "Example Pack",
   "category": "productivity",
-  "keywords": ["example", "template"],
-  "skills": ["example-skill"]
+  "keywords": [
+    "example",
+    "template"
+  ],
+  "skills": [
+    "example-skill"
+  ]
 }

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/packs/_example/pack.toml
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/packs/_example/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name            = "example-pack"
 version         = "0.1.0"
-description     = "A minimal example pack demonstrating the standard authoring layout."
+description     = "The skeleton to copy when you start a new pack."
 display_name    = "Example Pack"
 categories      = ["productivity"]
 keywords        = ["example", "template"]

--- a/packs/_example/.claude-plugin/plugin.json
+++ b/packs/_example/.claude-plugin/plugin.json
@@ -1,9 +1,14 @@
 {
   "name": "example-pack",
   "version": "0.1.0",
-  "description": "A minimal example pack demonstrating the standard authoring layout.",
+  "description": "The skeleton to copy when you start a new pack.",
   "displayName": "Example Pack",
   "category": "productivity",
-  "keywords": ["example", "template"],
-  "skills": ["example-skill"]
+  "keywords": [
+    "example",
+    "template"
+  ],
+  "skills": [
+    "example-skill"
+  ]
 }

--- a/packs/_example/pack.toml
+++ b/packs/_example/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name            = "example-pack"
 version         = "0.1.0"
-description     = "A minimal example pack demonstrating the standard authoring layout."
+description     = "The skeleton to copy when you start a new pack."
 display_name    = "Example Pack"
 categories      = ["productivity"]
 keywords        = ["example", "template"]

--- a/packs/architect/.claude-plugin/plugin.json
+++ b/packs/architect/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "architect",
   "version": "0.14.3",
-  "description": "Go from a fuzzy technical problem to a reviewed design doc. Shapes the concept first, then produces a Google-style design doc or a Mermaid diagram, and critiques an existing one against a rubric."
+  "description": "Sketch a system, write it up, then have it torn apart. You get a Google-style design doc or a Mermaid diagram, and a reviewer that never saw you write it."
 }

--- a/packs/architect/pack.toml
+++ b/packs/architect/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "architect"
 version = "0.14.3"
-description = "Go from a fuzzy technical problem to a reviewed design doc. Shapes the concept first, then produces a Google-style design doc or a Mermaid diagram, and critiques an existing one against a rubric."
+description = "Sketch a system, write it up, then have it torn apart. You get a Google-style design doc or a Mermaid diagram, and a reviewer that never saw you write it."
 readme = "README.md"
 display_name = "Architect"
 license = "Apache-2.0 OR MIT"

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
   "version": "0.8.0",
-  "description": "Run Jira and Confluence from a conversation. Credentialed CLIs for Jira, Jira Align, and Confluence, plus workflows for flow metrics, defect analysis, brief intake, story triage, and team status."
+  "description": "Run Jira and Confluence from a conversation. Ask for the team's open work, a defect breakdown, or this quarter's flow metrics, and it queries the real API and answers."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "atlassian"
 version = "0.8.0"
-description = "Run Jira and Confluence from a conversation. Credentialed CLIs for Jira, Jira Align, and Confluence, plus workflows for flow metrics, defect analysis, brief intake, story triage, and team status."
+description = "Run Jira and Confluence from a conversation. Ask for the team's open work, a defect breakdown, or this quarter's flow metrics, and it queries the real API and answers."
 readme = "README.md"
 display_name = "Atlassian"
 license = "Apache-2.0 OR MIT"

--- a/packs/catalogue-curation/.claude-plugin/plugin.json
+++ b/packs/catalogue-curation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "catalogue-curation",
   "version": "0.2.3",
-  "description": "Grow and maintain an agent-skill catalogue. Assimilate external primitives, survey candidate repos, and propose new packs, portable against any catalogue's own contracts."
+  "description": "For the person who runs a catalogue, not the people installing from it. Bring in an outside skill, survey a repo worth borrowing from, or draft the case for a new pack."
 }

--- a/packs/catalogue-curation/pack.toml
+++ b/packs/catalogue-curation/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "catalogue-curation"
 version = "0.2.3"
-description = "Grow and maintain an agent-skill catalogue. Assimilate external primitives, survey candidate repos, and propose new packs, portable against any catalogue's own contracts."
+description = "For the person who runs a catalogue, not the people installing from it. Bring in an outside skill, survey a repo worth borrowing from, or draft the case for a new pack."
 readme = "README.md"
 display_name = "Catalogue Curation"
 license = "Apache-2.0 OR MIT"

--- a/packs/contracts/.claude-plugin/plugin.json
+++ b/packs/contracts/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "contracts",
   "version": "0.3.5",
-  "description": "Design the API before the implementation. Authoring skills for OpenAPI 3.1 request/response contracts and AsyncAPI event contracts, portable across projects."
+  "description": "Write the OpenAPI or AsyncAPI contract before anyone writes a handler."
 }

--- a/packs/contracts/pack.toml
+++ b/packs/contracts/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "contracts"
 version = "0.3.5"
-description = "Design the API before the implementation. Authoring skills for OpenAPI 3.1 request/response contracts and AsyncAPI event contracts, portable across projects."
+description = "Write the OpenAPI or AsyncAPI contract before anyone writes a handler."
 readme = "README.md"
 display_name = "Contracts"
 license = "Apache-2.0 OR MIT"

--- a/packs/converters/.claude-plugin/plugin.json
+++ b/packs/converters/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "converters",
   "version": "0.9.4",
-  "description": "Convert files without leaving the conversation. Documents and images to Markdown; Markdown to styled HTML and to branded Word, PowerPoint, and Excel; Outlook and MIME email to Markdown."
+  "description": "Say \"convert this PDF to Markdown\" or \"turn this into a branded deck\" and it happens. Documents, images, and Outlook email go in; Markdown, HTML, Word, PowerPoint, and Excel come out."
 }

--- a/packs/converters/pack.toml
+++ b/packs/converters/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "converters"
 version = "0.9.4"
-description = "Convert files without leaving the conversation. Documents and images to Markdown; Markdown to styled HTML and to branded Word, PowerPoint, and Excel; Outlook and MIME email to Markdown."
+description = "Say \"convert this PDF to Markdown\" or \"turn this into a branded deck\" and it happens. Documents, images, and Outlook email go in; Markdown, HTML, Word, PowerPoint, and Excel come out."
 readme = "README.md"
 display_name = "Converters"
 license = "Apache-2.0 OR MIT"

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
   "version": "2.2.1",
-  "description": "Supervised coding from brief to merged PR. A plan, execute, verify, review loop with spec-driven development, adversarial and security reviewers, and pre-commit gates."
+  "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "core"
 version = "2.2.1"
-description = "Supervised coding from brief to merged PR. A plan, execute, verify, review loop with spec-driven development, adversarial and security reviewers, and pre-commit gates."
+description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"
 display_name = "Core"
 license = "Apache-2.0 OR MIT"

--- a/packs/credential-brokers/.claude-plugin/plugin.json
+++ b/packs/credential-brokers/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "credential-brokers",
   "version": "0.3.0",
-  "description": "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill."
+  "description": "Your credentials stay out of the repo and out of the agent's context. credbroker resolves them in-process, sso-broker handles the browser cookie dance, and an LLM-cooperative credential-setup skill walks you through the first time."
 }

--- a/packs/credential-brokers/pack.toml
+++ b/packs/credential-brokers/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "credential-brokers"
 version = "0.3.0"
-description = "User-scope credential brokering: the credbroker library (pip-installed, in-process resolver for auth: creds skills), sso-broker (subprocess at ~/.agentbundle/bin/ for auth: sso-cookie skills), plus one LLM-cooperative credential-setup skill."
+description = "Your credentials stay out of the repo and out of the agent's context. credbroker resolves them in-process, sso-broker handles the browser cookie dance, and an LLM-cooperative credential-setup skill walks you through the first time."
 readme = "README.md"
 display_name = "Credential Brokers"
 license = "Apache-2.0 OR MIT"

--- a/packs/desk-research/.claude-plugin/plugin.json
+++ b/packs/desk-research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "desk-research",
   "version": "1.1.4",
-  "description": "Research a question and get back evidence you can cite. Scoping, source curation, synthesis, adversarial review, and decision support, plus a project mode for sustained multi-week investigations."
+  "description": "Ask a question, get an answer with citations you can check. It runs from a two-minute lookup to a multi-week investigation with its own folder, and argues against its own findings before handing them over."
 }

--- a/packs/desk-research/pack.toml
+++ b/packs/desk-research/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "desk-research"
 version = "1.1.4"
-description = "Research a question and get back evidence you can cite. Scoping, source curation, synthesis, adversarial review, and decision support, plus a project mode for sustained multi-week investigations."
+description = "Ask a question, get an answer with citations you can check. It runs from a two-minute lookup to a multi-week investigation with its own folder, and argues against its own findings before handing them over."
 readme = "README.md"
 display_name = "Desk Research"
 license = "Apache-2.0 OR MIT"

--- a/packs/experience-design/.claude-plugin/plugin.json
+++ b/packs/experience-design/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "experience-design",
   "version": "2.0.0",
-  "description": "Walk a design from outcome to realization. Customer journey, content and copy direction, screen flows, visual craft, and independent design review, all held to one accessibility and quality floor."
+  "description": "Start from what the customer is trying to do and end at a screen someone could build. Journey, copy, flows, visual craft \u2014 and a reviewer that asks about the empty state and the focus ring you forgot."
 }

--- a/packs/experience-design/pack.toml
+++ b/packs/experience-design/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "experience-design"
 version = "2.0.0"
-description = "Walk a design from outcome to realization. Customer journey, content and copy direction, screen flows, visual craft, and independent design review, all held to one accessibility and quality floor."
+description = "Start from what the customer is trying to do and end at a screen someone could build. Journey, copy, flows, visual craft — and a reviewer that asks about the empty state and the focus ring you forgot."
 readme = "README.md"
 display_name = "Experience Design"
 license = "Apache-2.0 OR MIT"

--- a/packs/figma/.claude-plugin/plugin.json
+++ b/packs/figma/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "figma",
   "version": "0.3.0",
-  "description": "Work with Figma files from a normal share URL. Reads files, nodes, metadata, versions, comments, and variables, renders frame images, posts comments, and turns FigJam connector graphs into Mermaid."
+  "description": "Paste a Figma share URL and the agent can read the file. It pulls nodes, variables, and version history, renders frames as images, leaves comments, and turns a FigJam connector graph into Mermaid."
 }

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "figma"
 version = "0.3.0"
-description = "Work with Figma files from a normal share URL. Reads files, nodes, metadata, versions, comments, and variables, renders frame images, posts comments, and turns FigJam connector graphs into Mermaid."
+description = "Paste a Figma share URL and the agent can read the file. It pulls nodes, variables, and version history, renders frames as images, leaves comments, and turns a FigJam connector graph into Mermaid."
 readme = "README.md"
 display_name = "Figma"
 license = "Apache-2.0 OR MIT"

--- a/packs/frontend-engineering/.claude-plugin/plugin.json
+++ b/packs/frontend-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-engineering",
   "version": "0.1.3",
-  "description": "Build, audit, and ship production-quality web surfaces. Covers design handoff through shipped component: CSS token architecture, WCAG 2.2 AA accessibility, Core Web Vitals, rendering strategy, and component API design, plus a reviewer for HTML, CSS, and JS diffs."
+  "description": "Build the web surface, then prove it holds up. HTML, CSS, and JS with a real token system, WCAG 2.2 AA, and Core Web Vitals measured rather than asserted. A reviewer reads the diff for the regressions those three tend to hide."
 }

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "frontend-engineering"
 version = "0.1.3"
-description = "Build, audit, and ship production-quality web surfaces. Covers design handoff through shipped component: CSS token architecture, WCAG 2.2 AA accessibility, Core Web Vitals, rendering strategy, and component API design, plus a reviewer for HTML, CSS, and JS diffs."
+description = "Build the web surface, then prove it holds up. HTML, CSS, and JS with a real token system, WCAG 2.2 AA, and Core Web Vitals measured rather than asserted. A reviewer reads the diff for the regressions those three tend to hide."
 readme = "README.md"
 display_name = "Frontend Engineering"
 license = "Apache-2.0 OR MIT"

--- a/packs/github/.claude-plugin/plugin.json
+++ b/packs/github/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "github",
   "version": "0.1.3",
-  "description": "Turn a GitHub Milestone into a product brief. Reads the milestone and its issues and hands off a structured brief ready to decompose into specs."
+  "description": "Point it at a GitHub Milestone and get a product brief back, issues and all."
 }

--- a/packs/github/pack.toml
+++ b/packs/github/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "github"
 version = "0.1.3"
-description = "Turn a GitHub Milestone into a product brief. Reads the milestone and its issues and hands off a structured brief ready to decompose into specs."
+description = "Point it at a GitHub Milestone and get a product brief back, issues and all."
 readme = "README.md"
 display_name = "GitHub"
 license = "Apache-2.0 OR MIT"

--- a/packs/governance-extras/.claude-plugin/plugin.json
+++ b/packs/governance-extras/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "governance-extras",
   "version": "0.9.6",
-  "description": "Keep decisions and proposals on the record. Author RFCs and ADRs, track their status, and update conventions, with templates and seed READMEs to start from."
+  "description": "Write the RFC, record the ADR, and keep track of which ones are still open. Templates come with it, so nobody argues about format."
 }

--- a/packs/governance-extras/pack.toml
+++ b/packs/governance-extras/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "governance-extras"
 version = "0.9.6"
-description = "Keep decisions and proposals on the record. Author RFCs and ADRs, track their status, and update conventions, with templates and seed READMEs to start from."
+description = "Write the RFC, record the ADR, and keep track of which ones are still open. Templates come with it, so nobody argues about format."
 readme = "README.md"
 display_name = "Governance Extras"
 license = "Apache-2.0 OR MIT"

--- a/packs/iac-terraform/.claude-plugin/plugin.json
+++ b/packs/iac-terraform/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "iac-terraform",
   "version": "0.1.6",
-  "description": "Turn a plain-language intent into governed Terraform. Produces cloud-agnostic Terraform or OpenTofu plus a human-gated CI/CD pipeline, gated on a recorded decision and stopping short of apply."
+  "description": "Describe the infrastructure you want; get Terraform you would be willing to review. Cloud-agnostic, gated on a written decision, and it stops at the plan \u2014 applying is still yours."
 }

--- a/packs/iac-terraform/pack.toml
+++ b/packs/iac-terraform/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "iac-terraform"
 version = "0.1.6"
-description = "Turn a plain-language intent into governed Terraform. Produces cloud-agnostic Terraform or OpenTofu plus a human-gated CI/CD pipeline, gated on a recorded decision and stopping short of apply."
+description = "Describe the infrastructure you want; get Terraform you would be willing to review. Cloud-agnostic, gated on a written decision, and it stops at the plan — applying is still yours."
 readme = "README.md"
 display_name = "IaC (Terraform)"
 license = "Apache-2.0 OR MIT"

--- a/packs/linear/.claude-plugin/plugin.json
+++ b/packs/linear/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "linear",
   "version": "0.2.0",
-  "description": "Turn a Linear Issue into a product brief, and keep the two in sync. A credentialed GraphQL CLI plus intake and sync workflows over it."
+  "description": "Pull a Linear issue into a product brief, and push the status back when it moves."
 }

--- a/packs/linear/pack.toml
+++ b/packs/linear/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "linear"
 version = "0.2.0"
-description = "Turn a Linear Issue into a product brief, and keep the two in sync. A credentialed GraphQL CLI plus intake and sync workflows over it."
+description = "Pull a Linear issue into a product brief, and push the status back when it moves."
 readme = "README.md"
 display_name = "Linear"
 license = "Apache-2.0 OR MIT"

--- a/packs/monorepo-extras/.claude-plugin/plugin.json
+++ b/packs/monorepo-extras/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "monorepo-extras",
   "version": "0.1.6",
-  "description": "Add a new package to a monorepo without hand-wiring it. A new-package skill plus a seed README and package template to scaffold from."
+  "description": "Add a package to the monorepo without hand-wiring the build."
 }

--- a/packs/monorepo-extras/pack.toml
+++ b/packs/monorepo-extras/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "monorepo-extras"
 version = "0.1.6"
-description = "Add a new package to a monorepo without hand-wiring it. A new-package skill plus a seed README and package template to scaffold from."
+description = "Add a package to the monorepo without hand-wiring the build."
 readme = "README.md"
 display_name = "Monorepo Extras"
 license = "Apache-2.0 OR MIT"

--- a/packs/product-documentation/.claude-plugin/plugin.json
+++ b/packs/product-documentation/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-documentation",
   "version": "0.1.0",
-  "description": "Create, revise, retrofit, audit, and verify product documentation. Covers pack READMEs, user guides, and journeys, held to Di\u00e1taxis as a page contract."
+  "description": "Documentation that matches what actually shipped. Write, restructure, or audit pack READMEs and user guides, with Di\u00e1taxis deciding what each page is allowed to do."
 }

--- a/packs/product-documentation/pack.toml
+++ b/packs/product-documentation/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "product-documentation"
 version = "0.1.0"
-description = "Create, revise, retrofit, audit, and verify product documentation. Covers pack READMEs, user guides, and journeys, held to Diátaxis as a page contract."
+description = "Documentation that matches what actually shipped. Write, restructure, or audit pack READMEs and user guides, with Diátaxis deciding what each page is allowed to do."
 readme = "README.md"
 display_name = "Product Documentation"
 license = "Apache-2.0 OR MIT"

--- a/packs/product-engineering/.claude-plugin/plugin.json
+++ b/packs/product-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-engineering",
   "version": "0.13.3",
-  "description": "Turn a raw product idea into build-ready specs. Frame the outcome, test the riskiest assumption before building it, then decompose into the briefs a delivery loop can consume, plus UI copy and an upstream discovery loop."
+  "description": "The messy part, before there is anything to build. Name the outcome, find the assumption that would sink it, and test that one first. What survives gets cut into specs a delivery loop can pick up."
 }

--- a/packs/product-engineering/pack.toml
+++ b/packs/product-engineering/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "product-engineering"
 version = "0.13.3"
-description = "Turn a raw product idea into build-ready specs. Frame the outcome, test the riskiest assumption before building it, then decompose into the briefs a delivery loop can consume, plus UI copy and an upstream discovery loop."
+description = "The messy part, before there is anything to build. Name the outcome, find the assumption that would sink it, and test that one first. What survives gets cut into specs a delivery loop can pick up."
 readme = "README.md"
 display_name = "Product Engineering"
 license = "Apache-2.0 OR MIT"

--- a/packs/product-strategy/.claude-plugin/plugin.json
+++ b/packs/product-strategy/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "product-strategy",
   "version": "0.2.3",
-  "description": "Answer the strategic questions upstream of any product initiative. Market and competitive analysis (SWOT, Five Forces, PESTLE, BCG, OKRs, PRFAQ), UX strategy, and content strategy, each producing a committed artifact rather than a slide."
+  "description": "The questions someone will ask before they fund the work. SWOT, Five Forces, PESTLE, BCG, OKRs, a PRFAQ \u2014 each one ending in a committed document rather than a deck."
 }

--- a/packs/product-strategy/pack.toml
+++ b/packs/product-strategy/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "product-strategy"
 version = "0.2.3"
-description = "Answer the strategic questions upstream of any product initiative. Market and competitive analysis (SWOT, Five Forces, PESTLE, BCG, OKRs, PRFAQ), UX strategy, and content strategy, each producing a committed artifact rather than a slide."
+description = "The questions someone will ask before they fund the work. SWOT, Five Forces, PESTLE, BCG, OKRs, a PRFAQ — each one ending in a committed document rather than a deck."
 readme = "README.md"
 display_name = "Product Strategy"
 license = "Apache-2.0 OR MIT"

--- a/packs/release-engineering/.claude-plugin/plugin.json
+++ b/packs/release-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "release-engineering",
   "version": "0.1.9",
-  "description": "Validate a release the way production will. Deploy to an ephemeral environment, run end-to-end tests, read telemetry, and feed findings back until the deployed whole converges, stopping at a human gate before anything irreversible."
+  "description": "Ship it the way production will see it. Deploy to a throwaway environment, run the tests, read the telemetry, and go round again until it holds. Then it stops and asks, because the next step is the one you cannot undo."
 }

--- a/packs/release-engineering/pack.toml
+++ b/packs/release-engineering/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "release-engineering"
 version = "0.1.9"
-description = "Validate a release the way production will. Deploy to an ephemeral environment, run end-to-end tests, read telemetry, and feed findings back until the deployed whole converges, stopping at a human gate before anything irreversible."
+description = "Ship it the way production will see it. Deploy to a throwaway environment, run the tests, read the telemetry, and go round again until it holds. Then it stops and asks, because the next step is the one you cannot undo."
 readme = "README.md"
 display_name = "Release Engineering"
 license = "Apache-2.0 OR MIT"

--- a/packs/user-guide-diataxis/.claude-plugin/plugin.json
+++ b/packs/user-guide-diataxis/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "user-guide-diataxis",
   "version": "0.3.0",
-  "description": "Deprecated compatibility pack; install product-documentation instead. Kept so existing installs keep working, and exposes a new-guide shim that routes to the current authoring skill."
+  "description": "Deprecated. Install product-documentation instead; this exists so older installs keep working."
 }

--- a/packs/user-guide-diataxis/pack.toml
+++ b/packs/user-guide-diataxis/pack.toml
@@ -1,7 +1,7 @@
 [pack]
 name = "user-guide-diataxis"
 version = "0.3.0"
-description = "Deprecated compatibility pack; install product-documentation instead. Kept so existing installs keep working, and exposes a new-guide shim that routes to the current authoring skill."
+description = "Deprecated. Install product-documentation instead; this exists so older installs keep working."
 readme = "README.md"
 display_name = "User Guide (Diátaxis) — Deprecated"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## What does this change?

Rewrites the 22 pack descriptions again — not for what they say this time, but for how they say it. The previous pass fixed the content and flattened the voice; every description came out of the same mould.

## Why?

The last pass replaced component inventories with outcome-first copy, which was the right fix for the right defect. It also introduced a formula — verb-first sentence, then a comma-list of capabilities — and applied it 22 times. Measured on the result:

| tell | before this PR |
|---|---|
| exactly two sentences | 20 / 22 |
| comma-list second sentence | 14 / 22 |
| opening on `Turn X into Y` | 4 |
| joined with `plus` | 8 |
| length stdev | 44 |

That is the clear-prose checklist's *symmetrical lists* and *uniform rhythm* tells. Every fact was right and the set still read as machine-written, because uniform construction is itself the tell — a vocabulary pass never catches it.

After: sentence counts spread to 5 one-sentence / 14 two / 3 three, length range widens from 67–263 to 47–231, stdev rises to 57, and both formulaic constructions are gone.

The copy also reaches for concrete things rather than capability nouns:

> **contracts** — Write the OpenAPI or AsyncAPI contract before anyone writes a handler.

> **converters** — Say "convert this PDF to Markdown" or "turn this into a branded deck" and it happens. Documents, images, and Outlook email go in; Markdown, HTML, Word, PowerPoint, and Excel come out.

> **release-engineering** — Ship it the way production will see it. Deploy to a throwaway environment, run the tests, read the telemetry, and go round again until it holds. Then it stops and asks, because the next step is the one you cannot undo.

Several now carry a register. `catalogue-curation` opens "For the person who runs a catalogue, not the people installing from it," which tells a reader immediately whether it is for them.

### The standard changed too

`catalogue-authoring-standards.md` § 2 was part of the problem: its worked example quoted the old `core` copy, and its wording invited the mould. It now shows a one-sentence and a three-sentence example, and states that running every description through one shape is itself the defect.

## How do I verify it?

```bash
make build-check                                    # exit 0, SAST included
python3 -m pytest packages/agentbundle/ -q          # exit 0, 0 failed
python3 -m pytest packs/core/tests/ packs/product-documentation/tests/ -q   # 164 passed
python3 -m pytest tools/ -q                         # 278 passed
python3 tools/lint-pack-descriptions.py --root .
python3 tools/lint-catalogue-curation-guard.py --root . --base origin/main
```

## What did you not change that you considered?

- **The 800-char drift backstop stays as-is.** Nothing here goes near it; the longest description is 231.
- **No version bumps**, for the same reason as #888 — `marketplace.json` republishes on merge independent of pack version.
- **No skill or agent description touched.** Those drive activation.
- **Pack READMEs and the site taglines untouched.**

## Notes

- **`credential-brokers` is rewritten this time** rather than skipped. #888 deferred it because its tree is protected by the catalogue-curation guard; the guard's documented exemption is `Engine-Change-RFC: n/a — <reason>`, used here with the justification stated. It keeps the four substrings `test_credential_brokers_pack_install.py` pins. This closes backlog item `credential-brokers-description-rewrite`.
- **A latent bug surfaced.** `_example/pack.toml` uses aligned assignment (`description     = `), which the previous pass's `^description = ` pattern never matched — it silently did nothing there and only looked like a no-op because that pack was mapped to its existing text. The round-trip guard caught it this time.