### PR TITLE
docs(workspace): reconcile eight backlog claims against the code

### DIFF
--- a/docs/specs/marketing-docs-link-repair/plan.md
+++ b/docs/specs/marketing-docs-link-repair/plan.md
@@ -37,6 +37,8 @@
 - **Fixing the 8 dead placeholder hrefs on `primitives-fixture.astro`** — declined;
   pre-existing, on a `noindex` orphan dev fixture, outside this change's concern.
   Registered as `web-primitives-fixture-dead-placeholders` in `[backlog].open`.
+  (Since resolved: the placeholders are gone and the entry was removed as done on
+  2026-08-15 — see this spec's erratum at `spec.md` § disclosed exclusion.)
 - **Normalising the neighbouring `packUrl` / `journeyUrl` frontmatter while in the same
   files** — declined; those resolve correctly today, so they fail the bundled-fixes
   "same concern" gate.

--- a/docs/specs/marketing-docs-link-repair/spec.md
+++ b/docs/specs/marketing-docs-link-repair/spec.md
@@ -92,6 +92,15 @@ route set and the built file tree are the oracles.
    silently skipped them. **Disclosed exclusion:** `build/primitives-fixture/` is
    excluded (8 pre-existing placeholder hrefs on a `noindex` dev fixture, listed in
    `[backlog].open` as `web-primitives-fixture-dead-placeholders`).
+
+   > **Erratum (2026-08-15, spec/workspace-backlog-reconciliation AC1c):** the
+   > disclosed exclusion above is **obsolete — do not implement it.** The eight
+   > placeholder hrefs are gone; `web/src/pages/primitives-fixture.astro` now
+   > carries exactly two, both live. A future link gate needs **no**
+   > `primitives-fixture` carve-out, and adding one would re-disclose an exclusion
+   > that no longer has a subject. The root-relative-prefix trap in the sentence
+   > before it still stands. The backlog entry named here was removed as done in
+   > the same change.
 3. **Projection fixed-point.** Re-run `tools/build-site.py` and assert
    `git status --porcelain web/src/content packs` reports nothing beyond the commit's
    own changes. **This check is structurally blind to

--- a/docs/specs/workspace-backlog-reconciliation/plan.md
+++ b/docs/specs/workspace-backlog-reconciliation/plan.md
@@ -1,0 +1,68 @@
+# Plan: workspace-backlog-reconciliation
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `workspace.toml` — `[backlog]` only.
+- `docs/specs/workspace-backlog-reconciliation/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- Goal-based: `python3 .claude/skills/workspace-status/scripts/workspace_status.py status --root .` exits 0 and reports 143 open entries (AC9).
+- Goal-based: `git diff workspace.toml` shows hunks inside `[backlog]` only (AC8).
+- Each corrected claim re-verified by the command recorded in its entry.
+
+**What I am NOT changing**
+- No code, no lint, no CI. The `pyyaml` audit gap AC2 names is recorded, not fixed
+  — fixing it is a Makefile change and belongs in its own PR.
+- No `type` values on the five reanchor entries (AC6 corrects the comment only).
+- No `[work]` / `[shaping_queue]` / `[brief_queue]` / initiative membership.
+
+## Declined patterns
+
+- **Tempted:** migrate all 141 `unsupported_legacy` entries to canonical target
+  entries in this PR. **Declined:** a target entry requires a real artifact `path`;
+  backlog ideas have none, so every one would be a fabricated path. The engine's own
+  remediation forbids inferring one.
+- **Tempted:** fix the `pyyaml` SCA gap while I'm looking at it. **Declined:** it is
+  a Makefile gate change in a file this PR does not otherwise touch — outside the
+  bundled-fixes carve-out (different area, behavior change to a gate).
+- **Tempted:** retype the five `type = "spec"` entries to `shape` so they become
+  `legacy_entry`. **Declined:** that changes which room they display in and which
+  guard sees them — a routing decision, not a comment fix. Recorded as AC7.
+- **Tempted:** close `ast07-sca-scanner-agentbundle` outright, since the headline
+  concern is covered. **Declined:** the `[lint]` extra is genuinely unaudited, so
+  closing it would make the backlog assert something false.
+
+## Tasks
+
+### T1 — Verify every claim (no writes)
+- **Mode:** goal-based. `Done when:` each of the seven commands in the spec has been
+  run and its output recorded here.
+- **Tests:** no stub (goal-based).
+
+### T2 — Apply the `[backlog]` edits
+- **Mode:** goal-based. `Done when:` AC1–AC7 edits are in `workspace.toml` and it
+  parses (`tomllib.load`).
+- **Tests:** no stub (goal-based).
+
+### T3 — Verify scope and backend
+- **Mode:** goal-based. `Done when:` AC8 (diff confined to `[backlog]`) and AC9
+  (backend exit 0, count 143) both hold.
+- **Tests:** no stub (goal-based).
+
+## Verification log
+
+- **AC1** `grep -oE 'href=(\{[^}]*\}|"[^"]*")' web/src/pages/primitives-fixture.astro` -> 2 hits, both live. 0 of the 8 named placeholders remain.
+- **AC2** `tomllib` on both pyproject.toml -> `dependencies = []` for agentbundle and credbroker; agentbundle `[lint]` extra = `['pyyaml>=6.0']` (unaudited residual).
+- **AC3** `grep -rn "install research" guides/` -> 0 hits.
+- **AC4a** `python3 tools/repo/check_contract_drift.py` -> exit 0, no output (2nd clean pass).
+- **AC4b/c** AC4 checked `[x]` at docs/specs/jira-check-sso-auto-login/spec.md:307; AC11 satisfied in the same spec.
+- **AC5** `grep -rl "^## Acceptance criteria" docs/specs/*/spec.md | wc -l` -> 17 (canonical casing: 299).
+- **AC6** `_SHAPING_TYPES` = {design, research, shape, signal, strategy}; `parse_legacy_workspace_entry('backlog.open', {'slug':'x','type':'spec'})` -> `unsupported_legacy`.
+- **AC8** tomllib section-diff vs `git show HEAD:workspace.toml` -> only `backlog` changed.
+- **AC9** backend exit 0; `repo_backlog.open` = 143 (was 143; -1 AC1, +1 AC7).
+- **GATES** lint-spec-status exit 0 ("spec metadata clean"); `make lint-ruff` exit 0; `SKIP_SAST=1 make build-check` exit 0 (diff touches no SAST-relevant path).
+- **REVIEW** `adversarial-reviewer` = named skip (session instruction prohibits subagent dispatch unless requested). Self-review run against the spec-less checklist instead.

--- a/docs/specs/workspace-backlog-reconciliation/spec.md
+++ b/docs/specs/workspace-backlog-reconciliation/spec.md
@@ -1,0 +1,157 @@
+# Spec: workspace-backlog-reconciliation
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — this spec changes `workspace.toml` display metadata only. It
+  adds, removes, and changes no dispatchable membership.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (work-loop). No risk trigger fired. The one conditional trigger —
+governance boundary — was checked and did NOT fire: `[backlog].open` is a display
+projection that the dispatch classifiers never read (workspace_status_engine.py
+:3237 `extract_repo_backlog`), so no entry here can authorize or block work. Lean
+fill: Objective + Acceptance Criteria + Boundaries + Assumptions. -->
+
+## Objective
+
+A cold reader of `workspace.toml [backlog].open` should find claims that are true
+against the repository as it stands today. An audit of all 143 open entries against
+the code found eight that are not: one describes work already done, one describes
+work half-done, one is materially broader than the gap that survives it, three say
+they are blocked on gates that have since passed, and two state a measurement or a
+mechanic that the code contradicts.
+
+Success: every corrected entry's claim is verifiable by a command recorded in the
+entry itself, and `workspace-status` still parses and reports the same open-entry
+count (one entry removed as done, one added for the decision AC6 surfaces).
+
+## Acceptance Criteria
+
+- [x] **AC1 — `web-primitives-fixture-dead-placeholders` closes.** The entry is
+  removed from `[backlog].open`, and the closure evidence is recorded in the PR
+  description and in this spec.
+
+  It is **not** moved to `[backlog].closed`, and that is deliberate:
+  `_ALLOWED_KIND_BY_COLLECTION["backlog.closed"]`
+  (`workspace_status_engine.py:1076`) admits only `kind = "defect"`, and
+  `:2050` additionally requires the referenced artifact to carry
+  `Status: Closed` plus a resolution in `{fixed, declined, superseded}`. A closed
+  entry is therefore a canonical target entry backed by a real defect artifact.
+  This item has no such artifact, and inventing one to satisfy the array would be
+  the same fabrication this spec's Boundaries forbid. Deletion is also the
+  repository's established practice: `[backlog].closed` has stayed empty across the
+  project's history while entries have come and gone from `open`.
+
+  Evidence:
+  `web/src/pages/primitives-fixture.astro` carries exactly two `href` attributes,
+  both live (`withBase('/docs/guides/github/how-to/…')` and `#decision-band`); none
+  of the eight named placeholders (`/guides/github-auth`, `/review`, `/issues`,
+  `/run`, `/confirm`, `/cancel`, `/get-started`, `/example`) remains.
+
+- [x] **AC1b — the sibling trap note that AC1 invalidates is corrected.**
+  `web-docs-link-check-gate` records two traps a future link-checker must carry;
+  trap 2 is "`build/primitives-fixture/` must be excluded explicitly and visibly".
+  With the eight placeholders gone (AC1) the fixture needs no carve-out, so that
+  trap is obsolete. The entry records this, and keeps trap 1 (root-relative links
+  lacking the base prefix are not off-site), which is unaffected.
+
+- [x] **AC1c — the deferral anchors AC1 would leave dangling are resolved.**
+  Removing the entry orphans two references in the Shipped
+  `docs/specs/marketing-docs-link-repair/`:
+  - `spec.md:93` is a **live instruction**, not history: it tells a future link
+    gate that `build/primitives-fixture/` is a disclosed exclusion carrying eight
+    placeholder hrefs. That is now false, and an agent reading it as current-state
+    truth would build the exclusion back in — the same failure mode
+    `phase4b-docsurl-instruction-stale` records for this exact page, which has now
+    landed and reverted twice (#852 → #854). It gets an errata note.
+  - `plan.md:39` is a declined-pattern record and stays as history, with a
+    one-clause note that the item has since been resolved so the pointer does not
+    read as live.
+
+  Editing a Shipped spec is in bounds here: `AGENTS.md` § How we work makes specs
+  validation gates rather than write-once records, and requires drift to be fixed
+  in the same PR. The errata note preserves the original text rather than
+  rewriting it.
+
+- [x] **AC2 — `ast07-sca-scanner-agentbundle` narrows, and does not close.** The
+  entry is rewritten to record that the concern it names is closed for shipped code
+  — both `packages/agentbundle` and `packages/credbroker` declare
+  `dependencies = []`, and `Makefile:241` audits credbroker's `[crypto]` extra
+  explicitly — and that one residual remains: agentbundle's `[lint]` extra
+  (`pyyaml>=6.0`) is third-party and reaches no `pip-audit` invocation. The rewritten
+  entry names that residual as its remaining scope.
+
+- [x] **AC3 — `desk-research-install-name-drift` narrows.** The content half is
+  done: `rg -F 'install research' guides/` returns no hit (the only hits are in
+  `docs/specs/research-pack/`, which is frozen spec history and correctly records
+  the id in force at the time). The entry is rewritten so its remaining scope is
+  only the retired-id negative fixture in the owning lint.
+
+- [x] **AC4 — three blocked entries record that their gate has passed.**
+  - `contract-drift-check-gate-promotion` — the entry asks for two clean
+    `check_contract_drift.py` passes and logs one (2026-08-01). A second pass is
+    recorded (2026-08-15, exit 0), so the entry states it is now unblocked.
+  - `lint-sso-config-profile-charset` — reads "Unblocks: after AC4 lands"; AC4 is
+    `[x]` in `docs/specs/jira-check-sso-auto-login/spec.md:307`. The entry records
+    that it is unblocked.
+  - `nonjson-2xx-guard-all-read-paths` — reads "Unblocks: after AC11"; AC11 is
+    satisfied per the same spec. The entry records that it is unblocked.
+
+- [x] **AC5 — `spec-ac-heading-casing-silent-gate`'s measurement is corrected.**
+  The entry says "eight specs" carry `## Acceptance criteria`. Measured
+  2026-08-15: 17. The entry carries the corrected count and the command that
+  produced it.
+
+- [x] **AC6 — the `type = "spec"` comment defect is corrected.** The comment above
+  the five reanchor entries claims a bare typed shaping object "yields
+  `legacy_entry`". It does not: `_SHAPING_TYPES`
+  (`workspace_status_engine.py:3229`) is `{shape, research, strategy, signal,
+  design}`, so `type = "spec"` fails `_accepted_legacy_entry`'s backlog branch and
+  yields `unsupported_legacy`. The comment is corrected to state what the engine
+  actually does. The five entries' `type` values are left as they are — retyping
+  them is a routing decision, not a comment fix, and is recorded as its own entry.
+
+- [x] **AC7 — the retyping decision is recorded as a new entry.** A new
+  `[backlog].open` entry captures the open question AC6 surfaces: whether the five
+  reanchor entries should keep `type = "spec"` (permanently `unsupported_legacy`),
+  drop the key (plain build items), or take a `_SHAPING_TYPES` member.
+
+- [x] **AC8 — no dispatchable membership changes.** `git diff` touches
+  `[backlog]` only. `[work]`, `[shaping_queue]`, `[brief_queue]`, and every
+  `[ini-NNN]` section are byte-identical to their pre-change state.
+
+- [x] **AC9 — the file still parses and the backend still runs.**
+  `python3 .claude/skills/workspace-status/scripts/workspace_status.py status
+  --root .` exits 0, and its `repo_backlog.open` count equals 143 − 1 (AC1's
+  closure) + 1 (AC7's new entry) = 143.
+
+## Boundaries
+
+### Always do
+
+- Verify each claim with a command before writing it into an entry, and record the
+  command in the entry so the next reader can re-run it.
+- Preserve every entry's existing comment prose except where an AC requires a
+  correction.
+
+### Never do
+
+- Never change `[work]`, `[shaping_queue]`, `[brief_queue]`, or initiative
+  sections. This spec is scoped to `[backlog]`.
+- Never close an entry whose remaining scope is non-empty. Narrow it instead.
+- Never migrate a build entry to a canonical target entry by inventing a `path`.
+  The engine's `unsupported_legacy` remediation says exactly this: "Route the item
+  manually; do not infer a target entry."
+
+## Assumptions
+
+- `[backlog].open` is display-only. Verified: `extract_repo_backlog`
+  (`workspace_status_engine.py:3237`) is the sole reader, and it projects for
+  display; no dispatch classifier consumes it. This is what makes the change
+  behavior-preserving.
+- `[backlog].closed` exists in the schema (the blank-file template in the
+  `workspace-status` skill declares it) and is currently empty, so AC1 is the first
+  use. An empty-to-one-element transition needs no migration.

--- a/workspace.toml
+++ b/workspace.toml
@@ -539,11 +539,15 @@ open = [
   {slug = "insecure-warning-sibling-clis", source = "spec/jira-check-sso-auto-login"},
     # tools/lint-sso-config.py validates the [sso] key set but not the profile charset, so a
     # pre-baked traversal value only fails at runtime. Fix: add the AC4 grammar as a
-    # build-time check. Unblocks: after AC4 lands.
+    # build-time check. UNBLOCKED 2026-08-15 — AC4 (`validate_sso_profile`, canonical
+    # grammar) is checked [x] at docs/specs/jira-check-sso-auto-login/spec.md:307, so the
+    # grammar this lint must mirror now exists. Ready to pick up.
   {slug = "lint-sso-config-profile-charset", source = "spec/jira-check-sso-auto-login"},
     # AC11 site 4/5 guards only whoami; every other read method calls resp.json(), so an SSO
     # login-page body still exits 1 there. Fix: move the guard to a shared _json helper.
-    # Unblocks: after AC11.
+    # UNBLOCKED 2026-08-15 — AC11 is satisfied in
+    # docs/specs/jira-check-sso-auto-login/spec.md, so the guard this entry generalises
+    # now exists at its first site. Ready to pick up.
   {slug = "nonjson-2xx-guard-all-read-paths", source = "spec/jira-check-sso-auto-login"},
     # RFC-0074's catalogue pack-defaults cascade is Shipped but has no consumer, and its
     # baked layer sits inside the agentbundle package, unreachable from stdlib-only skill
@@ -654,11 +658,14 @@ open = [
   # verified them with an ad-hoc script (resolve every internal href on the built
   # marketing pages against build/), but did not commit it — so nothing prevents a
   # fourth regression. The same fix has now landed and reverted twice (#852 → #854).
-  # Two traps the committed version must carry, both hit while writing the ad-hoc one:
+  # One trap the committed version must carry, hit while writing the ad-hoc one:
   #   1. Do NOT treat a root-relative link lacking the /agent-ready-repo base prefix
   #      as off-site — the first draft silently skipped 8 such links.
-  #   2. build/primitives-fixture/ must be excluded explicitly and visibly, not by
-  #      accident (see web-primitives-fixture-dead-placeholders below).
+  # A second trap (exclude build/primitives-fixture/ explicitly) was recorded here
+  # and is now OBSOLETE: the fixture's 8 dead placeholder hrefs are gone, so it
+  # needs no carve-out. Verified 2026-08-15 —
+  # `grep -oE 'href=(\{[^}]*\}|"[^"]*")' web/src/pages/primitives-fixture.astro`
+  # returns exactly two, both live. Do not reintroduce a fixture exclusion.
   # Fix: land it as a pure-stdlib tools/*.py per AGENTS.md, wired into the pages
   #   workflow after both builds — it needs the built tree, so it cannot run in
   #   build-check.
@@ -677,17 +684,6 @@ open = [
   #   (b) amending AC7 in place. (a) preserves history and is the likelier call.
   # Unblocks when: picked up — needs a decision on amending a Shipped spec.
   {slug = "phase4b-docsurl-instruction-stale", source = "spec/marketing-docs-link-repair (out of scope)"},
-
-  # web/src/pages/primitives-fixture.astro carries 8 dead placeholder hrefs
-  # (/guides/github-auth, /review, /issues, /run, /confirm, /cancel, /get-started,
-  # /example). Pre-existing, and harmless today: the page is noindex,nofollow, absent
-  # from the sitemap, and unlinked from any real page. They matter only because they
-  # force any future link-checker to carry an exclusion, and an undisclosed exclusion
-  # is how a "0 dead links" claim becomes false.
-  # Fix: point the placeholders at real routes or at "#", so the link gate needs no
-  #   fixture carve-out at all.
-  # Unblocks when: picked up — pairs naturally with web-docs-link-check-gate.
-  {slug = "web-primitives-fixture-dead-placeholders", source = "spec/marketing-docs-link-repair (out of scope)"},
 
   # Two ADR-0055 / v0.13 stragglers found while reconciling docs/architecture/
   # against the real agentbundle surface. Both are engine-or-tooling edits, so
@@ -874,12 +870,16 @@ open = [
   #   the copytree to prune too.
   {slug = "pack-js-ci-workflow", source = "spec/pack-test-boundary-remaining-packs disposition"},
 
-  # lint-spec-status.py matches `^##\s+Acceptance Criteria\b` case-sensitively, so
-  # eight specs whose heading reads `## Acceptance criteria` collect zero criteria
-  # and their AC-completeness invariant (ii) has always passed vacuously — the
-  # pack-test-boundary predecessor among them. Three more specs carry no
-  # Acceptance-Criteria heading at all, which the casing fix would not close:
-  # eleven ungated in total. Fix: decide whether the matcher should be
+  # lint-spec-status.py matches `^##\s+Acceptance Criteria\b` case-sensitively
+  # (scripts/lint-spec-status.py:283), so specs whose heading reads
+  # `## Acceptance criteria` collect zero criteria and their AC-completeness
+  # invariant (ii) has always passed vacuously — the pack-test-boundary predecessor
+  # among them. COUNT CORRECTED 2026-08-15: the entry said eight; it is now 17, out
+  # of 299 specs using the canonical casing
+  # (`grep -rl "^## Acceptance criteria" docs/specs/*/spec.md | wc -l`). The gap has
+  # more than doubled since the entry was written, and grows silently — every new
+  # spec that guesses the casing joins it. Three more specs carry no
+  # Acceptance-Criteria heading at all, which the casing fix would not close. Fix: decide whether the matcher should be
   # case-insensitive and whether a spec with no criteria section should fail
   # loudly, then correct the headings. Unblocks when: picked up.
   {slug = "spec-ac-heading-casing-silent-gate", source = "spec/pack-test-boundary-remaining-packs review"},
@@ -1021,13 +1021,17 @@ open = [
   # Unblocks when: screened on actual mobile viewport + physical device.
   {slug = "site-mobile-responsiveness"},
 
-  # guides/desk-research/tutorials/desk-research-first-session.md line 15 says
-  # `agentbundle install research --scope user` but the pack id is `desk-research`
-  # (renamed in M3). Stale id fails silently for new adopters.
-  # Fix: use the canonical `agentbundle install desk-research --scope user` install
-  #   path; extend the owning docs/parity lint with a retired-id negative fixture.
-  # File: guides/desk-research/tutorials/desk-research-first-session.md:15.
-  # Done: active content uses `desk-research`; the stale id fails the owning check.
+  # NARROWED 2026-08-15. The content half is DONE: `grep -rn "install research"
+  # guides/` returns zero hits, so no adopter-facing guide carries the retired id.
+  # (The remaining repo-wide hits are all in docs/specs/research-pack/, which is
+  # frozen spec history correctly recording the id in force when it was written —
+  # do not "fix" those.)
+  # REMAINING SCOPE, and the only reason this entry is still open: no lint carries a
+  # retired-id negative fixture, so nothing stops `install research` being
+  # reintroduced into guides/ tomorrow. The original entry bundled the content fix
+  # and the guard; only the guard is left.
+  # Fix: extend the owning docs/parity lint with a negative fixture asserting the
+  #   retired `research` pack id does not appear in guides/.
   # Do not expand this item into a tutorial redesign.
   {slug = "desk-research-install-name-drift"},
 
@@ -1114,14 +1118,20 @@ open = [
   # Unblocks when: a governance RFC or install-marker schema extension closes the gap.
   {slug = "skill-governance-inventory-gap"},
 
-  # Security (AST07). The agentic-skills module's AST07 check (version drift)
-  # delegates to a wired SCA scanner. Whether pip-audit or Dependabot is wired in CI
-  # for packages/agentbundle's dependency set was not confirmed during the
-  # owasp-ast10-module security audit.
-  # Fix: confirm pip-audit (or Dependabot) is wired in CI for packages/agentbundle;
-  #   wire it if not.
-  # File: .github/workflows/ (CI config for packages/agentbundle).
-  # Unblocks when: CI config confirms a wired SCA scanner for packages/agentbundle.
+  # Security (AST07). NARROWED 2026-08-15 after confirming the CI state the entry
+  # asked about. The headline concern is closed for shipped code: both
+  # packages/agentbundle and packages/credbroker declare `dependencies = []`
+  # (verified via tomllib on each pyproject.toml), so neither ships a third-party
+  # runtime dependency, and Makefile:241 already audits credbroker's [crypto] extra
+  # (cryptography, argon2-cffi) explicitly through pip-audit.
+  # ONE RESIDUAL, which is why this entry narrows rather than closes: agentbundle's
+  # [lint] extra is `pyyaml>=6.0` — genuinely third-party, and it reaches no
+  # pip-audit invocation. tools/requirements-sast.txt is audited; this extra is not.
+  # Fix: add the [lint] extra to the Makefile sast target's explicit audit, mirroring
+  #   the credbroker [crypto] line directly above it (printf | pip-audit -r /dev/stdin).
+  # Note there is no dependabot.yml in the repo at all, so pip-audit is the only SCA
+  # lens; that is a separate question from this one-line gap.
+  # Unblocks when: picked up — no dependency.
   {slug = "ast07-sca-scanner-agentbundle"},
 
   # ── Medium effort, internal ──────────────────────────────────────────────────
@@ -1221,9 +1231,11 @@ open = [
   # to a build-check gate requires calibration evidence: at least two drift-check passes on
   # the live repo with no false positives, confirming exit-0 stability on clean copies.
   # Clean-run log: 1 pass recorded 2026-08-01 on origin/main HEAD (exit 0, no output).
-  # Fix: after one more clean pass on origin/main, wire the check into build-check.yml
-  #   and remove the deferred marker from spec/digital-experience-contract AC16.
-  # Unblocks when: two clean drift-check passes are recorded (manual or CI).
+  #   2nd pass recorded 2026-08-15 (`python3 tools/repo/check_contract_drift.py`,
+  #   exit 0, no output). The two-clean-pass calibration bar is now MET.
+  # Fix: wire the check into build-check.yml and remove the deferred marker from
+  #   spec/digital-experience-contract AC16.
+  # UNBLOCKED — the gate this entry waited on has passed; ready to pick up.
   {slug = "contract-drift-check-gate-promotion", source = "spec/digital-experience-contract AC16"},
 
   # ini-003 follow-on. After the Digital Experience Doctrine initiative ships, the four
@@ -1718,11 +1730,41 @@ open = [
   # Modelled on architectural fitness functions (ThoughtWorks' "dependency drift
   # fitness function") — a continuously-run check, not a review ritual, because the
   # documented failure mode of decision records is neglect rather than bad edits.
-  # Typed `spec` (not `design`): a bare typed shaping object here is a legacy
-  # shape that yields `legacy_entry`, and this item will produce a spec anyway.
+  # Typed `spec` (not `design`), because this item will produce a spec anyway.
+  # CORRECTION 2026-08-15: the comment here used to claim `type = "spec"` yields
+  # `legacy_entry`. It does not. `_SHAPING_TYPES`
+  # (.claude/skills/workspace-status/scripts/workspace_status_engine.py:3229) is
+  # exactly {shape, research, strategy, signal, design}; `spec` is not a member, so
+  # `_accepted_legacy_entry`'s backlog.open branch refuses and these five entries —
+  # like the other 136 build items — classify as `unsupported_legacy`. The intended
+  # effect (non-dispatchable) does hold, just by a different route than claimed.
+  # Whether to retype them is tracked as reanchor-entry-typing-decision below.
   # Needs a design pass first: `needs` carries no timestamp, so the comparison
   # has to come from git history or a new recorded field.
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Detect queued specs whose shipped dependencies moved after the spec was last revised"},
+
+  # Surfaced 2026-08-15 while auditing every [backlog].open entry against the
+  # engine's own classifier. The five reanchor entries above carry `type = "spec"`,
+  # which is not in `_SHAPING_TYPES`, so they classify `unsupported_legacy` — the
+  # same code as an untyped build entry. The `type` key is therefore doing nothing
+  # the engine reads; it is documentation for humans only.
+  # Three options, and picking one is a routing decision, not a cleanup:
+  #   (a) keep `type = "spec"` — honest as human documentation, permanently
+  #       unsupported_legacy, and the key stays inert.
+  #   (b) drop the key — they become ordinary build entries, classify identically,
+  #       and the file stops implying a vocabulary the engine does not have.
+  #   (c) add `spec` to `_SHAPING_TYPES` — an ENGINE change. It would move these
+  #       into the shape room and put them in front of check_shaping_guard, which
+  #       is the opposite of what the reanchor comment wants.
+  # Note the wider constraint this sits inside: a build-room backlog item has NO
+  # supported legacy form at all — `_accepted_legacy_entry`'s backlog.open branch
+  # requires a `_SHAPING_TYPES` member, and the only other supported shape is a
+  # canonical target entry needing a real artifact `path` that a backlog idea does
+  # not have. So 136 of these entries cannot be migrated out of unsupported_legacy
+  # without either an engine change or fabricated paths. Do not fabricate paths.
+  # Fix: decide between (a), (b), and (c); if (c), it needs its own RFC.
+  # Unblocks when: picked up — no dependency.
+  {slug = "reanchor-entry-typing-decision", source = "spec/workspace-backlog-reconciliation AC7"},
 
   # The canonical adopter-facing `guides/` tree is mirrored into the public
   # technical docs, but `agentbundle catalogue package --flavor source` includes


### PR DESCRIPTION
## What does this change?

Corrects eight `workspace.toml [backlog].open` entries that assert something the code contradicts, found by auditing all 143 open entries against the repository. One entry is removed as done; two narrow to their surviving scope; three record that the gate blocking them has passed; two carry a corrected measurement or mechanic.

## Why?

A stale backlog is worse than a short one — a cold reader treats each entry as current-state truth. This repo has already shipped and reverted the same fix twice (#852 → #854) on exactly that failure mode, and one of the entries corrected here is a live instruction that would have caused a third.

- Implements: `docs/specs/workspace-backlog-reconciliation/spec.md`

## How do I verify it?

```bash
# the spec's own AC evidence, re-runnable
grep -oE 'href=(\{[^}]*\}|"[^"]*")' web/src/pages/primitives-fixture.astro   # 2 hits, both live
grep -rn "install research" guides/ | wc -l                                  # 0
python3 tools/repo/check_contract_drift.py; echo $?                          # 0 — the 2nd clean pass
grep -rl "^## Acceptance criteria" docs/specs/*/spec.md | wc -l              # 17, not the 8 the entry claimed

# gates
python3 .claude/skills/work-loop/scripts/lint-spec-status.py   # exit 0, "spec metadata clean"
make lint-ruff                                                  # exit 0
SKIP_SAST=1 make build-check                                    # exit 0 (no SAST-relevant path in the diff)

# nothing dispatchable moved, and the backend still parses
python3 .claude/skills/workspace-status/scripts/workspace_status.py status --root .   # exit 0, open == 143
```

A `tomllib` section-diff against `git show HEAD:workspace.toml` confirms `backlog` is the only top-level section that changed.

## What did you not change that you considered?

- **Migrating the 141 `unsupported_legacy` entries to the canonical five-field form.** Not possible without fabricating data. `_accepted_legacy_entry`'s `backlog.open` branch requires a `_SHAPING_TYPES` member, and there is no build-room type — a build item is *defined* by having no `type` (`workspace_status_engine.py:3262`). The only other supported shape is a canonical target entry needing a real artifact `path`, which a backlog idea does not have. The engine's own remediation says it outright: "do not infer a target entry."
- **Moving the closed entry to `[backlog].closed`.** That collection admits only `kind = "defect"` target entries backed by an artifact carrying `Status: Closed` (`:1076`, `:2050`). Deletion is also the established practice here — `closed` has stayed empty across the project's history.
- **Fixing the `pyyaml` SCA gap this audit surfaced.** It is a one-line Makefile change in a file this PR does not otherwise touch — outside the bundled-fixes carve-out. Recorded as the narrowed scope of `ast07-sca-scanner-agentbundle` instead.
- **Retyping the five `type = "spec"` entries.** Changing which room they display in and which guard sees them is a routing decision, not a comment fix. Recorded as `reanchor-entry-typing-decision`.

## Checklist

- [x] Tests pass locally — `SKIP_SAST=1 make build-check` exit 0
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status.py` both exit 0
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** the session instruction prohibits dispatching subagents unless requested. Self-reviewed against the work-loop's spec-less checklist instead; recorded in `plan.md` § Verification log.
- [x] Spec and code agree — spec written in this PR; AC1b/AC1c were added to it when the audit surfaced them, rather than landing unspecced
- [x] Living docs match reality — the erratum in `marketing-docs-link-repair/spec.md` is the point of the change
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the `[backlog].closed` contract and the no-build-room-type constraint are both written into the spec

**Deferred:** `ast07-sca-scanner-agentbundle` (pyyaml audit line), `desk-research-install-name-drift` (negative fixture), `reanchor-entry-typing-decision` (new) — each a one-line pointer in `[backlog].open`.