### PR TITLE
fix(core): close a path traversal in lint-spec-status, and make argv path boundaries legible to taint scanners (core 2.3.0)

### DIFF
--- a/.agents/skills/work-loop/references/state-schema.md
+++ b/.agents/skills/work-loop/references/state-schema.md
@@ -35,7 +35,7 @@ write-second ordering.
 | `review_round_count` | Total review rounds (all outcomes), incremented by `review record --fingerprint`, `--report`, and `--all-skipped`. |
 | `review_retry_count` | Findings-only review rounds; incremented by `review record --fingerprint` only (not `--report` or `--all-skipped`). `check --phase review` exits non-zero when `review_retry_count >= max_review_retries`. |
 | `max_review_retries` | Cap. Default: `5`. |
-| `finding_fingerprints` | `sha1("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
+| `finding_fingerprints` | `sha256("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
 | `previous_finding_fingerprints` | `finding_fingerprints` from the round before last. Rotated atomically with `finding_fingerprints` by `review record`. |
 | `auto_parallel` | Always `false` in Phase 1; `dispatch-decision` and `auto-parallel` verbs are disabled. |
 | `last_commit_sha` | Latest commit SHA (informational; set externally). |

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -309,6 +309,26 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*, because that is the shape taint analysers recognise. Same
+    pattern as `check-spec-status.py:72-80`.
+
+    Normalises and asserts directory-ness only — it does not confine the root
+    to a fixed prefix, since `--root` is the caller-supplied scan scope. Note
+    this also fixes a real usability trap: before the check, a typo'd `--root`
+    scanned an empty tree and reported "spec metadata clean".
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-spec-status: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     try:
         r = subprocess.run(
@@ -439,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-ref", default=None)
     args = parser.parse_args(argv)
 
-    root = args.root.resolve() if args.root else _repo_root()
+    root = _validated_root(args.root)
     base_ref = args.base_ref if args.base_ref else resolve_default_base_ref(root)
 
     hard, warn = check(root, base_ref)

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -95,7 +95,13 @@ _CODE_EXTS = (".py", ".toml", ".sh", ".json")
 # Header contract line (invariant v), e.g. `- **Contract:** `contracts/openapi/orders.yaml``.
 _CONTRACT_HEADER_RE = re.compile(r"\*\*Contract:\*\*\s*(.+?)\s*$")
 # A repo-relative contract path token under the `contracts/` tree.
-_CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
+# Segments may not be `.` or `..`: the token is joined onto `--root` and read,
+# so a permissive class containing `.` and `/` let `contracts/../../secret.json`
+# escape the tree. `_within()` at the join site is the actual control; this
+# rejects the traversal earlier so the warning text stays honest. Each segment
+# must therefore start with an alphanumeric.
+_CONTRACT_SEGMENT = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+_CONTRACT_TOKEN_RE = re.compile(rf"contracts/(?:{_CONTRACT_SEGMENT}/)*{_CONTRACT_SEGMENT}")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
@@ -309,6 +315,51 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+# Skip implausibly large files — an untrusted repo could ship a multi-GB
+# spec.md or contract; reading it whole is a memory-exhaustion DoS. Mirrors
+# lint-traceability.py's guard of the same name.
+_MAX_FILE_BYTES = 8 * 1024 * 1024
+
+
+def _read(path: Path) -> str | None:
+    """Size-guarded read. Returns None when the file is too large or unreadable."""
+    try:
+        if path.stat().st_size > _MAX_FILE_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _within(path: Path, root: Path) -> bool:
+    """True when `path` is inside `root` after symlink resolution.
+
+    Ported from lint-traceability.py, which has carried this confinement since
+    it was written. This file did not, and that was a real gap, not a stylistic
+    one: `Contract:` header tokens are matched by `_CONTRACT_TOKEN_RE`, whose
+    character class contains `.` and `/`, so a header reading
+    `contracts/../../secret.json` in an untrusted spec.md resolved outside
+    `--root` and was read. That produced both an existence oracle (two distinct
+    warnings depending on whether the target existed) and a content-substring
+    oracle. `docs/architecture/security.md` declares `filesystem_read_untrusted`
+    a boundary, so hostile repo content is in scope.
+    """
+    try:
+        return path.resolve().is_relative_to(root)
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+
+def _confined(paths, root: Path) -> list[Path]:
+    """Globbed / iterated paths filtered to those within `root`.
+
+    `pathlib.glob` follows symlinked directories, so each result is re-checked
+    before it is read — a symlinked `docs/specs/<slug>` cannot pull in a
+    spec.md from outside the tree.
+    """
+    return [p for p in paths if _within(p, root)]
+
+
 def _validated_root(candidate: Path | None) -> Path:
     """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
 
@@ -321,7 +372,17 @@ def _validated_root(candidate: Path | None) -> Path:
     this also fixes a real usability trap: before the check, a typo'd `--root`
     scanned an empty tree and reported "spec metadata clean".
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-spec-status: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
     if not root.is_dir():
@@ -360,9 +421,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         )
 
     specs_dir = root / "docs" / "specs"
-    for spec_path in sorted(specs_dir.glob("*/spec.md")):
+    for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
         rel = spec_path.relative_to(root).as_posix()
-        text = spec_path.read_text(encoding="utf-8", errors="replace")
+        text = _read(spec_path)
+        if text is None:
+            continue
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -432,7 +495,9 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
             for lineno, token in contract_refs:
                 contract_file = root / token
-                if not contract_file.is_file():
+                # Confinement precedes the existence probe: an unconfined
+                # is_file() is itself an existence oracle for files outside root.
+                if not _within(contract_file, root) or not contract_file.is_file():
                     warn.append(
                         f"{rel}:{lineno}: invariant (v) — Contract: '{token}' does "
                         f"not resolve to a file (warn-only)"
@@ -440,7 +505,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                     continue
                 backward = False
                 if token.endswith(_XSPEC_FORMATS):
-                    ctext = contract_file.read_text(encoding="utf-8", errors="replace")
+                    ctext = _read(contract_file) or ""
                     backward = "x-spec" in ctext and feature_dir in ctext
                 if not backward:
                     backward = token in registry_text and feature_dir in registry_text

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -221,6 +221,12 @@ def load_layout(root: Path) -> dict:
         return {}
     for cfg in (root / "agentbundle-layout.toml",
                 Path.home() / ".agentbundle" / "agentbundle-layout.toml"):
+        # Confine the root-relative candidate only: a symlink planted at
+        # `<root>/agentbundle-layout.toml` in an untrusted tree would otherwise
+        # be followed. The user-scope candidate is deliberately outside `root`
+        # and is operator-owned, so it is exempt by design, not by oversight.
+        if cfg.parent == root and not _within(cfg, root):
+            continue
         text = _read(cfg)  # stat-size-guarded; None if absent/oversized/unreadable
         if text is None:
             continue
@@ -257,7 +263,12 @@ def resolve_base(layer: str, root: Path, layout: dict) -> tuple[Path | None, str
     # Tier 3: discover by marker. Only reached when the default is absent — the
     # common case is "this layer is simply unpopulated", so a miss is not an
     # error. A bounded search keeps it from walking vendored trees.
-    candidates = _discover_layer_dirs(root, layer)
+    # `_confined` completes the control here: on Windows `os.path.islink()` is
+    # False for NTFS junctions, so `_iter_dirs`' `followlinks=False` does not
+    # stop `os.walk` descending one, and a discovered candidate can resolve
+    # outside `root`. Every downstream read is `_confined` already, so this is
+    # the one asymmetry rather than an exploit path — closed for consistency.
+    candidates = _confined(_discover_layer_dirs(root, layer), root)
     if not candidates:
         return None, None
     if len(candidates) > 1:

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -1221,6 +1221,30 @@ def _drift_check(root: Path, layout: dict, sidecar_g: Graph) -> list[str]:
             for missing in sorted(loc - side)]
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied scan root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*. Taint analysers recognise that shape; they do not follow
+    the `_within()` / `_confined()` confinement applied to every path derived
+    from this root, because that check is interprocedural and expressed as a
+    comprehension filter. Same pattern as `check-spec-status.py:72-80`.
+
+    This normalises and asserts directory-ness; it deliberately does **not**
+    confine the root to a fixed prefix. `--root` *is* the caller-supplied scan
+    scope of a repo linter (see the module docstring), so restricting which
+    directory may be scanned would break the tool's purpose. The security
+    control remains `_within()`: every path *derived* from this root is
+    re-checked against it before being read.
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-traceability: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-traceability: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     """Best-effort root for a bare manual run (git toplevel, else the script's
     grandparent). The CI gate and self-tests always pass `--root` explicitly."""
@@ -1248,7 +1272,7 @@ def main(argv: list[str] | None = None) -> int:
              "dangling edges and cycles exit 1 in every mode.",
     )
     args = parser.parse_args(argv)
-    root = (args.root.resolve() if args.root else _repo_root()).resolve()
+    root = _validated_root(args.root)
 
     try:
         out, hard, exit_hint = check(root, args.strict)

--- a/.agents/skills/work-loop/scripts/lint-traceability.py
+++ b/.agents/skills/work-loop/scripts/lint-traceability.py
@@ -1237,7 +1237,17 @@ def _validated_root(candidate: Path | None) -> Path:
     control remains `_within()`: every path *derived* from this root is
     re-checked against it before being read.
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-traceability: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-traceability: --root does not exist: {root}")
     if not root.is_dir():

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -67,7 +67,14 @@ CLEAN_SUBSTRING = "Clean — ready to commit."
 # Specialist reviewers (experience-reviewer, frontend-reviewer) emit "SHIP IT"
 # on its own line as their clean verdict instead of CLEAN_SUBSTRING.
 _SHIP_IT_RE = re.compile(r"^SHIP IT\s*$", re.MULTILINE)
-_RE_SHA1 = re.compile(r"^[0-9a-f]{40}$")
+# Fingerprints are SHA-256 (64 hex). The 40-hex SHA-1 form is still accepted
+# so a cohort that was mid-review when core upgraded can finish: its
+# state.json holds SHA-1 values and `review record --fingerprint` would
+# otherwise hard-reject them. Stasis detection compares sets computed by the
+# same binary, so a straddling run misses a match for exactly one round and
+# self-heals on the next. Drop the 40-hex alternative once no in-flight
+# cohort predates core 2.3.0.
+_RE_FINGERPRINT = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
 
 def _template_max_implementation_retries(fallback: int = 5) -> int:
@@ -969,10 +976,10 @@ FINDING_LINE_RE_WHERE = re.compile(
 
 
 def parse_findings(report_text: str) -> list[str]:
-    """Return SHA1 fingerprints for findings in a reviewer report.
+    """Return SHA-256 fingerprints for findings in a reviewer report.
 
     Algorithm pinned by the work-loop SKILL §REVIEW:
-        sha1("<file>|<line>|<title>")
+        sha256("<file>|<line>|<title>")
     where <file> is the cited path exactly as written, <line> is the first
     integer after the first colon in the citation, and <title> is the
     bolded heading including the surrounding `**` markers.
@@ -1000,7 +1007,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try Where: <location> (experience-reviewer)
@@ -1010,7 +1017,7 @@ def parse_findings(report_text: str) -> list[str]:
             location = m.group("location").strip()
             key = f"{location}|0|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try unquoted file:line (frontend-reviewer)
@@ -1024,7 +1031,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
     return fingerprints
 
@@ -1042,7 +1049,15 @@ def _resolved_report(candidate: str) -> Path:
     normalisation adjacent to the argv read, where a taint analyser can see it,
     instead of leaving a raw `Path(args.report)` as the boundary.
     """
-    return Path(candidate).resolve()
+    try:
+        return Path(candidate).resolve()
+    except (OSError, ValueError, RuntimeError):
+        # resolve() raises on an embedded null (ValueError) and on Windows
+        # reserved names (OSError). Falling back to the unresolved path keeps
+        # the value flowing to _classify_report, which classifies it `invalid`
+        # at exit 0 — the defined outcome. Raising here would reintroduce
+        # exactly the operational error this helper's docstring rules out.
+        return Path(candidate)
 
 
 def _classify_report(report_path: Path, state: dict) -> dict:
@@ -1139,10 +1154,11 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     if args.fingerprint:
         # Findings branch: --fingerprint <hex> ...
         fingerprints = sorted(set(args.fingerprint))
-        bad = [fp for fp in fingerprints if not _RE_SHA1.match(fp)]
+        bad = [fp for fp in fingerprints if not _RE_FINGERPRINT.match(fp)]
         if bad:
             return stop(
-                f"review record: --fingerprint must be lowercase 40-char SHA-1 hex; "
+                f"review record: --fingerprint must be lowercase 64-char SHA-256 hex "
+                f"(40-char SHA-1 still accepted for a run that predates core 2.3.0); "
                 f"invalid: {bad!r}"
             )
         state["previous_finding_fingerprints"] = list(state.get("finding_fingerprints", []))
@@ -1365,7 +1381,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--fingerprint",
         action="append",
         default=None,
-        help="explicit fingerprint (hex sha1); use for findings rounds",
+        help="explicit fingerprint (hex sha256); use for findings rounds",
     )
     _rr_grp.add_argument(
         "--all-skipped",

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -1029,6 +1029,22 @@ def parse_findings(report_text: str) -> list[str]:
     return fingerprints
 
 
+def _resolved_report(candidate: str) -> Path:
+    """Normalise the CLI-supplied `--report` path at the argv boundary.
+
+    Normalise-only, deliberately. The two `--root` linters in this skill raise
+    on an unusable path, but `--report` must not: `review inspect` classifies an
+    unreadable report as `invalid`, which the work-loop SKILL documents as a
+    Surface signal rather than a crash. Raising here would convert a defined
+    outcome into an operational error.
+
+    The `resolve()` still does the job it is here for — it puts the
+    normalisation adjacent to the argv read, where a taint analyser can see it,
+    instead of leaving a raw `Path(args.report)` as the boundary.
+    """
+    return Path(candidate).resolve()
+
+
 def _classify_report(report_path: Path, state: dict) -> dict:
     """Classify a reviewer report. Exits 0 for all report-content outcomes.
 
@@ -1080,7 +1096,7 @@ def cmd_review_inspect(args: argparse.Namespace) -> int:
         # Operational error (spec-dir unresolvable or state.json unreadable)
         return stop(str(exc))
 
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
 
     if args.json:
@@ -1144,7 +1160,7 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     # Clean branch: --report <path>
     if not args.report:
         return stop("review record: one of --report or --fingerprint is required")
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
     if result["classification"] != "clean":
         cls = result["classification"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -158,7 +158,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "2.2.1"
+      "version": "2.3.0"
     },
     {
       "author": {

--- a/.claude/skills/work-loop/references/state-schema.md
+++ b/.claude/skills/work-loop/references/state-schema.md
@@ -35,7 +35,7 @@ write-second ordering.
 | `review_round_count` | Total review rounds (all outcomes), incremented by `review record --fingerprint`, `--report`, and `--all-skipped`. |
 | `review_retry_count` | Findings-only review rounds; incremented by `review record --fingerprint` only (not `--report` or `--all-skipped`). `check --phase review` exits non-zero when `review_retry_count >= max_review_retries`. |
 | `max_review_retries` | Cap. Default: `5`. |
-| `finding_fingerprints` | `sha1("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
+| `finding_fingerprints` | `sha256("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
 | `previous_finding_fingerprints` | `finding_fingerprints` from the round before last. Rotated atomically with `finding_fingerprints` by `review record`. |
 | `auto_parallel` | Always `false` in Phase 1; `dispatch-decision` and `auto-parallel` verbs are disabled. |
 | `last_commit_sha` | Latest commit SHA (informational; set externally). |

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -309,6 +309,26 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*, because that is the shape taint analysers recognise. Same
+    pattern as `check-spec-status.py:72-80`.
+
+    Normalises and asserts directory-ness only — it does not confine the root
+    to a fixed prefix, since `--root` is the caller-supplied scan scope. Note
+    this also fixes a real usability trap: before the check, a typo'd `--root`
+    scanned an empty tree and reported "spec metadata clean".
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-spec-status: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     try:
         r = subprocess.run(
@@ -439,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-ref", default=None)
     args = parser.parse_args(argv)
 
-    root = args.root.resolve() if args.root else _repo_root()
+    root = _validated_root(args.root)
     base_ref = args.base_ref if args.base_ref else resolve_default_base_ref(root)
 
     hard, warn = check(root, base_ref)

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -95,7 +95,13 @@ _CODE_EXTS = (".py", ".toml", ".sh", ".json")
 # Header contract line (invariant v), e.g. `- **Contract:** `contracts/openapi/orders.yaml``.
 _CONTRACT_HEADER_RE = re.compile(r"\*\*Contract:\*\*\s*(.+?)\s*$")
 # A repo-relative contract path token under the `contracts/` tree.
-_CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
+# Segments may not be `.` or `..`: the token is joined onto `--root` and read,
+# so a permissive class containing `.` and `/` let `contracts/../../secret.json`
+# escape the tree. `_within()` at the join site is the actual control; this
+# rejects the traversal earlier so the warning text stays honest. Each segment
+# must therefore start with an alphanumeric.
+_CONTRACT_SEGMENT = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+_CONTRACT_TOKEN_RE = re.compile(rf"contracts/(?:{_CONTRACT_SEGMENT}/)*{_CONTRACT_SEGMENT}")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
@@ -309,6 +315,51 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+# Skip implausibly large files — an untrusted repo could ship a multi-GB
+# spec.md or contract; reading it whole is a memory-exhaustion DoS. Mirrors
+# lint-traceability.py's guard of the same name.
+_MAX_FILE_BYTES = 8 * 1024 * 1024
+
+
+def _read(path: Path) -> str | None:
+    """Size-guarded read. Returns None when the file is too large or unreadable."""
+    try:
+        if path.stat().st_size > _MAX_FILE_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _within(path: Path, root: Path) -> bool:
+    """True when `path` is inside `root` after symlink resolution.
+
+    Ported from lint-traceability.py, which has carried this confinement since
+    it was written. This file did not, and that was a real gap, not a stylistic
+    one: `Contract:` header tokens are matched by `_CONTRACT_TOKEN_RE`, whose
+    character class contains `.` and `/`, so a header reading
+    `contracts/../../secret.json` in an untrusted spec.md resolved outside
+    `--root` and was read. That produced both an existence oracle (two distinct
+    warnings depending on whether the target existed) and a content-substring
+    oracle. `docs/architecture/security.md` declares `filesystem_read_untrusted`
+    a boundary, so hostile repo content is in scope.
+    """
+    try:
+        return path.resolve().is_relative_to(root)
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+
+def _confined(paths, root: Path) -> list[Path]:
+    """Globbed / iterated paths filtered to those within `root`.
+
+    `pathlib.glob` follows symlinked directories, so each result is re-checked
+    before it is read — a symlinked `docs/specs/<slug>` cannot pull in a
+    spec.md from outside the tree.
+    """
+    return [p for p in paths if _within(p, root)]
+
+
 def _validated_root(candidate: Path | None) -> Path:
     """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
 
@@ -321,7 +372,17 @@ def _validated_root(candidate: Path | None) -> Path:
     this also fixes a real usability trap: before the check, a typo'd `--root`
     scanned an empty tree and reported "spec metadata clean".
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-spec-status: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
     if not root.is_dir():
@@ -360,9 +421,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         )
 
     specs_dir = root / "docs" / "specs"
-    for spec_path in sorted(specs_dir.glob("*/spec.md")):
+    for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
         rel = spec_path.relative_to(root).as_posix()
-        text = spec_path.read_text(encoding="utf-8", errors="replace")
+        text = _read(spec_path)
+        if text is None:
+            continue
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -432,7 +495,9 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
             for lineno, token in contract_refs:
                 contract_file = root / token
-                if not contract_file.is_file():
+                # Confinement precedes the existence probe: an unconfined
+                # is_file() is itself an existence oracle for files outside root.
+                if not _within(contract_file, root) or not contract_file.is_file():
                     warn.append(
                         f"{rel}:{lineno}: invariant (v) — Contract: '{token}' does "
                         f"not resolve to a file (warn-only)"
@@ -440,7 +505,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                     continue
                 backward = False
                 if token.endswith(_XSPEC_FORMATS):
-                    ctext = contract_file.read_text(encoding="utf-8", errors="replace")
+                    ctext = _read(contract_file) or ""
                     backward = "x-spec" in ctext and feature_dir in ctext
                 if not backward:
                     backward = token in registry_text and feature_dir in registry_text

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -221,6 +221,12 @@ def load_layout(root: Path) -> dict:
         return {}
     for cfg in (root / "agentbundle-layout.toml",
                 Path.home() / ".agentbundle" / "agentbundle-layout.toml"):
+        # Confine the root-relative candidate only: a symlink planted at
+        # `<root>/agentbundle-layout.toml` in an untrusted tree would otherwise
+        # be followed. The user-scope candidate is deliberately outside `root`
+        # and is operator-owned, so it is exempt by design, not by oversight.
+        if cfg.parent == root and not _within(cfg, root):
+            continue
         text = _read(cfg)  # stat-size-guarded; None if absent/oversized/unreadable
         if text is None:
             continue
@@ -257,7 +263,12 @@ def resolve_base(layer: str, root: Path, layout: dict) -> tuple[Path | None, str
     # Tier 3: discover by marker. Only reached when the default is absent — the
     # common case is "this layer is simply unpopulated", so a miss is not an
     # error. A bounded search keeps it from walking vendored trees.
-    candidates = _discover_layer_dirs(root, layer)
+    # `_confined` completes the control here: on Windows `os.path.islink()` is
+    # False for NTFS junctions, so `_iter_dirs`' `followlinks=False` does not
+    # stop `os.walk` descending one, and a discovered candidate can resolve
+    # outside `root`. Every downstream read is `_confined` already, so this is
+    # the one asymmetry rather than an exploit path — closed for consistency.
+    candidates = _confined(_discover_layer_dirs(root, layer), root)
     if not candidates:
         return None, None
     if len(candidates) > 1:

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -1221,6 +1221,30 @@ def _drift_check(root: Path, layout: dict, sidecar_g: Graph) -> list[str]:
             for missing in sorted(loc - side)]
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied scan root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*. Taint analysers recognise that shape; they do not follow
+    the `_within()` / `_confined()` confinement applied to every path derived
+    from this root, because that check is interprocedural and expressed as a
+    comprehension filter. Same pattern as `check-spec-status.py:72-80`.
+
+    This normalises and asserts directory-ness; it deliberately does **not**
+    confine the root to a fixed prefix. `--root` *is* the caller-supplied scan
+    scope of a repo linter (see the module docstring), so restricting which
+    directory may be scanned would break the tool's purpose. The security
+    control remains `_within()`: every path *derived* from this root is
+    re-checked against it before being read.
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-traceability: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-traceability: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     """Best-effort root for a bare manual run (git toplevel, else the script's
     grandparent). The CI gate and self-tests always pass `--root` explicitly."""
@@ -1248,7 +1272,7 @@ def main(argv: list[str] | None = None) -> int:
              "dangling edges and cycles exit 1 in every mode.",
     )
     args = parser.parse_args(argv)
-    root = (args.root.resolve() if args.root else _repo_root()).resolve()
+    root = _validated_root(args.root)
 
     try:
         out, hard, exit_hint = check(root, args.strict)

--- a/.claude/skills/work-loop/scripts/lint-traceability.py
+++ b/.claude/skills/work-loop/scripts/lint-traceability.py
@@ -1237,7 +1237,17 @@ def _validated_root(candidate: Path | None) -> Path:
     control remains `_within()`: every path *derived* from this root is
     re-checked against it before being read.
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-traceability: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-traceability: --root does not exist: {root}")
     if not root.is_dir():

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -67,7 +67,14 @@ CLEAN_SUBSTRING = "Clean — ready to commit."
 # Specialist reviewers (experience-reviewer, frontend-reviewer) emit "SHIP IT"
 # on its own line as their clean verdict instead of CLEAN_SUBSTRING.
 _SHIP_IT_RE = re.compile(r"^SHIP IT\s*$", re.MULTILINE)
-_RE_SHA1 = re.compile(r"^[0-9a-f]{40}$")
+# Fingerprints are SHA-256 (64 hex). The 40-hex SHA-1 form is still accepted
+# so a cohort that was mid-review when core upgraded can finish: its
+# state.json holds SHA-1 values and `review record --fingerprint` would
+# otherwise hard-reject them. Stasis detection compares sets computed by the
+# same binary, so a straddling run misses a match for exactly one round and
+# self-heals on the next. Drop the 40-hex alternative once no in-flight
+# cohort predates core 2.3.0.
+_RE_FINGERPRINT = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
 
 def _template_max_implementation_retries(fallback: int = 5) -> int:
@@ -969,10 +976,10 @@ FINDING_LINE_RE_WHERE = re.compile(
 
 
 def parse_findings(report_text: str) -> list[str]:
-    """Return SHA1 fingerprints for findings in a reviewer report.
+    """Return SHA-256 fingerprints for findings in a reviewer report.
 
     Algorithm pinned by the work-loop SKILL §REVIEW:
-        sha1("<file>|<line>|<title>")
+        sha256("<file>|<line>|<title>")
     where <file> is the cited path exactly as written, <line> is the first
     integer after the first colon in the citation, and <title> is the
     bolded heading including the surrounding `**` markers.
@@ -1000,7 +1007,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try Where: <location> (experience-reviewer)
@@ -1010,7 +1017,7 @@ def parse_findings(report_text: str) -> list[str]:
             location = m.group("location").strip()
             key = f"{location}|0|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try unquoted file:line (frontend-reviewer)
@@ -1024,7 +1031,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
     return fingerprints
 
@@ -1042,7 +1049,15 @@ def _resolved_report(candidate: str) -> Path:
     normalisation adjacent to the argv read, where a taint analyser can see it,
     instead of leaving a raw `Path(args.report)` as the boundary.
     """
-    return Path(candidate).resolve()
+    try:
+        return Path(candidate).resolve()
+    except (OSError, ValueError, RuntimeError):
+        # resolve() raises on an embedded null (ValueError) and on Windows
+        # reserved names (OSError). Falling back to the unresolved path keeps
+        # the value flowing to _classify_report, which classifies it `invalid`
+        # at exit 0 — the defined outcome. Raising here would reintroduce
+        # exactly the operational error this helper's docstring rules out.
+        return Path(candidate)
 
 
 def _classify_report(report_path: Path, state: dict) -> dict:
@@ -1139,10 +1154,11 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     if args.fingerprint:
         # Findings branch: --fingerprint <hex> ...
         fingerprints = sorted(set(args.fingerprint))
-        bad = [fp for fp in fingerprints if not _RE_SHA1.match(fp)]
+        bad = [fp for fp in fingerprints if not _RE_FINGERPRINT.match(fp)]
         if bad:
             return stop(
-                f"review record: --fingerprint must be lowercase 40-char SHA-1 hex; "
+                f"review record: --fingerprint must be lowercase 64-char SHA-256 hex "
+                f"(40-char SHA-1 still accepted for a run that predates core 2.3.0); "
                 f"invalid: {bad!r}"
             )
         state["previous_finding_fingerprints"] = list(state.get("finding_fingerprints", []))
@@ -1365,7 +1381,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--fingerprint",
         action="append",
         default=None,
-        help="explicit fingerprint (hex sha1); use for findings rounds",
+        help="explicit fingerprint (hex sha256); use for findings rounds",
     )
     _rr_grp.add_argument(
         "--all-skipped",

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -1029,6 +1029,22 @@ def parse_findings(report_text: str) -> list[str]:
     return fingerprints
 
 
+def _resolved_report(candidate: str) -> Path:
+    """Normalise the CLI-supplied `--report` path at the argv boundary.
+
+    Normalise-only, deliberately. The two `--root` linters in this skill raise
+    on an unusable path, but `--report` must not: `review inspect` classifies an
+    unreadable report as `invalid`, which the work-loop SKILL documents as a
+    Surface signal rather than a crash. Raising here would convert a defined
+    outcome into an operational error.
+
+    The `resolve()` still does the job it is here for — it puts the
+    normalisation adjacent to the argv read, where a taint analyser can see it,
+    instead of leaving a raw `Path(args.report)` as the boundary.
+    """
+    return Path(candidate).resolve()
+
+
 def _classify_report(report_path: Path, state: dict) -> dict:
     """Classify a reviewer report. Exits 0 for all report-content outcomes.
 
@@ -1080,7 +1096,7 @@ def cmd_review_inspect(args: argparse.Namespace) -> int:
         # Operational error (spec-dir unresolvable or state.json unreadable)
         return stop(str(exc))
 
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
 
     if args.json:
@@ -1144,7 +1160,7 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     # Clean branch: --report <path>
     if not args.report:
         return stop("review record: one of --report or --fingerprint is required")
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
     if result["classification"] != "clean":
         cls = result["classification"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,12 @@ on:
       - 'packs/core/tests/skills/work-loop/test-loop-cohort.py'
       - 'packs/core/tests/skills/work-loop/test-loop-engine.py'
       - 'packs/core/tests/skills/work-loop/test-loop-cohort.sh'
+      - 'packs/core/tests/skills/work-loop/test-root-validation.py'
+      - 'packs/core/tests/skills/work-loop/test-fingerprint-width.py'
+      - 'packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py'
+      - 'packs/core/.apm/skills/work-loop/scripts/lint-traceability.py'
+      - 'tools/semgrep/**'
+      - 'tools/test-semgrep-argv-boundary.py'
       - 'tools/hooks/**'
       - 'tools/test-all.py'
       - 'tools/lint-pack-test-boundary.py'
@@ -95,6 +101,10 @@ jobs:
         run: python3 packs/core/tests/skills/work-loop/test-loop-cohort.py
       - name: Python test suite — loop-engine FSM (84 unit/integration tests)
         run: python3 packs/core/tests/skills/work-loop/test-loop-engine.py
+      - name: Python test suite — CLI path-argument boundary validators
+        run: python3 packs/core/tests/skills/work-loop/test-root-validation.py
+      - name: Python test suite — review-fingerprint algorithm + width contract
+        run: python3 packs/core/tests/skills/work-loop/test-fingerprint-width.py
       - name: Pack runtime boundary (no pack's .apm/ carries tests; projection is clean)
         run: python3 tools/lint-pack-test-boundary.py
       - name: Pack runtime boundary — self-test (falsified in both directions)

--- a/.snyk
+++ b/.snyk
@@ -23,12 +23,18 @@
 #
 # Likely first candidates (ADR-0017): Snyk Code keys its weak-hash rule on the
 # `hashlib.sha1(...)` call, not on the `usedforsecurity=False` kwarg, so it may
-# still flag the two NON-security SHA-1 digests our gate already cleared:
+# still flag NON-security SHA-1 digests our own gate already cleared:
 #   - packages/agentbundle/agentbundle/config.py  (8-char derivation cache key)
-#   - packs/core/.apm/skills/work-loop/scripts/loop-cohort.py  (review fingerprint)
-# Both are documented non-security digests (see their docstrings); changing the
-# algorithm would diverge from documented spec/skill contracts. If the org scan
-# flags them, accept here with the Snyk-assigned ID — do not change the code.
+# That one is a documented non-security digest (see its docstring). If the org
+# scan flags it, accept here with the Snyk-assigned ID.
+#
+# RESOLVED (core 2.3.0): loop-cohort.py's review fingerprint was the second
+# candidate. Rather than suppress it we switched the digest to SHA-256 — the
+# fingerprints are opaque tokens compared set-wise for stasis detection, so the
+# change is behaviour-preserving, and a real fix satisfies Bandit, Semgrep AND
+# Snyk where a policy entry reaches only the last. That also removed the need
+# for the Semgrep sha1 rule exclusion to cover this file. Prefer this route
+# whenever the digest is genuinely non-security: ADR-0017 rung 1 beats rung 3.
 #
 # Worked example (commented — not active; replace with a real ID before use):
 #

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,14 @@ print-sast-dirs:
 
 print-sast-config:
 	@echo $(SAST_CONFIG)
+# Deliberately-vulnerable rule fixtures. tools/semgrep/fixtures/**/positive.py
+# exists to PROVE a custom rule fires; if the gate scanned it, every custom rule
+# with a positive fixture would red the build by design. Mirrors bandit.yaml's
+# `*/tests/*` exclusion, for the same reason. The fixtures are still scanned —
+# by tools/test-semgrep-argv-boundary.py, which asserts the exact finding count
+# on each. Excluding them here removes them from the gate, not from coverage.
 SEMGREP_EXCLUDE := \
+	--exclude tools/semgrep/fixtures \
 	--exclude-rule python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1 \
 	--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
 	--exclude-rule python.lang.security.use-defused-xml.use-defused-xml \

--- a/Makefile
+++ b/Makefile
@@ -149,9 +149,15 @@ build-check:
 # These four Semgrep rules are excluded as duplicates of findings already
 # dispositioned for Bandit, with no coverage loss (Bandit still flags new
 # instances of each class):
-#   - sha1   → the two sites are documented non-security digests annotated
-#              `usedforsecurity=False`; Bandit B324 is satisfied, Semgrep's rule
-#              can't read the kwarg. Bandit B324 still flags any new sha1.
+#   - sha1   → ONE remaining site (packages/agentbundle/agentbundle/config.py —
+#              an 8-char derivation cache key), a documented non-security digest
+#              annotated `usedforsecurity=False`; Bandit B324 is satisfied,
+#              Semgrep's rule can't read the kwarg. Bandit B324 still flags any
+#              new sha1. The second site (loop-cohort.py's review fingerprint)
+#              was FIXED in core 2.3.0 rather than suppressed — a real fix
+#              satisfies Bandit, Semgrep and the org's Snyk scan, which no
+#              exclusion here can reach. Retire this exclusion entirely once
+#              config.py's digest is migrated too.
 #   - urllib → constant/operator-configured bases, line-precise `# nosec B310`.
 #   - xml    → stdlib ElementTree (no external entities/DTDs), `# nosec B314`.
 #   - chmod  → the one hit is a restrictive 0o700 (secure); Bandit B103 is
@@ -224,6 +230,13 @@ sast:
 	# explicitly. Mirror packages/credbroker/pyproject.toml [crypto].
 	@printf 'cryptography>=42\nargon2-cffi>=23\n' | pip-audit -r /dev/stdin
 	semgrep --config p/python --config p/security-audit --config tools/semgrep/ --error --quiet --metrics off $(SEMGREP_EXCLUDE) $(SAST_DIRS)
+	# Prove the custom rules still fire. The scan above is silent both when the
+	# rules work and when they have been broken into no-ops, so it cannot tell
+	# the two apart — this self-test asserts the exact finding count on a
+	# deliberately-vulnerable fixture and on its fixed twin. It lives here, not
+	# in docs.yml, because it needs semgrep on PATH: there it would skip
+	# silently and gate nothing.
+	python3 tools/test-semgrep-argv-boundary.py
 
 build-scaffold:
 	@test -n "$(OUTPUT)" || (echo "make build-scaffold OUTPUT=<dir> required" >&2; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,17 @@ print-sast-config:
 # Deliberately-vulnerable rule fixtures. tools/semgrep/fixtures/**/positive.py
 # exists to PROVE a custom rule fires; if the gate scanned it, every custom rule
 # with a positive fixture would red the build by design. Mirrors bandit.yaml's
-# `*/tests/*` exclusion, for the same reason. The fixtures are still scanned —
-# by tools/test-semgrep-argv-boundary.py, which asserts the exact finding count
-# on each. Excluding them here removes them from the gate, not from coverage.
+# `*/tests/*` exclusion, for the same reason.
+#
+# Scoped to `positive.py` specifically, NOT the whole fixtures/ directory: a
+# directory-wide exclusion would also drop every future negative fixture and
+# helper from p/python and p/security-audit, which is wider than the need.
+# Residual coverage on what IS excluded: Bandit (bandit.yaml excludes only
+# `*/tests/*`) plus tools/test-semgrep-argv-boundary.py, which asserts the exact
+# finding count. That self-test runs ONLY the custom rule, so it is not a
+# substitute for the registry rulesets — hence keeping the exclusion narrow.
 SEMGREP_EXCLUDE := \
-	--exclude tools/semgrep/fixtures \
+	--exclude "tools/semgrep/fixtures/*/positive.py" \
 	--exclude-rule python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1 \
 	--exclude-rule python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected \
 	--exclude-rule python.lang.security.use-defused-xml.use-defused-xml \

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -54,6 +54,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a repository policy lint, not a packaged one: `pack.schema.json` and the
   packaged pack lint both run against *adopter* catalogues, so a rule in either
   would turn this catalogue's house style into someone else's build break.
+## [core][2.3.0] — 2026-08-07
+
+### Fixed
+
+- **A mistyped `--root` no longer reports success.** `lint-spec-status` and
+  `lint-traceability` accepted any path you gave them. Point either at a
+  directory that does not exist and it scanned an empty tree and announced
+  "spec metadata clean" — a green result that meant nothing. Both now refuse
+  an unusable `--root` and name the offending path. A valid root, an omitted
+  root, and a relative root all behave exactly as before.
+
+### Changed
+
+- **Path arguments are validated where they enter.** The work-loop scripts
+  already confined every file they read to within `--root`; that check now
+  also happens at the point the argument is read. This is a legibility change
+  for security scanners: the existing confinement runs across several
+  functions, which taint analysers cannot follow, so scanners in adopter
+  repositories reported path-traversal against code that was never vulnerable.
+  No file the scripts would previously read is now out of reach.
+
+  **Upgrade note:** an invocation that passed a nonexistent or non-directory
+  `--root` used to exit 0 and now exits non-zero. If CI depends on that
+  false pass, fix the path — the previous result was not a real check.
 
 ## [agentbundle][0.29.7] — 2026-08-06
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -58,14 +58,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A mistyped `--root` no longer reports success.** `lint-spec-status` and
+- **A nonexistent or non-directory `--root` no longer reports success.** `lint-spec-status` and
   `lint-traceability` accepted any path you gave them. Point either at a
   directory that does not exist and it scanned an empty tree and announced
   "spec metadata clean" — a green result that meant nothing. Both now refuse
   an unusable `--root` and name the offending path. A valid root, an omitted
   root, and a relative root all behave exactly as before.
 
+- **A crafted `Contract:` header can no longer read files outside the repo.**
+  `lint-spec-status` matched contract paths with a pattern that allowed `.` and
+  `/`, so a spec file containing `- **Contract:** contracts/../../secret.json`
+  made the linter read that file from outside the directory it was scanning and
+  reveal, through which warning it printed, whether the file existed and roughly
+  what it contained. A symlinked spec directory could escape the same way. Both
+  are closed, and files are now size-capped before reading.
+
 ### Changed
+
+- **Review fingerprints now use SHA-256** instead of SHA-1. These are internal
+  markers used to notice when a review round returns the same findings twice;
+  they are never shown to you. A run already in progress when you upgrade keeps
+  working — its older markers stay valid.
 
 - **Path arguments are validated where they enter.** The work-loop scripts
   already confined every file they read to within `--root`; that check now

--- a/docs/specs/pack-script-root-boundary-validation/plan.md
+++ b/docs/specs/pack-script-root-boundary-validation/plan.md
@@ -1,0 +1,130 @@
+# Plan: boundary validation for CLI path arguments in shipped work-loop scripts
+
+- **Status:** Approved
+- **Spec:** [`spec.md`](spec.md)
+
+## Constraints
+
+- **Shipped-artifact change.** These scripts install into adopter repos.
+  Touching `packs/` forces a `packs/core` version bump across three files
+  (`pack.toml`, `plugin.json`, `marketplace.json`) — `make build-self` syncs
+  none of them.
+- **Projections must be re-synced.** `.claude/` and `.agents/` carry copies;
+  `make build-self` regenerates them. Run it *after* the source edit and
+  verify `git status` is clean.
+- **Engine path-gate.** `packages/agentbundle/**` is untouched by design, so no
+  `Engine-Change-RFC` trailer is needed. Do not let the sweep drift into it.
+- **CLI surface is frozen.** No new flags, no changed defaults. AC5 is the guard.
+- **`check-spec-status.py` is read-only in this change** (AC4).
+
+## Anchor-test sweep
+
+Ran before task 1 — searched `packs/core/tests/` and `tools/` for tests that
+pin the content of the four in-scope files.
+
+| Risk | Finding |
+|---|---|
+| Content hashes / snapshots of the scripts | None found |
+| Version-pinned tests against `packs/core` | `packs/core/pack.toml` version is asserted by the agentbundle suite — the bump in task 6 must land with it |
+| Line-count or counted assertions | None found |
+
+## Tasks
+
+### T1 — Red tests for the validator contract
+**Depends on:** none
+**Mode:** TDD
+**Tests:** new `packs/core/tests/skills/work-loop/test_root_validation.py`:
+- `test_nonexistent_root_exits_nonzero_with_diagnostic` — asserts exit != 0 and the path appears in stderr (AC6)
+- `test_file_valued_root_exits_nonzero` — `--root` pointing at a file, not a dir (AC6)
+- `test_valid_root_unchanged` / `test_omitted_root_unchanged` / `test_relative_root_unchanged` — exit code + stdout parity vs. current behaviour (AC5)
+
+Invoke via `subprocess` against the real script path — not a synthesised
+import — so the test exercises the documented invocation.
+
+**Done when:** all five tests exist and fail for the right reason.
+
+### T2 — `_validated_root()` in `lint-traceability.py`
+**Depends on:** T1
+**Mode:** TDD
+**Tests:** T1 suite goes green for this script.
+**Approach:** add the helper adjacent to `_repo_root()` (`:1224`); rewrite
+`:1251` to call it. Docstring cites `check-spec-status.py:75` as the reference
+pattern. Leave `_within`/`_confined` untouched — they remain the real control.
+**Traces to:** AC1, AC5, AC6
+
+### T3 — Same for `lint-spec-status.py`
+**Depends on:** T1
+**Mode:** TDD
+**Tests:** T1 suite goes green for this script.
+**Approach:** helper adjacent to `_repo_root()` (`:312`); rewrite `:442`.
+**Traces to:** AC2, AC5, AC6
+
+### T4 — `--report` boundary in `loop-cohort.py`
+**Depends on:** T1
+**Mode:** TDD
+**Tests:** T1 suite extended for a nonexistent `--report`.
+**Approach:** both sites (`:1083`, `:1147`) call one shared helper. `--report`
+names a file, not a directory — assert file-ness, not dir-ness. Do not disturb
+the SHA-1 fingerprint logic (`:1003–1027`); it is out of scope here.
+**Traces to:** AC3, AC6
+
+### T5 — Semgrep boundary rule + fixtures
+**Depends on:** T2, T3, T4
+**Mode:** TDD
+**Tests:** `tools/test-semgrep-argv-boundary.py` runs the rule over two
+committed fixtures and asserts 1 finding on the positive, 0 on the negative.
+**Approach:** new `tools/semgrep/argv-path-boundary.yml`, a **structural** rule
+(not `mode: taint` — proven unable to cross a call). Must not fire on the
+`resolve()`-then-`is_relative_to()` guard shape, or it false-positives on
+`check-spec-status.py:72`. Scope via `paths.include` to the three fixed
+scripts; record in a rule comment that a repo-wide scope is 73 findings and
+name the expansion condition.
+**Traces to:** AC7, AC8
+
+### T6 — Version bump, projections, changelog, backlog
+**Depends on:** T5
+**Mode:** Goal-based
+**Done when:** three-file version bump greps clean; `make build-self` run and
+`git status` clean afterwards; CHANGELOG `[Unreleased]` entry present;
+three backlog slugs parse out of `workspace.toml`.
+**Traces to:** AC11, AC12, AC13
+
+### T7 — Real-invocation QA + full gates
+**Depends on:** T6
+**Mode:** Visual / manual QA
+**Done when:** each of the three modified scripts invoked for real against this
+repo (valid `--root`, omitted, relative) with exit code and stdout recorded in
+the PR; `make sast`, `python3 tools/lint-ruff.py`, `python3 -m pytest packs/core/tests -q`
+all green.
+**Traces to:** AC5, AC9, AC10
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Fix does not satisfy Snyk** (unverifiable from here — Assumption 2) | Change is independently justified by AC6; if the org scan still reports, escalate to `.snyk` + the YAML-merge backlog item |
+| Semgrep rule false-positives on the `is_relative_to` guard | T5 test asserts silence on that shape explicitly |
+| `make build-self` reverts projection-only edits | Memory: check `git status` after; close in-PR |
+| Directory assertion breaks an adopter invocation | AC5 parity tests across three valid `--root` forms |
+| Version bump misses one of three files | T6 greps all three |
+
+## Declined patterns
+
+| Tempted to | Declined because |
+|---|---|
+| Add `mode: taint` argv sources to `env-path-taint.yml` (the original ask) | Spike proved it cannot reach the finding (0 on the real file) and floods the gate (20 FPs). The structural rule in T5 replaces it. |
+| Sweep all 73 sites in one PR | Migration, not a fix. Backlogged as `pack-argv-path-boundary-sweep`. |
+| Confine `--root` to a hardcoded prefix | Breaks the linter's documented purpose — `--root` *is* the scan scope. |
+| Extract a shared `pathsafe.py` across the four scripts | Skill scripts are standalone by design; no second consumer outside work-loop yet. Inline per file; extract when a real second caller appears. |
+| Build the YAML-merge so packs can ship `.snyk` | Large agentbundle change, wrong layer, and still needs each org to enable Consistent Ignores. Backlogged. |
+| Change SHA-1 → SHA-256 in `loop-cohort.py` while in the file | Separate concern with a state migration and a SKILL contract edit. Not this PR. |
+
+## Resolve-vs-surface disposition record
+
+| Item | Disposition |
+|---|---|
+| Are the Snyk findings real? | **Resolved** — CodeQL `py/path-injection` independently clears them |
+| Can a taint rule reproduce them? | **Resolved** — spike, empirically no |
+| Will the fix satisfy Snyk? | **Surfaced** — unverifiable without Snyk access; recorded as Assumption 2 |
+| Scope: 4 files or all 73 sites? | **Surfaced at the approval gate** — spec scopes to 4, backlogs the rest |
+| Ship `.snyk` per pack? | **Resolved** — structurally unavailable; backlogged |

--- a/docs/specs/pack-script-root-boundary-validation/plan.md
+++ b/docs/specs/pack-script-root-boundary-validation/plan.md
@@ -1,6 +1,6 @@
 # Plan: boundary validation for CLI path arguments in shipped work-loop scripts
 
-- **Status:** Approved
+- **Status:** Done
 - **Spec:** [`spec.md`](spec.md)
 
 ## Constraints
@@ -62,11 +62,15 @@ pattern. Leave `_within`/`_confined` untouched — they remain the real control.
 ### T4 — `--report` boundary in `loop-cohort.py`
 **Depends on:** T1
 **Mode:** TDD
-**Tests:** T1 suite extended for a nonexistent `--report`.
-**Approach:** both sites (`:1083`, `:1147`) call one shared helper. `--report`
-names a file, not a directory — assert file-ness, not dir-ness. Do not disturb
-the SHA-1 fingerprint logic (`:1003–1027`); it is out of scope here.
-**Traces to:** AC3, AC6
+**Tests:** `test-root-validation.py` asserts `classification == "invalid"` at
+exit 0 for a missing report — see the amended AC3.
+**Approach:** both sites call one shared `_resolved_report()`. **Revised during
+EXECUTE:** normalise-only, not file-ness assertion — `_classify_report` returns
+`invalid` for an unreadable report and SKILL.md defines that as a Surface
+signal, so raising would convert a defined outcome into an operational error.
+The `resolve()` is wrapped against `ValueError` (embedded null) so it does not
+become a raising site itself.
+**Traces to:** AC3
 
 ### T5 — Semgrep boundary rule + fixtures
 **Depends on:** T2, T3, T4
@@ -85,8 +89,8 @@ name the expansion condition.
 **Depends on:** T5
 **Mode:** Goal-based
 **Done when:** three-file version bump greps clean; `make build-self` run and
-`git status` clean afterwards; CHANGELOG `[Unreleased]` entry present;
-three backlog slugs parse out of `workspace.toml`.
+`git status` clean afterwards; changelog entry present; every backlog slug
+named by AC13 parses out of `workspace.toml` (count lives in AC13, not here).
 **Traces to:** AC11, AC12, AC13
 
 ### T7 — Real-invocation QA + full gates
@@ -117,7 +121,8 @@ all green.
 | Confine `--root` to a hardcoded prefix | Breaks the linter's documented purpose — `--root` *is* the scan scope. |
 | Extract a shared `pathsafe.py` across the four scripts | Skill scripts are standalone by design; no second consumer outside work-loop yet. Inline per file; extract when a real second caller appears. |
 | Build the YAML-merge so packs can ship `.snyk` | Large agentbundle change, wrong layer, and still needs each org to enable Consistent Ignores. Backlogged. |
-| Change SHA-1 → SHA-256 in `loop-cohort.py` while in the file | Separate concern with a state migration and a SKILL contract edit. Not this PR. |
+| ~~Change SHA-1 → SHA-256 in `loop-cohort.py`~~ | **Reversed on request during EXECUTE** — folded in as AC15 after confirming it cannot break the loop: fingerprints are opaque tokens compared set-wise between rounds, and `_RE_FINGERPRINT` accepts both widths so an in-flight cohort survives the upgrade. |
+| Convert `test-loop-cohort.sh` to Python in this PR | Raised during EXECUTE. Real portability defect (493 lines, ~20 bash-isms, unrunnable on Windows) but not urgent — `docs.yml:92` runs it on ubuntu and pack tests never install into adopter repos. Bundling a 51-case sequential port into a security fix would obscure both. Backlogged as `loop-cohort-shell-suite-to-python`. |
 
 ## Resolve-vs-surface disposition record
 

--- a/docs/specs/pack-script-root-boundary-validation/plan.md
+++ b/docs/specs/pack-script-root-boundary-validation/plan.md
@@ -33,7 +33,7 @@ pin the content of the four in-scope files.
 ### T1 — Red tests for the validator contract
 **Depends on:** none
 **Mode:** TDD
-**Tests:** new `packs/core/tests/skills/work-loop/test_root_validation.py`:
+**Tests:** new `packs/core/tests/skills/work-loop/test-root-validation.py` (hyphens — matches the sibling convention; note pytest's default `test_*.py` will NOT collect it, so it needs an explicit runner):
 - `test_nonexistent_root_exits_nonzero_with_diagnostic` — asserts exit != 0 and the path appears in stderr (AC6)
 - `test_file_valued_root_exits_nonzero` — `--root` pointing at a file, not a dir (AC6)
 - `test_valid_root_unchanged` / `test_omitted_root_unchanged` / `test_relative_root_unchanged` — exit code + stdout parity vs. current behaviour (AC5)
@@ -81,8 +81,8 @@ committed fixtures and asserts 1 finding on the positive, 0 on the negative.
 (not `mode: taint` — proven unable to cross a call). Must not fire on the
 `resolve()`-then-`is_relative_to()` guard shape, or it false-positives on
 `check-spec-status.py:72`. Scope via `paths.include` to the three fixed
-scripts; record in a rule comment that a repo-wide scope is 73 findings and
-name the expansion condition.
+scripts; record the repo-wide finding count and the expansion condition in the rule
+header — one location, since it drifts as the ratchet expands.
 **Traces to:** AC7, AC8
 
 ### T6 — Version bump, projections, changelog, backlog

--- a/docs/specs/pack-script-root-boundary-validation/spec.md
+++ b/docs/specs/pack-script-root-boundary-validation/spec.md
@@ -1,0 +1,211 @@
+# Spec: boundary validation for CLI path arguments in shipped work-loop scripts
+
+- **Status:** Implementing
+- **Owner:** maintainer
+- **Plan:** [`plan.md`](plan.md)
+- **Mode:** full (governance surface — ADR-0017 SAST gate; public-interface change — shipped pack scripts installed into adopter repos)
+- **Constrained by:**
+  - [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md) — SAST/SCA gate authority; remediation ladder (fix > pragma > `.snyk`)
+  - `packs/core/.apm/skills/work-loop/scripts/check-spec-status.py:72–80` — the in-repo exemplar of the target pattern
+  - `tools/semgrep/env-path-taint.yml` — existing custom taint rule; this spec adds a sibling, does not modify it
+- **Contract:** none (script-internal; CLI surface unchanged)
+- **Shape:** fix
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Make the shipped `work-loop` scripts read CLI path arguments through a
+**visible, intraprocedural normalize-and-validate boundary**, so that
+taint-based SAST engines running in *adopter* repositories stop reporting
+CWE-22/23 path-traversal findings against code we ship.
+
+This is a **scanner-legibility fix, not a vulnerability fix**. The scripts are
+already safe: every read under `--root` is re-confined through `_within()` /
+`_confined()`. The defect is that the confinement is *interprocedural and
+shaped as a list-comprehension filter*, which no taint engine follows.
+
+## Why suppression is not available
+
+Three suppression vehicles exist; none reaches an adopter.
+
+1. **`# nosec`** — Bandit-only. Does not reach Snyk (ADR-0017 § remediation ladder).
+2. **Semgrep rule exclusion** — our gate only. Does not reach an adopter.
+3. **`.snyk` policy file** — does not ship in any pack, and *cannot* without new
+   machinery: `agentbundle install` has no YAML-merge mode, so two packs each
+   shipping a `.snyk` would clobber one another. Deferred — see
+   `[backlog].open` slug `agentbundle-install-yaml-merge`.
+
+Suppression also does not scale: each adopter org runs its own scanner
+(Snyk, Checkmarx, Veracode) with its own ignore store. **Fixing the source is
+the only remediation that reaches every adopter at once.** This is ADR-0017's
+own rung 1.
+
+## Evidence
+
+18 Snyk Code CWE-23 findings were reported against two shipped scripts,
+observed in an adopter checkout at `.kiro/skills/work-loop/scripts/`
+(an adapter projection; `.kiro/` is absent from this repo).
+
+Every finding traces to **two lines**:
+
+| File | Line | Expression |
+|---|---|---|
+| `lint-spec-status.py` | 442 | `root = args.root.resolve() if args.root else _repo_root()` |
+| `lint-traceability.py` | 1251 | `root = (args.root.resolve() if args.root else _repo_root()).resolve()` |
+
+Snyk flags derived sinks up to ~800 lines downstream, including lines whose
+*immediately preceding statement* is `if not _within(d, root): continue` —
+conclusive evidence the existing sanitizer is not recognised.
+
+### Verified analyser limits (spike, this session)
+
+| Claim | Method | Result |
+|---|---|---|
+| OSS Semgrep taint is intraprocedural | Control with source in `main()`, sink in a called function, same file | **0 findings** — does not cross a call |
+| A taint rule cannot reproduce the Snyk finding | Ran argv-source taint rule against real `lint-traceability.py` | **0 findings** |
+| A taint rule would flood the gate | Same rule across `tools packs packages` | **20 findings**, all operator-supplied-root false positives |
+| A boundary rule *can* pin the root cause | Structural rule at the argv-entry site | **Fires on exactly the 2 lines above** |
+| A boundary rule cannot be repo-wide | Same rule across `tools packs packages` | **73 findings** — untenable as a blocking gate |
+| CodeQL already clears this flow | `py/path-injection` in `security-extended`, run log confirmed executed | **0 alerts** |
+
+## Scope
+
+**In scope** — the four shipped `work-loop` scripts with an argv→path boundary:
+
+| File | Line(s) | Argument |
+|---|---|---|
+| `lint-traceability.py` | 1251 | `--root` |
+| `lint-spec-status.py` | 442 | `--root` |
+| `loop-cohort.py` | 1083, 1147 | `--report` |
+| `check-spec-status.py` | 72 | `spec_dir` / `--file` — **already correct**; used as the reference pattern, not modified |
+
+**Out of scope** (deferred to `[backlog].open`):
+
+- The other ~68 argv→path sites across `packs/` (converters, atlassian,
+  workspace-status, receive-brief) and `packages/agentbundle` — slug
+  `pack-argv-path-boundary-sweep`.
+- `tools/` — not shipped; ADR-0017 explicitly carves out dev-only CLIs.
+- YAML-merge in `agentbundle install` — slug `agentbundle-install-yaml-merge`.
+- Making CodeQL a required check — slug `codeql-required-check`.
+- **JS SAST coverage** — slug `sast-javascript-coverage`. Split out because
+  enabling coverage is the small half; triaging the findings it turns on is
+  the real cost, and bundling that here would stall this fix.
+
+**Declined, not deferred:**
+
+- **Extending `SAST_DIRS` to `web/`** (62 JS/TS/Astro files). `web/` is the
+  platform site — built and deployed from this repo, never installed into an
+  adopter repo. It carries none of the shipped-artifact exposure that
+  motivates this spec. Revisit only if `web/` gains a server-side runtime.
+
+## Coverage audit (this session)
+
+A scanner-coverage audit was run before finalising scope, to check whether the
+Snyk findings pointed at a wider gap. Findings recorded here so the next
+reader does not repeat it:
+
+| Question | Result |
+|---|---|
+| Do unloaded Semgrep rulesets find anything? | 32 findings; 4 new classes — `path-join-resolve-traversal`, `tarfile-extractall-traversal`, `non-literal-import`, `detect-non-literal-regexp` |
+| Are any of them genuine? | **No.** `catalogue.py:150` and `archive.py:379` both already pass `filter="data"`; `render-proof.js:418–441` findings sit inside that file's own `validateOutputPath` |
+| What does Bandit contribute at the gate floor? | **Nothing today** — 266 findings, all LOW severity, zero at or above medium/medium. The gate can only fire on *new* medium+ findings |
+| Is shipped JS scanned? | **No** — by any of the three scanners. Quantified in the `sast-javascript-coverage` backlog entry |
+
+### CWE coverage vs. Snyk Code
+
+Snyk Code's published rule tables were parsed and diffed against our stack
+(Snyk Python rules: 43 rules / 43 CWEs; JS+TS: 53 rules / 42 CWEs; ours:
+376 Semgrep rules → 74 CWEs, plus Bandit's 24 — union **84**).
+
+| | Snyk CWEs | Ours | Gap |
+|---|---|---|---|
+| Python | 43 | 84 (union) | **10** — CWE-23, 209, 280, 321, 346, 453, 547, 757, 916, 1104 |
+| JS/TS | 42 | 84 nominal, **0 effective** (Bandit is Python-only; `p/python` is Python-only) | **13** — CWE-23, 126, 208, 312, 346, 347, 547, 606, 640, 770, 916, 1287, 1321 |
+
+**The load-bearing conclusion: rule count is not our problem.** We nominally
+cover roughly twice Snyk's CWE count. The reported CWE-23 finding got through
+not because we lack a path-traversal rule — we have CWE-22 rules and CWE-23 is
+its near-synonym — but because **Bandit has no dataflow engine and OSS Semgrep
+taint cannot cross a function boundary** (both verified this session). Adding
+more CWE-tagged rules does not close a depth gap.
+
+CWE tags are a coverage *proxy*, not proof of equivalent detection: two tools
+can tag the same CWE and catch disjoint cases. This session is itself the
+proof.
+
+The one lever that does address depth is CodeQL, which already runs
+`security-extended` for Python and is absent for JS — folded into
+`sast-javascript-coverage`.
+
+## Design
+
+Add a module-local helper to each in-scope script, placed **in the same
+function that reads `argv`** so the normalize-and-check is intraprocedural:
+
+```python
+def _validated_root(candidate: Path | None, fallback: Callable[[], Path]) -> Path:
+    """Resolve a CLI-supplied scan root and assert it is a real directory.
+
+    The normalize-then-check is deliberately intraprocedural and adjacent to
+    the argv read: taint analysers recognise this shape, whereas the
+    downstream `_within()` / `_confined()` confinement (which remains the
+    actual security control) is interprocedural and is not followed.
+    """
+```
+
+**Non-goal: confining `--root` to a hardcoded prefix.** `--root` *is* the
+caller-supplied scan scope of a repo linter (`lint-traceability.py:1226`
+documents this). Constraining it to a fixed parent would break legitimate use.
+The validator normalises and asserts directory-ness; it does not restrict
+*which* directory.
+
+## Acceptance criteria
+
+- [ ] **AC1** — `lint-traceability.py` reads `--root` through `_validated_root()`; the resolve-and-check is in the same function as `parse_args()`.
+- [ ] **AC2** — `lint-spec-status.py` likewise.
+- [ ] **AC3** — `loop-cohort.py` reads `--report` through an equivalent boundary validator at both sites (1083, 1147).
+- [ ] **AC4** — `check-spec-status.py` is **unmodified**; its existing pattern is cited in the new helpers' docstrings as the reference.
+- [ ] **AC5** — CLI behaviour is unchanged for every valid input: same exit codes, same stdout, for a valid `--root`, an omitted `--root`, and a relative `--root`.
+- [ ] **AC6** — An invalid `--root` (nonexistent path, or a file rather than a directory) exits non-zero with a diagnostic naming the offending path, rather than raising a traceback.
+- [ ] **AC7** — A new Semgrep rule `tools/semgrep/argv-path-boundary.yml` fires on the pre-fix form and is silent on the post-fix form, proven by committed positive **and** negative fixtures.
+- [ ] **AC8** — That rule is scoped (`paths.include`) to the fixed scripts only — a ratchet, not a repo-wide sweep — with the 73-site figure and the expansion condition recorded in a rule comment.
+- [ ] **AC9** — `make sast` passes with the new rule loaded; no new findings in the existing gate.
+- [ ] **AC10** — Full existing test suite for `packs/core` work-loop scripts passes unchanged.
+- [ ] **AC11** — `packs/core` version bumped in all three required files (`pack.toml`, `plugin.json`, `marketplace.json`); projections re-synced via `make build-self`.
+- [ ] **AC12** — CHANGELOG `[Unreleased]` records the skill-script change.
+- [ ] **AC13** — Deferred items recorded in `workspace.toml [backlog].open`: `pack-argv-path-boundary-sweep`, `agentbundle-install-yaml-merge`, `codeql-required-check`, `sast-javascript-coverage`, `sast-cwe-delta-review`; and the `web/` decline recorded with its reason.
+
+## Testing strategy
+
+| AC | Mode | Mechanism |
+|---|---|---|
+| AC1–AC4 | Goal-based | `grep` for `_validated_root` at each site; `git diff --exit-code` on `check-spec-status.py` |
+| AC5 | Visual / manual QA | Invoke each script for real — valid `--root`, omitted, relative — and record exit code + stdout |
+| AC6 | TDD | Test asserting non-zero exit + diagnostic on a nonexistent and a file-valued `--root` |
+| AC7 | TDD | Semgrep run over committed `positive.py` / `negative.py` fixtures; assert 1 finding then 0 |
+| AC8 | Goal-based | Assert `paths.include` present; assert rule comment records the figure |
+| AC9 | Goal-based | `make sast` exit 0 |
+| AC10 | Goal-based | `python3 -m pytest packs/core/tests -q` |
+| AC11 | Goal-based | Three-file version grep; `git status` clean after `make build-self` |
+| AC12–AC13 | Goal-based | grep CHANGELOG; parse `workspace.toml` for the three slugs |
+
+**Verification mechanism confirmed to exist before claiming these modes:**
+`packs/core/tests/skills/work-loop/` is present; `make sast` and
+`make build-self` are live Makefile targets.
+
+## Assumptions
+
+1. **The Snyk findings are false positives.** Corroborated independently by
+   CodeQL's `py/path-injection` (interprocedural, `security-extended`,
+   confirmed executed) returning zero. If this is wrong, the fix is
+   insufficient and the confinement logic itself needs rework.
+2. **Snyk recognises the resolve-then-check shape.** Standard for taint
+   engines and matches the pattern already used at `check-spec-status.py:75`,
+   but **unverifiable from here** — we have no Snyk access. Residual risk:
+   the fix lands and the org scan still reports. Mitigation: the change is
+   independently justified as defensive hardening (AC6 converts a traceback
+   into a diagnostic), so it is not wasted even if Snyk still flags.
+3. **No adopter passes a `--root` that fails the new directory assertion.**
+   AC5 covers the valid cases; AC6 makes the failure mode explicit.

--- a/docs/specs/pack-script-root-boundary-validation/spec.md
+++ b/docs/specs/pack-script-root-boundary-validation/spec.md
@@ -184,7 +184,7 @@ The validator normalises and asserts directory-ness; it does not restrict
 - [x] **AC5** — CLI behaviour is unchanged for every valid input: same exit codes, same stdout, for a valid `--root`, an omitted `--root`, and a relative `--root`.
 - [x] **AC6** — An invalid `--root` (nonexistent path, or a file rather than a directory) exits non-zero with a diagnostic naming the offending path, rather than raising a traceback.
 - [x] **AC7** — A new Semgrep rule `tools/semgrep/argv-path-boundary.yml` fires on the pre-fix form and is silent on the post-fix form, proven by committed positive **and** negative fixtures.
-- [x] **AC8** — That rule is scoped (`paths.include`) to the fixed scripts only — a ratchet, not a repo-wide sweep — with the 73-site figure and the expansion condition recorded in a rule comment.
+- [x] **AC8** — That rule is scoped (`paths.include`) to the fixed scripts only — a ratchet, not a repo-wide sweep — with the repo-wide finding count and the expansion condition recorded in the rule header. The number lives in `tools/semgrep/argv-path-boundary.yml` alone; it drifts as the ratchet expands, so nothing else restates it.
 - [x] **AC9** — `make sast` passes with the new rule loaded; no new findings in the existing gate.
 - [x] **AC10** — Full existing test suite for `packs/core` work-loop scripts passes unchanged.
 - [x] **AC11** — `packs/core` version bumped in all three required files (`pack.toml`, `plugin.json`, `marketplace.json`); projections re-synced via `make build-self`.

--- a/docs/specs/pack-script-root-boundary-validation/spec.md
+++ b/docs/specs/pack-script-root-boundary-validation/spec.md
@@ -1,6 +1,6 @@
 # Spec: boundary validation for CLI path arguments in shipped work-loop scripts
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** maintainer
 - **Plan:** [`plan.md`](plan.md)
 - **Mode:** full (governance surface — ADR-0017 SAST gate; public-interface change — shipped pack scripts installed into adopter repos)
@@ -9,7 +9,7 @@
   - `packs/core/.apm/skills/work-loop/scripts/check-spec-status.py:72–80` — the in-repo exemplar of the target pattern
   - `tools/semgrep/env-path-taint.yml` — existing custom taint rule; this spec adds a sibling, does not modify it
 - **Contract:** none (script-internal; CLI surface unchanged)
-- **Shape:** fix
+- **Shape:** service
 
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.
@@ -21,10 +21,24 @@ Make the shipped `work-loop` scripts read CLI path arguments through a
 taint-based SAST engines running in *adopter* repositories stop reporting
 CWE-22/23 path-traversal findings against code we ship.
 
-This is a **scanner-legibility fix, not a vulnerability fix**. The scripts are
-already safe: every read under `--root` is re-confined through `_within()` /
-`_confined()`. The defect is that the confinement is *interprocedural and
-shaped as a list-comprehension filter*, which no taint engine follows.
+This is **mostly** a scanner-legibility fix, plus one genuine vulnerability
+found during review.
+
+`lint-traceability.py` was already safe: every read under `--root` is
+re-confined through `_within()` / `_confined()`, and the only defect is that
+the confinement is *interprocedural and shaped as a comprehension filter*,
+which no taint engine follows.
+
+**`lint-spec-status.py` had no confinement at all** — `grep -c "_within\|_confined"`
+returned 0 against 25 in its sibling. An earlier draft of this spec asserted the
+control covered both scripts; that was wrong and unverified. Review caught it,
+and it concealed a real traversal: `_CONTRACT_TOKEN_RE` admitted `.` and `/`, so
+a `- **Contract:** contracts/../../secret.json` header in an untrusted `spec.md`
+resolved outside `--root` and was read. Reproduced end-to-end — the target's
+presence changed the warning text, giving an existence oracle, plus a
+content-substring oracle via `"x-spec" in ctext`. `docs/architecture/security.md`
+declares `filesystem_read_untrusted` a boundary, so hostile repo content is in
+scope. This spec now also closes that.
 
 ## Why suppression is not available
 
@@ -163,19 +177,22 @@ The validator normalises and asserts directory-ness; it does not restrict
 
 ## Acceptance criteria
 
-- [ ] **AC1** — `lint-traceability.py` reads `--root` through `_validated_root()`; the resolve-and-check is in the same function as `parse_args()`.
-- [ ] **AC2** — `lint-spec-status.py` likewise.
-- [ ] **AC3** — `loop-cohort.py` reads `--report` through an equivalent boundary validator at both sites (1083, 1147).
-- [ ] **AC4** — `check-spec-status.py` is **unmodified**; its existing pattern is cited in the new helpers' docstrings as the reference.
-- [ ] **AC5** — CLI behaviour is unchanged for every valid input: same exit codes, same stdout, for a valid `--root`, an omitted `--root`, and a relative `--root`.
-- [ ] **AC6** — An invalid `--root` (nonexistent path, or a file rather than a directory) exits non-zero with a diagnostic naming the offending path, rather than raising a traceback.
-- [ ] **AC7** — A new Semgrep rule `tools/semgrep/argv-path-boundary.yml` fires on the pre-fix form and is silent on the post-fix form, proven by committed positive **and** negative fixtures.
-- [ ] **AC8** — That rule is scoped (`paths.include`) to the fixed scripts only — a ratchet, not a repo-wide sweep — with the 73-site figure and the expansion condition recorded in a rule comment.
-- [ ] **AC9** — `make sast` passes with the new rule loaded; no new findings in the existing gate.
-- [ ] **AC10** — Full existing test suite for `packs/core` work-loop scripts passes unchanged.
-- [ ] **AC11** — `packs/core` version bumped in all three required files (`pack.toml`, `plugin.json`, `marketplace.json`); projections re-synced via `make build-self`.
-- [ ] **AC12** — CHANGELOG `[Unreleased]` records the skill-script change.
-- [ ] **AC13** — Deferred items recorded in `workspace.toml [backlog].open`: `pack-argv-path-boundary-sweep`, `agentbundle-install-yaml-merge`, `codeql-required-check`, `sast-javascript-coverage`, `sast-cwe-delta-review`; and the `web/` decline recorded with its reason.
+- [x] **AC1** — `lint-traceability.py` reads `--root` through `_validated_root()`. **Corrected during review:** the helper is called *from* the function holding `parse_args()`, not inlined into it. The original wording ("in the same function") was not met and would not have been, since a module-local helper is the readable form. What matters is that the normalise-and-check is a single hop from the argv read rather than scattered across the call graph — but note this means OSS Semgrep still cannot connect them, and the check is existence/type, not containment. Assumption 2's confidence rests on Snyk being interprocedural, which it is.
+- [x] **AC2** — `lint-spec-status.py` likewise, **plus** the confinement it never had: `_within()`, `_confined()` and a size-guarded `_read()` ported from `lint-traceability.py`, applied at the spec glob, the contract join, and both reads; and `_CONTRACT_TOKEN_RE` tightened to reject `.`/`..` segments.
+- [x] **AC3** — `loop-cohort.py` reads `--report` through a shared boundary helper at both sites. **Amended during EXECUTE:** this helper is *normalise-only* (`_resolved_report()` — `Path(...).resolve()`), not a raising validator as originally drafted. `_classify_report` returns `invalid` for an unreadable report, and `SKILL.md` defines `invalid` as a Surface signal with `review inspect` exiting 0 for every report-content outcome; raising would convert a defined outcome into an operational error. The normalise still meets the spec's actual goal — putting the boundary next to the argv read, where a taint analyser can see it.
+- [x] **AC4** — `check-spec-status.py` is **unmodified**; its existing pattern is cited in the new helpers' docstrings as the reference.
+- [x] **AC5** — CLI behaviour is unchanged for every valid input: same exit codes, same stdout, for a valid `--root`, an omitted `--root`, and a relative `--root`.
+- [x] **AC6** — An invalid `--root` (nonexistent path, or a file rather than a directory) exits non-zero with a diagnostic naming the offending path, rather than raising a traceback.
+- [x] **AC7** — A new Semgrep rule `tools/semgrep/argv-path-boundary.yml` fires on the pre-fix form and is silent on the post-fix form, proven by committed positive **and** negative fixtures.
+- [x] **AC8** — That rule is scoped (`paths.include`) to the fixed scripts only — a ratchet, not a repo-wide sweep — with the 73-site figure and the expansion condition recorded in a rule comment.
+- [x] **AC9** — `make sast` passes with the new rule loaded; no new findings in the existing gate.
+- [x] **AC10** — Full existing test suite for `packs/core` work-loop scripts passes unchanged.
+- [x] **AC11** — `packs/core` version bumped in all three required files (`pack.toml`, `plugin.json`, `marketplace.json`); projections re-synced via `make build-self`.
+- [x] **AC12** — CHANGELOG `[Unreleased]` records the skill-script change.
+- [x] **AC13** — Deferred items recorded in `workspace.toml [backlog].open`: `pack-argv-path-boundary-sweep`, `agentbundle-install-yaml-merge`, `codeql-required-check`, `sast-javascript-coverage`, `sast-cwe-delta-review`, `loop-cohort-shell-suite-to-python`; and the `web/` decline recorded with its reason.
+- [x] **AC14** — *(added during review)* The `lint-spec-status.py` path traversal is closed: `_within()` / `_confined()` / size-guarded `_read()` ported in and applied at the spec glob, the contract join, and both read sites; `_CONTRACT_TOKEN_RE` rejects `.` and `..` segments while still accepting every legitimate `contracts/<type>/<name>.<ext>` form. Proven by re-running the reproduction: the existence oracle and the symlink escape both produce no output, and invariant (v) still fires on real contracts.
+- [x] **AC15** — *(folded in on request)* Review fingerprints use SHA-256. `_RE_FINGERPRINT` accepts **both** 64-hex and 40-hex so a cohort mid-review at upgrade time does not hard-fail on its stored SHA-1 values; `state-schema.md` and the `--fingerprint` help text updated. Stasis detection is unaffected — fingerprints are opaque tokens compared set-wise between rounds computed by the same binary; a straddling run misses one match and self-heals.
+- [x] **AC16** — *(added during review)* Both new suites gate in CI. `tools/test-all.py` is executed by no workflow (`docs.yml:102`), so `test-root-validation.py` and `test-fingerprint-width.py` get explicit `docs.yml` steps plus path triggers, and `test-semgrep-argv-boundary.py` is chained into `make sast` where semgrep is guaranteed present (in `docs.yml` it would skip silently and gate nothing).
 
 ## Testing strategy
 
@@ -183,7 +200,7 @@ The validator normalises and asserts directory-ness; it does not restrict
 |---|---|---|
 | AC1–AC4 | Goal-based | `grep` for `_validated_root` at each site; `git diff --exit-code` on `check-spec-status.py` |
 | AC5 | Visual / manual QA | Invoke each script for real — valid `--root`, omitted, relative — and record exit code + stdout |
-| AC6 | TDD | Test asserting non-zero exit + diagnostic on a nonexistent and a file-valued `--root` |
+| AC6 | TDD | Test asserting non-zero exit + diagnostic on a nonexistent and a file-valued `--root`. For `--report` (per amended AC3) the assertion is instead `classification == "invalid"` at exit 0 — and the fixture must initialise a **real cohort**, since an empty spec dir exits non-zero on the missing `state.json` before the report path is read, i.e. green for a reason unrelated to the feature |
 | AC7 | TDD | Semgrep run over committed `positive.py` / `negative.py` fixtures; assert 1 finding then 0 |
 | AC8 | Goal-based | Assert `paths.include` present; assert rule comment records the figure |
 | AC9 | Goal-based | `make sast` exit 0 |

--- a/packs/core/.apm/skills/work-loop/references/state-schema.md
+++ b/packs/core/.apm/skills/work-loop/references/state-schema.md
@@ -35,7 +35,7 @@ write-second ordering.
 | `review_round_count` | Total review rounds (all outcomes), incremented by `review record --fingerprint`, `--report`, and `--all-skipped`. |
 | `review_retry_count` | Findings-only review rounds; incremented by `review record --fingerprint` only (not `--report` or `--all-skipped`). `check --phase review` exits non-zero when `review_retry_count >= max_review_retries`. |
 | `max_review_retries` | Cap. Default: `5`. |
-| `finding_fingerprints` | `sha1("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
+| `finding_fingerprints` | `sha256("<file>\|<line>\|<title>")` per finding in the last findings round. Written by `review record --fingerprint`; used for stasis detection via `review inspect`. |
 | `previous_finding_fingerprints` | `finding_fingerprints` from the round before last. Rotated atomically with `finding_fingerprints` by `review record`. |
 | `auto_parallel` | Always `false` in Phase 1; `dispatch-decision` and `auto-parallel` verbs are disabled. |
 | `last_commit_sha` | Latest commit SHA (informational; set externally). |

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -309,6 +309,26 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*, because that is the shape taint analysers recognise. Same
+    pattern as `check-spec-status.py:72-80`.
+
+    Normalises and asserts directory-ness only — it does not confine the root
+    to a fixed prefix, since `--root` is the caller-supplied scan scope. Note
+    this also fixes a real usability trap: before the check, a typo'd `--root`
+    scanned an empty tree and reported "spec metadata clean".
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-spec-status: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     try:
         r = subprocess.run(
@@ -439,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-ref", default=None)
     args = parser.parse_args(argv)
 
-    root = args.root.resolve() if args.root else _repo_root()
+    root = _validated_root(args.root)
     base_ref = args.base_ref if args.base_ref else resolve_default_base_ref(root)
 
     hard, warn = check(root, base_ref)

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -95,7 +95,13 @@ _CODE_EXTS = (".py", ".toml", ".sh", ".json")
 # Header contract line (invariant v), e.g. `- **Contract:** `contracts/openapi/orders.yaml``.
 _CONTRACT_HEADER_RE = re.compile(r"\*\*Contract:\*\*\s*(.+?)\s*$")
 # A repo-relative contract path token under the `contracts/` tree.
-_CONTRACT_TOKEN_RE = re.compile(r"contracts/[A-Za-z0-9._/-]+")
+# Segments may not be `.` or `..`: the token is joined onto `--root` and read,
+# so a permissive class containing `.` and `/` let `contracts/../../secret.json`
+# escape the tree. `_within()` at the join site is the actual control; this
+# rejects the traversal earlier so the warning text stays honest. Each segment
+# must therefore start with an alphanumeric.
+_CONTRACT_SEGMENT = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+_CONTRACT_TOKEN_RE = re.compile(rf"contracts/(?:{_CONTRACT_SEGMENT}/)*{_CONTRACT_SEGMENT}")
 # Vendor-extension-bearing contract formats (carry `x-spec` inline); other
 # formats (e.g. .proto, .graphql) use the REGISTRY.md back-ref channel.
 _XSPEC_FORMATS = (".yaml", ".yml", ".json")
@@ -309,6 +315,51 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     return r.stdout if r.returncode == 0 else None
 
 
+# Skip implausibly large files — an untrusted repo could ship a multi-GB
+# spec.md or contract; reading it whole is a memory-exhaustion DoS. Mirrors
+# lint-traceability.py's guard of the same name.
+_MAX_FILE_BYTES = 8 * 1024 * 1024
+
+
+def _read(path: Path) -> str | None:
+    """Size-guarded read. Returns None when the file is too large or unreadable."""
+    try:
+        if path.stat().st_size > _MAX_FILE_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _within(path: Path, root: Path) -> bool:
+    """True when `path` is inside `root` after symlink resolution.
+
+    Ported from lint-traceability.py, which has carried this confinement since
+    it was written. This file did not, and that was a real gap, not a stylistic
+    one: `Contract:` header tokens are matched by `_CONTRACT_TOKEN_RE`, whose
+    character class contains `.` and `/`, so a header reading
+    `contracts/../../secret.json` in an untrusted spec.md resolved outside
+    `--root` and was read. That produced both an existence oracle (two distinct
+    warnings depending on whether the target existed) and a content-substring
+    oracle. `docs/architecture/security.md` declares `filesystem_read_untrusted`
+    a boundary, so hostile repo content is in scope.
+    """
+    try:
+        return path.resolve().is_relative_to(root)
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+
+def _confined(paths, root: Path) -> list[Path]:
+    """Globbed / iterated paths filtered to those within `root`.
+
+    `pathlib.glob` follows symlinked directories, so each result is re-checked
+    before it is read — a symlinked `docs/specs/<slug>` cannot pull in a
+    spec.md from outside the tree.
+    """
+    return [p for p in paths if _within(p, root)]
+
+
 def _validated_root(candidate: Path | None) -> Path:
     """Resolve the CLI-supplied root, or fall back to `_repo_root()`.
 
@@ -321,7 +372,17 @@ def _validated_root(candidate: Path | None) -> Path:
     this also fixes a real usability trap: before the check, a typo'd `--root`
     scanned an empty tree and reported "spec metadata clean".
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-spec-status: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-spec-status: --root does not exist: {root}")
     if not root.is_dir():
@@ -360,9 +421,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         )
 
     specs_dir = root / "docs" / "specs"
-    for spec_path in sorted(specs_dir.glob("*/spec.md")):
+    for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
         rel = spec_path.relative_to(root).as_posix()
-        text = spec_path.read_text(encoding="utf-8", errors="replace")
+        text = _read(spec_path)
+        if text is None:
+            continue
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -432,7 +495,9 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
             for lineno, token in contract_refs:
                 contract_file = root / token
-                if not contract_file.is_file():
+                # Confinement precedes the existence probe: an unconfined
+                # is_file() is itself an existence oracle for files outside root.
+                if not _within(contract_file, root) or not contract_file.is_file():
                     warn.append(
                         f"{rel}:{lineno}: invariant (v) — Contract: '{token}' does "
                         f"not resolve to a file (warn-only)"
@@ -440,7 +505,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                     continue
                 backward = False
                 if token.endswith(_XSPEC_FORMATS):
-                    ctext = contract_file.read_text(encoding="utf-8", errors="replace")
+                    ctext = _read(contract_file) or ""
                     backward = "x-spec" in ctext and feature_dir in ctext
                 if not backward:
                     backward = token in registry_text and feature_dir in registry_text

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -221,6 +221,12 @@ def load_layout(root: Path) -> dict:
         return {}
     for cfg in (root / "agentbundle-layout.toml",
                 Path.home() / ".agentbundle" / "agentbundle-layout.toml"):
+        # Confine the root-relative candidate only: a symlink planted at
+        # `<root>/agentbundle-layout.toml` in an untrusted tree would otherwise
+        # be followed. The user-scope candidate is deliberately outside `root`
+        # and is operator-owned, so it is exempt by design, not by oversight.
+        if cfg.parent == root and not _within(cfg, root):
+            continue
         text = _read(cfg)  # stat-size-guarded; None if absent/oversized/unreadable
         if text is None:
             continue
@@ -257,7 +263,12 @@ def resolve_base(layer: str, root: Path, layout: dict) -> tuple[Path | None, str
     # Tier 3: discover by marker. Only reached when the default is absent — the
     # common case is "this layer is simply unpopulated", so a miss is not an
     # error. A bounded search keeps it from walking vendored trees.
-    candidates = _discover_layer_dirs(root, layer)
+    # `_confined` completes the control here: on Windows `os.path.islink()` is
+    # False for NTFS junctions, so `_iter_dirs`' `followlinks=False` does not
+    # stop `os.walk` descending one, and a discovered candidate can resolve
+    # outside `root`. Every downstream read is `_confined` already, so this is
+    # the one asymmetry rather than an exploit path — closed for consistency.
+    candidates = _confined(_discover_layer_dirs(root, layer), root)
     if not candidates:
         return None, None
     if len(candidates) > 1:

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -1221,6 +1221,30 @@ def _drift_check(root: Path, layout: dict, sidecar_g: Graph) -> list[str]:
             for missing in sorted(loc - side)]
 
 
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve the CLI-supplied scan root, or fall back to `_repo_root()`.
+
+    The normalise-then-check is deliberately kept *in one function, adjacent to
+    the argv read*. Taint analysers recognise that shape; they do not follow
+    the `_within()` / `_confined()` confinement applied to every path derived
+    from this root, because that check is interprocedural and expressed as a
+    comprehension filter. Same pattern as `check-spec-status.py:72-80`.
+
+    This normalises and asserts directory-ness; it deliberately does **not**
+    confine the root to a fixed prefix. `--root` *is* the caller-supplied scan
+    scope of a repo linter (see the module docstring), so restricting which
+    directory may be scanned would break the tool's purpose. The security
+    control remains `_within()`: every path *derived* from this root is
+    re-checked against it before being read.
+    """
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.exists():
+        raise SystemExit(f"lint-traceability: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-traceability: --root is not a directory: {root}")
+    return root
+
+
 def _repo_root() -> Path:
     """Best-effort root for a bare manual run (git toplevel, else the script's
     grandparent). The CI gate and self-tests always pass `--root` explicitly."""
@@ -1248,7 +1272,7 @@ def main(argv: list[str] | None = None) -> int:
              "dangling edges and cycles exit 1 in every mode.",
     )
     args = parser.parse_args(argv)
-    root = (args.root.resolve() if args.root else _repo_root()).resolve()
+    root = _validated_root(args.root)
 
     try:
         out, hard, exit_hint = check(root, args.strict)

--- a/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-traceability.py
@@ -1237,7 +1237,17 @@ def _validated_root(candidate: Path | None) -> Path:
     control remains `_within()`: every path *derived* from this root is
     re-checked against it before being read.
     """
-    root = (candidate if candidate is not None else _repo_root()).resolve()
+    raw = candidate if candidate is not None else _repo_root()
+    # `_within()` in the sibling script already catches this trio; resolve()
+    # raises ValueError on an embedded null and OSError on a Windows reserved
+    # name, neither of which is an OSError-only case. Letting them through
+    # would produce the traceback this function exists to replace.
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-traceability: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
     if not root.exists():
         raise SystemExit(f"lint-traceability: --root does not exist: {root}")
     if not root.is_dir():

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -67,7 +67,14 @@ CLEAN_SUBSTRING = "Clean — ready to commit."
 # Specialist reviewers (experience-reviewer, frontend-reviewer) emit "SHIP IT"
 # on its own line as their clean verdict instead of CLEAN_SUBSTRING.
 _SHIP_IT_RE = re.compile(r"^SHIP IT\s*$", re.MULTILINE)
-_RE_SHA1 = re.compile(r"^[0-9a-f]{40}$")
+# Fingerprints are SHA-256 (64 hex). The 40-hex SHA-1 form is still accepted
+# so a cohort that was mid-review when core upgraded can finish: its
+# state.json holds SHA-1 values and `review record --fingerprint` would
+# otherwise hard-reject them. Stasis detection compares sets computed by the
+# same binary, so a straddling run misses a match for exactly one round and
+# self-heals on the next. Drop the 40-hex alternative once no in-flight
+# cohort predates core 2.3.0.
+_RE_FINGERPRINT = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
 
 def _template_max_implementation_retries(fallback: int = 5) -> int:
@@ -969,10 +976,10 @@ FINDING_LINE_RE_WHERE = re.compile(
 
 
 def parse_findings(report_text: str) -> list[str]:
-    """Return SHA1 fingerprints for findings in a reviewer report.
+    """Return SHA-256 fingerprints for findings in a reviewer report.
 
     Algorithm pinned by the work-loop SKILL §REVIEW:
-        sha1("<file>|<line>|<title>")
+        sha256("<file>|<line>|<title>")
     where <file> is the cited path exactly as written, <line> is the first
     integer after the first colon in the citation, and <title> is the
     bolded heading including the surrounding `**` markers.
@@ -1000,7 +1007,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try Where: <location> (experience-reviewer)
@@ -1010,7 +1017,7 @@ def parse_findings(report_text: str) -> list[str]:
             location = m.group("location").strip()
             key = f"{location}|0|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
             continue
         # Try unquoted file:line (frontend-reviewer)
@@ -1024,7 +1031,7 @@ def parse_findings(report_text: str) -> list[str]:
                 continue
             key = f"{file_part}|{line_match.group(0)}|{title}"
             fingerprints.append(
-                hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+                hashlib.sha256(key.encode("utf-8")).hexdigest()
             )
     return fingerprints
 
@@ -1042,7 +1049,15 @@ def _resolved_report(candidate: str) -> Path:
     normalisation adjacent to the argv read, where a taint analyser can see it,
     instead of leaving a raw `Path(args.report)` as the boundary.
     """
-    return Path(candidate).resolve()
+    try:
+        return Path(candidate).resolve()
+    except (OSError, ValueError, RuntimeError):
+        # resolve() raises on an embedded null (ValueError) and on Windows
+        # reserved names (OSError). Falling back to the unresolved path keeps
+        # the value flowing to _classify_report, which classifies it `invalid`
+        # at exit 0 — the defined outcome. Raising here would reintroduce
+        # exactly the operational error this helper's docstring rules out.
+        return Path(candidate)
 
 
 def _classify_report(report_path: Path, state: dict) -> dict:
@@ -1139,10 +1154,11 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     if args.fingerprint:
         # Findings branch: --fingerprint <hex> ...
         fingerprints = sorted(set(args.fingerprint))
-        bad = [fp for fp in fingerprints if not _RE_SHA1.match(fp)]
+        bad = [fp for fp in fingerprints if not _RE_FINGERPRINT.match(fp)]
         if bad:
             return stop(
-                f"review record: --fingerprint must be lowercase 40-char SHA-1 hex; "
+                f"review record: --fingerprint must be lowercase 64-char SHA-256 hex "
+                f"(40-char SHA-1 still accepted for a run that predates core 2.3.0); "
                 f"invalid: {bad!r}"
             )
         state["previous_finding_fingerprints"] = list(state.get("finding_fingerprints", []))
@@ -1365,7 +1381,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--fingerprint",
         action="append",
         default=None,
-        help="explicit fingerprint (hex sha1); use for findings rounds",
+        help="explicit fingerprint (hex sha256); use for findings rounds",
     )
     _rr_grp.add_argument(
         "--all-skipped",

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -1029,6 +1029,22 @@ def parse_findings(report_text: str) -> list[str]:
     return fingerprints
 
 
+def _resolved_report(candidate: str) -> Path:
+    """Normalise the CLI-supplied `--report` path at the argv boundary.
+
+    Normalise-only, deliberately. The two `--root` linters in this skill raise
+    on an unusable path, but `--report` must not: `review inspect` classifies an
+    unreadable report as `invalid`, which the work-loop SKILL documents as a
+    Surface signal rather than a crash. Raising here would convert a defined
+    outcome into an operational error.
+
+    The `resolve()` still does the job it is here for — it puts the
+    normalisation adjacent to the argv read, where a taint analyser can see it,
+    instead of leaving a raw `Path(args.report)` as the boundary.
+    """
+    return Path(candidate).resolve()
+
+
 def _classify_report(report_path: Path, state: dict) -> dict:
     """Classify a reviewer report. Exits 0 for all report-content outcomes.
 
@@ -1080,7 +1096,7 @@ def cmd_review_inspect(args: argparse.Namespace) -> int:
         # Operational error (spec-dir unresolvable or state.json unreadable)
         return stop(str(exc))
 
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
 
     if args.json:
@@ -1144,7 +1160,7 @@ def cmd_review_record(args: argparse.Namespace) -> int:
     # Clean branch: --report <path>
     if not args.report:
         return stop("review record: one of --report or --fingerprint is required")
-    report_path = Path(args.report)
+    report_path = _resolved_report(args.report)
     result = _classify_report(report_path, state)
     if result["classification"] != "clean":
         cls = result["classification"]

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.2.1"
+version = "2.3.0"
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"
 display_name = "Core"

--- a/packs/core/tests/skills/work-loop/test-fingerprint-width.py
+++ b/packs/core/tests/skills/work-loop/test-fingerprint-width.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fingerprint algorithm + width contract for loop-cohort.py (core 2.3.0).
+
+Review-finding fingerprints moved from SHA-1 to SHA-256. They are opaque
+tokens compared set-wise for stasis detection, never displayed and never a key
+into anything external, so the switch is behaviour-preserving — with one edge:
+a cohort that was mid-review when core upgraded holds 40-hex values in its
+state.json, and `review record --fingerprint` would hard-reject them if the
+validator only accepted the new width.
+
+These cases live here rather than in test-loop-cohort.sh because that fixture
+is sequential and its counter assertions accumulate — inserting a successful
+`review record` there shifts every downstream expected count.
+
+Run: python3 test-fingerprint-width.py
+Exit 0 = all pass; exit non-zero = at least one failure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_SKILL_DIR = Path(__file__).resolve().parents[3] / ".apm" / "skills" / "work-loop"
+COHORT = _SKILL_DIR / "scripts" / "loop-cohort.py"
+if not COHORT.is_file():
+    raise SystemExit(f"subject not found at {COHORT} — check the parents[] depth")
+
+_spec = importlib.util.spec_from_file_location("loop_cohort_under_test", COHORT)
+lc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lc)
+
+failures: list[str] = []
+ran = 0
+
+
+def ok(name: str) -> None:
+    global ran
+    ran += 1
+    print(f"ok   [{name}]")
+
+
+def fail(name: str, reason: str) -> None:
+    global ran
+    ran += 1
+    failures.append(name)
+    print(f"FAIL [{name}]: {reason}", file=sys.stderr)
+
+
+def test_parse_findings_emits_sha256() -> None:
+    """A parsed finding yields a 64-hex digest, not 40-hex."""
+    name = "parse_findings emits 64-hex (SHA-256)"
+    fps = lc.parse_findings("**1. Broken thing** `foo/bar.py:42`\n")
+    if len(fps) != 1:
+        fail(name, f"expected 1 fingerprint, got {len(fps)}: {fps}")
+    elif len(fps[0]) != 64:
+        fail(name, f"expected width 64, got {len(fps[0])}: {fps[0]}")
+    elif not re.fullmatch(r"[0-9a-f]{64}", fps[0]):
+        fail(name, f"not lowercase hex: {fps[0]}")
+    else:
+        ok(name)
+
+
+def test_fingerprint_is_stable() -> None:
+    """The same finding hashes identically across calls — stasis detection
+    compares sets between rounds, so an unstable digest would break it."""
+    name = "fingerprint is deterministic across calls"
+    report = "**1. Broken thing** `foo/bar.py:42`\n"
+    if lc.parse_findings(report) != lc.parse_findings(report):
+        fail(name, "same report produced different fingerprints")
+    else:
+        ok(name)
+
+
+def test_distinct_findings_differ() -> None:
+    """Different findings must not collide, or stasis fires spuriously."""
+    name = "distinct findings produce distinct fingerprints"
+    a = lc.parse_findings("**1. Thing A** `foo/bar.py:42`\n")
+    b = lc.parse_findings("**1. Thing B** `foo/bar.py:42`\n")
+    if a == b:
+        fail(name, f"collision: {a} == {b}")
+    else:
+        ok(name)
+
+
+def test_validator_accepts_both_widths() -> None:
+    """64-hex is current; 40-hex stays valid for cohorts straddling the upgrade."""
+    for width, label in ((64, "sha256 (current)"), (40, "sha1 (legacy, in-flight)")):
+        name = f"validator accepts {width}-hex — {label}"
+        if lc._RE_FINGERPRINT.match("a" * width):
+            ok(name)
+        else:
+            fail(name, f"{width}-hex rejected; an in-flight cohort would hard-fail")
+
+
+def test_validator_rejects_other_widths() -> None:
+    """The widened validator must not have degraded to 'any hex string'."""
+    for bad in ("a" * 8, "a" * 39, "a" * 41, "a" * 63, "a" * 65, "", "z" * 64):
+        name = f"validator rejects {bad[:6]!r}(len={len(bad)})"
+        if lc._RE_FINGERPRINT.match(bad):
+            fail(name, "accepted a value that is neither sha1 nor sha256 hex")
+        else:
+            ok(name)
+
+
+def main() -> int:
+    test_parse_findings_emits_sha256()
+    test_fingerprint_is_stable()
+    test_distinct_findings_differ()
+    test_validator_accepts_both_widths()
+    test_validator_rejects_other_widths()
+
+    total = ran
+    passed = total - len(failures)
+    print(f"\n{passed}/{total} passed")
+    if failures:
+        print("Failed:", ", ".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packs/core/tests/skills/work-loop/test-loop-cohort.py
+++ b/packs/core/tests/skills/work-loop/test-loop-cohort.py
@@ -104,8 +104,14 @@ def write_plan(
     return p
 
 
-def _sha1(key: str) -> str:
-    return hashlib.sha1(key.encode("utf-8"), usedforsecurity=False).hexdigest()
+def _fingerprint(key: str) -> str:
+    """Independent recomputation of the documented fingerprint algorithm.
+
+    Deliberately spelled out here rather than imported from loop-cohort, so a
+    change to the algorithm has to be made in two places and cannot slip
+    through as a tautology.
+    """
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
 def init_pair(tmp: Path, feature: str = "myfeature", mode: str = "code") -> tuple[Path, str]:
@@ -1536,7 +1542,7 @@ def test_clean_substring_constant(tmp: Path) -> None:
 
 
 def test_parse_findings_canonical_algorithm(tmp: Path) -> None:
-    """parse_findings must produce sha1('<file>|<line>|<title>') per finding."""
+    """parse_findings must produce sha256('<file>|<line>|<title>') per finding."""
     name = "parse-findings-algorithm"
     report = """\
 ## Blockers
@@ -1548,7 +1554,7 @@ def test_parse_findings_canonical_algorithm(tmp: Path) -> None:
         fail(name, f"expected 1 fingerprint; got {len(fps)}")
         return
     expected_key = "src/foo.py|99|**1. Bad thing.**"
-    expected_fp = hashlib.sha1(expected_key.encode("utf-8"), usedforsecurity=False).hexdigest()
+    expected_fp = hashlib.sha256(expected_key.encode("utf-8")).hexdigest()
     if fps[0] != expected_fp:
         fail(name, f"fingerprint mismatch: {fps[0]!r} != {expected_fp!r}")
     else:
@@ -1562,7 +1568,7 @@ def test_parse_findings_specialist_formats(tmp: Path) -> None:
     fe_report = "**1. Token drift.** src/styles.css:42. Lens: CSS. Fix: use token.\n"
     fps_fe = parse_findings(fe_report)
     fe_key = "src/styles.css|42|**1. Token drift.**"
-    fe_fp = hashlib.sha1(fe_key.encode("utf-8"), usedforsecurity=False).hexdigest()
+    fe_fp = hashlib.sha256(fe_key.encode("utf-8")).hexdigest()
     if len(fps_fe) != 1:
         fail(name, f"frontend-reviewer: expected 1 fingerprint; got {len(fps_fe)}")
         return
@@ -1576,7 +1582,7 @@ def test_parse_findings_specialist_formats(tmp: Path) -> None:
     )
     fps_exp = parse_findings(exp_report)
     exp_key = "Hero screen|0|**1. Incoherent contrast.**"
-    exp_fp = hashlib.sha1(exp_key.encode("utf-8"), usedforsecurity=False).hexdigest()
+    exp_fp = hashlib.sha256(exp_key.encode("utf-8")).hexdigest()
     if len(fps_exp) != 1:
         fail(name, f"experience-reviewer: expected 1 fingerprint; got {len(fps_exp)}")
         return

--- a/packs/core/tests/skills/work-loop/test-loop-cohort.sh
+++ b/packs/core/tests/skills/work-loop/test-loop-cohort.sh
@@ -398,7 +398,12 @@ fi
 
 # ── review record ────────────────────────────────────────────────────────
 
-# --fingerprint path: increments both counters
+# --fingerprint path: increments both counters.
+# NOTE: this fixture is sequential and the counters accumulate — a new
+# `review record` case inserted here shifts every downstream count assertion.
+# Fingerprint-width coverage lives in test-fingerprint-width.py instead.
+# 40-hex (SHA-1) is the legacy width, still accepted so a cohort that was
+# mid-review when core upgraded to SHA-256 can finish.
 run_and_check "review-record-fingerprint" 0 "" -- $PY review record "$SPEC1" --fingerprint "aabbccdd112233445566778899001122334455aa" --expect-run-id "$RUN_ID"
 
 ran=$((ran + 1))

--- a/packs/core/tests/skills/work-loop/test-root-validation.py
+++ b/packs/core/tests/skills/work-loop/test-root-validation.py
@@ -147,10 +147,10 @@ def test_missing_report_classifies_invalid_not_crash() -> None:
             fail(name, f"could not initialise a cohort fixture (rc={rc} err={err!r})")
             return
 
-        missing = Path(td) / "no-such-report.md"
         rc, out, err = run(
             LOOP_COHORT, "review", "inspect", str(spec_dir),
-            "--report", str(missing), "--json",
+            "--report", "no-such-report.md", "--json",
+            cwd=Path(td),
         )
         combined = f"{out}\n{err}"
         if "Traceback" in combined:
@@ -169,12 +169,51 @@ def test_missing_report_classifies_invalid_not_crash() -> None:
                 ok(name)
 
 
+def test_report_sites_route_through_resolver() -> None:
+    """Both `--report` call sites go through `_resolved_report` — a STRUCTURAL
+    check, deliberately, because there is no behavioural one to make.
+
+    `_resolved_report` only calls `.resolve()`. `_classify_report` returns
+    `invalid` for an unreadable path whether or not it was resolved, and a
+    readable report reads the same through either form — so reverting the
+    helper changes no observable output. Verified: with both call sites
+    reverted to bare `Path(args.report)`, every behavioural case in this file
+    still passed.
+
+    The helper exists for scanner legibility, not behaviour, so the honest
+    guard is that the call sites still use it. Do not replace this with a
+    behavioural assertion that appears stronger; it would be green either way.
+    """
+    name = "loop-cohort: both --report sites route through _resolved_report"
+    src = LOOP_COHORT.read_text(encoding="utf-8")
+    # Match assignment form only: `_resolved_report`'s own docstring names
+    # `Path(args.report)` in prose, and a substring count would score that as
+    # a live call site.
+    routed = src.count("= _resolved_report(args.report)")
+    bare = src.count("= Path(args.report)")
+    if routed != 2:
+        fail(name, f"expected 2 routed call sites, found {routed}")
+    elif bare:
+        fail(name, f"found {bare} bare Path(args.report) call site(s) — should be 0")
+    else:
+        ok(name)
+
+
 # ---------------------------------------------------------------------------
 # AC5 — every currently-valid invocation is unchanged
 # ---------------------------------------------------------------------------
 
 def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[4]
+    """The repository root — parents[5], NOT parents[4].
+
+    parents[4] is `<repo>/packs`, which both linters also happily accept, so
+    the off-by-one produced green parity tests that were not exercising the
+    repo at all.
+    """
+    root = Path(__file__).resolve().parents[5]
+    if not (root / "docs" / "specs").is_dir():
+        raise SystemExit(f"repo root not found at {root} — check the parents[] depth")
+    return root
 
 
 def test_valid_root_unchanged() -> None:
@@ -187,7 +226,12 @@ def test_valid_root_unchanged() -> None:
         name = f"{label}: valid explicit --root is accepted"
         rc, out, err = run(script, "--root", str(root))
         combined = f"{out}\n{err}"
-        if "Traceback" in combined:
+        # AC5 promises "same exit codes". Asserting rc is what makes this a
+        # parity test — without it the case passes against an implementation
+        # whose exit codes changed entirely.
+        if rc != 0:
+            fail(name, f"expected exit 0 on a valid invocation, got {rc}: {combined!r}")
+        elif "Traceback" in combined:
             fail(name, f"raised a traceback on a valid root:\n{combined}")
         elif "is not a directory" in combined or "does not exist" in combined:
             fail(name, f"validator rejected a legitimate root: {combined!r}")
@@ -202,7 +246,12 @@ def test_omitted_root_unchanged() -> None:
         name = f"{label}: omitted --root still resolves via fallback"
         rc, out, err = run(script, cwd=root)
         combined = f"{out}\n{err}"
-        if "Traceback" in combined:
+        # AC5 promises "same exit codes". Asserting rc is what makes this a
+        # parity test — without it the case passes against an implementation
+        # whose exit codes changed entirely.
+        if rc != 0:
+            fail(name, f"expected exit 0 on a valid invocation, got {rc}: {combined!r}")
+        elif "Traceback" in combined:
             fail(name, f"raised a traceback with --root omitted:\n{combined}")
         elif "is not a directory" in combined or "does not exist" in combined:
             fail(name, f"fallback root was rejected by the validator: {combined!r}")
@@ -221,7 +270,12 @@ def test_relative_root_unchanged() -> None:
         name = f"{label}: relative --root is resolved and accepted"
         rc, out, err = run(script, "--root", ".", cwd=root)
         combined = f"{out}\n{err}"
-        if "Traceback" in combined:
+        # AC5 promises "same exit codes". Asserting rc is what makes this a
+        # parity test — without it the case passes against an implementation
+        # whose exit codes changed entirely.
+        if rc != 0:
+            fail(name, f"expected exit 0 on a valid invocation, got {rc}: {combined!r}")
+        elif "Traceback" in combined:
             fail(name, f"raised a traceback on a relative root:\n{combined}")
         elif "is not a directory" in combined or "does not exist" in combined:
             fail(name, f"validator rejected a relative root: {combined!r}")
@@ -233,6 +287,7 @@ def main() -> int:
     test_nonexistent_root_exits_nonzero_with_diagnostic()
     test_file_valued_root_exits_nonzero()
     test_missing_report_classifies_invalid_not_crash()
+    test_report_sites_route_through_resolver()
     test_valid_root_unchanged()
     test_omitted_root_unchanged()
     test_relative_root_unchanged()

--- a/packs/core/tests/skills/work-loop/test-root-validation.py
+++ b/packs/core/tests/skills/work-loop/test-root-validation.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Tests for the CLI path-argument boundary validator (spec/pack-script-root-boundary-validation).
+
+Covers the three scripts that read a filesystem path from argv:
+`lint-traceability.py --root`, `lint-spec-status.py --root`, and
+`loop-cohort.py review inspect --report`.
+
+Two properties are asserted, and they pull in opposite directions:
+
+  1. *Parity* (AC5) — every currently-valid invocation keeps its exit code.
+     The validator must not narrow what the linters can scan; `--root` is the
+     caller-supplied scan scope, not a confined subdirectory.
+  2. *Diagnostic* (AC6) — an unusable path exits non-zero naming the offending
+     path, rather than surfacing a traceback.
+
+Every case invokes the real script through `subprocess`, never a synthesised
+import, so the test exercises the documented invocation path.
+
+Run: python3 test-root-validation.py
+Exit 0 = all pass; exit non-zero = at least one failure.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+# The pack ships tests under packs/<pack>/tests/ and runtime primitives under
+# packs/<pack>/.apm/ — tests are visible in the catalogue and never installed.
+_SKILL_DIR = Path(__file__).resolve().parents[3] / ".apm" / "skills" / "work-loop"
+SCRIPT_DIR = _SKILL_DIR / "scripts"
+
+if not SCRIPT_DIR.is_dir():  # wrong parents[] depth after a move
+    raise SystemExit(f"subject dir not found at {SCRIPT_DIR} — check the parents[] depth")
+
+TRACEABILITY = SCRIPT_DIR / "lint-traceability.py"
+SPEC_STATUS = SCRIPT_DIR / "lint-spec-status.py"
+LOOP_COHORT = SCRIPT_DIR / "loop-cohort.py"
+
+# The two `--root` scripts. `loop-cohort.py` takes `--report` and is driven
+# separately because it needs a subcommand and cohort state.
+ROOT_SCRIPTS = [("lint-traceability", TRACEABILITY), ("lint-spec-status", SPEC_STATUS)]
+
+failures: list[str] = []
+ran = 0
+
+
+def ok(name: str) -> None:
+    global ran
+    ran += 1
+    print(f"ok   [{name}]")
+
+
+def fail(name: str, reason: str) -> None:
+    global ran
+    ran += 1
+    failures.append(name)
+    print(f"FAIL [{name}]: {reason}", file=sys.stderr)
+
+
+def run(script: Path, *args: str, cwd: Path | None = None) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [sys.executable, str(script)] + list(args),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        cwd=str(cwd) if cwd else None,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+# ---------------------------------------------------------------------------
+# AC6 — an unusable --root is a diagnostic, not a traceback
+# ---------------------------------------------------------------------------
+
+def test_nonexistent_root_exits_nonzero_with_diagnostic() -> None:
+    """A --root that does not exist must exit non-zero and name the path.
+
+    Guards the failure mode the boundary validator introduces: turning an
+    unusable path into an explicit refusal rather than letting it flow into a
+    walk that silently yields nothing.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        missing = Path(td) / "no-such-directory"
+        for label, script in ROOT_SCRIPTS:
+            name = f"{label}: nonexistent --root exits non-zero with diagnostic"
+            rc, out, err = run(script, "--root", str(missing))
+            combined = f"{out}\n{err}"
+            if rc == 0:
+                fail(name, f"expected non-zero exit, got 0 (stdout={out!r} stderr={err!r})")
+            elif "Traceback" in combined:
+                fail(name, f"raised a traceback instead of a diagnostic:\n{combined}")
+            elif "no-such-directory" not in combined:
+                fail(name, f"diagnostic does not name the offending path: {combined!r}")
+            else:
+                ok(name)
+
+
+def test_file_valued_root_exits_nonzero() -> None:
+    """A --root pointing at a file rather than a directory must be refused."""
+    with tempfile.TemporaryDirectory() as td:
+        a_file = Path(td) / "not-a-dir.txt"
+        a_file.write_text("x", encoding="utf-8")
+        for label, script in ROOT_SCRIPTS:
+            name = f"{label}: file-valued --root exits non-zero"
+            rc, out, err = run(script, "--root", str(a_file))
+            combined = f"{out}\n{err}"
+            if rc == 0:
+                fail(name, f"expected non-zero exit, got 0 (stdout={out!r} stderr={err!r})")
+            elif "Traceback" in combined:
+                fail(name, f"raised a traceback instead of a diagnostic:\n{combined}")
+            elif "not-a-dir.txt" not in combined:
+                fail(name, f"diagnostic does not name the offending path: {combined!r}")
+            else:
+                ok(name)
+
+
+def test_missing_report_classifies_invalid_not_crash() -> None:
+    """`review inspect --report <missing>` yields `invalid`, and still exits 0.
+
+    `--report` is normalise-only at the boundary, unlike the two `--root`
+    scripts. SKILL.md defines `invalid` as a Surface signal for a malformed
+    reviewer report, and `review inspect` exits 0 for every report-content
+    outcome. Raising on an unreadable path would convert that defined outcome
+    into an operational error.
+
+    This case needs a REAL initialised cohort. Pointing at an empty directory
+    would exit non-zero on the missing `state.json` before the report path is
+    ever read — green for a reason that has nothing to do with `--report`.
+    """
+    name = "loop-cohort: missing --report classifies invalid (exit 0)"
+    with tempfile.TemporaryDirectory() as td:
+        spec_dir = Path(td) / "spec"
+        spec_dir.mkdir()
+        run_id = "00000000-1111-2222-3333-444444444444"
+        rc, out, err = run(LOOP_COHORT, "init", str(spec_dir), "--run-id", run_id)
+        if rc != 0 or not (spec_dir / "state.json").is_file():
+            fail(name, f"could not initialise a cohort fixture (rc={rc} err={err!r})")
+            return
+
+        missing = Path(td) / "no-such-report.md"
+        rc, out, err = run(
+            LOOP_COHORT, "review", "inspect", str(spec_dir),
+            "--report", str(missing), "--json",
+        )
+        combined = f"{out}\n{err}"
+        if "Traceback" in combined:
+            fail(name, f"raised a traceback instead of classifying:\n{combined}")
+        elif rc != 0:
+            fail(name, f"expected exit 0 for a report-content outcome, got {rc}: {combined!r}")
+        else:
+            try:
+                classification = json.loads(out)["classification"]
+            except (ValueError, KeyError) as exc:
+                fail(name, f"could not read classification from {out!r} ({exc})")
+                return
+            if classification != "invalid":
+                fail(name, f"expected classification 'invalid', got {classification!r}")
+            else:
+                ok(name)
+
+
+# ---------------------------------------------------------------------------
+# AC5 — every currently-valid invocation is unchanged
+# ---------------------------------------------------------------------------
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def test_valid_root_unchanged() -> None:
+    """An explicit, valid --root behaves exactly as before the validator.
+
+    Baseline is this repository, which both linters are expected to accept.
+    """
+    root = _repo_root()
+    for label, script in ROOT_SCRIPTS:
+        name = f"{label}: valid explicit --root is accepted"
+        rc, out, err = run(script, "--root", str(root))
+        combined = f"{out}\n{err}"
+        if "Traceback" in combined:
+            fail(name, f"raised a traceback on a valid root:\n{combined}")
+        elif "is not a directory" in combined or "does not exist" in combined:
+            fail(name, f"validator rejected a legitimate root: {combined!r}")
+        else:
+            ok(name)
+
+
+def test_omitted_root_unchanged() -> None:
+    """With --root omitted, the script still falls back to its repo-root discovery."""
+    root = _repo_root()
+    for label, script in ROOT_SCRIPTS:
+        name = f"{label}: omitted --root still resolves via fallback"
+        rc, out, err = run(script, cwd=root)
+        combined = f"{out}\n{err}"
+        if "Traceback" in combined:
+            fail(name, f"raised a traceback with --root omitted:\n{combined}")
+        elif "is not a directory" in combined or "does not exist" in combined:
+            fail(name, f"fallback root was rejected by the validator: {combined!r}")
+        else:
+            ok(name)
+
+
+def test_relative_root_unchanged() -> None:
+    """A relative --root resolves against cwd and is accepted.
+
+    The validator normalises with resolve(); this is the case that would break
+    if it instead compared the raw, unresolved string.
+    """
+    root = _repo_root()
+    for label, script in ROOT_SCRIPTS:
+        name = f"{label}: relative --root is resolved and accepted"
+        rc, out, err = run(script, "--root", ".", cwd=root)
+        combined = f"{out}\n{err}"
+        if "Traceback" in combined:
+            fail(name, f"raised a traceback on a relative root:\n{combined}")
+        elif "is not a directory" in combined or "does not exist" in combined:
+            fail(name, f"validator rejected a relative root: {combined!r}")
+        else:
+            ok(name)
+
+
+def main() -> int:
+    test_nonexistent_root_exits_nonzero_with_diagnostic()
+    test_file_valued_root_exits_nonzero()
+    test_missing_report_classifies_invalid_not_crash()
+    test_valid_root_unchanged()
+    test_omitted_root_unchanged()
+    test_relative_root_unchanged()
+
+    total = ran
+    passed = total - len(failures)
+    print(f"\n{passed}/{total} passed")
+    if failures:
+        print("Failed:", ", ".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/semgrep/argv-path-boundary.yml
+++ b/tools/semgrep/argv-path-boundary.yml
@@ -1,0 +1,94 @@
+# Custom Semgrep boundary rule for the SAST gate (ADR-0017).
+#
+# WHY THIS IS NOT A TAINT RULE
+# ---------------------------
+# The obvious shape for "argv reaches a filesystem path" is `mode: taint` with
+# an argv source and a Path/os.walk sink. That shape was built and measured
+# (spec/pack-script-root-boundary-validation), and it does not work here:
+#
+#   * OSS Semgrep taint is INTRAPROCEDURAL. A control with the source in
+#     `main()` and the sink in a function it calls — same file — returns zero
+#     findings. Interprocedural/interfile taint is a Semgrep Pro feature.
+#   * Against the real `lint-traceability.py`, whose source is at :1251 and
+#     whose sinks are hundreds of lines away in other functions, it therefore
+#     returned 0 findings — while an adopter's Snyk Code (which *is*
+#     interprocedural) reported 18.
+#   * Run repo-wide it produced 20 findings, every one an operator-supplied
+#     scan root. That is the false-positive flood ADR-0017 rejected Semgrep's
+#     default rulesets for.
+#
+# So this rule guards the BOUNDARY instead of tracking the flow: it fires where
+# argv first becomes a Path, which is intraprocedural by construction and is
+# the one line a fix can address. It is a regression guard for the validator
+# pattern, NOT an attempt to reproduce Snyk's reach. CodeQL
+# (.github/workflows/codeql.yml, security-extended / py/path-injection) remains
+# the only interprocedural lens in the stack.
+#
+# SCOPE IS A RATCHET, NOT A SWEEP
+# -------------------------------
+# `paths.include` below lists only scripts that have already adopted the
+# validator. Measured at authoring time, an unrestricted scope over
+# `tools packs packages` yields 73 findings — nearly every Python CLI in the
+# repo does `Path(args.x)`, so a repo-wide blocking rule is untenable.
+#
+# EXPANSION CONDITION: add a path here as its script adopts a boundary
+# validator (`_validated_root` / `_resolved_report` or equivalent). Do not add
+# a path before the fix lands, or the gate goes red on unrelated work. The
+# remaining ~68 sites are tracked in workspace.toml [backlog].open under
+# `pack-argv-path-boundary-sweep`.
+
+rules:
+  - id: argv-path-without-boundary-validator
+    languages: [python]
+    severity: WARNING
+    message: >-
+      A CLI path argument is converted to a Path without a boundary validator.
+      Route it through the script's `_validated_root(...)` / `_resolved_report(...)`
+      helper so the normalise-and-check sits next to the argv read, where a
+      taint analyser can see it (CWE-22/23). The downstream `_within()` /
+      `_confined()` confinement is the real control, but it is interprocedural
+      and no taint engine follows it.
+    metadata:
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory"
+        - "CWE-23: Relative Path Traversal"
+      category: security
+      confidence: HIGH
+      references:
+        - https://docs.snyk.io/scan-with-snyk/snyk-code
+    paths:
+      include:
+        - "packs/core/.apm/skills/work-loop/scripts/lint-traceability.py"
+        - "packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py"
+        - "packs/core/.apm/skills/work-loop/scripts/loop-cohort.py"
+        - "tools/semgrep/fixtures/argv-path-boundary/**"
+    patterns:
+      - pattern-either:
+          - pattern: $ARGS.$FIELD.resolve()
+          - pattern: pathlib.Path($ARGS.$FIELD)
+          - pattern: Path($ARGS.$FIELD)
+      # `check-spec-status.py:72-80` is the in-repo reference pattern: resolve,
+      # then assert containment with is_relative_to in the same function. That
+      # shape is already legible to a taint analyser, so it must not fire —
+      # without this clause the rule false-positives on its own exemplar.
+      #
+      # The `<... ... ...>` deep-expression operator is load-bearing. A plain
+      # `$P.is_relative_to(...)` only matches the call in statement position,
+      # so it misses the idiomatic `if not target.is_relative_to(base):` where
+      # the call sits inside the condition — which is exactly how
+      # check-spec-status.py writes it. Verified: the plain form leaves the
+      # negative fixture firing; the deep form silences it while the positive
+      # fixture still fires.
+      - pattern-not-inside: |
+          def $F(...):
+            ...
+            <... $P.is_relative_to(...) ...>
+            ...
+      # The validators themselves legitimately contain the raw conversion;
+      # firing inside them would make the fix unimplementable.
+      - pattern-not-inside: |
+          def _validated_root(...):
+            ...
+      - pattern-not-inside: |
+          def _resolved_report(...):
+            ...

--- a/tools/semgrep/argv-path-boundary.yml
+++ b/tools/semgrep/argv-path-boundary.yml
@@ -31,6 +31,20 @@
 # `tools packs packages` yields 73 findings — nearly every Python CLI in the
 # repo does `Path(args.x)`, so a repo-wide blocking rule is untenable.
 #
+# KNOWN LIMITATIONS — do not over-trust this rule
+# ----------------------------------------------
+# It guards the CONVERSION site (`args.x` becoming a Path), so two shapes slip
+# past it, both verified:
+#   * An intermediate binding. `raw = args.root` then `raw.resolve()` yields 0
+#     findings — the match needs the attribute access and the call adjacent.
+#   * Argv handed to a helper. `_validated_root(args.root)` is an argument, not
+#     a conversion, so a helper that validates NOTHING is indistinguishable
+#     from one that validates correctly. That is why the behavioural test
+#     (packs/core/tests/skills/work-loop/test-root-validation.py, wired into
+#     docs.yml) is the real guard and this rule is only the tripwire.
+# Treat a green result here as "the obvious regression did not happen", never
+# as "the boundary is validated".
+#
 # EXPANSION CONDITION: add a path here as its script adopts a boundary
 # validator (`_validated_root` / `_resolved_report` or equivalent). Do not add
 # a path before the fix lands, or the gate goes red on unrelated work. The
@@ -80,15 +94,14 @@ rules:
       # negative fixture firing; the deep form silences it while the positive
       # fixture still fires.
       - pattern-not-inside: |
-          def $F(...):
-            ...
-            <... $P.is_relative_to(...) ...>
-            ...
-      # The validators themselves legitimately contain the raw conversion;
-      # firing inside them would make the fix unimplementable.
-      - pattern-not-inside: |
-          def _validated_root(...):
-            ...
-      - pattern-not-inside: |
-          def _resolved_report(...):
-            ...
+          $P = Path($ARGS.$FIELD).resolve()
+          ...
+          <... $Q.is_relative_to($P) ...>
+      # NOTE: there is deliberately no `def _validated_root(...)` /
+      # `def _resolved_report(...)` exemption. Name-based exemptions certify a
+      # function's NAME, not that it validates anything — verified that
+      # `def _validated_root(c): return Path(c)`, with no check at all, scanned
+      # to zero findings under the old form. They are also unnecessary: both
+      # helpers take a plain parameter, so their bodies read `Path(candidate)`
+      # rather than `Path(args.x)`, and `$ARGS.$FIELD` requires an attribute
+      # access. The rule cannot fire inside them regardless.

--- a/tools/semgrep/fixtures/argv-path-boundary/negative.py
+++ b/tools/semgrep/fixtures/argv-path-boundary/negative.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Negative fixture: the post-fix shape. The rule MUST be silent here.
+
+Two distinct silent shapes are covered:
+  1. `_validated_root(...)` — the validator this spec introduces.
+  2. resolve()-then-is_relative_to() in one function — the pre-existing
+     exemplar at check-spec-status.py:72-80, which was already taint-legible
+     and must not be flagged.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path.cwd()
+
+
+def _validated_root(candidate: Path | None) -> Path:
+    root = (candidate if candidate is not None else _repo_root()).resolve()
+    if not root.is_dir():
+        raise SystemExit(f"--root is not a directory: {root}")
+    return root
+
+
+def main_with_validator() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args()
+    root = _validated_root(args.root)   # silent
+    print(root)
+    return 0
+
+
+def main_with_containment_check() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("spec_dir")
+    parser.add_argument("--file", default="spec.md")
+    args = parser.parse_args()
+    spec_dir = Path(args.spec_dir).resolve()          # silent — guarded below
+    target_path = (spec_dir / args.file).resolve()
+    if not target_path.is_relative_to(spec_dir):
+        return 1
+    print(target_path)
+    return 0

--- a/tools/semgrep/fixtures/argv-path-boundary/positive.py
+++ b/tools/semgrep/fixtures/argv-path-boundary/positive.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Positive fixture: the pre-fix shape. The rule MUST fire exactly once here.
+
+Mirrors lint-traceability.py:1251 as it stood before
+spec/pack-script-root-boundary-validation. Not executable production code —
+this file exists only so the gate's own rule is proven to fire.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path.cwd()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args()
+    root = args.root.resolve() if args.root else _repo_root()   # rule fires here
+    print(root)
+    return 0

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -114,6 +114,9 @@ TESTS: list[tuple[str, list[str]]] = [
     ("pack-test-boundary-self-test",
      [sys.executable, "tools/test-lint-pack-test-boundary.py"]),
     ("pre-pr", ["bash", "tools/test-pre-pr.sh"]),
+    ("root-validation", [sys.executable,
+                         "packs/core/tests/skills/work-loop/test-root-validation.py"]),
+    ("semgrep-argv-boundary", [sys.executable, "tools/test-semgrep-argv-boundary.py"]),
     ("session-start", ["bash", "packs/core/tests/hooks/test_session_start_projection.sh"]),
     ("session-start-source", ["bash", "packs/core/tests/hooks/test_session_start_bash.sh"]),
 ]

--- a/tools/test-semgrep-argv-boundary.py
+++ b/tools/test-semgrep-argv-boundary.py
@@ -60,8 +60,14 @@ def fail(name: str, reason: str) -> None:
     print(f"FAIL [{name}]: {reason}", file=sys.stderr)
 
 
-def scan(target: Path) -> list[dict]:
-    """Run the rule over `target`; return its findings."""
+def scan(target: Path) -> tuple[list[dict], list[str]]:
+    """Run the rule over `target`; return (findings, files_actually_scanned).
+
+    `scanned` is returned alongside the findings because zero findings is an
+    ambiguous result: it means both "the rule ran and the file is clean" and
+    "the rule's paths.include excluded the file entirely". Asserting on
+    findings alone lets a paths.include regression pass as success.
+    """
     proc = subprocess.run(
         [
             "semgrep", "--config", str(RULE),
@@ -76,12 +82,13 @@ def scan(target: Path) -> list[dict]:
     )
     if not proc.stdout.strip():
         raise RuntimeError(f"semgrep produced no output for {target} — stderr: {proc.stderr}")
-    return json.loads(proc.stdout)["results"]
+    payload = json.loads(proc.stdout)
+    return payload["results"], list(payload.get("paths", {}).get("scanned", []))
 
 
 def test_positive_fixture_fires() -> None:
     name = "positive fixture fires exactly once"
-    hits = scan(FIXTURES / "positive.py")
+    hits, _ = scan(FIXTURES / "positive.py")
     if len(hits) != 1:
         fail(name, f"expected 1 finding, got {len(hits)}: {[h['start']['line'] for h in hits]}")
     else:
@@ -90,7 +97,7 @@ def test_positive_fixture_fires() -> None:
 
 def test_negative_fixture_silent() -> None:
     name = "negative fixture is silent (validator + is_relative_to exemplar)"
-    hits = scan(FIXTURES / "negative.py")
+    hits, _ = scan(FIXTURES / "negative.py")
     if hits:
         lines = [h["start"]["line"] for h in hits]
         fail(name, f"expected 0 findings, got {len(hits)} at lines {lines}")
@@ -104,8 +111,14 @@ def test_fixed_scripts_silent() -> None:
         if not script.is_file():
             fail(name, f"subject not found at {script} — path drifted?")
             continue
-        hits = scan(script)
-        if hits:
+        hits, scanned = scan(script)
+        # Order matters: prove the rule REACHED the file before trusting its
+        # silence. Dropping this path from the rule's paths.include also
+        # yields zero findings, so a findings-only assertion would stay green
+        # while the ratchet covered nothing.
+        if not scanned:
+            fail(name, "rule did not scan this file — check paths.include in the rule")
+        elif hits:
             lines = [h["start"]["line"] for h in hits]
             fail(name, f"expected 0 findings, got {len(hits)} at lines {lines}")
         else:

--- a/tools/test-semgrep-argv-boundary.py
+++ b/tools/test-semgrep-argv-boundary.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Self-test for tools/semgrep/argv-path-boundary.yml.
+
+The rule is excluded from `make sast`'s scan of its own fixtures (see
+SEMGREP_EXCLUDE in the Makefile), so without this file the fixtures would be
+dead weight and the rule would be unproven. This is the gate that keeps them
+honest.
+
+Asserts three things:
+  1. The rule FIRES on the pre-fix shape (positive fixture) — a rule that
+     never fires is indistinguishable from no rule at all.
+  2. The rule is SILENT on both post-fix shapes (negative fixture): the
+     `_validated_root(...)` validator, and the pre-existing
+     resolve()-then-is_relative_to() exemplar from check-spec-status.py.
+  3. The rule is SILENT on the three production scripts it is scoped to,
+     i.e. the fix actually satisfies it.
+
+Run: python3 tools/test-semgrep-argv-boundary.py
+Exit 0 = all pass; exit non-zero = at least one failure. Skips (exit 0) when
+semgrep is not installed, matching `make sast`'s optional-tool posture.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RULE = REPO_ROOT / "tools" / "semgrep" / "argv-path-boundary.yml"
+FIXTURES = REPO_ROOT / "tools" / "semgrep" / "fixtures" / "argv-path-boundary"
+
+SCRIPTS_DIR = REPO_ROOT / "packs" / "core" / ".apm" / "skills" / "work-loop" / "scripts"
+FIXED_SCRIPTS = [
+    SCRIPTS_DIR / "lint-traceability.py",
+    SCRIPTS_DIR / "lint-spec-status.py",
+    SCRIPTS_DIR / "loop-cohort.py",
+]
+
+failures: list[str] = []
+ran = 0
+
+
+def ok(name: str) -> None:
+    global ran
+    ran += 1
+    print(f"ok   [{name}]")
+
+
+def fail(name: str, reason: str) -> None:
+    global ran
+    ran += 1
+    failures.append(name)
+    print(f"FAIL [{name}]: {reason}", file=sys.stderr)
+
+
+def scan(target: Path) -> list[dict]:
+    """Run the rule over `target`; return its findings."""
+    proc = subprocess.run(
+        [
+            "semgrep", "--config", str(RULE),
+            "--json", "--quiet", "--metrics", "off", str(target),
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    if not proc.stdout.strip():
+        raise RuntimeError(f"semgrep produced no output for {target} — stderr: {proc.stderr}")
+    return json.loads(proc.stdout)["results"]
+
+
+def test_positive_fixture_fires() -> None:
+    name = "positive fixture fires exactly once"
+    hits = scan(FIXTURES / "positive.py")
+    if len(hits) != 1:
+        fail(name, f"expected 1 finding, got {len(hits)}: {[h['start']['line'] for h in hits]}")
+    else:
+        ok(name)
+
+
+def test_negative_fixture_silent() -> None:
+    name = "negative fixture is silent (validator + is_relative_to exemplar)"
+    hits = scan(FIXTURES / "negative.py")
+    if hits:
+        lines = [h["start"]["line"] for h in hits]
+        fail(name, f"expected 0 findings, got {len(hits)} at lines {lines}")
+    else:
+        ok(name)
+
+
+def test_fixed_scripts_silent() -> None:
+    for script in FIXED_SCRIPTS:
+        name = f"{script.name} is silent after the fix"
+        if not script.is_file():
+            fail(name, f"subject not found at {script} — path drifted?")
+            continue
+        hits = scan(script)
+        if hits:
+            lines = [h["start"]["line"] for h in hits]
+            fail(name, f"expected 0 findings, got {len(hits)} at lines {lines}")
+        else:
+            ok(name)
+
+
+def main() -> int:
+    if shutil.which("semgrep") is None:
+        print("skip: semgrep not on PATH (install: pip install -r tools/requirements-sast.txt)")
+        return 0
+    if not RULE.is_file():
+        print(f"FAIL: rule not found at {RULE}", file=sys.stderr)
+        return 1
+
+    test_positive_fixture_fires()
+    test_negative_fixture_silent()
+    test_fixed_scripts_silent()
+
+    total = ran
+    passed = total - len(failures)
+    print(f"\n{passed}/{total} passed")
+    if failures:
+        print("Failed:", ", ".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -1517,6 +1517,80 @@ open = [
   {slug = "starlight-migration-rfc", summary = "Open RFC for the docs-site/ top-level directory (mirrors RFC-0061 precedent)", source = "spec/starlight-migration"},
 
   # catalogue-init-sh-phase2: shipped in 0.26.0 — all deferred ACs resolved.
+
+  # ── Adopter-SAST follow-ons (spec/pack-script-root-boundary-validation) ────
+  # An adopter's org Snyk Code scan reports CWE-23 path-traversal against the
+  # work-loop scripts we ship, at the adapter-projection path
+  # (.kiro/skills/...). All findings are false positives: the confinement via
+  # _within()/_confined() is interprocedural, so no taint engine follows it.
+  # CodeQL's py/path-injection (security-extended) independently clears them.
+  # The parent spec fixes the four work-loop scripts by moving the
+  # normalize-and-check to the argv boundary. These are the leftovers.
+  #
+  # ~68 further argv->path boundary sites exist across the other packs and
+  # packages/agentbundle (measured this session: 73 repo-wide, 5 fixed by the
+  # parent spec). Same class, same fix. Not swept in the parent PR because a
+  # 73-site rewrite is a migration, not a fix, and the pattern should be proven
+  # on one skill first. Expand tools/semgrep/argv-path-boundary.yml's
+  # paths.include as each pack adopts the validator.
+  {slug = "pack-argv-path-boundary-sweep", summary = "Apply the argv->path boundary validator to the remaining ~68 sites across converters/atlassian/workspace-status/receive-brief packs and packages/agentbundle", source = "spec/pack-script-root-boundary-validation"},
+
+  # Suppression cannot be shipped to adopters today: `agentbundle install` has
+  # no YAML-merge mode, so two packs each shipping a .snyk would clobber one
+  # another (self_host.py's merge-json / managed-block-inline do not apply --
+  # that is the self-hosting projection path, not the install path). Until this
+  # exists, fixing the source is the only remediation that reaches an adopter.
+  # Note: Snyk Code ignores additionally require the org to enable "Consistent
+  # Ignores", so this unblocks the vehicle but not the policy.
+  {slug = "agentbundle-install-yaml-merge", summary = "Add a YAML-merge conflict mode to `agentbundle install` so packs can ship mergeable .snyk (and other YAML) policy files without clobbering each other", source = "spec/pack-script-root-boundary-validation"},
+
+  # CodeQL runs security-extended on every PR and is the only lens we have with
+  # Snyk-Code-class interprocedural taint (Bandit has no dataflow; OSS Semgrep
+  # taint cannot cross a function boundary -- both verified this session). It is
+  # currently advisory: branch protection requires only "make build-check", so a
+  # genuine taint finding would annotate and still merge. Making it blocking is
+  # a branch-protection setting, not a workflow change (ADR-0017, codeql.yml:10).
+  {slug = "codeql-required-check", summary = "Make the CodeQL check required in branch protection so interprocedural taint findings block a merge instead of only annotating", source = "spec/pack-script-root-boundary-validation"},
+
+  # We ship JavaScript to adopters and scan it with nothing. Measured this
+  # session: Bandit is Python-only by construction; codeql.yml:51 sets
+  # `languages: python`; and our Semgrep config (p/python + p/security-audit)
+  # parses the JS but carries none of the JS security rules. Proof: current
+  # gate config over render.js + render-proof.js = 0 findings, while
+  # p/default + p/owasp-top-ten over the same two files = 5
+  # (path-join-resolve-traversal x4, detect-non-literal-regexp x1).
+  #
+  # Two production files ship: packs/converters/.apm/skills/markdown-to-html/
+  # scripts/render.js and .../render-proof/scripts/render-proof.js.
+  #
+  # Split out of the parent spec because enabling coverage is the small half —
+  # the real cost is triaging the findings it turns on. The 5 known ones all
+  # look like sanitizer-blindness (they sit inside render-proof.js's own
+  # validateOutputPath), but that must be confirmed per-finding, and new rules
+  # will surface more. Do both scanners in one pass so the triage happens once.
+  {slug = "sast-javascript-coverage", summary = "Give shipped JS real SAST coverage: add JS security rulesets to the Semgrep gate config and add javascript-typescript to codeql.yml languages, then triage and fix the findings both turn on", source = "spec/pack-script-root-boundary-validation"},
+
+  # CWE-delta review against Snyk Code's published rule tables. Measured
+  # 2026-08-07: Snyk Python = 43 rules/43 CWEs, Snyk JS+TS = 53 rules/42 CWEs;
+  # ours = 376 Semgrep rules (74 CWEs) + Bandit (24 CWEs), union 84. Residual
+  # gap is 10 CWEs for Python and 13 for JS/TS -- enumerated in the parent
+  # spec's "CWE coverage vs. Snyk Code" table.
+  #
+  # Deliberately scoped as a REVIEW, not "add all missing rules". We already
+  # nominally cover ~2x Snyk's CWE count; the CWE-23 finding got through on
+  # analysis depth (no dataflow in Bandit, no cross-function taint in OSS
+  # Semgrep), not on a missing rule. CWE tags are a coverage proxy, not proof
+  # of equivalent detection. Judge each of the 23 on whether the class is real
+  # for this codebase before adding anything -- several (CWE-347 signature
+  # verification, CWE-312 cleartext secret storage, CWE-640 password recovery)
+  # have no corresponding surface here.
+  {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
+
+  # Deliberately NOT backlogged: extending SAST_DIRS to web/ (62 JS/TS/Astro
+  # files). Decided 2026-08-07 — web/ is the platform site, built and deployed
+  # from this repo only; it is never installed into an adopter repo, so it
+  # carries none of the shipped-artifact exposure that motivates the entries
+  # above. Revisit only if web/ ever gains a server-side runtime.
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/workspace.toml
+++ b/workspace.toml
@@ -1586,6 +1586,26 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
+  # test-loop-cohort.sh is 493 lines / 51 cases of bash and uses ~20 bash-isms
+  # ([[, local, $(), declare). AGENTS.md's "New tool scripts: Python, not bash"
+  # rule grandfathers existing .sh, but this one is a portability dead end: a
+  # maintainer on Windows cannot run it, and it can never join
+  # build-check-windows.yml. Not urgent -- docs.yml:92 runs it on ubuntu-latest
+  # where bash is fine, and pack tests are never installed into adopter repos,
+  # so no adopter executes it.
+  #
+  # Convert as its own PR, not folded into a security fix: the fixture is
+  # SEQUENTIAL and its counter assertions accumulate, so a naive port silently
+  # changes expected values. Demonstrated 2026-08-07 -- inserting one extra
+  # `review record` case shifted a downstream count from 2/1 to 3/2 and broke
+  # three assertions. Port case-by-case against the current output, and split
+  # the shared-state cases onto independent fixtures while doing it.
+  #
+  # Also measured: the suite exceeds 10 minutes locally. Worth profiling during
+  # the port -- it spawns a Python subprocess per case and invokes the
+  # 2133-line test-loop-cohort.py as one of them.
+  {slug = "loop-cohort-shell-suite-to-python", summary = "Port test-loop-cohort.sh (493 lines, 51 sequential cases) to pure-stdlib Python so it runs on Windows, decoupling the shared-counter fixtures and profiling its >10min runtime", source = "spec/pack-script-root-boundary-validation"},
+
   # Deliberately NOT backlogged: extending SAST_DIRS to web/ (62 JS/TS/Astro
   # files). Decided 2026-08-07 — web/ is the platform site, built and deployed
   # from this repo only; it is never installed into an adopter repo, so it


### PR DESCRIPTION
## What does this change?

Shipped `work-loop` scripts now read CLI path arguments through a visible boundary validator, so taint-based scanners in adopter repositories stop reporting CWE-22/23 against code that was never vulnerable. While doing that, review found one place that genuinely **was** vulnerable, and this closes it.

## Why?

- Implements: `docs/specs/pack-script-root-boundary-validation/spec.md`
- Follows from: [ADR-0017](docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md) — remediation ladder, rung 1 (fix the code) over rung 3 (suppress)

An adopter's org Snyk Code scan reported 18 CWE-23 findings against `lint-traceability.py` and `lint-spec-status.py` at the adapter-projection path. Those 18 are false positives — they trace to operator-supplied `--root`, which crosses no privilege boundary, and CodeQL's `py/path-injection` (`security-extended`, confirmed executed in the run log) independently returns zero. Our confinement is interprocedural and shaped as a comprehension filter, which no taint engine follows.

**Suppression cannot reach an adopter.** `# nosec` is Bandit-only, a Semgrep rule exclusion is our gate only, and `.snyk` cannot ship in a pack — `agentbundle install` has no YAML-merge mode, so two packs each shipping one would clobber the other. Fixing the source is the only remediation that reaches every adopter at once.

### The real vulnerability

The spec originally asserted that *"every read under `--root` is re-confined through `_within()` / `_confined()`."* That was true of `lint-traceability.py` (25 uses) and **false of `lint-spec-status.py` (zero)**. The gap hid a live traversal: `_CONTRACT_TOKEN_RE` admitted `.` and `/`, so a `- **Contract:** contracts/../../secret.json` header in an untrusted `spec.md` joined onto `--root` and was read. Reproduced end to end — the target's presence changed which warning printed (existence oracle), and its content was substring-matched (`"x-spec" in ctext`). A symlinked spec directory escaped the same way. `docs/architecture/security.md` declares `filesystem_read_untrusted` a boundary, and this script ships into adopter repos where it can run over fork-authored branches.

### Also folded in

Review fingerprints move SHA-1 → SHA-256. They are opaque tokens compared set-wise for stasis detection, so the switch is behaviour-preserving. `_RE_FINGERPRINT` accepts **both** widths: a cohort mid-review at upgrade time holds 40-hex values and would otherwise hard-reject them. This let us **delete** a predicted `.snyk` entry rather than add one.

## How do I verify it?

```bash
make build-check                                    # exit 0, SAST/SCA included
python3 packs/core/tests/skills/work-loop/test-root-validation.py     # 12/12
python3 packs/core/tests/skills/work-loop/test-fingerprint-width.py   # 12/12
python3 packs/core/tests/skills/work-loop/test-loop-cohort.py         # 88/88
python3 tools/test-semgrep-argv-boundary.py                           # 5/5
```

Traversal reproduction, against the projected copy an adopter installs:

```bash
mkdir -p /tmp/tv/repo/docs/specs/demo /tmp/tv/repo/contracts
printf 'SECRET x-spec demo\n' > /tmp/tv/secret.json
printf -- '# Spec\n\n- **Status:** Draft\n- **Contract:** contracts/../../secret.json\n\n## Objective\nd\n' \
  > /tmp/tv/repo/docs/specs/demo/spec.md
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root /tmp/tv/repo | grep -i contract
# before: warning text differs by whether the target exists.  after: no output.
```

Behaviour parity, all five cases confirmed on the real artifact: valid `--root` → 0; omitted → 0; relative → 0; nonexistent → 1 naming the path; file-valued → 1 naming the path.

Every fix in the reviewer-concerns commit was **falsified before acceptance** — including deleting a path from the Semgrep rule's `paths.include` to prove the self-test catches it.

## What did you not change that you considered?

- **The other ~68 argv→path sites** across other packs and `packages/agentbundle`. A 73-site rewrite is a migration, not a fix; the pattern should prove itself on one skill first. (`pack-argv-path-boundary-sweep`)
- **JS SAST coverage.** We ship two JavaScript files that **no scanner in our stack has ever examined** — Bandit is Python-only, `codeql.yml` sets `languages: python`, and our Semgrep config carries no JS rules. Enabling coverage is the small half; triaging what it turns on is the real cost. (`sast-javascript-coverage`)
- **Adding the 23 missing Snyk CWEs.** We already cover ~2× Snyk's CWE count; the CWE-23 finding got through on analysis *depth*, not a missing rule. Scoped as a review, not a bulk add. (`sast-cwe-delta-review`)
- **Extending `SAST_DIRS` to `web/`** — declined outright, not deferred: it never installs into an adopter repo.
- **Porting `test-loop-cohort.sh` to Python.** Real portability defect, but not urgent, and its sequential counter fixtures make a naive port silently wrong — demonstrated when a one-line insertion shifted a downstream count and broke three assertions. (`loop-cohort-shell-suite-to-python`)
- **Confining `--root` to a fixed prefix** — that *is* the linter's scan scope; confining it would break the tool.

### Known limitation, stated plainly

**We cannot verify from here that the fix satisfies Snyk** — no access to the org scan. It is the standard resolve-then-check shape and matches the pre-existing exemplar at `check-spec-status.py:72-80`, but if the org scan still reports, escalation is `.snyk` plus the YAML-merge backlog item. Recorded as Assumption 2 in the spec. The change is independently justified regardless: it closes a real traversal and converts a traceback into a diagnostic.

Two Windows-reasoned findings (NTFS junctions in tier-3 confinement; `resolve()` on reserved names) were **reasoned from CPython semantics, not executed** — this was developed on macOS. The Windows CI leg is the check that matters for those.