### PR TITLE
docs(sso): consolidate destination trust-boundary decision

### DIFF
--- a/docs/adr/0080-generic-headed-sso-capture-remains-operator-only.md
+++ b/docs/adr/0080-generic-headed-sso-capture-remains-operator-only.md
@@ -1,0 +1,133 @@
+# ADR-0080: Generic headed SSO capture remains operator-only
+
+- **Status:** Accepted
+- **Date:** 2026-08-11
+- **Decision-makers:** eugenelim
+- **Consulted:** security-reviewer, adversarial-reviewer
+- **Supersedes:** none
+- **Related:** [RFC-0084](../rfc/0084-sso-destination-trust-boundary.md),
+  [ADR-0026](0026-sso-consumer-resolution-in-credbroker.md),
+  [credential architecture](../architecture/credentials.md), and the
+  [`jira-check-sso-auto-login` spec](../specs/jira-check-sso-auto-login/spec.md)
+
+## Decision summary
+
+- **Decision:** The baseline credential-brokers installation will not
+  implement or claim a same-principal destination enforcer. Generic headed
+  SSO-cookie capture remains operator-only, and automatic refresh remains
+  headless.
+- **Because:** Every component the supported installation can deploy is owned
+  by or bypassable by the same operating-system account as agent-controlled
+  code.
+- **Applies to:** Generic SSO-cookie capture through `credbroker`,
+  `sso-broker.py`, and projected skill scripts.
+- **Tradeoff accepted:** Interactive capture retains a known destination-
+  poisoning exposure to hostile same-principal code.
+- **Revisit if:** A concrete consumer supports remotely bound authorization,
+  or the supported deployment can install a component under independent
+  authority.
+
+## Context
+
+The supported installation consists of a user-scoped `credbroker` Python
+package or vendored fallback, `sso-broker.py`, and projected skill scripts.
+Moving destination validation into another Python package, virtual
+environment, signed file, or in-process verifier would not change who owns,
+modifies, or bypasses the enforcement path.
+
+The current generic SSO-cookie workflow does not use a system-browser callback.
+An operator explicitly starts registration, the broker runs its existing
+visible capture flow, and later agent-triggered use consumes stored state
+headlessly. Automatic refresh must fail when human interaction is required
+rather than displaying a login page.
+
+A future OAuth, OpenID Connect, or device-authorization mode could use an
+external browser and a remotely bound response. That would return
+protocol-specific credentials for a concrete supported consumer, not generic
+SAML session cookies, and is not authorized by this decision.
+
+## Decision
+
+The credential-brokers baseline provides no destination security boundary
+against hostile code running under the agent principal.
+
+Within supported catalogue workflows:
+
+1. Interactive capture is reachable only through an operator-typed
+   registration action.
+2. Automatic refresh is always headless and never falls back to visible login.
+3. Existing HTTPS, origin, derivation, and success-condition checks remain
+   defense in depth for mistakes and ordinary misconfiguration.
+4. Those checks must not be described as protection against hostile
+   same-principal destination poisoning.
+5. No second user-scoped Python package or verifier will be built as a
+   destination enforcer.
+
+A destination-protected mode requires a new proposal backed by either:
+
+- a remote authorization protocol that independently binds user approval for
+  a concrete consumer; or
+- a supported installation class whose code, policy, and invocation contract
+  are protected by another authority.
+
+## Decision drivers
+
+- Do not claim a security boundary the supported installation cannot provide.
+- Preserve generic SSO-cookie compatibility.
+- Prevent automatic workflows from soliciting credentials.
+- Avoid maintaining an additional package that changes packaging without
+  changing authority.
+- Keep future protocol-backed authentication possible without pretending it
+  solves generic cookie capture.
+
+## Consequences
+
+**Positive:**
+
+- Automatic agent workflows cannot legitimately open a headed login page.
+- The architecture accurately describes the same-principal limitation.
+- Four unimplementable destination-boundary backlog entries are closed without
+  producing duplicate implementations.
+- Other credential privacy, reliability, audit, packaging, and validation work
+  continues independently.
+
+**Negative:**
+
+- Generic interactive capture remains vulnerable if hostile same-principal
+  code poisons the destination and the operator does not detect it.
+- The current deployment has no engineering path to eliminate that exposure.
+- A future secure protocol mode would cover only consumers that support it and
+  may introduce another credential family.
+
+**Revisit if:** A concrete consumer supports remotely bound authorization, or
+the supported deployment can install a component under independent authority.
+
+## Confirmation
+
+- **Mode:** reviewer-checked
+- **Signal:** automatic refresh remains headless; headed capture remains
+  operator-typed; architecture and product specifications describe destination
+  validation only as defense in depth; no open workspace item claims a
+  same-principal destination enforcer
+- **Owner:** credential-brokers maintainers
+
+## Alternatives considered
+
+- **Another Python package or virtual environment.** Rejected because it remains
+  owned and bypassable by the agent principal.
+- **A root-owned or signed policy with the current verifier.** Rejected because
+  a user-writable or bypassable verifier cannot enforce that policy.
+- **A browser extension, privileged helper, or local service.** Technically
+  viable, but outside the supported installation envelope.
+- **Implement protocol-backed authorization now.** Rejected without a concrete
+  consumer, issuer contract, client registration, credential type, and
+  migration path.
+- **Remove generic headed capture.** Rejected because explicit operator capture
+  remains a useful compatibility workflow when its limitation is understood.
+
+## References
+
+- [RFC-0084](../rfc/0084-sso-destination-trust-boundary.md)
+- [Credential architecture](../architecture/credentials.md)
+- [RFC 8252: OAuth 2.0 for Native Apps](https://www.rfc-editor.org/rfc/rfc8252.html)
+- [RFC 8628: OAuth 2.0 Device Authorization Grant](https://www.rfc-editor.org/rfc/rfc8628.html)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,6 +85,7 @@
 | 0077 | [Feature projection is gated; tracker authority follows lifecycle](0077-feature-projection-and-tracker-authority.md) | Accepted |
 | 0078 | [Standalone intake with an artifact-backed workspace index](0078-standalone-intake-and-deterministic-workspace-index.md) | Accepted |
 | 0079 | [Executable plugin branch — dedicated publisher identity](0079-executable-plugin-branch-publisher-identity.md) | Accepted |
+| 0080 | [Generic headed SSO capture remains operator-only](0080-generic-headed-sso-capture-remains-operator-only.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/architecture/credentials.md
+++ b/docs/architecture/credentials.md
@@ -90,6 +90,14 @@ So the boundary is not a verb and not a subsystem. It is:
 Where a control is warranted, it must satisfy the anchor test below — integrity
 protection for the destination fields specifically, not for the whole config.
 
+[RFC-0084](../rfc/0084-sso-destination-trust-boundary.md) applies that test to
+the supported deployment and finds that no qualifying component can be shipped
+inside the user-scoped Python package and projected-script envelope. Generic
+headed cookie capture therefore remains operator-only and carries an accepted
+same-principal destination-poisoning limitation; no baseline enforcement work
+is deferred. A protocol-backed mode or privileged installation class requires a
+new proposal tied to a concrete consumer and deployment path.
+
 **What actually closes the same-principal case**, from a survey of comparable
 projects (see the references below), is always a trust anchor the agent's process
 cannot forge or reach:

--- a/docs/rfc/0084-sso-destination-trust-boundary.md
+++ b/docs/rfc/0084-sso-destination-trust-boundary.md
@@ -1,0 +1,342 @@
+# RFC-0084: Single sign-on destination trust boundary
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-11
+- **Date closed:** 2026-08-11
+- **Decision weight:** heavy
+- **Related:** [RFC-0035](0035-sso-cookie-auth-for-atlassian-pack.md),
+  [RFC-0083](0083-work-intake-and-artifact-routing.md),
+  [ADR-0026](../adr/0026-sso-consumer-resolution-in-credbroker.md),
+  [credential architecture](../architecture/credentials.md), and the
+  [`jira-check-sso-auto-login` spec](../specs/jira-check-sso-auto-login/spec.md).
+  Consolidates and closes the backlog items
+  `sso-destination-field-integrity`, `sso-privilege-separated-config`,
+  `sso-branch2-destination-attestation`, and
+  `sso-live-browser-destination-derivation`.
+
+## Reviewer brief
+
+- **Decision:** What destination security can the catalogue actually provide
+  when installation is limited to a user-scoped Python package and projected
+  skill scripts?
+- **Accepted outcome:** The deployment boundary is accepted and the four
+  local-enforcement proposals are retired.
+- **Effect:** Generic headed single sign-on (SSO) cookie capture
+  remains operator-only and explicitly unprotected from a hostile process
+  running under the agent principal. No second Python package or implementation
+  spec is created. Protocol-backed modes require a future proposal tied to a
+  supported consumer.
+- **Affected surface:** SSO-cookie security contract, credential architecture,
+  the shipped `jira-check-sso-auto-login` spec, and `workspace.toml`; no runtime
+  code changes.
+- **Stakes:** The repository must not promise a same-principal security boundary
+  it cannot deploy, but it must also avoid turning the limitation into permission
+  for automated credential entry.
+- **Review focus:** Whether the recorded generic-cookie limitation is more
+  accurate than retaining unbuildable enforcement work.
+- **Not in scope:** Adding administrator-installed software, a browser extension,
+  a local service, or a new authentication protocol.
+
+## The ask
+
+**Recommendation (bottom line up front).** Do not build a destination enforcer
+inside the current credential-brokers distribution. Everything the catalogue can
+install today—the `credbroker` package, its vendored floor, `sso-broker.py`, and
+skill scripts—is writable or bypassable by the same operating-system principal
+as the agent. A second package, virtual environment, signed data file, or
+additional in-process check would add complexity without creating independent
+authority.
+
+Keep generic headed cookie capture as an explicitly operator-invoked
+compatibility mode. Keep automatic refresh headless. Preserve destination
+derivation as defense in depth, but describe hostile same-principal destination
+poisoning as an accepted limitation rather than deferred implementation work.
+
+In this RFC, **capture** means navigating a browser through login, waiting for a
+declared success URL, and storing the resulting cookies. A **headed** capture
+shows an interactive browser in which a human can enter credentials; a
+**headless** capture has no human-facing window. The **destination** is the login
+journey: its initial URL, interactive origins (scheme, host, and port), and
+success condition. The **agent principal** is the operating-system account under
+which agent-controlled code runs. The **operator** is the human who types a
+registration command and controls the visible browser; this is an action role,
+not a separate operating-system identity. An **erring agent** follows supported
+catalogue workflows but can make a mistake; a **hostile same-principal process**
+can modify or bypass those workflows intentionally.
+
+| ID | Question | Decision | Why | Disposition |
+| --- | --- | --- | --- | --- |
+| D1 | What boundary does the baseline distribution provide? | None against a hostile agent principal; retain the current erring-agent protection only. | User-scoped Python and scripts cannot constrain code running as their owner. | Accepted limitation. |
+| D2 | What happens to generic headed cookie capture? | Keep it operator-only; never permit an automatic path to display login UI. | It preserves compatibility without creating a new agent-triggered credential-harvesting capability. | Baseline workflow contract. |
+| D3 | What future secure modes remain possible? | Permit a new proposal only for a remotely bound authorization protocol supported by a concrete consumer, or after the deployment envelope admits a protected component. | The remote issuer or protected installation—not another Python package—would supply the missing authority. | Future intake only; no implementation authorized. |
+| D4 | How is the workspace consolidated? | Remove all four entries and replace their spec and survey deferral language with an accepted limitation. | There is no actionable baseline implementation to schedule. | Closed rather than blocked. |
+
+## Problem & goals
+
+The SSO-cookie broker can render a browser so an operator can complete a
+corporate login. The initial URL and success condition currently arrive through
+`sso-config.toml`, a file editable by the installing user. The broker executable,
+its Python library, and its stored profile also live under that user's authority.
+Agent-controlled code running as that user can change the destination, replace
+the verifier, invoke the engine directly, or launch another browser.
+
+The browser holds authority supplied by a human login while a less-trusted
+caller can name its destination. The Internet Engineering Task Force describes
+the underlying cookie problem as separating designation in a URL from
+authorization in ambient cookies ([RFC 6265, section 8.2](https://www.rfc-editor.org/rfc/rfc6265.html#section-8.2)).
+Here the possible authority being acquired includes an identity-provider
+password and multi-factor authentication, not merely an existing cookie.
+
+The original four findings proposed integrity-protected fields, separated
+configuration, another derivation branch, and live-browser derivation. Their
+shared assumption was that a component inside the supported installation could
+enforce the result. The installation sweep disproved that assumption.
+
+In that installation, the **vendored floor** is the fallback copy of the
+`credbroker` Python library written to `~/.agentbundle/lib/credbroker/`.
+`sso-broker.py` is written to `~/.agentbundle/bin/`, and **projected skill
+scripts** are catalogue-owned script files copied into the installed skills.
+All are installed for, owned by, and executed as the same user account as the
+agent principal.
+
+### Goals
+
+- State exactly what the baseline distribution does and does not protect.
+- Prevent automatic code paths from rendering an agent-influenced login page.
+- Retain useful mismatch detection without calling it independent authority.
+- Close four unbuildable proposals instead of leaving them as misleading work.
+- Define what evidence would justify a new proposal later.
+
+### Non-goals
+
+- Add another user-scoped Python package, virtual environment, or signed policy.
+- Require administrator installation, a local service, or a browser extension.
+- Replace generic SSO cookies with OAuth or OpenID Connect for deployments that
+  do not support those protocols.
+- Change capture, refresh, storage, or consumer behavior in this RFC.
+- Defend the rest of the credential subsystem from a hostile same-principal
+  process; that broader limitation remains accepted.
+
+## Proposal
+
+### 1. Make the deployment boundary normative
+
+The baseline credential-brokers installation provides no destination security
+boundary against hostile code running as the installing user. This is a
+deployment fact, not a missing validation rule.
+
+The following do not change that fact:
+
+- another package or virtual environment installed by the same user;
+- a root-owned or signed policy read by a user-writable verifier;
+- origin comparison, server derivation, or live browser state observed by the
+  same mutable engine;
+- prompts, tool hooks, or instructions rendered by agent-controlled code; or
+- isolating Python imports while leaving the executable and policy replaceable
+  or bypassable.
+
+A Python implementation could become a real boundary only if its code, policy,
+interpreter path, and invocation contract were protected by another privilege.
+That is an administrator-installed component even if its source language is
+Python, and it is outside the supported installation envelope.
+
+### 2. Retain generic cookie capture as an operator-only compatibility mode
+
+Within supported catalogue workflows, interactive first capture remains
+reachable only through an operator-typed registration action. This is a
+workflow contract, not operating-system enforcement against a hostile
+same-principal process. Capture retains the current derivation, HTTPS checks,
+origin comparison, and success-condition validation as defense in depth. The
+derivation asks the configured service for a candidate authorization origin and
+compares that origin with the configured login origin; because the service and
+login values are editable together, it catches mistakes but is not independent
+authority. Documentation must not describe it as protection from hostile
+same-principal destination poisoning.
+
+Automatic refresh remains structurally headless and accepts only a profile
+selector. If the stored browser state cannot complete authentication without a
+human, refresh fails and directs the operator to the explicit registration
+workflow. No automatic path may fall back to a visible login page.
+
+This is the effort's security outcome: preserve the useful workflow while
+refusing to automate the one action that could acquire credentials the agent did
+not already possess.
+
+### 3. Do not create another local enforcer package
+
+`credbroker` is already delivered both as a pip-installed package and as a
+user-scope vendored floor. `sso-broker.py` is projected to the same user's
+`~/.agentbundle/bin`. Splitting destination checks into another distribution
+would change packaging but not ownership, mutability, or bypassability.
+
+The four original proposals are therefore closed as standalone work:
+
+- destination-field integrity cannot help when the verifier can be replaced;
+- privilege-separated config is not privilege-separated when installed at user
+  scope;
+- branch-2 attestation would add a check to the common topology in which the
+  configured login and service hosts are equal, but would still compare
+  agent-controlled designations; and
+- live-browser derivation is not independent when the agent controls the
+  browser and can launch a different one.
+
+### 4. Treat protocol-backed authentication as a different future capability
+
+For a service that supports it, a future `credbroker` mode could open the
+system browser and receive a Proof Key for Code Exchange (PKCE)-bound
+authorization response. Native-app guidance requires an external user agent and
+a registered redirect back to the client
+([RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html)). A device authorization
+flow can instead have the user approve a short-lived code through an
+authorization server while the client polls for the result
+([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html)).
+
+In those modes, the authorization server supplies the independent binding and
+returns a token. They do not generically return an arbitrary browser's Security
+Assertion Markup Language (SAML) session cookies and therefore do not replace
+the current cookie-capture topology.
+
+No such mode is authorized by this RFC. A concrete consumer with protocol
+support must justify a new proposal, including issuer selection, client
+registration, redirect binding, token storage, migration, and fallback. If the
+catalogue later permits administrator-installed or externally trusted software,
+that deployment change likewise requires a new proposal.
+
+### 5. Close the workspace items as an accepted limitation
+
+This change removes the four original entries from `workspace.toml`'s
+`[backlog].open` list of schedulable work. The
+[`jira-check-sso-auto-login` spec](../specs/jira-check-sso-auto-login/spec.md)
+and its
+[`agent-triggered-credential-capture` survey](../specs/jira-check-sso-auto-login/agent-triggered-credential-capture-survey.md)
+retain the security finding but label it an accepted limitation under RFC-0084
+rather than unresolved implementation work.
+
+No implementation spec follows from this RFC. A later protocol-backed or
+privileged design starts with new evidence and its own governance artifact; it
+does not silently revive one of the closed backlog solutions.
+
+## Options considered
+
+The options are exhaustive along the relevant deployment axis: keep the
+baseline as-is, rearrange code within the same principal, rely on a remote
+authorization protocol, or introduce a separately protected local or external
+component.
+
+| Option | What it buys | Cost and disposition |
+| --- | --- | --- |
+| **A. Do nothing and retain four backlog proposals** | Avoids deciding whether any proposal is deployable. | Rejected: it advertises work that cannot meet its own security claim. |
+| **B. Accept the baseline limitation** | Preserves generic cookie compatibility and the current install model without overstating protection. | Recommended: headed capture stays operator-only and automatic refresh stays headless. |
+| **C. Add another user-scoped package or verifier** | Can centralize checks and reduce accidental misconfiguration. | Rejected as a security boundary: it remains mutable and bypassable by the agent principal. Existing derivation already supplies the warranted defense in depth. |
+| **D. Add protocol-backed browser or device authorization** | Uses a remote authorization server to bind approval and keeps passwords outside the client. | Viable only for supported consumers; returns protocol credentials rather than generic SAML cookies. Requires a new proposal, not baseline work. |
+| **E. Add a protected local helper, browser extension, or remote service** | Can place policy and enforcement outside the agent principal. | Technically viable but rejected from the baseline because it adds a privileged install or another deployed component. Revisit only if the deployment envelope changes. |
+
+The policy-scope question from the original findings becomes conditional rather
+than actionable. If a future protected local enforcer is proposed, its minimum
+policy must bind the profile selector, initial login URL, allowed interactive
+origins, and success condition. No current component is authorized to claim that
+role.
+
+## Risks & what would make this wrong
+
+### Pre-mortem
+
+- **Accepted limitation becomes permission for unsafe automation.** Mitigation:
+  automatic refresh remains headless by contract; interaction-required is a
+  terminal outcome, not a fallback trigger.
+- **Users mistake derivation for protection.** Mitigation: architecture and spec
+  call it defense in depth and name the same-principal bypass.
+- **A second package is proposed later as if packaging created privilege.**
+  Mitigation: this RFC makes ownership of code, policy, interpreter, and
+  invocation contract the test.
+- **A protocol-backed mode is assumed to solve generic cookie capture.**
+  Mitigation: any future proposal must name a concrete consumer, credential
+  returned, issuer binding, and unsupported fallback behavior.
+- **Removing backlog entries hides the exposure.** Mitigation: the shipped spec,
+  architecture document, RFC, and follow-on ADR record it as an accepted
+  limitation rather than unfinished work.
+
+### Key assumptions
+
+- The supported installer writes all broker code and policy under the same user
+  authority. Falsifier: a supported installation path that creates an
+  independently protected executable and policy.
+- Generic target deployments cannot be assumed to support a native-app or device
+  authorization protocol. Falsifier: a concrete supported consumer contract
+  that provides registered redirect or device authorization and returns a usable
+  credential.
+- Operator-only headed capture does not add an automated credential-harvesting
+  capability. Falsifier: a supported unattended path that can cause the operator
+  to see and use the headed login page.
+
+### Drawbacks
+
+- Generic headed capture retains a known phishing exposure if the operator does
+  not verify the displayed destination.
+- The repository provides no engineering path to eliminate that exposure under
+  its current deployment constraints.
+- Protocol-backed authentication, if later added, will cover fewer deployments
+  and may create a second credential family beside SSO cookies.
+- Closing the backlog items means changed constraints must trigger new intake;
+  no dormant implementation task remains to resume automatically.
+
+## Evidence & prior art
+
+### De-risk spike
+
+The riskiest assumption was that a protected destination file enforced by the
+current broker—or by another Python package—could close the boundary without a
+new deployment class.
+
+Supported headed calls converge at the broker's `_do_register` function before
+`_capture(..., headless=False)`, so one logical gate could cover supported call
+paths. The engine is nevertheless a Python script installed under the user's
+home directory. The same-principal agent can modify it, bypass the register
+branch, import browser automation directly, or launch another browser. The pip
+package and vendored floor run under the same authority. The spike therefore
+disproved the assumption: rearranging user-scoped Python cannot create
+independent enforcement.
+
+### Repository precedent
+
+- `docs/architecture/credentials.md` accepts the same-principal limit and names
+  headed credential entry as its only high-blast-radius carve-out.
+- The `jira-check-sso-auto-login` acceptance criteria keep automatic refresh
+  headless, record derivation as partial, and retain direct engine invocation as
+  an open capability of the operator account.
+- RFC-0035 made the reference SSO config adopter-editable and kept the broker
+  user-scoped.
+- ADR-0026 places consumer resolution in the `credbroker` library while leaving
+  capture in the projected broker engine. Neither side has a separate principal.
+- RFC-0083 assigns executable work to specs. Because this RFC authorizes no
+  implementation, closing rather than queuing a spec preserves that boundary.
+
+### External prior art
+
+- [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265.html#section-8.2)
+  supplies the designation-versus-authority diagnosis for cookie-bearing user
+  agents.
+- [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252.html) separates native-app
+  authorization into an external browser and a registered response channel,
+  with PKCE protecting the authorization response.
+- [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html) moves user approval to
+  an authorization server and lets a client poll with a device code.
+- [Python isolated mode](https://docs.python.org/3.11/using/cmdline.html#cmdoption-I)
+  can remove user site-packages and `PYTHON*` environment influence from import
+  resolution; it does not change filesystem ownership or prevent an authorized
+  user from invoking different code.
+
+## Open questions
+
+None. Protocol support or an expanded deployment envelope is a future intake
+trigger, not unfinished implementation scope in this RFC.
+
+## Follow-on artifacts
+
+- ADR: the baseline credential-brokers install provides no same-principal
+  destination enforcer; generic headed SSO cookie capture remains operator-only.
+- No implementation spec, plan, or workspace entry follows from this RFC.
+- A future protocol-backed mode or protected installation class begins with a
+  new proposal tied to concrete deployment evidence.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -84,6 +84,7 @@
 | [0080](0080-local-scope-install.md) | Local scope install — `--scope local` installs pack files into the working tree and excludes them via `.git/info/exclude` so they never appear in `git status` or get committed. | Accepted | 2026-08-04 | 2026-08-04 |
 | [0082](0082-test-ownership-boundaries-and-inclusion.md) | Test ownership boundaries and per-surface inclusion — every test owned by the engine, the catalogue, or one pack, each with its own tree; `packages/<pkg>/<pkg>/` is the engine's runtime export boundary; inclusion decided per surface *and* per owner, so `agentbundle catalogue init` ships a catalogue that can verify itself. | Accepted | 2026-08-07 | 2026-08-08 |
 | [0083](0083-work-intake-and-artifact-routing.md) | Work intake and artifact routing — classify incoming work by content and altitude, route feature intents through a shippability gate, replace `capture-work` with standalone `work-intake`, make workspace dispatch deterministic from canonical artifacts, and transfer tracker authority explicitly by lifecycle. | Accepted | 2026-08-08 | 2026-08-08 |
+| [0084](0084-sso-destination-trust-boundary.md) | Single sign-on destination trust boundary | Accepted | 2026-08-11 | 2026-08-11 |
 
 ## Adding a new RFC
 

--- a/docs/specs/jira-check-sso-auto-login/agent-triggered-credential-capture-survey.md
+++ b/docs/specs/jira-check-sso-auto-login/agent-triggered-credential-capture-survey.md
@@ -300,9 +300,10 @@ sessions.
 **Net effect on this spec:** nothing found contradicts the design. Parameter
 elimination (our AC1) is the named correct fix; no source treats prompt-level
 confirmation as a real control, which is why AC15 records it as a non-control.
-The two ideas worth pursuing are F10's — recorded as
-*(deferred: sso-live-browser-destination-derivation)* and
-*(deferred: sso-privilege-separated-config)*.
+F10's live-browser and privilege-separated mechanisms would require a browser or
+administrator-installed component outside the supported user-scope deployment.
+RFC-0084 therefore closes them as baseline work and records destination
+poisoning as an accepted limitation.
 
 `ASM (Agent Skill Manager)` was also checked: it is an Agent Skill Manager with **no
 credential broker** — the comparison premise did not hold. Its one transferable

--- a/docs/specs/jira-check-sso-auto-login/spec.md
+++ b/docs/specs/jira-check-sso-auto-login/spec.md
@@ -3,7 +3,15 @@
 - **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](./plan.md)
-- **Constrained by:** [RFC-0035](../../rfc/0035-sso-cookie-auth-for-atlassian-pack.md) — pins the dual-auth selector and the fail-closed no-downgrade rule; [ADR-0026](../../adr/0026-sso-consumer-resolution-in-credbroker.md) — places SSO consumer resolution in `credbroker`, which this spec extends from resolution-only to resolution-plus-recapture.
+- **Constrained by:** [RFC-0035](../../rfc/0035-sso-cookie-auth-for-atlassian-pack.md)
+  — pins the dual-auth selector and the fail-closed no-downgrade rule;
+  [ADR-0026](../../adr/0026-sso-consumer-resolution-in-credbroker.md) — places
+  SSO consumer resolution in `credbroker`, which this spec extends from
+  resolution-only to resolution-plus-recapture; and
+  [RFC-0084](../../rfc/0084-sso-destination-trust-boundary.md) with
+  [ADR-0080](../../adr/0080-generic-headed-sso-capture-remains-operator-only.md)
+  — accepts the baseline's same-principal destination limitation, keeps headed
+  capture operator-only, and requires automatic refresh to remain headless.
 - **Architecture:** [`docs/architecture/credentials.md § The `sso-cookie` broker`](../../architecture/credentials.md#the-sso-cookie-broker) — the engine/library split, the consumer API, destination pinning, the profile grammar, and the auto-recovery contract live there. This spec does not restate them; it implements them.
 - **Contract:** none
 - **Brief:** none
@@ -507,18 +515,21 @@ fix, so the pack bumps and the change is named in the changelog.
       This closes the gap between this spec's own threat analysis and its ACs.
       The spec identifies "a human types credentials into a page whose
       destination the agent could influence" as the single exposure whose blast
-      radius leaves the machine, and AC15 defers the destination-integrity
-      control that would contain it — yet bare `check` reached exactly that state
-      whenever the IdP session had expired too, using destination fields from the
-      agent-writable `~/.agentbundle/sso-profiles/<profile>.toml`. Deferring the
-      control while shipping the flow it was meant to contain is not a defensible
-      order of operations.
+      radius leaves the machine. RFC-0084 records that the supported deployment
+      cannot enforce a destination-integrity boundary against its own principal.
+      Bare `check` nevertheless reached exactly that state whenever the IdP
+      session had expired, using destination fields from the agent-writable
+      `~/.agentbundle/sso-profiles/<profile>.toml`. Accepting that limitation
+      while shipping an automatic headed flow is not a defensible order of
+      operations.
 
       So the harvest surface is removed from the automatic path entirely rather
       than guarded: silent re-auth ships (it is the common case and involves no
       human), interactive capture is reachable **only** from an operator-typed
-      command. `sso-destination-field-integrity` remains the prerequisite for ever
-      relaxing this — until it lands, no automated path may render a login page.
+      command. RFC-0084 accepts the current deployment's lack of a
+      same-principal destination boundary. No automated path may render a login
+      page; changing that ceiling requires a new proposal with an independently
+      bound authorization mechanism.
 
       **The enforceable engine contract: `refresh` is universally headless.**
       An abort rule alone is unimplementable — `_do_refresh` delegates to
@@ -568,10 +579,12 @@ fix, so the pack bumps and the change is named in the changelog.
       design whose blast radius leaves the machine, and it is the only one that
       earns a control.
 
-      **The control, narrowed to fit.** Integrity-protect the two destination
-      fields — `login_url` and `success_url_pattern` — rather than the whole
-      config or the whole flow. Everything else in `sso-config.toml` stays
-      adopter-editable. *(deferred: sso-destination-field-integrity)*
+      **The control, narrowed to fit.** Integrity-protect the headed-login
+      destination policy rather than the whole config or the whole flow.
+      RFC-0084 records that the current user-scope installation cannot provide
+      that integrity boundary. Everything in `sso-config.toml` remains
+      adopter-editable, and the exposure is an accepted limitation rather than
+      deferred baseline work.
 
       AC21 still puts `--register` under the SKILL.md rule that the agent relays
       the command rather than running it, and AC21's negative eval still asserts
@@ -765,8 +778,8 @@ fix, so the pack bumps and the change is named in the changelog.
       majority topology, **derivation is effective only on IdP-host topologies.**
       This is accepted rather than fixed: requiring derivation in branch 2 would
       refuse every SSO-with-local-fallback adopter, and derivation is explicitly
-      not the control — AC15 is. Recorded as
-      *(deferred: sso-branch2-destination-attestation)*.
+      not the control — AC15 is. RFC-0084 closes a standalone branch-2 remedy as
+      part of the accepted same-principal limitation.
 
       **Branch 2 is evaluated first and short-circuits.** Where `login_url`'s host
       equals `base_url`'s host, **no derivation request is made** and the
@@ -1292,9 +1305,10 @@ Every entry was established by reading source or executing a probe on
 - The non-JSON-2xx guard on read paths other than `whoami` — every method calls
   `resp.json()`, so the same login-page body still exits 1 elsewhere.
   *(deferred: nonjson-2xx-guard-all-read-paths)*
-- Attestation for SP-initiated topologies, where `login_url` and `base_url`
-  share a host and AC32's branch 2 consults no server.
-  *(deferred: sso-branch2-destination-attestation)*
+- Headed-login destination poisoning remains an accepted limitation under
+  RFC-0084: the supported user-scope installation cannot enforce a boundary
+  against its own principal. Generic interactive capture stays operator-only;
+  no baseline implementation is deferred.
 - A pack-shipped `PreToolUse` hook denying **both** agent-facing capture
   commands — `jira.py check --register` and `setup_sso.py` — while allowing bare
   `check`. Explicitly **belt-only, not a boundary**: it lands in
@@ -1302,14 +1316,6 @@ Every entry was established by reading source or executing a probe on
   uneven (`kiro-ide` drops hook-wiring); and it cannot stop a direct
   `sso-broker.py register`. A real boundary needs privilege separation.
   *(deferred: sso-register-pretooluse-hook)*
-- Deriving the sign-in destination from the **browser's live state** rather than
-  config, after 1Password's extension model (inject only when the browser is
-  already on the matching origin; approve via a biometric prompt the agent cannot
-  reach). *(deferred: sso-live-browser-destination-derivation)*
-- Privilege-separating `sso-config.toml` so the agent cannot write it, after
-  a practitioner writeup's `sudo`-gated `gh` wrappers — the only mechanism found in the
-  prior-art sweep that actually protects an agent-editable credential config.
-  *(deferred: sso-privilege-separated-config)*
 - The profile grammar in `tools/lint-sso-config.py`, so a pre-baked traversal
   value fails at build time as well as at runtime.
   *(deferred: lint-sso-config-profile-charset)*

--- a/workspace.toml
+++ b/workspace.toml
@@ -606,16 +606,12 @@ open = [
     # baked layer sits inside the agentbundle package, unreachable from stdlib-only skill
     # scripts. Fix: installer projects [pack-defaults.<pack>] to
     # ~/.agentbundle/<pack>/defaults.toml; needs an RFC-0074 addendum plus an ADR extending
-    # ADR-0059. CONSTRAINT (AC25): a projected defaults.toml is NOT trusted merely because
-    # the installer wrote it — its contents come from catalogue.toml, so if it can supply
-    # auth_default or a sign-in destination it becomes a second adopter-writable source for
-    # an automated launch; the addendum must keep the automatic path pinned to
-    # broker-written state exactly as AC1 does. Unblocks: after the addendum is Accepted.
+    # ADR-0059. CONSTRAINT (AC25, RFC-0084): a projected defaults.toml is NOT trusted merely
+    # because the installer wrote it — its contents come from catalogue.toml. It may not
+    # supply a sign-in destination or make any automatic path headed; automatic refresh
+    # stays pinned to broker-written state exactly as AC1 requires. Unblocks: after the
+    # addendum is Accepted.
   {slug = "pack-config-catalogue-sso-defaults", source = "spec/jira-check-sso-auto-login"},
-    # AC32 branch 2 (login_url host == base_url host, the majority SP-initiated SAML
-    # topology) consults no server, so derivation attests nothing there. Fix: an attestation
-    # that works when SP and IdP share a host. Unblocks: needs design.
-  {slug = "sso-branch2-destination-attestation", source = "spec/jira-check-sso-auto-login"},
     # sso-broker.py creates browser-state/<profile> with umask-default mode and stores
     # context.cookies() unfiltered, so IdP cookies persist at rest though the consumer
     # filters at load. Fix: 0700 mode + capture-time domain filter. Unblocks: now.
@@ -629,20 +625,6 @@ open = [
     # whose literal meaning the check carve-out inverts. Fix: amend the pinned phrase set.
     # Unblocks: needs a lint-contract change.
   {slug = "sso-cookie-lint-phrase-amendment", source = "spec/jira-check-sso-auto-login"},
-    # Derive the destination from the browser's live state rather than config, after
-    # 1Password's extension model (inject only when already on the matching origin). Fix:
-    # design a live-state derivation. Unblocks: needs design.
-  {slug = "sso-live-browser-destination-derivation", source = "spec/jira-check-sso-auto-login"},
-    # login_url and success_url_pattern are the only fields that can point a human at a
-    # login page; everything else in sso-config.toml can stay adopter-editable. Fix:
-    # integrity-protect just those two (root-owned or signed). Unblocks: now — this is the
-    # one control the accepted threat profile says earns its cost.
-  {slug = "sso-destination-field-integrity", source = "spec/jira-check-sso-auto-login"},
-    # sso-config.toml is agent-writable, so no validation closes poisoning; a practitioner writeup's
-    # sudo-gated gh wrappers are the only mechanism found that actually protects such a
-    # file. Fix: privilege-separate the config at install. Unblocks: needs an install-path
-    # decision.
-  {slug = "sso-privilege-separated-config", source = "spec/jira-check-sso-auto-login"},
     # AC16 logs recapture via log.info, but jira.py:780-783 configures logging with no filename,
     # so the record goes to stderr the agent may discard - an unattended re-auth stays repudiable.
     # Fix: append-only 0600 log under ~/.agentbundle/logs/. Unblocks: now.
@@ -706,7 +688,9 @@ open = [
     # check --register and setup_sso.py) while allowing bare check. Belt-only, not a
     # boundary: lands in .claude/settings.local.json, an agent-writable repo file; uneven
     # adapter coverage (kiro-ide drops hook-wiring); cannot stop direct sso-broker.py
-    # register. Fix: only if an adopter wants it knowing the limits. Unblocks: on request.
+    # register. RFC-0084 permits this only as erring-agent defense in depth, never as
+    # destination protection. Fix: only if an adopter wants it knowing the limits.
+    # Unblocks: on request.
   {slug = "sso-register-pretooluse-hook", source = "spec/jira-check-sso-auto-login"},
   # `test_version_matches_pyproject` hardcodes "0.6.0" instead of reading
   # pyproject.toml dynamically. A future version bump can reintroduce the same
@@ -1441,7 +1425,8 @@ open = [
   # independently enforced (AC4/5/6/20). Deferred pending the live-DC transcript
   # clarifying actual broker behavior with the pattern host.
   # Fix: after the live-DC transcript, decide whether to tighten pattern-host
-  #   validation at the broker (capture-time) layer.
+  #   validation at the broker (capture-time) layer. Per RFC-0084 this can be
+  #   defense in depth only; it cannot become a same-principal destination boundary.
   # Unblocks when: atlassian-sso-cookie-live-dc-read-transcript is complete.
   {slug = "atlassian-sso-cookie-success-url-pattern-host-confinement", needs = "backlog:atlassian-sso-cookie-live-dc-read-transcript"},
 


### PR DESCRIPTION
  Accept RFC-0084 and ADR-0080, retiring the four competing
  destination-enforcement proposals without replacement.

  Record generic headed SSO capture as operator-only, keep automatic
  refresh headless, and preserve unrelated credential backlog work.