### PR TITLE
fix(tooling): make three checks actually check what they claim

### DIFF
--- a/docs/specs/catalogue-corporate-trust-store/spec.md
+++ b/docs/specs/catalogue-corporate-trust-store/spec.md
@@ -186,7 +186,7 @@ before proceeding; *Never do* is a hard rule, even under time pressure.
       named as its own cause, and repaired by additionally reading Apple's root
       program; the failure text omits the proxy framing in that case.
 - [ ] Administrator "Never Trust" settings honoured (deferred: catalogue-trust-store-trust-settings)
-- [ ] WSL adopters get guidance naming the Windows/distribution trust-store split (deferred: catalogue-trust-store-wsl-diagnosis)
+- [ ] WSL adopters get guidance naming the Windows/distribution trust-store split (Deferred, and since **delivered** on 2026-08-16 by `spec/tooling-gate-hygiene`: `system_trust.running_under_wsl` detects the distribution and the failure message names the two-trust-store split plus the `update-ca-certificates` remedy. Detection only — a test pins that it reaches no Windows interop.)
 
 ## Assumptions
 

--- a/docs/specs/digital-experience-contract/spec.md
+++ b/docs/specs/digital-experience-contract/spec.md
@@ -50,7 +50,7 @@ The contract template is additive — it ships alongside existing skills without
 - Adding, removing, or renaming any field in the contract template (each change is a schema change; the drift check enforces schema-version parity)
 - Changing the anchor skill path for any pack (the anchor paths are defined in ACs and the drift check hardcodes them)
 - Adding the contract to SKILL.md files — that is the job of downstream doctrine specs; do not pre-empt them here
-- Promoting the drift check to a build-check gate — it runs on demand; promotion to gate requires calibration evidence (deferred: contract-drift-check-gate-promotion)
+- Promoting the drift check to a build-check gate — it ran on demand; promotion to gate required calibration evidence. **Delivered 2026-08-16** by `spec/tooling-gate-hygiene`: three clean passes on `origin/main` were recorded (2026-08-01, 2026-08-15, 2026-08-16) against a two-pass bar, and the check is now a `build_gate_chain.py` step, so it runs in both `make build-check` and CI. The compat shim path this bullet names (`tools/check-contract-drift.py`) was relocated to `tools/repo/check_contract_drift.py`; the gate wires the real path.
 
 ### Never do
 
@@ -196,7 +196,7 @@ The table below defines every field, its owning discipline, and its minimum tier
 - [x] No SKILL.md, pack.toml, or eval file is modified.
 - [x] `workspace.toml` passes `python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb'))"` after any workspace.toml edit.
 - [ ] (deferred: digital-experience-contract-pe-journey-xref) PE journey page cross-reference — deferred to `spec/product-engineering-shaping-doctrine` where the PE journey page will be authored.
-- [ ] (deferred: contract-drift-check-gate-promotion) Promotion of drift check to a build-check gate — deferred pending calibration evidence from at least two passes on the live repo.
+- [x] Promotion of drift check to a build-check gate — was deferred pending calibration evidence from at least two passes on the live repo. **Delivered 2026-08-16** by `spec/tooling-gate-hygiene`: three clean passes recorded (2026-08-01, 2026-08-15, 2026-08-16), and the check is now a `build_gate_chain.py` step, so it runs in `make build-check` and in CI.
 
 ## Assumptions
 

--- a/docs/specs/tooling-gate-hygiene/plan.md
+++ b/docs/specs/tooling-gate-hygiene/plan.md
@@ -1,0 +1,56 @@
+# Plan: tooling-gate-hygiene
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `tools/build-site.py`, `tools/test_build_site_dry_run.py` (new) — AC1/AC2.
+- `packages/agentbundle/agentbundle/{system_trust,catalogue}.py` and
+  `tests/unit/test_catalogue_trust_fallback.py` — AC3–AC5.
+- `tools/repo/build_gate_chain.py`, `tools/test_build_gate_chain.py` — AC6/AC8.
+- `docs/specs/digital-experience-contract/spec.md` — AC9.
+- `workspace.toml` — AC10.
+
+**What demonstrates done**
+- Mutation test for AC1; subprocess tests; `make ci`.
+
+**What I am NOT changing**
+- The drift check's logic — promotion is wiring only.
+- Any Windows-interop path.
+
+## Declined patterns
+
+- **Tempted:** keep the line-window heuristic for the structural dry-run test.
+  **Declined:** three correctly guarded writes sit 9–11 lines below their guard,
+  so any fixed window either misses real defects or fails correct code. Scoped to
+  the enclosing function instead.
+- **Tempted:** let the structural test stand as the dry-run guarantee.
+  **Declined:** it would not have caught this defect. Said so in its docstring
+  rather than leaving a reader to assume otherwise.
+- **Tempted:** chmod the real `docs-site/` tree to test the non-writable case.
+  **Declined:** it would break a concurrent build. Asserted the property that
+  makes such a run possible — no write at all — with a tmp-dir control proving
+  the test can observe a write.
+- **Tempted:** wire the drift check into `build-check.yml` directly. **Declined:**
+  CI invokes `make build-check`, so a gate-chain step is covered on both sides
+  with no parity disposition to maintain.
+
+## Anchor-test sweep
+
+- `test_build_gate_chain.py` pins the step sequence — updated (AC8).
+- `test_catalogue_trust_fallback.py`'s plain-linux test asserts on the message —
+  extended rather than left to pass vacuously (AC5).
+
+## Verification log
+
+- **AC1/AC2** `--dry-run` leaves no generated tree; mutation-verified — reverting
+  the guard fails `test_dry_run_creates_no_generated_directory`, restoring passes.
+- **AC3–AC5** 27 tests in `test_catalogue_trust_fallback.py` green, covering both
+  branches and the no-interop rail.
+- **AC6/AC8** `test_build_gate_chain.py` 16 passed after extending the pinned list.
+- **AC7** third clean drift pass recorded 2026-08-16 (exit 0).
+- **AC10** slug diff vs `origin/main`: exactly the three intended removed.
+- **REVIEW** `adversarial-reviewer` = named skip (session instruction prohibits
+  subagent dispatch). Self-reviewed against the spec-less checklist.

--- a/docs/specs/tooling-gate-hygiene/spec.md
+++ b/docs/specs/tooling-gate-hygiene/spec.md
@@ -1,0 +1,88 @@
+# Spec: tooling-gate-hygiene
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none new. One user-visible message gains a branch; one on-demand
+  check becomes a gate.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. One risk trigger fires: structural / CI-behaviour change —
+promoting the contract-drift check to a build-check gate changes what can merge.
+The G-plan human gates are satisfied by the operator's standing authorization for
+this run; every other full-mode obligation is run as written. -->
+
+## Objective
+
+Three tooling defects that each make a check less useful than it appears: a
+read-only flag that writes, a diagnostic that names the wrong cause, and a
+correct check that gates nothing because it only runs when asked.
+
+## Acceptance Criteria
+
+- [x] **AC1 — `build-site.py --dry-run` writes nothing.** Every write in the
+  script honoured the flag except one `mkdir` for the generated `packs/`
+  directory, which ran unconditionally — so a dry run created directories on its
+  way to reporting that it would create them. That makes the flag useless as a
+  read-only check: it fails outright against a non-writable tree, and against a
+  writable one it leaves generated directories behind.
+
+- [x] **AC2 — the dry-run guarantee is pinned behaviourally.** A test runs the
+  real script as a subprocess and asserts no generated directory appears.
+  **Mutation-verified:** reverting the guard fails exactly this test, and
+  restoring it passes. A structural companion test asserts no *function* writes
+  without referencing `dry_run` — and its docstring states plainly that it would
+  NOT have caught this defect (the unguarded `mkdir` lived in `main()`, which
+  references `dry_run` throughout), so nobody mistakes it for the real guarantee.
+
+- [x] **AC3 — WSL gets a diagnosis naming a cause it can act on.** A WSL
+  distribution reports `sys.platform == "linux"` and does not inherit the Windows
+  trust store, so an authority pushed by Group Policy or Intune is invisible until
+  installed into the distribution too. The old message said the fallback is
+  macOS-only: true, and useless. The new branch names the two-trust-store split
+  and the `update-ca-certificates` remedy.
+
+- [x] **AC4 — detection only; no reach across the trust boundary.**
+  `running_under_wsl` reads `WSL_DISTRO_NAME` / `WSL_INTEROP` and `/proc/version`.
+  A test asserts its source contains no `/mnt/c`, `certutil`, `powershell.exe`,
+  `cmd.exe`, or `wslpath` — reading the Windows store from inside WSL would
+  auto-trust material from outside the distribution's own trust domain.
+
+- [x] **AC5 — both message branches are covered, and cannot swap.** A test drives
+  the WSL branch end-to-end and asserts the generic platform message does *not*
+  also fire; the pre-existing plain-linux test now asserts the WSL text does not
+  appear. Either branch silently taking the other's traffic fails a test.
+
+- [x] **AC6 — the contract-drift check is a gate.** It is a `build_gate_chain.py`
+  step, so it runs in `make build-check` and in CI, which invokes the same target.
+  No `lint-ci-parity` disposition is needed for that reason.
+
+- [x] **AC7 — the calibration bar is met and recorded.** The deferral asked for
+  two clean passes on `origin/main` with no false positive. Three are recorded:
+  2026-08-01, 2026-08-15, 2026-08-16.
+
+- [x] **AC8 — the gate-chain anchor tests are updated, not bypassed.**
+  `test_build_gate_chain.py` pins the exact step sequence and caught the addition;
+  its pinned list is extended.
+
+- [x] **AC9 — the deferral marker is cleared.** The deferral bullet naming this promotion in
+  `spec/digital-experience-contract` records delivery, and notes that the path it
+  names was since relocated to `tools/repo/check_contract_drift.py`.
+
+- [x] **AC10 — the three backlog entries are removed.** Verified by diffing the
+  slug set against `origin/main`: exactly three removed, none added.
+
+## Boundaries
+
+### Never do
+
+- Never read the Windows trust store from inside WSL. AC4 is the rail.
+- Never widen the drift check's scope while promoting it. Promotion is a wiring
+  change; the check's logic is untouched.
+
+## Testing Strategy
+
+- **TDD + mutation** for AC1/AC2. **TDD** for AC3–AC5. **Goal-based** for
+  AC6–AC10.

--- a/packages/agentbundle/agentbundle/catalogue.py
+++ b/packages/agentbundle/agentbundle/catalogue.py
@@ -379,6 +379,23 @@ def _fetch_and_extract(url: str, dest: Path) -> None:
                     "/Library/Keychains/System.keychain is read, because it is "
                     "the one store that requires administrator rights to write."
                 )
+            elif system_trust.running_under_wsl():
+                # True on WSL but not on Windows, and the distinction is the
+                # whole point: Windows needs no fallback (Python reads the CA
+                # and ROOT stores and honours per-certificate trust settings),
+                # while a WSL distribution reports linux and inherits none of
+                # it. The generic linux message is accurate and useless here —
+                # it does not name the cause the adopter can act on.
+                note = (
+                    "No operating-system trust anchors were consulted: this is a "
+                    "WSL distribution, which keeps its own trust store separate "
+                    "from Windows'. A certificate authority pushed to Windows by "
+                    "Group Policy or Intune is not visible here until it is "
+                    "installed into the distribution as well — export the "
+                    "authority to a .crt, place it in "
+                    "/usr/local/share/ca-certificates/, and run "
+                    "`sudo update-ca-certificates`."
+                )
             else:
                 note = (
                     f"No operating-system trust anchors were consulted on "

--- a/packages/agentbundle/agentbundle/system_trust.py
+++ b/packages/agentbundle/agentbundle/system_trust.py
@@ -120,6 +120,35 @@ def _default_runner(argv: list[str]) -> str:
 _RUNNER = _default_runner
 
 
+def running_under_wsl(env: dict | None = None) -> bool:
+    """True when this interpreter is inside a WSL distribution.
+
+    Windows itself needs no trust fallback — Python's ``load_default_certs``
+    reads the Windows CA and ROOT stores and honours per-certificate trust
+    settings. A WSL distribution reports ``sys.platform == "linux"`` and does
+    **not** inherit that store, so an authority pushed to Windows by Group
+    Policy or Intune is invisible inside WSL until it is installed into the
+    distribution itself. Callers use this to name that cause instead of
+    reporting the generic "no anchors on linux".
+
+    Two signals, because either can be absent: ``WSL_DISTRO_NAME`` is set by
+    recent WSL2 but not by every launcher or service context, and
+    ``/proc/version`` carries "microsoft" on both WSL1 and WSL2.
+
+    Detection only. Nothing here reaches across the boundary to read the
+    Windows store — doing so would auto-trust material from outside the
+    distribution's own trust domain.
+    """
+    source = os.environ if env is None else env
+    if source.get("WSL_DISTRO_NAME") or source.get("WSL_INTEROP"):
+        return True
+    try:
+        version = Path("/proc/version").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "microsoft" in version.lower()
+
+
 def system_trust_disabled(env: dict | None = None) -> bool:
     """True when the adopter has opted out of the system-trust fallback."""
     source = os.environ if env is None else env

--- a/packages/agentbundle/tests/unit/test_catalogue_trust_fallback.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_trust_fallback.py
@@ -156,6 +156,7 @@ def test_no_retry_when_no_system_anchors_are_available(
 
     assert len(stub.calls) == 1, "must not re-dial with an identical context"
     assert "macOS-only" in str(exc.value)
+    assert "WSL" not in str(exc.value), "plain linux must not get the WSL diagnosis"
     assert "retrying with" not in capsys.readouterr().err
 
 
@@ -478,3 +479,97 @@ def test_certificate_hint_carries_a_real_version_or_is_omitted(monkeypatch, tmp_
         raising=False,
     )
     assert catalogue._install_certificates_hint() is None
+
+
+# ---------------------------------------------------------------------------
+# WSL diagnosis
+#
+# A WSL distribution reports sys.platform == "linux" and does not inherit the
+# Windows trust store, so an authority pushed by Group Policy or Intune is
+# invisible until it is installed into the distribution too. The generic linux
+# message is true and unhelpful: it does not name the cause the adopter can act
+# on. Windows itself needs no fallback at all.
+# ---------------------------------------------------------------------------
+
+
+def test_wsl_is_detected_from_the_env_marker() -> None:
+    assert system_trust.running_under_wsl({"WSL_DISTRO_NAME": "Ubuntu"}) is True
+    assert system_trust.running_under_wsl({"WSL_INTEROP": "/run/WSL/8_interop"}) is True
+
+
+def test_plain_linux_env_is_not_wsl(monkeypatch, tmp_path) -> None:
+    """No env marker and no 'microsoft' in /proc/version → not WSL.
+
+    /proc/version is redirected at the module's Path so the assertion holds on a
+    developer machine that has no /proc at all (macOS) as well as on real Linux.
+    """
+    fake = tmp_path / "version"
+    fake.write_text("Linux version 6.8.0-generic (gcc 13)\n", encoding="utf-8")
+    monkeypatch.setattr(
+        system_trust, "Path", lambda *_a, **_k: fake  # noqa: ARG005
+    )
+    assert system_trust.running_under_wsl({}) is False
+
+
+def test_wsl_is_detected_from_proc_version(monkeypatch, tmp_path) -> None:
+    fake = tmp_path / "version"
+    fake.write_text(
+        "Linux version 5.15.167.4-microsoft-standard-WSL2 (gcc 11)\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        system_trust, "Path", lambda *_a, **_k: fake  # noqa: ARG005
+    )
+    assert system_trust.running_under_wsl({}) is True
+
+
+def test_missing_proc_version_is_not_wsl(monkeypatch, tmp_path) -> None:
+    """An unreadable /proc/version must answer False, not raise."""
+    missing = tmp_path / "nope" / "version"
+    monkeypatch.setattr(
+        system_trust, "Path", lambda *_a, **_k: missing  # noqa: ARG005
+    )
+    assert system_trust.running_under_wsl({}) is False
+
+
+def test_wsl_detection_reads_no_windows_store() -> None:
+    """Scope rail: detection only, never interop into the Windows trust domain.
+
+    Reading the Windows store from inside WSL would auto-trust material from
+    outside the distribution's own trust domain, which the entry that asked for
+    this diagnosis ruled out explicitly.
+    """
+    import inspect
+
+    src = inspect.getsource(system_trust.running_under_wsl)
+    for banned in ("/mnt/c", "certutil", "powershell.exe", "cmd.exe", "wslpath"):
+        assert banned not in src, banned
+
+
+def test_wsl_gets_the_two_trust_store_diagnosis_not_the_generic_linux_one(
+    monkeypatch, tmp_path, capsys, no_env
+):
+    """On WSL, name the cause the adopter can act on.
+
+    sys.platform is "linux" here, so without the diagnosis the adopter is told
+    the fallback is macOS-only — true, and useless. What they need to know is
+    that WSL keeps its own trust store, so an authority pushed to Windows by
+    Group Policy or Intune is invisible until installed into the distribution.
+    """
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(system_trust, "running_under_wsl", lambda *a, **k: True)
+    stub = _Stub([_verify_error()])
+    monkeypatch.setattr(urllib.request, "urlopen", stub)
+    monkeypatch.setattr(system_trust, "system_anchor_pem", lambda **k: None)
+
+    with pytest.raises(CatalogueError) as exc:
+        catalogue._fetch_and_extract(URL, tmp_path)
+
+    message = str(exc.value)
+    assert "WSL distribution" in message
+    assert "update-ca-certificates" in message, "the message must carry the remedy"
+    assert "macOS-only" not in message, (
+        "the generic platform message must not also fire — it sends the adopter "
+        "after the wrong cause"
+    )
+    assert len(stub.calls) == 1, "must not re-dial with an identical context"
+    assert "retrying with" not in capsys.readouterr().err

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1144,7 +1144,13 @@ def main() -> None:
     packs = discover_packs(REPO_ROOT, site_toml)
 
     print("build-site: copying pack READMEs …")
-    packs_out.mkdir(parents=True, exist_ok=True)
+    # Guarded: every other write in this script honours --dry-run, and this one
+    # did not, so `--dry-run` created generated directories on its way to
+    # reporting that it would create them. That makes the flag useless as a
+    # read-only check — it fails outright against a non-writable tree, and
+    # against a writable one it leaves directories behind.
+    if not args.dry_run:
+        packs_out.mkdir(parents=True, exist_ok=True)
     for p in packs:
         src = packs_dir / p["slug"] / "README.md"
         dst = packs_out / f"{p['slug']}.md"

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -317,6 +317,15 @@ def build_check(args: argparse.Namespace) -> int:
             "test-test-all",
             "tools", "test-test-all.py",
         ),
+        # Promoted from an on-demand tool to a gate. It was held back pending
+        # calibration evidence — two clean passes on origin/main with no false
+        # positive, to confirm exit-0 stability before a red build could be
+        # blamed on the check itself. Recorded: 2026-08-01, 2026-08-15,
+        # 2026-08-16 (three, one more than the bar asked for).
+        _script_step(
+            "check-contract-drift",
+            "tools", "repo", "check_contract_drift.py",
+        ),
     ]
     return _run_chain(steps)
 

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -220,6 +220,7 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-build-check-windows-workflow.py",
     "tools/lint-ci-parity.py",
     "tools/test-test-all.py",
+    "tools/repo/check_contract_drift.py",
 ]
 
 

--- a/tools/test_build_site_dry_run.py
+++ b/tools/test_build_site_dry_run.py
@@ -1,0 +1,128 @@
+"""`build-site.py --dry-run` must be side-effect-free from process start.
+
+The flag's whole value is as a read-only routing check: run it against a clean
+checkout, or in a read-only CI stage, and learn what a build *would* emit.
+
+It was not read-only. Every write in the script honoured `--dry-run` except one
+`mkdir` for the generated `packs/` directory, which ran unconditionally. So a
+dry run created directories on its way to reporting that it would create them:
+useless against a non-writable tree (it raised), and against a writable one it
+left generated directories behind.
+
+Two kinds of test, deliberately:
+
+* the **behavioural** ones run the real script as a subprocess and assert it
+  leaves nothing behind — this is the guarantee, and it is mutation-verified:
+  reverting the guard fails it;
+* the **structural** one is a tripwire for a whole function added later with no
+  dry-run awareness. Read its docstring before trusting it: it would NOT have
+  caught the defect above.
+
+Run with pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "tools" / "build-site.py"
+GENERATED = REPO_ROOT / "docs-site" / "src" / "content" / "docs" / "packs"
+
+
+def _run_dry() -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=600,
+    )
+
+
+def test_dry_run_creates_no_generated_directory() -> None:
+    """The plain case: a dry run must not leave a generated tree behind."""
+    existed_before = GENERATED.exists()
+    proc = _run_dry()
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    if not existed_before:
+        assert not GENERATED.exists(), (
+            f"--dry-run created {GENERATED.relative_to(REPO_ROOT)}; it must write nothing"
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits; Windows ACLs differ")
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores the write bit")
+def test_dry_run_succeeds_against_a_non_writable_output_tree(tmp_path) -> None:
+    """The condition that makes --dry-run a usable read-only check.
+
+    A dry run that needs write permission is not a read-only check. Rather than
+    chmod the repo's real docs-site tree (which would break a concurrent build),
+    this asserts the property that makes such a run possible: the run performs
+    no write at all, so the parent directory's mode is irrelevant. The mode
+    fixture below is the control — it proves the test can observe a write.
+    """
+    proc = _run_dry()
+    assert proc.returncode == 0, proc.stderr[-2000:]
+
+    probe = tmp_path / "readonly"
+    probe.mkdir()
+    probe.chmod(0o500)
+    try:
+        with pytest.raises(PermissionError):
+            (probe / "child").mkdir()
+    finally:
+        probe.chmod(0o700)
+
+
+def test_every_writing_function_handles_dry_run() -> None:
+    """Structural backstop: no function writes without knowing about --dry-run.
+
+    A line-window heuristic was tried first and rejected: three correctly
+    guarded writes sit 9-11 lines below their `if dry_run:` (inside the `else:`
+    of a guard at the top of a loop body), so any fixed window either misses
+    real defects or fails on correct code. The enclosing *function* is the
+    honest unit — if it writes, it must take or reference `dry_run`.
+
+    **What this does not catch, stated plainly:** the defect that prompted this
+    file. The unguarded `mkdir` lived in `main()`, which references `dry_run`
+    many times, so this check passes on it. It catches only a *whole function*
+    added with no dry-run awareness at all. The behavioural test above is what
+    catches a single unguarded write inside a function that otherwise handles
+    the flag — and it does: with the guard reverted, it fails.
+    """
+    lines = SCRIPT.read_text(encoding="utf-8").splitlines()
+    write_call = re.compile(
+        r"\.(mkdir|write_text|write_bytes)\(|shutil\.(copy2|copytree|rmtree)\("
+    )
+    def_line = re.compile(r"^(def|async def)\s+(\w+)")
+
+    current = "<module level>"
+    body: list[str] = []
+    offenders: list[str] = []
+
+    def _flush(name: str, block: list[str]) -> None:
+        writes = any(
+            write_call.search(ln) and not ln.lstrip().startswith("#") for ln in block
+        )
+        if writes and not any("dry_run" in ln for ln in block):
+            offenders.append(name)
+
+    for line in lines:
+        m = def_line.match(line)
+        if m:
+            _flush(current, body)
+            current, body = m.group(2), []
+        body.append(line)
+    _flush(current, body)
+
+    assert not offenders, (
+        "these functions write to disk but never mention dry_run: "
+        f"{offenders}. Every write in build-site.py must honour --dry-run."
+    )

--- a/workspace.toml
+++ b/workspace.toml
@@ -1224,19 +1224,6 @@ open = [
   # Unblocks when: spec/product-engineering-shaping-doctrine is Shipped.
   {slug = "digital-experience-contract-pe-journey-xref", source = "spec/digital-experience-contract AC15", needs = "ini-003:work:spec/product-engineering-shaping-doctrine"},
 
-  # spec/digital-experience-contract deferred AC. The drift check ships as an on-demand
-  # tool at tools/repo/check_contract_drift.py (relocated by ini-005 Wave 5 reorganisation;
-  # compat shim kept at tools/check-contract-drift.py until next minor; stale path
-  # reference in this entry corrected during Phase 0 reconciliation 2026-08-01). Promoting
-  # to a build-check gate requires calibration evidence: at least two drift-check passes on
-  # the live repo with no false positives, confirming exit-0 stability on clean copies.
-  # Clean-run log: 1 pass recorded 2026-08-01 on origin/main HEAD (exit 0, no output).
-  #   2nd pass recorded 2026-08-15 (`python3 tools/repo/check_contract_drift.py`,
-  #   exit 0, no output). The two-clean-pass calibration bar is now MET.
-  # Fix: wire the check into build-check.yml and remove the deferred marker from
-  #   spec/digital-experience-contract AC16.
-  # UNBLOCKED — the gate this entry waited on has passed; ready to pick up.
-  {slug = "contract-drift-check-gate-promotion", source = "spec/digital-experience-contract AC16"},
 
   # ini-003 follow-on. After the Digital Experience Doctrine initiative ships, the four
   # packs (product-strategy, product-engineering, experience-design, core) form a coherent
@@ -1778,13 +1765,6 @@ open = [
   # and release-boundary decision. Unblocks: now; no tracked prerequisite.
   {slug = "catalogue-package-guides", source = "spec/documentation-entry-navigation"},
 
-  # `python3 tools/build-site.py --dry-run` currently calls mkdir for generated
-  # docs directories before honoring dry-run, so read-only verification fails
-  # even though no generated content should be written. Fix: make dry-run
-  # side-effect-free from process start, add a construction test using a
-  # non-writable output tree, and document it as the supported source-only site
-  # routing check. Unblocks: now; no tracked prerequisite.
-  {slug = "build-site-dry-run-write-free", source = "spec/documentation-entry-navigation AC15"},
 
   # A full generated-HTML crawl performed after the documentation-entry
   # navigation build found 67 older unresolved internal targets across 53,871
@@ -1809,20 +1789,6 @@ open = [
   # the trust-settings domain (`security dump-trust-settings -d`) and filtering
   # the dump against it.
   { slug = "catalogue-trust-store-trust-settings", source = "spec/catalogue-corporate-trust-store — Never Trust criterion" },
-  # WSL-aware diagnosis for the catalogue trust fallback. Windows itself needs no
-  # fallback — Python's `load_default_certs` loads the Windows CA and ROOT stores
-  # and honours per-certificate trust settings — but a WSL distribution reports
-  # `sys.platform == "linux"` and does NOT inherit that store, so a corporate
-  # authority pushed to Windows by Group Policy or Intune is invisible inside WSL
-  # until installed into the distribution. Today such an adopter gets the generic
-  # "no operating-system trust anchors were available on this platform (linux)"
-  # message, which is true but does not name the actionable cause. The work:
-  # detect WSL (`WSL_DISTRO_NAME`, or "microsoft" in /proc/version) and emit
-  # guidance naming the two-trust-store split plus the update-ca-certificates
-  # remedy. Documentation-and-message scope only — do not reach across the
-  # boundary to read the Windows store via interop; that would auto-trust
-  # material from outside the distribution's own trust domain.
-  { slug = "catalogue-trust-store-wsl-diagnosis", source = "spec/catalogue-corporate-trust-store — WSL guidance criterion" },
   # ---------------------------------------------------------------------------
   # Tech-site design review 2026-08-14 — deferred findings + implementation
   # surfacings.


### PR DESCRIPTION
## What does this change?

Three tooling defects that each leave a check less useful than it appears: a read-only flag that writes to disk, a diagnostic that names the wrong cause, and a correct check that gates nothing because it only runs when asked.

## Why?

- Implements: `docs/specs/tooling-gate-hygiene/spec.md`
- Closes: `build-site-dry-run-write-free`, `catalogue-trust-store-wsl-diagnosis`, `contract-drift-check-gate-promotion`

## How do I verify it?

```bash
# --dry-run now leaves nothing behind
rm -rf docs-site/src/content/docs/packs
python3 tools/build-site.py --dry-run && ls docs-site/src/content/docs/packs   # should not exist

python3 -m pytest tools/test_build_site_dry_run.py tools/test_build_gate_chain.py -q
python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_trust_fallback.py -q
python3 tools/repo/check_contract_drift.py; echo $?    # 0 — now also a build-check step
make ci
```

### Three things worth a reviewer's attention

- **The dry-run guarantee is mutation-verified, not asserted.** I reverted the guard and confirmed `test_dry_run_creates_no_generated_directory` fails, then restored it and confirmed it passes.
- **The structural companion test would NOT have caught this defect, and says so.** The unguarded `mkdir` lived in `main()`, which references `dry_run` throughout, so a function-scoped check passes on it. Its docstring states that outright — a tripwire that reads like a guarantee is worse than no tripwire. (A line-window heuristic was tried first and rejected: three correctly guarded writes sit 9–11 lines below their guard, so any fixed window either misses real defects or fails correct code.)
- **The WSL work is detection only.** A test pins that `running_under_wsl`'s source contains no `/mnt/c`, `certutil`, `powershell.exe`, `cmd.exe`, or `wslpath`. Reading the Windows store from inside WSL would auto-trust material from outside the distribution's own trust domain, which the backlog entry ruled out explicitly.

## What did you not change that you considered?

- **`chmod`-ing the real `docs-site/` tree** to test the non-writable case. It would break a concurrent build. The test asserts the property that makes such a run possible — no write at all — with a tmp-dir control proving the test can actually observe a write.
- **Wiring the drift check into `build-check.yml` directly.** CI invokes `make build-check`, so a gate-chain step covers both sides with no `lint-ci-parity` disposition to keep in sync.
- **The drift check's logic.** Promotion is wiring; widening its scope at the same time would make a red build ambiguous between the two changes.

## Checklist

- [x] Tests pass locally — `make ci`
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. Self-reviewed against the work-loop's spec-less checklist.
- [x] Spec and code agree
- [x] Living docs match reality — three deferral markers cleared across `spec/catalogue-corporate-trust-store` and `spec/digital-experience-contract` (`lint-spec-status` hard-failed until they were)
- [x] No new top-level directories
- [x] Conventional commit format