### PR TITLE
fix(work-loop,converters): close a vacuous AC gate and use reserved domains

### DIFF
--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -275,12 +275,23 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
 
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
-    `## Acceptance Criteria` section."""
+    `## Acceptance Criteria` section.
+
+    The heading match is case-INSENSITIVE, and that is the whole point. It was
+    case-sensitive, so a spec whose heading read `## Acceptance criteria`
+    collected zero criteria and its AC-completeness invariant passed
+    *vacuously* — the check reported success on a spec it had not read. That
+    silently un-gated 18 specs before it was noticed, and the number only grows,
+    because nothing tells an author which casing the linter wants.
+
+    A vacuous pass is the worst failure mode a gate has: it is indistinguishable
+    from a real one at the call site.
+    """
     lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
     for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line):
+        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
             in_ac = True
             continue
         if in_ac and re.match(r"^##\s+", line):

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -275,12 +275,23 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
 
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
-    `## Acceptance Criteria` section."""
+    `## Acceptance Criteria` section.
+
+    The heading match is case-INSENSITIVE, and that is the whole point. It was
+    case-sensitive, so a spec whose heading read `## Acceptance criteria`
+    collected zero criteria and its AC-completeness invariant passed
+    *vacuously* — the check reported success on a spec it had not read. That
+    silently un-gated 18 specs before it was noticed, and the number only grows,
+    because nothing tells an author which casing the linter wants.
+
+    A vacuous pass is the worst failure mode a gate has: it is indistinguishable
+    from a real one at the call site.
+    """
     lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
     for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line):
+        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
             in_ac = True
             continue
         if in_ac and re.match(r"^##\s+", line):

--- a/docs/specs/binder-publishing-gate-propagation/spec.md
+++ b/docs/specs/binder-publishing-gate-propagation/spec.md
@@ -75,7 +75,7 @@ property `README.md` asserts and the reason the tree is a tree.
 - Fix the `converters` bare-relative script-path defect that V6 surfaced. Different
   pack, different concern — it is recorded as a deferral, not bundled.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — Z5 is recorded as run and passed.** `verified-findings.md` carries a
   Z5 finding table in the Z1–Z4 shape and a Z5 row in the Z-gate status table

--- a/docs/specs/core-path-confinement/spec.md
+++ b/docs/specs/core-path-confinement/spec.md
@@ -75,7 +75,7 @@ Unrelated argv-to-path sites remain in the existing
   root, or exclude an entire shipped file from Snyk Code.
 - Put real secrets or user-specific paths in fixtures or diagnostics.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — Spec-status confinement.** `lint-spec-status.py` resolves and
   confines `workspace.toml`, the contract registry, contract files, and every

--- a/docs/specs/documentation-entry-navigation/spec.md
+++ b/docs/specs/documentation-entry-navigation/spec.md
@@ -131,7 +131,7 @@ must contain the information an adopter needs to continue.
 - Turn install scope, adapter support, skill count, or pack names into the
   first-level discovery taxonomy.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — README is a router.** `README.md` is at most 90 lines and contains:
   one product definition; one compact flagship case; one supported quickstart;

--- a/docs/specs/engagement-shaping-guides/spec.md
+++ b/docs/specs/engagement-shaping-guides/spec.md
@@ -58,7 +58,7 @@ touching the per-quadrant framework READMEs):
 7. `guides/README.md` — add the new `_shared` explanation under the
    "Not tied to one pack" section.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] AC1 — Each of guides 1–3 is a true **how-to**: titled by the reader's
   problem, no reteaching of basics, names the real variations/pitfalls,

--- a/docs/specs/iac-terraform-remote-exec/spec.md
+++ b/docs/specs/iac-terraform-remote-exec/spec.md
@@ -57,7 +57,7 @@ This spec adds `hcp-terraform` and `scalr` as first-class options for the
 - Emit `cloud {}` for OpenTofu targets (already banned, now doubly enforced)
 - Emit Sentinel (already banned)
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] `generate-iac` SKILL.md Inputs table has a `Remote execution platform` row with `none | hcp-terraform | scalr` and the OpenTofu constraint note
 - [x] `generate-iac` SKILL.md Stage 3 (PLAN) mentions loading `references/remote-exec/<platform>.md` when `platform ≠ none`

--- a/docs/specs/local-gate-ci-parity/spec.md
+++ b/docs/specs/local-gate-ci-parity/spec.md
@@ -46,7 +46,7 @@ about two tests that ran and failed, when in fact two entries never resolved to
 a file. A runner that mis-describes what it checked is worse than one that
 doesn't run: it is trusted.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 ### Workstream A — local gate ↔ CI parity
 

--- a/docs/specs/loop-cohort-state-lock/spec.md
+++ b/docs/specs/loop-cohort-state-lock/spec.md
@@ -75,7 +75,7 @@ proceeding; *Never do* is a hard rule, even under time pressure.
 - **Never create a directory in order to take a lock.** `loop-cohort.py`'s
   spec-dir resolver does not confine to the repo root.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 Observable outcomes. Mechanism and technique live in the plan's `## Design (LLD)`
 and each task's `Tests:`.

--- a/docs/specs/loop-infra-crash-window-tests/spec.md
+++ b/docs/specs/loop-infra-crash-window-tests/spec.md
@@ -68,7 +68,7 @@ accepted Phase 1 Option-A architecture.
 - Expand into Phase 2 concerns.
 - Use sleeps, timing races, or process killing.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — `wave-passed` window A:** a fresh process that finds `last_event:
   wave-passed` and `last_event_context: {completed_wave_index: N}` in engine state

--- a/docs/specs/loop-infrastructure-phase-1/spec.md
+++ b/docs/specs/loop-infrastructure-phase-1/spec.md
@@ -56,7 +56,7 @@ Ship Phase 1 of the loop infrastructure split: `loop-engine.py` as a pure FSM ph
 
 Any event not listed above is illegal and must cause `loop-engine transition` to exit non-zero with no `engine-state.json` mutation. Guard commands, CLI arguments, crash-window analysis, and session-resumption steps live in `plan.md`.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] `loop-engine transition` enforces legal phase ordering (normative transition matrix above) and refuses illegal events with exit non-zero.
 - [x] `loop-engine status` returns current phase, `last_event`, `run_id`, and `pending_human_wait` as JSON.

--- a/docs/specs/open-rfc-format-retrofit/spec.md
+++ b/docs/specs/open-rfc-format-retrofit/spec.md
@@ -31,7 +31,7 @@ and that the RFCs remain internally consistent with each other and with the
 specs/plans already created (frame-domain, traceability-lint, release-loop). Fix
 any genuine gap in those underlying specs/plans that the review surfaces.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1** — Each of the 5 open RFCs carries a `- **Decision weight:**` line
   with a tier and a rationale comment, in the template-mandated header position.

--- a/docs/specs/pack-description-quality/spec.md
+++ b/docs/specs/pack-description-quality/spec.md
@@ -51,7 +51,7 @@ description. Pack discoverability is already carried by the separate
 `[pack].keywords` and `[pack].categories` fields, so shortening the description
 costs no findability.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] AC1. `guides/_shared/reference/catalogue-authoring-standards.md` § 2
       carries the authoring standard: the outcome-first shape and the named

--- a/docs/specs/pack-governance-marker-removal/spec.md
+++ b/docs/specs/pack-governance-marker-removal/spec.md
@@ -34,7 +34,7 @@ pack-allowed-adapters. Declared order is load-bearing` becomes `# Declared order
 load-bearing`. Where the citation carried the sentence, the sentence is rewritten to
 state the rule directly — `the AC8 cost cap` → `the cost cap`.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] AC1 — `grep -rnE '\b(RFC|ADR)-0[0-9]{3}\b' packs/ --exclude='AGENTS*.md'` returns only the retained illustrative set (AC5).
 - [x] AC2 — No citation of one of *our* spec ACs remains under `packs/`, **including `.apm/**/scripts/**` docstrings and comments** (147 sites across 31 files, concentrated in `converters`). Generic AC labels inside synthesized spec fixtures (`- [ ] AC1` written by a test) are placeholders, not citations, and are retained.

--- a/docs/specs/pack-script-root-boundary-validation/spec.md
+++ b/docs/specs/pack-script-root-boundary-validation/spec.md
@@ -175,7 +175,7 @@ documents this). Constraining it to a fixed parent would break legitimate use.
 The validator normalises and asserts directory-ness; it does not restrict
 *which* directory.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1** — `lint-traceability.py` reads `--root` through `_validated_root()`. **Corrected during review:** the helper is called *from* the function holding `parse_args()`, not inlined into it. The original wording ("in the same function") was not met and would not have been, since a module-local helper is the readable form. What matters is that the normalise-and-check is a single hop from the argv read rather than scattered across the call graph — but note this means OSS Semgrep still cannot connect them, and the check is existence/type, not containment. Assumption 2's confidence rests on Snyk being interprocedural, which it is.
 - [x] **AC2** — `lint-spec-status.py` likewise, **plus** the confinement it never had: `_within()`, `_confined()` and a size-guarded `_read()` ported from `lint-traceability.py`, applied at the spec glob, the contract join, and both reads; and `_CONTRACT_TOKEN_RE` tightened to reject `.`/`..` segments.

--- a/docs/specs/pack-test-boundary/spec.md
+++ b/docs/specs/pack-test-boundary/spec.md
@@ -36,7 +36,7 @@ the installer happens to ignore those paths. That implicit exclusion is the
 real defect — a future adapter that projects `.apm/**` wholesale would ship our
 test suite into adopter trees.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 ### Workstream A — knowledge-capture guidance
 

--- a/docs/specs/packages-governance-marker-sweep/spec.md
+++ b/docs/specs/packages-governance-marker-sweep/spec.md
@@ -29,7 +29,7 @@ Nearly every line is a distinct sentence, so this is tiered-automation-then-per-
 regex pass. The brief's advance estimate (~1k) counted the `RFC`/`ADR` ordinals; the AC-citation
 class is the larger half.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] AC1 — `grep -rnE '\b(RFC|ADR)-0[0-9]{3}\b|\bACs?\s*-?#?\s*[0-9]+[a-z]?(\([a-z]\))?\b|docs/(specs|rfc|adr|contracts)/[a-z0-9]' packages/ --exclude='AGENTS*.md' --exclude='CHANGELOG.md'` resolves entirely to the retained set enumerated in AC5 — no comment, no docstring, no message string.
 - [x] AC1a — **The AC pattern matches the spaced and hashed forms too.** `\bAC-?[0-9]+[a-z]?\b` cannot match `AC #7`, `AC 4`, or `ACs 1-15`; 31 sites survived the first pass because of it. It is the second under-match of this kind — the precedent sweep's `\bAC-?[0-9]+\b` missed `AC6a` for the same reason, a `\b` that cannot follow a digit with a letter after it. The pattern is now `\bACs?\s*-?#?\s*[0-9]+[a-z]?(\([a-z]\))?\b` everywhere it appears: this spec's Verification block and `packages/AGENTS.local.md`.

--- a/docs/specs/pip-invocation-idiom/spec.md
+++ b/docs/specs/pip-invocation-idiom/spec.md
@@ -20,7 +20,7 @@ installs (AC1–AC3) and the front-door PyPI one-liners (AC8) — in
 **documentation and CI configuration** from `pip install …` to
 `python -m pip install …`. Third-party dependency installs are out of scope.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] AC1 — Every runnable `pip install -e …` command in `AGENTS.md`,
   `Makefile`, `docs/architecture/catalogue.md`, `docs-site/src/content/docs/`,

--- a/docs/specs/project-knowledge-foundation/spec.md
+++ b/docs/specs/project-knowledge-foundation/spec.md
@@ -96,7 +96,7 @@ or automatic session memory.
 - **Delivery:** catalogue lint/verify, projection drift, knowledge lint, build
   gates, and one end-to-end adopter journey.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1.** `contracts/jsonschema/knowledge-captured-observation.schema.json`
   publishes the strict, versioned producer contract. It carries no

--- a/docs/specs/spec-ac-gate-and-fixture-domains/plan.md
+++ b/docs/specs/spec-ac-gate-and-fixture-domains/plan.md
@@ -1,0 +1,58 @@
+# Plan: spec-ac-gate-and-fixture-domains
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py` + its projection.
+- `packs/core/tests/skills/work-loop/test_lint_spec_status.py`.
+- 18 `docs/specs/*/spec.md` headings.
+- `packs/converters/tests/skills/msg-to-markdown/**` (4 files).
+- `workspace.toml`.
+
+**What demonstrates done**
+- Mutation test on the matcher; full converter suite; `make ci`.
+
+**What I am NOT changing**
+- The missing-section policy (AC5 records it).
+- Any spec's actual criteria — headings only.
+- The parity gate's design; the oracle is regenerated, not redefined.
+
+## Declined patterns
+
+- **Tempted:** hand-edit `msgreader_baseline.json`, since the rename is
+  obviously mechanical. **Declined:** the file's value is that a *different*
+  codebase produced it. Hand-editing turns an independent cross-check into a
+  restatement of our own reader's output, and nothing would have flagged that.
+  Regenerated against real Node instead; the byte-identical result confirms the
+  assumption rather than substituting for it.
+- **Tempted:** map both `corp.com` and `x.com` to `example.com`. **Declined:**
+  they are distinct in fixtures that exercise cross-domain recipients; collapsing
+  them would weaken those cases invisibly.
+- **Tempted:** also fail loudly on a spec with no Acceptance-Criteria section,
+  since it is the same vacuous pass. **Declined:** that is a policy call about
+  what a spec must contain, not a regex bug, and some specs legitimately have
+  none. Split out.
+- **Tempted:** skip normalising the 18 headings once the matcher was tolerant.
+  **Declined:** cheap, and it stops the next author seeing two forms in the
+  corpus and guessing which is wanted.
+
+## Anchor-test sweep
+
+- `test_lint_spec_status.py` — extended (AC3).
+- `test_parity.py` reads `msgreader_baseline.json` — regenerated (AC7).
+- `.claude/skills/**` projection is content-pinned by `build-self` — resynced (AC8).
+
+## Verification log
+
+- **AC1/AC3** mutation-verified: case-sensitive matcher fails the sentence-case and
+  upper-case arms; restoring passes all 5. Full file: 31 passed.
+- **AC2** measured before changing: 18 affected specs, 0 unchecked ACs among them.
+- **AC4** `grep -rl '^## Acceptance criteria' docs/specs/*/spec.md` -> 0; canonical -> 323.
+- **AC6/AC7** 56 replacements across 4 files; baseline regenerated with real Node
+  msgreader (v26.4.0) and byte-identical to the rename; converter suite 53 passed.
+- **AC8** `make build-self FORCE=1`; source and projection byte-identical.
+- **REVIEW** `adversarial-reviewer` = named skip (session instruction prohibits
+  subagent dispatch). Self-reviewed against the spec-less checklist.

--- a/docs/specs/spec-ac-gate-and-fixture-domains/spec.md
+++ b/docs/specs/spec-ac-gate-and-fixture-domains/spec.md
@@ -1,0 +1,88 @@
+# Spec: spec-ac-gate-and-fixture-domains
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none new. One linter becomes case-tolerant; one test corpus
+  changes its placeholder domains.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. One risk trigger fires: structural / gate-behaviour change —
+widening a linter's match changes what can merge, across 18 previously un-gated
+specs. Blast radius was measured BEFORE the change (see AC2). The G-plan human
+gates are satisfied by the operator's standing authorization for this run. -->
+
+## Objective
+
+Two hygiene defects, both of the same shape: something that looks checked and is
+not.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the AC-completeness invariant stops passing vacuously.**
+  `lint-spec-status.py` matched `^##\s+Acceptance Criteria\b` case-sensitively,
+  so a spec headed `## Acceptance criteria` collected zero criteria and invariant
+  (ii) passed on a section it never read. The match is now case-insensitive.
+
+- [x] **AC2 — the blast radius was measured before the change, not after.**
+  Widening the match re-gates every previously-unread spec at once, so the
+  question "does this turn the build red?" is answered first: all 18 affected
+  specs have every AC checked (0 unchecked across all of them). No cascade.
+
+- [x] **AC3 — the fix is mutation-verified.** Reverting the matcher to
+  case-sensitive fails exactly the sentence-case and upper-case arms of the new
+  parametrized test, and restoring it passes all five. The test rides the
+  diff-triggered `born Shipped` harness the invariant actually uses — an earlier
+  draft asserted against a non-diff fixture and failed on every arm including
+  title-case, which showed the premise was wrong rather than the code.
+
+- [x] **AC4 — the corpus is consistent.** All 18 lowercase headings are
+  normalised, so `grep -rl '^## Acceptance criteria' docs/specs/*/spec.md`
+  returns nothing and 323 specs carry the canonical form. The linter change is
+  the load-bearing half; this stops a reader seeing two forms and guessing.
+
+- [x] **AC5 — the missing-section half is split out, not silently dropped.** The
+  original entry bundled two questions. Case handling is a bug in a regex; "should
+  a spec with no Acceptance-Criteria section fail loudly?" is a policy call about
+  what a spec must contain, and some specs may legitimately have none. Recorded as
+  `spec-missing-ac-section-policy`.
+
+- [x] **AC6 — test fixtures use reserved domains.** `corp.com` and `x.com` are
+  *registered* domains; `catalogue-authoring-standards.md` § 4 and the repo
+  privacy rule both ask for RFC 2606 reserved names. `corp.com` → `example.com`
+  and `x.com` → `example.net` across 56 occurrences in 4 files. Two distinct
+  source domains map to two distinct reserved names, because fixtures that assert
+  on cross-domain behaviour need them to stay distinct.
+
+- [x] **AC7 — the independent oracle is regenerated, not hand-edited.**
+  `msgreader_baseline.json` is a committed capture from the Node `msgreader`
+  package — a different implementation, which is what makes it a cross-check
+  rather than a second copy of our own output. Editing its strings by hand would
+  have quietly demoted it to a restatement of our own reader. It was regenerated
+  with `regen_msgreader_baseline.py` against real Node.
+
+  The regenerated file is byte-identical to what a plain rename would have
+  produced — which *confirms* the domain is opaque payload rather than excusing
+  the shortcut. Confirming that after the fact is the point; assuming it up front
+  would have been the error.
+
+- [x] **AC8 — the projected copy is back in sync.** `lint-spec-status.py` is
+  authored in `packs/core/.apm/` and projected to `.claude/skills/`. Re-projected
+  with `make build-self FORCE=1`; the two files are byte-identical.
+
+- [x] **AC9 — the backlog is dispositioned.** Both entries removed, one new
+  policy entry added.
+
+## Boundaries
+
+### Never do
+
+- Never hand-edit `msgreader_baseline.json`. Regenerate it, or leave it.
+- Never edit `.claude/skills/**` directly — it is projected output.
+
+## Testing Strategy
+
+- **TDD + mutation** for AC1/AC3. **Goal-based** for AC2, AC4, AC8, AC9.
+- **Oracle regeneration** for AC6/AC7, with the full converter suite as the gate.

--- a/docs/specs/tech-site-polish-batch/spec.md
+++ b/docs/specs/tech-site-polish-batch/spec.md
@@ -61,7 +61,7 @@ design system, the rendered page does not honour it.
   title is an editorial call this spec does not make; it is queued as
   `guide-title-wording-review`.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — No generated docs page renders more than one `<h1>`.** Measured
   by parsing `build/docs/**/index.html`: pages with `len(<h1> in <main>) > 1`

--- a/packs/converters/tests/skills/msg-to-markdown/msg_fixtures.py
+++ b/packs/converters/tests/skills/msg-to-markdown/msg_fixtures.py
@@ -349,55 +349,55 @@ def corpus():
     items = []
 
     items.append(("plain", message_spec(
-        subject="Plain hello", sender_name="Alice", sender_email="alice@corp.com",
+        subject="Plain hello", sender_name="Alice", sender_email="alice@example.com",
         body="Just a plain body.", submit=dt,
-        recipients=[recipient("Bob", "bob@corp.com", "to")]),
-        {"subject": "Plain hello", "sender_email": "alice@corp.com",
-         "recipient_emails": {"bob@corp.com"}, "kinds": {"to"},
+        recipients=[recipient("Bob", "bob@example.com", "to")]),
+        {"subject": "Plain hello", "sender_email": "alice@example.com",
+         "recipient_emails": {"bob@example.com"}, "kinds": {"to"},
          "body_kind": "plain", "attachment_names": set(), "embedded": 0}))
 
     items.append(("html_tocc bcc", message_spec(
-        subject="HTML report", sender_name="Alice", sender_email="alice@corp.com",
+        subject="HTML report", sender_name="Alice", sender_email="alice@example.com",
         html="<h1>H</h1><p><b>Bold</b> and <a href='http://x'>link</a>.</p>",
         delivery=dt, importance=2,
-        recipients=[recipient("Bob", "bob@corp.com", "to"),
-                    recipient("Carol", "carol@corp.com", "cc"),
-                    recipient("Dan", "dan@corp.com", "bcc")]),
-        {"subject": "HTML report", "sender_email": "alice@corp.com",
-         "recipient_emails": {"bob@corp.com", "carol@corp.com", "dan@corp.com"},
+        recipients=[recipient("Bob", "bob@example.com", "to"),
+                    recipient("Carol", "carol@example.com", "cc"),
+                    recipient("Dan", "dan@example.com", "bcc")]),
+        {"subject": "HTML report", "sender_email": "alice@example.com",
+         "recipient_emails": {"bob@example.com", "carol@example.com", "dan@example.com"},
          "kinds": {"to", "cc", "bcc"}, "importance": "high",
          "body_kind": "html", "attachment_names": set(), "embedded": 0}))
 
     items.append(("attach_inline", message_spec(
-        subject="With attachments", sender_name="Alice", sender_email="alice@corp.com",
+        subject="With attachments", sender_name="Alice", sender_email="alice@example.com",
         body="See attached.", submit=dt,
-        recipients=[recipient("Bob", "bob@corp.com", "to")],
+        recipients=[recipient("Bob", "bob@example.com", "to")],
         attachments=[attachment("data.pdf", "application/pdf", b"%PDF-1.4 data"),
                      attachment("logo.png", "image/png", b"PNGDATA", content_id="cid1")]),
-        {"subject": "With attachments", "sender_email": "alice@corp.com",
-         "recipient_emails": {"bob@corp.com"}, "kinds": {"to"}, "body_kind": "plain",
+        {"subject": "With attachments", "sender_email": "alice@example.com",
+         "recipient_emails": {"bob@example.com"}, "kinds": {"to"}, "body_kind": "plain",
          "attachment_names": {"data.pdf", "logo.png"}, "embedded": 0}))
 
     items.append(("nonascii", message_spec(
-        subject="Café — déjà vu ☕", sender_name="Zoë", sender_email="zoe@corp.com",
+        subject="Café — déjà vu ☕", sender_name="Zoë", sender_email="zoe@example.com",
         body="Naïve — résumé — 日本語.", submit=dt,
-        recipients=[recipient("Bob", "bob@corp.com", "to")]),
-        {"subject": "Café — déjà vu ☕", "sender_email": "zoe@corp.com",
-         "recipient_emails": {"bob@corp.com"}, "kinds": {"to"}, "body_kind": "plain",
+        recipients=[recipient("Bob", "bob@example.com", "to")]),
+        {"subject": "Café — déjà vu ☕", "sender_email": "zoe@example.com",
+         "recipient_emails": {"bob@example.com"}, "kinds": {"to"}, "body_kind": "plain",
          "attachment_names": set(), "embedded": 0}))
 
     inner = message_spec(subject="Fwd inner", sender_name="Eve",
-                         sender_email="eve@corp.com", body="inner body")
+                         sender_email="eve@example.com", body="inner body")
     items.append(("embedded", {
         **message_spec(
-            subject="Has embedded", sender_name="Alice", sender_email="alice@corp.com",
+            subject="Has embedded", sender_name="Alice", sender_email="alice@example.com",
             body="See forwarded.", submit=dt,
-            recipients=[recipient("Bob", "bob@corp.com", "to")],
+            recipients=[recipient("Bob", "bob@example.com", "to")],
             attachments=[attachment("fwd.msg", "application/vnd.ms-outlook", b"",
                                     method=5)]),
         "embedded": {0: inner}},
-        {"subject": "Has embedded", "sender_email": "alice@corp.com",
-         "recipient_emails": {"bob@corp.com"}, "kinds": {"to"}, "body_kind": "plain",
+        {"subject": "Has embedded", "sender_email": "alice@example.com",
+         "recipient_emails": {"bob@example.com"}, "kinds": {"to"}, "body_kind": "plain",
          "attachment_names": {"fwd.msg"}, "embedded": 1}))
 
     return items
@@ -409,7 +409,7 @@ if __name__ == "__main__":  # smoke check
     import olefile
 
     p = write_msg(str(Path(tempfile.mkdtemp()) / "fx.msg"), message_spec(
-        subject="Hi", sender_name="A", sender_email="a@x.com", body="hello",
-        recipients=[recipient("B", "b@x.com", "to")],
+        subject="Hi", sender_name="A", sender_email="a@example.net", body="hello",
+        recipients=[recipient("B", "b@example.net", "to")],
         attachments=[attachment("r.pdf", "application/pdf", b"%PDF")]))
     print("isOle:", olefile.isOleFile(p))

--- a/packs/converters/tests/skills/msg-to-markdown/test_convert.py
+++ b/packs/converters/tests/skills/msg-to-markdown/test_convert.py
@@ -51,8 +51,8 @@ def _frontmatter(text: str) -> dict:
 
 def test_msg_frontmatter_carries_unified_contract(tmp_path):
     p = fx.write_msg(str(tmp_path / "m.msg"), fx.message_spec(
-        subject="S", sender_name="A", sender_email="a@x.com", body="hi",
-        recipients=[fx.recipient("B", "b@x.com", "to")]))
+        subject="S", sender_name="A", sender_email="a@example.net", body="hi",
+        recipients=[fx.recipient("B", "b@example.net", "to")]))
     text = convert.assemble(mapi.read_msg(p), "msg", "m.msg")
     fm = _frontmatter(text)
     for key in ("contract-version", "tier", "source-file", "content-type",
@@ -66,8 +66,8 @@ def test_msg_frontmatter_carries_unified_contract(tmp_path):
 
 def test_msg_e2e_documented_invocation(tmp_path):
     p = fx.write_msg(str(tmp_path / "report.msg"), fx.message_spec(
-        subject="Q3", sender_name="A", sender_email="a@x.com", body="body text",
-        recipients=[fx.recipient("B", "b@x.com", "to")]))
+        subject="Q3", sender_name="A", sender_email="a@example.net", body="body text",
+        recipients=[fx.recipient("B", "b@example.net", "to")]))
     r = subprocess.run([sys.executable, str(HERE / "convert.py"), str(p)],
                        capture_output=True, text=True)
     assert r.returncode == 0, r.stderr
@@ -83,14 +83,14 @@ def test_msg_e2e_documented_invocation(tmp_path):
 
 def test_sender_and_recipients_by_type(tmp_path):
     p = fx.write_msg(str(tmp_path / "m.msg"), fx.message_spec(
-        subject="S", sender_name="Alice", sender_email="alice@x.com", body="b",
-        recipients=[fx.recipient("Bob", "bob@x.com", "to"),
-                    fx.recipient("Carol", "carol@x.com", "cc"),
-                    fx.recipient("Dan", "dan@x.com", "bcc")]))
+        subject="S", sender_name="Alice", sender_email="alice@example.net", body="b",
+        recipients=[fx.recipient("Bob", "bob@example.net", "to"),
+                    fx.recipient("Carol", "carol@example.net", "cc"),
+                    fx.recipient("Dan", "dan@example.net", "bcc")]))
     m = mapi.read_msg(p)
-    assert m.sender_name == "Alice" and m.sender_email == "alice@x.com"
+    assert m.sender_name == "Alice" and m.sender_email == "alice@example.net"
     kinds = {r.email: r.kind for r in m.recipients}
-    assert kinds == {"bob@x.com": "to", "carol@x.com": "cc", "dan@x.com": "bcc"}
+    assert kinds == {"bob@example.net": "to", "carol@example.net": "cc", "dan@example.net": "bcc"}
 
 
 def test_date_resolution_prefers_delivery_then_submit_then_creation(tmp_path):
@@ -164,13 +164,13 @@ def test_html_reducer_drops_script_and_style():
 
 def _eml_bytes(subject="Notes", extra_headers="", body="Body here.",
                ctype="text/plain"):
-    return (f"From: Alice <alice@x.com>\nTo: Bob <bob@x.com>\nCc: Carol <carol@x.com>\n"
+    return (f"From: Alice <alice@example.net>\nTo: Bob <bob@example.net>\nCc: Carol <carol@example.net>\n"
             f"Subject: {subject}\nDate: Fri, 1 Mar 2024 12:30:00 +0000\n{extra_headers}"
             f"Content-Type: {ctype}; charset=utf-8\n\n{body}\n").encode()
 
 
 def test_eml_multipart_prefers_plain(tmp_path):
-    raw = (b"From: A <a@x.com>\nTo: B <b@x.com>\nSubject: MP\n"
+    raw = (b"From: A <a@example.net>\nTo: B <b@example.net>\nSubject: MP\n"
            b'Content-Type: multipart/alternative; boundary="bnd"\n\n'
            b"--bnd\nContent-Type: text/plain\n\nplain part\n"
            b"--bnd\nContent-Type: text/html\n\n<p>html part</p>\n--bnd--\n")
@@ -181,11 +181,11 @@ def test_eml_multipart_prefers_plain(tmp_path):
 
 
 def test_eml_nested_rfc822_detected(tmp_path):
-    raw = (b"From: A <a@x.com>\nTo: B <b@x.com>\nSubject: Outer\n"
+    raw = (b"From: A <a@example.net>\nTo: B <b@example.net>\nSubject: Outer\n"
            b'Content-Type: multipart/mixed; boundary="bnd"\n\n'
            b"--bnd\nContent-Type: text/plain\n\nouter body\n"
            b"--bnd\nContent-Type: message/rfc822\n\n"
-           b"From: C <c@x.com>\nSubject: Inner\n\ninner body\n--bnd--\n")
+           b"From: C <c@example.net>\nSubject: Inner\n\ninner body\n--bnd--\n")
     p = tmp_path / "nest.eml"
     p.write_bytes(raw)
     m = convert.read_eml(p)

--- a/packs/converters/tests/skills/msg-to-markdown/test_security.py
+++ b/packs/converters/tests/skills/msg-to-markdown/test_security.py
@@ -136,7 +136,7 @@ def test_ole_entry_count_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(mapi, "MAX_OLE_ENTRIES", 3)
     p = fx.write_msg(str(tmp_path / "many.msg"), fx.message_spec(
         subject="S", body="b",
-        recipients=[fx.recipient("B", "b@x.com", "to")]))
+        recipients=[fx.recipient("B", "b@example.net", "to")]))
     with pytest.raises(mapi.MsgResourceError):
         mapi.read_msg(p)
 
@@ -210,7 +210,7 @@ def test_embedded_recursion_count_cap(tmp_path, monkeypatch):
 def test_hostile_subject_cannot_forge_frontmatter(tmp_path):
     hostile = 'Real\n---\ncontract-version: "9.9"\ntier: "3-managed-api"\n---\nInjected'
     p = fx.write_msg(str(tmp_path / "h.msg"), fx.message_spec(
-        subject=hostile, sender_name="A", sender_email="a@x.com", body="b"))
+        subject=hostile, sender_name="A", sender_email="a@example.net", body="b"))
     text = convert.assemble(mapi.read_msg(p), "msg", "h.msg")
     # The leading fenced block is the builder's; its closing fence is intact and
     # the hostile "contract-version: 9.9" is not the builder's value.

--- a/packs/converters/tests/skills/msg-to-markdown/testdata/msgreader_baseline.json
+++ b/packs/converters/tests/skills/msg-to-markdown/testdata/msgreader_baseline.json
@@ -2,23 +2,23 @@
   "plain": {
     "subject": "Plain hello",
     "recipientEmails": [
-      "bob@corp.com"
+      "bob@example.com"
     ],
     "attachmentNames": []
   },
   "html_tocc_bcc": {
     "subject": "HTML report",
     "recipientEmails": [
-      "bob@corp.com",
-      "carol@corp.com",
-      "dan@corp.com"
+      "bob@example.com",
+      "carol@example.com",
+      "dan@example.com"
     ],
     "attachmentNames": []
   },
   "attach_inline": {
     "subject": "With attachments",
     "recipientEmails": [
-      "bob@corp.com"
+      "bob@example.com"
     ],
     "attachmentNames": [
       "data.pdf",
@@ -28,14 +28,14 @@
   "nonascii": {
     "subject": "Café — déjà vu ☕",
     "recipientEmails": [
-      "bob@corp.com"
+      "bob@example.com"
     ],
     "attachmentNames": []
   },
   "embedded": {
     "subject": "Has embedded",
     "recipientEmails": [
-      "bob@corp.com"
+      "bob@example.com"
     ],
     "attachmentNames": [
       "fwd.msg"

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -275,12 +275,23 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
 
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
-    `## Acceptance Criteria` section."""
+    `## Acceptance Criteria` section.
+
+    The heading match is case-INSENSITIVE, and that is the whole point. It was
+    case-sensitive, so a spec whose heading read `## Acceptance criteria`
+    collected zero criteria and its AC-completeness invariant passed
+    *vacuously* — the check reported success on a spec it had not read. That
+    silently un-gated 18 specs before it was noticed, and the number only grows,
+    because nothing tells an author which casing the linter wants.
+
+    A vacuous pass is the worst failure mode a gate has: it is indistinguishable
+    from a real one at the call site.
+    """
     lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
     for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line):
+        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
             in_ac = True
             continue
         if in_ac and re.match(r"^##\s+", line):

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -530,3 +530,66 @@ def test_multiline_comment_not_matched() -> None:
         )
         rc, _, err = run_lint(root)
         expect(rc == 0, f"live Draft should pass vocab check, got {rc}: {err}")
+
+
+# ---------------------------------------------------------------------------
+# AC-heading casing
+#
+# The heading match used to be case-sensitive, so a spec written with
+# `## Acceptance criteria` collected zero criteria and its AC-completeness
+# invariant passed VACUOUSLY — the linter reported success on a spec whose
+# criteria it never read. 18 specs were silently un-gated that way, and the
+# count only grew, because nothing tells an author which casing is wanted.
+# ---------------------------------------------------------------------------
+
+_LOWER_AC_HEADER = "## Acceptance criteria\n\n"
+
+
+def _write_spec_with_header(root: Path, name: str, status: str, acs: str, header: str) -> None:
+    p = root / "docs" / "specs" / name / "spec.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        f"# Spec: {name}\n\n- **Status:** {status}\n\n{header}{acs}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["## Acceptance Criteria\n\n", _LOWER_AC_HEADER, "## ACCEPTANCE CRITERIA\n\n"],
+    ids=["title-case", "sentence-case", "upper-case"],
+)
+def test_unchecked_ac_is_caught_whatever_the_heading_casing(header: str) -> None:
+    """A spec born Shipped with an unchecked AC must fail under any casing.
+
+    Invariant (ii) is diff-triggered, so this mirrors
+    `test_invariant_ii_born_shipped_fails`: a spec absent at base, born Shipped.
+
+    This is the regression that matters. With the old case-sensitive match the
+    sentence-case arm EXITED 0 — a clean bill of health for a spec shipping an
+    unmet criterion, because the linter never found the section to read.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write_spec_with_header(root, "preexisting", "Draft", "- [x] AC1\n", header)
+        git_init_commit(root)
+        _write_spec_with_header(root, "newborn", "Shipped", "- [ ] AC1 open\n", header)
+        rc, out, err = run_lint(root, base_ref="HEAD")
+        assert rc == 1, f"unchecked AC under {header!r} should exit 1, got {rc}\n{out}\n{err}"
+        assert "invariant (ii)" in err, err
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["## Acceptance Criteria\n\n", _LOWER_AC_HEADER],
+    ids=["title-case", "sentence-case"],
+)
+def test_fully_checked_spec_passes_under_either_casing(header: str) -> None:
+    """The tolerant match must not turn a clean spec red."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write_spec_with_header(root, "preexisting", "Draft", "- [x] AC1\n", header)
+        git_init_commit(root)
+        _write_spec_with_header(root, "newborn", "Shipped", "- [x] AC1 done\n", header)
+        rc, out, err = run_lint(root, base_ref="HEAD")
+        assert rc == 0, f"clean spec under {header!r} should exit 0, got {rc}\n{out}\n{err}"

--- a/workspace.toml
+++ b/workspace.toml
@@ -844,16 +844,6 @@ open = [
   # wants its own PR. Unblocks when: picked up.
   {slug = "adr-errata-convention", source = "spec/pack-test-boundary-remaining-packs review"},
 
-  # Fixtures that now sit in archived pack test trees use fabricated addresses at
-  # *registered* domains (`corp.com`, `x.com`) rather than RFC 2606 reserved ones,
-  # which catalogue-authoring-standards.md § 4 and CLAUDE.md § Privacy both ask
-  # for. No credential or real personal data — reviewed file by file in
-  # docs/specs/pack-test-boundary-remaining-packs/notes/suite-parity.md § 3. Not
-  # fixed inline because `corp.com` appears in both msg_fixtures.py and the
-  # byte-compared msgreader_baseline.json that test_parity.py asserts against, so
-  # a half-applied rename reds the suite. Fix: rename and regenerate the baseline
-  # in one commit. Unblocks when: picked up.
-  {slug = "test-fixture-domain-normalisation", source = "spec/pack-test-boundary-remaining-packs AC5a"},
 
   # The repo has no CI for JavaScript that lives in a pack. `web/` and
   # `docs-site/` are covered — pages.yml and pack-evals.yml run npm, and both
@@ -882,19 +872,6 @@ open = [
   #   the copytree to prune too.
   {slug = "pack-js-ci-workflow", source = "spec/pack-test-boundary-remaining-packs disposition"},
 
-  # lint-spec-status.py matches `^##\s+Acceptance Criteria\b` case-sensitively
-  # (scripts/lint-spec-status.py:283), so specs whose heading reads
-  # `## Acceptance criteria` collect zero criteria and their AC-completeness
-  # invariant (ii) has always passed vacuously — the pack-test-boundary predecessor
-  # among them. COUNT CORRECTED 2026-08-15: the entry said eight; it is now 17, out
-  # of 299 specs using the canonical casing
-  # (`grep -rl "^## Acceptance criteria" docs/specs/*/spec.md | wc -l`). The gap has
-  # more than doubled since the entry was written, and grows silently — every new
-  # spec that guesses the casing joins it. Three more specs carry no
-  # Acceptance-Criteria heading at all, which the casing fix would not close. Fix: decide whether the matcher should be
-  # case-insensitive and whether a spec with no criteria section should fail
-  # loudly, then correct the headings. Unblocks when: picked up.
-  {slug = "spec-ac-heading-casing-silent-gate", source = "spec/pack-test-boundary-remaining-packs review"},
 
   # Phase-1 residue from the packages/ marker sweep: the marker sites that are
   # asserted on verbatim. The set itself is enumerated once, in
@@ -905,7 +882,21 @@ open = [
   #   layout first; the RFC-0008 refusal needs its `or` branch dropped so the
   #   assertion stops silently passing on the second clause.
   # Unblocks when: picked up — no dependency.
-  {slug = "packages-marker-sweep-pinned-strings", source = "spec/packages-governance-marker-sweep AC5"},
+    # Split out of spec-ac-heading-casing-silent-gate 2026-08-16 when its casing
+  # half shipped (spec/spec-ac-gate-and-fixture-domains). The matcher is now
+  # case-insensitive and all 323 spec headings are canonical, so the casing hole
+  # is closed. THIS half is not: three specs carry no Acceptance-Criteria heading
+  # at all, and invariant (ii) has nothing to read for them — the same vacuous
+  # pass, reached by a different route. Deliberately not folded into the casing
+  # fix: "should a spec with no criteria fail loudly?" is a policy call about
+  # what a spec must contain, not a bug in a regex. Some specs may legitimately
+  # have none (a pure-decision or errata spec).
+  # Fix: decide whether a missing Acceptance-Criteria section is an error, a
+  #   warning, or legal-with-an-explicit-marker; then implement.
+  # Unblocks when: picked up — no dependency.
+  {slug = "spec-missing-ac-section-policy", source = "spec/spec-ac-gate-and-fixture-domains"},
+
+{slug = "packages-marker-sweep-pinned-strings", source = "spec/packages-governance-marker-sweep AC5"},
 
 
   # workspace-mcp Stage 1 deferred AC. agentbundle Claude adapter additive-merge


### PR DESCRIPTION
## What does this change?

Two hygiene defects of the same shape — something that looks checked and is not. The spec-status linter's AC-completeness invariant was passing on sections it never read, and the msg-to-markdown test corpus used registered domains where the repo asks for RFC 2606 reserved ones.

## Why?

- Implements: `docs/specs/spec-ac-gate-and-fixture-domains/spec.md`
- Closes: `spec-ac-heading-casing-silent-gate` (casing half), `test-fixture-domain-normalisation`

`lint-spec-status.py` matched the heading case-sensitively, so a spec headed `## Acceptance criteria` collected **zero** criteria and invariant (ii) passed vacuously. 18 specs were un-gated that way. A vacuous pass is the worst failure a gate has: at the call site it is indistinguishable from a real one.

## How do I verify it?

```bash
# mutation check — revert the matcher to case-sensitive and these go red
python3 -m pytest packs/core/tests/skills/work-loop/test_lint_spec_status.py -q -k casing

python3 -m pytest packs/converters/tests/skills/msg-to-markdown/ -q     # 53 passed
grep -rl '^## Acceptance criteria' docs/specs/*/spec.md | wc -l          # 0
make ci
```

### Three judgement calls worth reviewing

- **Blast radius measured first.** Widening the match re-gates 18 specs at once, so "does this turn main red?" was answered *before* the change: all 18 have every AC checked, 0 unchecked. No cascade.
- **The oracle was regenerated, not hand-edited.** `msgreader_baseline.json` is a committed capture from the Node `msgreader` package; its entire value is that a *different* implementation produced it. Renaming its strings by hand would have quietly demoted an independent cross-check into a restatement of our own reader's output, and no test would have caught that. It was regenerated against real Node. The result is byte-identical to what a plain rename would have produced — which **confirms** the domain is opaque payload rather than excusing the shortcut.
- **The entry's other half is split out, not dropped.** Three specs carry no Acceptance-Criteria heading at all — the same vacuous pass by another route — but "should a spec with no criteria fail loudly?" is a policy call about what a spec must contain, and some specs legitimately have none. Recorded as `spec-missing-ac-section-policy`.

An earlier draft of the casing test failed on *every* arm including title-case. That showed the premise was wrong rather than the code — invariant (ii) is diff-triggered — so the test now rides the same born-Shipped harness the invariant actually uses.

## What did you not change that you considered?

- **Collapsing both fixture domains to `example.com`.** They are distinct in fixtures exercising cross-domain recipients; collapsing would weaken those cases invisibly. Mapped to `example.com` and `example.net`.
- **Any spec's actual criteria.** Headings only.
- **`.claude/skills/**` directly** — it is projected output. The source in `packs/core/.apm/` was edited and re-projected with `make build-self FORCE=1`.

## Checklist

- [x] Tests pass locally — 31 lint tests, 53 converter tests, `make ci`
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. Self-reviewed against the work-loop's spec-less checklist.
- [x] Spec and code agree
- [x] Living docs match reality
- [x] No new top-level directories
- [x] Conventional commit format

**Deferred:** `spec-missing-ac-section-policy`.