### PR TITLE
docs(rfc-0083): record a delivery-plan erratum and reanchor the ini-008 waves

### DIFF
--- a/docs/rfc/0083-work-intake-and-artifact-routing.md
+++ b/docs/rfc/0083-work-intake-and-artifact-routing.md
@@ -1270,3 +1270,59 @@ Following acceptance:
   navigation, and routing examples.
 - Maintainer documentation: workspace and adapter contract guides, architecture
   updates, routing-evaluation guidance, pack references, and README corrections.
+
+## Errata
+
+This RFC is Accepted: the body above is preserved as the original decision
+record. Corrections are appended here, Approver-signed.
+
+- **2026-08-13 (Approver: eugenelim) — § *Delivery plan and exit criteria* is
+  reanchored after Groups 2 and 3 shipped. The seven-group decomposition is a
+  forecast, not part of the decision; Groups 4–7 are re-cut against shipped
+  reality before each is built.**
+
+  The decision this RFC records — that work intake and artifact routing should
+  exist in the shape described in § *Proposal* — stands unchanged. What did not
+  survive contact is the *delivery forecast*. Groups 1–7 were cut in one pass on
+  2026-08-09, when nothing had shipped and the visible horizon was Group 2. Group
+  2 landed 2026-08-10 (`normalized-intake-workspace-contracts`, 25/25 ACs) and
+  Group 3 on 2026-08-12 (`workspace-routing-invariants`, 27/27 ACs). Between them
+  they changed the substrate that Groups 4–7 were specified against.
+
+  **The concrete drift.** Group 3 made canonical routing the enforced contract.
+  Its own initiative's queue was never migrated to that contract, so on
+  2026-08-13 every `ini-008` work entry — including the two this RFC records as
+  shipped — still used the legacy `spec/<slug>` form, produced
+  `invalid_artifact_path` findings, and was non-dispatchable. The initiative
+  shipped the rule that made its own remaining work unroutable. The four
+  unstarted specs also reference the shipped surfaces at very uneven depth
+  (`work-intake-migration-docs` names `canonical` 14 times and `dispatchable`
+  five; `tracker-intake-adapters` names neither), so their exposure to the change
+  differs and a single blanket revision would be wrong.
+
+  **What changes.** Groups 4–7 remain the intended sequence and their exit
+  criteria remain the target. Each is re-cut immediately before it is built,
+  against what has actually shipped, rather than treated as settled by this
+  document. Re-cutting may split, merge, or retire a group's spec; that is a
+  plan correction and does not require superseding this RFC. A change to
+  § *Proposal* — the decision itself — still would.
+
+  **Why an erratum rather than a new RFC.** Freezing a perishable forecast inside
+  an immutable decision record is what made this expensive: correcting a plan
+  should not cost a governance cycle. The split follows established practice —
+  Kubernetes KEPs keep durable Motivation/Proposal and rewritable Graduation
+  Criteria in one document with friction rising as it matures ("You do not need a
+  new KEP to move from beta to GA"); Python PEPs freeze Standards-track at Final
+  while Process/Informational stay Active; IETF pushes the perishable phase into
+  Internet-Drafts upstream of the frozen RFC. This repo already has the mechanism
+  (RFC-0011, RFC-0013 § Errata); it simply had not been applied to a delivery
+  plan.
+
+  **The missing control.** Nothing detected the drift — it surfaced only when a
+  human asked. Detection belongs in tooling, not vigilance: a staleness check
+  that flags a queued spec whose declared `needs` shipped after that spec was
+  last revised, in the shape of an architectural fitness function. Tracked as
+  `ini-008-anchor-staleness-check` in `workspace.toml [backlog].open`.
+
+  Recorded in `workspace.toml` (`["ini-008"]` milestone and `["ini-008".work]`
+  entries) and in the four `*-reanchor` backlog items.

--- a/workspace.toml
+++ b/workspace.toml
@@ -1743,6 +1743,37 @@ open = [
   # remains non-dispatchable until a separate spec is approved.
   {slug = "capture-work-alias-removal", source = "spec/work-intake-migration-docs AC14"},
 
+  # ── ini-008 reanchor: refresh open specs on shipped Group 2/3 reality ───────
+  # RFC-0083 Groups 2 and 3 shipped AFTER these four specs were authored
+  # (specs #903 2026-08-09; Group 2 #905 2026-08-10; Group 3 #928 2026-08-12), so
+  # each spec's assumptions predate the contracts and routing rules it builds on.
+  # Each item below proposes ONE spec/plan refresh loop, run immediately before
+  # that spec's build loop, reanchoring it on what actually shipped: the
+  # structured workspace entry schema (Group 2) and canonical routing, typed
+  # needs, fail-closed dispatch and RoutingFinding codes (Group 3).
+  # Slugs are deliberately distinct from the spec slugs: work-loop's shaping-item
+  # guard refuses to build any spec whose slug matches a [backlog].open entry.
+  # Non-dispatchable by construction — [backlog].open is a display projection and
+  # is never passed to the dispatch classifiers.
+  {slug = "work-intake-surface-reanchor", type = "spec", source = "spec/work-intake-surface", summary = "Reanchor the intake-surface spec/plan on shipped Group 2/3 contracts before its build loop"},
+  {slug = "tracker-intake-adapters-reanchor", type = "spec", source = "spec/tracker-intake-adapters", summary = "Reanchor the tracker-adapters spec/plan on the shipped normalized-intake contract"},
+  {slug = "tracker-refresh-writeback-reanchor", type = "spec", source = "spec/tracker-refresh-writeback", summary = "Reanchor the refresh/write-back spec/plan on shipped lifecycle and authority rules"},
+  {slug = "work-intake-migration-docs-reanchor", type = "spec", source = "spec/work-intake-migration-docs", summary = "Reanchor the migration/docs spec/plan on shipped canonical routing and finding codes"},
+  # Anchor-staleness fitness function. Nothing detected that Group 3 (#928) had
+  # invalidated four unstarted Group 4-7 specs — it surfaced only because a human
+  # asked. The reanchor items above are the one-off correction; this is the control
+  # that stops it recurring. Shape: for each spec in work.queue, if any declared
+  # `needs` target reached Shipped AFTER that spec's last revision, emit a
+  # `stale_anchor` finding and refuse dispatch until the spec is re-approved.
+  # Modelled on architectural fitness functions (ThoughtWorks' "dependency drift
+  # fitness function") — a continuously-run check, not a review ritual, because the
+  # documented failure mode of decision records is neglect rather than bad edits.
+  # Typed `spec` (not `design`): a bare typed shaping object here is a legacy
+  # shape that yields `legacy_entry`, and this item will produce a spec anyway.
+  # Needs a design pass first: `needs` carries no timestamp, so the comparison
+  # has to come from git history or a new recorded field.
+  {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Detect queued specs whose shipped dependencies moved after the spec was last revised"},
+
   # The canonical adopter-facing `guides/` tree is mirrored into the public
   # technical docs, but `agentbundle catalogue package --flavor source` includes
   # only `guides/_shared/`, not the pack-specific guide corpus. An organization
@@ -2028,17 +2059,36 @@ queue   = [
 ["ini-008"]
 name      = "Work Intake and Artifact Routing"
 status    = "active"
-milestone = "Wave 2 · Routing invariants"
+milestone = "Wave 3 · Intake surface"
 
 ["ini-008".work]
+# Entries are canonical target records (RFC-0083 delivery groups). Each carries its
+# own path, kind, source, summary and typed `needs`, so it is dispatchable without
+# reading a neighbouring comment. Legacy `spec/<slug>` strings are NOT valid here:
+# `workspace-routing-invariants` (Group 3, shipped) made canonical routing the
+# enforced contract, and a legacy path yields `invalid_artifact_path` and refuses
+# dispatch. Needs are typed objects — the canonical parser rejects bare strings.
 shipped = [
-  "spec/normalized-intake-workspace-contracts",
-  {path = "spec/workspace-routing-invariants", kind = "spec", source = {mode = "repo-origin"}, summary = "Make lifecycle, reconciliation, and dispatch routing deterministic", needs = ["work:spec/normalized-intake-workspace-contracts"]},
+  # Group 2 — transient normalized-intake contract + structured workspace entry
+  # schema (provenance, authority, summary, dependencies, lifecycle, validation).
+  {path = "docs/specs/normalized-intake-workspace-contracts/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Normalize intake and workspace contracts", needs = []},
+  # Group 3 — parsing, reconciliation, status and dispatch enforce the target
+  # rules: a missing spec or plan fails closed; comments cannot change routing.
+  {path = "docs/specs/workspace-routing-invariants/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Make lifecycle, reconciliation, and dispatch routing deterministic", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}]},
 ]
 active = []
 queue = [
-  {path = "spec/work-intake-surface", kind = "spec", source = {mode = "repo-origin"}, summary = "Provide one core entry point for work intake and routing", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants"]},
-  {path = "spec/tracker-intake-adapters", kind = "spec", source = {mode = "repo-origin"}, summary = "Normalize tracker work through shared intake contracts", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/work-intake-surface"]},
-  {path = "spec/tracker-refresh-writeback", kind = "spec", source = {mode = "repo-origin"}, summary = "Review tracker deltas and constrain lifecycle-aware write-back", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants", "work:spec/work-intake-surface", "work:spec/tracker-intake-adapters"]},
-  {path = "spec/work-intake-migration-docs", kind = "spec", source = {mode = "repo-origin"}, summary = "Migrate legacy entries and document intake compatibility", needs = ["work:spec/normalized-intake-workspace-contracts", "work:spec/workspace-routing-invariants", "work:spec/work-intake-surface", "work:spec/tracker-intake-adapters", "work:spec/tracker-refresh-writeback"]},
+  # Group 4 — standalone `work-intake`; corrects author-brief, receive-brief,
+  # new-spec, work-loop, workspace-status; `capture-work` becomes the alias.
+  # Exit: start/remember/status work with no optional shaping pack.
+  {path = "docs/specs/work-intake-surface/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Provide one core entry point for work intake and routing", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/workspace-routing-invariants/spec.md"}]},
+  # Group 5 — Jira, Jira Align, Linear and GitHub adapters converge on the shared
+  # contract. Acquisition and normalization stay adapter-specific.
+  {path = "docs/specs/tracker-intake-adapters/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Normalize tracker work through shared intake contracts", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/work-intake-surface/spec.md"}]},
+  # Group 6 — origin-aware refresh, conflict resolution, execution locks and
+  # limited post-execution write-back across supported trackers.
+  {path = "docs/specs/tracker-refresh-writeback/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Review tracker deltas and constrain lifecycle-aware write-back", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/workspace-routing-invariants/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/work-intake-surface/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/tracker-intake-adapters/spec.md"}]},
+  # Group 7 — reconcile legacy workspaces, publish the alias window and removal
+  # criteria, finish cross-links, run the full evaluation matrix.
+  {path = "docs/specs/work-intake-migration-docs/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Migrate legacy entries and document intake compatibility", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/workspace-routing-invariants/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/work-intake-surface/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/tracker-intake-adapters/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/tracker-refresh-writeback/spec.md"}]},
 ]


### PR DESCRIPTION
## What does this change?

Records an Approver-signed erratum on RFC-0083 separating its **durable decision**
from its **perishable delivery forecast**, and reanchors the `ini-008` waves in
`workspace.toml` so the initiative's remaining work is routable again.

No code changes. Governance correction only.

## Why?

- Follows from: RFC-0083 (Accepted) — `## Errata`, the RFC-0011 / RFC-0013 pattern
  this repo already uses
- Triggered by: #928 (`workspace-routing-invariants`, RFC-0083 Group 3)

**The initiative shipped the rule that made its own remaining work unroutable.**
Group 3 made canonical routing the enforced contract. `ini-008`'s own queue was
never migrated to it, so on 2026-08-13 every entry — *including the two the RFC
records as shipped* — still used the legacy `spec/<slug>` form, produced
`invalid_artifact_path` findings, and was non-dispatchable. Zero of six could be
picked up by `work-loop`.

The root cause is structural, not careless. RFC-0083 cut seven delivery groups in
one pass on 2026-08-09, when nothing had shipped and the visible horizon was Group
2. Group 2 landed 08-10, Group 3 landed 08-12. A **forecast** was frozen inside an
**immutable decision record**, so correcting it appeared to require a whole new RFC.

## How do I verify it?

```bash
python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb'))"
make build-check          # SAST/SCA included — exits 0
```

Canonical reconciliation, before and after:

| | before | after |
|---|---|---|
| `invalid_artifact_path` / `legacy_entry` findings on ini-008 | 6 | **0** |
| dispatchable entries | **0** | 1 (`work-intake-surface`) |
| remaining findings | — | `unsatisfied_dependency` only — correct queue ordering |

The surviving findings are the engine correctly reporting that Groups 5–7 are
blocked on Group 4. That is the chain working, not an error.

## What did you not change that you considered?

- **Did not supersede RFC-0083.** § *Proposal* — the decision — is unchanged and
  still binding. Only the delivery forecast moved.
- **Did not edit the RFC body.** The erratum is appended; the body above it is
  preserved verbatim, per `CONVENTIONS.md` § Document lifecycle.
- **Did not migrate the whole `workspace.toml` grammar.** ~79 legacy entries exist
  repo-wide. Scoped to `ini-008`, which this change actually breaks.
- **Did not write briefs for the four open specs.** `docs/product/briefs/` does not
  exist, `workspace.toml` itself records the brief-queue layout as *"not yet
  standardised… deferred until ratified"*, and briefs are upstream intake that
  *produce* specs — these already have Approved specs and plans. Retro-writing them
  would invert the lifecycle and create a second source of truth.
- **Did not refresh the four specs in this PR.** Each gets its own loop, run
  just-in-time — which is the point of the erratum.

## What changes

**Erratum (RFC-0083).** Groups 4–7 are re-cut against shipped reality immediately
before each is built. Re-cutting may split, merge, or retire a group's spec without
superseding the RFC; a change to § *Proposal* still would.

**Waves reanchored (`workspace.toml`).** All six `ini-008` entries converted to
canonical form with typed object needs; milestone advanced off "Wave 2 · Routing
invariants" (shipped) to "Wave 3 · Intake surface"; per-entry comments name the RFC
group so each entry stands on its own.

**Refresh proposed, not performed.** One `*-reanchor` item per open spec in
`[backlog].open` — a display projection *"not passed to the classifiers"*, so it
records intent with zero execution. Exposure is uneven and a blanket revision would
be wrong: `work-intake-migration-docs` names `canonical` 14× and `dispatchable` 5×;
`tracker-intake-adapters` names neither.

Slugs are deliberately **not** the spec slugs — `work-loop`'s shaping guard refuses
to build any spec whose slug matches a `[backlog].open` entry, so reusing them would
have re-blocked the specs this PR unblocks. Verified: `extract_repo_backlog()` sees
all four (visible in workspace-status); `extract_top_level_backlog()` sees none (not
shaping items).

**The missing control.** `ini-008-anchor-staleness-check`: flag any queued spec whose
declared `needs` reached Shipped *after* that spec's last revision, and refuse
dispatch until re-approved. Nothing detected this drift — it surfaced only because
someone asked. Shaped as an architectural fitness function (a continuously-run check,
not a review ritual) because the documented failure mode of decision records is
**neglect, not bad edits**.

## Order of work after this lands

`work-intake-surface` (Group 4) → `tracker-intake-adapters` (5) →
`tracker-refresh-writeback` (6) → `work-intake-migration-docs` (7), each preceded by
its reanchor loop. Then backlog `capture-work-alias-removal`, gated on external
conditions (two minor releases, 90 days, Approver sign-off) and correctly carrying no
machine-readable `needs` edge.

## Evidence, and its limits

An applied survey backs the split (Kubernetes KEP: durable Motivation/Proposal +
rewritable Graduation Criteria, *"You do not need a new KEP to move from beta to
GA"*; Python PEP Provisional; Rust RFC + tracking issue; IETF Internet-Drafts).

Stated plainly because it should temper the confidence: **the popular arguments here
are weaker than they are usually presented.** No controlled study shows front-loaded
decomposition causes rework; no audited case quantifies under-planning's cost either.
Standish/CHAOS is dismissed by peer-reviewed critique as *"a business, not science."*
Menzies et al. (2016, N=171) undercuts the Boehm cost-of-change curve. *"No plan
survives first contact"* is a compression of Moltke that dropped his actual doctrine —
prepare **branching option sets**, not plan less.

So this argues from **our own instance** — #928 invalidating four unstarted specs —
rather than borrowed authority.

## Deferred

- `ini-008-anchor-staleness-check` needs a design pass: `needs` carries no timestamp,
  so the comparison must come from git history or a new recorded field.
- Whether the durable/perishable split should generalise to `CONVENTIONS.md` § Document
  lifecycle, rather than living as a per-RFC erratum. Worth an RFC if we want it as a
  rule.

---

## Checklist

- [x] Tests pass locally (`make build-check`, SAST/SCA included)
- [x] Lint and typecheck pass
- [ ] Reviewer subagents — not run; no code diff, and the substance is a governance
      judgement for the Approver rather than an implementation review
- [x] Spec and code agree (no spec change; spec statuses untouched)
- [x] Living docs match reality: `workspace.toml` now matches shipped state
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured (in the erratum itself, and as the staleness-check item)
