### PR TITLE
chore(release): agentbundle 0.31.0

### DIFF
--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
-## [Unreleased]
+## [0.31.0] — 2026-08-10
 
 ### Changed
 

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -247,7 +247,10 @@ ignore them there; the separation is structural, not incidental.
 `keywords` once; the build projects the cleanly-mappable subset — plus the
 pack's `README.md` — into each distribution route's manifest (the `plugin.json`
 / `marketplace.json` entry), so the catalogue describes each pack richly rather
-than with a single sentence. A marketplace entry's `source` is a `git-subdir`
+than with a single sentence. The Claude-plugin route carries only packs whose
+`[pack.install] allowed-scopes` admits `user`: a plugin's code lands in the
+adopter's global cache, so a repo-only pack gets no `marketplace.json` entry
+and is reached with `agentbundle install` instead. A marketplace entry's `source` is a `git-subdir`
 object (`url`, `path`, and one of `ref`/`sha`) pointing at the pack's directory
 on the published distribution branch, and every entry is schema-validated at
 build time against `marketplace-entry.schema.json`. Extra fields stay in `pack.toml`; the projection

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.30.1"
+CLI_VERSION = "0.31.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.30.1"
+version = "0.31.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []


### PR DESCRIPTION
## What

Cuts `agentbundle` **0.31.0**. Closes `[Unreleased]` into a dated section and
bumps the two live version pins (`pyproject.toml`, `agentbundle/version.py`).

## Why this version

PyPI is at **0.29.8**. `0.30.0` and `0.30.1` exist as changelog sections and in
`pyproject.toml` but were never tagged, so they were never published — this one
release carries all three sections. Verified against the PyPI JSON API rather
than assumed.

A **minor** bump is the right shape: the section carries three `BREAKING`
entries, and this changelog's own header says a minor bump on a 0.x release MAY
be breaking. Tagging `0.30.1` as-is was the alternative and is wrong — the
plugin-route change sat in `[Unreleased]`, so that tag would have shipped code
its own changelog said wasn't in it.

## Also in this PR

`README-pypi.md` — the file this release publishes to PyPI — said the build
projects each pack's metadata into "each distribution route's manifest (the
`plugin.json` / `marketplace.json` entry)" without qualification. After #907 the
Claude-plugin route carries only packs whose `allowed-scopes` admits `user`, so
a repo-only pack gets no marketplace entry. It is not one of the eight sites
`lint-plugin-route-docs` guards, which is why #907's doc sweep did not reach it.
Shipping a README that misstates the release it accompanies isn't acceptable, so
it's corrected here rather than deferred.

## Verification

- `agentbundle --version` → `agentbundle 0.31.0 (spec 0.17)` — the real
  artifact, not a unit assertion.
- `tests/unit/test_version.py` asserts `pyproject.version == CLI_VERSION`.
  Mutation-checked: desyncing the pair reddens it. That guard is the reason
  this bump is two files and not a silent `--version` lie.
- `make build-check` exits 0 **with SAST**; agentbundle and `tools/` suites
  green; ruff and mypy (110 files) clean.

## After merge

Tag `agentbundle-v0.31.0` on the merge commit to trigger `release-agentbundle`,
which asserts the tag matches `pyproject.version` before publishing.
