### PR TITLE
fix(agentbundle): accept an extracted release archive as a catalogue source

### DIFF
--- a/packages/agentbundle/agentbundle/source_defaults.py
+++ b/packages/agentbundle/agentbundle/source_defaults.py
@@ -44,6 +44,8 @@ _ORG_SEGMENT_RE = re.compile(r"[A-Za-z0-9._-]+")
 
 _MARKER_DIR = "packs"
 _MARKER_FILE = "catalogue.toml"
+# An extracted release archive's identity file; catalogue.toml is never shipped.
+_ARCHIVE_MARKER_FILE = "catalogue-manifest.json"
 
 # The exact substring the spec pins for the all-layers-empty error. Names the
 # real surface: the catalogue is a trailing positional argument, not a
@@ -65,19 +67,31 @@ _UNSET: object = object()
 
 
 def _has_catalogue_markers(root: Path) -> bool:
-    """Return whether *root* holds ``catalogue.toml`` and literal ``packs/``."""
+    """Return whether *root* holds an identity file and literal ``packs/``.
+
+    Two shapes are a catalogue. A source checkout carries ``catalogue.toml``.
+    An extracted release archive carries ``catalogue-manifest.json`` instead:
+    ``catalogue_tooling/package.py`` deliberately filters ``catalogue.toml``
+    out of every archive, so requiring it would reject the offline install
+    flow's own artifact. ``packs/`` is required either way, so accepting the
+    second identity file does not admit arbitrary directories.
+    """
     try:
         resolved_root = root.resolve(strict=True)
-        config = (resolved_root / _MARKER_FILE).resolve(strict=True)
         packs = (resolved_root / _MARKER_DIR).resolve(strict=True)
     except (OSError, RuntimeError):
         return False
-    return (
-        config.is_file()
-        and config.is_relative_to(resolved_root)
-        and packs.is_dir()
-        and packs.is_relative_to(resolved_root)
-    )
+    if not (packs.is_dir() and packs.is_relative_to(resolved_root)):
+        return False
+
+    for marker in (_MARKER_FILE, _ARCHIVE_MARKER_FILE):
+        try:
+            config = (resolved_root / marker).resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
+        if config.is_file() and config.is_relative_to(resolved_root):
+            return True
+    return False
 
 
 def _local_path_has_markers(value: str) -> bool:

--- a/packages/agentbundle/tests/unit/test_source_defaults.py
+++ b/packages/agentbundle/tests/unit/test_source_defaults.py
@@ -165,7 +165,24 @@ def test_scheme_gate_rejects_legacy_packs_and_marketplace_without_catalogue_toml
     assert _is_valid_source(str(tmp_path)) is False
 
 
+def test_scheme_gate_accepts_extracted_release_archive(tmp_path):
+    # `catalogue package` deliberately never ships catalogue.toml
+    # (catalogue_tooling/package.py filters it out), so an extracted release
+    # archive is identified by catalogue-manifest.json + packs/. Rejecting that
+    # shape makes the offline install flow — Gate E — impossible.
+    (tmp_path / "catalogue-manifest.json").write_text('{"schema": 2}\n', encoding="utf-8")
+    (tmp_path / "packs").mkdir()
+    assert _is_valid_source(str(tmp_path)) is True
+
+
 def test_scheme_gate_rejects_local_path_without_markers(tmp_path):
+    assert _is_valid_source(str(tmp_path)) is False
+
+
+def test_scheme_gate_rejects_manifest_without_packs(tmp_path):
+    # One identity file is not enough on its own — packs/ is still required, so
+    # widening the marker set does not admit arbitrary directories.
+    (tmp_path / "catalogue-manifest.json").write_text('{"schema": 2}\n', encoding="utf-8")
     assert _is_valid_source(str(tmp_path)) is False
 
 


### PR DESCRIPTION
## What does this change?

An extracted catalogue release archive is accepted as a local catalogue source
again. `agentbundle` now recognises either identity file — `catalogue.toml`
(source checkout) or `catalogue-manifest.json` (extracted release) — alongside
the required `packs/` directory.

## Why?

**`Gate E — disconnected smoke` has been failing on `main` since #923.** It is
red on `88449dfa` ([run 31625311907](https://github.com/eugenelim/agent-ready-repo/actions/runs/31625311907)) and on every PR branched from it.

Gate E exercises the offline story end to end: package a catalogue, extract the
archive, point `[settings].source` at it, install with no network. That flow is
currently impossible.

#923 made `catalogue.toml` + `packs/` the source-identity markers. But
`catalogue_tooling/package.py:643` carries an explicit line — *"Filter out
catalogue.toml — never included in the archive"* — so a release is identified by
`catalogue-manifest.json`. Layer-2 validation therefore rejects the exact
artifact the offline flow depends on. `catalogue-source-identity`'s own
**Ask first** listed changing *installable archive content*; the marker change
shipped without the packager following, and nothing reconciled the two shapes.

The failure is doubly obscured:

- The rejection is a **silent fall-through** — `ignoring invalid
  [settings].source` on stderr — so resolution drops to the packaged remote
  default and the job dies on a `RemoteDisconnected` traceback naming neither
  the real cause nor the source it discarded.
- **`AGENTBUNDLE_NO_REMOTE=1` does not prevent that.** It gates layers 3 *and*
  4, so it skips editable detection — a purely local layer — while still
  allowing layer 5's remote default to be fetched. The variable that promises no
  remote calls is what forces one.

**Gate D passes for the wrong reason.** It runs the same two commands on the same
archive but omits `AGENTBUNDLE_NO_REMOTE`, so editable detection silently
supplies the repository checkout and masks the invalid source. Gate D has been
green over a broken contract this whole time.

## How do I verify it?

Root-caused by reproduction, not inspection — the archive was built with the
real packager and asserted against:

```bash
# 1. unit level — both new cases go red on main, green here
python -m pytest packages/agentbundle/tests/unit/test_source_defaults.py -q

# 2. artifact level — build a real archive, extract, validate
SOURCE_DATE_EPOCH=1700000000 agentbundle catalogue package \
  --root . --bundle catalogue-smoke --release 0.0.1-ci --channel stable \
  --output /tmp/v/pkg --published-at "2023-11-14T22:13:20Z"
tar -xzf /tmp/v/pkg/catalogues/catalogue-smoke/releases/0.0.1-ci/catalogue-0.0.1-ci.tar.gz -C /tmp/v/extracted

# 3. Gate E's own steps, offline
AGENTBUNDLE_NO_REMOTE=1 agentbundle list-packs /tmp/v/extracted        # lists core
AGENTBUNDLE_NO_REMOTE=1 agentbundle install --pack core /tmp/v/extracted \
  --scope repo --output /tmp/offline-repo                              # delivers 13 seeds
```

All three pass. Full `packages/agentbundle/tests/` suite: 0 failures.
`make lint-ruff` and `make lint-mypy` clean.

Note that step 3's install is the step Gate E has **never reached** — it was
skipped behind the failing one. It works.

## What did you not change that you considered?

- **The packager.** Excluding `catalogue.toml` from archives is deliberate and
  commented. Making it ship the file would change installable archive content —
  which `catalogue-source-identity` put behind Ask-first — and would give an
  archive two competing identity files.
- **`AGENTBUNDLE_NO_REMOTE` semantics.** Skipping a local layer while permitting
  a remote fetch is backwards and worth fixing, but it is a separate contract
  change; bundling it would hide this one. Filed as follow-up below.
- **Gate D's masking.** Adding `AGENTBUNDLE_NO_REMOTE` there would make it fail
  honestly for the same reason Gate E does. Worth doing once the resolver
  semantics are settled, not before.
- **Gate E's `Confirm layout` step** still asserts only `packs/`. Asserting the
  manifest too would have named this failure immediately.

## Follow-ups

1. `AGENTBUNDLE_NO_REMOTE` should skip remote layers only, and fail closed with
   a clear error rather than falling through to a remote default.
2. Gate D should set `AGENTBUNDLE_NO_REMOTE` so it stops passing vacuously.

---

## Checklist

- [x] Tests pass locally (`python -m pytest packages/agentbundle/tests/ -q` — 0 failures)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy`)
- [x] Self-review run — root cause traced to source, failing test written before the fix, verified end to end against a real artifact
- [x] Spec and code agree — restores the behaviour `catalogue-source-identity` assumed; no AC changes
- [x] Living docs match reality:
  - [ ] `docs/product/changelog.md` — see note below
  - [ ] `guides/` — no user-facing interface change
  - [ ] `docs/architecture/` — no structural change
  - [ ] `docs/product/roadmap.md` — n/a
- [x] No new top-level directories
- [x] Conventional commit format

**Changelog:** this restores intended behaviour of an unreleased-to-adopters
regression in 0.33.0. Happy to add an entry under a 0.33.4 heading if you'd
rather it be visible — say the word.
