### PR TITLE
chore(workspace): move two shipped specs out of their work queues

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -139,11 +139,11 @@ shipped = [
   "spec/catalogue-test-carve-out",         # ADR-0075 ownership carve-out + shipped catalogue conformance + sdist test graft
   "spec/workspace-status-simplification-order-2b", # repair-plan + repair-apply; post-publication closeout
   "spec/workspace-mcp",                    # RFC-0078 Stage 1; deferred follow-ons remain in backlog
+  {path = "docs/specs/m6-live-demo-guide/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run a peer-led shaping-to-spec demonstration on the adopting organization's repository", needs = []},
 ]
 queue   = [
   # P5 · Adopt — gated on adopter-persona research (evidence base)
   {path = "spec/m6-astro-project-index",         needs = "research:adopter-persona"},  # Astro site: PM-facing project index from docs/product/projects/
-  {path = "docs/specs/m6-live-demo-guide/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run a peer-led shaping-to-spec demonstration on the adopting organization's repository", needs = []},  # ≥3 team types; ≤30-min shaping→brief→spec narration on org's own repo
   {path = "spec/m6-enterprise-rollout-playbook", needs = "research:adopter-persona"},  # champion→CTO→platform→engineers; staged rollout + retro template
 ]
 
@@ -1985,12 +1985,9 @@ shipped = [
   # (agentbundle catalogue contracts list/show/export), init next-step hints, and
   # authoring-hub section 12 for offline readers.
   {path = "docs/specs/catalogue-wave3-enterprise-authoring-discovery/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Expose bundled contracts for offline enterprise authoring", needs = [{type = "local", kind = "spec", path = "docs/specs/catalogue-wave2-pack-integrations/spec.md"}]},
+  {path = "docs/specs/rendered-site-link-debt/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Repair rendered internal links and enforce generated-site link closure", needs = []},
 ]
 queue   = [
-
-  # Follow-on from documentation-entry-navigation AC15. The approved spec
-  # remediates the whole rendered-link corpus before enabling its Pages gate.
-  {path = "docs/specs/rendered-site-link-debt/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Repair rendered internal links and enforce generated-site link closure", needs = []},
 
   # Catalogue verifier correctness. Independent (no unsatisfied predecessor). Gated on
   # Wave 2 (already shipped). Serialized AFTER Wave 3 to avoid concurrent agentbundle


### PR DESCRIPTION
## What does this change?

Moves two `Status: Shipped` specs out of `[work].queue` and into `[work].shipped` in `workspace.toml`. Index-only — no spec, code, or behavior changes.

## Why?

`workspace-status reconcile` reported two Type 2 findings (queue entry present, spec already Shipped):

| Spec | Initiative | Spec status |
| --- | --- | --- |
| `docs/specs/m6-live-demo-guide/spec.md` | ini-002 | Shipped |
| `docs/specs/rendered-site-link-debt/spec.md` | ini-007 | Shipped |

Both shipped in 573c7dd9, which updated the spec files but not the coordination index. Left uncorrected, `workspace-status` keeps reporting them as blocked (`impossible_transition`, `unapproved_spec`) and they clutter every session-start orientation.

No spec/ADR/RFC: this is a mechanical index repair executed by the tooling that detects it — the reconciliation output above is the whole justification.

## How do I verify it?

```bash
python3 .claude/skills/workspace-status/scripts/workspace_status.py reconcile --root .
# type2: 0  (was 2)

SKIP_SAST=1 make build-check   # exit 0
make lint-ruff                 # exit 0
```

`SKIP_SAST=1` is the correct gate here and matches CI: `workspace.toml` is outside `SAST_DIRS` and `SAST_CONFIG`, so `build-check.yml` sets the same flag for this diff.

The edit was made by the skill's own deterministic writer (`repair-plan` -> `repair-apply --yes`), not by hand. It preserves each structured entry whole, re-reads each spec's `Status` from disk immediately before writing, and writes atomically via `tempfile.mkstemp`.

## What did you not change that you considered?

- **The Type 1 finding** — `spec/self-host-cross-owner-write` is `Status: Implementing` but registered in no initiative. Its work shipped in #926, so the spec status is likely stale, but confirming that means checking its acceptance criteria, not moving a line. Deliberately out of scope; it lands in the next PR.
- **The 79 `legacy_entry` memberships** — retained compatibility records that never dispatch. Migrating them to canonical target entries is a decision, not a chore.
- **Hand-editing `workspace.toml`** — the workspace-status skill names `repair-apply` as the only cleanup writer and explicitly forbids manual edits as a fallback.
- **Restoring the trailing inline comment** on the `m6-live-demo-guide` entry, which `repair-apply` drops when relocating a structured entry. The entry's `summary` field carries the same description, and hand-patching would violate the point above.

Bundled fixes:
- Removed the now-orphaned two-line comment in `[ini-007 work].queue` that described the `rendered-site-link-debt` entry this PR moved out. Same file, same concern, stale-comment cleanup.

---

## Checklist

- [x] Tests pass locally (`SKIP_SAST=1 make build-check` — exit 0)
- [x] Lint and typecheck pass (`make lint-ruff` — exit 0)
- [x] Self-review run — in-code review for this spec-less change; `adversarial-reviewer` is a **named skip** (agent dispatch disabled for this session). Reviewed against the spec-less checklist: diff matches plan; no functions touched so coverage is unchanged; the one out-of-plan hunk is the bundled comment cleanup above.
- [x] Spec and code agree — spec files unchanged; this PR makes the index agree with them
- [x] Living docs match reality — no user-visible behavior change; `docs/product/changelog.md`, `guides/`, `docs/architecture/`, `docs/product/roadmap.md` all unaffected
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — see below

**Learning captured:** shipping a spec has two steps, and the second is easy to drop. Writing `Status: Shipped` does not move the `workspace.toml` entry; `repair-plan` -> `repair-apply` is the deterministic way to close the gap, and `reconcile` (not `status`) is what surfaces the untracked-spec case at all.