### PR TITLE
fix(guides): align IaC stages with generate-iac

### DIFF
--- a/guides/iac-terraform/README.md
+++ b/guides/iac-terraform/README.md
@@ -1,7 +1,14 @@
+---
+title: IaC (Terraform) guides
+summary: Find the governed Terraform and OpenTofu generation workflow, drift checks, and validated provider coverage.
+pack: iac-terraform
+kind: reference
+---
+
 # `iac-terraform` — guides
 
 An opt-in accelerator for Terraform and OpenTofu IaC generation. Two skills —
-`generate-iac` (8-stage generation loop) and `reconcile-iac` (drift audit
+`generate-iac` (seven-stage governance-to-plan loop) and `reconcile-iac` (drift audit
 before every follow-on change) — plus a reference library covering per-cloud
 provider contracts, standards, and pipeline patterns.
 
@@ -14,7 +21,7 @@ set one up.
 
 | Skill | Trigger | What it does |
 | --- | --- | --- |
-| `generate-iac` | "provision X", "create Terraform for", "generate IaC for" | 8-stage generate → plan → policy-gate → handoff loop |
+| `generate-iac` | "provision X", "create Terraform for", "generate IaC for" | Stage 0 ADR gate → SPECIFY → CLARIFY → PLAN → TASKS → WRITE TF → VERIFY → G4 handoff |
 | `reconcile-iac` | "check for drift", "reconcile IaC" | Runs `terraform plan` and classifies every change before follow-on work |
 
 ## How-to
@@ -36,8 +43,10 @@ dual-engine, loop-arc alignment, category taxonomy) is in the pack README at
 
 - **Generate IaC for a new workload** — invoke `generate-iac`. It asks for
   target cloud, engine (terraform/tofu), environment, and region. Stage 0 reads
-  your governance index; Stage 1 scaffolds the directory; Stages 2–7 apply
-  standards and emit the plan.
+  your governance index. Stages 1–2 specify the workload and collect inputs;
+  Stage 3 plans; Stage 4 orders tasks; Stage 5 writes Terraform and the CI
+  pipeline; Stage 6 formats, validates, plans, runs policy and security checks,
+  and records the plan digest for handoff.
 
 - **Check for drift before a follow-on change** — invoke `reconcile-iac`.
   It runs `terraform plan`, classifies every planned change by reversibility
@@ -48,8 +57,9 @@ dual-engine, loop-arc alignment, category taxonomy) is in the pack README at
   `mode: infra`. The `new-adr` infra mode (governance-extras 0.6.0) gives you
   the right framing question for each of the seven IaC ADR topics.
 
-- **Set up the CI pipeline** — after Stage 6 of `generate-iac`, a pipeline
-  file is emitted for your CI system. The GitHub Actions reference is at
+- **Set up the CI pipeline** — Stage 5 of `generate-iac` emits a pipeline
+  file for your CI system; Stage 6 verifies the generated configuration. The
+  GitHub Actions reference is at
   `packs/iac-terraform/.apm/skills/generate-iac/references/pipeline/github-actions.md`.
 
 ## Validated providers (v1)

--- a/workspace.toml
+++ b/workspace.toml
@@ -524,15 +524,6 @@ open = [
     # move user-must-act off 2. node exits 1 (MODULE_NOT_FOUND), so node-backed skills are
     # unaffected. Unblocks: now; spans atlassian, figma, linear and converters.
   {slug = "skill-script-exit-2-collision", source = "spec/binder-publishing-gate-propagation AC10"},
-    # guides/iac-terraform/README.md advertises an "8-stage generation loop" and
-    # "Stages 2-7 apply standards"; the skill it documents
-    # (packs/iac-terraform/.apm/skills/generate-iac/SKILL.md) runs Stage 0-6 with
-    # entirely different names. Adopter-facing, so an agent following the README
-    # looks for stages that do not exist. Deferred from guides-sidebar-generation:
-    # pre-existing, user-visible content drift, invisible to the sidebar generator,
-    # so it fails the bundled-fixes carve-out. Fix: rewrite the README's skill
-    # table against SKILL.md's actual stage sequence. Unblocks: now.
-  {slug = "iac-guides-readme-stage-drift", source = "spec/guides-sidebar-generation (out of scope)"},
   # Codex renders skill descriptions into a ~2% context budget and truncates to
   # fit, warning "Skill descriptions were shortened to fit the 2% skills context
   # budget" (observed on Codex CLI 0.146.0). The catalogue ships 122 skills whose


### PR DESCRIPTION
The guide documented an eight-stage workflow even though generate-iac defines Stages 0–6. Align the guide with the canonical sequence, add its required frontmatter, and remove the completed backlog entry.