### PR TITLE
chore(workspace): reconcile work-intake initiative lifecycle

### DIFF
--- a/docs/specs/workspace-mcp/spec.md
+++ b/docs/specs/workspace-mcp/spec.md
@@ -1,6 +1,6 @@
 # Spec: workspace-mcp — Stage 1 implementation
 
-- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0078](../../rfc/0078-workspace-mcp.md) (Accepted 2026-08-03)

--- a/docs/specs/workspace-routing-invariants/spec.md
+++ b/docs/specs/workspace-routing-invariants/spec.md
@@ -1,6 +1,6 @@
 # Spec: Workspace routing invariants
 
-- **Status:** Approved
+- **Status:** Implementing
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** RFC-0083, ADR-0077, ADR-0078

--- a/docs/specs/workspace-status-simplification-order-2b/spec.md
+++ b/docs/specs/workspace-status-simplification-order-2b/spec.md
@@ -1,6 +1,6 @@
 # Spec: workspace-status simplification — Order 2B
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** maintainer
 - **Plan:** [`plan.md`](plan.md)
 - **Mode:** full (write-authority boundary + public-interface change + multi-feature/dependent tasks + workspace.toml mutation without comment loss)

--- a/workspace.toml
+++ b/workspace.toml
@@ -134,6 +134,8 @@ shipped = [
   "spec/jira-check-sso-auto-login",       # jira check SSO auto-recovery in credbroker; credbroker 0.5.0 + engine errata RFC-0035/0013
   "spec/catalogue-curation-qa-coverage",   # closes the 4 deferred catalogue-curation QA paths
   "spec/catalogue-test-carve-out",         # ADR-0075 ownership carve-out + shipped catalogue conformance + sdist test graft
+  "spec/workspace-status-simplification-order-2b", # repair-plan + repair-apply; post-publication closeout
+  "spec/workspace-mcp",                    # RFC-0078 Stage 1; deferred follow-ons remain in backlog
 ]
 queue   = [
   # P5 · Adopt — gated on adopter-persona research (evidence base)
@@ -2031,4 +2033,29 @@ queue   = [
   # complete site projection; old external catalogues verified valid; security+
   # quality reviews clean; workspace.toml closed out.
   {path = "spec/catalogue-wave9-migration-closeout", needs = ["work:spec/catalogue-wave2-pack-integrations", "work:spec/catalogue-wave5-release-integrity", "work:spec/catalogue-wave7-marketing-evaluator", "work:spec/catalogue-wave8-readme-contributing"]},
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ini-008 · Work Intake and Artifact Routing
+# Authority: RFC-0083, ADR-0077, ADR-0078
+# Cross-spec execution is intentionally serial. Parallelism belongs only inside
+# each approved plan and is not represented as separate workspace entries.
+# ────────────────────────────────────────────────────────────────────────────
+["ini-008"]
+name      = "Work Intake and Artifact Routing"
+status    = "active"
+milestone = "Wave 2 · Routing invariants"
+
+["ini-008".work]
+shipped = [
+  "spec/normalized-intake-workspace-contracts",
+]
+active = [
+  {path = "spec/workspace-routing-invariants", kind = "spec", source = {mode = "repo-origin"}, summary = "Make lifecycle, reconciliation, and dispatch routing deterministic", needs = ["work:spec/normalized-intake-workspace-contracts"]},
+]
+queue = [
+  {path = "spec/work-intake-surface", kind = "spec", source = {mode = "repo-origin"}, summary = "Provide one core entry point for work intake and routing", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants"]},
+  {path = "spec/tracker-intake-adapters", kind = "spec", source = {mode = "repo-origin"}, summary = "Normalize tracker work through shared intake contracts", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/work-intake-surface"]},
+  {path = "spec/tracker-refresh-writeback", kind = "spec", source = {mode = "repo-origin"}, summary = "Review tracker deltas and constrain lifecycle-aware write-back", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants", "work:spec/work-intake-surface", "work:spec/tracker-intake-adapters"]},
+  {path = "spec/work-intake-migration-docs", kind = "spec", source = {mode = "repo-origin"}, summary = "Migrate legacy entries and document intake compatibility", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants", "work:spec/work-intake-surface", "work:spec/tracker-intake-adapters", "work:spec/tracker-refresh-writeback"]},
 ]


### PR DESCRIPTION
## What does this change?

  Adds `ini-008` for Work Intake and Artifact Routing and records its intentionally serial work
  graph. It also closes the seven untracked-live-spec findings by activating routing, queuing its
  successors, and shipping the two completed `ini-002` specs.

  ## Why?

  `workspace.toml` had seven Type 1 reconciliation findings despite the canonical specs having clear
  lifecycle states.

  - Follows from: RFC-0083
  - Follows from: ADR-0077
  - Follows from: ADR-0078

  The graph remains:

  Contracts → Routing → Core intake → Tracker adapters → Refresh/write-back → Migration/docs

  ## How do I verify it?

  ```sh
  env PYTHONDONTWRITEBYTECODE=1 \
    python3 .agents/skills/workspace-status/scripts/workspace_status.py \
    reconcile \
    --root .

  Confirm Type 1, Type 2, and Type 3 are empty; routing is active; and every later ini-008 item is
  blocked by its intended predecessor chain.

  Focused checks completed:

  env PYTHONDONTWRITEBYTECODE=1 \
    PYTHONPATH=packages/agentbundle \
    python3 packs/core/tests/skills/workspace-status/test_workspace_status_projection.py \
    SourceInvariantTests \
    RealTreeProjectionTests \
    EndToEndCLITests

  env PYTHONDONTWRITEBYTECODE=1 \
    python3 packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py \
    --root . \
    --base-ref main

  env PYTHONDONTWRITEBYTECODE=1 \
    RUFF_NO_CACHE=true \
    make lint-ruff

  git diff \
    --check

  Results:

  - workspace.toml parses successfully.
  - Reconciliation: Type 1 0, Type 2 0, Type 3 0.
  - Focused workspace-status tests: 8 passed.
  - Spec-status lint and Ruff passed.
  - Adversarial and quality reviews returned clean.

  Full pytest and generated-output build gates were not runnable in the read-only checkout because
  it cannot create temporary or build-output files; CI should run them.

  ## What did you not change that you considered?

  - Did not use repair-apply; these were manual Type 1 lifecycle findings.
  - Did not change product code or approved plans.
  - Did not make complete specs parallel-ready or expose internal plan tasks in the workspace queue.
  - Did not alter unrelated initiatives or backlog entries.
  - Preserved capture-work-alias-removal as separately gated backlog work.
  - Did not create or manage branches or worktrees.

  ———

  ## Checklist

  - [x] Focused tests pass locally
  - [x] Lint passes; typecheck is not applicable to this metadata-only change
  - [x] Adversarial and quality reviewer passes are clean
  - [x] Specs and workspace lifecycle metadata agree
  - [x] Living docs match reality; no changelog, guide, architecture, or roadmap update is required
  - [x] No new top-level directories
  - [x] Conventional commit format
  - [x] No new reusable learning required capture