### PR TITLE
docs: streamline product navigation and catalogue discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,25 @@
 
 Thanks for thinking about contributing. This catalogue grows by *primitives* — packs, skills, subagents — and each kind of contribution has a different shape. Pick the lane that fits your change.
 
+## Understand the product before changing it
+
+The [technical documentation](https://eugenelim.github.io/agent-ready-repo/docs/) is the best product-level entry point: it routes by use case and role into the adopter guides and generated pack reference. The source is deliberately split:
+
+- [`guides/`](guides/) owns public tutorials, how-tos, reference, and explanation.
+- [`packs/<pack>/README.md`](packs/) owns what each pack ships; the docs build generates the complete pack reference from those sources and `pack.toml`.
+- [`docs-site/src/content/docs/`](docs-site/src/content/docs/) owns only the technical-doc entry pages; generated pack and guide pages are not edited there.
+- [`docs/architecture/overview.md`](docs/architecture/overview.md) maps the repository implementation for contributors.
+
+For a quick orientation, go from [technical docs](https://eugenelim.github.io/agent-ready-repo/docs/) → the relevant [pack guide](guides/) → its source under [`packs/`](packs/) → the current architecture or contract. This lets you see the adopter experience before changing the machinery behind it.
+
+## How decisions become changes
+
+```text
+research or observed problem → RFC → ADR when needed → spec + plan → implementation → adopter docs
+```
+
+The chain is proportional, not ceremonial: small fixes can go straight to a PR, while a new public contract, pack, top-level structure, or substantive charter change starts with an RFC. Research under [`docs/product/research/`](docs/product/research/) supplies evidence; RFCs record the proposal and trade-offs; ADRs record durable architectural decisions; specs and plans define the accepted behavior and implementation. If the answer is absent from those sources, it has not been decided—ask or open an RFC rather than inferring policy from nearby code.
+
 ## Before you start
 
 Two reads will save you time:
@@ -25,7 +44,9 @@ Full rule with the projected-paths list: [`CONVENTIONS.md § Pack source-of-trut
 
 ### Adding a new pack
 
-A new pack is a coherent slice — a workflow, a reviewer lens, a document shape — packaged as a unit. The ceremony exists because a pack adds public contract surface: a name in the catalogue, a row in the `Packs` table, an install URI adopters will pin against.
+A new pack is a coherent slice — a workflow, a reviewer lens, a document shape — packaged as a unit. The ceremony exists because a pack adds public contract surface: a name in the published catalogue, an install URI adopters may pin against, and guidance they will rely on.
+
+Start with the portable [`catalogue-authoring-standards.md`](guides/_shared/reference/catalogue-authoring-standards.md) hub. It is the canonical contract for pack structure, metadata, composition, public guidance, and verification.
 
 Steps:
 
@@ -38,7 +59,9 @@ Steps:
    - `seeds/` — upstream for seed-projected files (README, governance content). Files prefixed `_` are composition fragments, not standalone.
 3. **Run the pack validator.** `agentbundle validate packs/<your-pack>`; fix anything it reports before opening the PR.
 4. **If you claim `user` scope**, justify it. The user-scope eligibility test is falsifiable: content must be project-portable (no hooks that wire into a specific repo's surface, no seeds that name *this* project).
-5. **Update the `Packs` table in [`README.md`](README.md)** and the catalogue manifest (`make build-self` regenerates the latter).
+5. **Declare optional composition when it exists.** Add `[[pack.integrations]]` entries to `pack.toml` for useful cross-pack relationships that are not required dependencies. This convention shipped in Wave 2; the [authoring standards](guides/_shared/reference/catalogue-authoring-standards.md) carry the complete contract.
+6. **Complete public discovery at the sources.** Add the pack guide home and journey required by the authoring standards and register its curated site group in `site.toml`. The public catalogue and technical pack index derive from pack metadata; do not add a row to the root README or edit generated site output.
+7. **Regenerate the catalogue manifest.** `make build-self` updates the projected marketplace and self-hosted outputs.
 
 ### Adding or modifying a skill
 
@@ -126,11 +149,17 @@ The **one-time** PyPI Trusted Publisher — a Pending Publisher matching `releas
 | You want to know… | Look here |
 | --- | --- |
 | Mission, scope, principles | [`docs/CHARTER.md`](docs/CHARTER.md) |
+| Public product behavior and task guidance | [Technical docs](https://eugenelim.github.io/agent-ready-repo/docs/) and their source in [`guides/`](guides/) |
+| Current repository architecture | [`docs/architecture/overview.md`](docs/architecture/overview.md) |
 | How we work, document hierarchy | [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) |
+| Evidence informing a product direction | [`docs/product/research/`](docs/product/research/) |
 | Why we chose X over Y | [`docs/adr/`](docs/adr/) |
 | In-flight proposals | [`docs/rfc/`](docs/rfc/) |
+| Accepted behavior and build plan | [`docs/specs/`](docs/specs/) |
+| Current initiative and dependency state | [`workspace.toml`](workspace.toml) |
 | Per-IDE adapter contract | [`contracts/adapter.toml`](contracts/adapter.toml) |
 | Pack manifest schema | [`contracts/pack.schema.json`](contracts/pack.schema.json) |
+| Portable catalogue authoring standards and contracts | [`guides/_shared/reference/catalogue-authoring-standards.md`](guides/_shared/reference/catalogue-authoring-standards.md) |
 | Catalogue model rationale | [RFC-0001](docs/rfc/0001-bundle-distribution-by-adapter-spec.md) |
 
 ## When this file is wrong

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ test:
 	@n=$$($(PYTHON) -m pytest packs/desk-research/tests/ -q --collect-only | grep -c '::' || true); \
 	 if [ "$$n" -lt 16 ]; then echo "packs/desk-research/tests/ collected $$n, expected >= 16" >&2; exit 1; fi
 	$(PYTHON) -m pytest packs/desk-research/tests/ -q
-	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_build_site_routing.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py -q
+	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_build_site_routing.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q
 	$(PYTHON) -m pytest \

--- a/README.md
+++ b/README.md
@@ -1,156 +1,65 @@
 # agent-ready-repo
 
-**The supervised AI operating model for software teams.**
+**The supervised agentic build loop—and the catalogue of workflows around it.**
 
-```
-Raw idea → Gate: Idea → Spec → Gate: Spec → Shipped code → Gate: PR → Production
+Decide what to build, design the product and system, implement and review software, plan infrastructure, validate releases, document what ships, and govern the catalogue your organization owns.
+
+```text
+Reversible agent work → mechanical checks → independent review → human decision
 ```
 
 [![PyPI](https://img.shields.io/pypi/v/agentbundle)](https://pypi.org/project/agentbundle/) [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](#license) [![OWASP Agentic Skills Top 10](https://img.shields.io/badge/OWASP-Agentic%20Skills%20Top%2010%20v1.0-blue)](https://owasp.org/www-project-agentic-skills-top-10/)
 
-[Quick Start](#quick-start) · [The Three Loops](#the-three-loops) · [The Catalogue](#the-catalogue) · [Docs](guides/) · [Contributing](CONTRIBUTING.md)
+[Build with `core`](#build-with-core) · [Explore use cases](https://eugenelim.github.io/agent-ready-repo/#use-cases) · [Get started](https://eugenelim.github.io/agent-ready-repo/docs/getting-started/) · [Browse the catalogue](https://eugenelim.github.io/agent-ready-repo/catalogue/) · [Contribute](CONTRIBUTING.md)
 
-> "You shouldn't be prompting coding agents anymore. You should be designing loops that prompt your agents." — [Peter Steinberger](https://x.com/steipete/status/2063697162748260627)
+## Choose a use case
 
-Agent coding tools moved the leverage from the prompt to the loop. But an unattended loop also makes unattended mistakes — and it will self-certify its way out of every check you give it. The answer is a supervised loop with mechanical gates the agent cannot bypass.
+- **Product managers and strategists:** move from strategy and evidence to a bounded decision brief with `product-strategy`, `desk-research`, and `product-engineering`.
+- **Platform, infrastructure, and SRE teams:** design the boundary, author contracts, produce reviewable Terraform, and validate the deployed result with `architect`, `contracts`, `iac-terraform`, and `release-engineering`.
+- **Software teams:** take a brief or spec through implementation, hard gates, independent review, and a human merge decision with `core`.
+- **Design, research, documentation, and enablement teams:** [explore the use cases](https://eugenelim.github.io/agent-ready-repo/#use-cases) that map your work to the relevant packs.
 
-Three peer loops span the full SDLC. Discovery takes a raw idea to a ratified brief. The build loop runs spec to shipped code with hard gates and cold-read reviewers. The release loop validates the deployed whole before any human touches a prod switch. Human gates sit at every irreversible handoff; nothing runs past them automatically.
+Packs are composable units, not departments. Install only what you need, or use a profile when a curated starting set fits. The [complete catalogue](https://eugenelim.github.io/agent-ready-repo/catalogue/) remains the source for current pack inventory and install commands.
 
-`core` is the flagship pack — the build loop, in one command:
+## Build with `core`
+
+`core` is the catalogue's flagship and its strongest reason to start. It is a complete build system for coding agents: spec and plan before code, mechanical gates before claims, a cold independent review before handoff, and a human decision before merge.
 
 ```bash
 python -m pip install agentbundle
 agentbundle install --pack core
 ```
 
-## Quick start
+Then ask your coding agent:
 
-**Install via Claude Code** (no extra tooling required). This route installs at
-user scope, so it carries the packs that permit it — repo-scoped packs like
-`core` install with `agentbundle` instead:
+```text
+Implement <small, testable feature> with the work-loop.
+```
+
+The loop keeps fixing until the checks and review are clean. If it repeats the same failure, crosses a boundary, or reaches an irreversible decision, it stops and surfaces the choice instead of self-certifying. [See how `core` compares with prompt-and-approve coding, Spec Kit, and Kiro](guides/core/explanation/core-pack.md).
+
+Using Claude? You can also [add this catalogue as a plugin marketplace](https://eugenelim.github.io/agent-ready-repo/docs/getting-started/install/#route-2-claude-plugins) and install any user-scope pack directly. Repo-scoped packs such as `core` install with `agentbundle` so the whole team shares the same loop.
+
+## Own the system
+
+`agentbundle` projects portable skills, subagents, hooks, commands, and seeds into the layout each supported agent expects. Installed files remain readable and editable; upgrades preserve local changes as explicit companions instead of silently clobbering them.
+
+Create an organization-owned catalogue without forking this repository:
 
 ```bash
-# Add the marketplace once
-claude plugin marketplace add eugenelim/agent-ready-repo
-
-# Install any *user-scope* pack by name
-claude plugin install architect@agent-ready-repo
-
-# Browse all available packs with install commands
-# → https://eugenelim.github.io/agent-ready-repo/plugins/
+agentbundle catalogue init my-catalogue --name my-catalogue
+agentbundle catalogue verify --root my-catalogue
 ```
 
-**Or install via agentbundle CLI** (supports all agent adapters):
+[Understand packs, profiles, adapters, composition, and self-hosting](guides/_shared/explanation/pack-catalogue.md) · [Create a catalogue](guides/_shared/how-to/create-a-catalogue.md) · [Read the authoring standards](guides/_shared/reference/catalogue-authoring-standards.md)
 
-```bash
-# Install the CLI (one-time)
-python -m pip install agentbundle
+## Go deeper
 
-# See the catalogue
-agentbundle list-packs
-
-# See what you have installed — version + whether an upgrade is available
-agentbundle list-installed
-
-# Install the flagship loop into this repo
-agentbundle install --pack core
-
-# Install a pack at user scope — follows you across every project
-agentbundle install --pack desk-research --scope user
-
-# Install a whole curated profile in one command
-agentbundle install --profile solution-architect
-
-# Upgrade a pack to the catalogue's version (asks before writing; --yes for CI)
-agentbundle upgrade --pack core
-
-# Preview any install without writing a file
-agentbundle install --pack core --dry-run
-```
-
-`--dry-run` previews every file before anything is written — one line per file, then a `create`/`overwrite` count. Installs auto-detect your agent and fall back to Claude Code; [configure a different default →](guides/_shared/how-to/configure-adapter.md)
-
-Every source verb defaults to this catalogue when you don't name one; pass a git URL or local path to use a different one, or `agentbundle config set source <catalogue>` to change the default.
-
-**Machine-readable catalogue:** `https://raw.githubusercontent.com/eugenelim/agent-ready-repo/claude-plugins-dist/marketplace.json`
-
-## The three loops
-
-```
-product-engineering              core                    release-engineering
-───────────────────              ────                    ───────────────────
-discovery-lead                   work-loop               release-lead
-Raw idea → Brief  ─Gate: Idea─▶  Spec → Shipped code  ─Gate: PR─▶  Production
-```
-
-Each loop is autonomous where the work is reversible and surfaces to a human at every irreversible step.
-
-### Discovery — `product-engineering`
-
-Raw idea → ratified brief. Five candidate shapes explored in parallel, collapsed through product, UX, architecture, and safety lenses.
-
-**Human gate.** You approve a ratified decision brief, not a validated solution. The loop never advances past Gate: Idea automatically.
-
-→ [Discovery loop guide](guides/product-engineering/) · [Walk a discovery end-to-end](guides/product-engineering/tutorials/walk-a-discovery-end-to-end.md)
-
-### Build — `core`
-
-Spec → shipped code. Lint, typecheck, and tests must pass. Three specialist reviewers each read the diff cold, in a fresh session — adversarial by design. Gate: Spec sits between the approved spec and the first line of implementation.
-
-**Human gate.** You merge only when adversarial review is clean and all gates pass.
-
-→ [The `core` pack as a system](guides/core/explanation/core-pack.md)
-
-### Release — `release-engineering`
-
-Built → production. Autonomous e2e convergence on ephemeral environments; deployed findings feed back to the build loop automatically.
-
-**Human gate.** Prod ship always surfaces to a human. Always.
-
-→ [Release loop guide](guides/release-engineering/) · [The release loop explained](guides/release-engineering/explanation/the-release-loop.md)
-
-## The catalogue
-
-Three packs form the operating model. The rest are curated kits — each distilled from the best practices of its discipline. Install only what your team needs.
-
-| Pack | Scope | What it does |
-| --- | --- | --- |
-| [`core`](guides/core/) | **repo** | The build loop. `work-loop`, `new-spec`, `bug-fix`, the four reviewer/executor subagents, hooks, governance seeds. **Install this first.** |
-| [`product-engineering`](guides/product-engineering/) | user | The discovery loop — raw idea to build-ready brief. |
-| [`release-engineering`](guides/release-engineering/) | **repo** | The release loop — build to production. Hard-depends on `core`. |
-| [`governance-extras`](guides/governance-extras/) | repo | RFC/ADR ceremony for teams and long-lived repos. |
-| [`product-documentation`](guides/product-documentation/) | user / repo | Create, revise, audit, and verify product documentation. |
-| [`monorepo-extras`](guides/monorepo-extras/) | repo | Scaffold packages in a monorepo. |
-| [`desk-research`](guides/desk-research/) | user / repo | Go from a question to an evidence-grounded answer. |
-| [`contracts`](guides/contracts/) | user / repo | Author an API contract (OpenAPI 3.1). |
-| [`converters`](guides/converters/) | user / repo | Move documents in and out of Markdown. |
-| [`atlassian`](guides/atlassian/) | user / repo | Work Jira and Confluence from the agent. |
-| [`figma`](guides/figma/) | user / repo | Read and render Figma designs. |
-| [`architect`](guides/architect/) | user / repo | Design a system and pressure-test it. |
-| [`experience-design`](guides/experience-design/) | user / repo | Carry the whole design thread — journey to realization. |
-
-A profile is a blessed combination of packs: `full-ceremony` adds the governance packs to `core`; `solution-architect` lands `architect` + `desk-research` + `contracts`; `inception` takes an idea from zero to a buildable repo. `agentbundle list-profiles` shows them all — see the [install-a-profile how-to](guides/_shared/how-to/install-a-profile.md).
-
-Run `agentbundle catalogue init` to create a new catalogue from the managed scaffold. Write your conventions and review standards into `core`, add skills for your stack, and ship one catalogue every engineer installs in a single line — identical across every machine and every agent. The same bundler works for any domain, not just software delivery. [How to build your org's catalogue →](guides/_shared/how-to/create-a-catalogue.md)
-
-## Ecosystem
-
-Your skills, subagents, and hooks are files you own. No SDK, no runtime, no service. Version and compose them like any other code.
-
-- Works with Claude Code, Codex, Cursor, Copilot, Gemini, and Kiro. One adapter pipeline projects the same primitives into the layout each agent expects.
-- The mechanics are prose you can read and `git diff`. Outgrow a default? Edit the file.
-- Packs layer cleanly. Colliding files land as `*.upstream` companions to merge, not clobber.
-- Every pack is shaped through practitioner research and an RFC-and-ADR governance process.
-
-Two standalone packages underpin it:
-
-- **[`agentbundle`](https://pypi.org/project/agentbundle/)** — installs and upgrades packs, projects each primitive into the layout every agent expects, and builds catalogues of your own.
-- **[`credbroker`](https://pypi.org/project/credbroker/)** — resolves secrets in-process through environment variable → OS keyring → dotfile. Cleartext never reaches the model. See [credential handling](docs/architecture/credentials.md).
-
-## Contributing
-
-Adding a pack, skill, or subagent? [`CONTRIBUTING.md`](CONTRIBUTING.md) has the three contribution lanes, the pack source-of-truth split, and the gates your PR has to pass.
+- **Use the catalogue:** [technical docs](https://eugenelim.github.io/agent-ready-repo/docs/) · [install routes](guides/_shared/explanation/install-routes.md) · [adapter support](guides/_shared/reference/adapter-support.md) · [`agentbundle` reference](guides/_shared/reference/agentbundle.md)
+- **Understand the operating model:** [the three supervised loops](guides/_shared/explanation/the-three-loops.md) · [file safety](guides/_shared/explanation/file-safety-contract.md)
+- **Inspect the implementation:** [architecture](docs/architecture/) · [machine contracts](contracts/) · [security model](docs/architecture/security.md)
+- **Contribute:** [contribution lanes and gates](CONTRIBUTING.md) · [pack authoring](packs/) · [repository conventions](docs/CONVENTIONS.md)
 
 ## License
 
-Licensed under either of [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) at your option. Contributions are dual-licensed under the same terms unless you state otherwise.
+Licensed under either [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) at your option. Contributions are dual-licensed under the same terms unless you state otherwise.

--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -39,6 +39,9 @@ export default defineConfig({
       title: 'agent-ready-repo',
       description:
         'The complete AI operating model for software teams — from first idea to production.',
+      // Reuse the marketing site's root asset. Starlight otherwise prefixes its
+      // default `/favicon.svg` with the docs base and emits a missing file.
+      favicon: 'https://eugenelim.github.io/agent-ready-repo/favicon.svg',
       editLink: {
         baseUrl: 'https://github.com/eugenelim/agent-ready-repo/edit/main/',
       },

--- a/docs-site/src/content/docs/getting-started/index.mdx
+++ b/docs-site/src/content/docs/getting-started/index.mdx
@@ -1,106 +1,105 @@
 ---
-title: Get Started
-description: From zero to your first loop in under five minutes.
+title: Get started
+description: Install a supervised agent workflow matched to the work you need to do.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import PromptBlock from '../../../components/primitives/PromptBlock.astro';
 
-agent-ready-repo ships the complete AI operating model for software teams. This guide gets you from zero to your first loop in under five minutes.
+Start with a real task whose result you can verify. Most software teams should start with `core`: it is the catalogue's flagship build system, not merely a sample. Product, design, infrastructure, research, and catalogue work remain first-class starting points alongside it.
 
-## What you're installing
+## What a pack installs
 
-When you install a pack, you get:
+Depending on the pack and adapter, an installation can add:
 
-- **Skills** — slash commands your agent runs on request (`/work-loop`, `/new-spec`, `/bug-fix`)
-- **Subagents** — specialist reviewers that read your diff cold (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`)
-- **Hooks** — automation that fires at session start and before a PR opens
-- **Seeds** — scaffolding for your repo's governance docs
+- **Skills** — repeatable workflows your agent discovers from your request.
+- **Subagents** — specialist executors or reviewers that receive bounded tasks.
+- **Hooks and commands** — adapter-supported automation and explicit entry points.
+- **Seeds and configuration** — repository scaffolding or pack defaults delivered through declared contracts.
 
-Everything lands as files in your repo (or your home directory for user-scope packs). No runtime, no service, no lock-in.
+The result is a set of readable files in your repository or user-scope agent directory. `agentbundle` installs and upgrades them; it is not a hosted agent runtime.
 
-## Step 1: Install the CLI
+## Step 1: install the CLI
 
 ```bash
 python -m pip install agentbundle
 ```
 
-The `agentbundle` CLI manages pack installation, upgrade, and discovery. One-time setup — upgrade it like any other pip package.
+Before any real install, add `--dry-run` to preview the rendered files and any preserved companions.
 
-## Step 2: Pick your starting point
+Claude users can also [add this catalogue as a plugin marketplace](/agent-ready-repo/docs/getting-started/install/#route-2-claude-plugins) for user-scope packs. `core` and other repo-scoped packs install with `agentbundle` so the workflow is shared and versioned with the project.
+
+## Step 2: choose your starting work
 
 <Tabs>
-  <TabItem label="Just the build loop">
-    The flagship pack. Works in any repo, any stack.
+  <TabItem label="Build and review">
+    Install the flagship supervised work loop into a repository:
 
     ```bash
     agentbundle install --pack core
     ```
 
-    You get: `work-loop`, `new-spec`, `bug-fix`, four reviewer subagents, session-start and pre-PR hooks.
+    Start with a feature or bug whose tests and diff you can inspect. The loop makes assumptions explicit, plans against the repository's real contracts, implements, runs mechanical gates, and sends the diff into a cold independent review. It fixes findings until clean, stops if progress stalls, and never crosses the human merge gate for you.
   </TabItem>
-  <TabItem label="Full company OS">
-    All three loops — discovery, build, release.
+  <TabItem label="Product decisions">
+    Install the portable strategy, evidence, and shaping workflows you need:
+
+    ```bash
+    agentbundle install --pack product-strategy --scope user
+    agentbundle install --pack desk-research --scope user
+    agentbundle install --pack product-engineering --scope user
+    ```
+
+    You can install these independently. Together they move from a strategic question or uncertain idea through evidence and competing shapes to a decision brief a delivery team can act on. A human ratifies the bet before it crosses into implementation.
+  </TabItem>
+  <TabItem label="Infrastructure and release">
+    Install the supervised build spine, reviewable Terraform workflow, and release loop into the repository:
 
     ```bash
     agentbundle install --pack core
-    agentbundle install --pack product-engineering --scope user
+    agentbundle install --pack iac-terraform
     agentbundle install --pack release-engineering
     ```
+
+    `iac-terraform` stops at a reviewable plan; it never runs `terraform apply`. `release-engineering` converges in an ephemeral environment and stops at the human production gate. Add user-scope `architect` and `contracts` when the system and interface decisions also need shaping.
   </TabItem>
-  <TabItem label="Inception profile">
-    For taking a raw idea from zero to a buildable repo.
+  <TabItem label="Curated profile">
+    Use a profile when its single-scope pack set matches your starting job:
 
     ```bash
+    agentbundle list-profiles
     agentbundle install --profile inception
     ```
 
-    Lands: `desk-research` + `product-engineering` + `architect`
-  </TabItem>
-  <TabItem label="Solution architect">
-    Design, research, and API contracts.
-
-    ```bash
-    agentbundle install --profile solution-architect
-    ```
-
-    Lands: `architect` + `desk-research` + `contracts`
+    `inception` supports idea-to-buildable-repo work; `solution-architect` groups architecture, research, and contracts; `full-ceremony` adds the repository governance set around `core`.
   </TabItem>
 </Tabs>
 
-## Step 3: Adapt to your repo
+## Step 3: make the first request
 
-After install, open your agent and run:
-
-```
-/adapt-to-project
-```
-
-This reads your repo's stack and conventions, then tailors the installed skills to match. It fills in the command stubs in your `AGENTS.md` and wires up the hooks correctly.
-
-## Step 4: Use the loop
-
-Your first real task:
+Use natural language. Installed skills are discovered from the work you ask for.
 
 <PromptBlock
   speaker="You"
-  prompt="Implement <feature> with the work-loop."
+  prompt="Implement the smallest testable version of <feature> with the work-loop."
   mode="read-only"
 />
 
-The build loop will:
+Other credible first requests:
 
-1. **Plan** — name the files it'll touch, write the tests, name what it won't change
-2. **Execute** — red-green-refactor or goal-based, depending on the task
-3. **Gate** — lint, typecheck, tests must all pass
-4. **Review** — adversarial reviewer reads the diff cold in a fresh context
-5. **Decide** — fix blockers, defer nits, ship
+- **Product:** “Compare the evidence for these three product bets and help me place one bounded bet.”
+- **Infrastructure:** “Design the deployment boundary, then generate a reviewable Terraform plan. Do not apply it.”
+- **Catalogue owner:** “Initialize a catalogue for our organization and show me the contracts I need to customize.”
 
----
+## Step 4: inspect the result and boundary
 
-## What's next
+The first-value artifact should be something you can judge in minutes: a decision brief, architecture note, contract, tested diff, Terraform plan, documentation change, or release-readiness record. Check what the agent did, what remains unverified, and which decision it surfaced to a human.
 
-- [Install routes](install/) — CLI, Claude Plugins, APM, and local clone
-- [The three loops explained](three-loops/) — how discovery, build, and release compose
-- [Choose your packs](../packs/) — the full catalogue with one-liner descriptions
-- [Adapter support matrix](../guides/_shared/reference/adapter-support/) — what works in your agent
+## Continue
+
+- [Choose work by outcome and role](/agent-ready-repo/docs/).
+- [Browse every pack](/agent-ready-repo/docs/packs/).
+- [Compare install routes](/agent-ready-repo/docs/guides/_shared/explanation/install-routes/).
+- [Check adapter support](/agent-ready-repo/docs/guides/_shared/reference/adapter-support/).
+- [Install a profile](/agent-ready-repo/docs/guides/_shared/how-to/install-a-profile/).
+- [Understand the three loops](/agent-ready-repo/docs/getting-started/three-loops/).

--- a/docs-site/src/content/docs/getting-started/install.md
+++ b/docs-site/src/content/docs/getting-started/install.md
@@ -130,4 +130,4 @@ The pack's README documents which scope it defaults to. Override with `--scope u
 
 Installs never silently overwrite your edits. If a file you've modified would be overwritten, it lands as `<name>.upstream` instead — a companion file you merge at your own pace. Your edits are always preserved.
 
-[File safety contract explained](../guides/_shared/explanation/file-safety-contract/)
+[File safety contract explained](/agent-ready-repo/docs/guides/_shared/explanation/file-safety-contract/)

--- a/docs-site/src/content/docs/getting-started/three-loops.md
+++ b/docs-site/src/content/docs/getting-started/three-loops.md
@@ -31,7 +31,7 @@ The result isn't a validated solution — it's a **connected hypothesis with val
 
 **Three human consent gates:** G0 (ratify the value seed), G1.5 (ratify the MVP boundary), G2 (ratify the decision). The loop never auto-advances past an irreversible gate.
 
-[Discovery loop deep dive](../guides/product-engineering/explanation/the-discovery-loop/)
+[Discovery loop deep dive](/agent-ready-repo/docs/guides/product-engineering/explanation/the-discovery-loop/)
 
 ---
 
@@ -59,7 +59,7 @@ The loop scales by risk: **light mode** for low-risk work (lean inline spec, sin
 
 The security lens **shifts left**: on security-boundary work it also runs at spec stage, catching a missing control as a one-sentence acceptance criterion instead of a post-implementation round-trip.
 
-[Core pack deep dive](../guides/core/explanation/core-pack/)
+[Core pack deep dive](/agent-ready-repo/docs/guides/core/explanation/core-pack/)
 
 ---
 
@@ -82,7 +82,7 @@ The security lens **shifts left**: on security-boundary work it also runs at spe
 
 Deploy credentials are broker-mediated and scoped to the ephemeral tier only. No credential can reach prod.
 
-[Release loop deep dive](../guides/release-engineering/explanation/the-release-loop/)
+[Release loop deep dive](/agent-ready-repo/docs/guides/release-engineering/explanation/the-release-loop/)
 
 ---
 
@@ -95,4 +95,4 @@ The inner/outer split:
 - **Outer loops** (discovery, release) — run per feature or release cycle
 - **Feedback flows inward** — released findings return as build tasks; discovered constraints shape specs
 
-[The three loops as a system](../guides/_shared/explanation/the-three-loops/)
+[The three loops as a system](/agent-ready-repo/docs/guides/_shared/explanation/the-three-loops/)

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,80 +1,65 @@
 ---
-title: Reference documentation
-description: Pack reference, getting-started guides, and the full skill catalogue.
+title: Agent-ready catalogue documentation
+description: Choose, install, operate, and build catalogues of supervised agent workflows.
 hero:
-  tagline: Pack reference, getting-started guides, and the full skill catalogue. For an overview of the supervised loops and the pack catalogue, see the platform site.
+  tagline: Choose, install, operate, and build catalogues of supervised agent workflows. Start with the work you need to accomplish; pack names and installation details come next.
   actions:
-    - text: Getting started
+    - text: Choose a starting point
       link: /agent-ready-repo/docs/getting-started/
       icon: right-arrow
       variant: primary
-    - text: Browse packs
+    - text: Browse every pack
       link: /agent-ready-repo/docs/packs/
       icon: right-arrow
 ---
 
-import { Tabs, TabItem, CardGrid, Card } from '@astrojs/starlight/components';
+## Choose what you want to achieve
 
-## Quick install
+| I need to… | Start here |
+| --- | --- |
+| **Decide what to build** | [Product strategy](/agent-ready-repo/docs/guides/product-strategy/), [evidence-grounded research](/agent-ready-repo/docs/guides/desk-research/), then [product shaping](/agent-ready-repo/docs/guides/product-engineering/) |
+| **Design the product and system** | [Experience design](/agent-ready-repo/docs/guides/experience-design/), [architecture](/agent-ready-repo/docs/guides/architect/), [contracts](/agent-ready-repo/docs/guides/contracts/), and [frontend engineering](/agent-ready-repo/docs/guides/frontend-engineering/) |
+| **Build and review software** | The [`core` supervised work loop](/agent-ready-repo/docs/guides/core/) |
+| **Provision and release safely** | [Architecture](/agent-ready-repo/docs/guides/architect/), [Terraform planning](/agent-ready-repo/docs/guides/iac-terraform/), and [release engineering](/agent-ready-repo/docs/guides/release-engineering/) |
+| **Work with team systems and evidence** | [Atlassian](/agent-ready-repo/docs/guides/atlassian/), [GitHub](/agent-ready-repo/docs/guides/github/), [Linear](/agent-ready-repo/docs/guides/linear/), [Figma](/agent-ready-repo/docs/guides/figma/), and [converters](/agent-ready-repo/docs/guides/converters/) |
+| **Document what ships** | [Product documentation](/agent-ready-repo/docs/guides/product-documentation/) |
+| **Build and govern a catalogue** | [Create a catalogue](/agent-ready-repo/docs/guides/_shared/how-to/create-a-catalogue/), then apply the [authoring standards](/agent-ready-repo/docs/guides/_shared/reference/catalogue-authoring-standards/) |
 
-<Tabs>
-  <TabItem label="Flagship loop">
-    ```bash
-    python -m pip install agentbundle
-    agentbundle install --pack core
-    ```
-  </TabItem>
-  <TabItem label="With discovery">
-    ```bash
-    agentbundle install --pack core
-    agentbundle install --pack product-engineering --scope user
-    ```
-  </TabItem>
-  <TabItem label="Full inception profile">
-    ```bash
-    agentbundle install --profile inception
-    ```
-  </TabItem>
-  <TabItem label="Solution architect">
-    ```bash
-    agentbundle install --profile solution-architect
-    ```
-  </TabItem>
-</Tabs>
+The [`core` build loop](/agent-ready-repo/docs/guides/core/) is the catalogue's flagship and its strongest standalone product: spec and plan before code, mechanical gates before claims, a cold independent review before handoff, stasis detection when the loop stops making progress, and a human decision before merge. The catalogue extends that supervised-work model beyond coding; it does not dilute the build loop.
 
-## Packs
+## Choose by role
 
-**Supervised loops (start here):**
+- **Product manager or strategist:** [decide](/agent-ready-repo/docs/guides/product-strategy/), [research](/agent-ready-repo/docs/guides/desk-research/), and [shape](/agent-ready-repo/docs/guides/product-engineering/) before work reaches a delivery team.
+- **Platform, infrastructure, or SRE team:** [design the system](/agent-ready-repo/docs/guides/architect/), [author contracts](/agent-ready-repo/docs/guides/contracts/), [produce a reviewable infrastructure plan](/agent-ready-repo/docs/guides/iac-terraform/), and [stop at the production gate](/agent-ready-repo/docs/guides/release-engineering/).
+- **Engineer:** [start with `core`](/agent-ready-repo/docs/guides/core/), then add the domain pack the change needs.
+- **Designer or architect:** [design the experience](/agent-ready-repo/docs/guides/experience-design/) or [system](/agent-ready-repo/docs/guides/architect/); **researcher or analyst:** [start with evidence](/agent-ready-repo/docs/guides/desk-research/).
+- **AI enablement or catalogue owner:** [initialize an organization-owned catalogue](/agent-ready-repo/docs/guides/_shared/how-to/create-a-catalogue/) and govern what it distributes.
 
-| Pack | Scope | What it installs |
-|---|---|---|
-| [Core](packs/core/) | `repo` | `work-loop`, `new-spec`, `bug-fix`, specialist reviewers, hooks |
-| [Product Engineering](packs/product-engineering/) | `user` | `discovery-loop`, `frame-intent`, `de-risk-intent`, `decompose-intent` |
-| [Release Engineering](packs/release-engineering/) | `repo` | `release-loop`, `release-lead` |
+## Use a catalogue
 
-**User-scope packs (follow you across repos):**
+- [Get started](/agent-ready-repo/docs/getting-started/) with a path matched to your work.
+- [Compare install routes](/agent-ready-repo/docs/guides/_shared/explanation/install-routes/) and [adapter support](/agent-ready-repo/docs/guides/_shared/reference/adapter-support/).
+- [Browse every pack](/agent-ready-repo/docs/packs/) or [install a curated profile](/agent-ready-repo/docs/guides/_shared/how-to/install-a-profile/).
+- [Preview an install or upgrade](/agent-ready-repo/docs/guides/_shared/how-to/preview-install-or-upgrade/) before writing, then [upgrade safely](/agent-ready-repo/docs/guides/_shared/how-to/upgrade-packs/).
+- Using Claude? [Add this catalogue as a plugin marketplace](/agent-ready-repo/docs/getting-started/install/#route-2-claude-plugins) for user-scope packs. Repo-scoped packs such as `core` install with `agentbundle`.
 
-| Pack | What it installs |
-|---|---|
-| [Desk Research](packs/desk-research/) | `desk-research`, `source-map`, `compare-hypotheses`, `devils-advocate`, `decision-archaeology` |
-| [Architect](packs/architect/) | `architect-design`, `architect-diagram`, `architect-review`, `design-reviewer` subagent |
-| [Experience Design](packs/experience-design/) | Journey mapping, screen flows, creative direction, experience reviewers |
-| [Contracts](packs/contracts/) | `api-contract` (OpenAPI 3.1), `event-contract` (AsyncAPI) |
-| [Converters](packs/converters/) | PDF/DOCX/PPTX → Markdown, Markdown → HTML/Word/PowerPoint/Excel |
-| [Atlassian](packs/atlassian/) | `jira`, `jira-align`, `confluence-crawler`, `confluence-publisher`, `flow-metrics` |
-| [Figma](packs/figma/) | Figma REST API — files, frames, variables, FigJam → Mermaid |
-| [Credential Brokers](packs/credential-brokers/) | `credbroker`, `sso-broker`, `credential-setup` |
+## Build and operate a catalogue
 
-**Repo-scope packs (per-project conventions):**
+An organization can initialize a clean catalogue without forking this repository:
 
-| Pack | What it installs |
-|---|---|
-| [Governance Extras](packs/governance-extras/) | `new-rfc`, `new-adr`, `update-conventions` |
-| [Product Documentation](packs/product-documentation/) | `author-product-docs` (five-mode: create, revise, retrofit, audit, verify) |
-| [Monorepo Extras](packs/monorepo-extras/) | `new-package`, `packages/_example/` template |
+```bash
+agentbundle catalogue init my-catalogue --name my-catalogue
+agentbundle catalogue verify --root my-catalogue
+```
 
-## A foundation to build on
+- [Create the first valid catalogue](/agent-ready-repo/docs/guides/_shared/how-to/create-a-catalogue/).
+- [Understand packs, profiles, adapters, composition, and self-hosting](/agent-ready-repo/docs/guides/_shared/explanation/pack-catalogue/).
+- [Author against the portable standards](/agent-ready-repo/docs/guides/_shared/reference/catalogue-authoring-standards/).
+- [Implement the provider-neutral verify → package → publish contract](/agent-ready-repo/docs/guides/_shared/reference/catalogue-ci-contract/).
 
-Run `agentbundle catalogue init` to create a new catalogue from the managed scaffold — no fork required.
+## Understand and reference
 
-[How to build your org's catalogue](guides/_shared/how-to/build-an-org-stack-pack/)
+- [The three supervised loops](/agent-ready-repo/docs/getting-started/three-loops/) — discovery, build, release, and their human gates.
+- [The file-safety contract](/agent-ready-repo/docs/guides/_shared/explanation/file-safety-contract/) — how local edits survive installs and upgrades.
+- [`agentbundle` CLI reference](/agent-ready-repo/docs/guides/_shared/reference/agentbundle/) — exact commands and flags.
+- [Complete pack reference](/agent-ready-repo/docs/packs/) — generated from the current catalogue rather than maintained on this page.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -11,27 +11,23 @@
 ├── AGENTS.local.md       # repo-specific addendum — self-host drift rules etc.
 ├── packages/
 │   ├── agentbundle/      # the reference CLI + runtime library (Python, stdlib-only)
+│   ├── credbroker/       # credential resolver used by credentialed pack helpers
 │   └── _example/         # template package consumed by the new-package skill
-├── packs/                # the catalogue — one directory per shippable pack
-│   ├── core/             # the load-bearing pack; every other pack composes against it
-│   ├── governance-extras/
-│   ├── product-documentation/
-│   ├── monorepo-extras/
-│   ├── contracts/
-│   ├── converters/
-│   ├── atlassian/
-│   └── figma/
+├── packs/                # catalogue sources — one directory per pack
+├── profiles/             # curated single-scope combinations of packs
+├── guides/               # public adopter guidance, mirrored into the docs site
+├── contracts/            # portable TOML/JSON contracts and schemas
 ├── docs/
 │   ├── CHARTER.md        # mission, scope, principles
 │   ├── CONVENTIONS.md    # how we work
-│   ├── backlog.md        # open spec items, top-level index
 │   ├── rfc/              # proposals (governance)
 │   ├── adr/              # architecture decisions (frozen history)
 │   ├── specs/            # feature specs and plans
 │   ├── architecture/     # this directory — internals for contributors
-│   ├── contracts/        # adapter.toml, JSON schemas — the publishable spec
 │   ├── product/          # roadmap + changelog
-│   └── guides/           # Diátaxis: tutorials, how-to, reference, explanation
+│   └── guides/           # maintainer-only tooling and repository guidance
+├── web/                  # authored marketing and catalogue site
+├── docs-site/            # technical-doc shell; most content is generated
 ├── tools/                # build/lint/test scripts (.py preferred; .sh grandfathered)
 ├── .claude/              # Claude Code self-host projection — local only
 ├── .codex/               # Codex self-host agents + hook wiring — local only
@@ -53,29 +49,18 @@ Edit seeds under `packs/<pack>/.apm/...`, not these projections. See
 
 ## The catalogue
 
-`packs/` is a catalogue of reference packs. The relationship is
-"compose around `core`", not "subclass": every other pack assumes `core`'s
-seeds and reviewer-agents are available, but they don't import code from
-each other. Each pack's full metadata (license, maintainers, links,
-categories, keywords) lives in its `pack.toml` and is projected into the
-catalogue listing — see [`pack-manifest.md`](pack-manifest.md).
+`packs/` is the source catalogue. Each pack owns its manifest, portable
+primitives, tests, seeds, README, and journey; `profiles/` composes those packs
+without introducing new primitives. The complete current inventory belongs to
+the [generated catalogue](https://eugenelim.github.io/agent-ready-repo/catalogue/)
+and [technical pack reference](https://eugenelim.github.io/agent-ready-repo/docs/packs/),
+not to a hand-maintained architecture table.
 
-| Pack | Scope | Carries |
-| --- | --- | --- |
-| `core` | repo only | `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the four reviewer agents (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`, `implementer`), `session-start.py` + `pre-pr.py` hooks, `conventions-check`, `workspace-mcp` (per-session MCP server for harness-controlled sessions), layer-0 seeds (`AGENTS.md`, `docs/CHARTER.md`, `docs/CONVENTIONS.md`). |
-| `governance-extras` | repo only | `new-rfc`, `new-adr`, `update-conventions` skills + `docs/rfc/` and `docs/adr/` shapes. Requires `core`. |
-| `product-documentation` | repo or user | `author-product-docs` skill for creating, revising, retrofitting, auditing, and verifying product docs. No `core` dependency. `user-guide-diataxis@0.3.0` (deprecated compat pack) depends on this pack. |
-| `monorepo-extras` | repo only | `new-package` skill + `packages/_example/` template. Requires `core`. |
-| `contracts` | user (default) or repo | `api-contract` (OpenAPI 3.1) and `event-contract` (AsyncAPI). |
-| `converters` | user (default) or repo | Document/image → Markdown, Markdown → styled HTML, Outlook `.msg` → Markdown. |
-| `atlassian` | user (default) or repo | `jira`, `jira-align`, `confluence-crawler` (credentialed CLIs) + the `flow-metrics`, `ai-adoption-report`, `jira-defect-flow`, `jira-brief-intake`, `jira-align-brief-intake` workflows that compose them. |
-| `github` | user (default) or repo | `github-brief-intake` — turns a GitHub Milestone into a product brief and hands off to `receive-brief`. Uses the `gh` CLI; no credentialed-skill frontmatter. |
-| `figma` | user (default) or repo | `figma` credentialed CLI (REST API reads, frame renders, FigJam → Mermaid). |
-| `linear` | user (default) or repo | `linear` credentialed CLI (GraphQL reads: issues, projects, pagination) + `linear-brief-intake` and `linear-brief-sync` workflows that compose it with `receive-brief`. |
-| `research` | user (default) or repo | Seven research skills (scoping → synthesis → decision support) + two read-only retrieval subagents. |
-| `architect` | user (default) or repo | `architect-design`, `architect-diagram`, `architect-review` (Mermaid + Google-style design docs). |
-| `credential-brokers` | user (default) or repo | `credentials_shim`, the `sso-broker` subprocess, and the `credential-setup` skill — user-scope credential brokering for credentialed packs. |
-| `product-engineering` | user (default) or repo | `frame-intent`, `de-risk-intent`, `decompose-intent` — shaping product intent into shippable specs. |
+[`core`](../../guides/core/explanation/core-pack.md) is the flagship build
+system. Other packs may depend on it, integrate with it, or remain independently
+useful; composition is declared in `pack.toml`, not inferred from directory
+adjacency. Each pack's full metadata lives in that manifest and is projected
+into catalogue listings — see [`pack-manifest.md`](pack-manifest.md).
 
 What it means for `core` to be load-bearing: its
 `session-start.py` is the single read-side of the install→adapt chain —

--- a/docs/specs/catalogue-wave8-readme-contributing/plan.md
+++ b/docs/specs/catalogue-wave8-readme-contributing/plan.md
@@ -1,6 +1,7 @@
 # Plan: catalogue-wave8-readme-contributing
 
-- **Status:** Drafting
+- **Status:** Done
+- **Superseded by:** [`documentation-entry-navigation`](../documentation-entry-navigation/plan.md)
 - **Spec:** [`spec.md`](spec.md)
 
 ## Mode and declined patterns
@@ -71,12 +72,12 @@ subsection:
 ```markdown
 ### Evaluate or build a catalogue
 
-**Evaluating?** The [portable authoring hub](guides/_shared/reference/catalogue-authoring-standards.md)
+**Evaluating?** The [portable authoring hub](../../../guides/_shared/reference/catalogue-authoring-standards.md)
 explains the catalogue structure, available contracts, and how to assess whether the
 catalogue model fits your organisation's needs.
 
 **Building?** Run `agentbundle catalogue init <target>` to scaffold a new catalogue in
-`<target>`. See [Create a catalogue](guides/_shared/how-to/create-a-catalogue.md) for
+`<target>`. See [Create a catalogue](../../../guides/_shared/how-to/create-a-catalogue.md) for
 a walkthrough.
 ```
 
@@ -178,7 +179,7 @@ prominent note before the numbered steps:
 
 ```markdown
 > Before starting: familiarise yourself with the
-> [portable authoring standards](guides/_shared/reference/catalogue-authoring-standards.md)
+> [portable authoring standards](../../../guides/_shared/reference/catalogue-authoring-standards.md)
 > — it covers the expected pack structure, JOURNEY.md convention, and contract files.
 ```
 
@@ -200,7 +201,7 @@ prominent note before the numbered steps:
 Locate the "Where to find authoritative information" table. Add a new row:
 
 ```markdown
-| Catalogue authoring standards and contracts | [`guides/_shared/reference/catalogue-authoring-standards.md`](guides/_shared/reference/catalogue-authoring-standards.md) |
+| Catalogue authoring standards and contracts | [`guides/_shared/reference/catalogue-authoring-standards.md`](../../../guides/_shared/reference/catalogue-authoring-standards.md) |
 ```
 
 **Done when:** Within the "Where to find authoritative information" table section,
@@ -226,7 +227,7 @@ In the `### Adding a new pack` section, after the main numbered steps, add a not
 **Optional cross-pack composition:** If the pack declares optional composition with other
 packs, add `[[pack.integrations]]` entries to `pack.toml`. The `[[pack.integrations]]`
 convention shipped with Wave 2 (0.27.0); see the
-[authoring hub](guides/_shared/reference/catalogue-authoring-standards.md) for the
+[authoring hub](../../../guides/_shared/reference/catalogue-authoring-standards.md) for the
 full contract spec.
 ```
 

--- a/docs/specs/catalogue-wave8-readme-contributing/spec.md
+++ b/docs/specs/catalogue-wave8-readme-contributing/spec.md
@@ -1,6 +1,7 @@
 # Spec: catalogue-wave8-readme-contributing
 
-- **Status:** Approved
+- **Status:** Archived
+- **Superseded by:** [`documentation-entry-navigation`](../documentation-entry-navigation/spec.md) — the replacement removes the hand-maintained README pack table, migrates its adopter information to canonical public surfaces, and absorbs this spec's CONTRIBUTING requirements.
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0076 D1–D4](../../rfc/0076-catalogue-contracts-composition-semantics-discovery.md)
@@ -9,6 +10,9 @@
 
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.
+
+> Archived before implementation on 2026-08-12. The replacement spec is the
+> authoritative contract; the unchecked criteria below remain historical.
 
 Mode: full (public interface: README.md and CONTRIBUTING.md are public-facing documents;
 structural: adds a named section to README.md)
@@ -123,7 +127,7 @@ change is required; this wave touches documentation only.
 - [ ] AC2: The subsection heading `### Evaluate or build a catalogue` produces
   an anchor that is reachable via the README navigation link strip at the top of
   the file (or the navigation link strip is updated to include it). Either the
-  existing `[The Catalogue](#the-catalogue)` link covers it, or a new link is
+  then-existing `The Catalogue` README link covers it, or a new link is
   added — either is acceptable; do not add a link that does not resolve.
 
 ### Phase B — README.md: Fork language and pack table

--- a/docs/specs/documentation-entry-navigation/notes/information-architecture.md
+++ b/docs/specs/documentation-entry-navigation/notes/information-architecture.md
@@ -1,0 +1,444 @@
+# Cross-surface information architecture
+
+## Product model
+
+The catalogue is the product. Packs are composable units inside it, profiles are
+curated combinations, `agentbundle` is the distribution mechanism, and this
+repository's self-hosted projections are working proof that the system can govern
+itself across agent adapters.
+
+`core` remains the flagship pack because supervised build work is the shortest,
+most legible demonstration of the model. It is an entry hook, not the taxonomy
+for the rest of the catalogue.
+
+## Reader problem
+
+The current public surfaces organize discovery around internal objects:
+
+- the root README moves from the three loops into a partial pack table;
+- `/catalogue/` presents one flat, SDLC-ordered pack grid;
+- `/journeys/` presents another pack-name grid;
+- the docs landing page divides packs mainly by install scope;
+- `guides/README.md` contains role routing, loop routing, a complete pack
+  inventory, shared guides, and guide-author instructions on one page.
+
+A reader must already know that `product-engineering` is where ambiguous product
+work is shaped, or that `architect` + `contracts` + `iac-terraform` +
+`release-engineering` form a useful infrastructure path. Product managers and
+infrastructure teams therefore fail before pack quality matters: they do not
+recognize their job in the navigation.
+
+## IA principles
+
+1. Lead with the change the reader wants, then reveal the packs that produce it.
+2. Preserve packs as the stable implementation and installation layer.
+3. Let a pack appear in more than one outcome path; the catalogue is
+   many-to-many, not a folder taxonomy.
+4. Keep self-hosting visible as a first-class product capability, not a
+   contributor footnote.
+5. Give each surface one job: marketing creates recognition, the catalogue helps
+   readers choose, docs help them act, and source-control pages expose authority.
+6. Keep every primary journey within two navigation actions of its entry hub.
+7. Use the same outcome names across the website, docs, and GitHub README while
+   allowing each surface to change density.
+8. Keep the raw all-packs index available for readers and agents who already know
+   what they need.
+9. Author a fact once and project or link to it elsewhere. A public surface may
+   summarize a canonical source, but it must not become a second handbook.
+
+## Reduced surface model
+
+The documentation system should have four public jobs and one private job. This
+is a smaller model than treating every repository landing page as an independent
+documentation product.
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| Marketing site | Recognition, outcome promises, proof, and the self-hosted catalogue story | Installation detail, exhaustive pack inventory, contributor procedure |
+| Catalogue | Choosing a pack, profile, or outcome path from the complete inventory | Long-form teaching or repository internals |
+| Technical docs site | Getting started, task guidance, system explanation, and reference | Repeating the marketing argument or maintaining a second pack inventory by hand |
+| GitHub README | Identifying the project and routing users, evaluators, and contributors to the right surface | The catalogue table, full operating-model explanation, or complete install/reference docs |
+| Contributor repository pages | Source ownership, architecture, contracts, authoring, build, and governance procedure | Public acquisition copy |
+
+The source-to-surface flow is therefore:
+
+```text
+Canonical source                         Presentation
+──────────────────────────────────────   ─────────────────────────────────────
+packs/*/README.md ─────────────────────► pack detail in the technical docs
+guides/** ──────────────────────────────► adopter guides in the technical docs
+pack.toml + JOURNEY.md ─────────────────► catalogue cards and journey evidence
+docs-site authored entry pages ─────────► technical orientation and getting started
+web authored pages ─────────────────────► marketing and catalogue discovery
+docs/** + CONTRIBUTING.md ──────────────► contributor and architecture off-ramps
+README.md ──────────────────────────────► repository router only
+```
+
+This model deliberately does not project the root README into either website.
+The README and the sites serve different reading contexts. They should share a
+message hierarchy and link to the same canonical facts, not reuse a long body of
+copy that fits none of the contexts well.
+
+## README benchmark
+
+The useful pattern in strong developer-tool repositories is not merely brevity;
+it is decisive off-ramping:
+
+- [OpenAI Codex](https://github.com/openai/codex/blob/main/README.md) uses a
+  one-sentence definition, routes adjacent product variants immediately, offers
+  one quickstart, and ends with four documentation links. Its source README is
+  72 lines.
+- [Terraform](https://github.com/hashicorp/terraform/blob/main/README.md) keeps
+  its 38-line README to a value summary, core features, public learning routes,
+  and contributor routes.
+- [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/README.md)
+  makes the audience split explicit with “start using” and “start developing”
+  routes instead of combining both journeys.
+- [Awesome Copilot](https://github.com/github/awesome-copilot) is the closest
+  catalogue analogue: its README directs readers to the searchable website and
+  uses a compact resource-type table instead of embedding the full collection.
+- [uv](https://github.com/astral-sh/uv) demonstrates the opposite trade-off: a
+  persuasive feature-rich README can work for a single CLI, but its long inline
+  feature manual is not the right model for a multi-pack catalogue with separate
+  marketing and documentation sites.
+
+The target root README should be materially shorter than its current 156 lines
+and contain only:
+
+1. one definition and one proof sentence;
+2. three primary routes: find work, start using, and browse the catalogue;
+3. the supervised build loop as a compact flagship example;
+4. one supported quickstart, with alternatives off-ramped to the docs;
+5. one short statement that the catalogue is composable and self-hostable;
+6. contributor, architecture, security, and license links.
+
+The full pack table, testimonial, detailed three-loop explanation, adapter
+matrix, alternate installation procedures, and ecosystem tour move to their
+existing canonical homes rather than being rewritten below the fold.
+
+## Entry-surface copy direction
+
+The public entry surfaces use **flagship first, breadth immediately visible**.
+`core` leads with its earned differentiation—spec discipline, mechanical gates,
+cold independent review, stasis detection, and a human merge decision. The
+catalogue follows immediately as the way that supervised-work model reaches
+other software-product jobs. This avoids both failure modes: reducing the
+product to a generic catalogue, or implying that the build loop is all it does.
+
+Ranked copy goals:
+
+1. **Earned specificity** — lead with mechanics a skeptical engineer can verify,
+   not “best-in-class” or another unsupported superlative.
+2. **Flagship conviction** — describe `core` as the strongest standalone reason
+   to adopt, not a quick demo that can be mentally discarded after evaluation.
+3. **Breadth without dilution** — show product, design, infrastructure, release,
+   research, documentation, and catalogue work immediately after the flagship.
+4. **Plain-language orientation** — use reader vocabulary before pack names or
+   catalogue implementation terms.
+
+The dominant goal is earned specificity. When forceful promotion conflicts with
+proof, the verifiable mechanism wins. When brevity conflicts with catalogue
+breadth above the fold, `core` gets the detailed claim and breadth gets one
+compact sentence plus the use-case route. These goals are directional: the
+adopter research grounds audience needs, but the repo contains no direct VoC
+verbatim supporting comparative “best” language.
+
+### Navigation-label pressure test
+
+| Candidate | Result |
+| --- | --- |
+| **Find your work** | Reject: vague, internally framed, and easily read as employment navigation |
+| **Choose an outcome** | Accurate but abstract; sounds like IA language rather than a product invitation |
+| **Explore workflows** | Reveals the implementation object before the reader recognizes their need |
+| **What it can do** | Plain, but weak as a durable primary-navigation noun |
+| **Use cases** | Select: familiar, compact, high-scent, and compatible with outcome-first cards |
+
+The primary-navigation label is **Use cases**. Longer CTA copy may say “Explore
+use cases”; headings can ask what the reader wants to achieve. The shared anchor
+is `#use-cases` so public links do not preserve the rejected phrase in the URL.
+
+## The portable guide tree
+
+`guides/` is catalogue-facing source content. It must remain useful when read
+outside this repository's contributor context, and the docs-site build already
+mirrors it into the public technical site. That makes it the right canonical
+home for adopter tutorials, how-tos, reference, and explanation—not another
+marketing or contributor surface.
+
+`guides/README.md` should shrink from a combined role router, loop explainer,
+manual pack inventory, shared-guide index, and authoring manual into a portable
+catalogue guide index:
+
+1. choose a recognizable outcome;
+2. understand shared versus pack-specific guidance;
+3. reach the complete generated pack index;
+4. follow one link to the guide-authoring contract.
+
+The generated docs sidebar and catalogue own exhaustive discovery. The guide
+root should not hand-maintain a second list of every pack. Contributor-only
+instructions move to `docs/guides/` or `CONTRIBUTING.md`; portable catalogue
+authoring rules remain under `guides/_shared/reference/` and are linked once.
+
+### Packaging contract gap
+
+The current source-package allowlist includes `packs/`, `profiles/`, conformance
+tests, `guides/_shared/`, the marketplace manifest, and a small set of root
+files. It does **not** include pack-specific guide trees. Two shared guide
+references are also copied into the catalogue-authoring scaffold, and the
+docs-site build mirrors the full guide tree, but a packaged catalogue archive
+does not currently carry that full tree.
+
+Documentation must not claim that `guides/` ships in the archive until that
+behavior changes. If “adopter catalogues receive the full guide tree” is the
+intended product contract, it is a separate `agentbundle` packaging change with
+tests and release implications; the navigation work can make the content
+portable without silently changing distribution behavior.
+
+## Consolidation map
+
+| Current repeated content | Canonical destination | Root README treatment |
+| --- | --- | --- |
+| Product argument and testimonial | Marketing home | One definition and proof link |
+| Full three-loop explanation | Shared explanation guide | One flagship example and “how it works” link |
+| All-pack table | Generated catalogue and pack index | “Browse the catalogue” link |
+| Install alternatives and adapter detail | Technical getting-started and reference | One quickstart plus “other routes” link |
+| Outcome and role discovery | Marketing/catalogue outcome hub | Four compact outcome links |
+| Pack task guidance | `guides/<pack>/` | No duplication |
+| Catalogue authoring standards | Shared reference plus `packs/README.md` | “Build your own catalogue” link |
+| Repo architecture and contracts | `docs/architecture/` and `contracts/` | Evaluator/contributor off-ramp |
+| Guide author instructions | Portable shared reference or maintainer docs | No duplication |
+
+## Discovery axes
+
+The surfaces need four axes, but no single navigation control should carry all
+four.
+
+| Axis | Reader question | Primary home |
+| --- | --- | --- |
+| Outcome | What can this help me accomplish? | Marketing and catalogue hub |
+| Role | Is there a path for someone like me? | Guide hub and catalogue cross-links |
+| System | How do packs, profiles, adapters, and self-hosting fit? | Catalogue explanation and architecture |
+| Inventory | What exactly ships and how do I install it? | Pack index and pack detail |
+
+Install scope, adapter support, skill count, and dependency facts are filters or
+reference attributes. They are not first-level navigation.
+
+## Outcome hubs
+
+These hubs describe recognizable work. They are curated paths over the pack
+inventory, not mutually exclusive categories.
+
+| Outcome hub | Recognizable promise | Core pack path |
+| --- | --- | --- |
+| Decide what to build | Turn strategy, evidence, and an uncertain idea into a decision a delivery team can act on | `product-strategy` → `desk-research` → `product-engineering` |
+| Design the product and system | Move from customer intent through experience, architecture, interfaces, and an implementable surface | `experience-design` + `architect` + `contracts` + `frontend-engineering` |
+| Build and review software | Take a brief or spec through implementation, mechanical gates, and independent review | `core`, with `contracts`, `frontend-engineering`, `monorepo-extras`, and `governance-extras` as needed |
+| Provision and release safely | Make infrastructure and release decisions explicit, generate reviewable IaC, rehearse the deployment, and stop before irreversible action | `architect` → `contracts` → `iac-terraform` → `release-engineering`, supervised by `core` |
+| Work with team systems and evidence | Pull real work and source material into the agent without hiding provenance or mutation | `atlassian`, `github`, `linear`, `figma`, `desk-research`, `converters`, `credential-brokers` |
+| Document what ships | Create, restructure, and verify product documentation against canonical behavior | `product-documentation`, supported by `converters` and the owning domain pack |
+| Build and govern a catalogue | Create an organization-owned catalogue, author packs and profiles, validate contracts, publish it, and safely evolve local adaptations | `catalogue-curation` + `governance-extras` + `product-documentation`, distributed by `agentbundle` |
+
+The deprecated `user-guide-diataxis` compatibility pack stays out of discovery
+and remains findable only in the complete inventory and migration reference.
+
+## Role map
+
+Roles are secondary shortcuts into the outcome hubs. They should not own separate
+copies of the same documentation.
+
+| Role | Default entry | Likely adjacent hubs |
+| --- | --- | --- |
+| Product manager or strategist | Decide what to build | Team systems and evidence; document what ships |
+| Software engineer | Build and review software | Design the system; provision and release |
+| Platform, infrastructure, or SRE team | Provision and release safely | Build and review; build and govern a catalogue |
+| Architect | Design the product and system | Provision and release; decide what to build |
+| Designer or UX practitioner | Design the product and system | Decide what to build; document what ships |
+| Researcher or analyst | Team systems and evidence | Decide what to build; document what ships |
+| Engineering or AI-adoption champion | Build and review software as proof | Build and govern a catalogue; provision and release |
+| Catalogue maintainer | Build and govern a catalogue | All outcome hubs as the catalogue's customers |
+| Coding agent | Complete inventory and machine contracts | The task and source-of-truth links named by the current artifact |
+
+Self-service, specialist-assisted enterprise, champion-led rollout, and
+under-supported mid-market adoption remain arrival pathways. They change the
+amount of guidance and proof a role needs; they do not create new role pages.
+
+## Target surface tree
+
+```text
+Marketing site /
+├── Hook: governed agent work across the software lifecycle
+├── Flagship product: supervised brief/spec → reviewed change
+├── Use cases: outcome hubs
+├── See the system: packs + profiles + adapters + human gates
+├── Own the system: create and self-host a catalogue
+└── Start: try the flagship loop or choose another outcome
+
+Catalogue /catalogue/
+├── Browse by outcome
+│   ├── Decide what to build
+│   ├── Design the product and system
+│   ├── Build and review software
+│   ├── Provision and release safely
+│   ├── Work with team systems and evidence
+│   ├── Document what ships
+│   └── Build and govern a catalogue
+├── Browse by role
+├── Start with a profile
+├── Understand the catalogue system
+└── Browse every pack
+    └── Pack detail /packs/<pack>/
+        ├── Outcome and suitable readers
+        ├── Natural-language starter request
+        ├── Expected result and human decision
+        ├── Install routes, scope, dependencies, and safety boundary
+        ├── Journey /journeys/<pack>/
+        └── Guides /docs/guides/<pack>/
+
+Documentation /docs/
+├── Start
+│   ├── Choose a starting outcome
+│   ├── Install and verify
+│   └── Understand the three-loop operating model
+├── Accomplish a task
+│   ├── Outcome hubs
+│   └── Role shortcuts
+├── Use and operate the catalogue
+│   ├── Packs and profiles
+│   ├── Install, upgrade, adapters, and file safety
+│   └── Credentials and integrations
+├── Build a catalogue
+│   ├── Initialize a catalogue
+│   ├── Author packs, skills, profiles, and journeys
+│   ├── Validate, package, and publish
+│   └── Contracts and schemas
+├── Understand the system
+│   ├── Catalogue composition and self-hosting
+│   ├── Three loops and human gates
+│   └── Architecture and security model
+└── Reference
+    ├── Complete pack and skill reference
+    ├── CLI and adapter reference
+    ├── Contracts
+    ├── Changelog
+    └── Contributing
+
+GitHub repository README.md
+├── Hook + flagship product case
+├── Choose an outcome
+│   └── guides/README.md
+├── Browse the catalogue
+│   └── public catalogue + pack guide homes
+├── Use or build a catalogue
+│   ├── getting-started and install guides
+│   └── packs/README.md + authoring standards
+├── Inspect why it is trustworthy
+│   ├── docs/architecture/README.md
+│   └── contracts/README.md
+└── Contribute
+    └── CONTRIBUTING.md
+```
+
+## GitHub two-level contract
+
+The root README is an orientation and routing page. It should not reproduce the
+complete guide index or pack reference.
+
+| Root destination | Level 1 job | Required level 2 destinations |
+| --- | --- | --- |
+| `guides/README.md` | Route by outcome and role | Pack guide homes, shared installation guidance, three-loop explanation |
+| `packs/README.md` | Explain how to author a pack in a catalogue | Authoring standards, pack schema, example pack, verification contract |
+| `profiles/README.md` | Explain curated multi-pack starting sets | Profile schema, example profile, install-profile guide |
+| `docs/architecture/README.md` | Explain the self-hosted system as built | Catalogue, pack layout, projections, CLI, credentials, security |
+| `contracts/README.md` | Expose machine authority | Each schema plus the human authoring standard that consumes it |
+| `CONTRIBUTING.md` | Route repository changes by ownership | Pack authoring, package work, docs work, gates |
+
+Each level 1 page should state its audience and job in its first paragraph,
+offer one likely next action, and avoid sending an external adopter into
+maintainer-only architecture unless they explicitly chose to inspect the system.
+
+## Surface navigation contracts
+
+### Marketing
+
+The initial hook is the supervised build loop because it demonstrates the
+catalogue's operating model in one concrete flow. The next visible section must
+broaden immediately to outcome hubs so the hook is not mistaken for the product
+boundary.
+
+Recommended primary navigation:
+
+```text
+How it works | Use cases | Catalogue | Docs | [Try the build loop]
+```
+
+`Journeys` leaves top-level navigation. Journeys remain valuable evidence from
+pack detail and outcome paths, but a visitor who does not know pack names cannot
+use them as a primary wayfinding category.
+
+### Catalogue
+
+Outcome and role routing appears before the complete pack grid. The complete grid
+remains canonical and filterable. Cards should answer “what change does this
+produce?” before skill count or install syntax.
+
+### Documentation
+
+The corpus is at the upper edge of hub-and-spoke scale. The landing page acts as
+an orientation map and gives search first-screen prominence. Sidebar groups may
+remain pack-based for stable lookup, but the landing and guide hub must provide
+outcome and role paths that cross those groups.
+
+### GitHub
+
+The README uses an F-pattern: the opening, outcome headings, and first sentence
+of each section carry the argument. Its “what next” chain prioritizes action and
+deeper system inspection, not an exhaustive list of equal-weight links.
+
+## Content-depth rules
+
+| Level | Answers | Excludes |
+| --- | --- | --- |
+| Entry | Why should I care, and where do I start? | Full inventories, schema detail, maintainer procedure |
+| Hub | Which path fits my outcome or role? | Exhaustive behavior and implementation history |
+| Detail | What exactly does this pack, workflow, or contract do? | Cross-catalogue persuasion |
+| Reference | What are the exact fields, commands, limits, and boundaries? | Marketing narrative |
+
+## Current-route implementation order
+
+The first implementation can establish this architecture without adding a new
+top-level route:
+
+1. Reframe `README.md` around catalogue breadth, self-hosting, the flagship
+   proof, and outcome routing.
+2. Rework `guides/README.md` into the outcome-and-role hub; move guide-author
+   instruction lower or link it to maintainer documentation.
+3. Rework `/catalogue/` so outcome and role sections precede the complete pack
+   grid.
+4. Rework `/docs/` as an orientation map with prominent search and explicit
+   “use” versus “build a catalogue” paths.
+5. Update marketing navigation to point at the outcome hub and treat journeys as
+   contextual evidence.
+6. Verify `docs/architecture/README.md` and `contracts/README.md` honor the
+   GitHub two-level contract; edit only if the new root routes expose a material
+   gap. Defer `packs/README.md` and `profiles/README.md` copy changes because
+   their authoring-scaffold projections require an `agentbundle` release. Their
+   existing procedures remain the canonical destinations in this iteration.
+
+Pack READMEs, pack guides, and journey bodies are a later systematic pass unless
+the entry-surface rewrite exposes a broken or contradictory immediate link.
+
+## Validation questions
+
+- Can a product manager find “turn an uncertain idea into a buildable decision”
+  without knowing a pack name?
+- Can an infrastructure team see the architecture → contract → IaC → rehearsal
+  → human release path from one hub?
+- Can an engineer try the flagship build loop without first reading the whole
+  catalogue model?
+- Can a platform owner find self-hosting, authoring standards, contracts, and CI
+  within two actions?
+- Can a specialist find a familiar outcome before encountering `pack`, `skill`,
+  or `scope` vocabulary?
+- Can a coding agent trace every human summary to a machine or canonical source?
+- Does every hub expose the complete inventory without forcing every reader
+  through it?

--- a/docs/specs/documentation-entry-navigation/notes/verification.md
+++ b/docs/specs/documentation-entry-navigation/notes/verification.md
@@ -1,0 +1,74 @@
+# Verification record
+
+Verified 2026-08-12 against the authored sources in this change.
+
+## Passed
+
+- `README.md` is 65 lines; the negative-content check found no testimonial,
+  all-packs table, adapter matrix, full three-loop walkthrough, or adopt-by-fork
+  instruction.
+- `workspace.toml` parses with Python `tomllib`; Wave 8 is archived, this spec
+  is shipped, and the Wave 6–9 dependency chain retains its future work.
+- `python3 tools/validate_guides.py` exits 0 with 0 errors. Its 161 frontmatter
+  migration warnings are pre-existing corpus-wide warnings rather than failures.
+- `python3 tools/check-guide-index.py` exits 0 and confirms direct guide-home
+  coverage for all 20 active packs.
+- `python3 tools/test_check_guide_index.py` exercises successful and missing-pack
+  exit codes and rejects links that are not direct guide-home routes.
+- `python3 tools/test_catalogue_navigation.py` confirms all 20 active packs have
+  an outcome, both marketing surfaces import the shared map, role anchors
+  resolve, and the guide and technical-doc entry pages retain the seven outcome
+  labels.
+- `python3 tools/test_documentation_entry_links.py` resolves the edited
+  README, contribution, guide, technical-doc, architecture, and spec links
+  against authored local files, source-backed GitHub Pages docs routes,
+  source-backed marketing routes, and homepage anchors.
+- `python3 tools/test_build_site_link_rewrites.py` confirms mirrored
+  same-directory, parent-index, cross-pack, frontmatter-slug, and
+  contributing-to-guide links become base-qualified technical-doc routes rather
+  than nesting under the current rendered page. Its corpus case rewrites every
+  guide plus `CONTRIBUTING.md` and confirms every emitted technical-guide link
+  resolves to a canonical projected route.
+  The same suite confirms guide route metadata rejects `..`, non-guide paths,
+  and non-string slugs before frontmatter can influence generated routes.
+- `ruff check --no-cache tools/build-site.py tools/check-guide-index.py
+  tools/test_check_guide_index.py tools/test_catalogue_navigation.py
+  tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py`
+  exits 0.
+- `git diff --check` exits 0.
+- The complete writable build (`make site-build`) succeeds. A generated-HTML
+  crawl resolves 3,098 internal links and fragments across the 12 changed entry,
+  contributor, catalogue, core, changelog, and immediate Get Started pages with
+  zero failures.
+- The same whole-site crawl checked 53,871 internal links across 263 pages and
+  isolated 67 older failures in unchanged pages (60 legacy-guide, 7 other).
+  Their source remediation plus a rendered-link CI gate is captured atomically
+  as `rendered-site-link-debt`; they are not represented as regressions or as
+  passed by this change.
+- The complete catalogue grid remains data-driven through
+  `getCollection('packs')`; the editorial outcome maps do not replace it.
+- Homepage and catalogue outcome membership, role routes, and anchors share
+  `web/src/lib/catalogue-navigation.ts`; the two surfaces cannot silently assign
+  different packs to the same outcome.
+- The catalogue grid routes to pack detail pages without duplicating install
+  commands; those mechanics remain at the detail layer.
+- Contextual journey links remain in loop and pack surfaces after Journeys was
+  removed from primary navigation.
+
+## Environment-blocked
+
+- `python3 tools/build-site.py --dry-run` is not currently side-effect-free: it
+  attempts to create `docs-site/src/content/docs/packs` before route generation,
+  and this workspace rejects that write. The defect is captured as
+  `build-site-dry-run-write-free` in the repository backlog.
+- Full marketing and technical-site builds required user-run generated-output
+  writes; the user completed the final build successfully and the rendered
+  output was audited afterward.
+- Pytest cannot initialize because its output capture asks `tempfile` for a
+  writable directory. The pure-stdlib construction suites run directly instead;
+  they pass.
+- Browser-based responsive and visual QA is unavailable because this session
+  exposes no browser-control runtime.
+
+The blocked gates are not represented as passed. Source-level route, anchor,
+inventory, syntax, lint, and link checks cover the changed navigation contract.

--- a/docs/specs/documentation-entry-navigation/plan.md
+++ b/docs/specs/documentation-entry-navigation/plan.md
@@ -1,0 +1,187 @@
+# Plan: documentation-entry-navigation
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+- **Mode:** full
+
+## Approach
+
+Reduce the documentation surface by moving the argument outward and the detail
+downward. The root README becomes a router. Existing marketing, catalogue,
+technical-doc, and guide routes become the destinations, strengthened before
+their duplicated README content is removed.
+
+The change keeps current routes and visual systems. It edits only authored
+sources: generated guide navigation, generated pack pages, adapter projections,
+and build output remain untouched.
+
+## Task sequence
+
+### T1 — Reconcile governance ownership
+
+**Depends on:** none  
+**Verification mode:** goal-based check  
+**Tests/artifacts:** `workspace.toml` TOML parse; unique-slug grep; archived-spec
+header inspection; ini-007 dependency inspection.
+
+- Archive `catalogue-wave8-readme-contributing` with a `Superseded by` link.
+- Update ini-007 in `workspace.toml`: complete the active IA design item, make
+  this spec the current-route implementation owner, archive Wave 8, and point
+  Wave 9's former Wave 8 dependency here.
+- Preserve Waves 6 and 7 with narrowed cold-start comments for the work still
+  gated on Wave 4: neutral-index/generated-reference consumption, deep
+  catalogue-builder navigation, `/evaluate/`, and integration relationships.
+- Verify the confirmed `catalogue-package-guides` repo backlog item exists once
+  with its cold-start context; append it only if absent.
+
+**Verify:** no dependency points to the archived Wave 8 spec; the current-route
+owner is singular; every index-dependent Wave 6–7 deliverable remains queued;
+TOML remains parseable.
+
+### T2 — Establish complete public destinations
+
+**Depends on:** none  
+**Verification mode:** goal-based check + visual/manual QA  
+**Tests/artifacts:** content-migration matrix inspection;
+`tools/validate_guides.py`; `tools/check-guide-index.py`; changed-guide link
+target inventory.
+
+- Tighten `guides/_shared/explanation/pack-catalogue.md` where needed so it
+  explains packs, profiles, adapters, composition, ownership, and self-hosting.
+- Confirm the existing three-loop, install-route, adapter-support,
+  profile-install, preview, and upgrade pages contain the facts the README will
+  stop carrying; amend only gaps.
+- Replace `guides/README.md` with a compact outcome-and-role hub plus one
+  authoring-contract link.
+- Generalize `tools/check-guide-index.py` from an “All packs” table parser to
+  direct pack-guide-home coverage so the gate preserves completeness without
+  prescribing the old layout.
+
+**Verify:** every migration-contract destination exists and has an actionable
+next link; guide validation and index checks pass where runnable.
+
+### T3 — Make the technical docs the action hub
+
+**Depends on:** T2  
+**Verification mode:** goal-based check + visual/manual QA  
+**Tests/artifacts:** authored-route existence script; source walkthroughs for
+product manager, infrastructure/SRE, engineer, and catalogue owner; relevant
+`tools/test_build_site_routing.py` and `tools/test_build_site_sidebar.py` tests
+where runnable.
+
+- Rework `docs-site/src/content/docs/index.mdx` into outcome-first task routes,
+  role shortcuts, “use” versus “build and operate” catalogue paths, and concise
+  reference off-ramps.
+- Update `docs-site/src/content/docs/getting-started/index.mdx` so product and
+  infrastructure teams can choose a credible first path alongside the flagship
+  build loop.
+- Keep the generated pack index and generated guide sidebar as the exhaustive
+  inventory; do not duplicate them on the landing page.
+
+**Verify:** page source contains each required role/outcome route and every
+local route target is backed by an authored or generated source.
+
+### T4 — Make marketing reveal catalogue breadth
+
+**Depends on:** T2  
+**Verification mode:** goal-based check + visual/manual QA  
+**Tests/artifacts:** `astro:content` inventory-source grep; `withBase()` route
+check; source walkthroughs for product manager, infrastructure/SRE, and
+catalogue owner; existing web unit tests where runnable.
+
+- Reframe the hero so it names the catalogue/system while retaining supervised
+  build work as the primary proof.
+- Replace the homepage's hand-maintained pack preview with outcome paths backed
+  by pack links and a route to the complete catalogue.
+- Update primary navigation to “Use cases,” Catalogue, Docs, and a
+  supervised-loop CTA; remove Journeys from primary navigation only.
+- Add outcome and role discovery before the complete data-driven grid on
+  `/catalogue/`.
+- Replace adopt-by-forking copy in the organization closer with the
+  `agentbundle catalogue init` and self-host model.
+
+**Verify:** the catalogue grid still derives from `getCollection('packs')`;
+product-management and infrastructure routes occur before it; existing journey
+pages remain linked from contextual surfaces.
+
+### T5 — Cut and reroute the README and contributor page
+
+**Depends on:** T2, T3, T4  
+**Verification mode:** goal-based check  
+**Tests/artifacts:** README line count; removed-content grep; Markdown target
+inventory; CONTRIBUTING authoring-source grep; completed content-migration
+matrix.
+
+- Rewrite `README.md` to the approved ≤90-line router contract only after T2–T4
+  destinations are complete.
+- Update `CONTRIBUTING.md` with the absorbed Wave 8 requirements and remove the
+  obsolete root-pack-table instruction. Add a short public-doc/source
+  orientation and decision chain for people changing the repository.
+- Check every migration-contract row against its destination after the cut.
+
+**Verify:** README line/count and negative-content checks; all root routes
+resolve; CONTRIBUTING names the real authoring sources and standards.
+
+### T6 — Verify and review
+
+**Depends on:** T1, T2, T3, T4, T5  
+**Verification mode:** goal-based check + visual/manual QA  
+**Tests/artifacts:** feasible targeted test logs; `git diff --check`; scoped
+diff inventory; adversarial review report; quality review report; final
+environment-limitation record.
+
+- Run static Markdown/TOML/Astro construction checks and repository tests that
+  are read-only in this workspace.
+- Run `git diff --check` and inspect the scoped diff.
+- Run adversarial review; fix blockers and majors, then re-run until clean.
+- Run quality review; fix blockers and majors, then re-run until clean.
+- Record build/tempfile restrictions and provide the smallest manual
+  verification command set only for checks that could not run here.
+
+## Content ownership after the change
+
+| Information | Canonical owner |
+| --- | --- |
+| Product promise and audience recognition | Marketing home |
+| Outcome-to-pack discovery | Marketing catalogue |
+| Complete pack inventory | Data-driven marketing and technical pack indexes |
+| Install and first run | Technical getting-started |
+| Pack task guidance | `guides/<pack>/` |
+| Cross-pack system explanation | `guides/_shared/explanation/` |
+| Pack detail | `packs/<pack>/README.md`, projected into technical docs |
+| Catalogue authoring | Portable shared references plus `packs/README.md` |
+| Repository internals | `docs/architecture/`, contracts, and CONTRIBUTING |
+| Repository orientation | Root README |
+
+## Rollback and risk
+
+The change is documentation and authored-site source only. Reverting the diff
+restores the previous navigation; no data or runtime migration is involved.
+
+Main risks:
+
+- **A README cut strands information.** Mitigation: T2–T4 precede T5 and the
+  migration table is an acceptance checklist.
+- **Outcome mappings drift from packs.** Mitigation: exhaustive inventory remains
+  data-driven; editorial mappings link to stable pack routes and are much smaller
+  than a duplicate pack catalogue.
+- **Site links break under the GitHub Pages base path.** Mitigation: use
+  `withBase()` in Astro and existing absolute `/agent-ready-repo/docs/` routes in
+  Starlight content; construction-check each target.
+- **Guide content is mistaken for archive payload.** Mitigation: preserve the
+  explicit packaging boundary in the guide and docs copy and track engine work
+  separately.
+
+## Declined patterns
+
+- New `/evaluate/` or role-specific routes: current anchors and hubs can prove
+  the navigation model without expanding route ownership.
+- A generated root README or shared-copy include system: the surfaces need
+  different densities; generation would couple unlike page contracts.
+- A hand-maintained complete pack table anywhere outside the canonical indexes:
+  it caused the current currency and recognition problem.
+- Editing scaffolded `packs/README.md` or `profiles/README.md`: useful follow-up
+  polish, but it would turn this documentation change into an `agentbundle`
+  release.
+- Search/filter UI: the catalogue needs outcome context first; a new interaction
+  and testing surface is not required for the first correction.

--- a/docs/specs/documentation-entry-navigation/spec.md
+++ b/docs/specs/documentation-entry-navigation/spec.md
@@ -1,0 +1,237 @@
+# Spec: documentation-entry-navigation
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** [RFC-0076 D9–D10](../../rfc/0076-catalogue-contracts-composition-semantics-discovery.md), [`docs-site-design-refresh`](../docs-site-design-refresh/spec.md), [`platform-site`](../platform-site/spec.md)
+- **Supersedes:** [`catalogue-wave8-readme-contributing`](../catalogue-wave8-readme-contributing/spec.md)
+- **Precedes:** ini-007 Wave 6–7; this spec delivers their current-route editorial and navigation foundation while preserving their Wave 4/index-dependent work
+- **Brief:** none
+- **Discovery:** [`notes/information-architecture.md`](notes/information-architecture.md)
+- **Contract:** existing guide, pack, and site content contracts only; no schema or engine change
+- **Shape:** cross-surface documentation and navigation retrofit
+
+> **Spec contract:** this document defines what “done” means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+Mode: full. The change restructures public entry points across the repository,
+marketing site, and technical documentation site.
+
+## Objective
+
+Turn the repository README into a concise hub-and-spoke router while preserving
+the information adopters need in canonical public destinations.
+
+The catalogue is the product. Packs are its composable units, profiles are
+curated starting sets, `agentbundle` distributes them, and this repository is a
+self-hosted example of the model. The supervised `core` build loop is the
+flagship and strongest standalone reason to adopt, but no entry surface may
+imply that software implementation is the catalogue's only use.
+
+A product manager must be able to recognize the strategy, research, and product
+shaping path. A platform, infrastructure, or SRE team must be able to recognize
+the architecture, contract, infrastructure-as-code, and release path. Engineers,
+designers, researchers, catalogue operators, and coding agents must retain
+predictable routes into the same inventory.
+
+The public surfaces have one job each:
+
+| Surface | Job |
+| --- | --- |
+| Marketing site | Create recognition through outcomes, proof, and the self-hosted catalogue story |
+| Catalogue | Help readers choose from the complete pack inventory |
+| Technical docs | Help adopters install, use, operate, and build catalogues |
+| `guides/` | Hold canonical adopter-facing tutorials, how-tos, reference, and explanation |
+| GitHub README | Identify the product and route readers to the right public or contributor surface |
+| Contributor pages | Explain source ownership, contracts, architecture, and repository procedure |
+
+## Approved assumptions
+
+- **Product:** the catalogue and its self-hosting system are the product;
+  `core` is the differentiated flagship product rather than the catalogue
+  taxonomy. Public copy leads with its verifiable mechanics and then reveals
+  catalogue breadth without an unsupported comparative superlative.
+- **Audience:** role and arrival pathway are orthogonal. Public discovery leads
+  with recognizable work, then reveals pack names and installation details.
+- **Content:** a fact is authored once. Other surfaces summarize and link; they
+  do not grow parallel handbooks or hand-maintained complete inventories.
+- **Navigation:** the first implementation uses current routes and anchors. It
+  does not add `/evaluate/`, a separate role-page hierarchy, or new top-level
+  directories. The `/evaluate/` route, neutral-index consumption, generated
+  field reference, and pack-integration relationship view remain owned by
+  ini-007 Waves 6–7 after Wave 4 ships.
+- **Guides:** `guides/` remains portable public source mirrored into the docs
+  site. Physically adding the full tree to packaged catalogue archives is a
+  separate `agentbundle` backlog item, not an implied part of this change.
+- **Scope:** content removed from the README must be strengthened at its
+  canonical destination in this same change. Marketing, technical docs,
+  adopter guides, contributor docs, and internal navigation are in scope where
+  the migration requires them.
+- **Approval:** the user approved this direction and expanded scope on
+  2026-08-12.
+
+## Content migration contract
+
+No README section is removed on the strength of a link alone. The destination
+must contain the information an adopter needs to continue.
+
+| README content being reduced | Canonical destination | Destination requirement |
+| --- | --- | --- |
+| Product argument and testimonial | Marketing home | State the supervised operating-model problem and sell the flagship through its verifiable mechanics without relying on the testimonial |
+| Detailed discovery/build/release explanation | [`guides/_shared/explanation/the-three-loops.md`](../../../guides/_shared/explanation/the-three-loops.md) and the marketing “How it works” section | Name each loop, its output, handoff, and human gate |
+| Curated pack table and pack descriptions | Marketing catalogue and generated technical pack index | Preserve the complete current inventory and expose outcome-first discovery before pack metadata |
+| Role routing | Marketing catalogue, docs landing, and `guides/README.md` | Product management and infrastructure routes must be explicit; other primary roles remain findable |
+| Install alternatives, adapter details, profiles, upgrades, and dry-run | Technical getting-started and shared install/reference guides | Preserve one clear first install plus routes to alternative installs, adapter support, profiles, preview, and upgrade |
+| Catalogue composition and self-hosting | Marketing “Build your organisation” section, docs landing, and pack-catalogue explanation | Explain packs, profiles, adapters, ownership, `catalogue init`, and the no-fork starting path |
+| Files-you-own and ecosystem mechanics | Pack-catalogue and file-safety explanations plus architecture links | Preserve editability, adapter projection, non-clobbering composition, and credential-safety routes without duplicating package internals in the README |
+| Contribution procedures | `CONTRIBUTING.md`, `packs/README.md`, and contracts | Remove the obsolete requirement to update a README pack table; retain portable authoring and contract routes |
+
+## Boundaries
+
+### Always do
+
+- Keep the root README at or below 90 lines.
+- Keep the flagship build-loop quickstart visible without presenting it as the
+  complete catalogue; sell its spec, gate, cold-review, stasis, and human-decision
+  mechanics as product strengths rather than describing it as a disposable demo.
+- Preserve one-click routes from the README to marketing discovery, technical
+  getting started, the complete catalogue, catalogue authoring, and contributing.
+- Put product-manager and infrastructure/platform outcomes in first-screen or
+  first-section discovery on the marketing catalogue, technical docs landing,
+  and guide hub.
+- Keep the complete pack grid data-driven from the existing content collection.
+- Verify every new internal link target exists.
+- Preserve the existing visual system, responsive behavior, focus behavior,
+  reduced-motion behavior, and page routes.
+- Update the old Wave 8 spec and workspace routing so this spec owns the
+  current-route work while the Wave 4/index-dependent remainder stays visible
+  under Waves 6–7.
+
+### Ask first
+
+- Adding a new top-level route or directory.
+- Changing the guide tree's catalogue-package distribution behavior.
+- Editing `packs/README.md`, `profiles/README.md`, or their projected authoring
+  scaffold copies; those changes carry an `agentbundle` release implication.
+- Introducing search/filter JavaScript, a new dependency, a schema change, or a
+  design-token/styling-system change.
+- Rewriting individual pack READMEs, pack journeys, or the complete guide corpus.
+
+### Never do
+
+- Delete public information without satisfying the destination requirement in
+  the migration contract.
+- Hand-maintain a complete pack inventory in the root README, guide root, docs
+  landing, or marketing homepage.
+- Edit generated guide navigation, generated pack pages, projected adapter
+  outputs, or generated site content directly.
+- Claim the full `guides/` tree ships in a packaged catalogue archive.
+- Restore adopt-by-forking language; `agentbundle catalogue init` is the clean
+  starting route.
+- Turn install scope, adapter support, skill count, or pack names into the
+  first-level discovery taxonomy.
+
+## Acceptance criteria
+
+- [x] **AC1 — README is a router.** `README.md` is at most 90 lines and contains:
+  one product definition; one compact flagship case; one supported quickstart;
+  routes to outcome discovery, technical getting started, complete catalogue,
+  catalogue authoring, architecture/contracts, contributing, security, and
+  license; and a short composable/self-hosted catalogue explanation.
+- [x] **AC2 — README duplication is removed.** `README.md` contains no
+  testimonial, full three-loop walkthrough, pack table, multi-route CLI manual,
+  adapter matrix, profiles tutorial, package ecosystem tour, or instruction to
+  fork the repository to adopt it.
+- [x] **AC3 — README cuts have complete destinations.** Every row in the content
+  migration contract is checked after implementation. The named destination
+  contains the required substance and its route from the README or an immediate
+  hub resolves.
+- [x] **AC4 — marketing broadens immediately after the hook.** The marketing
+  homepage leads with supervised build work as the differentiated flagship, then presents
+  outcome paths for deciding what to build, designing a product/system, building
+  and reviewing software, provisioning and releasing safely, working with team
+  systems/evidence, documenting what ships, and building/governing a catalogue.
+- [x] **AC5 — marketing navigation matches reader intent.** Primary navigation
+  includes “Use cases,” Catalogue, Docs, and a supervised-loop CTA.
+  Journeys remain reachable from pack and loop context but are not a primary
+  navigation category.
+- [x] **AC6 — self-hosting is first-class and current.** The marketing closer
+  and docs landing explain how an organization initializes, adapts, validates,
+  and distributes its own catalogue. Neither tells readers to fork this repo.
+- [x] **AC7 — catalogue discovery precedes inventory.** `/catalogue/` presents
+  outcome and role routes before the complete data-driven pack grid. Product
+  manager/strategist and infrastructure/platform/SRE routes are explicit. The
+  grid retains every pack supplied by the existing content collection and keeps
+  install metadata at the detail layer.
+- [x] **AC8 — docs landing separates use from build.** The technical docs home
+  provides: outcome-first task routes; role shortcuts; a “use a catalogue” path;
+  a “build and operate a catalogue” path; getting-started and reference routes;
+  and no hand-maintained complete pack table.
+- [x] **AC9 — getting started supports more than engineers.** The technical
+  getting-started page retains the flagship loop and adds recognizable starting
+  paths for product work and infrastructure/release work, with appropriate pack
+  or profile commands and human-boundary language.
+- [x] **AC10 — guide root is a portable hub.** `guides/README.md` routes by
+  outcome, includes role shortcuts, explains shared versus pack-specific
+  guidance, links the complete generated catalogue, and points once to the
+  guide-authoring contract. It links every active pack home without a prose
+  catalogue duplicated from every pack and has no long embedded authoring
+  manual. `tools/check-guide-index.py` verifies link coverage without requiring
+  an “All packs” section or a particular presentation.
+- [x] **AC11 — removed deep explanations remain public.** The shared three-loop,
+  pack-catalogue, install-route, adapter-support, profile-install, preview, and
+  upgrade pages are reachable from the docs landing, getting-started page, or
+  guide hub as appropriate.
+- [x] **AC12 — contributor navigation converges.** `CONTRIBUTING.md` points to
+  the portable catalogue authoring standards, documents optional
+  `[[pack.integrations]]` navigation, adds catalogue authoring to the authority
+  table, and replaces the obsolete “update the README Packs table” instruction
+  with the real data/guide/site registration sources. It routes contributors
+  through the public technical docs and explains the evidence → decision → spec
+  → implementation → adopter-doc chain without duplicating the source-of-truth
+  hierarchy.
+- [x] **AC13 — ownership is explicit without losing future work.** The old Wave
+  8 spec is Archived with a `Superseded by` link. ini-007 points Wave 9's former
+  Wave 8 dependency to this spec. Waves 6 and 7 remain queued, but their comments
+  name only the work this spec does not deliver: neutral-index and generated
+  reference consumption, the deep “Build a Catalogue” sidebar/reference
+  structure, `/evaluate/`, and pack-integration relationship presentation.
+- [x] **AC14 — no route or design-system expansion.** No new top-level route,
+  dependency, token, schema, pack payload, generated output, or packaging
+  behavior is introduced.
+- [x] **AC15 — feasible verification passes.** Static construction checks,
+  guide validation/index checks, site routing tests, formatting/lint checks that
+  do not require generated writes, and `git diff --check` pass. Build and
+  tempfile-dependent gates are reported as environment-blocked rather than
+  represented as passed.
+
+## Testing strategy
+
+- **Structure:** line-count and negative-content checks on `README.md`; heading,
+  label, and route checks on the two site entry points and guide hub.
+- **Inventory:** construction check that the marketing catalogue still maps the
+  full `astro:content` pack collection rather than a hard-coded subset.
+- **Links:** extract changed Markdown links and site route/anchor targets; verify
+  local targets and existing public route sources.
+- **Guides:** run `tools/validate_guides.py` and `tools/check-guide-index.py` if
+  they complete without creating temporary output.
+- **Sites:** run read-only routing/construction tests. Site sync/build commands
+  are blocked in this workspace because generated-output directories are not
+  writable; record that limitation and provide only the smallest final manual
+  verification set.
+- **Review:** adversarial review checks spec-to-content drift and missing
+  audience paths; quality review checks maintainability, duplicated ownership,
+  link durability, and test shape.
+
+## Completion signal
+
+A cold reader can answer, within two navigation actions:
+
+1. What is this product?
+2. What can it do for my role or outcome?
+3. Which pack or profile should I start with?
+4. How do I install and verify it?
+5. How does my organization own and self-host the system?
+6. Where do I contribute to the catalogue implementation?
+
+The README is no longer required to answer all six itself.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,135 +1,44 @@
 # Guides
 
-Documentation for this catalogue, organized to get you to the right place fast — by what you're trying to do, by your role, or by pack.
+Use this catalogue to add repeatable, supervised ways of working to your agent. Start with the outcome you need; the linked pack guides explain what to install, what to ask for, what the agent produces, and where a human decides.
 
-## What do you want to do?
+## Choose what you want to achieve
 
-**Ship a new feature or fix a bug →** [Install `core`](../guides/core/) and run `work-loop`. The build loop handles planning, gating, and adversarial review.
-
-**Turn a product idea into something buildable →** [Install `product-engineering`](product-engineering/) and run `discovery-loop`. Goes from a raw idea to a ratified decision brief in one supervised session.
-
-**Validate and ship to production →** [Install `release-engineering`](release-engineering/) and run `release-lead`. Deploys to an ephemeral environment, runs e2e, feeds back to the build loop, and surfaces a release-readiness record at the prod-ship gate.
-
-**Understand the full picture →** [The three loops as a system](../guides/_shared/explanation/the-three-loops.md) — how discovery, build, and release compose into a complete operating model.
-
----
-
-## By role
-
-| I work as… | Start here | Also useful |
+| I need to… | Start with | Continue with |
 | --- | --- | --- |
-| **Engineer** | [`core`](core/) — the build loop | [`architect`](architect/) for design; [`contracts`](contracts/) for API authoring; [`converters`](converters/) for document handling; [how engineers use the system](core/explanation/role-journeys.md) |
-| **Product manager / strategist** | [`product-engineering`](product-engineering/) — intent shaping and the discovery loop | [`desk-research`](desk-research/) for evidence; [`governance-extras`](governance-extras/) for decision trails; [how PMs use the system](core/explanation/role-journeys.md) |
-| **AI agent** | [`core`](core/) — the build loop; `workspace-status` + `work-loop` for autonomous execution | [how agents use the system](core/explanation/role-journeys.md) |
-| **Designer / UX** | [`experience-design`](experience-design/) — journey mapping, screen flows, service blueprints, design review | [`figma`](figma/) for Figma reads; [`product-engineering`](product-engineering/) for voice and microcopy |
-| **Architect** | [`architect`](architect/) — system design and pressure-testing | [`contracts`](contracts/) for API contracts; [`desk-research`](desk-research/) for prior art |
-| **SRE / DevOps** | [`release-engineering`](release-engineering/) — the release loop, ephemeral deploy, e2e convergence | [`core`](core/) (required dependency) |
-| **Researcher / analyst** | [`desk-research`](desk-research/) — evidence-grounded research with selectable depth | [`converters`](converters/) for document ingestion |
-| **Everyone, once** | [`core`](core/) — **install this even if you install nothing else** | — |
+| **Decide what to build** | [`product-strategy`](product-strategy/) for strategic choices | [`desk-research`](desk-research/) for evidence, then [`product-engineering`](product-engineering/) to shape a build-ready bet |
+| **Design the product and system** | [`experience-design`](experience-design/) for journeys and surfaces | [`architect`](architect/), [`contracts`](contracts/), and [`frontend-engineering`](frontend-engineering/) for the system, interfaces, and implementation |
+| **Build and review software** | [`core`](core/) for the supervised work loop | [`governance-extras`](governance-extras/) for durable decisions and [`monorepo-extras`](monorepo-extras/) for package scaffolding |
+| **Provision and release safely** | [`iac-terraform`](iac-terraform/) for reviewable infrastructure plans | [`release-engineering`](release-engineering/) for deployed validation and the human production gate, supervised by [`core`](core/) |
+| **Work with team systems and evidence** | [`atlassian`](atlassian/), [`github`](github/), [`linear`](linear/), or [`figma`](figma/) | [`converters`](converters/) for source material and [`credential-brokers`](credential-brokers/) for credential-safe access |
+| **Document what ships** | [`product-documentation`](product-documentation/) | [`converters`](converters/) and the guide for the pack whose behavior you are documenting |
+| **Build and govern a catalogue** | [`catalogue-curation`](catalogue-curation/) | [`governance-extras`](governance-extras/), [`product-documentation`](product-documentation/), and the [catalogue authoring standards](_shared/reference/catalogue-authoring-standards.md) |
 
----
+The [`core`](core/) build loop is the catalogue's flagship and its strongest standalone product: a spec-driven implementation loop with mechanical gates, cold independent review, stasis detection, and a human merge decision. Start there when you want the most rigorous coding-agent workflow; the rest of the catalogue applies the same supervised-work principle to other jobs.
 
-## The three loops
+## Choose by role
 
-This repository covers the full software delivery lifecycle through three peer supervisors:
+- **Product manager or strategist:** [decide what to build](product-strategy/), [gather evidence](desk-research/), then [shape the bet](product-engineering/).
+- **Platform, infrastructure, or SRE team:** [design the system](architect/), [author its contracts](contracts/), [plan infrastructure](iac-terraform/), and [validate the release](release-engineering/).
+- **Software engineer:** start with the [`core` work loop](core/), then add the design, contract, frontend, infrastructure, or governance pack your change needs.
+- **Designer or UX practitioner:** start with [`experience-design`](experience-design/) and connect the result to [`product-engineering`](product-engineering/) or [`frontend-engineering`](frontend-engineering/).
+- **Researcher or analyst:** start with [`desk-research`](desk-research/) and add the relevant team-system or conversion pack.
+- **AI enablement or catalogue owner:** start with [the pack catalogue](_shared/explanation/pack-catalogue.md), then use [`catalogue-curation`](catalogue-curation/) to evolve your organization-owned collection.
 
-| Loop | Pack | Agent | Scope | What it does |
-| --- | --- | --- | --- | --- |
-| Discovery | [`product-engineering`](product-engineering/) | `discovery-lead` | user | Raw idea → build-ready decision brief via multi-lens diverge/converge |
-| Build | [`core`](core/) | `work-loop` supervisor | repo | Spec → shipped code with hard gates and cold-eyed review |
-| Release | [`release-engineering`](release-engineering/) | `release-lead` | repo | Built code → production via ephemeral e2e convergence and G5 prod-ship gate |
+## Shared and pack-specific guidance
 
-Each loop is autonomous where the work is reversible, and surfaces to a human where it isn't. The G3 handoff moves a decision brief from discovery into the build loop; the G4 handoff moves a built artifact into the release loop; G5 is the human prod-ship consent gate.
+Pack directories contain task guidance for that pack. [`_shared/`](_shared/) contains cross-catalogue guidance that applies regardless of which packs you install:
 
-→ [The three loops as a system](_shared/explanation/the-three-loops.md)
+- [Get from zero to the three-loop operating model](_shared/explanation/the-three-loops.md).
+- [Understand packs, profiles, adapters, composition, and catalogue ownership](_shared/explanation/pack-catalogue.md).
+- [Choose an install route](_shared/explanation/install-routes.md) and [check adapter support](_shared/reference/adapter-support.md).
+- [Install a curated profile](_shared/how-to/install-a-profile.md), [preview a change](_shared/how-to/preview-install-or-upgrade.md), or [upgrade safely](_shared/how-to/upgrade-packs.md).
+- [Create your own catalogue](_shared/how-to/create-a-catalogue.md) and [apply its portable authoring standards](_shared/reference/catalogue-authoring-standards.md).
 
----
+Claude users can [add this catalogue as a plugin marketplace](_shared/explanation/install-routes.md) and install user-scope packs directly. Repo-scoped packs such as `core` still install with `agentbundle` so their workflow belongs to the project and team.
 
-## All packs
+The public documentation site generates the complete pack and guide navigation from this tree. [Browse the complete generated pack reference](https://eugenelim.github.io/agent-ready-repo/docs/packs/); this page stays a route map rather than duplicating that inventory by hand.
 
-| Pack | Home | What it ships |
-| --- | --- | --- |
-| [`core`](core/) | **The flagship.** | The build loop — `work-loop`, `new-spec`, `bug-fix`, `adapt-to-project`, the four reviewer/executor subagents, `pre-pr` + `session-start` hooks, governance seeds. Install this even if you install nothing else. |
-| [`product-engineering`](product-engineering/) | [home](product-engineering/) | The discovery loop and intent shaping — `discovery-loop`, `frame-intent`, `de-risk-intent`, `decompose-intent`, `ux-writing`, `align-value-stream`. |
-| [`release-engineering`](release-engineering/) | [home](release-engineering/) | The release loop — `release-loop`, `release-lead`; autonomous e2e convergence on ephemeral envs; inner↔outer feedback seam; release-readiness record at G5. |
-| [`architect`](architect/) | [home](architect/) | Solution architecture — `architect-design`, `architect-diagram`, `architect-review`, and the read-only `design-reviewer` subagent. |
-| [`desk-research`](desk-research/) | [home](desk-research/) | Evidence-grounded research — `desk-research` with selectable depth, plus `source-map`, `compare-hypotheses`, `devils-advocate`, and retrieval subagents. |
-| [`experience-design`](experience-design/) | [home](experience-design/) | The full design thread — journey mapping, screen flows, service blueprints, creative direction, design system, design review, and the `experience-reviewer` subagent. |
-| [`credential-brokers`](credential-brokers/) | [home](credential-brokers/) | The broker behind credentialed skills — secrets resolve in-process, never reaching the model. |
-| [`atlassian`](atlassian/) | [home](atlassian/) | Jira, Confluence, and flow metrics — `jira`, `confluence-crawler`/`-publisher`, `flow-metrics`, `jira-defect-flow`, and more. |
-| [`github`](github/) | [home](github/) | GitHub integration — `github-brief-intake` turns a Milestone into a product brief and hands off to `receive-brief`. |
-| [`contracts`](contracts/) | [home](contracts/) | Contract-first API design — `api-contract` (OpenAPI 3.1) with a pluggable house standard. |
-| [`converters`](converters/) | [home](converters/) | Documents in and out of Markdown — `file-to-markdown`, `markdown-to-docx`/`-pptx`/`-xlsx`, `mermaid-renderer`, `msg-to-markdown`. |
-| [`figma`](figma/) | [home](figma/) | The Figma REST primitive — read files, nodes, and comments; render frames; turn FigJam into Mermaid. |
-| [`linear`](linear/) | [home](linear/) | Linear Issues and Projects — `linear` credentialed CLI plus `linear-brief-intake` (issue → product brief) and `linear-brief-sync` (delta catch-up). |
-| [`governance-extras`](governance-extras/) | [home](governance-extras/) | A written trail for decisions — `new-rfc`, `new-adr`, `update-conventions`. |
-| [`monorepo-extras`](monorepo-extras/) | [home](monorepo-extras/) | Monorepo scaffolding — `new-package` and a package template. |
-| [`product-documentation`](product-documentation/) | [home](product-documentation/) | Product documentation authoring — create, revise, retrofit, audit, and verify guides, pack READMEs, and journeys using `author-product-docs`. |
-| [`product-strategy`](product-strategy/) | [home](product-strategy/) | Answer the committed strategic questions upstream of every initiative — `write-prfaq`, `run-swot`, `run-pestle-analysis`, `run-porters-five-forces`, `run-bcg-matrix`, `run-okr-cascade`, `synthesize-stakeholder-research`, `define-ux-strategy`, `define-content-strategy`. |
-| [`frontend-engineering`](frontend-engineering/) | [home](frontend-engineering/) | Build, audit, and ship production-quality web surfaces — `frontend-engineering` (four modes), `token-architecture`, `a11y-engineering`, `fe-performance`, `rendering-strategy`, `component-contract`, `responsive-layout`, `css-architecture`, `fe-status`, and the `frontend-reviewer` agent. |
-| [`iac-terraform`](iac-terraform/) | [home](iac-terraform/) | Governed Terraform from plain-language intent — `generate-iac` (ADR gate → spec → plan, stops before apply) and `reconcile-iac` (drift audit). Opt-in, repo-scope. |
-| [`catalogue-curation`](catalogue-curation/) | [home](catalogue-curation/) | Grow and maintain a catalogue — `assimilate-primitive`, `assimilate-repo`, `propose-catalogue-pack`, `export-catalogue`. For catalogue maintainers. |
+## Writing a guide
 
----
-
-## Shared guides
-
-Cross-cutting topics — about the catalogue itself, not any single pack — live in [`_shared/`](_shared/):
-
-- **Install & upgrade** — [from a clone](_shared/how-to/install-agentbundle-from-clone.md), into [Codex](_shared/how-to/install-user-scope-pack-into-codex.md) or [Kiro](_shared/how-to/install-user-scope-pack-into-kiro.md), [preview first with `--dry-run`](_shared/how-to/preview-install-or-upgrade.md), [upgrade an installed pack](_shared/how-to/upgrade-packs.md).
-- **Reference** — the [`agentbundle` CLI](_shared/reference/agentbundle.md), the [adapter support matrix](_shared/reference/adapter-support.md), the [tracker vocabulary](_shared/reference/tracker-vocabulary.md) (how brief/spec levels map across GitHub, Linear, Jira, and Jira Align), and the [Catalogue CI contract](_shared/reference/catalogue-ci-contract.md) (publication ordering, exit codes, and responsibility boundaries for CI-driven catalogue releases).
-- **Understand** — [the three loops](_shared/explanation/the-three-loops.md), [install routes](_shared/explanation/install-routes.md), [the pack catalogue](_shared/explanation/pack-catalogue.md), [the file-safety contract](_shared/explanation/file-safety-contract.md), and [shaping a new engagement](_shared/explanation/shaping-a-new-engagement.md).
-- **Contribute** — [how to author a skill](_shared/how-to/author-a-skill.md) for any pack.
-- **Tracker intake** — [choose a tracker integration](_shared/how-to/choose-a-tracker-integration.md) for the right brief-intake skill across GitHub, Linear, Jira, Jira Align, or no tracker.
-
----
-
-## For guide authors — the four Diátaxis kinds
-
-Each guide has exactly one `kind` — declared as frontmatter metadata, not derived from its directory. Mixing kinds is the most common cause of docs that frustrate everyone.
-
-|  | Practical (you *do* something) | Theoretical (you *understand* something) |
-| --- | --- | --- |
-| **Learning** (acquiring a skill) | `kind: tutorial` — *lessons.* "Take me through it from the start." | `kind: explanation` — *discussions.* "Help me understand why." |
-| **Task** (getting something done) | `kind: how-to` — *recipes.* "Help me solve this specific problem." | `kind: reference` — *information.* "Tell me exactly what this does." |
-
-### Source layout
-
-New guides are **flat by default**:
-
-```
-guides/<pack>/<slug>.md
-```
-
-Topic-first grouping is permitted where a user perceives a real domain:
-
-```
-guides/<pack>/<topic>/<slug>.md
-```
-
-Physical quadrant directories (`tutorials/`, `how-to/`, `reference/`, `explanation/`) are a migration-compatible legacy structure — they still work, but **new guides do not require them**. Do not create four empty quadrant directories. Do not create one guide of each type. Let the reader's need determine what you write.
-
-### Required frontmatter
-
-Every new guide needs four fields:
-
-```yaml
----
-title: "What this guide is called"
-summary: "One sentence for navigation surfaces."
-pack: core                  # must match a directory in packs/
-kind: how-to                # tutorial | how-to | reference | explanation
----
-```
-
-Optional: `slug` (overrides the output path), `aliases` (generates redirect stubs), `journey`, `order`, `status`.
-
-The `author-product-docs` skill applies the correct page contract automatically. The `validate_guides.py` tool checks frontmatter compliance. Navigation in the docs site derives from reader needs and metadata — not from physical folder structure.
-
-### What belongs in `docs/guides/`?
-
-`docs/guides/` is **internal maintainer documentation** — how-tos for repo contributors, not for pack adopters. It is not published as public documentation.
-
-## How this fits with the rest of the repo
-
-These guides are *living* — they must match current behavior, and a PR that changes what users see updates them in the same PR. That's different from [`../specs/`](../specs/) (feature contracts, frozen once shipped), [`../adr/`](../adr/) (architecture decisions), and [`../CHARTER.md`](../CHARTER.md) (the mission). See [`../CONVENTIONS.md`](../CONVENTIONS.md#5c-docsguides--for-users) §5c for the full lifecycle.
+Use the [`author-product-docs`](product-documentation/how-to/author-product-docs.md) workflow. It selects the right page contract and destination; the [catalogue authoring standards](_shared/reference/catalogue-authoring-standards.md) define the portable rules.

--- a/guides/_shared/explanation/pack-catalogue.md
+++ b/guides/_shared/explanation/pack-catalogue.md
@@ -1,69 +1,74 @@
 # The pack catalogue
 
-This repo isn't a starter template — it's a catalogue. You install packs à la carte: some land inside a repo you own (per-project infrastructure: agent conventions, governance scaffolding, monorepo primitives), others land at user scope (portable workflows that follow you across every repo on the machine). [The README's catalogue table](../../../../README.md#the-catalogue) is the live menu. The distinction matters because it changes what you're agreeing to when you adopt: you take the slices that fit, your edits are first-class, and the catalogue keeps a file-safety contract that says "your edits are never silently overwritten."
+The catalogue is an organization-owned distribution system for repeatable agent workflows. It is not a starter template and it is not one indivisible operating model. You choose packs for the work your team does, combine them into profiles when a standard starting set is useful, and use `agentbundle` to project the same source into each supported agent's native layout.
 
-## What a pack is
+This repository is both a reference catalogue and a self-hosted adopter of that system. Its `packs/` sources produce the skills and agent primitives it uses itself, so the published material and the repository's working practice can be checked for drift.
 
-A pack is a coherent slice of agent infrastructure — usually one of:
+## The four parts
 
-- A **workflow you can run** (`work-loop`, `new-spec`, `bug-fix`).
-- A **reviewer that pulls its weight** (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`).
-- The **document shape** that makes downstream agents work well (the Diátaxis quadrants, RFC/ADR templates, the `docs/CHARTER.md` scaffold).
-- A **credentialed primitive** plus the workflows that compose against it (`jira` + `flow-metrics` + `jira-defect-flow`).
+| Part | What it owns |
+| --- | --- |
+| **Pack** | A cohesive workflow or capability: skills, agents, hooks, commands, configuration, and optional seed files |
+| **Profile** | A curated, single-scope list of packs installed together in dependency order |
+| **Adapter** | The projection from portable pack primitives into an agent's on-disk conventions |
+| **Catalogue** | The organization-owned inventory, defaults, contracts, validation, packaging, and distribution policy |
 
-A pack ships skills, agents, hooks, commands, and seed documents. It does **not** import code from other packs — composition happens by convention, not import. Two packs landing in the same scope share nothing but the directory they project into (a repo working tree for repo-scope packs; a user-scope root like `~/.claude/` for user-scope packs).
+`agentbundle` is the transport and safety layer. It discovers catalogues, validates their contracts, installs or upgrades packs, records state, preserves adopter edits, and builds catalogue distributions. It is not a hosted service and it does not execute the installed skills.
 
-## Why `core` is the load-bearing pack
+## Start with an outcome, install a pack
 
-`core` carries the discipline. The plan → execute → verify → review loop, the reviewer agents that read diffs adversarially in a fresh session, the session-start hook that nudges you into `adapt-to-project` on first session — none of that lives in the other packs.
+Pack names are the stable installation layer, not the discovery language. A product manager may begin with “decide what to build” and arrive at `product-strategy`, `desk-research`, and `product-engineering`. An infrastructure team may begin with “provision and release safely” and arrive at `architect`, `contracts`, `iac-terraform`, `release-engineering`, and the supervised `core` loop.
 
-Concretely, every repo-scope pack assumes `core` is also installed in two ways (user-scope packs don't depend on `core` — see the composition rule below):
+The [guide hub](../../) maps the catalogue by outcome and role. Each pack guide then explains its natural-language starter request, expected artifact, safety boundary, and install route.
 
-1. **The session-start hook** in `core` is the single read-side of the install→adapt chain. Every install route drops the same `.adapt-install-marker.toml`; `core`'s hook surfaces it. Without `core`, the marker lands and nothing reads it.
-2. **The reviewer agents and the work-loop skill** in `core` are what the other packs' skills compose against when they say "run the work-loop." If you install `governance-extras` without `core`, the `new-rfc` skill still works but the loop discipline it points at isn't there.
+`core` is the flagship pack because supervised software implementation is a short, verifiable demonstration of the model. It provides the work loop, repository context, mechanical gates, and independent reviewers. Other packs can be useful before, beside, or after it; the catalogue is broader than the build loop.
 
-The fix is mechanical: install `core` first, then add whichever packs fit. The README's pack table is the menu. For a deeper look at *what* `core` ships and *why* the loop+reviewer+spec combination is more productive than vibe-coding or competing spec-driven workflows, see [The core pack as a system](../../core/explanation/core-pack.md).
+## Repo scope and user scope
 
-## Two scopes: repo and user
+Scope answers where a pack belongs, not who it is for.
 
-The catalogue's packs split by where they land on disk — the [README table](../../../../README.md#the-catalogue) tags each one.
+- **Repo-scope packs** install into a project and can carry repository-specific hooks, conventions, or seed files.
+- **User-scope packs** install into an adapter's user root and follow a practitioner across projects.
+- Some portable packs allow either scope. The pack manifest declares the allowed scopes and default; `agentbundle` refuses an unsupported placement.
 
-**Repo-scope.** `core` plus the governance, docs-skeleton, and monorepo scaffolding (`governance-extras`, `product-documentation`, `monorepo-extras`). These install into the root of a repo you own and only make sense per-project — they ship hooks, governance seeds (`AGENTS.md`, `docs/CHARTER.md`, `docs/CONVENTIONS.md`), the `docs/specs/` skeleton, and other content that's specific to the repo they land in. Their `[pack.install]` table declares `allowed-scopes = ["repo"]`; the bundler refuses any attempt to install them at user scope.
+Adapter support is also declared rather than assumed. The [adapter support reference](../reference/adapter-support.md) shows which primitive types each supported agent can represent and where fidelity differs.
 
-**User-scope.** The portable workflow packs — `desk-research`, `architect`, `contracts`, `product-engineering`, `experience-design`, the credentialed `atlassian` / `figma`, and more (the [README table](../../../../README.md#the-catalogue) lists the current set). These land under the user-scope root of whichever adapter you're using — `~/.claude/` for Claude Code, `~/.kiro/` for Kiro, `~/.agents/skills/` for Codex — and follow you across every repo on the machine. They declare `default-scope = "user"` with `allowed-scopes = ["user", "repo"]` and (since RFC-0011 / contract v0.6) an `allowed-adapters` set. Pass `--scope repo` if you want a copy local to one project (pinning a specific `jira` version per repo, for instance); pass `--adapter <name>` to override the auto-detected IDE when more than one CLI home is populated on your machine. See the [`Where primitives land`](../../../../README.md#where-primitives-land) table in the README for per-adapter target paths and the adapters each pack supports, and the [Kiro](../how-to/install-user-scope-pack-into-kiro.md) and [Codex](../how-to/install-user-scope-pack-into-codex.md) how-to guides for the adopter walkthroughs.
+## Profiles are starting sets, not mega-packs
 
-The two scopes never share files. A user-scope pack installed with `--scope repo` projects into that repo's working tree the way a repo-scope pack would; otherwise it stays in your user directory.
+A profile promotes a useful pack combination into one installable unit. It adds no primitives of its own and does not hide the packs it contains. Preflight validates the entire single-scope set before the first write, then installs it in dependency order.
 
-## Profiles: a curated set in one command
+Use [`agentbundle list-profiles`](../reference/agentbundle.md) to see the current sets and [install a profile](../how-to/install-a-profile.md) when one matches your role or project. Upgrade and removal continue to operate on individual packs.
 
-Some pack combinations are blessed — a solution architect's toolkit is `architect` + `research` + `contracts`; a repo's full governance setup is `core` + `governance-extras` + `product-documentation` + `monorepo-extras`. (Each name is a pack from [the README's catalogue table](../../../../README.md#the-catalogue), the authoritative menu.) A **profile** promotes that curated knowledge from prose into one executable unit: `agentbundle install --profile <name> <catalogue>` installs the whole set in one command, and `agentbundle list-profiles <catalogue>` shows what's on offer.
+## Composition stays visible
 
-A profile is a thin pointer list, not a pack — a hand-authored `profiles/<name>.toml` at the catalogue root that names packs in dependency-first order. It adds no primitives, no new dependency edges, and no state entity: the packs install exactly as they would one at a time, just sequenced and gated as a batch. Two properties make it safe rather than a mega-bundle:
+Packs may require another pack or declare an optional integration with one. Required dependencies control safe installation order. Optional `[[pack.integrations]]` entries describe useful composition without silently installing or dispatching another pack.
 
-- **Single-scope.** A profile is repo-only or user-only — it never mixes scopes, so there's no half-applied cross-scope install to reason about. The scope is declared in the manifest; you don't pass `--scope`.
-- **All-or-nothing pre-flight.** Every pack's preconditions run before the first write, on one pinned adapter, so the batch is no less safe than installing each pack by hand.
+This keeps the unit of ownership visible: installing a product-shaping pack does not quietly add an infrastructure workflow, and installing an integration does not grant it permission to mutate an external system. Each pack retains its own scope, dependencies, safety boundary, and human decision point.
 
-Profiles cover *installing* a set; there is no `upgrade --profile` or `uninstall --profile` — you act on the individual packs afterward. See [how to install a profile](../how-to/install-a-profile.md) for the walkthrough.
+When two installed packs target the same path, the [file-safety contract](file-safety-contract.md) protects adopter-owned changes. Catalogue-owned files can upgrade in place; changed files are preserved and the new upstream version is written as a companion for deliberate merging.
 
-## The composition rule
+## Own and self-host the system
 
-Packs compose by convention, not by import — no pack ever imports code from another pack. The rule is one-directional: repo-scope packs depend on `core`; user-scope packs don't.
+An organization does not need to fork this repository to create a catalogue. Initialize the managed scaffold:
 
-The one **runtime** dependency that catches adopters off-guard: every credentialed primitive in `atlassian` and `figma` imports `from credbroker import load_credentials`, so installing those packs via Claude plugins or APM still requires the standalone `credbroker` module (`pip install credbroker`) to be importable in the agent's shell-out subprocess. See [the `install-agentbundle-from-clone` guide](../how-to/install-agentbundle-from-clone.md) for the pip step that closes the loop, and the [README's install section](../../../../README.md#install) for the same caveat in the front-door framing.
+```bash
+agentbundle catalogue init my-catalogue --name my-catalogue
+```
 
-## Why a catalogue, not a template
+Then add or adapt packs, declare profiles and defaults, validate the contracts, and package the result through the portable catalogue commands. The [create-a-catalogue guide](../how-to/create-a-catalogue.md) walks through the first valid catalogue; the [authoring standards](../reference/catalogue-authoring-standards.md) define the pack, profile, guide, and contract boundaries; the [catalogue CI contract](../reference/catalogue-ci-contract.md) defines verify → package → publish without prescribing a CI provider.
 
-The obvious alternative would be: ship the bundle as a template, ask adopters to fork or clone, then merge updates by hand. We rejected that because the catalogue model gives three things a template can't:
+The full public guide tree is documentation source mirrored into this project's technical site. It is not currently included in archives produced by `agentbundle catalogue package`; catalogue operators should publish or distribute the guide site separately until that packaging contract changes.
 
-1. **Granular adoption.** Take `core` + `atlassian`; skip the rest. A template forces you to inherit the whole thing.
-2. **Upgrade-safe edits.** The file-safety contract distinguishes Tier-1 (catalogue-owned) from Tier-2 (you edited it) and writes `*.upstream.<ext>` companions on collision. A template fork loses that — every upgrade is a manual merge against a moving base.
-3. **Multiple install routes.** The same pack content reaches you via `agentbundle install`, `apm install`, or the four-line clone-and-pip dance — pick the one your environment allows. `/plugin install` carries the subset that permits user-scope install ([install routes](install-routes.md)). A template has one shape.
+## What you own after installation
 
-The tradeoff is that a catalogue needs the machinery to support those three properties. That machinery is the `agentbundle` CLI plus the adapter contract at `contracts/adapter.toml`, both versioned independently of the packs they project.
+Installed primitives are files you can read and version. There is no agent runtime or hosted control plane between your team and those files. The adapter projection is reproducible, and local changes remain visible in `git diff` or the user-scope filesystem.
 
-## Where to read next
+For sensitive integrations, the [`credential-brokers` guide](../../credential-brokers/) explains how credentials resolve inside the helper process instead of being copied into prompts or command arguments.
 
-- [Install routes](install-routes.md) — the four ways to install, and how they share work via the install→adapt chain.
-- [The file-safety contract](file-safety-contract.md) — the Tier-1/2/3 model that protects your edits.
-- [Credentialed skills](../../credential-brokers/explanation/credentialed-skills.md) — how packs like `atlassian` and `figma` get a token without ever putting it on argv.
-- [RFC-0001](../../../rfc/0001-bundle-distribution-by-adapter-spec.md) — the authoritative source for the catalogue model.
+## Where to go next
+
+- [Choose work by outcome or role](../../).
+- [Compare install routes](install-routes.md).
+- [Preview an install or upgrade](../how-to/preview-install-or-upgrade.md).
+- [Understand the three supervised loops](the-three-loops.md).
+- [Create a catalogue](../how-to/create-a-catalogue.md).

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -39,6 +39,7 @@ SITE_BASE = "/agent-ready-repo/docs"
 _GUIDE_ONLY_FIELDS = frozenset({
     "pack", "kind", "summary", "slug", "aliases", "status", "journey", "order",
 })
+_GUIDE_SLUG_PART_RE = re.compile(r"^[a-z0-9_][a-z0-9_-]*$")
 
 
 def discover_packs(root: Path, site_toml: Path) -> list[dict]:
@@ -146,6 +147,40 @@ def _parse_frontmatter(text: str) -> dict:
     except yaml.YAMLError:
         return {}
     return data if isinstance(data, dict) else {}
+
+
+def _normalise_guide_slug(
+    value: object, source_path: Path | None = None, field: str = "slug"
+) -> str | None:
+    """Return a confined guide slug, or ``None`` when frontmatter is invalid."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        if source_path is not None:
+            print(
+                f"  warn  {_relpath(source_path)}: non-string '{field}' ignored",
+                file=sys.stderr,
+            )
+        return None
+
+    slug = value.strip().strip("/")
+    if slug.endswith("/index"):
+        slug = slug[: -len("/index")]
+    parts = slug.split("/")
+    valid = (
+        len(parts) >= 2
+        and parts[0] == "guides"
+        and all(_GUIDE_SLUG_PART_RE.fullmatch(part) for part in parts[1:])
+    )
+    if valid:
+        return slug
+
+    if source_path is not None:
+        print(
+            f"  warn  {_relpath(source_path)}: invalid '{field}' ignored",
+            file=sys.stderr,
+        )
+    return None
 
 
 def _strip_guide_metadata(text: str) -> str:
@@ -269,15 +304,9 @@ def build_guide_inventory(guides_root: Path, enumerator=None) -> list[dict]:
         is_int = isinstance(raw_order, int) and not isinstance(raw_order, bool)
         order = raw_order if is_int else None
 
-        # Frontmatter is adopter-authored: a non-string here must degrade to the
-        # derived value, not crash the build with an AttributeError naming no
-        # file. `order` is coerced the same way a few lines above.
-        override = fm.get("slug")
-        if override is not None and not isinstance(override, str):
-            print(f"  warn  {_relpath(path)}: non-string 'slug' ignored", file=sys.stderr)
-            override = None
-        if override and override.endswith("/index"):
-            override = override[: -len("/index")]
+        # Frontmatter is adopter-authored: invalid route metadata must degrade
+        # to the derived value, not crash or write outside the guide route tree.
+        override = _normalise_guide_slug(fm.get("slug"), path)
 
         title = fm.get("title") or None
         if title is not None and not isinstance(title, str):
@@ -482,8 +511,9 @@ def mirror_guides(src: Path, site_docs: Path, dry_run: bool = False) -> int:
         fm = _parse_frontmatter(text)
 
         # Determine canonical slug and output path
-        if fm and fm.get("slug"):
-            canonical_slug = fm["slug"]
+        override = _normalise_guide_slug(fm.get("slug"), path) if fm else None
+        if override:
+            canonical_slug = override
             target = site_docs / (canonical_slug + ".md")
         else:
             # Derive slug from the (possibly renamed) relative parts
@@ -502,7 +532,7 @@ def mirror_guides(src: Path, site_docs: Path, dry_run: bool = False) -> int:
 
         if dry_run:
             action = "rename" if path.name == "README.md" else "copy"
-            if fm and fm.get("slug"):
+            if override:
                 action = "route"
             print(f"  {action} {_relpath(path)} → {_relpath(target)}")
         else:
@@ -512,16 +542,24 @@ def mirror_guides(src: Path, site_docs: Path, dry_run: bool = False) -> int:
 
         # Generate redirect stubs for aliases
         aliases = fm.get("aliases") if fm else None
-        if aliases:
+        if isinstance(aliases, list):
             canonical_url = f"{SITE_BASE}/{canonical_slug}/"
             for alias in aliases:
-                stub_target = site_docs / (alias + ".md")
+                alias_slug = _normalise_guide_slug(alias, path, "aliases")
+                if not alias_slug:
+                    continue
+                stub_target = site_docs / (alias_slug + ".md")
                 stub_content = _make_redirect_stub(canonical_url)
                 if dry_run:
-                    print(f"  stub  {alias} → {canonical_slug}")
+                    print(f"  stub  {alias_slug} → {canonical_slug}")
                 else:
                     stub_target.parent.mkdir(parents=True, exist_ok=True)
                     stub_target.write_text(stub_content, encoding="utf-8")
+        elif aliases is not None:
+            print(
+                f"  warn  {_relpath(path)}: non-list 'aliases' ignored",
+                file=sys.stderr,
+            )
 
     return count
 
@@ -568,15 +606,14 @@ def _rewrite_changelog(text: str) -> str:
     """Fix links in changelog.md when moved from docs/product/ to docs-site content.
 
     In source: relative to docs/product/changelog.md
-      ../guides/... → guides/...  (in-site, rewrite)
+      ../guides/... → base-qualified technical guide route
       ../rfc/...    → GitHub URL  (not in site)
       ../specs/...  → GitHub URL  (not in site)
     """
     def replace(m: re.Match) -> str:
         prefix, path, anchor = m.group(1), m.group(2), m.group(3) or ""
         if path.startswith("../guides/"):
-            # Strip the leading ../
-            return f"{prefix}{path[3:]}{anchor})"
+            return f"{prefix}{SITE_BASE}/{path[3:]}{anchor})"
         if path.startswith("../"):
             # Convert to GitHub URL
             clean = path[3:]  # remove ../
@@ -591,8 +628,8 @@ def _rewrite_pack_readme(text: str, pack_src_path: Path) -> str:
     """Rewrite links in pack READMEs moved from packs/<slug>/README.md
     to docs-site/src/content/docs/packs/<slug>.md.
 
-    Cross-pack links (../other-pack/README.md) → other-pack/
-    Links outside packs/ that resolve in the repo → GitHub URL.
+    Pack-home links (../other-pack/README.md) → other-pack/
+    Other repository files, including files beside the README → GitHub URL.
     """
     packs_root = (REPO_ROOT / "packs").resolve()
     repo_root = REPO_ROOT.resolve()
@@ -610,7 +647,10 @@ def _rewrite_pack_readme(text: str, pack_src_path: Path) -> str:
             # e.g. ../credential-brokers/README.md → ../credential-brokers/
             rel = resolved.relative_to(packs_root)
             pack_name = rel.parts[0]
-            return f"{prefix}{pack_name}/{anchor})"
+            if resolved.is_dir() or rel.parts[1:] == ("README.md",):
+                return f"{prefix}{pack_name}/{anchor})"
+            repo_rel = resolved.relative_to(repo_root)
+            return f"{prefix}{GITHUB_BASE}/{repo_rel}{anchor})"
 
         if _is_relative_to(resolved, repo_root):
             rel = resolved.relative_to(repo_root)
@@ -643,14 +683,14 @@ def _rewrite_guide(text: str, guide_src_path: Path) -> str:
         except Exception:
             return m.group(0)
 
-        # Within guides/ → keep relative (Starlight resolves them)
-        if _is_relative_to(resolved, guides_root):
-            if resolved.is_dir():
-                # Bare directory link → index
-                return m.group(0)
-            if resolved.exists():
-                return m.group(0)
-            # Stale link within guides/ — fall through
+        # Within guides/ → route to the mirrored page from the docs root.
+        # A relative source link cannot be preserved: Starlight serves each
+        # Markdown file as a directory route, so `sibling.md` from
+        # `/guide-name/` would incorrectly become `/guide-name/sibling/`.
+        if _is_relative_to(resolved, guides_root) and resolved.exists():
+            site_url = _guide_site_url(resolved, guides_root)
+            return f"{prefix}{site_url}{anchor})"
+        # Stale link within guides/ — fall through
 
         # Within repo but outside guides/ → GitHub URL
         if _is_relative_to(resolved, repo_root):
@@ -661,6 +701,26 @@ def _rewrite_guide(text: str, guide_src_path: Path) -> str:
 
     result = re.sub(r"(\]\()([^)#\"'\s]+)(#[^)]+)?\)", replace, text)
     return _strip_md_suffixes(result)
+
+
+def _guide_site_url(path: Path, guides_root: Path) -> str:
+    """Return the base-qualified technical-doc URL for a guide source path."""
+    source = path / "README.md" if path.is_dir() else path
+    rel = source.relative_to(guides_root)
+
+    if source.suffix == ".md" and source.exists():
+        frontmatter = _parse_frontmatter(source.read_text(encoding="utf-8"))
+        slug = _normalise_guide_slug(frontmatter.get("slug"), source)
+        if not slug:
+            parts = list(rel.parts)
+            if parts[-1] == "README.md":
+                parts = parts[:-1]
+            else:
+                parts[-1] = Path(parts[-1]).stem
+            slug = "/".join(("guides", *parts))
+        return f"{SITE_BASE}/{slug}/"
+
+    return f"{SITE_BASE}/guides/{rel.as_posix()}"
 
 
 def _is_relative_to(path: Path, base: Path) -> bool:
@@ -691,10 +751,12 @@ def _rewrite_contributing(text: str) -> str:
         except Exception:
             return m.group(0)
 
-        # Links within guides/ → site-relative (guides/ is in the site)
-        if _is_relative_to(resolved, guides_root):
-            rel = resolved.relative_to(guides_root)
-            return f"{prefix}guides/{rel}{anchor})"
+        # Links within guides/ → base-qualified mirrored guide route.
+        # CONTRIBUTING is served from /docs/contributing/, so a `guides/...`
+        # href would otherwise nest under that page.
+        if _is_relative_to(resolved, guides_root) and resolved.exists():
+            site_url = _guide_site_url(resolved, guides_root)
+            return f"{prefix}{site_url}{anchor})"
 
         # Any other repo-relative link → GitHub URL
         if _is_relative_to(resolved, repo_root):

--- a/tools/check-guide-index.py
+++ b/tools/check-guide-index.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Phase 4B regression check: verify every active pack appears in guides/README.md
-All-packs table.
+Verify every active pack has a direct guide-home link in guides/README.md.
 
 Exit 0 = all packs accounted for.
 Exit 1 = at least one active pack is absent from the guide index.
@@ -40,50 +39,55 @@ def discover_active_packs() -> list[str]:
     return packs
 
 
-def extract_indexed_packs(guide_index: Path) -> set[str]:
-    """
-    Extract pack IDs from the '## All packs' table in guides/README.md.
-    Only scans between the '## All packs' heading and the next '##' heading
-    to avoid false-positives from role/loop tables earlier in the file.
+def extract_linked_packs(guide_index: Path) -> set[str]:
+    """Extract pack IDs from direct ``<pack>/`` guide-home links.
+
+    The guide root may organize discovery by outcome, role, or another reader
+    need. Requiring one direct link per active pack preserves complete coverage
+    without requiring a duplicate all-packs table or a specific page layout.
     """
     if not guide_index.exists():
         return set()
     content = guide_index.read_text(encoding="utf-8")
-    # Slice to the "## All packs" section only
-    match = re.search(r"^## All packs\b", content, re.MULTILINE)
-    if not match:
-        return set()
-    section_start = match.end()
-    next_heading = re.search(r"^##", content[section_start:], re.MULTILINE)
-    if next_heading:
-        section = content[section_start : section_start + next_heading.start()]
-    else:
-        section = content[section_start:]
-    # Match rows like: | [`core`](core/) | ...
-    return set(re.findall(r"\|\s*\[`([a-z][a-z\-]+)`\]", section))
+    return set(re.findall(r"\]\(([a-z][a-z0-9-]*)/\)", content))
 
 
-def main() -> int:
-    active_packs = discover_active_packs()
-    indexed_packs = extract_indexed_packs(GUIDE_INDEX)
-
-    missing = [
+def find_missing_packs(
+    active_packs: list[str], indexed_packs: set[str]
+) -> list[str]:
+    """Return active packs that have no required direct guide-home link."""
+    return [
         p for p in active_packs
         if p not in indexed_packs and p not in GUIDE_OPTIONAL_PACKS
     ]
+
+
+def report_coverage(active_packs: list[str], indexed_packs: set[str]) -> int:
+    """Report guide-index coverage and return its process exit code."""
+    missing = find_missing_packs(active_packs, indexed_packs)
 
     if missing:
         print("check-guide-index: FAIL — active packs missing from guides/README.md:")
         for p in missing:
             print(f"  ✗ {p}")
         guide_index_rel = GUIDE_INDEX.relative_to(REPO_ROOT)
-        print(f"\nFix: add each missing pack to the 'All packs' table in {guide_index_rel}")
+        print(
+            "\nFix: add a direct '<pack>/' guide-home link for each missing "
+            f"pack in {guide_index_rel}"
+        )
         return 1
 
     print(
         f"check-guide-index: OK — all {len(active_packs)} active packs present in guide index"
     )
     return 0
+
+
+def main() -> int:
+    """Check the repository guide index."""
+    return report_coverage(
+        discover_active_packs(), extract_linked_packs(GUIDE_INDEX)
+    )
 
 
 if __name__ == "__main__":

--- a/tools/test_build_site_link_rewrites.py
+++ b/tools/test_build_site_link_rewrites.py
@@ -1,0 +1,133 @@
+"""Construction tests for links rewritten into mirrored technical docs."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "build_site_link_rewrites", _HERE / "build-site.py"
+)
+assert _SPEC and _SPEC.loader
+BUILD_SITE = importlib.util.module_from_spec(_SPEC)
+sys.modules["build_site_link_rewrites"] = BUILD_SITE
+_SPEC.loader.exec_module(BUILD_SITE)
+
+
+def test_same_directory_guide_link_is_base_qualified() -> None:
+    source = (
+        BUILD_SITE.REPO_ROOT
+        / "guides/_shared/explanation/pack-catalogue.md"
+    )
+    rewritten = BUILD_SITE._rewrite_guide(
+        "[File safety](file-safety-contract.md#upgrades)", source
+    )
+    assert rewritten == (
+        "[File safety](/agent-ready-repo/docs/guides/_shared/"
+        "explanation/file-safety-contract/#upgrades)"
+    )
+
+
+def test_parent_guide_index_link_is_base_qualified() -> None:
+    source = (
+        BUILD_SITE.REPO_ROOT
+        / "guides/_shared/explanation/pack-catalogue.md"
+    )
+    rewritten = BUILD_SITE._rewrite_guide("[Shared guides](../)", source)
+    assert rewritten == "[Shared guides](/agent-ready-repo/docs/guides/_shared/)"
+
+
+def test_cross_pack_guide_link_is_base_qualified() -> None:
+    source = (
+        BUILD_SITE.REPO_ROOT
+        / "guides/_shared/explanation/pack-catalogue.md"
+    )
+    rewritten = BUILD_SITE._rewrite_guide("[Core](../../core/)", source)
+    assert rewritten == "[Core](/agent-ready-repo/docs/guides/core/)"
+
+
+def test_contributing_guide_link_escapes_contributing_route() -> None:
+    rewritten = BUILD_SITE._rewrite_contributing(
+        "[Standards](guides/_shared/reference/"
+        "catalogue-authoring-standards.md)"
+    )
+    assert rewritten == (
+        "[Standards](/agent-ready-repo/docs/guides/_shared/reference/"
+        "catalogue-authoring-standards/)"
+    )
+
+
+def test_pack_sibling_file_links_to_repository_source() -> None:
+    source = BUILD_SITE.REPO_ROOT / "packs/core/README.md"
+    rewritten = BUILD_SITE._rewrite_pack_readme("[Design](DESIGN.md)", source)
+    assert rewritten == (
+        "[Design](https://github.com/eugenelim/agent-ready-repo/"
+        "blob/main/packs/core/DESIGN.md)"
+    )
+
+
+def test_changelog_guide_link_escapes_changelog_route() -> None:
+    rewritten = BUILD_SITE._rewrite_changelog(
+        "[Vision](../guides/product-engineering/how-to/"
+        "frame-a-product-vision.md)"
+    )
+    assert rewritten == (
+        "[Vision](/agent-ready-repo/docs/guides/product-engineering/"
+        "how-to/frame-a-product-vision/)"
+    )
+
+
+def test_frontmatter_slug_override_is_used_for_guide_links() -> None:
+    source = BUILD_SITE.REPO_ROOT / "guides/atlassian/README.md"
+    rewritten = BUILD_SITE._rewrite_guide(
+        "[Jira](work-with-jira.md)", source
+    )
+    assert rewritten == (
+        "[Jira](/agent-ready-repo/docs/guides/atlassian/"
+        "how-to/work-with-jira/)"
+    )
+
+
+def test_guide_slug_normalisation_rejects_route_escapes() -> None:
+    assert BUILD_SITE._normalise_guide_slug("guides/core/index") == "guides/core"
+    assert BUILD_SITE._normalise_guide_slug("guides/../outside") is None
+    assert BUILD_SITE._normalise_guide_slug("../outside") is None
+    assert BUILD_SITE._normalise_guide_slug("packs/core") is None
+    assert BUILD_SITE._normalise_guide_slug(123) is None
+
+
+def test_all_projected_guide_links_resolve_to_a_canonical_route() -> None:
+    guides_root = (BUILD_SITE.REPO_ROOT / "guides").resolve()
+    sources = sorted(guides_root.rglob("*.md"))
+    routes = {
+        BUILD_SITE._guide_site_url(source.resolve(), guides_root).rstrip("/")
+        for source in sources
+    }
+    failures = []
+    for source in (*sources, BUILD_SITE.REPO_ROOT / "CONTRIBUTING.md"):
+        content = source.read_text(encoding="utf-8")
+        rewritten = (
+            BUILD_SITE._rewrite_contributing(content)
+            if source.name == "CONTRIBUTING.md"
+            else BUILD_SITE._rewrite_guide(content, source.resolve())
+        )
+        targets = re.findall(
+            r"\]\((/agent-ready-repo/docs/guides/[^)#\s]*)(?:#[^)]*)?\)",
+            rewritten,
+        )
+        for target in targets:
+            if target.rstrip("/") not in routes:
+                failures.append(f"{source.relative_to(BUILD_SITE.REPO_ROOT)} -> {target}")
+
+    assert not failures, "\n".join(failures)
+
+
+if __name__ == "__main__":
+    for name, function in sorted(globals().items()):
+        if name.startswith("test_") and callable(function):
+            function()
+    print("test-build-site-link-rewrites: all cases passed.")
+    sys.exit(0)

--- a/tools/test_catalogue_navigation.py
+++ b/tools/test_catalogue_navigation.py
@@ -1,0 +1,80 @@
+"""Source contract for outcome-led catalogue navigation.
+
+The marketing homepage and catalogue import one outcome map. Public Markdown
+entry points remain authored for their medium, so this test keeps their labels
+aligned without requiring generated prose.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+NAVIGATION_SOURCE = REPO_ROOT / "web/src/lib/catalogue-navigation.ts"
+MARKETING_SURFACES = (
+    REPO_ROOT / "web/src/components/marketing/PackCatalogue.astro",
+    REPO_ROOT / "web/src/pages/catalogue/index.astro",
+)
+MARKDOWN_SURFACES = (
+    REPO_ROOT / "guides/README.md",
+    REPO_ROOT / "docs-site/src/content/docs/index.mdx",
+)
+EXCLUDED_PACKS = {"_example", "user-guide-diataxis"}
+
+
+def _navigation_source() -> str:
+    return NAVIGATION_SOURCE.read_text(encoding="utf-8")
+
+
+def _pack_memberships(source: str) -> set[str]:
+    blocks = re.findall(r"packs:\s*\[(.*?)\]", source, flags=re.DOTALL)
+    return {
+        pack
+        for block in blocks
+        for pack in re.findall(r"['\"]([a-z][a-z0-9-]*)['\"]", block)
+    }
+
+
+def _outcome_titles(source: str) -> set[str]:
+    return set(re.findall(r"^\s{4}title: '([^']+)'", source, flags=re.MULTILINE))
+
+
+def test_all_active_packs_have_an_outcome() -> None:
+    active = {
+        manifest.parent.name for manifest in (REPO_ROOT / "packs").glob("*/pack.toml")
+    } - EXCLUDED_PACKS
+    assert _pack_memberships(_navigation_source()) == active
+
+
+def test_marketing_surfaces_import_the_canonical_map() -> None:
+    for surface in MARKETING_SURFACES:
+        content = surface.read_text(encoding="utf-8")
+        assert "../../lib/catalogue-navigation" in content, surface
+        assert "const outcomes = [" not in content, surface
+
+
+def test_markdown_entry_points_keep_canonical_outcome_labels() -> None:
+    titles = _outcome_titles(_navigation_source())
+    assert len(titles) == 7
+    for surface in MARKDOWN_SURFACES:
+        content = surface.read_text(encoding="utf-8")
+        missing = sorted(title for title in titles if title not in content)
+        assert not missing, f"{surface.relative_to(REPO_ROOT)}: {missing}"
+
+
+def test_role_routes_resolve_to_outcomes() -> None:
+    source = _navigation_source()
+    outcome_ids = set(re.findall(r"^\s{4}id: '([^']+)'", source, flags=re.MULTILINE))
+    role_ids = set(re.findall(r"outcomeId: '([^']+)'", source))
+    assert role_ids
+    assert role_ids <= outcome_ids
+
+
+if __name__ == "__main__":
+    for name, function in sorted(globals().items()):
+        if name.startswith("test_") and callable(function):
+            function()
+    print("test-catalogue-navigation: all cases passed.")
+    sys.exit(0)

--- a/tools/test_check_guide_index.py
+++ b/tools/test_check_guide_index.py
@@ -1,0 +1,79 @@
+"""Construction tests for ``tools/check-guide-index.py``.
+
+The cases use in-memory inputs so the coverage contract stays testable in
+restricted environments without a writable temporary directory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "check_guide_index", _HERE / "check-guide-index.py"
+)
+assert _SPEC and _SPEC.loader
+CHECKER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(CHECKER)
+
+
+class _IndexText:
+    """Small ``Path`` stand-in for parser tests."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+    def exists(self) -> bool:
+        return True
+
+    def read_text(self, *, encoding: str) -> str:
+        assert encoding == "utf-8"
+        return self.content
+
+
+def test_extracts_only_direct_guide_home_links() -> None:
+    index = _IndexText(
+        "\n".join(
+            [
+                "[Core](core/)",
+                "[Pack guide](architect/how-to/plan.md)",
+                "[Site route](/packs/contracts/)",
+                "[Parent route](../linear/)",
+                "[Fragment](#product-engineering/)",
+            ]
+        )
+    )
+
+    assert CHECKER.extract_linked_packs(index) == {"core"}
+
+
+def test_missing_pack_returns_failure() -> None:
+    output = io.StringIO()
+    with redirect_stdout(output):
+        result = CHECKER.report_coverage(
+            ["architect", "core"], {"core"}
+        )
+
+    assert result == 1
+    assert "architect" in output.getvalue()
+
+
+def test_complete_index_returns_success() -> None:
+    output = io.StringIO()
+    with redirect_stdout(output):
+        result = CHECKER.report_coverage(
+            ["architect", "core"], {"architect", "core"}
+        )
+
+    assert result == 0
+    assert "all 2 active packs" in output.getvalue()
+
+
+if __name__ == "__main__":
+    for name, function in sorted(globals().items()):
+        if name.startswith("test_") and callable(function):
+            function()
+    print("test-check-guide-index: all cases passed.")

--- a/tools/test_documentation_entry_links.py
+++ b/tools/test_documentation_entry_links.py
@@ -1,0 +1,261 @@
+"""Construction checks for documentation-entry navigation links.
+
+This deliberately checks authored sources only. The site build mirrors guides
+and pack READMEs into generated pages, so route existence is reconstructed from
+those source trees rather than from generated output.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import string
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).parent.parent
+SITE_BASE = "/agent-ready-repo"
+DOCS_BASE = f"{SITE_BASE}/docs"
+
+DOC_SOURCES = (
+    "README.md",
+    "CONTRIBUTING.md",
+    "guides/README.md",
+    "guides/_shared/explanation/pack-catalogue.md",
+    "docs-site/src/content/docs/index.mdx",
+    "docs-site/src/content/docs/getting-started/index.mdx",
+    "docs-site/src/content/docs/getting-started/install.md",
+    "docs-site/src/content/docs/getting-started/three-loops.md",
+    "docs/architecture/overview.md",
+    "docs/specs/catalogue-wave8-readme-contributing/plan.md",
+    "docs/specs/catalogue-wave8-readme-contributing/spec.md",
+    "docs/specs/documentation-entry-navigation/spec.md",
+    "docs/specs/documentation-entry-navigation/plan.md",
+    "docs/specs/documentation-entry-navigation/notes/information-architecture.md",
+    "docs/specs/documentation-entry-navigation/notes/verification.md",
+)
+
+MARKETING_SOURCES = (
+    "web/src/components/layout/SiteNav.astro",
+    "web/src/components/marketing/BuildYourOrg.astro",
+    "web/src/components/marketing/Hero.astro",
+    "web/src/components/marketing/PackCatalogue.astro",
+    "web/src/pages/catalogue/index.astro",
+    "web/src/pages/index.astro",
+)
+
+MARKDOWN_LINK_RE = re.compile(
+    r"(?<!\!)\[[^\]]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)"
+)
+WITH_BASE_RE = re.compile(r"withBase\(['\"]([^'\"]+)['\"]\)")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+ID_RE = re.compile(r"id=[\"']([^\"']+)[\"']")
+
+
+def _load_build_site():
+    spec = importlib.util.spec_from_file_location(
+        "build_site_entry_link_check", REPO_ROOT / "tools" / "build-site.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_site_entry_link_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BUILD_SITE = _load_build_site()
+
+
+def _strip_fences(text: str) -> str:
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+def _split_anchor(raw: str) -> tuple[str, str | None]:
+    target, _marker, anchor = raw.partition("#")
+    return target, anchor or None
+
+
+def _slugify(text: str) -> str:
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"[`*_{}\[\](),:]", "", text)
+    text = text.strip().lower()
+    keep = string.ascii_lowercase + string.digits + " -_"
+    text = "".join(ch for ch in text if ch in keep)
+    return re.sub(r"\s+", "-", text)
+
+
+def _anchors_for(path: Path) -> set[str]:
+    if path.is_dir():
+        path = path / "README.md"
+    if not path.exists() or path.suffix not in {".astro", ".md", ".mdx"}:
+        return set()
+    text = _strip_fences(path.read_text(encoding="utf-8"))
+    return {_slugify(h) for h in HEADING_RE.findall(text)} | set(ID_RE.findall(text))
+
+
+def _resolve_local(source: Path, target: str) -> Path | None:
+    candidate = (source.parent / target).resolve()
+    if candidate.exists():
+        return candidate
+    if target.endswith("/"):
+        readme = candidate / "README.md"
+        return readme if readme.exists() else None
+    if candidate.suffix == "":
+        for alt in (
+            candidate / "README.md",
+            candidate.with_suffix(".md"),
+            candidate.with_suffix(".mdx"),
+        ):
+            if alt.exists():
+                return alt
+    return None
+
+
+def _docs_routes() -> set[str]:
+    routes = {DOCS_BASE, f"{DOCS_BASE}/"}
+    docs_root = REPO_ROOT / "docs-site/src/content/docs"
+    for source in docs_root.rglob("*"):
+        if source.suffix not in {".md", ".mdx"}:
+            continue
+        rel = source.relative_to(docs_root)
+        parts = list(rel.with_suffix("").parts)
+        if parts[-1] == "index":
+            parts = parts[:-1]
+        route = f"{DOCS_BASE}/" + "/".join(parts)
+        routes.add(route.rstrip("/"))
+        routes.add(route.rstrip("/") + "/")
+
+    guides_root = (REPO_ROOT / "guides").resolve()
+    for source in guides_root.rglob("*.md"):
+        route = BUILD_SITE._guide_site_url(source.resolve(), guides_root)
+        routes.add(route.rstrip("/"))
+        routes.add(route.rstrip("/") + "/")
+
+    for source in (REPO_ROOT / "packs").glob("*/README.md"):
+        slug = source.parent.name
+        if slug.startswith("_"):
+            continue
+        routes.add(f"{DOCS_BASE}/packs/{slug}")
+        routes.add(f"{DOCS_BASE}/packs/{slug}/")
+    routes.add(f"{DOCS_BASE}/packs")
+    routes.add(f"{DOCS_BASE}/packs/")
+    return routes
+
+
+def _web_routes() -> set[str]:
+    routes = {SITE_BASE, f"{SITE_BASE}/", f"{SITE_BASE}/catalogue", f"{SITE_BASE}/catalogue/"}
+    for source in (REPO_ROOT / "packs").glob("*/pack.toml"):
+        slug = source.parent.name
+        if not slug.startswith("_"):
+            routes.add(f"{SITE_BASE}/packs/{slug}")
+            routes.add(f"{SITE_BASE}/packs/{slug}/")
+    return routes
+
+
+def _homepage_anchors() -> set[str]:
+    sources = (
+        "web/src/pages/index.astro",
+        "web/src/components/marketing/AdapterMatrix.astro",
+        "web/src/components/marketing/BuildYourOrg.astro",
+        "web/src/components/marketing/HumanGates.astro",
+        "web/src/components/marketing/InstallTerminal.astro",
+        "web/src/components/marketing/PackCatalogue.astro",
+        "web/src/components/marketing/TheProblem.astro",
+        "web/src/components/marketing/ThreeLoops.astro",
+    )
+    anchors: set[str] = set()
+    for rel in sources:
+        anchors |= _anchors_for(REPO_ROOT / rel)
+    return anchors
+
+
+def _check_site_route(
+    route: str,
+    anchor: str | None,
+    docs_routes: set[str],
+    web_routes: set[str],
+    homepage_anchors: set[str],
+) -> str | None:
+    normalized = route.rstrip("/") or SITE_BASE
+    if normalized.startswith(DOCS_BASE):
+        if normalized not in {r.rstrip("/") for r in docs_routes}:
+            return f"missing docs route {route}"
+        return None
+    if normalized not in {r.rstrip("/") for r in web_routes}:
+        return f"missing web route {route}"
+    if anchor and normalized == SITE_BASE and anchor not in homepage_anchors:
+        return f"missing homepage anchor #{anchor}"
+    return None
+
+
+def test_changed_markdown_links_resolve() -> None:
+    docs_routes = _docs_routes()
+    web_routes = _web_routes()
+    homepage_anchors = _homepage_anchors()
+    failures: list[str] = []
+
+    for rel in DOC_SOURCES:
+        source = REPO_ROOT / rel
+        content = _strip_fences(source.read_text(encoding="utf-8"))
+        for raw in MARKDOWN_LINK_RE.findall(content):
+            target, anchor = _split_anchor(raw)
+            parsed = urlparse(target)
+            if parsed.scheme in {"http", "https"}:
+                if parsed.netloc != "eugenelim.github.io":
+                    continue
+                failure = _check_site_route(
+                    parsed.path, anchor, docs_routes, web_routes, homepage_anchors
+                )
+                if failure:
+                    failures.append(f"{rel}: {failure}")
+                continue
+            if target.startswith(("mailto:", "#")):
+                if target.startswith("#") and target[1:] not in _anchors_for(source):
+                    failures.append(f"{rel}: missing local anchor {target}")
+                continue
+            if target.startswith(SITE_BASE):
+                failure = _check_site_route(
+                    target, anchor, docs_routes, web_routes, homepage_anchors
+                )
+                if failure:
+                    failures.append(f"{rel}: {failure}")
+                continue
+
+            resolved = _resolve_local(source, target)
+            if resolved is None:
+                failures.append(f"{rel}: missing local target {target}")
+                continue
+            if anchor and anchor not in _anchors_for(resolved):
+                failures.append(
+                    f"{rel}: missing anchor #{anchor} in {resolved.relative_to(REPO_ROOT)}"
+                )
+
+    assert not failures, "\n".join(failures)
+
+
+def test_changed_marketing_routes_resolve() -> None:
+    docs_routes = _docs_routes()
+    web_routes = _web_routes()
+    homepage_anchors = _homepage_anchors()
+    failures: list[str] = []
+
+    for rel in MARKETING_SOURCES:
+        content = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for raw in WITH_BASE_RE.findall(content):
+            target, anchor = _split_anchor(raw)
+            route = SITE_BASE + target if target.startswith("/") else target
+            failure = _check_site_route(
+                route, anchor, docs_routes, web_routes, homepage_anchors
+            )
+            if failure:
+                failures.append(f"{rel}: {failure}")
+
+    assert not failures, "\n".join(failures)
+
+
+if __name__ == "__main__":
+    for name, function in sorted(globals().items()):
+        if name.startswith("test_") and callable(function):
+            function()
+    print("test-documentation-entry-links: all cases passed.")

--- a/web/src/components/layout/SiteLayout.astro
+++ b/web/src/components/layout/SiteLayout.astro
@@ -12,7 +12,7 @@ interface Props {
 
 const {
   title,
-  description = 'The supervised AI operating model for software teams — three peer loops across the full SDLC, with mechanical gates and human checkpoints the agent cannot bypass.',
+  description = 'A spec-driven agentic build loop with mechanical gates, cold independent review, and a human merge decision — plus a catalogue of supervised workflows for the rest of software delivery.',
   ogImage,
 } = Astro.props;
 

--- a/web/src/components/layout/SiteNav.astro
+++ b/web/src/components/layout/SiteNav.astro
@@ -2,12 +2,12 @@
 // Primary navigation. Dark zone — continuous with the hero below it, no gap.
 // Mobile menu is a <details>/<summary> disclosure: zero JavaScript.
 // Nav structure:
-//   Logo | How it works | Catalogue | Journeys | Docs ↗ | [Install →]
+//   Logo | How it works | Use cases | Catalogue | Docs ↗ | [Try the build loop →]
 import { withBase } from '../../lib/paths';
 const links = [
   { label: 'How it works', href: withBase('/#three-loops') },
+  { label: 'Use cases', href: withBase('/#use-cases') },
   { label: 'Catalogue', href: withBase('/catalogue/') },
-  { label: 'Journeys', href: withBase('/journeys/') },
 ];
 const homeHref = withBase('/');
 const docsHref = withBase('/docs/');
@@ -28,7 +28,7 @@ const installHref = withBase('/#install');
         </a>
       </li>
       <li>
-        <a class="nav__cta" href={installHref}>Install <span aria-hidden="true">→</span></a>
+        <a class="nav__cta" href={installHref}>Try the build loop <span aria-hidden="true">→</span></a>
       </li>
     </ul>
 
@@ -46,7 +46,7 @@ const installHref = withBase('/#install');
           </a>
         </li>
         <li>
-          <a class="nav__cta" href={installHref}>Install <span aria-hidden="true">→</span></a>
+          <a class="nav__cta" href={installHref}>Try the build loop <span aria-hidden="true">→</span></a>
         </li>
       </ul>
     </details>

--- a/web/src/components/marketing/BuildYourOrg.astro
+++ b/web/src/components/marketing/BuildYourOrg.astro
@@ -9,15 +9,15 @@ import { withBase } from '../../lib/paths';
 
 <Section tone="dark" labelledby="org-heading">
   <div class="org">
-    <h2 id="org-heading" class="org__headline">Make it your team's operating model.</h2>
+    <h2 id="org-heading" class="org__headline">Own the catalogue your team runs.</h2>
     <p class="org__body">
-      Adopt the catalogue as-is, or fork it as your own. Write your house conventions
-      and review standards into <code>core</code>, add skills for your stack, and ship
-      one catalogue every engineer installs in a single line — the loop, the reviewers,
-      and the standards come out identical on every machine and in every agent.
+      Initialize a clean managed scaffold with <code>agentbundle catalogue init</code>.
+      Choose the packs and profiles your organization supports, encode your conventions
+      and defaults, validate the contracts, and distribute one governed system across
+      machines and agent adapters. No repository fork is required.
     </p>
-    <a class="org__cta" href={withBase('/docs/guides/_shared/how-to/build-an-org-stack-pack/')}>
-      How to build your org's catalogue <span aria-hidden="true">→</span>
+    <a class="org__cta" href={withBase('/docs/guides/_shared/how-to/create-a-catalogue/')}>
+      Build your organization's catalogue <span aria-hidden="true">→</span>
     </a>
   </div>
 </Section>

--- a/web/src/components/marketing/Hero.astro
+++ b/web/src/components/marketing/Hero.astro
@@ -8,21 +8,25 @@ import { withBase } from '../../lib/paths';
 
 <section class="hero">
   <div class="hero__inner">
-    <h1 class="hero__headline">The supervised AI operating model for software teams.</h1>
+    <h1 class="hero__headline">The agentic build loop that cannot approve its own work.</h1>
     <p class="hero__subhead">
-      Three supervised peer loops across the full SDLC — mechanical gates the agent
-      cannot bypass, cold-read specialist reviewers, and human checkpoints it cannot
-      self-certify past.
+      <code>core</code> takes a brief or spec through implementation, mechanical gates,
+      and a cold independent review. It keeps going until the change is clean—or stops
+      and tells you why. The wider catalogue brings the same discipline to product,
+      design, infrastructure, release, research, and documentation work.
     </p>
     <div class="hero__actions">
       <a class="hero__cta hero__cta--primary" href={withBase('/#install')}>
-        Install the core loop <span aria-hidden="true">→</span>
+        Try the supervised build loop <span aria-hidden="true">→</span>
       </a>
-      <a class="hero__cta hero__cta--ghost" href={withBase('/catalogue/')}>
-        Browse the catalogue <span aria-hidden="true">→</span>
+      <a class="hero__cta hero__cta--ghost" href={withBase('/#use-cases')}>
+        Explore use cases <span aria-hidden="true">→</span>
       </a>
     </div>
-    <p class="hero__friction">Reversible. One command to try, one to remove.</p>
+    <p class="hero__friction">
+      One command. Every major coding agent. Human merge gate. User-scope packs also
+      ship through the <a href={withBase('/docs/getting-started/install/#route-2-claude-plugins')}>Claude plugin marketplace</a>.
+    </p>
   </div>
 </section>
 
@@ -54,6 +58,12 @@ import { withBase } from '../../lib/paths';
     font-size: var(--ds-type-body-lg);
     max-width: 60ch;
     margin-bottom: var(--ds-space-6);
+  }
+
+  .hero__subhead code {
+    background: none;
+    color: var(--ds-accent);
+    font-family: var(--ds-font-mono);
   }
 
   .hero__actions {
@@ -119,5 +129,11 @@ import { withBase } from '../../lib/paths';
     color: var(--ds-hero-fg-muted);
     margin-top: var(--ds-space-3);
     margin-bottom: 0;
+  }
+
+  .hero__friction a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 0.18em;
   }
 </style>

--- a/web/src/components/marketing/PackCatalogue.astro
+++ b/web/src/components/marketing/PackCatalogue.astro
@@ -1,241 +1,144 @@
 ---
-// Section 8 — THE CATALOGUE. Light zone. Progressive disclosure: the 3 loops
-// are always visible (large cards); the remaining 14 packs live behind a
-// <details> expander — zero JS. 3-always + 14-on-reveal (homepage-screen-flow.md).
-// Within each scope group, packs follow the SDLC value-stream order used on the
-// /catalogue/ page (RFC-0064): strategy → research → design → architecture →
-// contracts → infra → governance → docs, then supporting tooling and connectors.
+// Homepage outcome router. The complete inventory belongs to /catalogue/;
+// this section helps readers recognize their work before they know pack names.
 import Section from '../layout/Section.astro';
 import { withBase } from '../../lib/paths';
-import StatusChip from '../primitives/StatusChip.astro';
-
-const loops = [
-  {
-    name: 'Core',
-    scope: 'repo',
-    desc: 'The build loop. work-loop, new-spec, bug-fix, four specialist reviewers, hooks. Install this even if you install nothing else.',
-    install: 'agentbundle install --pack core',
-    journey: '/journeys/core/',
-  },
-  {
-    name: 'Product Engineering',
-    scope: 'user',
-    desc: 'The discovery loop. discovery-loop, frame-intent, de-risk-intent, decompose-intent, ux-writing, align-value-stream.',
-    install: 'agentbundle install --pack product-engineering --scope user',
-    journey: '/journeys/product-engineering/',
-  },
-  {
-    name: 'Release Engineering',
-    scope: 'repo',
-    desc: 'The release loop. release-loop, release-lead. Autonomous e2e convergence. Hard-depends on core.',
-    install: 'agentbundle install --pack release-engineering',
-    journey: '/journeys/release-engineering/',
-  },
-];
-
-const userPacks = [
-  { name: 'Product Strategy', desc: 'The strategy seat — SWOT, Porter, PESTLE, OKR cascade, PRFAQ, plus UX and content strategy.' },
-  { name: 'Desk Research', desc: 'Evidence-grounded research — surveys, source maps, competing-hypothesis analysis.' },
-  { name: 'Experience Design', desc: 'The full design thread — journey to realization, WCAG-aware quality floor.' },
-  { name: 'Architect', desc: 'System design — design docs, diagrams, architecture review.' },
-  { name: 'Contracts', desc: 'API-first design — OpenAPI 3.1 and AsyncAPI contracts.' },
-  { name: 'Converters', desc: 'Document conversion — PDF/DOCX/PPTX ↔ Markdown, HTML, Office, Mermaid.' },
-  { name: 'Credential Brokers', desc: 'Credential resolution — env → OS keyring → dotfile. Cleartext never reaches the model.' },
-  { name: 'Atlassian', desc: 'Jira and Confluence from the agent — flow and DORA metrics, SSO-cookie auth.' },
-  { name: 'Figma', desc: 'Read and render Figma designs — files, nodes, variables, FigJam → Mermaid.' },
-];
-
-const repoPacks = [
-  { name: 'IaC (Terraform)', desc: 'Plain-language intent → governed, cloud-agnostic Terraform. Human-gated; stops at plan.' },
-  { name: 'Governance Extras', desc: 'Decision trail — new-rfc, new-adr, update-conventions for long-lived repos.' },
-  { name: 'User Guide (Diátaxis)', desc: 'Docs scaffold — Diátaxis skeleton with new-guide.' },
-  { name: 'Monorepo Extras', desc: 'Package scaffolding — new-package, example package template.' },
-  { name: 'Catalogue Curation', desc: 'Grow the catalogue — assimilate primitives, survey repos, propose packs, export forks.' },
-];
+import { catalogueOutcomes } from '../../lib/catalogue-navigation';
 ---
 
-<Section tone="surface" labelledby="catalogue-heading">
-  <h2 id="catalogue-heading" class="catalogue__headline">The catalogue.</h2>
-  <p class="catalogue__subhead">
-    A curated library of packs — each shaped through practitioner research and RFC
-    governance. Start with the loops.
+<Section tone="surface" id="use-cases" labelledby="work-heading">
+  <p class="work__eyebrow">Use cases</p>
+  <h2 id="work-heading" class="work__headline">Start with the outcome. Meet the packs second.</h2>
+  <p class="work__subhead">
+    Packs are composable units, not departments. Choose the change you need and
+    install only the workflows that help produce it.
   </p>
 
-  <ul class="loop-cards">
-    {loops.map((p) => (
-      <li class="loop-card">
-        <div class="loop-card__head">
-          <h3 class="loop-card__name">{p.name}</h3>
-          <StatusChip label={p.scope} />
+  <ul class="work-grid" role="list">
+    {catalogueOutcomes.map((outcome) => (
+      <li class:list={['work-card', { 'work-card--flagship': outcome.flagship }]}>
+        <div class="work-card__head">
+          <h3 class="work-card__title">{outcome.title}</h3>
+          {outcome.flagship && <span class="work-card__flag">Flagship system</span>}
         </div>
-        <p class="loop-card__desc">{p.desc}</p>
-        <p class="loop-card__install"><code>{p.install}</code></p>
-        <a class="loop-card__link" href={withBase(p.journey)}>Read the journey <span aria-hidden="true">→</span></a>
+        <p class="work-card__audience">{outcome.forWhom}</p>
+        <p class="work-card__desc">{outcome.homepageDescription}</p>
+        <ul class="work-card__packs" aria-label={`Packs for ${outcome.title}`}>
+          {outcome.packs.map((pack) => (
+            <li><a href={withBase(`/packs/${pack}/`)}>{pack}</a></li>
+          ))}
+        </ul>
       </li>
     ))}
   </ul>
 
-  <details class="catalogue__more">
-    <summary class="catalogue__summary">
-      <span>See all 17 packs</span>
-      <span class="catalogue__summary-arrow" aria-hidden="true">→</span>
-    </summary>
-
-    <div class="catalogue__group">
-      <h3 class="catalogue__group-title">Install once, works across all your repos <StatusChip label="user" /></h3>
-      <ul class="pack-grid">
-        {userPacks.map((p) => (
-          <li class="pack-card">
-            <h4 class="pack-card__name">{p.name}</h4>
-            <p class="pack-card__desc">{p.desc}</p>
-          </li>
-        ))}
-      </ul>
-    </div>
-
-    <div class="catalogue__group">
-      <h3 class="catalogue__group-title">Install per project <StatusChip label="repo" /></h3>
-      <ul class="pack-grid">
-        {repoPacks.map((p) => (
-          <li class="pack-card">
-            <h4 class="pack-card__name">{p.name}</h4>
-            <p class="pack-card__desc">{p.desc}</p>
-          </li>
-        ))}
-      </ul>
-    </div>
-  </details>
+  <a class="work__all" href={withBase('/catalogue/')}>
+    Browse the complete catalogue by outcome and role <span aria-hidden="true">→</span>
+  </a>
 </Section>
 
 <style>
-  .catalogue__headline {
+  .work__eyebrow {
+    color: var(--ds-accent-deep);
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    font-weight: var(--ds-weight-semibold);
+    letter-spacing: var(--ds-track-label);
     margin-bottom: var(--ds-space-3);
+    text-transform: uppercase;
   }
 
-  .catalogue__subhead {
+  .work__headline {
+    margin-bottom: var(--ds-space-3);
+    max-width: 22ch;
+  }
+
+  .work__subhead {
     font-size: var(--ds-type-body-lg);
-    max-width: 60ch;
+    margin-bottom: var(--ds-space-7);
+    max-width: 62ch;
+  }
+
+  .work-grid {
+    display: grid;
+    gap: var(--ds-space-5);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     margin-bottom: var(--ds-space-7);
   }
 
-  /* ── Tier 1 — the three loops ──────────────────────────────────────── */
-  .loop-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--ds-space-5);
-    margin-bottom: var(--ds-space-6);
-  }
-
-  .loop-card {
+  .work-card {
     background-color: var(--ds-surface-alt);
     border: 1px solid var(--ds-border);
     border-radius: var(--ds-radius-lg);
     padding: var(--ds-space-6);
-    transition: border-color var(--ds-dur-moderate) var(--ds-ease-std);
   }
 
-  .loop-card:hover {
+  .work-card--flagship {
     border-color: var(--ds-accent);
   }
 
-  .loop-card__head {
+  .work-card__head {
+    align-items: flex-start;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
     gap: var(--ds-space-3);
-    margin-bottom: var(--ds-space-4);
-  }
-
-  .loop-card__name {
-    font-size: var(--ds-type-h3);
-  }
-
-  .loop-card__desc {
-    margin-bottom: var(--ds-space-4);
-    color: var(--ds-on-surface-2);
-  }
-
-  .loop-card__install {
-    margin-bottom: var(--ds-space-4);
-  }
-
-  .loop-card__install code {
-    display: block;
-    background-color: var(--ds-hero-bg);
-    color: var(--ds-hero-fg);
-    padding: var(--ds-space-3) var(--ds-space-4);
-    border-radius: var(--ds-radius-sm);
-    font-size: var(--ds-type-xs);
-    /* Commands wrap at spaces rather than clipping at the card edge. */
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-    line-height: var(--ds-lead-mono);
-  }
-
-  .loop-card__link {
-    font-weight: var(--ds-weight-semibold);
-  }
-
-  /* ── Tier 2/3 — expander ───────────────────────────────────────────── */
-  .catalogue__summary {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--ds-space-2);
-    cursor: pointer;
-    font-weight: var(--ds-weight-semibold);
-    color: var(--ds-accent-deep);
-    padding: var(--ds-space-3) 0;
-    list-style: none;
-  }
-
-  .catalogue__summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .catalogue__summary-arrow {
-    transition: transform var(--ds-dur-moderate) var(--ds-ease-std);
-  }
-
-  .catalogue__more[open] .catalogue__summary-arrow {
-    transform: rotate(90deg);
-  }
-
-  .catalogue__group {
-    margin-top: var(--ds-space-6);
-  }
-
-  .catalogue__group-title {
-    font-size: var(--ds-type-h3);
-    margin-bottom: var(--ds-space-4);
-  }
-
-  .pack-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: var(--ds-space-4);
-  }
-
-  .pack-card {
-    background-color: var(--ds-surface-alt);
-    border: 1px solid var(--ds-border);
-    border-radius: var(--ds-radius-md);
-    padding: var(--ds-space-5);
-  }
-
-  .pack-card__name {
-    font-size: var(--ds-type-body-lg);
+    justify-content: space-between;
     margin-bottom: var(--ds-space-2);
   }
 
-  .pack-card__desc {
-    font-size: var(--ds-type-sm);
-    color: var(--ds-on-surface-muted);
+  .work-card__title {
+    font-size: var(--ds-type-h3);
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .loop-card,
-    .catalogue__summary-arrow {
-      transition: none;
+  .work-card__flag {
+    background-color: var(--ds-accent-subtle);
+    border-radius: var(--ds-radius-pill);
+    color: var(--ds-accent-deep);
+    flex: 0 0 auto;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    padding: 0.2rem 0.55rem;
+  }
+
+  .work-card__audience {
+    color: var(--ds-accent-deep);
+    font-size: var(--ds-type-sm);
+    font-weight: var(--ds-weight-semibold);
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .work-card__desc {
+    color: var(--ds-on-surface-2);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .work-card__packs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ds-space-2);
+  }
+
+  .work-card__packs a {
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-pill);
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    padding: 0.2rem 0.6rem;
+  }
+
+  .work__all {
+    font-weight: var(--ds-weight-semibold);
+  }
+
+  @media (max-width: 420px) {
+    .work-card__head {
+      display: block;
+    }
+
+    .work-card__flag {
+      display: inline-block;
+      margin-top: var(--ds-space-2);
     }
   }
 </style>

--- a/web/src/content/packs/core.md
+++ b/web/src/content/packs/core.md
@@ -2,7 +2,7 @@
 name: Core
 pluginInstallable: false
 scope: repo
-tagline: "The build loop. Spec → shipped code. Supervised."
+tagline: "The agentic build loop that cannot self-certify."
 skills:
   - work-loop
   - new-spec
@@ -16,6 +16,6 @@ docsUrl: /docs/guides/core/
 journeyUrl: /journeys/core/
 ---
 
-Core is the engine of the build loop. After installing it, every coding task runs through `work-loop`: plan → execute → verify → adversarial review. Mechanical gates (lint, typecheck, tests) and three specialist reviewers run every diff before it reaches a decision point — whether that decision is yours at a keyboard or your harness answering a gate programmatically.
+Core is a complete build system for coding agents. Non-trivial work runs through `work-loop`: surface assumptions → plan → implement → lint, typecheck, and test → cold independent review → fix or finish. The adversarial reviewer is the hard review gate; security and quality lenses join when the diff warrants them. Fingerprinted findings expose stasis instead of letting the agent repeat the same failed approach.
 
-The loop cannot self-certify. It always stops at plan approval and PR merge. Who answers those gates — a person or a control harness — is up to you.
+The loop scales its ceremony with risk, but it never self-certifies. It stops at plan approval, unresolved boundaries, repeated findings, and PR merge. Who answers those gates—a person or a control harness—is up to you.

--- a/web/src/lib/catalogue-navigation.ts
+++ b/web/src/lib/catalogue-navigation.ts
@@ -1,0 +1,106 @@
+/**
+ * Canonical outcome and role routes for the marketing site.
+ *
+ * Homepage and catalogue copy can differ in depth, but pack membership and
+ * anchors must not drift between those two entry surfaces.
+ */
+export interface CatalogueOutcome {
+  id: string;
+  title: string;
+  forWhom: string;
+  homepageDescription: string;
+  cataloguePromise: string;
+  packs: readonly string[];
+  flagship?: boolean;
+}
+
+export const catalogueOutcomes: readonly CatalogueOutcome[] = [
+  {
+    id: 'decide',
+    title: 'Decide what to build',
+    forWhom: 'Product managers · strategists · founders',
+    homepageDescription:
+      'Move from strategy and evidence to a bounded decision brief a delivery team can act on.',
+    cataloguePromise:
+      'Turn strategy, evidence, and an uncertain idea into a bounded decision a delivery team can act on.',
+    packs: ['product-strategy', 'desk-research', 'product-engineering'],
+  },
+  {
+    id: 'design',
+    title: 'Design the product and system',
+    forWhom: 'Designers · architects · frontend teams',
+    homepageDescription:
+      'Connect customer intent to journeys, architecture, interfaces, and an implementable surface.',
+    cataloguePromise:
+      'Connect customer intent to the experience, architecture, interfaces, and implementable surface.',
+    packs: ['experience-design', 'architect', 'contracts', 'frontend-engineering'],
+  },
+  {
+    id: 'build',
+    title: 'Build and review software',
+    forWhom: 'Software teams · coding agents',
+    homepageDescription:
+      'Take a brief or spec through implementation, mechanical gates, independent review, and a human merge decision.',
+    cataloguePromise:
+      'Move a brief or spec through implementation, mechanical gates, independent review, and a human merge decision.',
+    packs: ['core', 'governance-extras', 'monorepo-extras'],
+    flagship: true,
+  },
+  {
+    id: 'operate',
+    title: 'Provision and release safely',
+    forWhom: 'Platform · infrastructure · SRE',
+    homepageDescription:
+      'Make system decisions explicit, produce a reviewable infrastructure plan, validate the deployed whole, and stop before irreversible action.',
+    cataloguePromise:
+      'Produce reviewable infrastructure and release evidence while stopping before apply and production.',
+    packs: ['architect', 'contracts', 'iac-terraform', 'release-engineering'],
+  },
+  {
+    id: 'evidence',
+    title: 'Work with team systems and evidence',
+    forWhom: 'Researchers · delivery teams · analysts',
+    homepageDescription:
+      'Bring trackers, source material, design files, and credentials into agent work without hiding provenance or mutation.',
+    cataloguePromise:
+      'Bring trackers, documents, designs, and credentials into agent work with provenance and mutation boundaries intact.',
+    packs: [
+      'atlassian',
+      'github',
+      'linear',
+      'figma',
+      'desk-research',
+      'converters',
+      'credential-brokers',
+    ],
+  },
+  {
+    id: 'document',
+    title: 'Document what ships',
+    forWhom: 'Product teams · documentation owners',
+    homepageDescription:
+      'Create, restructure, audit, and verify documentation against the behavior your product actually ships.',
+    cataloguePromise:
+      'Create, restructure, audit, and verify product documentation against canonical behavior.',
+    packs: ['product-documentation', 'converters'],
+  },
+  {
+    id: 'govern',
+    title: 'Build and govern a catalogue',
+    forWhom: 'AI enablement · platform owners',
+    homepageDescription:
+      'Create an organization-owned catalogue, curate packs and profiles, validate contracts, and distribute one governed system.',
+    cataloguePromise:
+      'Curate organization-owned packs and profiles, validate their contracts, and distribute one governed system.',
+    packs: ['catalogue-curation', 'governance-extras', 'product-documentation'],
+  },
+];
+
+export const catalogueRoles = [
+  { name: 'Product manager or strategist', outcomeId: 'decide' },
+  { name: 'Platform, infrastructure, or SRE', outcomeId: 'operate' },
+  { name: 'Software engineer', outcomeId: 'build' },
+  { name: 'Designer or architect', outcomeId: 'design' },
+  { name: 'Researcher or analyst', outcomeId: 'evidence' },
+  { name: 'AI enablement or catalogue owner', outcomeId: 'govern' },
+] as const;

--- a/web/src/pages/catalogue/index.astro
+++ b/web/src/pages/catalogue/index.astro
@@ -4,8 +4,10 @@ import SiteLayout from '../../components/layout/SiteLayout.astro';
 import Section from '../../components/layout/Section.astro';
 import { withBase } from '../../lib/paths';
 import StatusChip from '../../components/primitives/StatusChip.astro';
-
-const MARKETPLACE = 'agent-ready-repo';
+import {
+  catalogueOutcomes,
+  catalogueRoles,
+} from '../../lib/catalogue-navigation';
 
 // SDLC value-stream order (RFC-0064 three-altitude model + the three loops):
 // core anchors first, then strategy → research → shaping → design →
@@ -20,16 +22,20 @@ const SDLC_ORDER = [
   'experience-design',
   'architect',
   'contracts',
+  'frontend-engineering',
   'iac-terraform',
   'release-engineering',
   'governance-extras',
-  'user-guide-diataxis',
+  'product-documentation',
   'converters',
   'monorepo-extras',
   'catalogue-curation',
   'credential-brokers',
   'atlassian',
   'figma',
+  'github',
+  'linear',
+  'user-guide-diataxis',
 ];
 
 const allPacks = await getCollection('packs');
@@ -50,15 +56,15 @@ const packs = allPacks
       scope: e.data.scope,
       tagline: e.data.tagline,
       skillCount: e.data.skills.length,
-      cliCmd: e.data.installCommand,
-      // Only user-capable packs reach the Claude-plugin route; `null` renders
-      // no plugin block at all rather than a command the pack forbids.
-      pluginCmd: e.data.pluginInstallable
-        ? `claude plugin install ${slug}@${MARKETPLACE}`
-        : null,
       detailUrl: withBase(`/packs/${slug}/`),
     };
   });
+
+const roles = catalogueRoles.map((role) => {
+  const outcome = catalogueOutcomes.find(({ id }) => id === role.outcomeId);
+  if (!outcome) throw new Error(`Unknown catalogue outcome: ${role.outcomeId}`);
+  return { ...role, outcome: outcome.title, href: `#${outcome.id}` };
+});
 ---
 
 <SiteLayout
@@ -73,16 +79,55 @@ const packs = allPacks
         Every pack.<br />Your way.
       </h1>
       <p class="cat-hero__body">
-        {packs.length} packs for the full SDLC. Every one of them installs with
-        <code>agentbundle</code>; the packs that install at user scope are also
-        Claude plugins — their cards say so.
+        Start with the work you need to accomplish, then choose the packs that
+        produce it. The complete {packs.length}-pack inventory stays below for
+        readers who already know what they need.
       </p>
     </div>
   </section>
 
+  <!-- ── Outcome and role discovery ──────────────────────────────────── -->
+  <Section tone="surface-alt" labelledby="outcomes-heading">
+    <h2 id="outcomes-heading" class="outcomes__heading">What do you need to change?</h2>
+    <p class="outcomes__intro">
+      Packs are the stable installation layer. These paths are curated views over
+      that inventory, so the same pack can support more than one outcome.
+    </p>
+
+    <ul class="outcome-grid" role="list">
+      {catalogueOutcomes.map((outcome) => (
+        <li class="outcome-card" id={outcome.id}>
+          <h3>{outcome.title}</h3>
+          <p>{outcome.cataloguePromise}</p>
+          <ul class="outcome-card__packs" aria-label={`Packs for ${outcome.title}`}>
+            {outcome.packs.map((pack) => (
+              <li><a href={withBase(`/packs/${pack}/`)}>{pack}</a></li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+
+    <h2 class="roles__heading">Or start with your role</h2>
+    <ul class="role-grid" role="list">
+      {roles.map((role) => (
+        <li>
+          <a href={role.href}>
+            <strong>{role.name}</strong>
+            <span>{role.outcome} →</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </Section>
+
   <!-- ── Catalogue grid ───────────────────────────────────────────────── -->
   <Section tone="surface" labelledby="cat-grid-heading">
-    <h2 id="cat-grid-heading" class="visually-hidden">All packs</h2>
+    <h2 id="cat-grid-heading" class="cat-grid__heading">Browse every pack</h2>
+    <p class="cat-grid__intro">
+      Pack detail pages carry the exact scope, dependencies, install routes,
+      shipped primitives, journey, and guides.
+    </p>
 
     <ul class="cat-grid" role="list">
       {packs.map((pack) => (
@@ -104,79 +149,11 @@ const packs = allPacks
             </div>
           </a>
 
-          <!-- Install blocks — outside the navigating anchor -->
-          <div class="install-blocks">
-            <div class="install-block">
-              <div class="install-block__label">CLI</div>
-              <div class="install-block__row">
-                <code class="install-block__cmd">{pack.cliCmd}</code>
-                <button
-                  class="copy-btn"
-                  data-cmd={pack.cliCmd}
-                  aria-label={`Copy CLI install command for ${pack.name}`}
-                  type="button"
-                >
-                  <span class="copy-btn__icon" aria-hidden="true">
-                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <rect x="4" y="4" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.25"/>
-                      <path d="M2 10V2.5A1.5 1.5 0 0 1 3.5 1H10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
-                    </svg>
-                  </span>
-                  <span class="copy-btn__label">Copy</span>
-                </button>
-              </div>
-            </div>
-
-            {pack.pluginCmd && (
-              <div class="install-block install-block--plugin">
-                <div class="install-block__label">Plugin</div>
-                <div class="install-block__row">
-                  <code class="install-block__cmd install-block__cmd--truncate">{pack.pluginCmd}</code>
-                  <button
-                    class="copy-btn"
-                    data-cmd={pack.pluginCmd}
-                    aria-label={`Copy Claude plugin install command for ${pack.name}`}
-                    type="button"
-                  >
-                    <span class="copy-btn__icon" aria-hidden="true">
-                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <rect x="4" y="4" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.25"/>
-                        <path d="M2 10V2.5A1.5 1.5 0 0 1 3.5 1H10" stroke="currentColor" stroke-width="1.25" stroke-linecap="round"/>
-                      </svg>
-                    </span>
-                    <span class="copy-btn__label">Copy</span>
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
         </li>
       ))}
     </ul>
   </Section>
 </SiteLayout>
-
-<script>
-  document.querySelectorAll<HTMLButtonElement>('.copy-btn').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const cmd = btn.dataset.cmd ?? '';
-      try {
-        await navigator.clipboard.writeText(cmd);
-        const label = btn.querySelector<HTMLElement>('.copy-btn__label');
-        if (label) {
-          label.textContent = 'Copied!';
-          btn.classList.add('copy-btn--success');
-          setTimeout(() => {
-            label.textContent = 'Copy';
-            btn.classList.remove('copy-btn--success');
-          }, 2000);
-        }
-      } catch {
-        // Clipboard API unavailable — command is still visible and selectable.
-      }
-    });
-  });
-</script>
 
 <style>
   /* ── Hero ──────────────────────────────────────────────────────────── */
@@ -225,7 +202,94 @@ const packs = allPacks
     background: none;
   }
 
+  /* ── Outcome and role discovery ───────────────────────────────────── */
+  .outcomes__heading,
+  .roles__heading {
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .outcomes__intro,
+  .cat-grid__intro {
+    color: var(--ds-on-surface-2);
+    font-size: var(--ds-type-body-lg);
+    margin-bottom: var(--ds-space-7);
+    max-width: 64ch;
+  }
+
+  .outcome-grid {
+    display: grid;
+    gap: var(--ds-space-5);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin-bottom: var(--ds-space-8);
+  }
+
+  .outcome-card {
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-lg);
+    padding: var(--ds-space-6);
+    scroll-margin-top: var(--ds-space-7);
+  }
+
+  .outcome-card h3,
+  .outcome-card p {
+    margin-bottom: var(--ds-space-3);
+  }
+
+  .outcome-card p {
+    color: var(--ds-on-surface-2);
+  }
+
+  .outcome-card__packs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ds-space-2);
+  }
+
+  .outcome-card__packs a {
+    background-color: var(--ds-accent-subtle);
+    border-radius: var(--ds-radius-pill);
+    display: inline-block;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-xs);
+    padding: 0.2rem 0.6rem;
+  }
+
+  .role-grid {
+    display: grid;
+    gap: var(--ds-space-3);
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  .role-grid a {
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-md);
+    display: block;
+    padding: var(--ds-space-4);
+    text-decoration: none;
+  }
+
+  .role-grid a:hover {
+    border-color: var(--ds-accent);
+  }
+
+  .role-grid strong,
+  .role-grid span {
+    display: block;
+  }
+
+  .role-grid span {
+    color: var(--ds-accent-deep);
+    font-size: var(--ds-type-sm);
+    margin-top: var(--ds-space-2);
+  }
+
   /* ── Grid ──────────────────────────────────────────────────────────── */
+  .cat-grid__heading {
+    margin-bottom: var(--ds-space-3);
+  }
+
   .cat-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -301,116 +365,8 @@ const packs = allPacks
     color: var(--ds-accent);
   }
 
-  /* ── Install blocks ─────────────────────────────────────────────────── */
-  .install-blocks {
-    border-top: 1px solid var(--ds-border);
-  }
-
-  .install-block {
-    background-color: var(--ds-hero-bg);
-    padding: var(--ds-space-3) var(--ds-space-5);
-  }
-
-  .install-block--plugin {
-    border-top: 1px solid var(--ds-hero-border);
-  }
-
-  .install-block__label {
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-xs);
-    text-transform: uppercase;
-    letter-spacing: var(--ds-track-label);
-    color: var(--ds-hero-fg-muted);
-    margin-bottom: var(--ds-space-1);
-  }
-
-  .install-block__row {
-    display: flex;
-    align-items: center;
-    gap: var(--ds-space-3);
-    min-width: 0;
-  }
-
-  .install-block__cmd {
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-mono-sm);
-    color: var(--ds-hero-fg);
-    flex: 1;
-    min-width: 0;
-    line-height: var(--ds-lead-mono);
-    user-select: all;
-  }
-
-  .install-block__cmd--truncate {
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-  }
-
-  @media (max-width: 480px) {
-    .install-block__row {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    .copy-btn {
-      align-self: flex-start;
-    }
-  }
-
-  /* ── Copy button ────────────────────────────────────────────────────── */
-  .copy-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--ds-space-1);
-    flex-shrink: 0;
-    background-color: var(--ds-hero-elevated);
-    border: 1px solid var(--ds-hero-border-card);
-    border-radius: var(--ds-radius-sm);
-    color: var(--ds-hero-fg-muted);
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-xs);
-    font-weight: var(--ds-weight-medium);
-    padding: 0.3rem 0.6rem;
-    cursor: pointer;
-    transition:
-      background-color var(--ds-dur-quick) var(--ds-ease-std),
-      color var(--ds-dur-quick) var(--ds-ease-std),
-      border-color var(--ds-dur-quick) var(--ds-ease-std);
-  }
-
-  .copy-btn:hover {
-    background-color: var(--ds-accent-subtle-dk);
-    border-color: var(--ds-accent);
-    color: var(--ds-accent);
-  }
-
-  .copy-btn--success {
-    background-color: var(--ds-accent-subtle-dk);
-    border-color: var(--ds-accent);
-    color: var(--ds-accent);
-  }
-
-  .copy-btn__icon {
-    display: flex;
-    align-items: center;
-  }
-
-  /* ── Accessibility ──────────────────────────────────────────────────── */
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .cat-card,
-    .copy-btn {
+    .cat-card {
       transition: none;
     }
   }

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -11,14 +11,14 @@ import PackCatalogue from '../components/marketing/PackCatalogue.astro';
 import BuildYourOrg from '../components/marketing/BuildYourOrg.astro';
 ---
 
-<SiteLayout title="agent-ready-repo — the supervised AI operating model for software teams">
+<SiteLayout title="agent-ready-repo — the supervised agentic build loop">
   <Hero />
   <StatStrip />
+  <PackCatalogue />
   <TheProblem />
   <ThreeLoops />
   <HumanGates />
   <AdapterMatrix />
   <InstallTerminal />
-  <PackCatalogue />
   <BuildYourOrg />
 </SiteLayout>

--- a/workspace.toml
+++ b/workspace.toml
@@ -1728,6 +1728,41 @@ open = [
   # conjunctive gates, so this entry has no machine-readable `needs` edge and
   # remains non-dispatchable until a separate spec is approved.
   {slug = "capture-work-alias-removal", source = "spec/work-intake-migration-docs AC14"},
+
+  # The canonical adopter-facing `guides/` tree is mirrored into the public
+  # technical docs, but `agentbundle catalogue package --flavor source` includes
+  # only `guides/_shared/`, not the pack-specific guide corpus. An organization
+  # that distributes an archive therefore does not distribute the complete
+  # adopter guidance beside its packs and profiles.
+  # Fix: decide the archive layout and inclusion semantics, add package and
+  # install coverage, update the distribution contract and adopter docs, and
+  # ship the resulting `agentbundle` release. Keep this separate from the
+  # documentation-entry-navigation work: changing the allowlist is an engine
+  # and release-boundary decision. Unblocks: now; no tracked prerequisite.
+  {slug = "catalogue-package-guides", source = "spec/documentation-entry-navigation"},
+
+  # `python3 tools/build-site.py --dry-run` currently calls mkdir for generated
+  # docs directories before honoring dry-run, so read-only verification fails
+  # even though no generated content should be written. Fix: make dry-run
+  # side-effect-free from process start, add a construction test using a
+  # non-writable output tree, and document it as the supported source-only site
+  # routing check. Unblocks: now; no tracked prerequisite.
+  {slug = "build-site-dry-run-write-free", source = "spec/documentation-entry-navigation AC15"},
+
+  # A full generated-HTML crawl performed after the documentation-entry
+  # navigation build found 67 older unresolved internal targets across 53,871
+  # checked links: 60 in the legacy guide corpus and 7 in other unchanged pages.
+  # The 12 entry, contributor, catalogue, core, changelog, and immediate Get
+  # Started surfaces corrected by that spec are clean. A source-only audit cannot see
+  # these failures because Astro resolves relative links from rendered directory
+  # routes. Fix as one atomic change: correct the affected guide sources or
+  # projection rules, then add a generated-HTML internal href/fragment audit to
+  # the site CI gate. Do not enable the gate before remediation, because that
+  # would deliberately leave main failing. Affected areas: guides/, any owning
+  # build-site rewriter, Makefile/site CI, and focused construction coverage.
+  # Unblocks when the work runs in a writable site-build environment or CI; no
+  # tracked prerequisite.
+  {slug = "rendered-site-link-debt", source = "spec/documentation-entry-navigation AC15"},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1850,7 +1885,8 @@ status    = "active"
 milestone = "M2 · Authoring Discovery + Information Architecture"
 # Milestone advance (Phase 0, 2026-07-31): M1 (Shaping + Contract Convergence) is
 # complete. Waves 1 and 2 shipped; research and shaping entries completed and
-# removed from the active queue; information-architecture design now active.
+# removed from the active queue; information-architecture design and its
+# current-route implementation shipped in documentation-entry-navigation.
 # Wave 3 next engine wave (Approved spec + implementation-ready plan).
 
 ["ini-007".shaping_queue]
@@ -1858,27 +1894,12 @@ milestone = "M2 · Authoring Discovery + Information Architecture"
 # audience research and contract inventory artifacts; Wave 2 delivered the
 # optional-pack-integration-contract shape; the catalogue-semantics-release-shape
 # delivered the Wave 4 (Approved) spec. The IA design item is now the active work.
-active = [
-  # Design: technical docs IA for five audiences. Prerequisites satisfied:
-  # audience research (catalogue-audience-discovery.md, Wave 1 artifact) and
-  # semantic/index shape (catalogue-semantics-release-shape, Wave 4 Approved spec).
-  # Remaining deliverable (do not execute in Phase 0):
-  #   - "Use" (consumer) vs "Build or evaluate" (builder/evaluator) entry routes
-  #     on the docs-site home and the marketing site;
-  #   - top-level "Build a Catalogue" docs-site navigation (D9 structure outline);
-  #   - /evaluate/ marketing route structure and content outline (D10);
-  #   - pack integration relationship presentation (how D6 integrations surface);
-  #   - root README routing (evaluate → authoring hub; build → catalogue init;
-  #     contribute → CONTRIBUTING path);
-  #   - navigation-depth acceptance targets (≤2 clicks from any entry point to
-  #     the first actionable step for each audience);
-  #   - neutral-index factual ownership (what catalogue-index.json provides vs
-  #     what editorial narrative provides — no duplication);
-  #   - README, JOURNEY, guide, and editorial narrative ownership map.
-  # Unblocks: Wave 6 (docs-site IA implementation, needs this design) and
-  #   Wave 7 (marketing evaluator, needs Wave 6).
-  {slug = "catalogue-discovery-information-architecture", type = "design"},
-]
+# Catalogue discovery IA completed 2026-08-12. The cross-surface design,
+# content-ownership map, audience routes, and navigation-depth contract live in
+# docs/specs/documentation-entry-navigation/notes/information-architecture.md.
+# Its current-route implementation shipped below. Wave 6 and Wave 7 retain
+# only the Wave 4/index-dependent work the current implementation cannot own.
+active = []
 backlog = []
 
 ["ini-007".work]
@@ -1888,6 +1909,7 @@ shipped = [
   "spec/pack-test-boundary-remaining-packs",  # completes ADR-0071 — no pack ships tests in its runtime payload
   "spec/catalogue-wave1-contract-convergence",  # 0.26.1 — schema sync + authoring hub + parity gate
   "spec/catalogue-wave2-pack-integrations",     # 0.27.0 — D6 integrations schema + verifier + show + pilots + hub
+  "spec/documentation-entry-navigation",        # current-route hub-and-spoke README, marketing, docs, guide, and contributor IA
 ]
 queue   = [
 
@@ -1959,32 +1981,32 @@ queue   = [
   # release comparison; release evidence in catalogue-manifest.json; regression tests.
   {path = "spec/catalogue-wave5-release-integrity", needs = "work:spec/catalogue-wave4-semantic-contracts-index"},
 
-  # Wave 6 — Technical docs information architecture. Gated on Wave 4 + IA design
-  # + the docs-site design refresh (ini-002): both touch docs-site/astro.config.ts
-  # and the Starlight theme; the refresh owns the visual system (tokens, type,
-  # sidebar/link presentation, eyebrow group labels), so Wave 6 is IA/structure
-  # ONLY — new sections, routes, and sidebar reorganization on top of the
-  # refreshed theme, with no restyling and no token changes.
-  # Deliver: "Build a Catalogue" top-level docs-site section; generated field references;
-  # index consumption; "Use" vs "Build" home routes; sidebar links verified.
-  {path = "spec/catalogue-wave6-technical-docs-ia", needs = ["work:spec/catalogue-wave4-semantic-contracts-index", "shape:catalogue-discovery-information-architecture", "ini-002:work:spec/docs-site-design-refresh"]},
+  # Wave 6 — Index-backed technical catalogue reference. Gated on Wave 4 and
+  # the current-route editorial/navigation foundation. The foundation already
+  # delivers outcome/role routing and "Use" vs "Build" home paths without
+  # changing the refreshed visual system. Do not repeat that work here.
+  # Remaining deliverable: a top-level "Build a Catalogue" sidebar/reference
+  # section; generated field references; neutral catalogue-index consumption;
+  # and deep sidebar links verified against the generated inventory. No restyling.
+  {path = "spec/catalogue-wave6-technical-docs-ia", needs = ["work:spec/catalogue-wave4-semantic-contracts-index", "work:spec/documentation-entry-navigation", "ini-002:work:spec/docs-site-design-refresh"]},
 
-  # Wave 7 — Marketing evaluator surfaces. Gated on Wave 6.
-  # Deliver: /evaluate/ page; catalogue+pack pages consume neutral-index facts;
-  # composition relationship view; no visual system redesign.
+  # Wave 7 — Index-backed marketing evaluator surfaces. Gated on Wave 6.
+  # The current-route foundation already delivers outcome/role discovery,
+  # catalogue breadth, and the self-host story. Do not repeat those sections.
+  # Remaining deliverable: /evaluate/; catalogue and pack pages consuming
+  # neutral-index facts; and the optional-integration relationship view. No
+  # visual system redesign.
   {path = "spec/catalogue-wave7-marketing-evaluator", needs = "work:spec/catalogue-wave6-technical-docs-ia"},
 
-  # Wave 8 — Repository README and contributing convergence. Gated on Wave 1.
-  # May run in parallel with Waves 4-7. Deliver: "Evaluate or build a catalogue"
-  # section; fork language replaced; pack table generated or flagship subset;
-  # CONTRIBUTING updated with portable authoring rules + integration authoring rule.
-  {path = "spec/catalogue-wave8-readme-contributing", needs = "work:spec/catalogue-wave1-contract-convergence"},
+  # Wave 8 was superseded before implementation by the shipped cross-surface
+  # documentation-entry-navigation spec above.
 
-  # Wave 9 — First-party migration and closeout. Gated on Waves 2, 5, 7, 8.
+  # Wave 9 — First-party migration and closeout. Gated on Waves 2, 5, 7 and
+  # the Wave 8 replacement.
   # Deliver: all packs+profiles migrated; drift fixes; strict-resolution policy;
   # complete site projection; old external catalogues verified valid; security+
   # quality reviews clean; workspace.toml closed out.
-  {path = "spec/catalogue-wave9-migration-closeout", needs = ["work:spec/catalogue-wave2-pack-integrations", "work:spec/catalogue-wave5-release-integrity", "work:spec/catalogue-wave7-marketing-evaluator", "work:spec/catalogue-wave8-readme-contributing"]},
+  {path = "spec/catalogue-wave9-migration-closeout", needs = ["work:spec/catalogue-wave2-pack-integrations", "work:spec/catalogue-wave5-release-integrity", "work:spec/catalogue-wave7-marketing-evaluator", "work:spec/documentation-entry-navigation"]},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

  Reframes the repository as a concise product hub around the flagship `core` build loop and the
  broader catalogue of supervised workflows.

  The new navigation starts with use cases and roles, then routes readers into the marketing site,
  technical docs, adopter guides, catalogue reference, or contributor documentation without
  duplicating those destinations in the root README.

  ## What changed

  - Reduced `README.md` to a concise hub-and-spoke entry point.
  - Positioned `core` through its concrete differentiators: planning, mechanical gates, independent
  review, stasis detection, and human merge decisions.
  - Added outcome and role routes for product, engineering, infrastructure, design, research,
  documentation, and catalogue teams.
  - Replaced “Find your work” with the more direct “Use cases.”
  - Documented the Claude plugin marketplace route for user-scope packs while keeping repo-scoped
  `core` on `agentbundle`.
  - Restructured the marketing homepage, catalogue, technical-doc homepage, Get Started pages, and
  guide hub around the same seven outcomes.
  - Centralized marketing outcome membership and role anchors to prevent cross-page drift.
  - Expanded `CONTRIBUTING.md` with:
    - the contributor route from technical docs to guides, pack source, and architecture;
    - the decision chain from evidence and RFCs through specs, implementation, and adopter docs;
    - current catalogue authoring and generated-content boundaries.
  - Replaced the hand-maintained architecture pack inventory with generated catalogue and technical-
  reference routes.
  - Documented packs, profiles, adapters, catalogue ownership, self-hosting, and guide-distribution
  boundaries.
  - Corrected generated guide, contributor, changelog, pack-source, Get Started, and favicon routes.
  - Added construction checks for catalogue coverage, shared navigation, authored routes, rendered
  guide rewrites, and failure behavior.
  - Superseded the former Wave 8 scope while preserving the index-dependent work planned for Waves 6–7
  and the Wave 9 dependency chain.

  ## Verification

  - `make site-build` passes.
  - 3,098 internal links and fragments across the 12 affected rendered pages resolve with zero
  failures.
  - All 20 active packs have direct guide discovery and at least one outcome route.
  - Guide validation passes with 0 errors; existing migration warnings remain unchanged.
  - Construction tests pass.
  - Ruff passes.
  - `workspace.toml` parses successfully.
  - `git diff --check` passes.
  - Adversarial, quality, and security reviews are clean.

  ## Follow-up

  A whole-site rendered crawl identified 67 historical failures in unchanged pages: 60 in the legacy
  guide corpus and 7 elsewhere. These are captured as the atomic `rendered-site-link-debt` backlog
  item, coupling source remediation with a future generated-HTML link gate so CI is never
  intentionally left failing.

  Full guide-corpus inclusion in catalogue source archives and a side-effect-free site dry run remain
  separately captured backlog items.