### PR TITLE
fix(agentbundle): read the enabledPlugins shape the Claude client writes

### DIFF
--- a/docs/rfc/0008-claude-plugins-install-route-parity.md
+++ b/docs/rfc/0008-claude-plugins-install-route-parity.md
@@ -739,3 +739,39 @@ On acceptance:
   marketplace; close trigger = end-to-end demonstration of marker
   write + nudge fire + `/adapt-to-project` run per
   [Unresolved questions § Q5](#unresolved-questions).
+
+## Errata
+
+Corrections below are Approver-signed. The RFC body above is preserved
+unchanged; errata supersede where noted. (Approver: eugenelim, 2026-08-07.)
+
+- **2026-08-07 — the claude-plugins route wrote no marker, and the
+  `allowed-scopes` rail never fired, from first ship until `agentbundle`
+  0.29.8.** This RFC's design is unchanged; the erratum records that two
+  specified behaviours were inert in the shipped writer.
+
+  `install-marker.py` resolved the install scope by reading `enabledPlugins`
+  from the three settings files and required a JSON array. Claude Code writes
+  an object keyed by `name@marketplace` — confirmed on 2.1.223. The parse fell
+  through for every settings file the client produces, scope resolved to
+  `None`, and the writer exited 0 without writing.
+
+  Two consequences, both named in the body above:
+
+  1. **The install→adapt chain (§ Proposal, "Who writes the marker") never
+     started.** No marker was written on this route, so `core`'s session-start
+     nudge had nothing to read and never offered `/adapt-to-project`.
+  2. **The `allowed-scopes` refusal rail (§ Proposal step 2; § Scope mapping,
+     "defence in depth") could not refuse.** It compares a detected scope
+     against the pack's declaration, and no scope was ever detected. The
+     worked example in the body — an adopter installing a repo-only pack at
+     Claude-plugins user scope — was unprotected for the rail's whole life.
+
+  The integration suite was green throughout because every fixture hand-wrote
+  the array form, so the tests pinned the parser against a shape the client
+  does not emit. Verification for the fix is therefore end-to-end against the
+  real client, per Q5's close trigger, not the unit gate alone.
+
+  The APM route is unaffected: `_apm_detect_scope` resolves scope by the
+  writer's projected-path containment and never reads `enabledPlugins`, so
+  RFC-0010's copy of the rail has been enforcing all along.

--- a/docs/specs/claude-plugins-install-route/spec.md
+++ b/docs/specs/claude-plugins-install-route/spec.md
@@ -838,3 +838,34 @@ taxonomy.
   contract at v0.8 with `install-routes` including
   `"claude-plugins"`, schemas, skill amendment, and sibling-spec
   amendments all present); no deferrals.
+
+## Errata
+
+- 2026-08-07 (eugenelim): **AC2's `enabledPlugins` shape was wrong, so scope
+  detection never matched.** AC2's body treats "`enabledPlugins` present but
+  not a JSON array of plugin identifiers" as fall-through. Claude Code writes
+  an **object** keyed by `name@marketplace` whose boolean value is the enabled
+  state — confirmed on 2.1.223 — so the writer fell through at every scope and
+  the claude-plugins route wrote no marker at all. Corrected in `agentbundle`
+  0.29.8: the object form counts as opted in when the value is `true` (`false`
+  is an adopter who disabled the pack, and stays fall-through), and the array
+  form older clients wrote is still accepted. AC2's seven unit tests were green
+  throughout because each fixture hand-wrote the array form; the correction
+  adds cases driving the object form and is verified end-to-end against the
+  client, not by the unit gate alone.
+
+- 2026-08-07 (eugenelim): **AC2's identifier match compared only the part
+  before `@`.** Any marketplace's same-named pack satisfied the check, so
+  `core@other-marketplace` in a settings file opted in a `core` installed from
+  somewhere else. Corrected in `agentbundle` 0.29.8: a qualified identifier
+  must agree on the marketplace as well, read from the pack's own install path
+  (`<config>/plugins/cache/<marketplace>/<plugin>/<version>`). A bare `name`
+  makes no marketplace claim and still matches on name alone.
+
+- 2026-08-07 (eugenelim): **AC2's settings read is now bounded and
+  type-checked.** The 1 MiB limit was measured after the whole file had been
+  read, and the path was gated on existence rather than on being a regular
+  file — so a settings path that is a FIFO or a symlink to a character device
+  hung the writer, and undecodable bytes raised rather than falling through.
+  Corrected in `agentbundle` 0.29.8. The fall-through contract AC2 states is
+  unchanged; it now holds for these inputs too.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,31 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.29.8] — 2026-08-07
+
+### Fixed
+
+- **Packs installed with `claude plugin install` now complete their install.**
+  The bundled install-marker script decided whether you had opted a pack in by
+  reading `enabledPlugins` from your Claude Code settings, and expected a JSON
+  array. Current clients write an object keyed by `name@marketplace` — so the
+  script read every settings file as "not opted in", wrote no marker, and exited
+  quietly. Two things silently did nothing as a result: the hand-off that offers
+  to adapt a freshly installed pack to your repository, and the `allowed-scopes`
+  check that refuses to install a repo-only pack at user scope. Both work now.
+  The array form older clients wrote is still accepted.
+
+- **A pack of the same name from another marketplace no longer counts as this
+  one.** The identifier match compared only the part before the `@`, so
+  `core@some-other-marketplace` in your settings satisfied a check for our
+  `core`. Qualified identifiers now have to agree on the marketplace too.
+
+- **A hostile or oversized settings file can no longer hang or crash the
+  script.** The 1 MiB limit is applied to the read itself rather than measured
+  after the whole file is in memory, non-regular paths (a FIFO, a symlink to a
+  device) are refused rather than opened, and undecodable bytes fall through as
+  "not opted in" instead of raising.
+
 ## [0.29.7] — 2026-08-06
 
 ### Changed

--- a/packages/agentbundle/agentbundle/_data/install-marker.py
+++ b/packages/agentbundle/agentbundle/_data/install-marker.py
@@ -213,11 +213,66 @@ def _assert_portable_name(component: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Settings files are read under an adopter's ``${CLAUDE_PROJECT_DIR}``, whose
+# contents a cloned repo controls. Bound the read itself — measuring after
+# `read_text()` has already pulled the whole file in is no bound at all.
+_SETTINGS_READ_CAP = 1_048_576  # 1 MiB
+
+
+def _plugin_marketplace(
+    plugin_root: pathlib.Path,
+    plugin_name: str,
+) -> "str | None":
+    """Return the marketplace this pack was installed from, or ``None``.
+
+    The Claude-plugins client installs into
+    ``<config>/plugins/cache/<marketplace>/<plugin>/<version>``, so the pack
+    can read its own marketplace identity back out of ``${CLAUDE_PLUGIN_ROOT}``.
+    Verified against Claude Code 2.1.223.
+
+    Returns ``None`` when ``plugin_root`` does not have that shape. The caller
+    then matches on bare pack name alone — a layout we do not recognise must
+    degrade to the historical behaviour, not to "never opted in" (that is the
+    very failure this function's caller exists to fix).
+    """
+    parts = plugin_root.parts
+    if len(parts) < 4:
+        return None
+    if parts[-4] != "cache" or parts[-2] != plugin_name:
+        return None
+    return parts[-3] or None
+
+
+def _entry_matches(
+    entry: str,
+    plugin_name: str,
+    marketplace: "str | None",
+) -> bool:
+    """Does one ``enabledPlugins`` identifier name *this* pack?
+
+    Current clients write a qualified ``name@marketplace``; older ones wrote a
+    bare ``name``. A qualified identifier must agree on *both* halves whenever
+    we know our own marketplace, so another vendor's ``core@other-marketplace``
+    does not opt in a ``core`` that came from somewhere else.
+    """
+    name, sep, entry_marketplace = entry.strip().partition("@")
+    if name.strip() != plugin_name:
+        return False
+    if not sep:
+        # Bare name — the identifier makes no marketplace claim to check.
+        return True
+    if marketplace is None:
+        # Our own identity is unknown; the name is all there is to compare.
+        return True
+    return entry_marketplace.strip() == marketplace
+
+
 def _detect_origin(
     *,
     plugin_name: str,
     home: pathlib.Path,
     project_dir: pathlib.Path | None,
+    marketplace: "str | None",
 ) -> str | None:
     """Walk the three ``enabledPlugins`` settings files in precedence order.
 
@@ -226,9 +281,17 @@ def _detect_origin(
     (pack is not enabled at any scope).
 
     Precedence: local → project → user (most-specific wins).
-    Missing file, malformed JSON, absent ``enabledPlugins`` key, or
-    ``enabledPlugins`` present but not a JSON array are each treated as
-    "not opted in at that scope" and fall through.
+
+    ``enabledPlugins`` carries two shapes. Current clients write an **object**
+    keyed by plugin identifier whose boolean value is the enabled state — only
+    ``true`` counts as opted in, since ``false`` is an adopter who deliberately
+    disabled the pack. Older clients wrote a **JSON array** of identifiers;
+    both are accepted.
+
+    Every other outcome is "not opted in at that scope" and falls through: a
+    missing file, a non-regular path, a file past ``_SETTINGS_READ_CAP``,
+    undecodable bytes, malformed JSON, an absent ``enabledPlugins`` key, or a
+    value of any other type. A hostile settings file must never raise.
     """
     candidates: list[tuple[str, pathlib.Path]] = []
 
@@ -239,32 +302,38 @@ def _detect_origin(
     candidates.append(("user", home / ".claude" / "settings.json"))
 
     for origin, settings_path in candidates:
-        if not settings_path.exists():
+        # `.is_file()` where the old code used `.exists()`: a FIFO exists, and
+        # opening one for reading blocks until a writer appears. A character
+        # device such as /dev/zero exists too, and reads forever.
+        if not settings_path.is_file():
             continue
         try:
-            read_text = settings_path.read_text(encoding="utf-8")
+            with settings_path.open("rb") as fh:
+                blob = fh.read(_SETTINGS_READ_CAP + 1)
         except OSError:
             continue
-        # Cap read size to 1 MiB to guard against DoS via giant file.
-        if len(read_text) > 1_048_576:
+        if len(blob) > _SETTINGS_READ_CAP:
             continue
         try:
-            raw = json.loads(read_text)
-        except (json.JSONDecodeError, OSError):
+            # `json.loads` decodes UTF-8 itself; undecodable bytes raise
+            # UnicodeDecodeError and malformed JSON raises JSONDecodeError,
+            # both subclasses of ValueError.
+            raw = json.loads(blob)
+        except ValueError:
             continue
         if not isinstance(raw, dict):
             continue
         enabled = raw.get("enabledPlugins")
-        if not isinstance(enabled, list):
+        if isinstance(enabled, dict):
+            entries: list = [key for key, value in enabled.items() if value is True]
+        elif isinstance(enabled, list):
+            entries = enabled
+        else:
             continue
-        # Check whether this pack is in the list; compare by name prefix
-        # since installed plugins may appear as "name@marketplace-url".
-        for entry in enabled:
-            if not isinstance(entry, str):
-                continue
-            # Match by pack name as a prefix component (before '@').
-            entry_name = entry.split("@")[0].strip()
-            if entry_name == plugin_name:
+        for entry in entries:
+            if isinstance(entry, str) and _entry_matches(
+                entry, plugin_name, marketplace
+            ):
                 return origin
 
     return None
@@ -837,6 +906,7 @@ def _main_claude_plugins(args: argparse.Namespace) -> int:
         plugin_name=pack_name,
         home=home,
         project_dir=project_dir,
+        marketplace=_plugin_marketplace(plugin_root, pack_name),
     )
 
     if origin is None:

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.29.7"
+CLI_VERSION = "0.29.8"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.29.7"
+version = "0.29.8"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/templates/install-marker.py
+++ b/packages/agentbundle/templates/install-marker.py
@@ -213,11 +213,66 @@ def _assert_portable_name(component: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Settings files are read under an adopter's ``${CLAUDE_PROJECT_DIR}``, whose
+# contents a cloned repo controls. Bound the read itself — measuring after
+# `read_text()` has already pulled the whole file in is no bound at all.
+_SETTINGS_READ_CAP = 1_048_576  # 1 MiB
+
+
+def _plugin_marketplace(
+    plugin_root: pathlib.Path,
+    plugin_name: str,
+) -> "str | None":
+    """Return the marketplace this pack was installed from, or ``None``.
+
+    The Claude-plugins client installs into
+    ``<config>/plugins/cache/<marketplace>/<plugin>/<version>``, so the pack
+    can read its own marketplace identity back out of ``${CLAUDE_PLUGIN_ROOT}``.
+    Verified against Claude Code 2.1.223.
+
+    Returns ``None`` when ``plugin_root`` does not have that shape. The caller
+    then matches on bare pack name alone — a layout we do not recognise must
+    degrade to the historical behaviour, not to "never opted in" (that is the
+    very failure this function's caller exists to fix).
+    """
+    parts = plugin_root.parts
+    if len(parts) < 4:
+        return None
+    if parts[-4] != "cache" or parts[-2] != plugin_name:
+        return None
+    return parts[-3] or None
+
+
+def _entry_matches(
+    entry: str,
+    plugin_name: str,
+    marketplace: "str | None",
+) -> bool:
+    """Does one ``enabledPlugins`` identifier name *this* pack?
+
+    Current clients write a qualified ``name@marketplace``; older ones wrote a
+    bare ``name``. A qualified identifier must agree on *both* halves whenever
+    we know our own marketplace, so another vendor's ``core@other-marketplace``
+    does not opt in a ``core`` that came from somewhere else.
+    """
+    name, sep, entry_marketplace = entry.strip().partition("@")
+    if name.strip() != plugin_name:
+        return False
+    if not sep:
+        # Bare name — the identifier makes no marketplace claim to check.
+        return True
+    if marketplace is None:
+        # Our own identity is unknown; the name is all there is to compare.
+        return True
+    return entry_marketplace.strip() == marketplace
+
+
 def _detect_origin(
     *,
     plugin_name: str,
     home: pathlib.Path,
     project_dir: pathlib.Path | None,
+    marketplace: "str | None",
 ) -> str | None:
     """Walk the three ``enabledPlugins`` settings files in precedence order.
 
@@ -226,9 +281,17 @@ def _detect_origin(
     (pack is not enabled at any scope).
 
     Precedence: local → project → user (most-specific wins).
-    Missing file, malformed JSON, absent ``enabledPlugins`` key, or
-    ``enabledPlugins`` present but not a JSON array are each treated as
-    "not opted in at that scope" and fall through.
+
+    ``enabledPlugins`` carries two shapes. Current clients write an **object**
+    keyed by plugin identifier whose boolean value is the enabled state — only
+    ``true`` counts as opted in, since ``false`` is an adopter who deliberately
+    disabled the pack. Older clients wrote a **JSON array** of identifiers;
+    both are accepted.
+
+    Every other outcome is "not opted in at that scope" and falls through: a
+    missing file, a non-regular path, a file past ``_SETTINGS_READ_CAP``,
+    undecodable bytes, malformed JSON, an absent ``enabledPlugins`` key, or a
+    value of any other type. A hostile settings file must never raise.
     """
     candidates: list[tuple[str, pathlib.Path]] = []
 
@@ -239,32 +302,38 @@ def _detect_origin(
     candidates.append(("user", home / ".claude" / "settings.json"))
 
     for origin, settings_path in candidates:
-        if not settings_path.exists():
+        # `.is_file()` where the old code used `.exists()`: a FIFO exists, and
+        # opening one for reading blocks until a writer appears. A character
+        # device such as /dev/zero exists too, and reads forever.
+        if not settings_path.is_file():
             continue
         try:
-            read_text = settings_path.read_text(encoding="utf-8")
+            with settings_path.open("rb") as fh:
+                blob = fh.read(_SETTINGS_READ_CAP + 1)
         except OSError:
             continue
-        # Cap read size to 1 MiB to guard against DoS via giant file.
-        if len(read_text) > 1_048_576:
+        if len(blob) > _SETTINGS_READ_CAP:
             continue
         try:
-            raw = json.loads(read_text)
-        except (json.JSONDecodeError, OSError):
+            # `json.loads` decodes UTF-8 itself; undecodable bytes raise
+            # UnicodeDecodeError and malformed JSON raises JSONDecodeError,
+            # both subclasses of ValueError.
+            raw = json.loads(blob)
+        except ValueError:
             continue
         if not isinstance(raw, dict):
             continue
         enabled = raw.get("enabledPlugins")
-        if not isinstance(enabled, list):
+        if isinstance(enabled, dict):
+            entries: list = [key for key, value in enabled.items() if value is True]
+        elif isinstance(enabled, list):
+            entries = enabled
+        else:
             continue
-        # Check whether this pack is in the list; compare by name prefix
-        # since installed plugins may appear as "name@marketplace-url".
-        for entry in enabled:
-            if not isinstance(entry, str):
-                continue
-            # Match by pack name as a prefix component (before '@').
-            entry_name = entry.split("@")[0].strip()
-            if entry_name == plugin_name:
+        for entry in entries:
+            if isinstance(entry, str) and _entry_matches(
+                entry, plugin_name, marketplace
+            ):
                 return origin
 
     return None
@@ -837,6 +906,7 @@ def _main_claude_plugins(args: argparse.Namespace) -> int:
         plugin_name=pack_name,
         home=home,
         project_dir=project_dir,
+        marketplace=_plugin_marketplace(plugin_root, pack_name),
     )
 
     if origin is None:

--- a/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
+++ b/packages/agentbundle/tests/integration/test_claude_plugins_install_route.py
@@ -1521,3 +1521,271 @@ def test_hash_file_write_failure_self_heals(tmp_path, pack_root_factory):
     data = tomllib.loads(marker_path.read_text(encoding="utf-8"))
     core_entries = [e for e in data.get("packs-installed", []) if e["name"] == "core"]
     assert len(core_entries) == 1, f"Expected exactly 1 entry for 'core', got {len(core_entries)}"
+
+
+# ---------------------------------------------------------------------------
+# `enabledPlugins` shapes the real client writes
+#
+# The fixtures above hand-write the JSON-array form. Claude Code 2.1.223 writes
+# an OBJECT keyed by `name@marketplace` with boolean values, so every test above
+# exercises a shape the client does not produce. These cases pin the shapes the
+# client actually writes, plus the hardening rails on the settings read.
+# ---------------------------------------------------------------------------
+
+
+def _cache_shaped_root(
+    tmp_path: Path,
+    *,
+    marketplace: str,
+    name: str = "core",
+    version: str = "0.1.0",
+    allowed_scopes: list | None = None,
+) -> Path:
+    """Build a pack root at the client's install layout and return it.
+
+    The client installs to ``<config>/plugins/cache/<marketplace>/<plugin>/
+    <version>`` — the layout the writer reads its own marketplace identity
+    back out of. Tests that care about marketplace matching need this shape;
+    ``pack_root_factory`` deliberately does not have it.
+    """
+    if allowed_scopes is None:
+        allowed_scopes = ["repo"]
+    root = tmp_path / "cfg" / "plugins" / "cache" / marketplace / name / version
+    root.mkdir(parents=True)
+    (root / "pack.toml").write_text(
+        textwrap.dedent(f"""
+            [pack]
+            name = {json.dumps(name)}
+            version = {json.dumps(version)}
+            description = "Test pack."
+
+            [pack.install]
+            default-scope = {json.dumps(allowed_scopes[0])}
+            allowed-scopes = {json.dumps(allowed_scopes)}
+        """).lstrip(),
+        encoding="utf-8",
+        newline="\n",
+    )
+    return root
+
+
+def _write_project_settings(project_dir: Path, payload) -> Path:
+    """Write ``<project>/.claude/settings.json`` with a raw ``enabledPlugins``."""
+    settings_dir = project_dir / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    path = settings_dir / "settings.json"
+    path.write_text(
+        json.dumps({"enabledPlugins": payload}), encoding="utf-8", newline="\n"
+    )
+    return path
+
+
+def test_object_form_enabled_plugins_opts_in(pack_root_factory):
+    """The object form the real client writes counts as opted in.
+
+    Regression for the shipped detector, which tested ``isinstance(enabled,
+    list)`` and fell through for every settings file the client produces —
+    so no marker was ever written on the claude-plugins route.
+    """
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    _write_project_settings(project_dir, {"core@agent-ready-repo": True})
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    marker = project_dir / ".adapt-install-marker.toml"
+    assert marker.exists(), (
+        "Object-form enabledPlugins must opt the pack in; "
+        f"stderr={result.stderr!r}"
+    )
+    assert _read_marker(marker)["packs-installed"][0]["name"] == "core"
+
+
+def test_object_form_false_value_is_not_opted_in(pack_root_factory):
+    """``false`` means the adopter disabled the plugin — not opted in."""
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    _write_project_settings(project_dir, {"core@agent-ready-repo": False})
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (project_dir / ".adapt-install-marker.toml").exists()
+
+
+def test_array_form_enabled_plugins_still_opts_in(pack_root_factory):
+    """Older clients wrote a JSON array of bare names — still accepted."""
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    _write_project_settings(project_dir, ["core"])
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (project_dir / ".adapt-install-marker.toml").exists()
+
+
+def test_foreign_marketplace_does_not_opt_in(tmp_path):
+    """``core@other-marketplace`` must not satisfy a check for our ``core``.
+
+    The shipped matcher took ``entry.split("@")[0]``, so any marketplace's
+    pack of the same name opted ours in.
+    """
+    plugin_root = _cache_shaped_root(tmp_path, marketplace="agent-ready-repo")
+    plugin_data = tmp_path / "data"
+    plugin_data.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_settings(project_dir, {"core@other-marketplace": True})
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (project_dir / ".adapt-install-marker.toml").exists(), (
+        "A different marketplace's same-named pack must not opt this one in"
+    )
+
+
+def test_own_marketplace_opts_in(tmp_path):
+    """The positive half of the pair: our own ``name@marketplace`` matches."""
+    plugin_root = _cache_shaped_root(tmp_path, marketplace="agent-ready-repo")
+    plugin_data = tmp_path / "data"
+    plugin_data.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_settings(project_dir, {"core@agent-ready-repo": True})
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (project_dir / ".adapt-install-marker.toml").exists(), result.stderr
+
+
+def test_oversized_settings_file_falls_through(pack_root_factory):
+    """A settings file past the read cap is "not opted in", not a hang.
+
+    The cap must bound the READ; the shipped code read the whole file first
+    and measured afterwards.
+    """
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    settings = _write_project_settings(project_dir, {"core@agent-ready-repo": True})
+    # Pad past the 1 MiB cap with JSON-legal whitespace so the file stays
+    # parseable — only the cap can reject it.
+    with settings.open("a", encoding="utf-8", newline="\n") as fh:
+        fh.write(" " * 1_100_000)
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (project_dir / ".adapt-install-marker.toml").exists()
+
+
+def test_invalid_utf8_settings_file_falls_through(pack_root_factory):
+    """Undecodable bytes fall through as "not opted in" rather than raising.
+
+    ``read_text(encoding="utf-8")`` raises ``UnicodeDecodeError``, which is
+    not an ``OSError`` and was not caught.
+    """
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    settings_dir = project_dir / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "settings.json").write_bytes(b'{"enabledPlugins": {"\xff\xfe": true}}')
+
+    result = _run_writer(
+        _make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        )
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Traceback" not in result.stderr
+    assert not (project_dir / ".adapt-install-marker.toml").exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX FIFOs only")
+def test_fifo_settings_path_falls_through(pack_root_factory):
+    """A non-regular settings path must be refused, not opened.
+
+    Opening a FIFO for reading blocks until a writer appears; the shipped
+    code gated on ``.exists()``, which is true for a FIFO.
+    """
+    plugin_root, plugin_data, home, project_dir = pack_root_factory(
+        name="core", allowed_scopes=["repo"], opt_in_at=[]
+    )
+    settings_dir = project_dir / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    os.mkfifo(settings_dir / "settings.json")
+
+    result = subprocess.run(
+        [sys.executable, str(WRITER), "--install-route", "claude-plugins"],
+        env=_make_env(
+            plugin_root=plugin_root,
+            plugin_data=plugin_data,
+            home=home,
+            project_dir=project_dir,
+        ),
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not (project_dir / ".adapt-install-marker.toml").exists()


### PR DESCRIPTION
## What was broken

Packs installed with `claude plugin install` never finished installing.

The bundled install-marker script decides which scope you opted a pack in at by walking `enabledPlugins` across the three settings files, and required a **JSON array**. Claude Code writes an **object** keyed by `name@marketplace` whose boolean value is the enabled state — confirmed on 2.1.223:

```json
"enabledPlugins": { "core@agent-ready-repo": true }
```

So the parse fell through for every settings file the client produces, scope resolved to `None`, and the writer exited 0 without writing the marker. Two specified behaviours were inert as a result:

1. **The install→adapt hand-off never started.** No marker, so `core`'s session-start nudge had nothing to read.
2. **The `allowed-scopes` refusal rail could not refuse.** It compares a detected scope against the pack's declaration, and no scope was ever detected — so the worked example RFC-0008 names (installing a repo-only pack at Claude-plugins user scope) was unprotected for the rail's whole life.

**The green suite was evidence of the defect, not against it.** Every fixture hand-writes the array form, so 33 tests pinned the parser against a shape the client does not emit.

## Root cause

`_detect_origin` encodes a client data shape the client does not write. The defect is in the reader's assumption, not the caller — the caller correctly treats "no scope" as "not opted in". Introduced with the writer itself in f867c1f8e; never a regression, wrong since first ship.

**Why it wasn't caught:** no test ever fed the parser bytes the client produced. The coverage gap is "settings-file shapes the client actually emits", and the new tests close that class, not just the one input observed.

## Verification

**End-to-end against the real client** — install into a throwaway `CLAUDE_CONFIG_DIR`, then drive the `SessionStart` hook exactly as `plugin.json` declares it:

| Scenario | Before | After |
|---|---|---|
| `core` installed `--scope project` (allowed) | exit 0, **no marker** | marker written at `<project>/.adapt-install-marker.toml` |
| `core` (repo-only) installed `--scope user` | exit 0, silent — rail inert | `install-marker: pack core declares allowed-scopes=['repo'], detected install scope user; skipping marker write` |

The session launch itself could not be authenticated in a throwaway config dir in this non-interactive environment (`claude -p` reports "Not logged in"), so the declared hook command was driven directly against the state the real client wrote. Everything upstream of it — the settings bytes, the cache path, `installed_plugins.json` — is genuine client output, unedited.

**Unit** — 8 new tests; full `packages/agentbundle` suite green. The two new tests that were *already* green before the fix (foreign-marketplace, oversized-file) were mutation-tested to confirm they now fail for the right reason; both mutants died.

**Gates** — `make lint-ruff`, `make build-check` (full, SAST included), `catalogue self-host --check`: all green.

## Also fixed in the same walk

Both are defects in how this one function reads adopter-controlled bytes, not separate features:

- **Full-identifier match.** The matcher took `entry.split("@")[0]`, so any marketplace's same-named pack opted this one in. A qualified identifier must now agree on the marketplace too, read from the pack's own install path (`<config>/plugins/cache/<marketplace>/<plugin>/<version>`). A bare `name` makes no marketplace claim and still matches on name alone — that is what older clients wrote, and what every existing fixture uses.
- **Hardened read.** The 1 MiB limit was measured *after* `read_text()` had pulled the whole file in, and the path was gated on `.exists()` rather than on being a regular file. **The new FIFO test hangs for 30s against the old code** — this one was live, not theoretical. The read is now bounded, non-regular paths are refused before they are opened, and undecodable bytes fall through instead of raising `UnicodeDecodeError`.

## The APM route is unaffected

Asked explicitly in the brief. `_run_apm` resolves scope through `_apm_detect_scope` — writer projected-path containment — and never reads `enabledPlugins`. Its independent `allowed_scopes` read and refusal comparison have been enforcing all along. Nothing changed there, deliberately.

## Governance

Both frozen documents that specify the broken behaviour carry **errata** rather than body edits:

- **RFC-0008** (Accepted, frozen) — records that the marker write and the `allowed-scopes` rail were both inert from first ship until `agentbundle` 0.29.8.
- **`docs/specs/claude-plugins-install-route/spec.md`** (Shipped → frozen) — three errata against AC2, which pins the array-only shape, the prefix match, and the unbounded read. Follows the `docs/specs/adapt-to-project/spec.md` precedent for a shipped-spec erratum.

## Release

Version bumped 0.29.7 → 0.29.8 (`pyproject.toml` + `version.py`), CHANGELOG entry added. The fix reaches adopters only via a PyPI release, so this needs one after merge.

`README-pypi.md` needs no change: it documents the `agentbundle` CLI install route and says nothing about `claude plugin install` or the adapt hand-off, so nothing on the PyPI page is made wrong or right by this fix. It will be republished as-is with 0.29.8.

## Deferred

- **The claude-plugins route falls through silently.** When no scope resolves, the writer exits 0 with no output — which is exactly why this bug lived through a green suite and a shipped RFC. The APM route prints a line in the same situation. Adding one here is the honest fix, but it fires on every session for anyone who has a pack cached and disabled, so it needs a think about noise rather than a ride-along on a bug fix.
- **`CLAUDE_CONFIG_DIR` is not honoured by the user-scope leg.** The detector reads `$HOME/.claude/settings.json`; under a custom `CLAUDE_CONFIG_DIR` the client writes elsewhere, so user-scope opt-in is missed. Separate defect, found while building the test rig, out of scope here.
- **The branch name (`eugene/pypi-pages-update-release`) does not describe this change.** Left alone — renaming an open PR's branch closes it.