### PR TITLE
fix(agentbundle): type keychains as a variable-length tuple

### DIFF
--- a/packages/agentbundle/agentbundle/system_trust.py
+++ b/packages/agentbundle/agentbundle/system_trust.py
@@ -210,7 +210,7 @@ def system_anchor_pem(*, include_public_roots: bool = False) -> str | None:
     if sys.platform != "darwin":
         return None
 
-    keychains = _ADMIN_KEYCHAINS
+    keychains: tuple[str, ...] = _ADMIN_KEYCHAINS
     chunks: list[str] = []
 
     if include_public_roots:


### PR DESCRIPTION
## What does this change?

Annotates one local binding in `system_trust.py` as `tuple[str, ...]` so the macOS keychain fallback type-checks. One line; no runtime behavior change.

## Why?

`make lint-mypy` is **currently red on `main`**:

```
packages/agentbundle/agentbundle/system_trust.py:227: error: Incompatible types in assignment
  (expression has type "tuple[str, str]", variable has type "tuple[str]")  [assignment]
```

`_ADMIN_KEYCHAINS` is a one-element tuple (`system_trust.py:67`), so mypy infers `tuple[str]` at the first assignment. When the Apple TLS bundle is missing, the fallback rebinds to `(*_ADMIN_KEYCHAINS, _APPLE_ROOT_KEYCHAIN)` — a `tuple[str, str]` — and the assignment is rejected.

**Why CI did not catch it, and structurally could not.** mypy narrows on `sys.platform`. The enclosing function opens with:

```python
if sys.platform != "darwin":
    return None
```

Under `--platform linux` — what the ubuntu-latest runner uses — everything after that guard is unreachable, so mypy never type-checks the macOS branch at all:

```
$ python3 -m mypy --platform linux  packages/agentbundle/agentbundle/system_trust.py
Success: no issues found in 1 source file
$ python3 -m mypy --platform darwin packages/agentbundle/agentbundle/system_trust.py
packages/agentbundle/agentbundle/system_trust.py:227: error: Incompatible types in assignment ...
```

So the gate is green in CI and red for any maintainer running `make lint-mypy` or `make ci` on a Mac. Regression from #941.

This PR fixes the one error. It deliberately does **not** try to close the blind spot itself — see below.

## How do I verify it?

```bash
python3 -m mypy --platform darwin packages/agentbundle/agentbundle/system_trust.py  # Success (was: 1 error)
python3 -m mypy --platform linux  packages/agentbundle/agentbundle/system_trust.py  # Success (unchanged)

python3 tools/lint-mypy.py   # exit 0 — "Success: no issues found in 117 source files"
make lint-ruff               # exit 0
python3 -m pytest packages/agentbundle/tests/ -q -k trust   # 54 passed
make build-check             # exit 0 (full run, SAST included — this diff touches packages/)
```

The annotation is on a local variable, so it is not evaluated at runtime and cannot alter trust-store resolution.

## What did you not change that you considered?

- **Adding a macOS mypy leg to CI.** This is the real fix for the blind spot — the same trap hides every `sys.platform == "darwin"` and `== "win32"` branch in the codebase from the type checker, and `system_trust.py` is exactly the kind of platform-forked module where it bites. But adding a CI matrix leg is a workflow change with cost and failure-mode questions of its own, and bundling it here would bury a one-line correctness fix. Worth its own change; flagged here so the finding is not lost.
- **Widening `_ADMIN_KEYCHAINS` to `tuple[str, ...]` at its definition.** That would also silence the error, but it weakens the type of a module-level constant that genuinely is a fixed one-element tuple. Annotating the variable that actually varies is the more honest shape.
- **Restructuring the fallback** to build the tuple once instead of rebinding. A behavior-equivalent refactor of security-adjacent trust code is not worth the review surface for a type-only defect.
- **Anything else mypy reports.** Nothing else does — the run is clean at 117 files.

---

## Checklist

- [x] Tests pass locally (`pytest -k trust` — 54 passed; `make build-check` — exit 0)
- [x] Lint and typecheck pass (`make lint-ruff` exit 0; `python3 tools/lint-mypy.py` exit 0)
- [x] Self-review run — in-code review for this spec-less change; `adversarial-reviewer` is a **named skip** (agent dispatch disabled for this session). Diff is one annotation; verified green under both `--platform linux` and `--platform darwin` so the fix is not merely local-environment-shaped.
- [x] Spec and code agree — no spec governs this; it is a type-only correction
- [x] Living docs match reality — no user-visible behavior change, so `docs/product/changelog.md` and `guides/` are untouched by design
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — see below

**Learning captured:** a green mypy run on Linux says nothing about platform-forked code. Any module that early-returns on `sys.platform` has its other branches silently excluded from type checking, so a single-platform CI matrix type-checks strictly less than it appears to. Check platform-specific code with an explicit `--platform` flag rather than trusting the default.