### PR TITLE
fix(agentbundle): print a pasteable certificate-setup command, not a placeholder

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead — "Adapt to Project" now reads "How to adapt a freshly installed pack
   to your project". No page moved and no link changed. No pack version changes.
 
+### [agentbundle][0.35.2] — 2026-08-14
+
+#### Fixed
+
+- **The certificate-setup command shown on a trust failure can now be pasted as
+  is.** It previously printed `Python 3.x` as a placeholder, leaving the adopter
+  to work out their own version first. It now names the actual version, and is
+  left out altogether when that setup script is not present on the machine.
+
 ### [agentbundle][0.35.1] — 2026-08-14
 
 #### Fixed

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.35.2] — 2026-08-14
+
+### Fixed
+
+- **The certificate-setup command in the trust-failure message is now
+  copy-pasteable.** It printed a literal `Python 3.x` placeholder, so the one
+  audience that sees this message — an adopter whose interpreter trusts nothing —
+  had to know to substitute their own version before the command would run. It
+  now carries the running interpreter's actual version, and is omitted entirely
+  when the script does not exist, so a non-python.org build gets the portable
+  `SSL_CERT_FILE` advice instead of a command that would fail.
+
 ## [0.35.1] — 2026-08-14
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/catalogue.py
+++ b/packages/agentbundle/agentbundle/catalogue.py
@@ -163,6 +163,22 @@ def _github_archive_url(owner: str, repo: str, ref: str) -> str:
     return f"https://github.com/{owner}/{repo}/archive/{ref}.tar.gz"
 
 
+def _install_certificates_hint() -> str | None:
+    """The python.org certificate-setup command, with the real version in it.
+
+    Printing a literal "Python 3.x" placeholder means the adopter cannot paste
+    what they are shown — and the adopters who see this message are the ones who
+    least need an extra substitution step. Returns ``None`` when the script is
+    not present, which is the signal that this interpreter is not a python.org
+    framework build and the advice would be wrong.
+    """
+    minor = f"{sys.version_info.major}.{sys.version_info.minor}"
+    script = Path(f"/Applications/Python {minor}/Install Certificates.command")
+    if script.is_file():
+        return f'open "{script}"'
+    return None
+
+
 def _is_cert_verification_failure(exc: BaseException) -> bool:
     """True when *exc* is a certificate-verification failure.
 
@@ -205,15 +221,21 @@ def _verification_failure_message(
         # Almost certainly, not certainly: a populated capath is excluded before
         # we get here, but the store could still be empty *and* the network
         # inspected.
-        remedy = (
-            '       open "/Applications/Python 3.x/Install Certificates.command"\n'
-            "     Or point it at the system bundle:\n"
-            "       export SSL_CERT_FILE=/etc/ssl/cert.pem"
-            if sys.platform == "darwin"
-            else "       install your certificate authorities into this "
-            "interpreter's trust\n"
-            "     store, or set SSL_CERT_FILE to a PEM bundle containing them"
-        )
+        hint = _install_certificates_hint() if sys.platform == "darwin" else None
+        if hint:
+            remedy = (
+                f"       {hint}\n"
+                "     Or point it at the system bundle:\n"
+                "       export SSL_CERT_FILE=/etc/ssl/cert.pem"
+            )
+        elif sys.platform == "darwin":
+            remedy = "       export SSL_CERT_FILE=/etc/ssl/cert.pem"
+        else:
+            remedy = (
+                "       install your certificate authorities into this "
+                "interpreter's trust\n"
+                "     store, or set SSL_CERT_FILE to a PEM bundle containing them"
+            )
         steps.append(
             "This Python trusts ZERO certificate authorities, so every HTTPS\n"
             "     request from it fails — almost certainly not a corporate-proxy\n"
@@ -406,13 +428,16 @@ def _retry_with_system_trust(
             "the administrator keychain plus the system public certificate "
             "bundle" if sys.platform == "darwin" else "operating-system trust anchors"
         )
-        fix = (
-            '  open "/Applications/Python 3.x/Install Certificates.command"\n'
-            "  (or: export SSL_CERT_FILE=/etc/ssl/cert.pem)"
-            if sys.platform == "darwin"
-            else "  install your certificate authorities into this interpreter's\n"
-            "  trust store, or set SSL_CERT_FILE to a PEM bundle"
-        )
+        hint = _install_certificates_hint() if sys.platform == "darwin" else None
+        if hint:
+            fix = f"  {hint}\n  (or: export SSL_CERT_FILE=/etc/ssl/cert.pem)"
+        elif sys.platform == "darwin":
+            fix = "  export SSL_CERT_FILE=/etc/ssl/cert.pem"
+        else:
+            fix = (
+                "  install your certificate authorities into this interpreter's\n"
+                "  trust store, or set SSL_CERT_FILE to a PEM bundle"
+            )
         print(
             f"agentbundle: this Python trusts no certificate authorities, so "
             f"verification failed for {host}. Retrying against {extra} — this "

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.35.1"
+CLI_VERSION = "0.35.2"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.35.1"
+version = "0.35.2"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_catalogue_trust_fallback.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_trust_fallback.py
@@ -15,6 +15,7 @@ import os
 import ssl
 import sys
 import tarfile
+import types
 import urllib.error
 import urllib.request
 
@@ -313,7 +314,7 @@ def test_empty_store_message_names_the_real_cause(monkeypatch, tmp_path, no_env)
 
     message = str(exc.value)
     assert "trusts ZERO certificate authorities" in message
-    assert "Install Certificates.command" in message
+    assert "3.x" not in message, "the version placeholder must never reach an adopter"
     # Softened from an absolute after security review: a populated capath is
     # excluded before we get here, but a store can still be empty AND the
     # network inspected.
@@ -357,14 +358,21 @@ def test_successful_empty_store_recovery_still_tells_the_adopter(
     monkeypatch.setattr(urllib.request, "urlopen", _Stub([_verify_error(), _tarball()]))
 
     monkeypatch.setattr(sys, "platform", "darwin")
+    # Pin the hint too, not just the platform: the command is derived from the
+    # running interpreter's version and only exists on a python.org framework
+    # build, so asserting it unpinned depends on the developer's machine.
+    monkeypatch.setattr(
+        catalogue,
+        "_install_certificates_hint",
+        lambda: 'open "/Applications/Python 3.14/Install Certificates.command"',
+    )
     catalogue._fetch_and_extract(URL, tmp_path)
 
     err = capsys.readouterr().err
     assert "trusts no certificate authorities" in err
     assert "does not fix the interpreter" in err
-    # Pin the platform: the remedy is macOS-specific, so asserting it without
-    # pinning passes on a developer's Mac and fails on a Linux runner.
     assert "Install Certificates.command" in err
+    assert "3.x" not in err, "the version placeholder must never reach an adopter"
     assert (tmp_path / "repo-main" / "pack.toml").exists(), "install must still succeed"
 
 
@@ -447,3 +455,26 @@ def test_symlink_archive_extracts_where_symlinks_cannot_be_created(
     claude = tmp_path / "repo-main" / "CLAUDE.md"
     assert claude.exists(), "the link target must be copied when links are unavailable"
     assert claude.read_text() == "# agents\n", "copy must carry the target's content"
+
+
+def test_certificate_hint_carries_a_real_version_or_is_omitted(monkeypatch, tmp_path):
+    """Never print a path an adopter has to edit before it works.
+
+    The hint is derived from the running interpreter and returned only when the
+    script actually exists, so a non-framework build gets the portable advice
+    instead of a command that would fail.
+    """
+    hint = catalogue._install_certificates_hint()
+    if hint is not None:
+        assert "3.x" not in hint
+        assert f"{sys.version_info.major}.{sys.version_info.minor}" in hint
+
+    # A version whose script cannot exist must yield no hint at all. A bare
+    # tuple will not do: the code reads .major/.minor off version_info.
+    monkeypatch.setattr(
+        catalogue.sys,
+        "version_info",
+        types.SimpleNamespace(major=3, minor=99),
+        raising=False,
+    )
+    assert catalogue._install_certificates_hint() is None


### PR DESCRIPTION
## What does this change?

The trust-failure message told an adopter to open
`/Applications/Python 3.x/Install Certificates.command`. The `3.x` was a literal
placeholder, so the command failed if pasted as shown. It now carries the running
interpreter's actual version, and is omitted entirely when that script does not
exist.

## Why?

Surfaced by an adopter reading the 0.35.1 output on a real affected machine. The
fix itself worked — the install succeeded — and the remediation was the one part
still asking something of them.

The audience for this message is the worst possible one to hand a substitution
step to: someone whose interpreter trusts no certificate authority at all, for
whom `pip` and every other tool is also failing. Printing a command that does not
run is the same misdirection this release series exists to remove, in miniature.

The second half matters as much as the first. On a pyenv, Homebrew, or conda
build there is no `/Applications/Python …` script, so the advice was not merely
awkward — it was wrong. Those builds now get the portable `SSL_CERT_FILE` route
instead.

- Implements: `docs/specs/catalogue-corporate-trust-store/spec.md`
- Follows: RFC-0086 (Accepted, with Errata)
- Ships as: `agentbundle` 0.35.2

## How do I verify it?

```bash
python3 tools/lint-ruff.py                                        # exit 0
python3 -m pytest packages/agentbundle/tests/ -q                  # exit 0
python3 -m pytest tests/roster/test_workspace_status_projection.py -q   # release surfaces agree
```

Observed behaviour:

```
python.org build (version interpolated):
       open "/Applications/Python 3.14/Install Certificates.command"

pyenv build (script absent — hint omitted):
       export SSL_CERT_FILE=/etc/ssl/cert.pem
```

## What did you not change that you considered?

- **Running the command for them.** `agentbundle install` does not write to an
  interpreter it does not own; `uninstall` could not undo it. The message states
  plainly that the install was rescued and the interpreter is still broken.
- **Guessing the framework path when the script is absent.** Returning `None` and
  falling back to portable advice is better than emitting a path that does not
  exist on that machine.
- **Deriving the path from `sys.base_prefix`.** The setup script lives under
  `/Applications`, not in the framework tree, so the version is the only part
  worth deriving.

### Test shape

The tests pin the hint rather than the environment. It is derived from the running
interpreter and only present on a framework build, so asserting it unpinned would
pass or fail depending on where the suite ran — the same defect that broke three
CI checks earlier in this series. A guard asserts the `3.x` placeholder can never
reach an adopter again.

---

## Checklist

- [x] Tests pass locally; release-surface test run directly
- [x] Lint passes
- [x] Spec and code agree
- [x] Living docs match reality: both changelogs updated, version bumped in `pyproject.toml` and `version.py`
- [x] No new top-level directories
- [x] Conventional commit format with `Engine-Change-RFC: RFC-0086`
