### PR TITLE
fix(ci): disable prevent_self_review — the publisher approval gate was unsatisfiable

### DIFF
--- a/.github/claude-plugin-publish-control.json
+++ b/.github/claude-plugin-publish-control.json
@@ -24,7 +24,7 @@
       "main"
     ],
     "required_reviewers": 1,
-    "prevent_self_review": true,
+    "prevent_self_review": false,
     "allow_admin_bypass": false,
     "app_id_variable": "CLAUDE_PLUGIN_PUBLISHER_APP_ID",
     "private_key_secret": "CLAUDE_PLUGIN_PUBLISHER_PRIVATE_KEY"

--- a/docs/adr/0079-executable-plugin-branch-publisher-identity.md
+++ b/docs/adr/0079-executable-plugin-branch-publisher-identity.md
@@ -142,6 +142,26 @@ errata supersede where noted. This ADR is Accepted → Frozen
   evidence is refused, and so is the interim publisher once evidence lands. The
   decision is unchanged; it is now sequenced.
 
+- **2026-08-12 — `prevent_self_review` is disabled; the gate was unsatisfiable.**
+  The *Decision* above specifies an environment that "requires owner approval"
+  together with self-review prevention. On a repository where one person merges
+  every change, that person is always the deployment's triggering actor, so
+  GitHub withholds the approval control from the only account that holds it —
+  and with `can_admins_bypass` false there is no override. The first real
+  publication after rollout sat in `waiting` with
+  `current_user_can_approve: false` and **could not be approved by anyone**.
+
+  The canary probes did not catch this because they minted an App token directly
+  rather than routing through the environment, so the approval path was never
+  exercised end to end until a live publish.
+
+  `prevent_self_review` is therefore now `false`. The reviewer requirement
+  stands: every publication still waits for a human to release it deliberately,
+  and `can_admins_bypass` stays `false` so the gate cannot be stepped around.
+  What is lost is the second pair of eyes, which a single-maintainer repository
+  could never actually supply. Restoring `true` requires a second trusted
+  reviewer account, and would otherwise reintroduce the deadlock.
+
 - **2026-08-12 — no internal identifier is recorded.** The *Confirmation*
   signal "sanitized live settings snapshots" is narrowed: the evidence artifact
   carries no App, installation, ruleset, account, or node ID. The three-way

--- a/docs/specs/claude-plugin-hook-parity/publish-control-evidence.json
+++ b/docs/specs/claude-plugin-hook-parity/publish-control-evidence.json
@@ -24,7 +24,7 @@
       "main"
     ],
     "required_reviewers": 1,
-    "prevent_self_review": true,
+    "prevent_self_review": false,
     "allow_admin_bypass": false,
     "app_id_variable": "CLAUDE_PLUGIN_PUBLISHER_APP_ID",
     "private_key_secret": "CLAUDE_PLUGIN_PUBLISHER_PRIVATE_KEY"
@@ -36,6 +36,6 @@
     "publisher_app_update": "accepted",
     "live_branch_negative_tested": false
   },
-  "observed_at": "2026-08-12T15:50:59.127353+00:00",
+  "observed_at": "2026-08-12T17:24:21.761309+00:00",
   "observation_source": "github-api-sanitized"
 }

--- a/docs/specs/claude-plugin-hook-parity/spec.md
+++ b/docs/specs/claude-plugin-hook-parity/spec.md
@@ -609,3 +609,31 @@ invalid one before it reaches `merge_json`.
   traceable to the commit that produced it while `ref` stays mutable. AC35
   controls who may update the ref; it does not make the ref immutable or give an
   adopter an independently verifiable content digest.
+
+## Errata
+
+Corrections below are Approver-signed. The spec body above is preserved
+unchanged; errata supersede where noted. (Approver: eugenelim, 2026-08-12.)
+
+- **2026-08-12 — AC35 clause 4's `prevent_self_review` requirement is
+  withdrawn.** Clause 4 requires the environment to "require the repository
+  owner's approval" and AC35 clause 6's evidence pinned
+  `prevent_self_review: true`. Together those made the gate **unsatisfiable** on
+  this repository: the sole required reviewer is also the only person who
+  merges, so they are always the deployment's triggering actor and GitHub
+  withholds the approval control from them; `can_admins_bypass: false` removed
+  the override. The first real publication after rollout sat in `waiting` with
+  `current_user_can_approve: false`, approvable by nobody.
+
+  AC35's canary probes passed anyway because they minted an App token directly
+  rather than routing through the environment — the approval path was never
+  exercised until a live publish. That is a gap in the criterion's evidence, not
+  only in the settings.
+
+  The environment now sets `prevent_self_review: false`, and the desired-state
+  contract and lint expectation follow. Every other clause stands unchanged: one
+  required reviewer, `main`-only deployments, `can_admins_bypass: false`, and
+  the App-only ruleset bypass. Publication still waits for a deliberate human
+  release; what is withdrawn is the claim that the releaser is a second pair of
+  eyes, which a single-maintainer repository cannot supply. See the matching
+  [ADR-0079 erratum](../../adr/0079-executable-plugin-branch-publisher-identity.md#errata).

--- a/tools/lint-claude-plugin-publish-control.py
+++ b/tools/lint-claude-plugin-publish-control.py
@@ -285,7 +285,12 @@ def validate_desired(desired: dict) -> list[str]:
         "name": "claude-plugin-publish",
         "deployment_branches": ["main"],
         "required_reviewers": 1,
-        "prevent_self_review": True,
+        # False by necessity, not preference — see the ADR-0079 erratum of
+        # 2026-08-12. One required reviewer who is also the only person who
+        # merges is always the triggering actor, so self-review prevention made
+        # the gate unsatisfiable rather than strict: no publication could be
+        # approved by anyone, including the reviewer.
+        "prevent_self_review": False,
         "allow_admin_bypass": False,
         "app_id_variable": "CLAUDE_PLUGIN_PUBLISHER_APP_ID",
         "private_key_secret": "CLAUDE_PLUGIN_PUBLISHER_PRIVATE_KEY",

--- a/tools/test-lint-claude-plugin-publish-control.py
+++ b/tools/test-lint-claude-plugin-publish-control.py
@@ -43,6 +43,13 @@ def main() -> int:
             ("environment", "required_reviewers"),
             0,
         ),
+        # Re-enabling self-review prevention reintroduces the deadlock the
+        # ADR-0079 erratum of 2026-08-12 records: the sole reviewer is always
+        # the triggering actor, so no publication is approvable by anyone.
+        "desired self-review policy": (
+            ("environment", "prevent_self_review"),
+            True,
+        ),
         "desired canary result": (
             ("canary", "ordinary_update"),
             "accepted",

--- a/workspace.toml
+++ b/workspace.toml
@@ -399,6 +399,19 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # The publish job's environment gate asks a human to release executable plugin
+  # code adopters install, but GitHub's approval UI shows only the environment
+  # name and a comment box — nothing about what is being published. A summary
+  # step cannot fix it: `environment:` is job-level, so the whole job blocks on
+  # approval and nothing in it runs first. AC35 clause 3 also pins build and
+  # publish to one job, and constrains any cross-job artifact handoff to verify a
+  # producer-recorded digest before the token-bearing push. Fix: a SEPARATE
+  # non-gated workflow on the same push that posts a preview to the run summary —
+  # packs changed vs the current claude-plugins-dist, added/removed plugins, and
+  # any hook entries being registered. It feeds nothing into the publish job, so
+  # clause 3 is untouched; it only gives the approver something to read. Needs a
+  # spec note, since it changes what AC35's approval step means in practice.
+  {slug = "publish-approval-preview-summary", source = "spec/claude-plugin-hook-parity AC35"},
   # catalogue-tooling-ci-gates.yml Gate B builds a synthetic external catalogue
   # with `agentbundle catalogue build`, so an engine change can redden it while
   # every `make` target stays green — it did, on spec/claude-plugin-route-scope,


### PR DESCRIPTION
## What problem is this solving?

The publisher approval gate shipped in #930 **could not be satisfied by anyone.**

ADR-0079 specified an environment requiring owner approval *together with* `prevent_self_review`. On a repository where one person merges every change, that person is always the deployment's triggering actor — so GitHub withholds the approval control from the only account that holds it. With `can_admins_bypass: false`, there was no override either.

The first real publication after rollout, run `31620388838`, sat in `waiting` with:

```
reviewers:                [eugenelim]
triggering_actor:         eugenelim
current_user_can_approve: False
```

The control wasn't strict. It was impossible.

## Why the rollout evidence didn't catch it

AC35's canary probes minted an App installation token **directly** and pushed with it, rather than routing through the protected environment. So the approval path — the one thing the environment exists to enforce — was never exercised end to end until a live publish. That's a gap in the criterion's evidence, not only in the settings, and the erratum says so.

## What does this change?

`prevent_self_review` → `false`, live and in `.github/claude-plugin-publish-control.json`, with the lint expectation following.

**Everything else stands:** one required reviewer, `main`-only deployments, `can_admins_bypass: false`, and the App-only ruleset bypass on `claude-plugins-dist`. Publication still waits for a deliberate human release.

What's withdrawn is the claim that the releaser is a *second pair of eyes* — which a single-maintainer repository cannot supply at all. Restoring `true` needs a second trusted reviewer account and would otherwise reintroduce the deadlock.

## How is it verified?

- Live environment re-read after the change: `prevent_self_review: false`, `can_admins_bypass: false`, reviewer intact, `main` still the only deployment branch.
- `current_user_can_approve` flipped `false` → `true` on the stuck run.
- Evidence regenerated from live state; `--require-live-evidence` passes.
- New mutation case: flipping the flag back in the contract turns the lint red, so it cannot happen without this paperwork.
- `make build-check` green including SAST/SCA.

## Governance

Both governing artifacts are frozen, so this lands as **Approver-signed errata**, not body edits:

- **ADR-0079** — a new erratum recording the deadlock, why the canary missed it, and the trade accepted.
- **`docs/specs/claude-plugin-hook-parity/spec.md`** — now `Shipped`, so its first Errata section withdraws AC35 clause 4's `prevent_self_review` requirement and notes the evidence gap.

## What could go wrong?

**This is a genuine reduction in the control**, not a technicality. Anyone who can merge can now release a publication unreviewed. On a single-maintainer repository that was already true in substance — the alternative wasn't a stricter gate, it was no publishing at all — but if a second maintainer ever joins, `prevent_self_review: true` should come back with them, and the mutation case will make that a deliberate edit rather than a silent drift.