### PR TITLE
chore(release): call the release check at its canonical path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ zipapp:
 	$(PYTHON) tools/build_zipapp.py $(OUTPUT_DIR)
 
 release-preflight: lint-packs
-	@bash tools/release-check.sh
+	@bash tools/repo/release_check.sh
 
 # ── Static analysis + tests ──────────────────────────────────────────────────
 # Requires: python -m pip install -e packages/agentbundle ruff mypy pytest

--- a/packages/agentbundle/tests/unit/test_release_check.py
+++ b/packages/agentbundle/tests/unit/test_release_check.py
@@ -1,11 +1,16 @@
-"""Ship-time tag verifier — tools/release-check.sh.
+"""Ship-time tag verifier — tools/repo/release_check.sh.
 
 Spec AC: "the git tag `contract-v<version>` exists in this repo's
 history before `dist/agentbundle.pyz` is uploaded as a release asset".
 The CLI's `--version` output binds to that tag, so a `.pyz` claiming
 "spec 0.1" without a `contract-v0.1` anchor in git has no canonical
-source-of-truth check. `tools/release-check.sh` is the mechanical
+source-of-truth check. `tools/repo/release_check.sh` is the mechanical
 verifier; this test pins its refuse-and-explain behaviour.
+
+Drives the verifier at its canonical path, not the `tools/release-check.sh`
+compatibility shim — running through the shim tested an alias and printed a
+relocation warning into every run. The shim's own existence is covered by
+`tools/test_catalogue_tooling_rewire.py`.
 """
 
 from __future__ import annotations
@@ -17,13 +22,13 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
-RELEASE_CHECK = REPO_ROOT / "tools" / "release-check.sh"
+RELEASE_CHECK = REPO_ROOT / "tools" / "repo" / "release_check.sh"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="no Unix execute bits on Windows")
 def test_release_check_exists_and_executable():
-    assert RELEASE_CHECK.exists(), "tools/release-check.sh is missing"
-    assert RELEASE_CHECK.stat().st_mode & 0o111, "release-check.sh must be executable"
+    assert RELEASE_CHECK.exists(), "tools/repo/release_check.sh is missing"
+    assert RELEASE_CHECK.stat().st_mode & 0o111, "release_check.sh must be executable"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="bash encoding differs on Windows")


### PR DESCRIPTION
## The noise

`make release-preflight` printed this on every run:

```
WARNING: tools/release-check.sh moved to tools/repo/release_check.sh
```

It wasn't a stale external caller — it was **our own Makefile** routing through the compatibility shim left by the `tools/` reorganisation. The unit test drove the same shim, so the warning landed in pytest output too.

Both call sites now invoke `tools/repo/release_check.sh` directly. Two files, no behaviour change: the same script runs, just without the hop.

## What I did not do

**The shim stays.** It has three siblings from the same reorganisation — `tools/pre-pr-catalogue.py`, `tools/publish-claude-plugins.py`, `tools/check-contract-drift.py` — and `tools/test_catalogue_tooling_rewire.py` guards all four with `test_*_shim_exists`. Two of the three siblings print the same style of warning. Retiring them is one decision about the set, not a ride-along on a noise fix, so it's yours to call.

Swept for every consumer of the old path before deciding: `Makefile:235` and `packages/agentbundle/tests/unit/test_release_check.py` were the only two, plus the guard test that exists to assert the shim is there. Nothing else in the repo references it.

## Side benefit

`test_release_check.py` now drives the real verifier rather than an alias of it — its docstring claimed `tools/release-check.sh` "is the mechanical verifier", which stopped being true when the script moved.

## Verification

- `make release-preflight` — exit 0, and the only stderr left is the catalogue lint's own `ok:` line.
- `pytest packages/agentbundle/tests/unit/test_release_check.py` — 2 passed, no warning.
- `pytest tools/test_catalogue_tooling_rewire.py` — 20 passed; the shim's guard test is untouched and still green.
- `make lint-ruff` — clean.

Neither changed path is in `RELEASE_IMPACTING_PREFIXES`, so Gate G doesn't fire and no version bump or changelog entry is owed. `packages/agentbundle/tests/**` is inside the engine path-gate's test carve-out, so no `Engine-Change-RFC` trailer either — confirmed by running the guard against `origin/main`.