### PR TITLE
Intake arch

### DIFF
--- a/docs/adr/0019-product-intent-ontology-and-brief-projection.md
+++ b/docs/adr/0019-product-intent-ontology-and-brief-projection.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-06-13
 - **Deciders:** eugenelim
 - **Supersedes:** none
-- **Refined by:** ADR-0033 — its part 1 only (the `Level` enum is reopened to an open recognized set and decoupled from `Scale`); parts 2–3 stand. ADR-0019 stays Accepted; this is a metadata back-pointer, not a body edit.
+- **Refined by:** ADR-0033 refines part 1 (`Level` is an open recognized set, decoupled from `Scale`); ADR-0076 refines part 2 (briefs may persist and selected delivery dispatches only from spec/plan pairs). Part 3 and the remainder of part 2 stand. ADR-0019 stays Accepted; these are metadata back-pointers, not body edits.
 - **Related:** RFC-0030 (the product-engineering pack — the decision this records) · ADR-0009 (the brief layer this reframes) · ADR-0008 + RFC-0017 + RFC-0018 (the contract-authoring seam this stages) · RFC-0019 (receive-brief)
 
 ## Context

--- a/docs/adr/0076-briefs-persist-dispatch-starts-from-specs.md
+++ b/docs/adr/0076-briefs-persist-dispatch-starts-from-specs.md
@@ -1,0 +1,163 @@
+# ADR-0076: Briefs persist; dispatch starts from specs
+
+- **Status:** Accepted
+- **Date:** 2026-08-08
+- **Decision-makers:** eugenelim
+- **Supersedes:** none
+- **Related:** [ADR-0009](0009-product-brief-layer-and-plan-owned-lld.md),
+  [ADR-0019](0019-product-intent-ontology-and-brief-projection.md),
+  [ADR-0033](0033-intent-level-open-recognized-set-decoupled-from-scale.md),
+  [ADR-0051](0051-workspace-toml-toml-format-and-main-branch-coordination.md),
+  [`work-intake-and-artifact-routing.md`](../architecture/work-intake-and-artifact-routing.md)
+
+## Decision summary
+
+- **Decision:** An accepted brief may remain Ready without specs; only selected
+  delivery slices become spec/plan pairs, and agents may dispatch work only from
+  structured workspace entries that reference those files.
+- **Because:** a cold-start session needs a complete, reviewable contract and
+  deterministic routing rather than requirements reconstructed from comments.
+- **Applies to:** briefs, derived specs and plans, `workspace.toml`,
+  `receive-brief`, `new-spec`, `workspace-status`, and `work-loop`.
+- **Tradeoff accepted:** choosing work from a brief requires an explicit
+  materialization step before execution.
+- **Revisit if:** adopters need briefs themselves to be executable, or a
+  spec/plan pair stops being the smallest safe dispatch unit.
+
+## Context
+
+A brief and a spec answer different questions. A brief holds a shared outcome,
+its decomposition, and work that may be deferred. A spec is the complete
+contract for one independently shippable slice. Its plan describes how that
+contract will be built and verified.
+
+The current workspace model weakens this distinction. `capture-work` creates no
+spec artifact and instead asks for comments detailed enough that a later session
+can reconstruct one. Other workflow paths register tracker collections or brief
+prose before a shippable contract exists. Two sessions can therefore interpret
+the same queue differently because routing depends on prose, nearby comments, or
+context retained from an earlier conversation.
+
+Forcing the opposite extreme is also wrong. A valid brief may sit for weeks or
+months before the team chooses a slice. Creating every possible spec and plan as
+soon as the brief is accepted produces speculative delivery contracts that will
+age before anybody intends to build them.
+
+This decision refines ADR-0019 part 2. A feature does not automatically become an
+immediately executable brief. A brief may persist as the repo-local planning
+envelope; selected delivery materializes below it. ADR-0019 otherwise remains
+Accepted. ADR-0009's brief layer and plan-owned LLD, ADR-0033's open `Level`
+model, and ADR-0051's TOML/main-branch decisions remain in force.
+
+## Decision
+
+**We will allow accepted briefs to persist without specs, materialize only
+selected delivery slices as spec/plan pairs, and use `workspace.toml` as a
+deterministic index over those artifacts rather than as a requirements store.**
+
+A brief follows this lifecycle:
+
+- **Draft:** its load-bearing fields or acceptance are incomplete.
+- **Ready:** it is accepted and has no active child spec. It may have no specs,
+  queued specs, or shipped specs, and may remain Ready indefinitely.
+- **Executing:** at least one derived spec is active.
+- **Shipped:** the brief is explicitly closed, no in-scope work remains, and
+  every materialized child spec is shipped.
+
+When delivery is chosen from a Ready brief:
+
+1. `receive-brief` presents the proposed cut for the current delivery.
+2. The user confirms the independently shippable slices.
+3. `new-spec` creates `spec.md` and `plan.md` for each selected slice.
+4. Each spec records its `Brief:` back-link and source provenance.
+5. Structured work entries are added only after the files exist.
+6. `work-loop` reads the spec and plan; it never reconstructs requirements from
+   workspace comments.
+7. After the current batch ships, the brief returns to Ready if scope remains.
+
+Deferred work stays in the brief. It does not need a placeholder work entry and
+must not be stored only in a comment.
+
+Routing may use only parsed entry fields, file existence, machine-readable
+artifact status, and explicit hard dependencies. Comment text, list order,
+nearby prose, and prior-session memory have no routing meaning.
+
+A dispatchable entry must reference an existing `spec.md` with a sibling
+`plan.md`. A derived spec's `Brief:` value must match the brief path recorded in
+the workspace source index. Missing artifacts, mismatched links, malformed
+entries, duplicate lifecycle membership, and impossible transitions are
+reconciliation failures. Readers fail closed; they never fall back to comments.
+
+## Decision drivers
+
+- **Deterministic cold starts.** The same files must produce the same ready,
+  blocked, active, and reconciliation sets in every session.
+- **One responsibility per artifact.** Briefs hold shared intent and deferred
+  scope; specs hold delivery contracts; plans hold build strategy; the workspace
+  indexes and sequences them.
+- **Safe dispatch.** An agent begins only from a reviewed, existing contract.
+- **Useful deferral.** Accepting a brief must not force speculative specs.
+- **Visible drift.** Broken references become findings rather than hidden
+  inference.
+
+## Consequences
+
+**Positive:**
+
+- A Ready brief remains useful even when no delivery work has been selected.
+- Work cannot become executable until its spec and plan exist.
+- Deleting or rewriting comments cannot change routing.
+- `workspace-status` can report missing files and inconsistent provenance
+  mechanically.
+- A completed delivery batch does not falsely close a brief that still has
+  deferred scope.
+
+**Negative:**
+
+- Starting work from a brief takes an extra, explicit materialization step.
+- The brief relationship appears in both spec metadata and the workspace index;
+  readers must reconcile mismatches.
+- Ready briefs can age. Tracker-origin sources may need a reviewed refresh before
+  a deferred slice is materialized.
+- Existing comment-rich queue entries cannot remain dispatchable and will need
+  migration or classification as non-dispatchable captures.
+- `brief_queue` needs a structured Shipped state to retain completed history.
+
+**Revisit if:** adopters need briefs themselves to be executable, or a spec/plan
+pair stops being the smallest safe dispatch unit.
+
+## Confirmation
+
+- **Mode:** architecture fitness test
+- **Signal:** every dispatchable entry resolves to `spec.md` and sibling
+  `plan.md`; brief links agree; changing comments leaves routing unchanged; two
+  reads of the same tree return identical lifecycle and reconciliation sets; a
+  Ready brief with no specs remains valid and non-dispatchable.
+- **Owner:** maintainers
+
+## Alternatives considered
+
+**Dispatch briefs directly.** `work-loop` could infer a spec from the brief when
+execution starts. Rejected because a multi-spec brief does not identify one
+complete delivery contract, and inference would vary across sessions.
+
+**Create all specs when a brief becomes Ready.** This makes every planned slice
+immediately indexable. Rejected because it turns deferred work into speculative
+contracts that drift before implementation.
+
+**Keep requirements in workspace comments.** This is cheap at capture time and
+keeps everything in one file. Rejected because comments are untyped,
+unvalidated, and not a stable contract boundary.
+
+**Store full requirements as structured TOML.** This could make workspace-only
+dispatch deterministic. Rejected because it duplicates briefs and specs,
+creates a second requirements schema, and forces workspace changes whenever
+requirements change.
+
+## References
+
+- [`docs/architecture/work-intake-and-artifact-routing.md`](../architecture/work-intake-and-artifact-routing.md)
+- [ADR-0009](0009-product-brief-layer-and-plan-owned-lld.md)
+- [ADR-0019](0019-product-intent-ontology-and-brief-projection.md)
+- [ADR-0033](0033-intent-level-open-recognized-set-decoupled-from-scale.md)
+- [ADR-0051](0051-workspace-toml-toml-format-and-main-branch-coordination.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -81,6 +81,7 @@
 | 0073 | [Zensical is the v1 binder renderer — chosen for foundation continuity, not footprint](0073-zensical-as-the-v1-binder-renderer.md) | Accepted |
 | 0074 | [The work-loop owns its state lock](0074-the-work-loop-owns-its-state-lock.md) | Accepted |
 | 0075 | [Every test has one owner — engine, catalogue, pack, or tools — and inclusion follows the owner, not the surface alone](0075-test-ownership-taxonomy-and-per-owner-inclusion.md) | Accepted |
+| 0076 | [Briefs persist; dispatch starts from specs](0076-briefs-persist-dispatch-starts-from-specs.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -109,6 +109,10 @@ One file per non-trivial subsystem:
   (env / OS keyring / `~/.agentbundle/credentials.env`), the four
   brokers (`creds` / `env` / `cli` / `sso-cookie`), the
   credentialed-primitive contract, and the substring trap.
+- [`work-intake-and-artifact-routing.md`](work-intake-and-artifact-routing.md)
+  — proposed target architecture for routing work intake between intents,
+  briefs, specs, trackers, and `workspace.toml`; an input to follow-on
+  governance, not a description of current implementation.
 
 ## Packages
 

--- a/docs/architecture/work-intake-and-artifact-routing.md
+++ b/docs/architecture/work-intake-and-artifact-routing.md
@@ -12,6 +12,8 @@ The decisions are straightforward: use `work-intake` as the single standalone fr
 
 This design should let an adopter bring in work without knowing the local skill names or tracker vocabulary. It should leave a real artifact behind before anything becomes dispatchable. A later session should be able to see what is ready, what is blocked, and why, without guessing from old comments.
 
+The result is testable: every dispatchable entry resolves to a spec and plan; deleting or rewriting comments does not change routing; and two sessions reading the same files report the same ready, blocked, active, and reconciliation sets.
+
 It does not build a tracker replacement, a cross-repo control plane, or a new product-process mandate. It does not make every team create intents before writing a spec. It also does not change any skill, schema, parser, RFC, ADR, or `workspace.toml` in this change.
 
 ## The model
@@ -149,6 +151,8 @@ There are two modes.
 
 Tracker-origin does not mean “the tracker overwrites the repository.” Ownership is per field and recorded as provenance. Refresh is always a reviewed delta, not a blind sync.
 
+This lifecycle follows imported requirements through local acceptance and into a spec. A brief has its own, simpler lifecycle in the next section.
+
 ```mermaid
 stateDiagram-v2
   [*] --> Draft: source crosses trust boundary
@@ -167,6 +171,62 @@ In Draft, source-owned fields can refresh after a reviewed delta. In Ready and A
 
 This explains [linear-brief-sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md): it is a tracker-origin refresh before execution, not a mysterious exception to “trackers are one-way renders.” Repo-origin remains useful when a team authors locally and only publishes a tracker view.
 
+## What happens after a brief is received
+
+A brief is a durable planning envelope, not a dispatchable work item. It may stay Ready for as long as the team wants, with no specs or plans yet. Only the slices chosen for delivery move into specs and plans.
+
+```mermaid
+flowchart LR
+  B[Draft brief exists] --> V[Validate outcome and scope]
+  V --> R[Ready brief can wait]
+  R --> C[Choose and confirm current slices]
+  C --> S[Create spec.md + plan.md per slice]
+  S --> I[Index each spec in workspace.toml]
+  I --> Q[Queue or activate specs]
+  Q --> W[work-loop reads the spec]
+  W --> D{Brief has more work?}
+  D -->|yes| R
+  D -->|no| H[Ship the brief]
+```
+
+That flow gives each stage a concrete result:
+
+1. `work-intake` or `author-brief` writes the brief file and registers its path in `brief_queue.draft`.
+2. `receive-brief` fills the load-bearing gaps. Once the brief itself is accepted, it moves to Ready. The flow may stop here without creating delivery work.
+3. When the team chooses work from the brief, `receive-brief` shows the slice cut for that delivery and waits for confirmation.
+4. `new-spec` creates a `spec.md` and `plan.md` for each selected slice. Each spec carries its `Brief:` back-link and source provenance.
+5. Only then are structured work entries added to `workspace.toml`. Each entry names an existing `spec.md`, its brief as the source artifact, a display summary, and any hard `needs` edges.
+6. The brief is Executing while a child spec is active. When the current batch finishes, it returns to Ready if the brief still has in-scope work. It moves to Shipped only when the brief is explicitly closed and every materialized child spec is shipped.
+
+Deferred or future work stays in the brief's own scope and decomposition, where it can be reviewed. It does not need a placeholder work entry. If another slice is chosen later, create its spec and plan, then register it. Do not leave a proposed slice in a queue comment for a future session to interpret.
+
+Brief lifecycle follows these conditions. If stored membership disagrees with them, `workspace-status` reports drift instead of guessing:
+
+| Brief state | Condition |
+| --- | --- |
+| Draft | The brief exists, but its load-bearing fields or acceptance are incomplete. |
+| Ready | The brief is accepted and has no active child spec. It may have zero, queued, or shipped child specs and may remain here indefinitely. |
+| Executing | At least one child spec is active and not all children are shipped. |
+| Shipped | The brief is explicitly closed, has no remaining in-scope work, and every materialized child spec is shipped. It moves to `brief_queue.shipped` so the workspace keeps a structured history. |
+
+The children come from structured links: each derived spec's `Brief:` metadata and its workspace `source.artifact`. Remaining scope stays in the brief itself. Comments cannot add a child, change the cut, or move the brief between states.
+
+The target shape looks like this. The exact TOML syntax belongs to the RFC, but the references and meanings do not:
+
+```toml
+["ini-002".brief_queue]
+ready = [
+  { path = "docs/product/briefs/account-recovery.md", kind = "brief", source = { mode = "tracker-origin", ref = "PROJ-123" }, summary = "Make account recovery self-service" },
+]
+
+["ini-002".work]
+queue = [
+  { path = "docs/specs/self-service-reset/spec.md", kind = "spec", source = { artifact = "docs/product/briefs/account-recovery.md", ref = "PROJ-123" }, summary = "Let a user reset access without support", needs = [] },
+]
+```
+
+The brief holds the shared outcome, decomposition, and anything intentionally deferred. The spec holds a selected delivery contract. The plan holds its build strategy. `workspace.toml` holds only the index and lifecycle facts needed to find and sequence them. A Ready brief with no work entries is valid and non-dispatchable.
+
 ## What the existing skills should do
 
 | Surface | Target responsibility |
@@ -174,7 +234,7 @@ This explains [linear-brief-sync](../../packs/linear/.apm/skills/linear-brief-sy
 | `work-intake` | Standalone entry point for start, capture, status, and refresh routing |
 | `capture-work` | Removed or retained briefly as a compatibility alias |
 | `author-brief` | Turn unstructured multi-spec input into a Draft brief |
-| `receive-brief` | Validate an existing brief, cut it into specs, and produce those specs |
+| `receive-brief` | Validate an existing brief and leave it Ready; when delivery is chosen, confirm the current cut and produce specs |
 | `new-spec` | Materialize one shippable contract, including provenance |
 | `work-loop` | Execute an existing spec and plan; never rebuild requirements from workspace comments |
 | `workspace-status` | Show lifecycle, next actions, and reconciliation failures |
@@ -186,7 +246,7 @@ The important boundary is between acquisition and routing. An adapter knows how 
 
 ## The `workspace.toml` contract
 
-Every entry points to a real artifact. Queue membership is lifecycle state, not a substitute for the artifact.
+Every entry points to a real artifact. Queue membership is lifecycle state, not a substitute for the artifact. Given the same files and parsed TOML, two sessions must reach the same routing result.
 
 ```text
 path:     artifact path
@@ -196,18 +256,23 @@ summary:  display only
 needs:    hard dependencies
 ```
 
+Routing may use only the structured entry, whether the referenced file exists, machine-readable artifact status, and explicit `needs`. It must not depend on comment text, list order, nearby prose, or what a previous session happened to know.
+
 The RFC will choose exact field names and migration details. It must preserve these rules:
 
-- Dispatchable work points to an existing spec.
+- Dispatchable work points to an existing `spec.md`; its sibling `plan.md` must also exist before execution.
 - A brief queue entry points to an existing brief.
 - A shaping entry points to an intent, research artifact, or design artifact.
 - A missing artifact is a reconciliation failure, or it is a non-dispatchable capture.
 - Comments do not affect routing.
 - A queue entry never authorizes an agent to infer the complete contract from surrounding comments.
+- A spec derived from a brief has the same brief path in its `Brief:` metadata and workspace source index. A mismatch is a reconciliation failure.
+- `needs` contains hard artifact dependencies only. Priority, affinity, suggested ordering, and rationale belong elsewhere.
+- Unknown kinds, malformed entries, duplicate lifecycle membership, and impossible transitions fail closed as reconciliation findings. The parser never falls back to comments.
 
 Provenance records identifiers and links, not credentials or a copied tracker payload. Refresh happens on an explicit request; this design does not add a polling service or webhook.
 
-`workspace-status` should report broken references. A dispatcher should not start work until the referenced spec and its hard dependencies exist. A capture without an artifact can remain visible; it cannot quietly become dispatchable work.
+`workspace-status` should report broken references and inconsistent brief/spec links. A dispatcher should not start work until the referenced spec, plan, and hard dependencies exist. A capture without an artifact can remain visible; it cannot quietly become dispatchable work.
 
 ## Other shapes we could choose
 
@@ -224,6 +289,8 @@ The feature gate is a judgment call. A loose outcome can make unrelated tracker 
 Tracker-origin refresh can create difficult conflicts. Keep the first version small: record field ownership, show the delta, require an explicit decision, and lock requirement refresh once execution starts.
 
 Migration can leave old queue entries pointing nowhere. Treat each missing path as a visible reconciliation failure or an explicitly non-dispatchable capture. Do not silently promote it.
+
+A Ready brief can sit untouched long enough for its source or assumptions to age. `workspace-status` should keep it visible without calling it build-ready, and tracker-origin refresh rules still apply before a deferred slice is materialized.
 
 The operational failure to watch is a broken reference at session start. `workspace-status` needs to show it plainly, and dispatch needs to stop before an agent starts work from a comment.
 

--- a/docs/architecture/work-intake-and-artifact-routing.md
+++ b/docs/architecture/work-intake-and-artifact-routing.md
@@ -4,7 +4,7 @@
 
 We need one way to answer a basic question: given some work, what is the first local artifact worth creating? Today the answer varies by skill and tracker. That leaves us with a few awkward outcomes: a one-spec change wrapped in a brief, a tracker collection treated as a requirement, or a queue comment doing the job of a spec.
 
-This paper sets a common model. It needs a new RFC before implementation and a new ADR refining part 2 of [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md): an app-scale feature no longer becomes a brief by default. [ADR-0033](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md)'s decision on `Level` and `Scale` remains intact. So do [ADR-0009](../adr/0009-product-brief-layer-and-plan-owned-lld.md)'s brief layer and plan-owned LLD.
+This paper sets a common model. [RFC-0083](../rfc/0083-work-intake-and-artifact-routing.md) now proposes its adoption; implementation still needs that RFC accepted and two follow-on ADRs. One refines part 2 of [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md): an app-scale feature no longer becomes a brief by default. The other records standalone intake, deterministic workspace indexing, and the shared layout boundary. [ADR-0033](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md)'s decision on `Level` and `Scale` remains intact. So do [ADR-0009](../adr/0009-product-brief-layer-and-plan-owned-lld.md)'s brief layer and plan-owned LLD.
 
 The decisions are straightforward: use `work-intake` as the single standalone front door; create briefs only when they earn their keep; index artifacts rather than requirements in `workspace.toml`; and say who owns tracker-imported fields at each lifecycle stage.
 
@@ -42,6 +42,8 @@ In particular, a workspace initiative is a coordination scope. It is not proof t
 
 ```mermaid
 flowchart LR
+  accTitle: Canonical artifact and requirements flow
+  accDescr: Evidence and governance feed a level-tagged intent tree, feature projection creates a brief or spec, and only a spec with a plan reaches work-loop; workspace and tracker links are non-authoritative references.
   R[Study / research] --> I[Intent tree]
   F[RFC] --> I
   I --> G{Feature gate}
@@ -68,9 +70,11 @@ A brief earns its place when it holds something a spec cannot: the shared outcom
 | One independently shippable change in one repo | A spec |
 | Several independently shippable changes in one repo | A brief, then specs |
 | One feature spanning component repos | One brief per affected repo, then specs |
-| One spec with useful cross-repo coordination/provenance | A brief is allowed |
+| One repository's single-spec slice of a cross-repo feature | A brief is allowed only when it preserves shared identity, sibling ordering, or closure |
 
-This is a deliberate refinement of the current “app-scale feature intent is a brief” rule in [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md). A one-spec brief is not forbidden, but it needs a reason beyond “that is the usual shape.”
+This is a deliberate refinement of the current “app-scale feature intent is a brief” rule in [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md). Ordinary provenance belongs on the spec. A one-spec brief is justified only by a concrete cross-repo identity, ordering, or closure need.
+
+Cross-repo status is never read live during local dispatch. Each repo brief keeps a reviewed coordination receipt for a remote prerequisite, and the parent feature intent keeps reviewed closure receipts for its repo briefs. A receipt pins the remote locator, revision, terminal status, reviewer, and date. Its stable ID is local to the containing artifact. Accepting a new receipt revision updates matching local dependency pins atomically; rejection changes neither. That gives reconciliation durable local evidence without copying remote requirements or making one workspace authoritative for another.
 
 Start with shippability, not components. “The API” and “the screen” are not separate specs unless each can ship and be useful on its own. Likewise, a milestone, board, sprint, cycle, or JQL result is not a brief just because it contains several issues. It becomes one only when those issues serve one feature-level outcome and require several specs.
 
@@ -85,6 +89,7 @@ Start with shippability, not components. “The API” and “the screen” are 
 | Brief | Hold a repo's multi-spec or cross-repo projection envelope |
 | Spec | Define one shippable, verifiable behaviour |
 | Plan | Explain how to implement and verify one spec |
+| Defect context | Record expected and observed behavior, reproduction evidence, provenance, and a durable citation proving the expectation is already intended |
 | Tracker object | Represent upstream demand or external coordination |
 | `workspace.toml` | Index artifacts, lifecycle, hard dependencies, provenance, and short display summaries |
 
@@ -95,6 +100,8 @@ Names from other methods do not decide this. A BRD, PRD, FRD, SRS, or Jira Story
 - One shippable contract becomes a spec.
 - A cross-cutting proposal becomes an RFC.
 - Evidence becomes study/research.
+- A deviation from cited intended behavior becomes a defect context; without
+  that durable evidence, it remains unresolved intake or becomes a Draft spec.
 
 `workspace.toml` is not another requirements document. Its comments are for people reading the file. Routing ignores them, and a later agent must never have to reconstruct a full spec from a comment.
 
@@ -123,24 +130,30 @@ The profile still has to pass the coherence and shippability test. A board is us
 
 If the input is a product outcome or opportunity, `work-intake` can route or materialize an intent. It does not need special installation state to do so. It also does not invent an intent when the direct answer is a brief, spec, defect, or capture.
 
-This replaces `capture-work` in the target design. The RFC should decide whether to leave a short-lived alias for existing users or remove it directly. Either way, `work-intake` is the sole public intake surface.
+Shared intake owns only a minimal intent contract. It uses the existing `[core]` layout configuration with an in-repository parent; `docs/product/intents/` is the default, not a dependency on another workflow bundle. Keeping the parent in the repo lets every workspace entry use the same repository-relative path rule.
+
+This replaces `capture-work` in the target design. RFC-0083 keeps a temporary compatibility alias for two minor catalogue releases counted from the first write-new release and at least 90 days, then removes it after the migration gates pass. `work-intake` is the sole public intake surface throughout; the old name only forwards to it.
 
 ```mermaid
 flowchart LR
-  A[Start / do] --> Q[work-intake]
-  C[Remember] --> Q
-  S[Where are we] --> Q
-  R[Refresh tracker] --> Q
-  Q --> X[Acquire source]
-  X --> N[Normalize]
-  N --> K[Classify level or delivery unit]
-  K --> M[Make intent / brief / spec / defect]
-  M --> W[Register in workspace.toml]
-  W --> P[Shaping / receive-brief / new-spec + work-loop / bug-fix]
-  X -. tracker trust boundary .-> N
+  accTitle: Adopter-facing work intake
+  accDescr: Start and remember may create artifacts, refresh reviews a delta against an existing artifact, and status reads the workspace without creating work.
+  A[Start / remember] --> X[Acquire source]
+  F[Refresh tracker] --> X
+  S[Where are we] --> R[Read workspace + artifacts]
+  X -. tracker trust boundary .-> N[Normalize]
+  N -->|start / remember| K[Classify delivery unit]
+  K --> M[Make canonical artifact]
+  M --> W[Register structured entry]
+  N -->|refresh| D[Resolve existing artifact]
+  D --> J[Invoke refresh processor]
+  J --> U[Review delta + guarded update]
+  W --> P[Selected processor]
+  U --> P
+  R --> T[workspace-status]
 ```
 
-The common path is simple: acquire the source, normalize it, decide whether it is an intent or a delivery unit, make the right local artifact, register that artifact, then call the processor that owns the next step. Status is usually read-only; its source is the workspace index and the artifacts it names.
+The creation path is simple: acquire the source, normalize it, decide whether it is an intent or a delivery unit, make the right local artifact, register that artifact, then call the processor that owns the next step. Refresh instead resolves an existing artifact and invokes the configured refresh processor, which reviews the delta and updates only after acceptance. Intake copies only required fields, redacts secrets and unnecessary sensitive data, and stops if the destination is more visible than the source. Status is read-only; its source is the workspace index and the artifacts it names.
 
 ## Who owns imported requirements?
 
@@ -155,19 +168,26 @@ This lifecycle follows imported requirements through local acceptance and into a
 
 ```mermaid
 stateDiagram-v2
+  accTitle: Tracker-origin authority lifecycle
+  accDescr: Source-owned fields may refresh after review in Draft, require conflict resolution after local acceptance, lock during implementation, and allow trace-only writes after shipping.
   [*] --> Draft: source crosses trust boundary
-  Draft --> Ready: reviewed local acceptance
-  Ready --> Approved: scope / plan approved
-  Approved --> Executing: local spec takes control
-  Executing --> Shipped: verified delivery
   Draft --> Draft: refresh allowed after review
+  Draft --> Accepted: intent accepted
+  Draft --> Ready: brief accepted
+  Draft --> Approved: direct spec approved
+  Accepted --> Ready: feature projects to brief
+  Accepted --> Approved: feature projects to direct spec
+  Accepted --> Accepted: resolve conflict first
   Ready --> Ready: resolve conflict first
+  Ready --> Approved: selected spec and plan approved
   Approved --> Approved: resolve conflict first
-  Executing --> Executing: requirements refresh locked
+  Approved --> Implementing: local spec takes control
+  Implementing --> Shipped: verified delivery
+  Implementing --> Implementing: requirements refresh locked
   Shipped --> Shipped: links, status, comments, PR, closure only
 ```
 
-In Draft, source-owned fields can refresh after a reviewed delta. In Ready and Approved, a refresh needs explicit conflict resolution. In Executing, the spec is authoritative and requirement refresh is locked. After execution, tracker writes are limited to trace links, status, comments, PR links, and closure.
+In Draft, source-owned fields can refresh after a reviewed delta. After an intent is Accepted, a brief is Ready, or a spec is Approved, a refresh needs explicit conflict resolution. While the spec is Implementing, it is authoritative and requirement refresh is locked. The containing brief is Executing during that time. After execution, tracker writes are limited to trace links, status, comments, PR links, and closure.
 
 This explains [linear-brief-sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md): it is a tracker-origin refresh before execution, not a mysterious exception to “trackers are one-way renders.” Repo-origin remains useful when a team authors locally and only publishes a tracker view.
 
@@ -177,11 +197,14 @@ A brief is a durable planning envelope, not a dispatchable work item. It may sta
 
 ```mermaid
 flowchart LR
+  accTitle: Brief-to-delivery lifecycle
+  accDescr: A brief may remain Ready until slices are selected; each slice becomes an approved spec and plan before it can enter work-loop.
   B[Draft brief exists] --> V[Validate outcome and scope]
   V --> R[Ready brief can wait]
   R --> C[Choose and confirm current slices]
   C --> S[Create spec.md + plan.md per slice]
-  S --> I[Index each spec in workspace.toml]
+  S --> A[Review + approve each spec and plan]
+  A --> I[Index each spec in workspace.toml]
   I --> Q[Queue or activate specs]
   Q --> W[work-loop reads the spec]
   W --> D{Brief has more work?}
@@ -195,8 +218,8 @@ That flow gives each stage a concrete result:
 2. `receive-brief` fills the load-bearing gaps. Once the brief itself is accepted, it moves to Ready. The flow may stop here without creating delivery work.
 3. When the team chooses work from the brief, `receive-brief` shows the slice cut for that delivery and waits for confirmation.
 4. `new-spec` creates a `spec.md` and `plan.md` for each selected slice. Each spec carries its `Brief:` back-link and source provenance.
-5. Only then are structured work entries added to `workspace.toml`. Each entry names an existing `spec.md`, its brief as the source artifact, a display summary, and any hard `needs` edges.
-6. The brief is Executing while a child spec is active. When the current batch finishes, it returns to Ready if the brief still has in-scope work. It moves to Shipped only when the brief is explicitly closed and every materialized child spec is shipped.
+5. A human reviews each contract and plan. Only an Approved spec is added to `work.queue`; each entry names the existing `spec.md`, its brief as the source artifact, a display summary, and any hard `needs` edges.
+6. Claiming the first active child moves the work entry to active, the spec to Implementing, and the brief to Executing as one guarded change. Further child claims retain Executing. Each completion retains Executing while another child remains active; the last returns the brief to Ready. It moves to Shipped only through a separate explicit close event when no scope remains and every materialized child spec is shipped.
 
 Deferred or future work stays in the brief's own scope and decomposition, where it can be reviewed. It does not need a placeholder work entry. If another slice is chosen later, create its spec and plan, then register it. Do not leave a proposed slice in a queue comment for a future session to interpret.
 
@@ -216,12 +239,12 @@ The target shape looks like this. The exact TOML syntax belongs to the RFC, but 
 ```toml
 ["ini-002".brief_queue]
 ready = [
-  { path = "docs/product/briefs/account-recovery.md", kind = "brief", source = { mode = "tracker-origin", ref = "PROJ-123" }, summary = "Make account recovery self-service" },
+  { path = "docs/product/briefs/account-recovery.md", kind = "brief", source = { mode = "tracker-origin", ref = "PROJ-123", revision = "42" }, summary = "Make account recovery self-service", needs = [] },
 ]
 
 ["ini-002".work]
 queue = [
-  { path = "docs/specs/self-service-reset/spec.md", kind = "spec", source = { artifact = "docs/product/briefs/account-recovery.md", ref = "PROJ-123" }, summary = "Let a user reset access without support", needs = [] },
+  { path = "docs/specs/self-service-reset/spec.md", kind = "spec", source = { mode = "tracker-origin", artifact = "docs/product/briefs/account-recovery.md", ref = "PROJ-123", revision = "42" }, summary = "Let a user reset access without support", needs = [] },
 ]
 ```
 
@@ -232,7 +255,7 @@ The brief holds the shared outcome, decomposition, and anything intentionally de
 | Surface | Target responsibility |
 | --- | --- |
 | `work-intake` | Standalone entry point for start, capture, status, and refresh routing |
-| `capture-work` | Removed or retained briefly as a compatibility alias |
+| `capture-work` | Temporary compatibility alias that forwards to `work-intake` until the migration gates pass |
 | `author-brief` | Turn unstructured multi-spec input into a Draft brief |
 | `receive-brief` | Validate an existing brief and leave it Ready; when delivery is chosen, confirm the current cut and produce specs |
 | `new-spec` | Materialize one shippable contract, including provenance |
@@ -249,9 +272,9 @@ The important boundary is between acquisition and routing. An adapter knows how 
 Every entry points to a real artifact. Queue membership is lifecycle state, not a substitute for the artifact. Given the same files and parsed TOML, two sessions must reach the same routing result.
 
 ```text
-path:     artifact path
+path:     repository-relative artifact path
 kind:     intent | research | design | brief | spec | defect
-source:   origin, tracker identifier/URL when relevant, field ownership
+source:   origin mode, durable locator and revision, parent / coordination reference
 summary:  display only
 needs:    hard dependencies
 ```
@@ -268,9 +291,17 @@ The RFC will choose exact field names and migration details. It must preserve th
 - A queue entry never authorizes an agent to infer the complete contract from surrounding comments.
 - A spec derived from a brief has the same brief path in its `Brief:` metadata and workspace source index. A mismatch is a reconciliation failure.
 - `needs` contains hard artifact dependencies only. Priority, affinity, suggested ordering, and rationale belong elsewhere.
+- A cross-repo `needs` condition points to a reviewed coordination receipt in the local brief. Dispatch checks its pinned revision and Shipped status from local files; it never reads another repository live.
+- A defect dependency is satisfied only by a closed defect whose structured resolution is `fixed`; declined or superseded defects remain history but do not unblock work.
 - Unknown kinds, malformed entries, duplicate lifecycle membership, and impossible transitions fail closed as reconciliation findings. The parser never falls back to comments.
 
 Provenance records identifiers and links, not credentials or a copied tracker payload. Refresh happens on an explicit request; this design does not add a polling service or webhook.
+
+Field ownership lives only in the canonical artifact's source-authority record. `workspace.toml` mirrors the mode, locator, and revision needed for routing and display; it is not a second authority map.
+
+After every completed refresh comparison, the artifact's compared revision and its workspace mirror advance atomically even when the human keeps local requirements; accepted requirements and dependency pins do not change. A failed acquisition or comparison advances neither.
+
+Shipped entries may leave the active workspace index only after no live dependency or open parent refers to them. Their canonical artifacts and Git history remain. ADR-0051's threshold still applies: 50 or more active specs across initiatives requires a fresh scale decision rather than an ever-growing single-file assumption.
 
 `workspace-status` should report broken references and inconsistent brief/spec links. A dispatcher should not start work until the referenced spec, plan, and hard dependencies exist. A capture without an artifact can remain visible; it cannot quietly become dispatchable work.
 
@@ -310,17 +341,17 @@ This table separates evidence from the conclusion we should draw from it.
 
 ## Order the implementation this way
 
-1. **RFC and ADR refinement.** Done when the RFC settles routing, provenance, authority, and compatibility, and a new ADR records the ADR-0019 refinement without editing its frozen body.
+1. **RFC and ADR refinement.** Done when RFC-0083 settles routing, provenance, authority, and compatibility; one new ADR refines ADR-0019's projection and tracker rules; and another records standalone intake, the in-repo `[core]` layout consumer, deterministic workspace indexing, and the ADR-0051/ADR-0076 refinements.
 2. **Normalized intake and workspace contract.** Done when both have a versioned contract for path, kind, provenance, display summary, and hard `needs`.
 3. **Parser, status, and work-loop checks.** Done when broken references are visible and no dispatcher or work-loop run can get a contract from comments.
-4. **Standalone `work-intake` and core boundaries.** Done when it independently routes normalized input and the `capture-work` removal/alias decision is complete.
+4. **Standalone `work-intake` and core boundaries.** Done when start, remember, and status independently route normalized input, refresh delegates fail-closed until its processors land, and the `capture-work` alias is in place.
 5. **Tracker adapters.** Jira, Jira Align, Linear, and GitHub can change in parallel once they all normalize input, run the feature gate, and register artifacts the same way.
 6. **Refresh and write-back.** Done when reviewed deltas, conflicts, the execution lock, and allowed post-execution writes are implemented and tested.
 7. **Migration and guides.** Done when old entries are reconciled or marked as captures, aliases are documented if kept, and routing evaluations cover one spec, many specs, cross-repo work, collections, and defects.
 
 Roll this out in those phases, not as a big-bang rewrite. Each phase can be reverted by retaining the old reader or alias until the next contract is proven. The maintainer group that accepts the RFC owns the rollout window and decides when an old compatibility path can be removed.
 
-The remaining judgment call is whether `capture-work` gets a temporary alias. Both choices are reasonable: an alias reduces upgrade friction; direct removal keeps one front door truly singular. The RFC author and core maintainers should decide it from adopter migration evidence.
+RFC-0083 resolves the migration judgment: `capture-work` becomes a temporary alias that reads old state but writes only the new contract. Rollout is reader-first so the release immediately before write-new remains a dual-reader rollback target. Core maintainers own rollback from a reversible migration manifest; canonical artifacts are never deleted to make an old writer happy. The alias remains for two minor catalogue releases counted from the first write-new release and at least 90 days, then is removed only after the RFC's fixture, documentation, release-note, and Approver gates pass.
 
 ## Checks before adopting it
 

--- a/docs/architecture/work-intake-and-artifact-routing.md
+++ b/docs/architecture/work-intake-and-artifact-routing.md
@@ -1,0 +1,260 @@
+# Work intake and artifact routing
+
+> **Proposed architecture.** This describes where the repository should go next. It is not a claim about what the current skills, parser, or `workspace.toml` already do.
+
+We need one way to answer a basic question: given some work, what is the first local artifact worth creating? Today the answer varies by skill and tracker. That leaves us with a few awkward outcomes: a one-spec change wrapped in a brief, a tracker collection treated as a requirement, or a queue comment doing the job of a spec.
+
+This paper sets a common model. It needs a new RFC before implementation and a new ADR refining part 2 of [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md): an app-scale feature no longer becomes a brief by default. [ADR-0033](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md)'s decision on `Level` and `Scale` remains intact. So do [ADR-0009](../adr/0009-product-brief-layer-and-plan-owned-lld.md)'s brief layer and plan-owned LLD.
+
+The decisions are straightforward: use `work-intake` as the single standalone front door; create briefs only when they earn their keep; index artifacts rather than requirements in `workspace.toml`; and say who owns tracker-imported fields at each lifecycle stage.
+
+## Goals and boundaries
+
+This design should let an adopter bring in work without knowing the local skill names or tracker vocabulary. It should leave a real artifact behind before anything becomes dispatchable. A later session should be able to see what is ready, what is blocked, and why, without guessing from old comments.
+
+It does not build a tracker replacement, a cross-repo control plane, or a new product-process mandate. It does not make every team create intents before writing a spec. It also does not change any skill, schema, parser, RFC, ADR, or `workspace.toml` in this change.
+
+## The model
+
+An **intent** is one recursive artifact. It is tagged with a `Level`. The recognized starting set is:
+
+```text
+product-vision → product-strategy → capability → feature
+```
+
+The set is open. An organization can add `initiative`, `epic`, `solution`, or another useful rung. Decompose one level at a time. `feature` is the last intent level.
+
+A **spec** (or slice) is what a feature produces for delivery. It is not another intent level. A spec is one independently shippable, verifiable behavioural contract. Its plan says how to build and verify that one contract.
+
+Do not blend the following ideas:
+
+| Term | What it answers |
+| --- | --- |
+| `Level` | At what product altitude is this decision? |
+| `Scale` | Does this concern one app or a business unit? |
+| `Kind` | Is this an outcome or opportunity traceability role? |
+| Workspace type | Which operating route should handle it? |
+| Tracker object type | What does an external tool happen to call it? |
+
+In particular, a workspace initiative is a coordination scope. It is not proof that an intent has `Level: initiative`.
+
+```mermaid
+flowchart LR
+  R[Study / research] --> I[Intent tree]
+  F[RFC] --> I
+  I --> G{Feature gate}
+  G -->|one repo, one change| S[Spec]
+  G -->|many slices or repos| B[Repo brief]
+  B --> S
+  S --> P[Plan]
+  P --> W[work-loop]
+  X[workspace.toml] -. indexes .-> I
+  X -. indexes .-> B
+  X -. indexes .-> S
+  T[Tracker: outside repo trust boundary] -. source or projection .-> I
+  T -. source or projection .-> B
+```
+
+The solid arrows are the requirements path. The dotted arrows are references, provenance, or a controlled import/export. A tracker can be the source of imported fields without becoming the repository's source of truth for everything.
+
+## When a feature needs a brief
+
+A brief earns its place when it holds something a spec cannot: the shared outcome and cut across several specs, or the local slice of a cross-repo effort.
+
+| Situation | Create |
+| --- | --- |
+| One independently shippable change in one repo | A spec |
+| Several independently shippable changes in one repo | A brief, then specs |
+| One feature spanning component repos | One brief per affected repo, then specs |
+| One spec with useful cross-repo coordination/provenance | A brief is allowed |
+
+This is a deliberate refinement of the current “app-scale feature intent is a brief” rule in [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md). A one-spec brief is not forbidden, but it needs a reason beyond “that is the usual shape.”
+
+Start with shippability, not components. “The API” and “the screen” are not separate specs unless each can ship and be useful on its own. Likewise, a milestone, board, sprint, cycle, or JQL result is not a brief just because it contains several issues. It becomes one only when those issues serve one feature-level outcome and require several specs.
+
+## What each artifact is for
+
+| Artifact | Its job |
+| --- | --- |
+| Study/research | Hold evidence |
+| RFC | Propose a cross-cutting change and its governance constraints |
+| ADR | Record a durable architectural decision |
+| Intent | Hold an outcome, opportunity, assumptions, and product decomposition |
+| Brief | Hold a repo's multi-spec or cross-repo projection envelope |
+| Spec | Define one shippable, verifiable behaviour |
+| Plan | Explain how to implement and verify one spec |
+| Tracker object | Represent upstream demand or external coordination |
+| `workspace.toml` | Index artifacts, lifecycle, hard dependencies, provenance, and short display summaries |
+
+Names from other methods do not decide this. A BRD, PRD, FRD, SRS, or Jira Story can contain different kinds of work. Route the content instead:
+
+- A product outcome or opportunity becomes an intent at the right level.
+- A repo outcome that needs several specs becomes a brief.
+- One shippable contract becomes a spec.
+- A cross-cutting proposal becomes an RFC.
+- Evidence becomes study/research.
+
+`workspace.toml` is not another requirements document. Its comments are for people reading the file. Routing ignores them, and a later agent must never have to reconstruct a full spec from a comment.
+
+## Tracker profiles, not tracker ontology
+
+Different tools cut work at different places. Their names are hints, not local truth.
+
+| Local unit | Common tracker profiles |
+| --- | --- |
+| Product vision or strategy | Initiative, theme, strategy, roadmap item |
+| Capability | Initiative or portfolio epic |
+| Feature intent | Linear Project, Jira Align Feature, Jira Software Epic, GitHub Milestone |
+| Spec/slice | Linear Issue, Jira Story/Task, GitHub Issue |
+| Defect | A bug or defect workflow |
+
+The profile still has to pass the coherence and shippability test. A board is usually a scheduling view. A sprint is usually a time box. Neither tells us whether we should write a brief.
+
+## `work-intake`: one front door
+
+`work-intake` is the proposed standalone core front door. It does not depend on another pack, a particular tracker, or a pre-existing intent tree. It works from the material in front of it:
+
+- “Start/do this” creates or processes an intent, brief, spec, or defect.
+- “Remember this for later” records a capture without pretending it is ready to build.
+- “Where are we?” shows lifecycle, blocked work, broken references, and the next action.
+- “Refresh this from the tracker” fetches source data and applies a permitted reviewed change.
+
+If the input is a product outcome or opportunity, `work-intake` can route or materialize an intent. It does not need special installation state to do so. It also does not invent an intent when the direct answer is a brief, spec, defect, or capture.
+
+This replaces `capture-work` in the target design. The RFC should decide whether to leave a short-lived alias for existing users or remove it directly. Either way, `work-intake` is the sole public intake surface.
+
+```mermaid
+flowchart LR
+  A[Start / do] --> Q[work-intake]
+  C[Remember] --> Q
+  S[Where are we] --> Q
+  R[Refresh tracker] --> Q
+  Q --> X[Acquire source]
+  X --> N[Normalize]
+  N --> K[Classify level or delivery unit]
+  K --> M[Make intent / brief / spec / defect]
+  M --> W[Register in workspace.toml]
+  W --> P[Shaping / receive-brief / new-spec + work-loop / bug-fix]
+  X -. tracker trust boundary .-> N
+```
+
+The common path is simple: acquire the source, normalize it, decide whether it is an intent or a delivery unit, make the right local artifact, register that artifact, then call the processor that owns the next step. Status is usually read-only; its source is the workspace index and the artifacts it names.
+
+## Who owns imported requirements?
+
+There are two modes.
+
+- **Repo-origin.** The local intent, brief, or spec is authoritative. The tracker is a projection.
+- **Tracker-origin.** The tracker owns the fields imported from it until the local team accepts them.
+
+Tracker-origin does not mean “the tracker overwrites the repository.” Ownership is per field and recorded as provenance. Refresh is always a reviewed delta, not a blind sync.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft: source crosses trust boundary
+  Draft --> Ready: reviewed local acceptance
+  Ready --> Approved: scope / plan approved
+  Approved --> Executing: local spec takes control
+  Executing --> Shipped: verified delivery
+  Draft --> Draft: refresh allowed after review
+  Ready --> Ready: resolve conflict first
+  Approved --> Approved: resolve conflict first
+  Executing --> Executing: requirements refresh locked
+  Shipped --> Shipped: links, status, comments, PR, closure only
+```
+
+In Draft, source-owned fields can refresh after a reviewed delta. In Ready and Approved, a refresh needs explicit conflict resolution. In Executing, the spec is authoritative and requirement refresh is locked. After execution, tracker writes are limited to trace links, status, comments, PR links, and closure.
+
+This explains [linear-brief-sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md): it is a tracker-origin refresh before execution, not a mysterious exception to “trackers are one-way renders.” Repo-origin remains useful when a team authors locally and only publishes a tracker view.
+
+## What the existing skills should do
+
+| Surface | Target responsibility |
+| --- | --- |
+| `work-intake` | Standalone entry point for start, capture, status, and refresh routing |
+| `capture-work` | Removed or retained briefly as a compatibility alias |
+| `author-brief` | Turn unstructured multi-spec input into a Draft brief |
+| `receive-brief` | Validate an existing brief, cut it into specs, and produce those specs |
+| `new-spec` | Materialize one shippable contract, including provenance |
+| `work-loop` | Execute an existing spec and plan; never rebuild requirements from workspace comments |
+| `workspace-status` | Show lifecycle, next actions, and reconciliation failures |
+| Tracker adapters | Read and normalize source data, then route by local unit |
+| Tracker status/triage skills | Inspect or improve tracker state without creating repo artifacts by default |
+| Linear sync | Refresh source-owned fields before execution |
+
+The important boundary is between acquisition and routing. An adapter knows how to fetch a tracker object. It does not get to decide that every issue or collection deserves a brief. Defects stay on the defect route unless the input shows a different need.
+
+## The `workspace.toml` contract
+
+Every entry points to a real artifact. Queue membership is lifecycle state, not a substitute for the artifact.
+
+```text
+path:     artifact path
+kind:     intent | research | design | brief | spec | defect
+source:   origin, tracker identifier/URL when relevant, field ownership
+summary:  display only
+needs:    hard dependencies
+```
+
+The RFC will choose exact field names and migration details. It must preserve these rules:
+
+- Dispatchable work points to an existing spec.
+- A brief queue entry points to an existing brief.
+- A shaping entry points to an intent, research artifact, or design artifact.
+- A missing artifact is a reconciliation failure, or it is a non-dispatchable capture.
+- Comments do not affect routing.
+- A queue entry never authorizes an agent to infer the complete contract from surrounding comments.
+
+Provenance records identifiers and links, not credentials or a copied tracker payload. Refresh happens on an explicit request; this design does not add a polling service or webhook.
+
+`workspace-status` should report broken references. A dispatcher should not start work until the referenced spec and its hard dependencies exist. A capture without an artifact can remain visible; it cannot quietly become dispatchable work.
+
+## Other shapes we could choose
+
+We could keep the current rule that every feature becomes a brief. It is easy to explain, but it leaves a one-spec change with a wrapper that adds no useful information.
+
+We could make tracker objects the local model. That would reduce translation at first, but a Jira Epic, a Jira Align Feature, a Linear Project, and a GitHub Milestone do not mean the same thing. The local model would change every time a team changed tools.
+
+We could let `workspace.toml` comments carry enough detail for a later session to write a spec. That makes capture feel cheap, but it removes the acceptance criteria, provenance, and review point that make a spec safe to dispatch.
+
+## Risks and how to contain them
+
+The feature gate is a judgment call. A loose outcome can make unrelated tracker issues look coherent. The RFC should include routing examples and evaluations for one spec, many specs, cross-repo work, collections, and defects.
+
+Tracker-origin refresh can create difficult conflicts. Keep the first version small: record field ownership, show the delta, require an explicit decision, and lock requirement refresh once execution starts.
+
+Migration can leave old queue entries pointing nowhere. Treat each missing path as a visible reconciliation failure or an explicitly non-dispatchable capture. Do not silently promote it.
+
+The operational failure to watch is a broken reference at session start. `workspace-status` needs to show it plainly, and dispatch needs to stop before an agent starts work from a comment.
+
+## What conflicts today
+
+This table separates evidence from the conclusion we should draw from it.
+
+| Topic | Evidence | What it means | Proposed fix |
+| --- | --- | --- | --- |
+| Raw brief input | [receive-brief](../../packs/core/.apm/skills/receive-brief/SKILL.md) says it receives PRDs/packets and accepts pasted documents, links, and verbal sketches. Its anti-pattern says raw email or Linear input must first use `author-brief`. | The entry rule is unclear. | `author-brief` makes Draft briefs from unstructured multi-spec input; `receive-brief` processes an existing brief. |
+| Captures | [capture-work](../../packs/core/.apm/skills/capture-work/SKILL.md) writes only `workspace.toml`, creates no spec, and asks for comments sufficient to write a full spec later. | Comments can become the real requirements store. | Replace it with `work-intake`; captures stay non-dispatchable until an artifact exists. |
+| One issue | The [tracker guide](../../guides/_shared/how-to/choose-a-tracker-integration.md) says one issue is not a brief. The proposed [PM journey](../product/journeys/pm-intakes-from-tracker.md) and [RFC-0064](../rfc/0064-ini-001-ai-native-ecosystem.md) describe issue-to-brief intake. | Container names are doing too much routing work. | Use outcome coherence and shippability, not the object name. |
+| Feature equals brief | [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md) make an app-scale feature a brief. | A one-spec change gets an empty wrapper. | Adopt the feature gate through an ADR refinement. |
+| Tracker authority | The [intent reference](../../guides/product-engineering/reference/intent-fields-and-modes.md) calls trackers one-way renders. [Linear sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md) imports reviewed deltas and locks at Executing. | “One-way” does not explain the Linear path. | Name repo-origin and tracker-origin modes. |
+| Registration | `author-brief`, `receive-brief`, and [Linear intake](../../packs/linear/.apm/skills/linear-brief-intake/SKILL.md) explicitly update `brief_queue`; [Jira](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md), [Jira Align](../../packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md), and [GitHub](../../packs/github/.apm/skills/github-brief-intake/SKILL.md) stress file creation and handoff. | Queue visibility depends on the adapter. | Routing registers every materialized artifact. |
+| Collections | [Jira intake](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md) accepts a board, sprint, or JQL result as a brief story list without a confirmed common outcome. | A scheduling/query view can masquerade as one body of work. | Check shared outcome and multi-spec need before creating a brief. |
+
+## Order the implementation this way
+
+1. **RFC and ADR refinement.** Done when the RFC settles routing, provenance, authority, and compatibility, and a new ADR records the ADR-0019 refinement without editing its frozen body.
+2. **Normalized intake and workspace contract.** Done when both have a versioned contract for path, kind, provenance, display summary, and hard `needs`.
+3. **Parser, status, and work-loop checks.** Done when broken references are visible and no dispatcher or work-loop run can get a contract from comments.
+4. **Standalone `work-intake` and core boundaries.** Done when it independently routes normalized input and the `capture-work` removal/alias decision is complete.
+5. **Tracker adapters.** Jira, Jira Align, Linear, and GitHub can change in parallel once they all normalize input, run the feature gate, and register artifacts the same way.
+6. **Refresh and write-back.** Done when reviewed deltas, conflicts, the execution lock, and allowed post-execution writes are implemented and tested.
+7. **Migration and guides.** Done when old entries are reconciled or marked as captures, aliases are documented if kept, and routing evaluations cover one spec, many specs, cross-repo work, collections, and defects.
+
+Roll this out in those phases, not as a big-bang rewrite. Each phase can be reverted by retaining the old reader or alias until the next contract is proven. The maintainer group that accepts the RFC owns the rollout window and decides when an old compatibility path can be removed.
+
+The remaining judgment call is whether `capture-work` gets a temporary alias. Both choices are reasonable: an alias reduces upgrade friction; direct removal keeps one front door truly singular. The RFC author and core maintainers should decide it from adopter migration evidence.
+
+## Checks before adopting it
+
+An RFC based on this paper should challenge six things: did we give two artifacts the same job; did we skip an intent level; did a tracker label become canonical; did `workspace.toml` become a second requirements store; did we create a brief with no added value; and is refresh authority obvious at every lifecycle state?

--- a/docs/rfc/0083-work-intake-and-artifact-routing.md
+++ b/docs/rfc/0083-work-intake-and-artifact-routing.md
@@ -1,0 +1,1272 @@
+# RFC-0083: Work intake and artifact routing
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-08
+- **Date closed:** 2026-08-08
+- **Decision weight:** heavy — the proposal refines accepted architecture and
+  changes a public workflow, so it requires a de-risk spike, fresh adversarial
+  and cold-reader reviews, migration criteria, and explicit Approver sign-off.
+- **Related:** [Target architecture](../architecture/work-intake-and-artifact-routing.md),
+  [ADR-0009](../adr/0009-product-brief-layer-and-plan-owned-lld.md),
+  [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md),
+  [ADR-0033](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md),
+  [ADR-0051](../adr/0051-workspace-toml-toml-format-and-main-branch-coordination.md),
+  [ADR-0076](../adr/0076-briefs-persist-dispatch-starts-from-specs.md),
+  [RFC-0019](0019-product-brief-intake.md),
+  [RFC-0064](0064-ini-001-ai-native-ecosystem.md), and
+  [RFC-0068](0068-linear-pack.md)
+
+## Reviewer brief
+
+- **Decision:** how incoming work becomes a durable local artifact, enters the
+  workspace lifecycle, and becomes safe to execute.
+- **Recommended outcome:** accept.
+- **Change if accepted:**
+  - Introduce a standalone `work-intake` surface that replaces `capture-work`,
+    classifies work by content and altitude, and owns the minimal Draft intent
+    contract needed to work without any optional shaping process.
+  - Route feature intents through a shippability gate, support explicit
+    repo-origin and tracker-origin authority, and let accepted briefs remain
+    deferred until slices are selected.
+  - Make `workspace.toml` a deterministic index of canonical artifacts; only an
+    existing spec and plan may authorize execution.
+- **Affected surface:** shared intake, brief, spec, status, and execution skills;
+  `workspace.toml` contracts and parsers; tracker adapters and sync; ADR-0019;
+  conventions and architecture; adopter guides, tracker guides, installed-workflow
+  references, journeys, website navigation, generated public documentation,
+  and routing evaluations.
+- **Stakes:** costly to reverse because this changes a public entry point,
+  refines an accepted ADR, and migrates existing workspace entries.
+- **Review focus:** whether the feature projection gate is sharp enough;
+  whether authority is unambiguous during refresh; whether a Ready brief
+  remains useful without becoming executable; and whether routing is
+  deterministic from artifacts and structured state alone.
+- **Not in scope:** implementing skills, schemas, parsers, adapters, or
+  migrations in this RFC change; making tracker vocabulary canonical;
+  requiring any optional pack; storing complete requirements in
+  `workspace.toml`; or editing generated website output by hand.
+
+## The ask
+
+**Recommendation (bottom line up front).** Adopt one intake and artifact-routing
+contract for the repository. Incoming names such as product requirements
+document (PRD), Story, Project, board, or sprint are clues, not answers: the
+router classifies the content, creates or references the right canonical
+artifact, records structured lifecycle state, and dispatches only an existing
+spec and plan.
+
+Four terms carry the proposal. An **intent** describes an outcome or opportunity
+at a named product altitude. A **brief** is a repo-local envelope for a coherent
+outcome that benefits from decomposition or cross-repo coordination. A **spec**
+is one independently shippable and verifiable behavioral contract.
+`workspace.toml` is an **index** of those artifacts and their lifecycle, not
+another place to write their requirements.
+
+`workspace.toml` lives at the repository root. An `ini-NNN` table represents an
+operational coordination scope and contains shaping, brief, and spec-work
+memberships; the repository-level backlog holds captured work not yet assigned
+to one. The file points to artifacts and records lifecycle facts, while the
+artifacts remain authoritative for requirements.
+
+The repository already has the right artifacts, but its entry points disagree
+about when to create them. In particular, `capture-work` can place an apparently
+buildable entry in the work queue without creating its spec, leaving a later
+agent to reconstruct the contract from comments. Tracker adapters also disagree
+about whether one issue is a brief and who owns refreshed fields. The question
+is whether to preserve those local rules or replace them with one deterministic
+contract.
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | How is incoming material classified? | Route by content and altitude; treat document and tracker names as hints. | The local ontology must not change when an adopter changes tracker vocabulary. | This review | Confirm the artifact-routing crosswalk. |
+| D2 | When does a feature intent become a brief? | Use the shippability and coordination gate. | A brief should add decomposition or concrete cross-repo coordination value rather than merely wrap one spec. | This review | Confirm the direct-spec, multi-spec, and cross-repo rules. |
+| D3 | Which surface owns intake? | Replace `capture-work` with standalone `work-intake` and a shared minimal intent contract. | One public router can support adopters regardless of how they shape or prioritize work. | This review | Confirm the replacement and independence boundary. |
+| D4 | Where do deferred and executable requirements live? | Keep requirements in canonical artifacts and index them structurally. | This makes routing deterministic without making `workspace.toml` a second requirements store. | This review | Confirm that briefs may persist and only specs with plans may dispatch. |
+| D5 | Who owns tracker-origin requirements? | Declare origin and transfer authority by lifecycle. | Reviewed Draft refresh remains possible while Executing contracts stay stable. | This review | Confirm refresh, conflict, lock, and write-back boundaries. |
+| D6 | How do existing adopters migrate? | Ship a reader-first release, then read old/write new for two minor releases and at least 90 days, with a temporary alias and gated removal. | A bounded bridge avoids both a breaking cutover and permanent dual semantics. | This review | Confirm the duration, fixture gate, Approver sign-off, and fail-closed reconciliation rule. |
+
+Acceptance also makes documentation part of each implementation group's exit
+criterion. Adopter guides, maintainer references, tracker pages, journeys, and
+website discovery must change with the behavior they describe. Generated site
+output remains generated; its sources live under `guides/`.
+
+### Inherited constraints
+
+This RFC changes two earlier rules and preserves the rest. A reviewer does not
+need to reconstruct those documents to understand the boundary:
+
+| Prior artifact | Constraint inherited here |
+| --- | --- |
+| Target architecture | Proposed end-to-end model and evidence inventory; this RFC is the adoption decision, not a claim about current behavior. |
+| ADR-0009 | A brief owns shared product scope; a plan owns implementation detail. |
+| ADR-0019 | Intent is recursive, the repo is the spec-context boundary, and detailed contracts belong at spec stage. This RFC refines only unconditional feature-to-brief identity and universal one-way tracker projection. |
+| ADR-0033 | `Level` is open, seeded by four recognized levels, and independent of `Scale`. |
+| ADR-0030 | Durable output remains relocatable through `agentbundle-layout.toml`. This RFC opts shared intake into that contract as a `[core]` consumer rather than assigning its intent path to an optional pack. |
+| ADR-0051 | `workspace.toml` remains TOML and remains the repository coordination index. This RFC narrows comment semantics and adds fail-closed references. |
+| ADR-0076 | A Ready brief may persist without specs; selected slices become spec/plan pairs; dispatch begins only from a spec and plan. |
+| RFC-0019 | `receive-brief` is the shared processor for an existing repo-local brief. |
+| RFC-0064 | The workspace has separate shaping, brief, and work lifecycle collections; its comment-backed capture behavior is one of the rules replaced here. |
+| RFC-0068 | Reviewed pre-execution delta sync is the existing tracker-origin precedent generalized here. |
+
+RFC means Request for Comments: a proposal reviewed before implementation. ADR
+means Architecture Decision Record: the durable record created after an
+architectural choice is accepted.
+
+## Problem & goals
+
+The present workflow has three separate problems that reinforce one another.
+
+First, the source's label often decides the destination. An Epic, Project,
+Story, PRD, board, or query result can become a brief because a source adapter
+says so, even though those names describe different things in different tools.
+A source adapter is the tracker-specific reader that acquires an external
+object and converts it into the shared transient intake shape.
+Conversely, the same one-issue request is rejected as “not a brief” in one path
+and materialized as a brief in another.
+
+Second, feature projection is too automatic. ADR-0019 says an app-scale feature
+intent is a brief. That is useful when the feature needs several independently
+shippable changes, but it leaves a one-change feature with a one-spec wrapper
+that adds no decomposition or coordination value.
+
+Third, the workspace can look more certain than the repository is. The current
+`capture-work` path writes a future `spec/<slug>` entry without creating
+`spec.md`; its comments are expected to contain enough prose for another
+session to recreate the contract. The parser can therefore call missing work
+ready while reconciliation stays silent. That is not a safe cold-start
+contract: a fresh session using only committed artifacts and structured state
+cannot reproduce the intended decision.
+
+### Goals
+
+- Give adopters one obvious way to start work, remember it for later, check
+  status, or refresh it from an external source.
+- Keep `work-intake` independent of any optional shaping method. An adopter—the
+  team installing these workflows into its repository—may use another shaping
+  workflow, substitute its own, or use none.
+- Classify by content, altitude, coherence, and shippability rather than by
+  document title, workspace type, or tracker object name.
+- Preserve the recursive intent ontology while making a feature the final
+  intent level and a spec the delivery leaf beneath it.
+- Use briefs only when decomposition or cross-repo coordination adds value.
+- Let a valid brief remain Ready without forcing speculative specs or plans.
+- Make routing deterministic from canonical artifacts and structured
+  `workspace.toml` state. Comments must not affect the result.
+- Name who owns imported requirements at every lifecycle stage.
+- Migrate existing adopters without keeping two meanings of queued work
+  forever.
+- Update guides, website discovery, references, and evaluations alongside the
+  behavior.
+
+### Non-goals
+
+- Implement any skill, schema, parser, adapter, workflow, or migration in this
+  RFC change.
+- Add a new requirements-document type or force adopters to rename their BRDs,
+  PRDs, FRDs, or SRSs.
+- Define a universal tracker hierarchy.
+- Require a particular discovery, prioritization, or shaping method upstream of
+  `work-intake`.
+- Make a brief directly executable.
+- Copy complete briefs, specs, tracker payloads, or acceptance criteria into
+  `workspace.toml`.
+- Add polling, webhooks, or an always-on synchronization service.
+- Hand-edit `docs-site` output generated from `guides/`.
+
+## Proposal
+
+### 1. Keep one intent shape and keep the axes separate
+
+Intent remains one recursive, level-tagged artifact. `Level` is an open
+recognized set seeded by:
+
+```text
+product-vision → product-strategy → capability → feature
+```
+
+An organization may insert levels such as `initiative`, `epic`, or `solution`,
+but only above `feature`. Decomposition moves one intent level at a time.
+`feature` is the final intent level; a spec or delivery slice is produced from
+it and is not another intent level.
+
+Five labels that are easy to conflate remain orthogonal:
+
+| Field | What it answers |
+| --- | --- |
+| `Level` | What product altitude is this outcome at? |
+| `Scale` | How far does it reach: `app` for one application context or `business-unit` for coordinated component repositories? |
+| Intent `Kind` | Does it play the optional `outcome` or `opportunity` traceability role? This is distinct from a workspace entry's lowercase `kind`. |
+| Workspace type | Which adopter-configured operational shaping route is active? It has no closed ontology in this RFC and cannot change artifact classification. |
+| Tracker type | Which external vocabulary and mapping hint did the source use? |
+
+A workspace initiative is a coordination scope. It is not automatically an
+intent with `Level: initiative`. In TOML it is the concrete `ini-NNN` table that
+groups lifecycle entries; it does not create a product artifact by itself.
+
+To make the intake surface genuinely standalone, the minimal intent artifact
+contract moves to the shared intake layer. Shared intake becomes a `[core]`
+consumer of ADR-0030's `agentbundle-layout.toml`; its default parent is
+`docs/product`, so the default Draft path is
+`docs/product/intents/<slug>.md`. An adopter may relocate the parent through
+the existing layout contract without changing artifact identity or routing,
+but the `[core]` parent must resolve inside the repository. Workspace-registered
+artifacts require repository-relative paths, so shared intake refuses an
+out-of-repo core parent instead of creating an unindexable intent.
+The artifact carries `Status`, `Level`, `Outcome`, `Opportunity`,
+`Assumptions`, and `Source`. `work-intake` may create that Draft without any
+optional installation bundle. More elaborate discovery and shaping workflows
+may enrich the same artifact by reference, but they neither own the contract
+nor change its routing semantics.
+
+The shared intent lifecycle is small. `Draft` means the outcome or its evidence
+is still being shaped. `Accepted` means a human has accepted the outcome,
+level, assumptions, and current source revision as the basis for further
+decomposition. `Fulfilled` means every materialized delivery projection has
+closed and the outcome's closure evidence has been reviewed. `Superseded`
+retains history but cannot satisfy a new dependency. Optional workflows may
+expose more detailed working stages, but they must map them to these shared
+states at the intake boundary.
+
+### 2. Give every artifact one job
+
+| Artifact | Responsibility |
+| --- | --- |
+| Study or research | Evidence: observations, sources, experiments, and conclusions. |
+| RFC | A cross-cutting proposal and the governance constraints needed to adopt it. |
+| ADR | A durable architectural decision and its consequences. |
+| Intent | Outcome, opportunity, assumptions, and recursive product decomposition. |
+| Brief | A local file that carries a shared outcome and remaining scope, preserves cross-repo coordination when needed, and decomposes into specs. |
+| Spec | One independently shippable and verifiable behavioral contract. |
+| Plan | The implementation and verification strategy for one spec. |
+| Defect context | Evidence of a deviation from intended behavior: expected and observed behavior, reproduction, provenance, and a citation to the existing contract or other durable evidence that establishes the expectation. It feeds `bug-fix`; it is not a feature contract. |
+| Tracker object | Upstream demand or an external coordination representation. |
+| `workspace.toml` | Local artifact references, lifecycle membership, hard dependencies, source provenance, and display summaries. |
+
+Workspace comments are non-semantic. They may help a person read the file, but
+they cannot contain the only requirements needed to reconstruct a spec, decide
+readiness, resolve a dependency, or choose a processor.
+
+### 3. Route requirements documents by content
+
+Names such as business requirements document (BRD), product requirements
+document (PRD), functional requirements document (FRD), software requirements
+specification (SRS), study, Jira Story, and similar labels do not determine the
+local artifact. The router asks what the material contains and where it sits:
+
+| Content | Local route |
+| --- | --- |
+| Product-level outcome or opportunity | Intent at the appropriate `Level` |
+| Repo-local outcome requiring multiple specs | Brief |
+| One independently shippable contract | Spec |
+| Cross-cutting proposal or governance change | RFC |
+| Evidence or an investigation result | Study or research |
+| Deviation from already-intended behavior | Defect route |
+
+The classification tests are observable:
+
+- **Content** means the substantive outcomes, constraints, evidence, and
+  behaviors acquired from the source, excluding its title and object type.
+- **Altitude** is the highest unresolved product outcome: product existence and
+  direction, capability, or a final feature outcome.
+- **Coherent outcome** means every included item is necessary to the same named
+  outcome and can be accepted or closed against that outcome. Sharing a sprint,
+  label, owner, milestone, or query is not coherence.
+- **Independently shippable** means the change can be merged or deployed and
+  deliver observable value without another proposed slice landing first, apart
+  from declared hard dependencies.
+- **Verifiable** means the artifact can state objective acceptance checks for
+  its behavior. “Improve the experience” without an observable result is not
+  yet verifiable.
+
+For example, one issue containing two changes that can ship separately routes
+to a brief and two specs. Ten unrelated issues in one sprint route separately,
+not to a brief. One cross-repo feature routes to linked repo briefs. A reported
+regression routes to a defect context even when the tracker calls it a Story.
+
+When the input is incomplete, intake may create a Draft artifact and record the
+gaps. It must not declare the work build-ready merely because the prose sounds
+specific. If it cannot safely distinguish the routes, it asks for the smallest
+missing choice instead of guessing.
+
+### 4. Put a gate between a feature intent and delivery
+
+This deliberately refines ADR-0019's rule that an app-scale feature intent
+always becomes a brief.
+
+| Feature shape | Projection |
+| --- | --- |
+| One independently shippable change in one repository | Feature intent → spec |
+| Multiple independently shippable changes in one repository | Feature intent → brief → specs |
+| Work spanning multiple component repositories | Feature intent → one brief per affected repository → specs |
+
+A one-spec brief is justified only when it is one repository's projection of a
+cross-repo feature and must preserve the parent feature identity, affected-repo
+set, sibling coordination, or shared closure rule. Ordinary source provenance—a
+tracker reference, source revision, or parent document—belongs on the spec and
+workspace entry and never justifies a wrapper brief. “The tracker called it a
+Project” is not enough.
+
+Every cross-repo brief records the same durable parent-intent locator and
+coordination reference. The parent intent lists the affected repositories and
+their brief locators. A repository never evaluates a dependency by reading
+another repository live. Instead, its local brief records a reviewed
+**coordination receipt** for each remote prerequisite: the durable remote
+locator, accepted revision, reported status, reviewer, and recording date. A
+local `needs` edge points to that brief and names the receipt condition. The
+receipt is a coordination fact, not a copy of remote requirements, and changes
+only through an explicit reviewed refresh. Reconciliation therefore reaches
+the same answer offline from the local brief and workspace entry.
+
+The receipt condition is a closed semantic record even though the follow-on
+spec chooses its TOML punctuation:
+
+```text
+id:                 stable identifier local to the containing artifact
+remote_kind:        brief | spec
+remote_ref:         durable repository and artifact locator
+accepted_revision: non-empty remote revision reviewed locally
+required_status:    Shipped
+reported_status:    status observed at accepted_revision
+reviewed_by:        local approver
+reviewed_at:        review timestamp
+```
+
+A cross-repo `needs` edge names the local brief path, receipt `id`, and pinned
+`accepted_revision`. It is satisfied if and only if all three match, the remote
+kind is recognized, both status fields are exactly `Shipped`, the reviewer and
+timestamp are present, and no unresolved refresh conflict exists. Any other
+status or missing field is unsatisfied. The same record shape, restricted to
+`remote_kind: brief`, carries the parent intent's child-brief closure receipts.
+When a reviewed refresh accepts a newer receipt revision, the receipt and every
+local `needs` pin whose full key matches the containing-artifact path, receipt
+`id`, and prior pinned revision update as one guarded operation. An ID alone is
+never globally unique. A rejected or unresolved refresh leaves the receipt and
+every dependency pin unchanged.
+
+A repo brief can close its local scope, but the parent feature becomes
+`Fulfilled` only when its intent artifact holds one reviewed closure receipt per
+affected repo brief. Each receipt records the repository and brief locators,
+accepted revision, reported `Shipped` status, reviewer, and recording date.
+Those local receipts—not a live remote read—are the durable closure evidence.
+These links provide shared identity without making one repo's workspace
+authoritative for another.
+
+The gate asks two concrete questions:
+
+1. Can this outcome be shipped and verified as one contract in this repo?
+2. If yes, is this one repository projection of a cross-repo feature whose
+   shared identity, sibling ordering, or closure rule must survive locally?
+
+If question 1 is yes and question 2 is no, route directly to a spec. Otherwise
+the brief holds the shared outcome and the **slice cut**: the confirmed set of
+independently shippable contracts selected from the brief.
+
+### 5. Treat tracker names as profiles, not ontology
+
+Tracker mappings remain likely defaults, never identity rules:
+
+A tracker **profile** is the versioned adapter configuration that maps external
+object types to classification hints. It may suggest a starting route, but it
+cannot override the shared content and shippability tests. The installed tracker
+adapter declares and documents the profile; normalized intake records its
+identifier and version so the classification can be reproduced.
+
+| Local unit | Likely external representations |
+| --- | --- |
+| Product vision or strategy | Initiative, theme, strategy, or roadmap object |
+| Capability | Initiative or portfolio epic |
+| Feature intent | Linear Project, Jira Align Feature, Jira Software Epic, or GitHub Milestone, depending on the configured profile |
+| Spec or slice | Linear Issue, Jira Story or Task, or GitHub Issue |
+| Defect | Bug or defect workflow |
+
+Every adapter still checks outcome coherence and shippability. A board, sprint,
+cycle, milestone, Jira Query Language (JQL) result, saved view, or other
+collection is not
+automatically a brief. It becomes one only when its contents serve one coherent
+feature-level outcome and require multiple specs. Otherwise the adapter routes
+each canonical unit separately or reports that the selection is only a view.
+
+### 6. Make `work-intake` the standalone front door
+
+`work-intake` presents four adopter intents:
+
+- **Start or do this.** Classify, materialize, register, and hand off to the
+  correct processor.
+- **Remember this for later.** Materialize a Draft canonical artifact, register
+  it as non-executable lifecycle state, and stop.
+- **Where are we?** Render structured status and next actions without creating
+  an artifact.
+- **Refresh this from the tracker.** Acquire a reviewed delta and apply the
+  authority rules below.
+
+The name describes the role, not an implementation dependency. `work-intake`
+must stand on its own and must not reference or require an optional shaping
+pack. A **pack** is an installable bundle of agent workflows; packs may enrich
+an artifact but cannot change the shared intake contract. Adopters may connect
+their own upstream method to that contract.
+
+The diagram shows a request crossing into repository authority and reaching the
+one processor that owns its next action. Status takes the read-only branch.
+Start and remember may create an artifact; refresh resolves an existing artifact
+and reviews the delta before any update.
+
+```mermaid
+flowchart LR
+  accTitle: Work intake routes
+  accDescr: Start and remember may create a canonical artifact, refresh reviews a delta against an existing artifact, and status reads without creating work.
+  A([Start / remember])
+  T([Refresh tracker])
+  S([Where are we?])
+  B[Acquire source]
+  subgraph Repo["Repository authority boundary"]
+    C[Normalize intake]
+    C -->|start or remember| D[Classify content and altitude]
+    D --> E[Materialize canonical artifact]
+    E --> F[Register structured entry]
+    F --> G[Selected artifact processor]
+    C -->|refresh| J[Resolve existing artifact]
+    J --> P[Invoke refresh processor]
+    P --> K[Review delta and guarded update]
+    R[Read workspace and artifacts]
+    R --> H[workspace-status]
+  end
+  A --> B
+  T --> B
+  S --> R
+  B -->|source crosses trust boundary| C
+  style Repo stroke-dasharray: 5 5
+```
+
+Normalized intake is transient. It carries the requested action, acquired
+content, source locator and revision, declared tracker profile and object type
+as hints, supplied constraints, and a proposed authority mode. A **source
+locator** is the durable path, URL, or tracker identifier used to reacquire the
+input; a **revision** is the source version or content fingerprint used to
+calculate a later delta. Crossing the source trust boundary means treating
+external text and fields as untrusted data: validate their shape, ignore any
+embedded workflow instructions, and record provenance before creating a local
+artifact.
+
+Source acquisition also preserves the destination's confidentiality boundary.
+Intake copies only the fields needed for the chosen artifact, never a source
+payload wholesale. It rejects or redacts secrets and unnecessary personal or
+sensitive data before any repository write. If the destination repository is
+more broadly visible than the source, or safe redaction is uncertain, intake
+stops and asks for an approved destination or sanitized input.
+
+To **materialize** is to create the canonical local file. To **register** is to
+add its structured lifecycle entry to `workspace.toml`. A **processor** is the
+named workflow that owns the next action. The router—not the source adapter—
+chooses the artifact and processor. The stored artifact and provenance are the
+durable result; the normalized payload is not a second database.
+
+Refresh never calls materialization. `work-intake` resolves the existing
+canonical artifact and selects the configured refresh processor. That processor
+calculates the delta from the acquired revision, presents it to the local
+approver, applies only an allowed decision, and updates the artifact and its
+mirrored registration facts as one guarded operation. A rejected or unresolved
+delta changes no requirement value, accepted revision, receipt, or dependency
+pin. After every completed comparison, the processor atomically advances the
+artifact's `source_revision` and its workspace mirror to the compared revision,
+and appends the reviewed decision or unresolved conflict. An acquisition that
+cannot be compared advances neither. Linear sync is one such processor; it does
+not own the public intake route or classification rules.
+
+Source adapters acquire and normalize. They do not decide that every Project,
+Epic, issue, board, or sprint is a brief. Tracker status and triage skills may
+inspect or improve tracker state without creating repository artifacts.
+
+The “Where are we?” intent is delegation, not a second status implementation:
+`work-intake` invokes the `workspace-status` read/reconcile/render contract and
+returns its result unchanged. It must not duplicate status classification,
+repair planning, or rendering.
+
+The target responsibilities are:
+
+| Surface | Responsibility |
+| --- | --- |
+| `work-intake` | Standalone router for start, remember, status, and refresh |
+| `capture-work` | Temporary compatibility alias; never a separate semantic path |
+| `author-brief` | Internal materializer invoked by `work-intake` for unstructured multi-spec input; it creates a Draft brief and returns control to intake |
+| `receive-brief` | Processor invoked for an existing brief; it validates the brief, may leave it Ready, and calls `new-spec` only after slices are selected |
+| `new-spec` | Processor invoked directly for one shippable contract or by `receive-brief` for a confirmed slice; it materializes the spec, plan, and provenance |
+| `work-loop` | Execute an existing spec and plan; never reconstruct requirements from workspace comments |
+| `workspace-status` | Render structured lifecycle, reconciliation failures, and next actions |
+| Tracker adapters | Acquire and normalize source data, then call the shared router |
+| Tracker status and triage | Inspect or improve external state without automatically creating local artifacts |
+| Linear sync | Refresh processor invoked by `work-intake` for controlled tracker-origin delta review before execution |
+
+### 7. Let a brief live until delivery is chosen
+
+A brief is a durable planning envelope, not a dispatchable work item. It may
+remain Ready indefinitely with no specs or plans. Only slices selected for a
+delivery become spec/plan pairs.
+
+| Brief state | Condition |
+| --- | --- |
+| Draft | The brief exists, but load-bearing fields or acceptance are incomplete. |
+| Ready | A human approver has passed the Ready gate below and no child spec is Implementing. It may have zero, queued, or shipped child specs. |
+| Executing | At least one derived spec has entered `Implementing`. |
+| Shipped | The brief is explicitly closed, no in-scope work remains, and every materialized child spec is shipped. |
+
+The Ready gate is deliberately useful without speculative specs. `receive-brief`
+checks that the brief has a non-empty outcome; explicit in-scope and out-of-scope
+boundaries; constraints or appetite; named assumptions or risks; durable source
+provenance; and, for tracker-origin work, the reviewed source revision. It also
+checks that the contents form one coherent outcome. A human approver then records
+the acceptance event in the brief and moves it to Ready. A placeholder spec map
+is not required.
+
+Child specs have their own lifecycle: `Draft` is incomplete;
+`Approved` means a human approved the behavioral contract and its sibling plan
+exists; `Implementing` begins when `work-loop` claims it; `Shipped` means its
+acceptance and verification gates passed. An archived spec may be retained in
+repository history, but `Archived` is not an active workspace lifecycle state
+and does not satisfy a new dependency. In workspace language, a **queued** child is an Approved spec in
+`work.queue`, an **active** child is an Implementing spec in `work.active`, and a
+**shipped** child is a Shipped spec in `work.shipped`.
+
+When delivery is selected from a Ready brief:
+
+1. `receive-brief` presents the proposed slice cut for the current delivery
+   batch—the set of slices chosen to move now.
+2. A human confirms which slices to materialize.
+3. `new-spec` creates `spec.md` and `plan.md` for each selected slice.
+4. Each spec records the brief back-link and source provenance.
+5. A human reviews each behavioral contract and plan; passing that gate changes
+   the spec from Draft to Approved.
+6. Only those existing Approved specs enter the work queue.
+7. `work-loop` reads the spec and plan.
+8. After the batch ships, the brief returns to Ready. If scope remains, it may
+   wait for another slice cut; if none remains, a human may explicitly close it
+   as Shipped.
+
+Deferred work stays in the brief. It does not need a placeholder work entry or
+a comment that a later session must interpret.
+
+### 8. Make `workspace.toml` deterministic
+
+The target path is always a repository-relative filesystem path to a canonical
+artifact, such as `docs/specs/<slug>/spec.md`. The current shorthand
+`spec/<slug>` is a legacy logical identifier accepted only by the compatibility
+reader.
+
+Every target-state lifecycle entry has five semantic fields:
+
+```text
+path:     repository-relative canonical artifact path
+kind:     intent | research | design | brief | spec | defect
+source:   origin mode, durable source reference and revision, and parent
+          artifact or cross-repo coordination reference when relevant
+summary:  display-only text
+needs:    hard artifact dependencies
+```
+
+The RFC fixes those meanings. The follow-on workspace-contract spec will choose
+only the exact TOML encoding and compatibility representation. It may not add a
+new routing meaning to comments, `summary`, list order, or tracker type.
+
+Lifecycle membership is also fixed here:
+
+| Membership | Allowed artifact and meaning |
+| --- | --- |
+| `[backlog].open` | Existing Draft artifact not yet assigned to an initiative, including a remembered Draft spec, plus repository-level `docs/product/defects/<slug>.md` defect contexts; never dispatchable by `work-loop` |
+| `[backlog].closed` | Retained capture, or defect context with a structured resolution outcome of `fixed`, `declined`, or `superseded` |
+| `shaping_queue.backlog` | Existing intent, research, or design artifact waiting for its named processor |
+| `shaping_queue.active` | Existing intent, research, or design artifact currently being processed; not implementation work |
+| `brief_queue.draft` | Existing Draft brief |
+| `brief_queue.ready` | Existing brief that passed the human Ready gate and has no Implementing child |
+| `brief_queue.executing` | Existing brief with at least one Implementing child spec |
+| `brief_queue.shipped` | Explicitly closed brief whose materialized children are all Shipped |
+| `work.queue` | Existing Approved spec with an existing sibling plan, waiting to be claimed |
+| `work.active` | Existing Implementing spec claimed by `work-loop` |
+| `work.shipped` | Existing Shipped spec retained as dependency and history |
+
+An `ini-NNN` table is active only when its structured initiative record has
+`status = "active"`. Paused or closed initiatives are non-dispatchable. An
+unassigned intent, research, design artifact, or brief appears only in
+`[backlog].open`; assignment moves it into the matching shaping or brief
+membership as one guarded operation. A Draft spec moves out of the backlog only
+after its human approval, directly into `work.queue` as an Approved spec with a
+plan. Defect contexts remain in the repository-level backlog because `bug-fix`
+does not dispatch through an initiative work queue. No artifact may remain in
+both backlog and initiative membership.
+
+Shipped entries do not have to remain in the active index forever. The Group 2
+workspace contract defines compaction, but it may remove a Shipped spec or
+brief entry only when no live `needs` edge or open parent references it and all
+closure evidence is durable in the canonical artifacts. Compaction never
+deletes those artifacts or their Git history. Consistent with ADR-0051, 50 or
+more active specs across initiatives triggers a fresh scale decision rather
+than silently stretching the single-file workspace contract.
+
+A local defect context is small: expected behavior, observed behavior,
+reproduction evidence or error signature, source provenance, and a durable
+citation establishing that the expected behavior is already intended. It is
+routed to `bug-fix`, which restores already-intended behavior, not to
+`work-loop`. If no such citation exists, the item remains unresolved intake and
+cannot enter the defect route; a net-new behavior request becomes a Draft spec.
+A confirmed defect moves from `[backlog].open` to `[backlog].closed` when fixed,
+declined, or superseded, and records that exact resolution outcome. Membership
+alone does not imply that the defect was fixed.
+
+Queue membership remains lifecycle state. Routing may use the structured entry,
+the referenced artifact's existence and machine-readable status, and explicit
+`needs`. It must ignore comments, list order, nearby prose, and previous-session
+memory.
+
+**Reconciliation** is the read-only comparison between workspace membership and
+the artifacts, statuses, plans, provenance, and dependencies it names. A
+reconciliation finding explains a mismatch and the smallest safe next action;
+it never repairs or dispatches work by inference.
+
+The invariants are:
+
+- A dispatchable work entry references an existing `spec.md` and its sibling
+  `plan.md` exists.
+- A brief queue entry references an existing brief.
+- A shaping entry references an intent, research artifact, or design artifact.
+- A spec derived from a brief has the same brief path in spec metadata and
+  workspace provenance.
+- Missing artifacts, missing plans, mismatched provenance, duplicate lifecycle
+  membership, unknown kinds, malformed entries, and impossible transitions are
+  reconciliation failures. An impossible transition includes Draft spec →
+  `work.active`, Ready brief → Shipped while scope remains, and any artifact in
+  two lifecycle memberships at once.
+- Readers **fail closed**: they report the entry as non-dispatchable and take no
+  execution action. They never fall back to comments.
+- No queue entry authorizes an agent to infer a full behavioral contract from
+  surrounding repository prose.
+- `needs` contains hard artifact dependencies only. Priority, affinity,
+  suggested order, and rationale are not dependencies.
+
+An entry is dispatchable if and only if all of these are true:
+
+1. It appears exactly once in `work.queue` under an active `ini-NNN`
+   coordination table.
+2. Its `kind` is `spec`, its `path` resolves inside the repository to
+   `docs/specs/<slug>/spec.md`, and the sibling `plan.md` exists.
+3. The spec's machine-readable status is `Approved`.
+4. Its workspace provenance agrees with the spec's source and brief metadata,
+   and tracker-origin work has no unresolved refresh conflict.
+5. Every `needs` edge is satisfied and reconciliation reports no finding for
+   the entry.
+
+Dependency satisfaction is positive and kind-specific: a spec dependency must
+be `Shipped`; a defect dependency must be in `[backlog].closed` with resolution
+`fixed`; a brief
+dependency must be Ready, Executing, or Shipped; an intent dependency must be
+`Accepted` or `Fulfilled`; a research dependency must be `Complete`; and a
+design dependency must be `Approved`. A cross-repo condition is satisfied only by the matching
+reviewed coordination receipt in the local brief; reconciliation never fetches
+remote state while deciding dispatch. Unknown or superseded status is
+unsatisfied. Claiming work moves the entry to `work.active` and the spec to
+`Implementing` as one guarded operation. If the spec is derived from a brief,
+the first active-child claim also moves that brief from `brief_queue.ready` to
+`brief_queue.executing`. A later child claim requires the brief to be Executing
+and retains that state.
+
+When a child ships, the guarded completion moves the spec to `work.shipped` and
+retains the brief in Executing while another child remains Implementing. If it
+was the last Implementing child, the same operation returns the brief to
+`brief_queue.ready`, whether or not scope remains. Moving the brief from Ready
+to Shipped is always a separate, explicit close event and is allowed only when
+no in-scope work remains and every materialized child is Shipped.
+
+Legacy comment-backed entries may remain visible during migration, but they are
+explicitly non-dispatchable until a human chooses a canonical route and the
+referenced artifact exists. This is a compatibility state, not a target entry
+kind. New `work-intake` writes always materialize an artifact; “remember for
+later” creates Draft state rather than an imaginary Ready spec.
+
+A target entry can therefore look like this:
+
+```toml
+["ini-002".brief_queue]
+ready = [
+  { path = "docs/product/briefs/account-recovery.md", kind = "brief", source = { mode = "tracker-origin", ref = "PROJ-123", revision = "42" }, summary = "Make account recovery self-service", needs = [] },
+]
+
+["ini-002".work]
+queue = [
+  { path = "docs/specs/self-service-reset/spec.md", kind = "spec", source = { mode = "tracker-origin", ref = "PROJ-123", revision = "42", artifact = "docs/product/briefs/account-recovery.md" }, summary = "Let a user reset access without support", needs = [] },
+]
+```
+
+The brief holds shared scope and deferred work. The spec holds the selected
+contract. The plan holds implementation and verification strategy. The
+workspace holds only enough structure to find, order, explain, and reconcile
+them.
+
+`ini-002` and `PROJ-123` in the example are illustrative initiative and tracker
+identifiers, not required names.
+
+### 9. Name authority and transfer it deliberately
+
+Two modes are explicit:
+
+- **Repo-origin:** the local intent, brief, or spec is authoritative. A tracker
+  is a projection used for external coordination.
+- **Tracker-origin:** named imported fields remain source-owned while the
+  artifact is Draft. Provenance records the source reference, revision, and
+  field ownership.
+
+The refresh route branches on that mode. For repo-origin work, tracker
+requirement deltas are never applied to the authoritative artifact. Intake may
+show projection drift and offer to bring non-requirement tracker metadata back
+into line with the repo; a tracker-authored requirement change becomes separate
+Draft intake unless a human explicitly changes the origin mode before local
+acceptance. For tracker-origin work, the lifecycle rules below govern a
+reviewed requirements delta.
+
+Tracker-origin does not mean blind overwrite. Every refresh is an explicit,
+reviewed delta. The human who is authorized to accept an intent, move a brief
+to Ready, or approve a spec is the **local approver** and is the only actor who
+may accept a delta or resolve a requirements conflict.
+
+Each tracker-origin intent, brief, or spec carries one authoritative **Source
+authority** record in the artifact itself:
+
+```text
+mode:              tracker-origin
+source_ref:        durable tracker locator
+source_revision:   last revision compared
+accepted_revision: revision accepted at Accepted, Ready, or Approved, if any
+owned_fields:      field name → source | local
+```
+
+`workspace.toml` mirrors only the mode, locator, and revision needed for routing
+and display. The artifact owns the field map. A mismatch is a reconciliation
+failure, not a reason to choose the newest copy.
+
+At the human Accepted event for an intent or Ready event for a brief, every
+accepted requirement field transfers to local ownership and the reviewed
+revision is pinned as `accepted_revision`. At spec approval, every behavior,
+acceptance, constraint, and plan-linked requirement is local-owned. Source-only
+coordination fields may remain source-owned only when they cannot change
+requirements—for example, a tracker display status.
+
+Every reviewed delta after local acceptance is recorded in an append-only
+**Source decisions** section of the canonical artifact. Each row names the
+source revision, field, decision, local approver, and date. The allowed decisions
+are:
+
+- `keep-local`: retain the local value and local ownership;
+- `accept-source`: update the local value from the source, then retain local
+  ownership; or
+- `revise-both`: write an explicitly reviewed third value locally and, when the
+  adapter supports it, propose that value for tracker write-back.
+
+The authority stages follow the current requirement-bearing artifact rather
+than pretending one file changes type. `Accepted` belongs to an intent, `Ready`
+to a brief, `Approved` and `Implementing` to a spec, and `Executing` to the
+brief that contains an Implementing child. Direct-to-spec work moves from a
+Draft spec to Approved; brief-derived work moves from a Ready brief to a newly
+materialized and Approved spec.
+
+| Local lifecycle | Requirements refresh | Authority rule |
+| --- | --- | --- |
+| Draft | Permitted after the local approver reviews the delta | Accepted changes update source-owned fields; local-only fields remain local. The decision and new compared revision are recorded. |
+| Accepted intent or Ready brief | Gated | Accepted requirement fields are local-owned. Every source change to them requires a recorded `keep-local`, `accept-source`, or `revise-both` decision. |
+| Approved spec | Gated | The spec and plan are local-owned. Every source requirements change requires the same recorded conflict decision before execution. |
+| Implementing spec / Executing brief | Locked | The Implementing local spec is authoritative; requirements refresh is refused. |
+| Shipped | Locked | Local-to-tracker writes are limited to trace links, status, comments, pull-request links, and closure. |
+
+The diagram shows authority tightening as tracker-origin work moves from Draft
+to accepted local work and then execution.
+
+```mermaid
+stateDiagram-v2
+  accTitle: Tracker-origin authority lifecycle
+  accDescr: Source-owned fields may refresh after review in Draft, require conflict resolution after local acceptance, lock during implementation, and allow only trace and status writes after shipping.
+  [*] --> Draft: external source crosses trust boundary
+  Draft --> Draft: reviewed refresh allowed
+  Draft --> Accepted: intent accepted
+  Draft --> Ready: brief accepted
+  Draft --> Approved: direct spec approved
+  Accepted --> Ready: feature projects to brief
+  Accepted --> Approved: feature projects to direct spec
+  Accepted --> Accepted: conflict resolution required
+  Ready --> Approved: selected spec and plan approved
+  Ready --> Ready: conflict resolution required
+  Approved --> Approved: conflict resolution required
+  Approved --> Implementing: local spec takes authority
+  Implementing --> Shipped: verified delivery
+  Implementing --> Implementing: requirements refresh locked
+  Shipped --> Shipped: trace and status writes only
+  Shipped --> [*]: authority lifecycle complete
+```
+
+If an executing brief returns to Ready because a delivery batch shipped while
+scope remains, a future tracker refresh may update only the brief fields that
+describe not-yet-materialized scope, after Ready-state conflict resolution.
+Shipped child specs and their provenance never change. Queued Approved child
+specs use their own Approved-state conflict gate. A delta that would rewrite
+completed behavior is refused and routed as new work or a defect, not applied as
+a refresh.
+
+Linear delta-sync is an implementation of tracker-origin mode. It is not an
+exception to a universal one-way rule. Repo-origin remains the default when
+work is authored locally.
+
+### 10. Migrate without preserving two contracts
+
+Migration uses temporary compatibility:
+
+1. Rollout is reader-first. The first compatibility release reads both target
+   and legacy entries while existing writers still emit legacy entries. Only
+   the following release may enable write-new behavior, so its immediate
+   predecessor remains a safe dual-reader rollback target.
+2. Readers accept the legacy shapes shipped at RFC acceptance: bare
+   `spec/<slug>` strings in work arrays; bare slugs and
+   `{slug, type, needs}` objects in shaping arrays; brief-path strings in
+   `brief_queue`; and comment-rich `[backlog].open` entries. Any missing
+   artifact or plan is non-dispatchable.
+3. Reconciliation presents each legacy finding with its durable source, current
+   list membership, and the smallest next action. It does not reconstruct a
+   contract from the comment.
+4. A human routes the item to a Draft intent, brief, spec/plan, research/design
+   artifact, or defect context. Only then does it enter target structured state.
+5. `capture-work` becomes an alias that calls `work-intake`; it writes only the
+   new contract and emits a deprecation notice.
+6. Tracker adapters read their legacy state where necessary but write only the
+   normalized source and workspace contracts.
+7. The alias and legacy reader remain for two consecutive minor catalogue
+   releases and at least 90 days after the first write-new release, whichever is
+   later. The two-release count begins with that first write-new release; the
+   earlier reader-first release does not count. They are removed only when
+   every legacy shape above has a passing migration fixture, no supported
+   workflow or workspace seed writes a legacy shape, current guides contain no
+   legacy invocation, and the RFC Approver signs the removal checklist. The
+   release notes name the removal release at
+   least one minor release in advance.
+
+There is no automatic prose-to-Approved-spec migration. That would reproduce
+the unsafe inference this RFC removes.
+
+Core maintainers own rollback. Before converting an entry, migration records a
+reversible mapping from its old representation to the new entry and any newly
+created artifact; the migration contract chooses the durable manifest location.
+If write-new rollout must be reversed, maintainers disable new writers and
+return to the previous dual-reader release. The manifest restores converted
+legacy entries without deleting canonical artifacts. Entries created originally
+in the target shape remain readable by that dual reader and stay fail-closed for
+new writes until the corrected release. Alias removal and rollback readiness
+are separate gates: passing the removal clock never excuses an untested rollback
+path during the compatibility window.
+
+“Supported legacy fixtures” means the workspace seeds and entry shapes written
+by the released `capture-work`, brief intake, and tracker adapter workflows at
+the moment this RFC is accepted. Private, undocumented TOML extensions are
+reported for manual routing but do not extend the compatibility window.
+
+Here, a **catalogue release** is a published version of the distributed
+workflow catalogue, and a **workspace seed** is a shipped starter fixture that
+creates an adopter's initial `workspace.toml`. These are release artifacts, not
+special lifecycle states.
+
+### 11. Treat documentation and the website as part of the change
+
+The implementation is incomplete until a cold adopter can discover and follow
+the new route. Each implementation group updates the documentation it changes;
+the migration group performs the final cross-surface pass.
+
+Required adopter-facing sources under `guides/` include:
+
+- a shared how-to for starting, deferring, checking, and refreshing work through
+  `work-intake`;
+- an explanation of intent, brief, spec, plan, tracker, and workspace
+  responsibilities without assuming a particular shaping method;
+- a reference for artifact routing, lifecycle states, source authority, and
+  reconciliation findings;
+- revised tracker vocabulary and tracker-integration selection guidance;
+- updated Jira, Jira Align, Linear, and GitHub intake and sync pages;
+- updated brief, spec, execution, and workspace-status journeys; and
+- compatibility and migration guidance for `capture-work` users.
+
+Required maintainer documentation includes:
+
+- `docs/CONVENTIONS.md` rules for the canonical artifact boundary, comment
+  semantics, authority modes, and dispatch invariants;
+- the linked target-architecture document and its overview/index link;
+- internal adapter, workspace-contract, reconciliation, and routing-evaluation
+  guidance under `docs/guides/` where appropriate;
+- pack READMEs and skill references that name the old entry point or old brief
+  projection rule; and
+- ADR-0019 metadata pointing to its accepted refinement once the refinement ADR
+  exists.
+
+`guides/` is the canonical adopter-facing source tree published to the public
+documentation website. `docs/guides/` is for repository maintainers and is not
+published. A **routing evaluation** is a versioned input/expected-route fixture
+that asserts the chosen artifact, lifecycle membership, processor, and authority
+mode.
+
+The public documentation website is built from `guides/`. Source pages and
+their metadata, links, aliases, navigation placement, and landing-page discovery
+must be updated. `docs-site/src/content/docs/guides/` is generated output and is
+not edited directly. The documentation exit gate includes guide validation, a
+site dry run and production build, internal-link checks, and routing evaluations
+whose examples appear in the relevant guides.
+
+## Delivery plan and exit criteria
+
+The order matters because adapters cannot converge until Group 2 defines the
+shared normalized-intake and workspace contracts.
+
+### Group 1: RFC and ADR refinement
+
+Accept this RFC, then record two durable decisions:
+
+1. an ADR refining ADR-0019's feature projection and universal tracker-render
+   rules; and
+2. an ADR establishing standalone `work-intake`, the shared minimal intent
+   contract, and `workspace.toml` as a deterministic index rather than a
+   requirements store. It also opts core intake into ADR-0030's relocatable
+   output contract, refines ADR-0051's comment consequence, and carries
+   ADR-0076's spec-only dispatch rule forward.
+
+The migration duration remains in this RFC and the implementation specs because
+it is a temporary rollout constraint, not durable architecture.
+
+**Exit criterion:** RFC-0083 is Accepted; both ADRs are Accepted and back-linked;
+the target architecture describes the same rules.
+
+### Group 2: Normalized intake and workspace contracts
+
+Define the transient normalized-intake contract and the structured workspace
+entry schema, including provenance, authority, summary, dependencies, lifecycle
+membership, validation, and compatibility reads.
+
+**Exit criterion:** contract tests cover every canonical route, both authority
+modes and the field-level decision record, a Ready brief with no specs, the
+minimal shared intent, defect context, and old entries; reference docs and
+examples match the accepted schemas; compaction tests retain every live
+dependency and parent reference.
+
+### Group 3: Workspace parser, status, and execution invariants
+
+Make parsing, reconciliation, status, and dispatch enforce the target rules.
+Comments and missing artifacts must never make work ready.
+
+**Exit criterion:** a missing spec or plan fails closed; comment-only mutations
+cannot change routing; two clean sessions given the same artifacts, TOML,
+adapter/profile version, and routing configuration produce the same
+classification and next action; status documentation shows every finding. Any
+configuration capable of changing routing is versioned and included in the
+comparison input.
+
+### Group 4: Single intake surface and shared skill boundaries
+
+Add standalone `work-intake`; correct `author-brief`, `receive-brief`,
+`new-spec`, `work-loop`, and `workspace-status`; turn `capture-work` into the
+temporary alias.
+
+**Exit criterion:** start, remember, and status work without any optional
+shaping pack; remember-for-later creates Draft artifact state; a Ready brief may
+stop without specs; and the refresh intent resolves the artifact and delegates
+fail-closed to the configured refresh processor. Until Group 6 lands, that
+processor reports requirements refresh as unavailable and changes nothing.
+Public shared-workflow guides and website discovery use `work-intake` as the
+front door.
+
+### Group 5: Tracker adapters
+
+Update Jira, Jira Align, Linear, and GitHub adapters in parallel after the
+shared contract lands. Acquisition and normalization stay adapter-specific;
+classification stays shared.
+
+**Exit criterion:** common fixtures route coherently across profiles: one
+shippable issue → spec; one coherent multi-spec outcome → brief; one cross-repo
+outcome → linked repo briefs; one collection without a common outcome → separate
+units or a view-only result; and one regression → defect context and `bug-fix`.
+Tracker guides and journeys show the same behavior.
+
+### Group 6: Refresh and write-back lifecycle
+
+Apply origin-aware refresh, conflict resolution, execution locks, and limited
+post-execution write-back across supported trackers.
+
+**Exit criterion:** delta tests cover Draft refresh, Accepted/Ready/Approved
+conflict resolution, Implementing refusal, and Shipped trace/status writes;
+authority is visible in status and documented for adopters; the fourth adopter
+intent is now operational for every supported tracker-origin profile.
+
+### Group 7: Migration, compatibility, guides, and routing evaluations
+
+Reconcile legacy workspaces, publish the alias window and removal criteria,
+finish cross-links and navigation, and run the full evaluation matrix.
+
+**Exit criterion:** supported legacy fixtures either migrate or surface a clear
+non-dispatchable finding; no current guide or website page teaches comment-backed
+spec reconstruction or unconditional feature-to-brief projection; guide
+validation, site build, link checks, and routing evaluations pass; the alias has
+completed the two-minor-release/90-day minimum and the Approver has signed the
+announced removal checklist.
+
+## Options considered
+
+Each decision uses one stated axis. Together, the options on that axis cover
+keeping the present rule, delegating the rule to an external label or local
+surface, and adopting the shared semantic rule proposed here.
+
+### D1: classification authority
+
+Grounding: configurable Jira hierarchies and flexible GitHub issue types show
+why source labels cannot be portable ontology; ADR-0033 already separates local
+altitude from operational vocabulary.
+
+- **Keep mixed skill rules (do nothing).** Smallest change; the same content
+  continues to route differently by entry point.
+- **Let tracker or document types decide.** Predictable per source, but external
+  configuration becomes the local ontology.
+- **Route by content and altitude (chosen).** Requires coherence and
+  shippability checks, but keeps the local model stable across sources.
+
+### D2: feature projection policy
+
+Grounding: ADR-0019 supplies the do-nothing identity rule; Linear's distinction
+between outcome Projects and constituent Issues and ADR-0076's selected-slice
+rule supply the conditional alternative.
+
+- **Always create a brief (do nothing).** Uniform, but adds wrappers with no
+  decomposition value.
+- **Never create a brief.** Simple for small work, but loses durable multi-spec
+  and cross-repo coordination.
+- **Let tracker type decide.** Easy for adapters, but identical work changes
+  meaning across profiles.
+- **Use the shippability and coordination gate (chosen).** Adds an explicit
+  judgment at intake and preserves briefs only where they help.
+
+### D3: routing ownership
+
+Grounding: the current shared `receive-brief` boundary proves a pack-neutral
+processor can exist, while `capture-work` and the adapter inconsistencies show
+the cost of several public routing owners.
+
+- **Keep the existing public entry points (do nothing).** No migration, but the
+  user must understand internal skill boundaries.
+- **Add `work-intake` beside `capture-work` permanently.** Easy adoption, but two
+  public capture meanings remain.
+- **Leave routing inside each adapter.** Adapters stay autonomous and semantic
+  drift becomes structural.
+- **Replace `capture-work` with standalone `work-intake` (chosen).** Requires a
+  compatibility window and a shared minimal intent contract, and gives adopters
+  one independent front door.
+
+### D4: requirements-source topology
+
+Grounding: ADR-0076 rejects comment-backed requirements and full workspace
+duplication; the OpenGitOps analogy supports declarative, reconciled state.
+
+- **Keep requirements in comments (do nothing).** Cheap capture, nondeterministic
+  cold starts.
+- **Copy full requirements into TOML.** Deterministic parsing, duplicated truth
+  and a second requirements schema.
+- **Discover everything by scanning files.** Fewer index writes, no explicit
+  lifecycle, provenance, priority, or dependencies.
+- **Keep requirements in artifacts and index them structurally (chosen).** Adds
+  reconciliation work and gives each fact one authoritative home.
+
+### D5: field authority
+
+Grounding: ADR-0019 supplies the repo-only do-nothing rule and RFC-0068's
+reviewed Linear delta-sync supplies the tracker-origin precedent.
+
+- **Keep universal repo authority (do nothing).** Simple, but cannot explain
+  imported source ownership or reviewed delta-sync.
+- **Keep universal tracker authority.** Current upstream truth, unstable local
+  execution contracts.
+- **Allow unrestricted bidirectional sync.** Flexible, but conflicts have no
+  durable owner.
+- **Declare origin and transfer authority by lifecycle (chosen).** More explicit
+  state handling, stable execution, and a clear place for conflicts.
+
+### D6: compatibility duration
+
+Grounding: the shipped string, inline-object, and comment-rich workspace shapes
+make a zero-window cutover unsafe, while the deterministic target makes
+permanent dual semantics unacceptable.
+
+- **Do nothing.** No disruption and no correction.
+- **Use a big-bang cutover.** Clean target, high upgrade risk.
+- **Support both contracts permanently.** Painless legacy operation, permanent
+  ambiguity and test burden.
+- **Use temporary read-old/write-new compatibility (chosen).** Two consecutive
+  minor releases and at least 90 days, with fixture and Approver removal gates,
+  bound migration cost without preserving unsafe semantics.
+
+## Risks & what would make this wrong
+
+### Pre-mortem
+
+- **The router becomes a classifier that sounds confident but is often wrong.**
+  Mitigation: require outcome coherence and independent shippability checks,
+  keep ambiguous work Draft, and cover the boundary with routing evaluations.
+- **Every feature still gets a brief because “coordination value” is interpreted
+  loosely.** Mitigation: require the one-spec exception to name a concrete
+  cross-repo identity, sibling-ordering, or shared-closure need.
+- **`workspace.toml` becomes a second requirements document.** Mitigation:
+  enforce the five-field index contract and make `summary` display-only.
+- **Tracker refresh changes work under execution.** Mitigation: record field
+  ownership, show reviewed deltas, and refuse requirements refresh while a spec
+  is Implementing.
+- **A long-lived brief silently goes stale.** Mitigation: keep it visible as
+  Ready, show source revision/refresh availability, and require conflict
+  resolution before materializing a new tracker-origin slice.
+- **Legacy comments are lost before their work is captured.** Mitigation: keep
+  compatibility reads during the published window and surface each entry for a
+  human routing choice; never delete or auto-promote it.
+- **The skills change but adopters keep following old guides or website pages.**
+  Mitigation: documentation and site checks are explicit exit criteria in every
+  implementation group.
+
+### Key assumptions
+
+- Content and altitude can classify most inputs with at most one small human
+  choice. If routine inputs need prolonged interrogation, the single-router
+  experience is wrong.
+- One independently shippable and verifiable change is a stable spec boundary.
+  If execution repeatedly needs shared acceptance across multiple specs, the
+  projection gate needs revision.
+- Structured artifact references plus lifecycle membership and hard
+  dependencies are enough for deterministic dispatch. If comments or copied
+  requirements remain necessary, the workspace contract is incomplete.
+- Imported field ownership can be recorded precisely enough to produce a
+  reviewed delta. If adapters cannot identify owned fields or source revision,
+  tracker-origin mode must remain unsupported for that profile.
+- Temporary compatibility is long enough for supported adopters to migrate. If
+  legacy fixtures cannot be classified without data loss, alias removal waits.
+
+### Drawbacks
+
+Intake does more judgment before it writes. Some captures that previously
+looked ready will become Draft or reconciliation findings. Tracker adapters need
+shared contract work before they can change in parallel. The compatibility
+reader and alias add temporary code and documentation. Finally, a deferred
+brief can age; keeping it durable does not remove the need to review it before
+starting a later slice.
+
+## Evidence & prior art
+
+### Spike: the missing-artifact invariant is absent today
+
+The riskiest assumption was that deterministic routing can separate a deferred
+brief from executable work without using comments or copying requirements into
+TOML.
+
+The current parser already models brief and work queues separately and parses
+TOML structurally. A read-only run against this repository successfully rendered
+empty brief queues alongside work entries. An in-memory probe then passed a
+synthetic `spec/does-not-exist` entry to the production
+[`classify_entries`](../../packs/core/.apm/skills/workspace-status/scripts/workspace_status_engine.py)
+function and then ran `run_reconciliation`. The expected target contract is
+“non-dispatchable plus one missing-artifact finding.” The observed result was
+`ready: true` and zero findings for that path:
+
+```text
+input:    work.queue = ["spec/does-not-exist"]; no spec file exists
+observed: ready = true; findings_for_path = 0
+target:   dispatchable = false; finding = missing_spec
+```
+
+The existing [AC2i missing-spec characterization
+fixture](../../tools/test_workspace_status.py) records the same current
+behavior: a missing spec is ready when dependencies are satisfied and is
+silently skipped by reconciliation. “AC2i” is only the test's identifier, not a
+target contract.
+
+This confirms both halves of the proposal. The existing structure can represent
+brief and work lifecycle separately, and the missing fail-closed check is real.
+The spike did not implement the fix. The direct pytest invocation was blocked by
+the local environment's lack of a writable temporary directory, so the
+production engine was invoked in memory instead.
+
+### Current contradictions
+
+The table distinguishes direct evidence, interpretation, and the proposed
+resolution.
+
+| Area | Direct evidence | Inference | Proposed resolution |
+| --- | --- | --- | --- |
+| Raw brief input | [`receive-brief`](../../packs/core/.apm/skills/receive-brief/SKILL.md) says it can meet a document, link, or verbal sketch where it is, then its anti-pattern section routes unstructured input through `author-brief`. | Two public descriptions claim the same boundary. | `work-intake` classifies first; `author-brief` materializes Draft multi-spec input; `receive-brief` processes an existing brief. |
+| Comment-backed capture | [`capture-work`](../../packs/core/.apm/skills/capture-work/SKILL.md) creates no spec and asks for comments sufficient to recreate one. | Workspace prose is acting as the missing contract. | Replace the path; Draft captures get artifacts and work entries require existing specs and plans. |
+| One issue | The [tracker chooser](../../guides/_shared/how-to/choose-a-tracker-integration.md) says one issue is not a brief; the [project-manager intake journey](../product/journeys/pm-intakes-from-tracker.md) and [RFC-0064](0064-ini-001-ai-native-ecosystem.md) describe issue-to-brief intake. | Object count and adapter identity are deciding the artifact. | Apply content, coherence, and shippability checks. |
+| Feature projection | [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) makes app-scale feature intent and brief identical. | A one-spec brief is mandatory even when it adds no value. | Refine ADR-0019 with the projection gate. |
+| Tracker authority | ADR-0019 calls trackers one-way renders; [`linear-brief-sync`](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md) imports reviewed deltas before execution. | Tracker-origin behavior exists but is described as an exception. | Name repo-origin and tracker-origin modes and transfer authority by lifecycle. |
+| Brief registration | [`linear-brief-intake`](../../packs/linear/.apm/skills/linear-brief-intake/SKILL.md) explicitly adds `brief_queue.draft`; the [Jira](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md), [Jira Align](../../packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md), and [GitHub](../../packs/github/.apm/skills/github-brief-intake/SKILL.md) paths do not state the same shared registration rule. | Equivalent adapters can leave different workspace state. | Make registration a shared router responsibility. |
+| Collections | The [Jira intake path](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md) can turn board, sprint, and Jira Query Language selections into briefs without first confirming a shared outcome. | A view is being treated as a semantic container. | Require one coherent feature outcome and multiple specs; otherwise route units separately. |
+
+The detailed file-by-file evidence and target diagrams live in the
+[architecture document](../architecture/work-intake-and-artifact-routing.md).
+
+### Repository decisions this proposal preserves or refines
+
+- ADR-0009's brief layer and plan-owned low-level design remain intact.
+- ADR-0033's open recognized `Level` set and Level/Scale separation remain
+  intact.
+- ADR-0076's persistent briefs, selected spec materialization, and spec-only
+  dispatch are implemented by this proposal.
+- ADR-0019 remains Accepted but needs a follow-on refinement for two statements:
+  unconditional app-scale feature-to-brief identity and trackers as universal
+  one-way renders.
+- ADR-0051's TOML format remains. This proposal narrows the semantic role of
+  comments and adds validation to the structured entries.
+
+### External prior art
+
+- [Linear Projects](https://linear.app/docs/projects) are outcome-oriented units
+  composed of issues, while [Linear Initiatives](https://linear.app/docs/initiatives)
+  group projects around objectives. [Cycles](https://linear.app/docs/use-cycles)
+  are timeboxes. These distinctions support profile mappings and coherence
+  checks rather than treating every collection as the same artifact.
+- Jira's [work type hierarchy](https://support.atlassian.com/jira-cloud-administration/docs/configure-the-issue-type-hierarchy/)
+  is configurable. Its [boards may be JQL-filtered views](https://support.atlassian.com/jira-software-cloud/docs/example-jql-queries-for-board-filters/),
+  and [sprints](https://support.atlassian.com/jira-software-cloud/docs/what-is-a-sprint/)
+  are timeboxes containing work items. Their names cannot define a portable
+  local ontology.
+- [GitHub Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/about-issues)
+  can represent ideas, features, tasks, and bugs, and
+  [sub-issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues)
+  add flexible hierarchy. Type and nesting are useful mapping hints, not proof
+  of local altitude or shippability.
+- The [OpenGitOps principles](https://opengitops.dev/) are an analogy, not a
+  workflow dependency: declarative, versioned, reconciled state supports the
+  narrower choice to derive routing from reviewable structure rather than
+  comments.
+- Shape Up separates a shaped [pitch](https://basecamp.com/shapeup/1.5-chapter-06)
+  from the later [decision to build it](https://basecamp.com/shapeup/2.1-chapter-07).
+  This proposal does not adopt its no-backlog doctrine, but the separation
+  supports allowing a brief to remain useful before delivery is selected.
+
+## Open questions
+
+None at opening. The author approved all six recommendations for drafting and
+accepted the RFC on 2026-08-08. This RFC fixes
+artifact responsibilities, routing tests, lifecycle memberships, dispatch
+conditions, authority transfer, compatibility duration, and removal gates.
+Follow-on specs may choose exact TOML punctuation and container shapes,
+implementation filenames, and guide filenames, but may not change those
+semantics.
+
+## Follow-on artifacts
+
+Following acceptance:
+
+- ADR: refine ADR-0019's feature projection and tracker authority rules.
+- ADR: establish standalone `work-intake`, the shared minimal intent contract,
+  and deterministic workspace indexing; opt core intake into ADR-0030's
+  in-repo relocatable layout; refine ADR-0051's comment consequence; and carry
+  ADR-0076's persistent-brief and spec-only dispatch rules forward.
+- Specs: normalized intake and workspace contracts; parser/status/execution
+  invariants; shared intake boundary changes; tracker adapters; refresh and
+  write-back; migration and documentation.
+- Convention change: canonical artifact responsibilities, comment semantics,
+  authority modes, and dispatch invariants in `docs/CONVENTIONS.md`.
+- Adopter documentation: shared intake how-to, artifact/lifecycle explanation
+  and reference, tracker guides, shared journeys, migration guide, website
+  navigation, and routing examples.
+- Maintainer documentation: workspace and adapter contract guides, architecture
+  updates, routing-evaluation guidance, pack references, and README corrections.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -83,6 +83,7 @@
 | [0079](0079-codebase-context-pack.md) | `codebase-context` pack — optional user-scope pack wrapping `codebase-memory-mcp` (C/tree-sitter, stdio subprocess) and `serena` (Python/LSP) as semantic graph MCP backends; `CBM_ALLOWED_ROOT` path confinement; three-tier freshness (file watcher / git hook `touch` / PLAN-time check); `agentbundle install` only. | Draft | 2026-08-03 | — |
 | [0080](0080-local-scope-install.md) | Local scope install — `--scope local` installs pack files into the working tree and excludes them via `.git/info/exclude` so they never appear in `git status` or get committed. | Accepted | 2026-08-04 | 2026-08-04 |
 | [0082](0082-test-ownership-boundaries-and-inclusion.md) | Test ownership boundaries and per-surface inclusion — every test owned by the engine, the catalogue, or one pack, each with its own tree; `packages/<pkg>/<pkg>/` is the engine's runtime export boundary; inclusion decided per surface *and* per owner, so `agentbundle catalogue init` ships a catalogue that can verify itself. | Accepted | 2026-08-07 | 2026-08-08 |
+| [0083](0083-work-intake-and-artifact-routing.md) | Work intake and artifact routing — classify incoming work by content and altitude, route feature intents through a shippability gate, replace `capture-work` with standalone `work-intake`, make workspace dispatch deterministic from canonical artifacts, and transfer tracker authority explicitly by lifecycle. | Accepted | 2026-08-08 | 2026-08-08 |
 
 ## Adding a new RFC
 


### PR DESCRIPTION
## Summary

  This PR settles how incoming work becomes a durable repository artifact and when it is safe for an agent to execute.

  It adds the target architecture, accepts RFC-0083, and records that briefs may remain deferred while execution starts only from an
  approved spec and plan.

  ## What changed

  - Added the work-intake and artifact-routing target architecture.
  - Added and accepted RFC-0083.
  - Added and accepted ADR-0076: briefs persist; dispatch starts from specs.
  - Updated ADR-0019’s refinement metadata.
  - Updated the RFC and ADR indexes.

  ## Decisions

  - `work-intake` becomes the standalone intake surface and does not depend on an optional shaping pack.
  - `capture-work` becomes a temporary compatibility alias.
  - Incoming work is routed by content, altitude, coherence, and shippability—not tracker object names.
  - A feature becomes:
    - one spec for one independently shippable change;
    - a brief and multiple specs for multiple changes;
    - one brief per affected repository for cross-repository work.
  - A Ready brief may remain deferred without creating speculative specs or plans.
  - `workspace.toml` indexes artifacts and lifecycle state; comments cannot carry executable requirements.
  - Dispatch requires an existing Approved spec, sibling plan, satisfied dependencies, and consistent structured provenance.
  - Tracker-origin refresh is reviewed and lifecycle-gated; requirements are locked during implementation.
  - Cross-repository dependencies use reviewed local coordination receipts rather than live remote reads.
  - Migration is reader-first, with a bounded `capture-work` alias and a tested rollback path.

  ## Scope

  Documentation and governance only. This PR does not change skills, schemas, parsers, tracker adapters, workflow code, or
  `workspace.toml`.

  Implementation is intentionally deferred to the follow-on ADRs and specs listed in RFC-0083.

  ## Validation

  - `git diff --check`
  - Relative Markdown links: 217 checked, 0 broken
  - Guide validation: 0 errors
  - Mermaid CLI availability check passed
  - Cold-reader review: clean
  - Adversarial review: clean
  - Architecture review: `SHIP IT — no findings`

  The guide validator reported 163 existing frontmatter migration warnings.

  Full Mermaid rendering and the generated-site dry run could not write their disposable output directories under the managed
  filesystem. The diagrams were reviewed using the architecture-diagram workflow, and `mmdc` was confirmed available.