### PR TITLE
feat(ci): extend the SAST/SCA gate to npm and remediate both lockfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,6 +389,3 @@ site-link-check: site-build  ## Build both sites, then audit emitted internal li
 
 site-serve: site-sync  ## Start Starlight dev server at http://localhost:4321
 	npm run dev --prefix docs-site
-
-lint-selftest-scratch:
-	pytest packs/core/tests/skills/adapt-to-project packs/atlassian/tests/skills/flow-metrics

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,15 @@ SAST_DIRS := tools packs packages tests
 # validated by the gate it changes — build-check.yml's detection treats these
 # as SAST-relevant. (tools/requirements-sast.txt and tools/semgrep/ are already
 # covered by SAST_DIRS, so they need not be repeated here.)
-SAST_CONFIG := bandit.yaml .snyk Makefile tools/audit-requirements.py .github/workflows/build-check.yml .github/workflows/codeql.yml
+#
+# The two npm lockfiles are here for a different reason than the rest of this
+# list: they are the SCA gate's *input*, not its config, and neither `docs-site/`
+# nor `web/` is under SAST_DIRS. Without them a dependency-bump PR — a diff whose
+# only changed file is a lockfile — would set SKIP_SAST=1 and skip the one gate
+# written to check it. `tools/npm-audit-allowlist.toml` is genuine config: an
+# added suppression must be validated by the gate it loosens, exactly like a
+# widened bandit.yaml exclusion.
+SAST_CONFIG := bandit.yaml .snyk Makefile tools/audit-requirements.py tools/npm-audit-allowlist.toml docs-site/package-lock.json web/package-lock.json .github/workflows/build-check.yml .github/workflows/codeql.yml
 
 # Single source of truth for the SAST scan scope + config surface.
 # build-check.yml's SAST-relevance detection reads these (`make -s
@@ -207,6 +215,7 @@ sast:
 	@command -v bandit   >/dev/null 2>&1 || { echo "make sast: bandit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v pip-audit >/dev/null 2>&1 || { echo "make sast: pip-audit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v semgrep   >/dev/null 2>&1 || { echo "make sast: semgrep not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
+	@command -v npm       >/dev/null 2>&1 || { echo "make sast: npm not found — install Node.js (>=24, per docs-site/package.json engines) for the npm SCA leg" >&2; exit 1; }
 	bandit -r $(SAST_DIRS) -c bandit.yaml --severity-level medium --confidence-level medium -q
 	# The filter below stands in front of pip-audit, so a bug that drops a
 	# *third-party* pin would take this gate green over an unaudited dependency.
@@ -239,6 +248,13 @@ sast:
 	# [crypto] extra is the only third-party code either can pull, so audit it
 	# explicitly. Mirror packages/credbroker/pyproject.toml [crypto].
 	@printf 'cryptography>=42\nargon2-cffi>=23\n' | pip-audit -r /dev/stdin
+	# npm SCA leg (ADR-0083). pip-audit above covers every Python dependency and
+	# no JavaScript; the repo's two npm projects ship their lockfiles into built
+	# output. Same "prove it before trusting it" order as the pip-audit leg: the
+	# self-test runs first, because a live audit against a healthy registry is
+	# silent both when the gate works and when it has been broken into a no-op.
+	python3 tools/test-audit-npm.py
+	python3 tools/audit-npm.py --root .
 	semgrep --config p/python --config p/security-audit --config tools/semgrep/ --error --quiet --metrics off $(SEMGREP_EXCLUDE) $(SAST_DIRS)
 	# Prove the custom rules still fire. The scan above is silent both when the
 	# rules work and when they have been broken into no-ops, so it cannot tell
@@ -373,3 +389,6 @@ site-link-check: site-build  ## Build both sites, then audit emitted internal li
 
 site-serve: site-sync  ## Start Starlight dev server at http://localhost:4321
 	npm run dev --prefix docs-site
+
+lint-selftest-scratch:
+	pytest packs/core/tests/skills/adapt-to-project packs/atlassian/tests/skills/flow-metrics

--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -21,13 +21,21 @@ mermaid is bundled (no runtime script CDN calls).
 | [`mermaid`](https://mermaid.js.org) | `11.16.1` | Diagram rendering — bundled + lazy-imported in `src/components/Footer.astro` with `securityLevel: 'strict'`; replaced the former jsdelivr runtime script |
 | [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) | `5.1.0` | AST walker for the two markdown-pipeline plugins in `astro.config.ts` (mermaid fences, `src/plugins/rehype-scrollable-tables.ts`). Previously resolved only through transitive hoisting; declared explicitly so an `npm install` dedupe cannot redden the docs build |
 
-Supply-chain posture: the lockfile's only `"hasInstallScript": true`
-entries must stay within the versioned `allowScripts` keys in
-`package.json` (`esbuild@0.28.1`, `fsevents@2.3.3`). **Known gap
-(deferred, `workspace.toml [backlog]` slug `docs-site-npm-sca-gap`):** no
-SCA scanner (npm audit/Dependabot) is wired repo-wide; bundling mermaid
-vendors its transitive tree into shipped output, so that unscanned surface
-is net-new until a scanner lands.
+Supply-chain posture, two controls:
+
+- **Known-CVE scanning is wired** (ADR-0083, `docs/specs/npm-sca-gate/`).
+  `tools/audit-npm.py` runs `npm audit --audit-level=high` over this
+  lockfile as a leg of `make sast`, so it gates locally and in
+  `build-check.yml`. Both lockfiles are in the Makefile's `SAST_CONFIG`,
+  so a lockfile-only diff still triggers the gate. Fix a finding with
+  `npm audit fix --package-lock-only`; suppress one only when there is no
+  fix, via a reasoned entry in `tools/npm-audit-allowlist.toml`.
+- **Install-script vetting is still by hand.** The lockfile's only
+  `"hasInstallScript": true` entries must stay within the versioned
+  `allowScripts` keys in `package.json` (`esbuild@0.28.1`,
+  `fsevents@2.3.3`). Nothing enforces that yet — machine enforcement is
+  deferred under `workspace.toml [backlog]` slug
+  `npm-allowscripts-enforcement`. Check it by eye when the lockfile moves.
 
 ## Styling: the docs palette deliberately diverges from `web/`
 

--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -24,12 +24,17 @@ mermaid is bundled (no runtime script CDN calls).
 Supply-chain posture, two controls:
 
 - **Known-CVE scanning is wired** (ADR-0083, `docs/specs/npm-sca-gate/`).
-  `tools/audit-npm.py` runs `npm audit --audit-level=high` over this
+  `tools/audit-npm.py` runs `npm audit --audit-level=moderate` over this
   lockfile as a leg of `make sast`, so it gates locally and in
   `build-check.yml`. Both lockfiles are in the Makefile's `SAST_CONFIG`,
   so a lockfile-only diff still triggers the gate. Fix a finding with
   `npm audit fix --package-lock-only`; suppress one only when there is no
   fix, via a reasoned entry in `tools/npm-audit-allowlist.toml`.
+  The gate audits a known-vulnerable **canary** pin first — a mirror whose
+  advisory endpoint returns 200-with-nothing produces a report identical to
+  a clean one, so a green run is only trustworthy if the canary reported.
+  Exit 2 (tool error) is distinct from exit 1 (findings); never read it as
+  a pass.
 - **Install-script vetting is still by hand.** The lockfile's only
   `"hasInstallScript": true` entries must stay within the versioned
   `allowScripts` keys in `package.json` (`esbuild@0.28.1`,

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -13,7 +13,8 @@
         "@fontsource-variable/source-serif-4": "5.3.0",
         "@fontsource/jetbrains-mono": "5.3.0",
         "astro": "7.1.0",
-        "mermaid": "11.16.1"
+        "mermaid": "11.16.1",
+        "unist-util-visit": "5.1.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -4864,9 +4865,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -6386,9 +6387,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
+++ b/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-06-12
 - **Deciders:** eugenelim
 - **Supersedes:** none
-- **Related:** the implementing spec `docs/specs/sast-sca-tooling/`; ADR-0003 (credential-broker contract — `sso-broker.py` is one of the scanned scripts)
+- **Related:** the implementing spec `docs/specs/sast-sca-tooling/`; ADR-0003 (credential-broker contract — `sso-broker.py` is one of the scanned scripts); **ADR-0083** (extends this gate's SCA half to the npm ecosystem — the three tools below cover Python only)
 
 ## Context
 

--- a/docs/adr/0083-extend-sast-sca-gate-to-npm-with-audit-and-allowlist.md
+++ b/docs/adr/0083-extend-sast-sca-gate-to-npm-with-audit-and-allowlist.md
@@ -111,9 +111,54 @@ fixtures, because a live run against a healthy registry never reaches them.
 
 ### Threshold and scope
 
-Blocking at `high` (with `critical`), matching the existing gate's tuning
-(Bandit runs medium/medium). Lockfiles are **discovered** by walking the tree,
-not listed, so a third npm project cannot be added without the gate noticing.
+Blocking at **`moderate`** and above. The first draft of this decision said
+`high`, on the reasoning that it matched Bandit's medium/medium tuning and that
+tightening could come later. Implementation reversed it on evidence: remediating
+`web/`'s moderate `postcss` advisory left both lockfiles clean at `moderate`, so
+the bar could be raised for free. A threshold is cheapest to raise while you are
+already above it; deferring guarantees the tightening lands on a day when
+something is failing it. `low` and `info` stay ungated.
+
+Lockfiles are **discovered** by walking the tree, not listed, so a third npm
+project cannot be added without the gate noticing.
+
+### Why a canary probe — reading the payload is not sufficient
+
+The rule above ("clean requires `auditReportVersion`") is necessary and **not
+sufficient**, which we measured rather than argued.
+
+Pointed at a local stub that answers the bulk-advisory endpoint with HTTP 200
+and an empty body, `npm audit` returns:
+
+```json
+{ "auditReportVersion": 2, "vulnerabilities": {},
+  "metadata": { "dependencies": { "total": 573, "...": "..." } } }
+```
+
+No `error` key. A correct report version. A full and entirely plausible
+dependency count — because **npm computes `metadata.dependencies` locally from
+the lockfile and never receives it from the registry.** The payload is
+byte-identical to a genuinely clean audit. No inspection of it can tell the two
+apart, which also rules out the obvious cross-check (comparing the audited
+dependency count against the lockfile's package count); that number is local
+knowledge and stays correct while the advisory data is missing entirely.
+
+The threat is mundane: an internal npm mirror — Artifactory, Nexus, Verdaccio —
+whose advisory endpoint is unimplemented, misconfigured, or silently degraded.
+ADR-0017 § Context establishes that this repo lives alongside an org-managed
+scanning estate, so a non-default registry is a realistic configuration rather
+than a hypothetical one.
+
+So the gate audits a **canary** first: a throwaway lockfile pinning
+`lodash@4.17.11`, whose critical prototype-pollution advisory
+(GHSA-jf85-cpcp-j695) has been published for years. If the endpoint does not
+report it, the endpoint is not reporting anything, and the run is a tool error
+rather than a pass.
+
+This is the same argument the `sast` recipe already makes for
+`tools/test-semgrep-argv-boundary.py`: a scan that is silent when it works and
+silent when it has been broken into a no-op cannot tell you which one happened,
+so something known-positive has to be run through it.
 
 ## Consequences
 
@@ -141,9 +186,18 @@ not listed, so a third npm project cannot be added without the gate noticing.
   mode this whole gate exists to avoid.
 
 **Neutral / to revisit:**
-- **Tightening to `--audit-level=moderate`.** Not taken now; `web/`'s moderate
-  `postcss` finding was fixed opportunistically rather than gated, so the
-  tightening is cheap whenever it is wanted.
+- **Tightening to `low`.** Not taken. `moderate` is the floor that maps most
+  nearly onto Bandit's `medium`; going lower would gate advisory noise that the
+  Python half of the same gate deliberately ignores.
+- **The canary pin is a maintenance item.** If GHSA-jf85-cpcp-j695 is ever
+  withdrawn, the probe goes silent and the gate wedges closed — loudly, with an
+  error naming the fix (repin the canary). Failing closed on a withdrawn
+  advisory is the correct direction for the error to point, but it is a real
+  future interrupt and is recorded here so it is diagnosable at a glance.
+- **The allowlist's `unblocked_when` is prose the gate never reads.** ADR-0017's
+  `.snyk` policy carries a machine-checked `expires`; mirroring that here would
+  stop a suppression rotting indefinitely. Deliberately not built while the
+  allowlist is empty — there is nothing to expire yet.
 - **Dependabot** (`npm-dependabot-wiring`) — complementary automation, left to
   the repo owner.
 - **Machine enforcement of the `allowScripts` install-script invariant**

--- a/docs/adr/0083-extend-sast-sca-gate-to-npm-with-audit-and-allowlist.md
+++ b/docs/adr/0083-extend-sast-sca-gate-to-npm-with-audit-and-allowlist.md
@@ -1,0 +1,158 @@
+# ADR-0083: Extend the SAST/SCA gate to npm with `npm audit` + a reasoned allowlist
+
+- **Status:** Accepted <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
+- **Date:** 2026-08-16
+- **Deciders:** eugenelim
+- **Supersedes:** none
+- **Related:** extends ADR-0017 (Bandit + pip-audit + Semgrep as the repo's SAST/SCA gate) to a second ecosystem; the implementing spec `docs/specs/npm-sca-gate/`
+
+## Context
+
+ADR-0017 adopted Bandit + pip-audit + Semgrep and named the result the repo's
+"SAST/SCA gate". The SCA half is `pip-audit`, and it is thorough: every
+third-party pin in `tools/requirements.txt`, every `packs/**/requirements.txt`,
+both PEP 517 build-system tables, the SAST tooling's own requirements, and
+`credbroker`'s optional `[crypto]` extra.
+
+It audits no JavaScript, because there was none in the tree when ADR-0017 was
+written. There is now:
+
+- `web/` — the marketing site, approved by RFC-0061, first Node toolchain in the
+  repo.
+- `docs-site/` — the Starlight docs site.
+
+Both commit a `package-lock.json`, and both ship their resolved trees into built
+output. `spec/docs-site-design-refresh` (AC9) made this materially worse in a way
+worth naming: it replaced mermaid's runtime CDN `<script>` with a bundled
+`mermaid@11.16.1` dependency. That was the right call for the CDN-call boundary
+it was solving, and it vendored mermaid's entire transitive tree into shipped
+output. That spec recorded the consequence honestly as a deferral
+(`docs-site-npm-sca-gap`) rather than pretending it was covered.
+
+The gap was not theoretical. At the time this ADR was written, both lockfiles
+carried two unremediated **high**-severity advisories (`js-yaml`
+GHSA-5p4m-2wfm-xmqj, `nanoid` GHSA-2v37-7h3g-55p8) and `web/` additionally
+carried a moderate `postcss` advisory. Nothing in the repo would have said so.
+That is precisely the class of finding ADR-0017 § Context names as its reason
+for existing: the org's Snyk scan reports it, and the maintainer cannot see that
+scan's output.
+
+## Decision
+
+**Add `npm audit` as a fourth scanner on the existing `make sast` gate, invoked
+through a thin stdlib wrapper (`tools/audit-npm.py`) that carries a reasoned
+advisory allowlist.**
+
+### Why a leg on `make sast` rather than a new workflow
+
+`make sast` is chained into `make build-check`, which is what `build-check.yml`
+runs — and `build-check.yml` is the **one** workflow inside
+`tools/lint-ci-parity.py`'s `WORKFLOW_SCOPE`. A gate added there is locally
+reproducible and drift-checked by construction.
+
+The alternatives all forfeit that. A job in `ci-security.yml` or a new workflow
+file lands outside parity scope, which is the exact defect
+`spec/local-gate-ci-parity` was written to close: a CI step with no local
+counterpart and nothing detecting the divergence. Putting npm SCA anywhere other
+than the gate already named "SCA" would also leave a reader reconciling two
+coverage stories by hand.
+
+One consequence has to be wired deliberately: **both lockfiles are added to the
+Makefile's `SAST_CONFIG`.** `build-check.yml` computes SAST relevance from
+`SAST_DIRS` + `SAST_CONFIG` against the PR's changed files and sets
+`SKIP_SAST=1` when nothing matches. Neither `docs-site/` nor `web/` is under
+`SAST_DIRS`, so without this a dependency-bump PR — a diff whose only changed
+file is a lockfile — would skip the one gate written to check it.
+
+### Why `npm audit` rather than Dependabot or Snyk Open Source
+
+| Option | Blocks a merge? | Cost | Verdict |
+|---|---|---|---|
+| **`npm audit`** | Yes — it is a gate | Zero: ships with npm, already on every runner and contributor machine | **Chosen** |
+| Dependabot | No — it opens bump PRs | Free, but changes team PR volume and review workload | Deferred (`npm-dependabot-wiring`); complementary, not a substitute |
+| Snyk Open Source | Yes | Needs an account and a token in CI | Rejected: ADR-0017 already rejected tool choices requiring org-scan access the maintainer does not have |
+
+Dependabot and `npm audit` answer different questions — "should we bump?" versus
+"may this merge?" — so choosing the gate first is not a rejection of Dependabot,
+only an ordering. Adopting it remains open as a backlog item, deliberately left
+to the repo owner because it changes how much review the team absorbs per week.
+
+### Why a wrapper rather than two `npm audit` lines in the recipe
+
+`npm audit` has **no per-advisory ignore**. Its only lever is `--audit-level`,
+which is repo-wide and coarse: the escape hatch for a single unfixable
+transitive advisory is to stop gating an entire severity band.
+
+That matters here specifically because suppressions are the observed steady state
+of this control in this repo, not a hypothesis. The sibling `pip-audit` leg runs
+today with four live `--ignore-vuln` entries (Semgrep's hard-pinned `mcp` and
+`click` transitive CVEs), each carrying a written diagnosis and an unblock
+condition. A gate shipped without an escape hatch would wedge every merge the
+first time a no-fix-available advisory lands — and the hatch would then be
+designed under exactly the pressure that produces a bad one.
+
+So `tools/npm-audit-allowlist.toml` ships **empty**, and every entry must carry
+`id`, a non-blank `reason`, and a non-blank `unblocked_when`. A missing or blank
+field is a tool error, not a silent pass: an allowlist that decays into an
+undocumented mute list is worse than no allowlist.
+
+### Why the verdict is read from the payload, not the exit code
+
+`npm audit` exits non-zero for *both* "found advisories" and "could not reach the
+registry". Reading the exit code alone would make a network outage, a proxy
+returning an HTML error page, or a corporate MITM indistinguishable from a clean
+tree — a gate that fails **open** exactly when the environment is degraded.
+
+So a "clean" verdict is reachable only from a parsed payload carrying
+`auditReportVersion`. Everything else — npm absent, unparseable output, an
+`error` key, an unrecognised schema, or zero lockfiles discovered — exits 2, the
+distinct tool-error code. `tools/test-audit-npm.py` pins those paths against
+fixtures, because a live run against a healthy registry never reaches them.
+
+### Threshold and scope
+
+Blocking at `high` (with `critical`), matching the existing gate's tuning
+(Bandit runs medium/medium). Lockfiles are **discovered** by walking the tree,
+not listed, so a third npm project cannot be added without the gate noticing.
+
+## Consequences
+
+**Positive:**
+- The gate's name and its coverage now agree. Both dependency ecosystems in the
+  tree are scanned by the same `make sast` invocation, locally and in CI.
+- Three real advisories were found and fixed on arrival — all transitive patch
+  bumps that left both `package.json` files untouched.
+- The escape hatch exists before it is needed, so the first suppression is a
+  reviewed diff with a written unblock condition rather than an emergency
+  `--audit-level` downgrade.
+- No new dependency: `npm` is already required to build either site, and the
+  wrapper is pure stdlib, preserving ADR-0017's dev/CI-only-tooling posture.
+
+**Negative:**
+- `make sast` gains another network-bound leg. ADR-0017 already accepted this
+  trade for Semgrep's registry fetches and pip-audit's index resolution;
+  `SKIP_SAST=1` remains the documented offline path.
+- The advisory database moves independently of the repo, so a previously green
+  gate can redden with no diff. Identical to the `pip-audit` and Semgrep legs;
+  the allowlist is the response.
+- `npm` becomes a hard requirement of `make sast` on a machine that previously
+  needed only Python. Guarded explicitly with an install hint rather than
+  skipped silently — a skipped SCA leg that still prints green is the failure
+  mode this whole gate exists to avoid.
+
+**Neutral / to revisit:**
+- **Tightening to `--audit-level=moderate`.** Not taken now; `web/`'s moderate
+  `postcss` finding was fixed opportunistically rather than gated, so the
+  tightening is cheap whenever it is wanted.
+- **Dependabot** (`npm-dependabot-wiring`) — complementary automation, left to
+  the repo owner.
+- **Machine enforcement of the `allowScripts` install-script invariant**
+  (`npm-allowscripts-enforcement`). Both `AGENTS.md` files document it as prose
+  and nothing checks it. Deliberately not built here: `web/`'s lockfile already
+  carries `playwright/node_modules/fsevents@2.3.2` outside its `allowScripts`
+  keys, so the gate would land CI red on arrival. That divergence needs a
+  disposition before the check can exist. Note the distinction — SCA scans for
+  *known CVEs*; `allowScripts` governs *arbitrary code execution at install
+  time*. Neither substitutes for the other.
+- **JavaScript SAST** (`sast-javascript-coverage`) remains open. SCA and SAST are
+  different lenses; this ADR adds only the first for npm.

--- a/docs/specs/npm-sca-gate/plan.md
+++ b/docs/specs/npm-sca-gate/plan.md
@@ -134,7 +134,7 @@ contributor changing the linter looks.
 
 ### T4 — remediate both lockfiles (AC5)
 
-**Tests:** goal-based + manual QA. `Done when:` `npm audit --audit-level=high`
+**Tests:** goal-based + manual QA. `Done when:` `npm audit --audit-level=moderate`
 reports 0 in each; `git diff --stat` shows no `package.json`; the
 `hasInstallScript` set is unchanged in both.
 

--- a/docs/specs/npm-sca-gate/plan.md
+++ b/docs/specs/npm-sca-gate/plan.md
@@ -1,0 +1,187 @@
+# Plan: npm-sca-gate
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Executing <!-- Drafting | Executing | Done -->
+
+> **Plan contract:** this is the implementation strategy. Unlike the spec, this
+> document is allowed to change as you learn. When it changes substantially
+> (a different approach, not just a re-ordering), note why in the changelog
+> at the bottom.
+
+## Approach
+
+### The integration-point decision (spec Objective)
+
+Four options were on the table for where npm SCA runs:
+
+| | Option | Local↔CI parity | Notes |
+|---|---|---|---|
+| (a) | New job in `ci-security.yml` | **No** | `ci-security.yml` is out of `lint-ci-parity.py`'s `WORKFLOW_SCOPE` — a step added there has no local counterpart and nothing detects that |
+| (b) | New standalone workflow | No | Fails `lint-ci-parity` until classified in `WORKFLOW_SCOPE`; classifying it out-of-scope reproduces (a)'s defect by hand |
+| (c) | `.github/dependabot.yml` only | n/a | Not a gate — proposes bumps, never blocks a merge. Does not discharge the deferral |
+| (d) | **New leg on `make sast`** | **Yes, by construction** | Already chained into `build-check` → `build-check.yml`, the one workflow `lint-ci-parity` holds in scope |
+
+**Chosen: (d).** ADR-0017 named the gate "SAST/SCA" and built it with `pip-audit`
+as the SCA leg. npm is a second ecosystem on the same control, not a new control.
+Putting it anywhere else would leave the repo with two SCA gates whose coverage a
+reader has to reconcile by hand.
+
+The decision has one non-obvious dependency: **`SAST_CONFIG` must gain both
+lockfiles.** `build-check.yml` computes SAST relevance from
+`make -s print-sast-dirs` / `print-sast-config` against the PR's changed files,
+and sets `SKIP_SAST=1` when nothing matches. Neither `docs-site/` nor `web/` is
+under `SAST_DIRS` (`tools packs packages tests`), so without the `SAST_CONFIG`
+addition a lockfile-only PR — precisely the diff shape a dependency bump has —
+would skip the gate that exists to check it. This is the same class of defect
+`spec/local-gate-ci-parity` was written to close, so repeating it here would be
+unforgivable.
+
+### The wrapper decision (spec § Boundaries, AC3)
+
+`npm audit` has no per-advisory ignore. Its only lever is `--audit-level`, which
+is repo-wide and coarse: the escape hatch for one unfixable transitive advisory
+is to stop gating an entire severity band.
+
+That is not a hypothetical problem for this repo. The `pip-audit` leg in
+`make sast` runs today with four live `--ignore-vuln` suppressions (Semgrep's
+hard-pinned `mcp` and `click` transitive CVEs), each carrying a written
+diagnosis and an unblock condition. The observed steady state of this control,
+in this repo, includes suppressions. A gate shipped without an escape hatch
+would wedge every merge the first time a no-fix-available advisory lands — and
+the hatch would then be designed under exactly the pressure that produces a bad
+one.
+
+So: a thin stdlib wrapper that parses `npm audit --json` and applies an
+ID-keyed allowlist. It ships **empty**; the mechanism exists so the first
+suppression is a reviewed diff rather than a `--audit-level` downgrade.
+
+Rejected: two bare `npm audit` lines in the `sast:` recipe (~2 lines vs ~150
+including the self-test). Cheaper today, and it forfeits the allowlist, the
+three-way exit code, lockfile discovery, and any way to prove the gate is not a
+no-op.
+
+### Discovery over a hardcoded list
+
+The tool walks for `package-lock.json` rather than naming `docs-site` and `web`.
+A hardcoded pair silently under-covers the moment a third npm project lands —
+the same failure mode as `WORKFLOW_SCOPE` being a hand-maintained list, which
+`lint-ci-parity` solves by failing on any unclassified file. Discovery is
+cheaper here than classification: there is nothing to decide per lockfile.
+
+`node_modules/` is excluded. Nested lockfiles inside an installed tree are
+dependency artifacts, not projects, and auditing them would both duplicate
+findings and depend on whether someone happened to run `npm ci`.
+
+### Remediation (AC5)
+
+`npm audit fix --package-lock-only` in each project. Verified on scratch copies
+before planning: it resolves all findings in both, and leaves both
+`package.json` files byte-identical — every fix is a transitive patch bump.
+
+| Project | Change |
+|---|---|
+| `docs-site/` | `js-yaml` 4.3.0 → 4.3.1, `nanoid` 3.3.16 → 3.3.18 |
+| `web/` | the same two, plus `postcss` 8.5.19 → 8.5.26 |
+
+The install-script invariant is re-checked after the bump: the
+`"hasInstallScript": true` set is unchanged in both lockfiles
+(`esbuild@0.28.1`, `fsevents@2.3.3`, and in `web/` a pre-existing
+`playwright/node_modules/fsevents@2.3.2`). That third entry already sits outside
+`web/package.json`'s `allowScripts` keys and is **pre-existing, not introduced
+here** — it is the reason `npm-allowscripts-enforcement` is deferred rather than
+built: turning that invariant into a gate today would land CI red on arrival.
+
+## Tasks
+
+### T1 — `tools/audit-npm.py` + self-test (AC1, AC3, AC4)
+
+**Tests:** `tools/test-audit-npm.py`, TDD, written first as a red stub. Eight
+cases against synthetic `npm audit --json` fixtures (no network, no npm):
+clean passes; `high` fails; `critical` fails; `moderate` passes; allowlisted
+`high` passes and prints; allowlist entry missing `reason`/`unblocked_when` is
+a tool error; **a payload carrying an `error` key is a tool error, not a pass**;
+**a payload with no `auditReportVersion` is a tool error, not a pass**. Plus a
+discovery case: a lockfile under `node_modules/` is not discovered.
+
+The last two are the fail-closed cases from AC1a and are the reason this task is
+TDD rather than goal-based — they are exactly the paths a live run against a
+healthy registry never exercises, so nothing but a fixture can prove them.
+
+**Approach:** pure functions for the two decidable parts — `discover_lockfiles`
+(path → list) and `evaluate(report, allowlist)` (parsed JSON → verdict) — with
+`subprocess` confined to one thin `run_audit` shim the tests do not touch.
+Mirrors `tools/audit-requirements.py`'s shape. Three-way exit: 0 clean,
+1 findings, 2 tool error.
+
+### T2 — chain into `make sast` + `SAST_CONFIG` (AC2)
+
+**Tests:** goal-based. `Done when:` `make -s print-sast-config` names both
+lockfiles, and `make sast` reaches the npm leg (observed in a real run).
+
+**Approach:** self-test line then audit line, placed with the other SCA legs and
+before the Semgrep scan, so the fast deterministic check fails before the slow
+network scan. `command -v npm` guard alongside the existing `bandit` /
+`pip-audit` / `semgrep` guards.
+
+### T3 — register in `tools/test-all.py` (AC4)
+
+**Tests:** goal-based. `Done when:` `python3 tools/test-all.py` runs the new
+entry and exits 0.
+
+**Approach:** one `TESTS` tuple, alphabetical position. Without this the
+self-test only runs inside `make sast`; the umbrella suite is where a
+contributor changing the linter looks.
+
+### T4 — remediate both lockfiles (AC5)
+
+**Tests:** goal-based + manual QA. `Done when:` `npm audit --audit-level=high`
+reports 0 in each; `git diff --stat` shows no `package.json`; the
+`hasInstallScript` set is unchanged in both.
+
+**Approach:** `npm audit fix --package-lock-only` per project. Verify the new
+gate then passes against the real tree — T4 is what turns T1's gate from
+"parses fixtures" into "exits 0 on this repo".
+
+### T5 — docs + ADR + backlog (AC6, AC7, AC8)
+
+**Tests:** goal-based. `Done when:` `tools/lint-agents-md.py` passes (≤150-line
+subdirectory cap); `lint-spec-status.py` resolves both deferral anchors against
+`[backlog].open`.
+
+**Approach:** rewrite `docs-site/AGENTS.md`'s Known-gap paragraph; add the
+matching paragraph to `web/AGENTS.md`; write ADR-0083 and add its back-reference
+to ADR-0017's `Related:` line; in `workspace.toml`, remove
+`docs-site-npm-sca-gap` and add the two new deferral slugs with
+cold-start-sufficient comments.
+
+### T6 — gates + PR (AC9)
+
+**Tests:** manual QA. `Done when:` `make ci` observed green locally; CI observed
+green on the PR with the SAST leg running (not skipped).
+
+## Constraints
+
+- Pure-stdlib Python; no new dependency (root `AGENTS.md`; ADR-0017's
+  zero-runtime-dependency posture).
+- `tools/audit-npm.py` must not mutate anything — no `npm audit fix`, no
+  `npm install`, no lockfile write.
+- Subdirectory `AGENTS.md` ≤ 150 lines, CI-enforced.
+- `docs.yml` `paths:` already covers `docs-site/**/AGENTS.md` and
+  `web/**/AGENTS.md`, so no workflow path change is needed for T5.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Advisory database moves under us — a clean gate reddens with no diff | Accepted, and identical to the `pip-audit` and Semgrep-registry legs ADR-0017 already accepts. The allowlist is the response |
+| `npm` absent on a contributor machine | Explicit `command -v npm` guard with the install hint, matching the three existing guards. Never a silent skip |
+| Network required at gate time | Accepted; `make sast` is already network-bound (Semgrep registry, PyPI). `SKIP_SAST=1` remains the documented offline path |
+| The `SAST_CONFIG` addition is forgotten | AC2 asserts it directly via `make -s print-sast-config`. Note the trap: this PR **cannot** test the predicate end-to-end, because its diff also touches `tools/` (already in `SAST_DIRS`), so `skip_sast=false` either way. Recorded as a stated residual on AC9 rather than claimed as covered |
+| The gate reads a registry error as "clean" | AC1a: exit 0 is reachable only from a parseable report carrying `auditReportVersion`. `npm audit` returns non-zero for both "found advisories" and "could not run", so the verdict is taken from the payload, never the exit code. Two of the six self-test cases pin this |
+
+## Changelog
+
+- **Initial draft** — integration point (d) chosen over a new workflow or
+  `ci-security.yml` job on local↔CI parity grounds; wrapper chosen over bare
+  `npm audit` lines on allowlist grounds, evidenced by the four live
+  `--ignore-vuln` suppressions the sibling `pip-audit` leg already carries.

--- a/docs/specs/npm-sca-gate/plan.md
+++ b/docs/specs/npm-sca-gate/plan.md
@@ -1,7 +1,7 @@
 # Plan: npm-sca-gate
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Executing <!-- Drafting | Executing | Done -->
+- **Status:** Done <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/npm-sca-gate/spec.md
+++ b/docs/specs/npm-sca-gate/spec.md
@@ -1,0 +1,239 @@
+# Spec: npm-sca-gate
+
+- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** ADR-0017, ADR-0083
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+**The repo's SCA gate covers one of its two dependency ecosystems, and nothing
+says so.**
+
+`make sast` is ADR-0017's SAST/SCA gate. It is chained into `make build-check`
+and therefore into `build-check.yml`, the required CI check. Its SCA leg is
+`pip-audit`, run over `tools/requirements.txt`, every `packs/**/requirements.txt`,
+the two PEP 517 build-system tables, `tools/requirements-sast.txt`, and
+`credbroker`'s `[crypto]` extra. Every Python dependency in the tree is audited.
+
+The repo also has two npm projects — `docs-site/` and `web/` — each with a
+committed `package-lock.json`. **Neither is scanned by anything.** No
+`npm audit` runs in any workflow or `make` target; `.github/dependabot.yml` does
+not exist. The gate's name says SCA; its coverage is Python-only, and ADR-0017
+never states the limit because npm was not in the tree when it was written.
+
+Two facts make this live rather than theoretical:
+
+1. **The unscanned surface is shipped code, and it is net-new.** `docs-site`
+   previously loaded mermaid from a CDN. `spec/docs-site-design-refresh` (AC9)
+   bundled `mermaid@11.16.1` instead, which vendors its entire transitive tree
+   into built output. That spec recorded the resulting gap as a deferral —
+   `workspace.toml [backlog].open` slug `docs-site-npm-sca-gap` — and
+   `docs-site/AGENTS.md` carries a matching **Known gap** note. This spec
+   discharges that deferral.
+
+2. **Both lockfiles carry unremediated high-severity advisories today.**
+   Observed at spec time via `npm audit`:
+
+   | Project | Package | Installed | Severity | Advisory |
+   |---|---|---|---|---|
+   | both | `js-yaml` | 4.3.0 | high | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU in `!!omap` resolution |
+   | both | `nanoid` | 3.3.16 | high | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators loop forever when `size` is 0 |
+   | `web/` | `postcss` | 8.5.19 | moderate | attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset |
+
+   All three are **transitive**; all three have fixes available as patch bumps
+   that leave both `package.json` files untouched. None is exploitable in this
+   repo's usage (build-time-only dependencies of two static sites, with no
+   attacker-controlled YAML input, no `nanoid` custom generator, and no
+   PostCSS invocation on untrusted CSS) — this is lockfile hygiene, not an
+   incident. It is nonetheless exactly the class of finding the org's Snyk Open
+   Source scan reports, which ADR-0017 § Context names as the reason the gate
+   exists at all.
+
+The deeper defect is (1), not (2). Bumping three transitive pins fixes today's
+findings and nothing else; the next advisory lands with the same silence. The
+gate is the deliverable.
+
+## Boundaries
+
+### Always do
+
+- Extend the **existing** ADR-0017 gate (`make sast`), rather than adding a new
+  workflow or a new job. `make sast` is already chained into `build-check` and
+  `build-check.yml`, and `build-check.yml` is the one workflow inside
+  `tools/lint-ci-parity.py`'s scope — so a leg added there is locally
+  reproducible and drift-checked by construction. `ci-security.yml` is
+  explicitly out of parity scope and is the wrong home for that reason.
+- Cover **both** npm projects. `docs-site-npm-sca-gap` names `docs-site` because
+  that is where the deferral was recorded, but the gap is repo-wide and `web/`
+  carries the same advisories.
+- Discover lockfiles from the tree, not from a hardcoded list, so a third npm
+  project cannot be added without the gate noticing.
+- Carry an **allowlist** with a documented reason and unblock condition per
+  entry, mirroring the `--ignore-vuln` suppressions the `pip-audit` leg already
+  runs with. Ship it empty.
+- Prove the gate before trusting it: a self-test asserting the parser and the
+  allowlist logic runs immediately before the live audit inside `make sast`,
+  the same pattern `tools/test-audit-requirements.py` already establishes.
+- Keep the tool pure-stdlib Python (root `AGENTS.md` § *New tool scripts:
+  Python, not bash*).
+
+### Never do
+
+- Never run `npm audit fix` — or any mutation — from the gate. A gate reports;
+  remediation lands in a PR a human reviews.
+- Never install `node_modules` to audit. `--package-lock-only` reads the
+  committed lockfile, which is the artifact under audit.
+- Never let an absent `npm` silently pass the gate.
+- Never widen the threshold below `high` to make a finding go away; use the
+  allowlist, which forces a written reason.
+
+## Acceptance Criteria
+
+- [ ] **AC1 (gate exists and is discovered, not listed).** `tools/audit-npm.py`
+      walks the repo for `package-lock.json` files, excluding `node_modules/`,
+      and audits each at `--audit-level=high` with `--package-lock-only`. It
+      exits 0 when every project is clean, 1 on any non-allowlisted advisory at
+      or above `high`, and 2 on a tool error. The three exit codes are
+      distinguishable, matching `tools/test-all.py`'s precedent that "failed"
+      and "never ran" are different facts.
+- [ ] **AC1a (the gate fails closed).** Exit 0 is reachable **only** from an
+      `npm audit` run that produced a parseable report with an
+      `auditReportVersion`. Every other outcome — npm absent, non-zero exit with
+      no parseable JSON, a payload carrying an `error` key (the shape
+      `npm audit` returns when it cannot reach the registry), unrecognised
+      report schema, or no lockfile discovered at all — is exit 2 with the cause
+      named on stderr. This is the AC the rest of the gate rests on: a
+      registry outage or a proxy returning HTML must never be indistinguishable
+      from "no vulnerabilities", and `npm audit` uses a non-zero exit for both
+      "found advisories" and "could not run", so the distinction has to be made
+      from the payload rather than the exit code.
+- [ ] **AC2 (chained into the existing gate, both directions).** `make sast`
+      runs `tools/test-audit-npm.py` then `tools/audit-npm.py`, positioned with
+      the other SCA legs. Both npm lockfiles are added to the `SAST_CONFIG`
+      variable, so `build-check.yml`'s SAST-relevance predicate treats a
+      lockfile-only diff as SAST-relevant — without this, a PR that bumps only a
+      lockfile sets `SKIP_SAST=1` and the gate never runs on the exact diff it
+      exists to catch.
+- [ ] **AC3 (allowlist).** An advisory may be suppressed only by its GHSA/CVE ID
+      in a committed allowlist, and only with a `reason` and an `unblocked_when`
+      string. An entry missing either field is a tool error (exit 2), not a
+      silent pass. Every applied suppression is printed. The allowlist ships
+      **empty** — it is the escape hatch, not a starting position.
+- [ ] **AC4 (self-test proves the gate, not just the plumbing).**
+      `tools/test-audit-npm.py` asserts, against synthetic `npm audit` JSON
+      fixtures: a clean report passes; a `high` finding fails; a `critical`
+      finding fails; a `moderate` finding does not fail; an allowlisted `high`
+      passes and is reported; an allowlist entry missing `reason` or
+      `unblocked_when` is a tool error; **a payload carrying an `error` key is a
+      tool error, not a pass**; **a payload with no `auditReportVersion` is a
+      tool error, not a pass**; and a lockfile under `node_modules/` is not
+      discovered. The two emphasised cases are AC1a's fail-closed paths — a live
+      run against a healthy registry never reaches them, so a fixture is the only
+      thing that can prove them. It is registered in `tools/test-all.py`'s
+      `TESTS`, so it runs in the umbrella suite rather than only when someone
+      remembers.
+- [ ] **AC5 (today's findings remediated).** `docs-site/package-lock.json` and
+      `web/package-lock.json` are updated so `npm audit --audit-level=high`
+      reports zero vulnerabilities in each. Both `package.json` files are
+      **unchanged** — the fixes are transitive. `web/`'s moderate `postcss`
+      advisory is fixed in the same pass because the same `npm audit fix`
+      resolves it; it is not left behind to make a later `--audit-level=moderate`
+      tightening harder. The set of `"hasInstallScript": true` entries is
+      **byte-identical to the pre-change baseline** in both lockfiles — stated
+      against the baseline, not against `allowScripts`, because
+      `web/package-lock.json` already carries a third such entry
+      (`playwright/node_modules/fsevents@2.3.2`) that sits outside
+      `web/package.json`'s `allowScripts` keys. That entry is **pre-existing and
+      untouched**; an AC phrased as "within `allowScripts`" would be false on
+      arrival and unverifiable. Closing that pre-existing divergence is
+      `npm-allowscripts-enforcement` (deferred, see § Assumptions).
+- [ ] **AC6 (documentation drift closed).** `docs-site/AGENTS.md`'s **Known gap**
+      paragraph — which names `docs-site-npm-sca-gap` and states no SCA scanner
+      is wired repo-wide — is replaced by a statement of what now runs.
+      `web/AGENTS.md` gains the equivalent supply-chain paragraph it currently
+      lacks entirely. Both files stay ≤ 150 lines (CI-enforced subdirectory cap).
+- [ ] **AC7 (the decision is recorded).** ADR-0083 records extending ADR-0017's
+      SAST/SCA gate to the npm ecosystem: why `npm audit` over Dependabot or
+      Snyk Open Source, why an allowlist wrapper over two bare Makefile lines,
+      and the accepted consequences (network dependency at gate time; no
+      per-advisory ignore in `npm audit` itself, hence the wrapper). ADR-0017
+      gains a `Related:` pointer so a reader arriving at the Python-only gate
+      finds the npm extension.
+- [ ] **AC8 (backlog reconciled).** `docs-site-npm-sca-gap` is removed from
+      `workspace.toml [backlog].open`. The two deferrals this spec declines are
+      recorded there with cold-start-sufficient comments:
+      `npm-dependabot-wiring` and `npm-allowscripts-enforcement`.
+- [ ] **AC9 (gates green).** `make ci` passes locally, and `build-check.yml`
+      passes on the PR with the SAST leg actually running (not `SKIP_SAST=1`).
+
+      **Stated residual — this PR does not exercise AC2's predicate.** The diff
+      touches `tools/`, which is already in `SAST_DIRS`, so `build-check.yml`
+      routes to `skip_sast=false` for this PR whether or not the `SAST_CONFIG`
+      addition landed. A green SAST leg here therefore proves the gate runs; it
+      does **not** prove the lockfile predicate works. The first real test of
+      that predicate is the next PR whose diff is lockfile-only. What *is*
+      verifiable now is the assertion in AC2 — `make -s print-sast-config` names
+      both lockfiles — and that is the check AC2 is written against. Recording
+      the residual rather than letting a green check imply more than it proves
+      is the same discipline `tools/lint-ci-parity.py` applies to its own
+      `roster-residual-hidden-gate-in-known-step`.
+
+## Testing Strategy
+
+| AC | Mode | Mechanism |
+|---|---|---|
+| AC1, AC3, AC4 | TDD | `tools/test-audit-npm.py` against synthetic `npm audit` JSON fixtures — no network, no npm, deterministic |
+| AC2 | Goal-based | `make sast` reaches the leg; `make -s print-sast-config` names both lockfiles |
+| AC5 | Goal-based + manual QA | `npm audit --audit-level=high` in each project reports 0; `git diff` shows both `package.json` untouched; install-script audit re-run over both lockfiles |
+| AC6, AC7, AC8 | Goal-based | `tools/lint-agents-md.py` line caps; `lint-spec-status.py` deferral-anchor resolution |
+| AC9 | Manual QA | `make ci` observed green locally; CI observed green on the PR |
+
+The self-test is the load-bearing one. A gate whose only proof is "it exited 0
+on a clean tree" cannot distinguish working from broken-into-a-no-op — the same
+reasoning the `sast` recipe already applies to `tools/test-semgrep-argv-boundary.py`
+and `tools/test-audit-requirements.py`.
+
+## Assumptions
+
+- **The human approval gates are pre-authorised.** The user directed this work
+  to run autonomously through PR and merge. That standing authorisation is taken
+  as the `spec-approved` and `plan-approved` signals; it is recorded here rather
+  than left implicit.
+- **Specialist reviewer subagents are unavailable in this session** (operator
+  configuration). The `adversarial-reviewer` and `security-reviewer` passes run
+  as inline self-review against the `security-checklists` `supply-chain` and
+  `config-misconfig` modules, and are recorded as **named skips** — not silent
+  ones — in the PR.
+- `npm` is present on GitHub's `ubuntu-latest` runners (Node is preinstalled) and
+  on contributor machines that already build either site. The gate fails loudly
+  rather than skipping when it is absent, so this assumption is checked at run
+  time rather than trusted.
+- Auditing at `high` matches the existing gate's tuning (Bandit runs at
+  `--severity-level medium --confidence-level medium`; the moderate `postcss`
+  finding is fixed opportunistically but not gated). Tightening to `moderate` is
+  a later decision, deliberately not taken here.
+- **Deferred (recorded in `[backlog].open`; AC8 verifies presence at ship
+  time):** Dependabot wiring for automated bump PRs — deferral slug
+  `npm-dependabot-wiring`. Machine enforcement of the `allowScripts`
+  install-script invariant that both `AGENTS.md` files document as prose —
+  deferral slug `npm-allowscripts-enforcement`.
+
+## Out of scope
+
+- **Dependabot.** Wiring it changes the team's PR volume and review workload —
+  a repo-owner decision, not one this loop should impose. It is also a different
+  control: Dependabot proposes bumps, it does not block a merge.
+- **`packs/converters/**/package.json`.** Those two skills declare npm
+  dependencies but commit no lockfile, so `npm audit` has nothing to read. Their
+  supply-chain integrity is a distinct concern already owned by
+  `[backlog].open` slug `pack-evals-npm-lockfile-integrity`.
+- **JavaScript SAST.** Giving shipped JS dataflow/pattern coverage is a separate
+  control with its own triage cost, already owned by `[backlog].open` slug
+  `sast-javascript-coverage`. SCA (known-CVE dependency scanning) and SAST
+  (source pattern analysis) are different lenses; this spec adds only the first.
+- **`ci-security.yml`.** Left untouched; see § Boundaries for why `make sast` is
+  the correct home.

--- a/docs/specs/npm-sca-gate/spec.md
+++ b/docs/specs/npm-sca-gate/spec.md
@@ -1,6 +1,6 @@
 # Spec: npm-sca-gate
 
-- **Status:** Implementing <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0017, ADR-0083
@@ -101,14 +101,14 @@ gate is the deliverable.
 
 ## Acceptance Criteria
 
-- [ ] **AC1 (gate exists and is discovered, not listed).** `tools/audit-npm.py`
+- [x] **AC1 (gate exists and is discovered, not listed).** `tools/audit-npm.py`
       walks the repo for `package-lock.json` files, excluding `node_modules/`,
       and audits each at `--audit-level=moderate` with `--package-lock-only`. It
       exits 0 when every project is clean, 1 on any non-allowlisted advisory at
       or above `high`, and 2 on a tool error. The three exit codes are
       distinguishable, matching `tools/test-all.py`'s precedent that "failed"
       and "never ran" are different facts.
-- [ ] **AC1a (the gate fails closed).** Exit 0 is reachable **only** from an
+- [x] **AC1a (the gate fails closed).** Exit 0 is reachable **only** from an
       `npm audit` run that produced a parseable report with an
       `auditReportVersion`. Every other outcome — npm absent, non-zero exit with
       no parseable JSON, a payload carrying an `error` key (the shape
@@ -119,7 +119,7 @@ gate is the deliverable.
       from "no vulnerabilities", and `npm audit` uses a non-zero exit for both
       "found advisories" and "could not run", so the distinction has to be made
       from the payload rather than the exit code.
-- [ ] **AC1b (a positive control, because the payload cannot prove coverage).**
+- [x] **AC1b (a positive control, because the payload cannot prove coverage).**
       Before auditing any project lockfile, the gate audits a **canary** — a
       throwaway lockfile pinning a package version with a permanent published
       advisory (`lodash@4.17.11`, GHSA-jf85-cpcp-j695). If that audit reports no
@@ -135,19 +135,19 @@ gate is the deliverable.
       no amount of payload inspection can separate them. Only a known-positive
       can. The relevant threat is mundane rather than exotic: an internal npm
       mirror whose advisory endpoint is unimplemented or misconfigured.
-- [ ] **AC2 (chained into the existing gate, both directions).** `make sast`
+- [x] **AC2 (chained into the existing gate, both directions).** `make sast`
       runs `tools/test-audit-npm.py` then `tools/audit-npm.py`, positioned with
       the other SCA legs. Both npm lockfiles are added to the `SAST_CONFIG`
       variable, so `build-check.yml`'s SAST-relevance predicate treats a
       lockfile-only diff as SAST-relevant — without this, a PR that bumps only a
       lockfile sets `SKIP_SAST=1` and the gate never runs on the exact diff it
       exists to catch.
-- [ ] **AC3 (allowlist).** An advisory may be suppressed only by its GHSA/CVE ID
+- [x] **AC3 (allowlist).** An advisory may be suppressed only by its GHSA/CVE ID
       in a committed allowlist, and only with a `reason` and an `unblocked_when`
       string. An entry missing either field is a tool error (exit 2), not a
       silent pass. Every applied suppression is printed. The allowlist ships
       **empty** — it is the escape hatch, not a starting position.
-- [ ] **AC4 (self-test proves the gate, not just the plumbing).**
+- [x] **AC4 (self-test proves the gate, not just the plumbing).**
       `tools/test-audit-npm.py` asserts, against synthetic `npm audit` JSON
       fixtures: a clean report passes; a `high` finding fails; a `critical`
       finding fails; a `moderate` finding does not fail; an allowlisted `high`
@@ -170,7 +170,7 @@ gate is the deliverable.
       that the same silent-mirror payload *passes* `evaluate()`, which is the
       whole justification for the canary existing, written as an executable
       claim rather than a comment.
-- [ ] **AC5 (today's findings remediated).** `docs-site/package-lock.json` and
+- [x] **AC5 (today's findings remediated).** `docs-site/package-lock.json` and
       `web/package-lock.json` are updated so `npm audit --audit-level=moderate`
       reports zero vulnerabilities in each. Both `package.json` files are
       **unchanged** — the fixes are transitive. `web/`'s moderate `postcss`
@@ -185,23 +185,23 @@ gate is the deliverable.
       untouched**; an AC phrased as "within `allowScripts`" would be false on
       arrival and unverifiable. Closing that pre-existing divergence is
       `npm-allowscripts-enforcement` (deferred, see § Assumptions).
-- [ ] **AC6 (documentation drift closed).** `docs-site/AGENTS.md`'s **Known gap**
+- [x] **AC6 (documentation drift closed).** `docs-site/AGENTS.md`'s **Known gap**
       paragraph — which names `docs-site-npm-sca-gap` and states no SCA scanner
       is wired repo-wide — is replaced by a statement of what now runs.
       `web/AGENTS.md` gains the equivalent supply-chain paragraph it currently
       lacks entirely. Both files stay ≤ 150 lines (CI-enforced subdirectory cap).
-- [ ] **AC7 (the decision is recorded).** ADR-0083 records extending ADR-0017's
+- [x] **AC7 (the decision is recorded).** ADR-0083 records extending ADR-0017's
       SAST/SCA gate to the npm ecosystem: why `npm audit` over Dependabot or
       Snyk Open Source, why an allowlist wrapper over two bare Makefile lines,
       and the accepted consequences (network dependency at gate time; no
       per-advisory ignore in `npm audit` itself, hence the wrapper). ADR-0017
       gains a `Related:` pointer so a reader arriving at the Python-only gate
       finds the npm extension.
-- [ ] **AC8 (backlog reconciled).** `docs-site-npm-sca-gap` is removed from
+- [x] **AC8 (backlog reconciled).** `docs-site-npm-sca-gap` is removed from
       `workspace.toml [backlog].open`. The two deferrals this spec declines are
       recorded there with cold-start-sufficient comments:
       `npm-dependabot-wiring` and `npm-allowscripts-enforcement`.
-- [ ] **AC9 (gates green).** `make ci` passes locally, and `build-check.yml`
+- [x] **AC9 (gates green).** `make ci` passes locally, and `build-check.yml`
       passes on the PR with the SAST leg actually running (not `SKIP_SAST=1`).
 
       **Stated residual — this PR does not exercise AC2's predicate.** The diff

--- a/docs/specs/npm-sca-gate/spec.md
+++ b/docs/specs/npm-sca-gate/spec.md
@@ -45,13 +45,21 @@ Two facts make this live rather than theoretical:
    | `web/` | `postcss` | 8.5.19 | moderate | attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset |
 
    All three are **transitive**; all three have fixes available as patch bumps
-   that leave both `package.json` files untouched. None is exploitable in this
-   repo's usage (build-time-only dependencies of two static sites, with no
-   attacker-controlled YAML input, no `nanoid` custom generator, and no
-   PostCSS invocation on untrusted CSS) — this is lockfile hygiene, not an
-   incident. It is nonetheless exactly the class of finding the org's Snyk Open
-   Source scan reports, which ADR-0017 § Context names as the reason the gate
-   exists at all.
+   that leave both `package.json` files untouched.
+
+   None is exploitable in this repo's usage, and that is checked rather than
+   assumed: reading each lockfile's dependency edges, `js-yaml` is reached only
+   through `astro` / `@astrojs/starlight` / `@astrojs/internal-helpers`,
+   `nanoid` only through `postcss`, and `postcss` only through `vite` and
+   `@expressive-code/core`. Every one of them is **build-time toolchain, not a
+   shipped page bundle** — notably *not* pulled in by the bundled `mermaid`.
+   Combined with the absence of attacker-controlled YAML input, any `nanoid`
+   custom generator, or PostCSS invocation on untrusted CSS, this is lockfile
+   hygiene rather than an incident, and needs no changelog `Security` entry.
+
+   It is nonetheless exactly the class of finding the org's Snyk Open Source
+   scan reports, which ADR-0017 § Context names as the reason the gate exists at
+   all.
 
 The deeper defect is (1), not (2). Bumping three transitive pins fixes today's
 findings and nothing else; the next advisory lands with the same silence. The
@@ -130,12 +138,16 @@ gate is the deliverable.
       passes and is reported; an allowlist entry missing `reason` or
       `unblocked_when` is a tool error; **a payload carrying an `error` key is a
       tool error, not a pass**; **a payload with no `auditReportVersion` is a
-      tool error, not a pass**; and a lockfile under `node_modules/` is not
-      discovered. The two emphasised cases are AC1a's fail-closed paths — a live
-      run against a healthy registry never reaches them, so a fixture is the only
-      thing that can prove them. It is registered in `tools/test-all.py`'s
-      `TESTS`, so it runs in the umbrella suite rather than only when someone
-      remembers.
+      tool error, not a pass**; **a package at blocking severity carrying no
+      `via` advisories is a tool error, not a pass** (while the same shape at a
+      non-blocking severity still passes, so the guard does not over-fire); a
+      lockfile under `node_modules/` is not discovered; and a symlinked
+      *directory* is pruned for loop safety while a symlinked *lockfile* is
+      still discovered. The emphasised cases are AC1a's fail-closed paths — a
+      live run against a healthy registry never reaches them, so a fixture is
+      the only thing that can prove them. It is registered in
+      `tools/test-all.py`'s `TESTS`, so it runs in the umbrella suite rather
+      than only when someone remembers.
 - [ ] **AC5 (today's findings remediated).** `docs-site/package-lock.json` and
       `web/package-lock.json` are updated so `npm audit --audit-level=high`
       reports zero vulnerabilities in each. Both `package.json` files are

--- a/docs/specs/npm-sca-gate/spec.md
+++ b/docs/specs/npm-sca-gate/spec.md
@@ -103,7 +103,7 @@ gate is the deliverable.
 
 - [ ] **AC1 (gate exists and is discovered, not listed).** `tools/audit-npm.py`
       walks the repo for `package-lock.json` files, excluding `node_modules/`,
-      and audits each at `--audit-level=high` with `--package-lock-only`. It
+      and audits each at `--audit-level=moderate` with `--package-lock-only`. It
       exits 0 when every project is clean, 1 on any non-allowlisted advisory at
       or above `high`, and 2 on a tool error. The three exit codes are
       distinguishable, matching `tools/test-all.py`'s precedent that "failed"
@@ -119,6 +119,22 @@ gate is the deliverable.
       from "no vulnerabilities", and `npm audit` uses a non-zero exit for both
       "found advisories" and "could not run", so the distinction has to be made
       from the payload rather than the exit code.
+- [ ] **AC1b (a positive control, because the payload cannot prove coverage).**
+      Before auditing any project lockfile, the gate audits a **canary** — a
+      throwaway lockfile pinning a package version with a permanent published
+      advisory (`lodash@4.17.11`, GHSA-jf85-cpcp-j695). If that audit reports no
+      advisory for the canary, the run is a tool error (exit 2), not a pass.
+
+      This exists because AC1a is necessary but **not sufficient**, which was
+      measured rather than assumed. Against a local stub returning HTTP 200 with
+      an empty advisory body, `npm audit` emits `auditReportVersion: 2`,
+      `vulnerabilities: {}`, **no** `error` key, and a complete, plausible
+      `metadata.dependencies` block (573 deps) — the last because npm computes
+      dependency counts locally from the lockfile and never receives them from
+      the registry. The payload is byte-identical to a genuinely clean audit, so
+      no amount of payload inspection can separate them. Only a known-positive
+      can. The relevant threat is mundane rather than exotic: an internal npm
+      mirror whose advisory endpoint is unimplemented or misconfigured.
 - [ ] **AC2 (chained into the existing gate, both directions).** `make sast`
       runs `tools/test-audit-npm.py` then `tools/audit-npm.py`, positioned with
       the other SCA legs. Both npm lockfiles are added to the `SAST_CONFIG`
@@ -148,8 +164,14 @@ gate is the deliverable.
       the only thing that can prove them. It is registered in
       `tools/test-all.py`'s `TESTS`, so it runs in the umbrella suite rather
       than only when someone remembers.
+
+      It additionally covers AC1b: the canary reads as live when the endpoint
+      answers and **not** live against the silent-mirror payload — and asserts
+      that the same silent-mirror payload *passes* `evaluate()`, which is the
+      whole justification for the canary existing, written as an executable
+      claim rather than a comment.
 - [ ] **AC5 (today's findings remediated).** `docs-site/package-lock.json` and
-      `web/package-lock.json` are updated so `npm audit --audit-level=high`
+      `web/package-lock.json` are updated so `npm audit --audit-level=moderate`
       reports zero vulnerabilities in each. Both `package.json` files are
       **unchanged** — the fixes are transitive. `web/`'s moderate `postcss`
       advisory is fixed in the same pass because the same `npm audit fix`
@@ -198,9 +220,10 @@ gate is the deliverable.
 
 | AC | Mode | Mechanism |
 |---|---|---|
-| AC1, AC3, AC4 | TDD | `tools/test-audit-npm.py` against synthetic `npm audit` JSON fixtures — no network, no npm, deterministic |
+| AC1, AC1a, AC3, AC4 | TDD | `tools/test-audit-npm.py` against synthetic `npm audit` JSON fixtures — no network, no npm, deterministic |
+| AC1b | Manual QA (adversarial) | Stand up a local stub answering the bulk-advisory endpoint with HTTP 200 and an empty body, point `npm_config_registry` at it, and run the gate: it must exit **2** naming the silent endpoint, not 0. Re-run against the real registry: exit 0 with the canary confirmed. Both observed and recorded in the PR — the fixture half is covered by the row above |
 | AC2 | Goal-based | `make sast` reaches the leg; `make -s print-sast-config` names both lockfiles |
-| AC5 | Goal-based + manual QA | `npm audit --audit-level=high` in each project reports 0; `git diff` shows both `package.json` untouched; install-script audit re-run over both lockfiles |
+| AC5 | Goal-based + manual QA | `npm audit --audit-level=moderate` in each project reports 0; `git diff` shows both `package.json` untouched; install-script audit re-run over both lockfiles |
 | AC6, AC7, AC8 | Goal-based | `tools/lint-agents-md.py` line caps; `lint-spec-status.py` deferral-anchor resolution |
 | AC9 | Manual QA | `make ci` observed green locally; CI observed green on the PR |
 
@@ -224,10 +247,17 @@ and `tools/test-audit-requirements.py`.
   on contributor machines that already build either site. The gate fails loudly
   rather than skipping when it is absent, so this assumption is checked at run
   time rather than trusted.
-- Auditing at `high` matches the existing gate's tuning (Bandit runs at
-  `--severity-level medium --confidence-level medium`; the moderate `postcss`
-  finding is fixed opportunistically but not gated). Tightening to `moderate` is
-  a later decision, deliberately not taken here.
+- **Auditing at `moderate`.** This spec originally set the threshold at `high`
+  to match the existing gate's tuning (Bandit runs `--severity-level medium
+  --confidence-level medium`) and deferred any tightening. That was reversed
+  during implementation, on evidence: fixing `web/`'s moderate `postcss`
+  advisory left **both lockfiles clean at `moderate`**, so raising the bar cost
+  nothing. The cheapest moment to raise a bar is while you are already above it
+  — deferring means tightening on a day when there *is* a moderate finding,
+  which turns a one-word diff into an argument. `low` and `info` remain
+  ungated; `moderate` is also the level Bandit's `medium` most nearly
+  corresponds to, so the gate is now *more* consistent with ADR-0017's tuning,
+  not less.
 - **Deferred (recorded in `[backlog].open`; AC8 verifies presence at ship
   time):** Dependabot wiring for automated bump PRs — deferral slug
   `npm-dependabot-wiring`. Machine enforcement of the `allowScripts`

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -106,17 +106,24 @@ def discover_lockfiles(root: Path) -> list[Path]:
         current = stack.pop()
         try:
             entries = list(current.iterdir())
-        except OSError:
-            # An unreadable directory is not a silent skip at the top level, but
-            # deep in a tree it is almost always a permissions artifact. The
-            # no-lockfile-found guard in main() catches the case where this
-            # swallowed everything.
+        except OSError as exc:
+            # Not silent: an unreadable directory is almost always a permissions
+            # artifact, but a walk that quietly skipped the one directory holding
+            # a lockfile would under-cover and still print green. The
+            # no-lockfile-found guard in main() only catches total failure, so
+            # partial failure has to announce itself.
+            print(f"audit-npm: warning: cannot read {current}: {exc}", file=sys.stderr)
             continue
         for entry in entries:
-            if entry.is_symlink():
-                continue
             if entry.is_dir():
-                if entry.name in _PRUNED_DIR_NAMES or entry.name.startswith("."):
+                # Symlinked directories are skipped for loop safety; symlinked
+                # *files* are not, so a lockfile linked into place is still
+                # audited rather than silently dropped.
+                if (
+                    entry.is_symlink()
+                    or entry.name in _PRUNED_DIR_NAMES
+                    or entry.name.startswith(".")
+                ):
                     continue
                 stack.append(entry)
             elif entry.name == LOCKFILE_NAME:
@@ -217,7 +224,16 @@ def evaluate(report: object, allowlist: dict[str, dict[str, str]]) -> Verdict:
     for package, detail in vulnerabilities.items():
         if not isinstance(detail, dict):
             raise AuditError(f"audit entry for {package!r} is not an object")
-        for via in detail.get("via", []):
+        via_entries = detail.get("via", [])
+        if detail.get("severity") in BLOCKING_SEVERITIES and not via_entries:
+            # A blocking package with no `via` at all is a shape npm does not
+            # emit. Reading it as "nothing to report" would drop a real finding,
+            # so it joins the AC1a fail-closed set rather than passing quietly.
+            raise AuditError(
+                f"audit entry for {package!r} is {detail.get('severity')} but "
+                f"carries no `via` advisories — unrecognised report shape"
+            )
+        for via in via_entries:
             if not isinstance(via, dict):
                 continue  # chain link; its root advisory is judged on its own entry
             severity = via.get("severity")
@@ -313,13 +329,10 @@ def _report(project: Path, verdict: Verdict, root: Path) -> None:
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=str(_REPO_ROOT))
-    parser.add_argument("--allowlist", default=None)
     args = parser.parse_args(argv)
 
     root = Path(args.root).resolve()
-    allowlist_path = (
-        Path(args.allowlist).resolve() if args.allowlist else root / DEFAULT_ALLOWLIST
-    )
+    allowlist_path = root / DEFAULT_ALLOWLIST
 
     try:
         allowlist = load_allowlist(allowlist_path)

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Run `npm audit` over every committed npm lockfile — the npm SCA leg of
+`make sast` (ADR-0017, extended to the npm ecosystem by ADR-0083).
+
+ADR-0017 named the repo's gate "SAST/SCA" and built its SCA half with
+`pip-audit`. That audits every Python dependency in the tree. It audits no
+JavaScript at all, and the repo has two npm projects — `docs-site/` and `web/` —
+whose committed lockfiles ship into built output. This closes that half.
+
+**Why a wrapper rather than two `npm audit` lines in the Makefile.** `npm audit`
+has no per-advisory ignore. Its only lever is `--audit-level`, which is
+repo-wide: the escape hatch for one unfixable transitive advisory is to stop
+gating an entire severity band. The sibling `pip-audit` leg in `make sast`
+already runs with four live `--ignore-vuln` suppressions, each carrying a
+written diagnosis and an unblock condition — suppressions are the observed
+steady state of this control in this repo, not a hypothetical. So the escape
+hatch is built now, as an ID-keyed allowlist that forces a reason and an unblock
+condition into a reviewed diff, and it ships empty.
+
+**Why the verdict comes from the payload, never the exit code.** `npm audit`
+exits non-zero for *both* "found advisories" and "could not reach the registry".
+Reading its exit code alone would make a network outage, a proxy returning an
+HTML error page, or a corporate MITM indistinguishable from a clean tree — a
+gate that fails open exactly when the environment is degraded. So a verdict of
+"clean" is reachable only from a parsed payload carrying `auditReportVersion`;
+everything else is a tool error. `tools/test-audit-npm.py` pins that path,
+because a live run against a healthy registry never reaches it.
+
+Lockfiles are **discovered**, not listed, so a third npm project cannot be added
+without the gate noticing. `node_modules/` and dot-directories are pruned:
+lockfiles inside an installed tree are dependency artifacts, not projects, and
+whether they exist at all depends on who last ran `npm ci`.
+
+Usage:
+    audit-npm.py [--root .] [--allowlist tools/npm-audit-allowlist.toml]
+
+Exit codes — three outcomes, deliberately distinguishable (same reasoning as
+`tools/test-all.py`: "found advisories" and "never actually ran" are different
+facts, and reporting the second as the first is how a gate sits green for weeks):
+
+  0  every discovered lockfile audited clean, or its only findings were
+     allowlisted (each printed).
+  1  at least one non-allowlisted advisory at or above the blocking threshold.
+  2  the gate could not run: npm absent, unreadable or unparseable audit output,
+     an error payload, an unrecognised report schema, a malformed allowlist, or
+     no lockfile discovered at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess  # nosec B404 - invokes `npm` with a fixed, non-shell argv
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+LOCKFILE_NAME = "package-lock.json"
+DEFAULT_ALLOWLIST = "tools/npm-audit-allowlist.toml"
+
+# Matches the `--audit-level=high` passed to npm. npm's own flag decides its
+# exit code; this set decides ours, and ours is the one that gates. Keeping both
+# means a future npm that changes its threshold semantics cannot quietly widen
+# the gate.
+BLOCKING_SEVERITIES = frozenset({"high", "critical"})
+AUDIT_LEVEL = "high"
+
+# Directories that never contain a *project* lockfile.
+_PRUNED_DIR_NAMES = frozenset({"node_modules"})
+
+
+class AuditError(Exception):
+    """The gate could not run. Always exit 2 — never a pass, never a finding."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    advisory_id: str
+    package: str
+    severity: str
+    title: str
+    url: str
+
+
+@dataclass(frozen=True)
+class Verdict:
+    blocking: list[Finding]
+    suppressed: list[Finding]
+
+
+def discover_lockfiles(root: Path) -> list[Path]:
+    """Every project `package-lock.json` under *root*, sorted for stable output.
+
+    Prunes `node_modules/` and dot-directories. Pruning happens on the walk, not
+    as a post-filter, so an installed `node_modules` tree costs nothing to skip.
+    """
+    found: list[Path] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            # An unreadable directory is not a silent skip at the top level, but
+            # deep in a tree it is almost always a permissions artifact. The
+            # no-lockfile-found guard in main() catches the case where this
+            # swallowed everything.
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name in _PRUNED_DIR_NAMES or entry.name.startswith("."):
+                    continue
+                stack.append(entry)
+            elif entry.name == LOCKFILE_NAME:
+                found.append(entry)
+    return sorted(found)
+
+
+def load_allowlist(path: Path) -> dict[str, dict[str, str]]:
+    """Parse the advisory allowlist. A malformed entry is an error, not a skip.
+
+    Every entry must carry `id`, a non-blank `reason`, and a non-blank
+    `unblocked_when`. Enforcing that here — rather than treating a bare `id` as
+    "suppress it" — is what keeps the allowlist from decaying into an
+    undocumented mute list, which is the failure mode that makes a suppression
+    mechanism worse than none.
+    """
+    if not path.is_file():
+        raise AuditError(f"allowlist not found: {path}")
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise AuditError(f"allowlist {path} is unreadable: {exc}") from exc
+
+    entries = data.get("allow", [])
+    if not isinstance(entries, list):
+        raise AuditError(f"allowlist {path}: `allow` must be an array of tables")
+
+    result: dict[str, dict[str, str]] = {}
+    for index, entry in enumerate(entries):
+        where = f"allowlist {path} entry #{index + 1}"
+        if not isinstance(entry, dict):
+            raise AuditError(f"{where}: must be a table")
+        advisory = entry.get("id")
+        if not isinstance(advisory, str) or not advisory.strip():
+            raise AuditError(f"{where}: missing a non-blank `id`")
+        for field in ("reason", "unblocked_when"):
+            value = entry.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise AuditError(
+                    f"{where} ({advisory}): missing a non-blank `{field}` — a "
+                    f"suppression without one is an undocumented mute"
+                )
+        result[advisory.strip()] = {
+            "reason": entry["reason"].strip(),
+            "unblocked_when": entry["unblocked_when"].strip(),
+        }
+    return result
+
+
+def advisory_id(via: dict) -> str:
+    """The advisory's stable public ID: GHSA-… or CVE-… from its URL.
+
+    Falls back to `npm:<source>` so an advisory without a GitHub URL is still
+    addressable by the allowlist rather than being unsuppressable.
+    """
+    url = via.get("url")
+    if isinstance(url, str) and url:
+        tail = url.rstrip("/").rsplit("/", 1)[-1]
+        if tail.startswith(("GHSA-", "CVE-")):
+            return tail
+    source = via.get("source")
+    if source is not None:
+        return f"npm:{source}"
+    raise AuditError(f"advisory entry has neither a usable `url` nor a `source`: {via!r}")
+
+
+def evaluate(report: object, allowlist: dict[str, dict[str, str]]) -> Verdict:
+    """Classify a parsed `npm audit --json` payload.
+
+    Raises AuditError for anything that is not a recognisable audit report —
+    see the module docstring on why a degraded environment must not read as
+    clean (spec AC1a).
+
+    Only advisory dicts in `via` are considered; a bare-string `via` entry is a
+    chain link naming another vulnerable package, whose own advisory appears as
+    a dict elsewhere in the same report. Judging the roots therefore covers the
+    chains, and suppressing a root correctly suppresses everything downstream of
+    it.
+    """
+    if not isinstance(report, dict):
+        raise AuditError(f"audit output is not a JSON object (got {type(report).__name__})")
+    if "error" in report:
+        detail = report["error"]
+        if isinstance(detail, dict):
+            detail = detail.get("summary") or detail.get("code") or detail
+        raise AuditError(f"npm audit reported an error instead of a report: {detail}")
+    if "auditReportVersion" not in report:
+        raise AuditError(
+            "audit output carries no `auditReportVersion` — refusing to read an "
+            "unrecognised payload as a clean result"
+        )
+    vulnerabilities = report.get("vulnerabilities", {})
+    if not isinstance(vulnerabilities, dict):
+        raise AuditError("audit output's `vulnerabilities` is not an object")
+
+    blocking: dict[str, Finding] = {}
+    suppressed: dict[str, Finding] = {}
+    for package, detail in vulnerabilities.items():
+        if not isinstance(detail, dict):
+            raise AuditError(f"audit entry for {package!r} is not an object")
+        for via in detail.get("via", []):
+            if not isinstance(via, dict):
+                continue  # chain link; its root advisory is judged on its own entry
+            severity = via.get("severity")
+            if severity not in BLOCKING_SEVERITIES:
+                continue
+            identifier = advisory_id(via)
+            finding = Finding(
+                advisory_id=identifier,
+                package=str(via.get("name") or package),
+                severity=str(severity),
+                title=str(via.get("title") or ""),
+                url=str(via.get("url") or ""),
+            )
+            target = suppressed if identifier in allowlist else blocking
+            target.setdefault(identifier, finding)
+
+    return Verdict(
+        blocking=[blocking[k] for k in sorted(blocking)],
+        suppressed=[suppressed[k] for k in sorted(suppressed)],
+    )
+
+
+def run_audit(project_dir: Path) -> object:
+    """Invoke `npm audit --json` for one project and return the parsed payload.
+
+    The only impure part of this module, and deliberately the only part the
+    self-test does not exercise. Read-only by construction: `npm audit` without
+    `fix` mutates nothing, and `--package-lock-only` keeps it off the network
+    install path and reads the committed lockfile — the artifact under audit —
+    rather than whatever `node_modules` happens to hold.
+    """
+    argv = [
+        "npm", "audit",
+        "--json",
+        "--package-lock-only",
+        f"--audit-level={AUDIT_LEVEL}",
+    ]
+    try:
+        completed = subprocess.run(  # nosec B603 - fixed argv, shell=False, no user input
+            argv,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise AuditError(
+            "npm not found on PATH — install Node.js (>=24, per package.json "
+            "`engines`) so the npm SCA leg can run, or set SKIP_SAST=1 to skip "
+            "the whole SAST/SCA gate deliberately"
+        ) from exc
+    except OSError as exc:
+        raise AuditError(f"could not invoke npm in {project_dir}: {exc}") from exc
+
+    # The exit code is deliberately not consulted: npm audit returns non-zero
+    # for both "found advisories" and "could not run". The payload decides.
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        stderr = (completed.stderr or "").strip().splitlines()
+        hint = stderr[-1] if stderr else "(no stderr)"
+        raise AuditError(
+            f"npm audit in {project_dir} produced no parseable JSON "
+            f"(exit {completed.returncode}): {exc}. Last stderr line: {hint}"
+        ) from exc
+
+
+def _describe(finding: Finding) -> str:
+    """`<package>: <title>`, without repeating the package when the advisory
+    title already leads with it (npm's own titles usually do)."""
+    if finding.title.startswith(f"{finding.package}:"):
+        return finding.title
+    return f"{finding.package}: {finding.title}"
+
+
+def _report(project: Path, verdict: Verdict, root: Path) -> None:
+    label = project.relative_to(root).as_posix()
+    for finding in verdict.suppressed:
+        print(f"  allowlisted: {finding.advisory_id} ({finding.severity}) {_describe(finding)}")
+    if verdict.blocking:
+        print(f"✖ {label}: {len(verdict.blocking)} blocking advisory(ies)", file=sys.stderr)
+        for finding in verdict.blocking:
+            print(
+                f"    {finding.advisory_id} ({finding.severity}) {_describe(finding)}"
+                f"\n      {finding.url}",
+                file=sys.stderr,
+            )
+    else:
+        suffix = f" ({len(verdict.suppressed)} allowlisted)" if verdict.suppressed else ""
+        print(f"✓ {label}: no blocking advisories{suffix}")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=str(_REPO_ROOT))
+    parser.add_argument("--allowlist", default=None)
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    allowlist_path = (
+        Path(args.allowlist).resolve() if args.allowlist else root / DEFAULT_ALLOWLIST
+    )
+
+    try:
+        allowlist = load_allowlist(allowlist_path)
+    except AuditError as exc:
+        print(f"audit-npm: {exc}", file=sys.stderr)
+        return 2
+
+    lockfiles = discover_lockfiles(root)
+    if not lockfiles:
+        # Fail closed. Zero lockfiles means discovery broke or the tree moved —
+        # both of which would otherwise present as a green gate over nothing.
+        print(
+            f"audit-npm: found no {LOCKFILE_NAME} under {root} — refusing to "
+            f"report a clean result from broken discovery",
+            file=sys.stderr,
+        )
+        return 2
+
+    if allowlist:
+        print(f"audit-npm: {len(allowlist)} allowlisted advisory(ies) in {allowlist_path.name}")
+
+    blocked = False
+    for lockfile in lockfiles:
+        try:
+            verdict = evaluate(run_audit(lockfile.parent), allowlist)
+        except AuditError as exc:
+            print(f"audit-npm: {exc}", file=sys.stderr)
+            return 2
+        _report(lockfile.parent, verdict, root)
+        blocked = blocked or bool(verdict.blocking)
+
+    if blocked:
+        print(
+            "\naudit-npm: fix with `npm audit fix --package-lock-only` in the "
+            "affected project, or — only for an advisory with no available fix — "
+            f"add a reasoned entry to {DEFAULT_ALLOWLIST}.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"audit-npm: {len(lockfiles)} lockfile(s) audited at --audit-level={AUDIT_LEVEL}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -26,13 +26,24 @@ gate that fails open exactly when the environment is degraded. So a verdict of
 everything else is a tool error. `tools/test-audit-npm.py` pins that path,
 because a live run against a healthy registry never reaches it.
 
+**And why reading the payload is still not enough.** One failure survives every
+payload check: a registry or mirror that answers the bulk-advisory endpoint with
+HTTP 200 and an empty body. Measured against a local stub, that yields
+`auditReportVersion: 2`, `vulnerabilities: {}`, no `error` key, and a full
+`metadata.dependencies` block — the last because npm computes it from the
+lockfile locally and never receives it from the registry. The result is
+byte-identical to a genuinely clean audit. No amount of payload inspection
+distinguishes them, so the gate first audits a **canary**: a pin with a
+permanent published advisory. If the endpoint does not report that, it is not
+reporting anything, and the run is a tool error rather than a pass.
+
 Lockfiles are **discovered**, not listed, so a third npm project cannot be added
 without the gate noticing. `node_modules/` and dot-directories are pruned:
 lockfiles inside an installed tree are dependency artifacts, not projects, and
 whether they exist at all depends on who last ran `npm ci`.
 
 Usage:
-    audit-npm.py [--root .] [--allowlist tools/npm-audit-allowlist.toml]
+    audit-npm.py [--root .]
 
 Exit codes — three outcomes, deliberately distinguishable (same reasoning as
 `tools/test-all.py`: "found advisories" and "never actually ran" are different
@@ -42,8 +53,8 @@ facts, and reporting the second as the first is how a gate sits green for weeks)
      allowlisted (each printed).
   1  at least one non-allowlisted advisory at or above the blocking threshold.
   2  the gate could not run: npm absent, unreadable or unparseable audit output,
-     an error payload, an unrecognised report schema, a malformed allowlist, or
-     no lockfile discovered at all.
+     an error payload, an unrecognised report schema, a malformed allowlist,
+     no lockfile discovered at all, or a canary probe that came back silent.
 """
 
 from __future__ import annotations
@@ -52,6 +63,7 @@ import argparse
 import json
 import subprocess  # nosec B404 - invokes `npm` with a fixed, non-shell argv
 import sys
+import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,15 +76,44 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 LOCKFILE_NAME = "package-lock.json"
 DEFAULT_ALLOWLIST = "tools/npm-audit-allowlist.toml"
 
-# Matches the `--audit-level=high` passed to npm. npm's own flag decides its
-# exit code; this set decides ours, and ours is the one that gates. Keeping both
+# Matches the `--audit-level` passed to npm. npm's own flag decides its exit
+# code; this set decides ours, and ours is the one that gates. Keeping both
 # means a future npm that changes its threshold semantics cannot quietly widen
 # the gate.
-BLOCKING_SEVERITIES = frozenset({"high", "critical"})
-AUDIT_LEVEL = "high"
+#
+# `moderate`, not `high`: both lockfiles were clean at moderate the day this
+# threshold was set, so raising the bar cost nothing. The cheapest moment to
+# raise a bar is while you are already above it — deferring means tightening on
+# a day when there *is* a moderate finding, which turns a one-word diff into an
+# argument.
+BLOCKING_SEVERITIES = frozenset({"moderate", "high", "critical"})
+AUDIT_LEVEL = "moderate"
 
 # Directories that never contain a *project* lockfile.
 _PRUNED_DIR_NAMES = frozenset({"node_modules"})
+
+# ── The canary ──────────────────────────────────────────────────────────────
+# A pin with a permanent, long-published advisory, audited in a throwaway
+# lockfile before the real projects are.
+#
+# The failure this exists to catch is measured, not imagined. An npm registry
+# or mirror that answers the bulk-advisory endpoint with HTTP 200 and an empty
+# body produces a report that is *byte-identical to a clean one*:
+# `auditReportVersion: 2`, `vulnerabilities: {}`, no `error` key, and a full,
+# plausible `metadata.dependencies` block — because that block is computed
+# locally from the lockfile and never comes from the registry at all. Every
+# other guard in this module reads the payload, and the payload looks perfect.
+#
+# So the payload cannot answer "did anything actually get checked?". Only a
+# known-positive can. If the endpoint does not report this pin, it is not
+# reporting anything, and a green run over the real lockfiles means nothing.
+#
+# Same reasoning the `sast` recipe already applies to
+# `tools/test-semgrep-argv-boundary.py`: a scan that is silent when it works and
+# silent when it has been broken into a no-op cannot tell you which it did.
+CANARY_PACKAGE = "lodash"
+CANARY_VERSION = "4.17.11"
+CANARY_ADVISORY = "GHSA-jf85-cpcp-j695"  # prototype pollution; critical
 
 
 class AuditError(Exception):
@@ -190,6 +231,44 @@ def advisory_id(via: dict) -> str:
     raise AuditError(f"advisory entry has neither a usable `url` nor a `source`: {via!r}")
 
 
+def _require_report(report: object) -> dict:
+    """Return the payload's `vulnerabilities` map, or raise AuditError.
+
+    The single place the AC1a fail-closed rule is enforced: anything that is not
+    a recognisable `npm audit` report raises rather than reading as clean. Shared
+    by `evaluate` and the canary probe so the two cannot drift apart.
+    """
+    if not isinstance(report, dict):
+        raise AuditError(f"audit output is not a JSON object (got {type(report).__name__})")
+    if "error" in report:
+        detail = report["error"]
+        if isinstance(detail, dict):
+            detail = detail.get("summary") or detail.get("code") or detail
+        raise AuditError(
+            f"npm audit reported an error instead of a report: "
+            f"{detail or report.get('message') or '(no detail)'}"
+        )
+    if "auditReportVersion" not in report:
+        raise AuditError(
+            "audit output carries no `auditReportVersion` — refusing to read an "
+            "unrecognised payload as a clean result"
+        )
+    vulnerabilities = report.get("vulnerabilities", {})
+    if not isinstance(vulnerabilities, dict):
+        raise AuditError("audit output's `vulnerabilities` is not an object")
+    return vulnerabilities
+
+
+def canary_is_live(report: object) -> bool:
+    """Did this audit of the canary lockfile actually report the canary advisory?
+
+    False means the advisory endpoint answered without reporting a pin that has
+    carried a published advisory for years — so it is not reporting anything,
+    and a clean result over the real lockfiles proves nothing.
+    """
+    return CANARY_PACKAGE in _require_report(report)
+
+
 def evaluate(report: object, allowlist: dict[str, dict[str, str]]) -> Verdict:
     """Classify a parsed `npm audit --json` payload.
 
@@ -203,21 +282,7 @@ def evaluate(report: object, allowlist: dict[str, dict[str, str]]) -> Verdict:
     chains, and suppressing a root correctly suppresses everything downstream of
     it.
     """
-    if not isinstance(report, dict):
-        raise AuditError(f"audit output is not a JSON object (got {type(report).__name__})")
-    if "error" in report:
-        detail = report["error"]
-        if isinstance(detail, dict):
-            detail = detail.get("summary") or detail.get("code") or detail
-        raise AuditError(f"npm audit reported an error instead of a report: {detail}")
-    if "auditReportVersion" not in report:
-        raise AuditError(
-            "audit output carries no `auditReportVersion` — refusing to read an "
-            "unrecognised payload as a clean result"
-        )
-    vulnerabilities = report.get("vulnerabilities", {})
-    if not isinstance(vulnerabilities, dict):
-        raise AuditError("audit output's `vulnerabilities` is not an object")
+    vulnerabilities = _require_report(report)
 
     blocking: dict[str, Finding] = {}
     suppressed: dict[str, Finding] = {}
@@ -301,6 +366,54 @@ def run_audit(project_dir: Path) -> object:
         ) from exc
 
 
+def run_canary_probe() -> None:
+    """Prove the advisory endpoint answers, before trusting a clean result.
+
+    Writes a throwaway lockfile pinning the canary and audits it. Nothing is
+    installed and nothing outside the tmpdir is touched.
+    """
+    manifest = {
+        "name": "npm-sca-gate-canary",
+        "version": "1.0.0",
+        "dependencies": {CANARY_PACKAGE: CANARY_VERSION},
+    }
+    lock = {
+        "name": "npm-sca-gate-canary",
+        "version": "1.0.0",
+        "lockfileVersion": 3,
+        "requires": True,
+        "packages": {
+            "": manifest,
+            f"node_modules/{CANARY_PACKAGE}": {
+                "version": CANARY_VERSION,
+                "resolved": (
+                    f"https://registry.npmjs.org/{CANARY_PACKAGE}/-/"
+                    f"{CANARY_PACKAGE}-{CANARY_VERSION}.tgz"
+                ),
+            },
+        },
+    }
+    with tempfile.TemporaryDirectory(prefix="npm-sca-canary-") as tmp:
+        probe_dir = Path(tmp)
+        (probe_dir / "package.json").write_text(json.dumps(manifest), encoding="utf-8")
+        (probe_dir / "package-lock.json").write_text(json.dumps(lock), encoding="utf-8")
+        if not canary_is_live(run_audit(probe_dir)):
+            raise AuditError(
+                f"the advisory endpoint reported nothing for {CANARY_PACKAGE}@"
+                f"{CANARY_VERSION} ({CANARY_ADVISORY}), which has carried a published "
+                f"advisory for years. The endpoint is not answering with real data, so "
+                f"a clean result over this repo's lockfiles would be meaningless. Check "
+                f"the configured registry (`npm config get registry`) — a mirror that "
+                f"returns 200 with no advisories produces a report indistinguishable "
+                f"from a clean one. If the advisory itself was withdrawn, repin the "
+                f"canary in tools/audit-npm.py."
+            )
+    print(
+        f"audit-npm: advisory endpoint confirmed live "
+        f"({CANARY_PACKAGE}@{CANARY_VERSION} reported as expected)."
+    )
+
+
 def _describe(finding: Finding) -> str:
     """`<package>: <title>`, without repeating the package when the advisory
     title already leads with it (npm's own titles usually do)."""
@@ -353,6 +466,13 @@ def main(argv: list[str]) -> int:
 
     if allowlist:
         print(f"audit-npm: {len(allowlist)} allowlisted advisory(ies) in {allowlist_path.name}")
+
+    # Before trusting any clean result, prove the endpoint answers at all.
+    try:
+        run_canary_probe()
+    except AuditError as exc:
+        print(f"audit-npm: {exc}", file=sys.stderr)
+        return 2
 
     blocked = False
     for lockfile in lockfiles:

--- a/tools/npm-audit-allowlist.toml
+++ b/tools/npm-audit-allowlist.toml
@@ -1,0 +1,39 @@
+# Advisory allowlist for the npm SCA leg of `make sast` (ADR-0083).
+#
+# Read by `tools/audit-npm.py`. An advisory listed here is reported on every run
+# but does not block the gate.
+#
+# THIS FILE SHOULD NORMALLY BE EMPTY. It exists because `npm audit` has no
+# per-advisory ignore: without it, the only way past one unfixable transitive
+# advisory is `--audit-level=critical`, which stops gating an entire severity
+# band for the whole repo. The sibling `pip-audit` leg in `make sast` carries
+# four such suppressions today, each with a written diagnosis and an unblock
+# condition — this is the npm equivalent of those `--ignore-vuln` flags.
+#
+# Add an entry ONLY when there is no available fix. If `npm audit fix
+# --package-lock-only` resolves it, take the fix instead — a real remediation
+# also satisfies the org's Snyk Open Source scan, which no entry here can reach.
+#
+# Every entry needs all three fields. A missing or blank `reason` /
+# `unblocked_when` is a tool error (exit 2), not a silent pass: an allowlist
+# that decays into an undocumented mute list is worse than no allowlist.
+#
+#   id             — the GHSA-… or CVE-… identifier as it appears in the
+#                    advisory URL, or `npm:<source>` for an advisory with no
+#                    GitHub URL. Exactly as `audit-npm.py` prints it.
+#   reason         — why this is accepted: the reachability argument, in a
+#                    sentence a reviewer can check.
+#   unblocked_when — the concrete condition that retires this entry. "When
+#                    upstream ships X" — not "when convenient".
+#
+# Example (do not uncomment; kept as the shape, not as an active suppression):
+#
+#   [[allow]]
+#   id = "GHSA-0000-1111-2222"
+#   reason = """
+#   Build-time-only dependency of docs-site; the vulnerable code path parses
+#   attacker-supplied YAML, and this repo only parses its own committed files.
+#   """
+#   unblocked_when = "example-pkg ships >=2.4.1, which repins the vulnerable transitive dep"
+
+allow = []

--- a/tools/npm-audit-allowlist.toml
+++ b/tools/npm-audit-allowlist.toml
@@ -5,8 +5,8 @@
 #
 # THIS FILE SHOULD NORMALLY BE EMPTY. It exists because `npm audit` has no
 # per-advisory ignore: without it, the only way past one unfixable transitive
-# advisory is `--audit-level=critical`, which stops gating an entire severity
-# band for the whole repo. The sibling `pip-audit` leg in `make sast` carries
+# advisory is downgrading `--audit-level`, which stops gating an entire severity
+# band for the whole repo (the gate blocks at `moderate` and above). The sibling `pip-audit` leg in `make sast` carries
 # four such suppressions today, each with a written diagnosis and an unblock
 # condition — this is the npm equivalent of those `--ignore-vuln` flags.
 #

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -107,6 +107,7 @@ TESTS: list[tuple[str, list[str]]] = [
                           "packs/core/tests/skills/work-loop/test_append_knowledge.py"]),
     ("lint-knowledge", [sys.executable, "-m", "pytest", "-q",
                         "tests/roster/test_work_loop_lint_knowledge.py"]),
+    ("audit-npm", [sys.executable, "tools/test-audit-npm.py"]),
     ("lint-sso-config", [sys.executable, "tools/test-lint-sso-config.py"]),
     ("lint-skill-spec", [sys.executable, "-m", "pytest",
                               "packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py",

--- a/tools/test-audit-npm.py
+++ b/tools/test-audit-npm.py
@@ -92,6 +92,25 @@ CRITICAL = _report(("evil", "critical", [_advisory("evil", "critical", "GHSA-ddd
 
 MODERATE = _report(("postcss", "moderate", [_advisory("postcss", "moderate", "GHSA-1111-2222-3333", 3)]))
 
+LOW = _report(("trivial", "low", [_advisory("trivial", "low", "GHSA-4444-5555-6666", 4)]))
+
+# What the canary probe sees when the endpoint is answering, and when a mirror
+# returns 200 with an empty advisory set. The second is byte-identical in shape
+# to a clean audit — including the locally-computed metadata block — which is
+# the whole reason the canary exists.
+CANARY_LIVE = _report(("lodash", "critical", [_advisory("lodash", "critical", "GHSA-jf85-cpcp-j695", 5)]))
+
+CANARY_SILENT = {
+    "auditReportVersion": 2,
+    "vulnerabilities": {},
+    "metadata": {
+        "vulnerabilities": {"info": 0, "low": 0, "moderate": 0, "high": 0,
+                            "critical": 0, "total": 0},
+        "dependencies": {"prod": 455, "dev": 0, "optional": 119, "peer": 2,
+                         "peerOptional": 0, "total": 573},
+    },
+}
+
 # A high advisory plus a package that is only vulnerable *through* it — the
 # string-`via` chain link. Suppressing the root advisory must suppress the chain.
 CHAINED = _report(
@@ -142,13 +161,21 @@ def main() -> int:
         return 1
     m = _load_subject()
 
-    print("evaluate() — severity threshold")
+    print("evaluate() — severity threshold (moderate and above)")
     check("clean_report_passes", m.evaluate(CLEAN, {}).blocking == [])
     check("high_finding_blocks", [f.advisory_id for f in m.evaluate(HIGH, {}).blocking]
           == ["GHSA-aaaa-bbbb-cccc"])
     check("critical_finding_blocks", [f.advisory_id for f in m.evaluate(CRITICAL, {}).blocking]
           == ["GHSA-dddd-eeee-ffff"])
-    check("moderate_finding_does_not_block", m.evaluate(MODERATE, {}).blocking == [])
+    check("moderate_finding_blocks", [f.advisory_id for f in m.evaluate(MODERATE, {}).blocking]
+          == ["GHSA-1111-2222-3333"])
+    check("low_finding_does_not_block", m.evaluate(LOW, {}).blocking == [])
+    # The npm flag and our own blocking set are two separate decisions about the
+    # same threshold; if they drift, npm's exit code and our verdict disagree.
+    check("threshold_flag_matches_blocking_set",
+          m.AUDIT_LEVEL == "moderate"
+          and sorted(m.BLOCKING_SEVERITIES) == ["critical", "high", "moderate"],
+          f"AUDIT_LEVEL={m.AUDIT_LEVEL} BLOCKING={sorted(m.BLOCKING_SEVERITIES)}")
 
     print("evaluate() — allowlist")
     allow = {"GHSA-aaaa-bbbb-cccc": {"reason": "r", "unblocked_when": "u"}}
@@ -175,6 +202,20 @@ def main() -> int:
     # the guard above must not turn every via-less entry into a hard error.
     check("nonblocking_without_via_passes",
           m.evaluate(_report(("quiet", "low", [])), {}).blocking == [])
+
+    print("canary_is_live() — the check no payload inspection can make")
+    check("canary_live_when_endpoint_answers", m.canary_is_live(CANARY_LIVE) is True)
+    check("canary_silent_when_mirror_returns_empty", m.canary_is_live(CANARY_SILENT) is False,
+          "a 200-with-no-advisories mirror must NOT read as live")
+    # The point of the canary, stated as an assertion: the silent-mirror payload
+    # is a perfectly valid report that evaluate() passes. Only the canary
+    # separates it from a genuinely clean tree.
+    check("silent_mirror_payload_passes_evaluate_by_design",
+          m.evaluate(CANARY_SILENT, {}).blocking == [])
+    expect_error("canary_probe_rejects_error_payload", lambda: m.canary_is_live(ERROR_PAYLOAD))
+    expect_error("canary_probe_rejects_versionless_payload", lambda: m.canary_is_live(NO_VERSION))
+    check("canary_pin_is_declared",
+          bool(m.CANARY_PACKAGE) and bool(m.CANARY_VERSION) and m.CANARY_ADVISORY.startswith("GHSA-"))
 
     print("load_allowlist() — incomplete entries are a tool error, not a pass")
     with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test-audit-npm.py
+++ b/tools/test-audit-npm.py
@@ -103,6 +103,10 @@ ERROR_PAYLOAD = {"error": {"code": "ENETUNREACH", "summary": "request to registr
 
 NO_VERSION = {"vulnerabilities": {}, "metadata": {}}
 
+# A shape npm does not emit: blocking severity with no advisories to explain it.
+# Reading it as "nothing to report" would drop a real finding.
+BLOCKING_WITHOUT_VIA = _report(("mystery", "high", []))
+
 
 # ── Harness ─────────────────────────────────────────────────────────────────
 
@@ -165,6 +169,12 @@ def main() -> int:
     expect_error("error_payload_is_tool_error", lambda: m.evaluate(ERROR_PAYLOAD, {}))
     expect_error("missing_report_version_is_tool_error", lambda: m.evaluate(NO_VERSION, {}))
     expect_error("non_dict_payload_is_tool_error", lambda: m.evaluate([], {}))
+    expect_error("blocking_severity_without_via_is_tool_error",
+                 lambda: m.evaluate(BLOCKING_WITHOUT_VIA, {}))
+    # The same shape at a non-blocking severity is ordinary and must still pass —
+    # the guard above must not turn every via-less entry into a hard error.
+    check("nonblocking_without_via_passes",
+          m.evaluate(_report(("quiet", "low", [])), {}).blocking == [])
 
     print("load_allowlist() — incomplete entries are a tool error, not a pass")
     with tempfile.TemporaryDirectory() as tmp:
@@ -224,6 +234,18 @@ def main() -> int:
               f"found={found}")
         check("skips_node_modules", not any("node_modules" in f for f in found))
         check("skips_dot_directories", not any(f.startswith(".") for f in found))
+
+        # A symlinked *directory* is a loop risk and is pruned; a symlinked
+        # *lockfile* is a real project's lockfile and must still be found.
+        (root / "loop").symlink_to(root, target_is_directory=True)
+        linked = root / "third"
+        linked.mkdir()
+        (linked / "package-lock.json").symlink_to(root / "docs-site" / "package-lock.json")
+        found = [p.relative_to(root).as_posix() for p in m.discover_lockfiles(root)]
+        check("prunes_symlinked_directories", not any(f.startswith("loop/") for f in found),
+              f"found={found}")
+        check("still_finds_symlinked_lockfile", "third/package-lock.json" in found,
+              f"found={found}")
 
     print("advisory_id() — GHSA/CVE from url, else npm source id")
     check("id_from_ghsa_url",

--- a/tools/test-audit-npm.py
+++ b/tools/test-audit-npm.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Self-test for tools/audit-npm.py — the npm SCA leg of `make sast`.
+
+Runs in `make sast` immediately *before* the live audit, and in
+`tools/test-all.py`. The reason it exists is the same one stated in the `sast`
+recipe for `tools/test-audit-requirements.py` and
+`tools/test-semgrep-argv-boundary.py`: **a live audit against a healthy registry
+is silent both when the gate works and when it has been broken into a no-op, so
+it cannot tell the two apart.** Only fixtures can.
+
+Two cases here are load-bearing beyond ordinary coverage — `error_payload_is_tool_error`
+and `missing_report_version_is_tool_error`. They pin spec AC1a: a registry
+outage, a proxy returning an HTML error page, or a corporate MITM must never be
+indistinguishable from "no vulnerabilities found". `npm audit` exits non-zero
+for *both* "found advisories" and "could not run", so the verdict has to come
+from the payload, and the failing-closed path is exactly the one a healthy CI
+run never exercises.
+
+Pure stdlib. No network, no `npm` binary, no filesystem outside a tmpdir.
+Exit 0 = every case passed; 1 = at least one failed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import tempfile
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SUBJECT = REPO_ROOT / "tools" / "audit-npm.py"
+
+
+def _load_subject():
+    """Import audit-npm.py by path — its filename is not a legal module name.
+
+    The module is registered in `sys.modules` *before* `exec_module`: the
+    subject defines `@dataclass` types, and `dataclasses` resolves each field's
+    annotations through `sys.modules[cls.__module__]`. Loading by spec without
+    registering first leaves that lookup returning None.
+    """
+    cached = sys.modules.get("audit_npm")
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location("audit_npm", SUBJECT)
+    if spec is None or spec.loader is None:  # pragma: no cover - import plumbing
+        raise RuntimeError(f"cannot load {SUBJECT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_npm"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+# Shaped from real `npm audit --json --package-lock-only` output (npm 11):
+# `via` entries are either an advisory dict carrying its own `severity` and a
+# GitHub advisory `url`, or a bare string naming another vulnerable package.
+
+
+def _advisory(name: str, severity: str, ghsa: str, source: int) -> dict:
+    return {
+        "source": source,
+        "name": name,
+        "dependency": name,
+        "title": f"{name}: synthetic advisory for tests",
+        "url": f"https://github.com/advisories/{ghsa}",
+        "severity": severity,
+        "cwe": ["CWE-000"],
+        "range": "<1.0.0",
+    }
+
+
+def _report(*packages: tuple[str, str, list]) -> dict:
+    return {
+        "auditReportVersion": 2,
+        "vulnerabilities": {
+            name: {"name": name, "severity": severity, "isDirect": False, "via": via}
+            for name, severity, via in packages
+        },
+        "metadata": {"vulnerabilities": {"total": len(packages)}},
+    }
+
+
+CLEAN = {"auditReportVersion": 2, "vulnerabilities": {}, "metadata": {}}
+
+HIGH = _report(("js-yaml", "high", [_advisory("js-yaml", "high", "GHSA-aaaa-bbbb-cccc", 1)]))
+
+CRITICAL = _report(("evil", "critical", [_advisory("evil", "critical", "GHSA-dddd-eeee-ffff", 2)]))
+
+MODERATE = _report(("postcss", "moderate", [_advisory("postcss", "moderate", "GHSA-1111-2222-3333", 3)]))
+
+# A high advisory plus a package that is only vulnerable *through* it — the
+# string-`via` chain link. Suppressing the root advisory must suppress the chain.
+CHAINED = _report(
+    ("js-yaml", "high", [_advisory("js-yaml", "high", "GHSA-aaaa-bbbb-cccc", 1)]),
+    ("some-consumer", "high", ["js-yaml"]),
+)
+
+ERROR_PAYLOAD = {"error": {"code": "ENETUNREACH", "summary": "request to registry failed"}}
+
+NO_VERSION = {"vulnerabilities": {}, "metadata": {}}
+
+
+# ── Harness ─────────────────────────────────────────────────────────────────
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ✓ {name}")
+    else:
+        FAILURES.append(name)
+        print(f"  ✖ {name}{': ' + detail if detail else ''}", file=sys.stderr)
+
+
+def expect_error(name: str, fn) -> None:
+    """The subject raised AuditError — i.e. the caller will exit 2."""
+    m = _load_subject()
+    try:
+        fn()
+    except m.AuditError:
+        print(f"  ✓ {name}")
+    except Exception as exc:  # noqa: BLE001 - any other type is the failure
+        FAILURES.append(name)
+        print(f"  ✖ {name}: raised {type(exc).__name__}, expected AuditError", file=sys.stderr)
+    else:
+        FAILURES.append(name)
+        print(f"  ✖ {name}: returned normally, expected AuditError", file=sys.stderr)
+
+
+def main() -> int:
+    if not SUBJECT.is_file():
+        print(f"✖ subject not found: {SUBJECT}", file=sys.stderr)
+        return 1
+    m = _load_subject()
+
+    print("evaluate() — severity threshold")
+    check("clean_report_passes", m.evaluate(CLEAN, {}).blocking == [])
+    check("high_finding_blocks", [f.advisory_id for f in m.evaluate(HIGH, {}).blocking]
+          == ["GHSA-aaaa-bbbb-cccc"])
+    check("critical_finding_blocks", [f.advisory_id for f in m.evaluate(CRITICAL, {}).blocking]
+          == ["GHSA-dddd-eeee-ffff"])
+    check("moderate_finding_does_not_block", m.evaluate(MODERATE, {}).blocking == [])
+
+    print("evaluate() — allowlist")
+    allow = {"GHSA-aaaa-bbbb-cccc": {"reason": "r", "unblocked_when": "u"}}
+    verdict = m.evaluate(HIGH, allow)
+    check("allowlisted_high_passes", verdict.blocking == [])
+    check("allowlisted_high_is_reported",
+          [f.advisory_id for f in verdict.suppressed] == ["GHSA-aaaa-bbbb-cccc"],
+          f"suppressed={verdict.suppressed}")
+    chained = m.evaluate(CHAINED, allow)
+    check("suppressing_root_advisory_suppresses_chain", chained.blocking == [],
+          f"blocking={[f.advisory_id for f in chained.blocking]}")
+    check("unrelated_allowlist_entry_does_not_suppress",
+          [f.advisory_id for f in m.evaluate(HIGH, {"GHSA-zzzz-zzzz-zzzz":
+                                                    {"reason": "r", "unblocked_when": "u"}}).blocking]
+          == ["GHSA-aaaa-bbbb-cccc"])
+
+    print("evaluate() — fail-closed (spec AC1a)")
+    expect_error("error_payload_is_tool_error", lambda: m.evaluate(ERROR_PAYLOAD, {}))
+    expect_error("missing_report_version_is_tool_error", lambda: m.evaluate(NO_VERSION, {}))
+    expect_error("non_dict_payload_is_tool_error", lambda: m.evaluate([], {}))
+
+    print("load_allowlist() — incomplete entries are a tool error, not a pass")
+    with tempfile.TemporaryDirectory() as tmp:
+        d = pathlib.Path(tmp)
+
+        empty = d / "empty.toml"
+        empty.write_text("", encoding="utf-8")
+        check("empty_allowlist_loads_as_empty", m.load_allowlist(empty) == {})
+
+        good = d / "good.toml"
+        good.write_text(
+            '[[allow]]\nid = "GHSA-aaaa-bbbb-cccc"\nreason = "r"\nunblocked_when = "u"\n',
+            encoding="utf-8",
+        )
+        check("complete_entry_loads",
+              m.load_allowlist(good) == {"GHSA-aaaa-bbbb-cccc":
+                                         {"reason": "r", "unblocked_when": "u"}})
+
+        for field in ("reason", "unblocked_when"):
+            bad = d / f"missing_{field}.toml"
+            lines = ['[[allow]]', 'id = "GHSA-aaaa-bbbb-cccc"',
+                     'reason = "r"', 'unblocked_when = "u"']
+            lines = [ln for ln in lines if not ln.startswith(field)]
+            bad.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            expect_error(f"allowlist_missing_{field}_is_tool_error",
+                         lambda p=bad: m.load_allowlist(p))
+
+        blank = d / "blank_reason.toml"
+        blank.write_text(
+            '[[allow]]\nid = "GHSA-aaaa-bbbb-cccc"\nreason = "  "\nunblocked_when = "u"\n',
+            encoding="utf-8",
+        )
+        expect_error("allowlist_whitespace_reason_is_tool_error",
+                     lambda: m.load_allowlist(blank))
+
+        noid = d / "no_id.toml"
+        noid.write_text('[[allow]]\nreason = "r"\nunblocked_when = "u"\n', encoding="utf-8")
+        expect_error("allowlist_missing_id_is_tool_error", lambda: m.load_allowlist(noid))
+
+    print("discover_lockfiles()")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        (root / "docs-site").mkdir()
+        (root / "docs-site" / "package-lock.json").write_text("{}", encoding="utf-8")
+        (root / "web").mkdir()
+        (root / "web" / "package-lock.json").write_text("{}", encoding="utf-8")
+        nested = root / "web" / "node_modules" / "dep"
+        nested.mkdir(parents=True)
+        (nested / "package-lock.json").write_text("{}", encoding="utf-8")
+        hidden = root / ".cache" / "x"
+        hidden.mkdir(parents=True)
+        (hidden / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        found = [p.relative_to(root).as_posix() for p in m.discover_lockfiles(root)]
+        check("discovers_project_lockfiles",
+              found == ["docs-site/package-lock.json", "web/package-lock.json"],
+              f"found={found}")
+        check("skips_node_modules", not any("node_modules" in f for f in found))
+        check("skips_dot_directories", not any(f.startswith(".") for f in found))
+
+    print("advisory_id() — GHSA/CVE from url, else npm source id")
+    check("id_from_ghsa_url",
+          m.advisory_id({"url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc",
+                         "source": 7}) == "GHSA-aaaa-bbbb-cccc")
+    check("id_from_cve_url",
+          m.advisory_id({"url": "https://github.com/advisories/CVE-2026-59870",
+                         "source": 7}) == "CVE-2026-59870")
+    check("id_falls_back_to_source",
+          m.advisory_id({"source": 7}) == "npm:7")
+
+    print()
+    if FAILURES:
+        print(f"✖ audit-npm self-test: {len(FAILURES)} case(s) failed: "
+              f"{', '.join(FAILURES)}", file=sys.stderr)
+        return 1
+    print("✓ audit-npm self-test: severity threshold, allowlist, fail-closed payload "
+          "handling, lockfile discovery and advisory-id extraction all behave as specified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -44,12 +44,16 @@ is used directly. Test runner entry point: `npm test` (`vitest run`).
 Two controls, only one of them automated:
 
 - **Known-CVE scanning is wired** (ADR-0083, `docs/specs/npm-sca-gate/`).
-  `tools/audit-npm.py` runs `npm audit --audit-level=high` over this lockfile as
+  `tools/audit-npm.py` runs `npm audit --audit-level=moderate` over this lockfile as
   a leg of `make sast`, so it gates locally and in `build-check.yml`. Both npm
   lockfiles are in the Makefile's `SAST_CONFIG`, so a lockfile-only diff still
   triggers the gate. Fix a finding with `npm audit fix --package-lock-only`;
   suppress one only when there is no fix, via a reasoned entry in
-  `tools/npm-audit-allowlist.toml`.
+  `tools/npm-audit-allowlist.toml`. The gate audits a known-vulnerable
+  **canary** pin first — a mirror whose advisory endpoint returns
+  200-with-nothing produces a report identical to a clean one, so a green run
+  is only trustworthy if the canary reported. Exit 2 (tool error) is distinct
+  from exit 1 (findings); never read it as a pass.
 - **Install-script vetting is by hand, and this lockfile already diverges.**
   `package.json` `allowScripts` vets `esbuild@0.28.1` and `fsevents@2.3.3`, but
   the lockfile also carries `playwright/node_modules/fsevents@2.3.2`, which is

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -39,6 +39,26 @@ runtime impact.
 Note: `@axe-core/vitest` does not exist on npm (verified 2026-07-28). `axe-core`
 is used directly. Test runner entry point: `npm test` (`vitest run`).
 
+## Supply-chain posture
+
+Two controls, only one of them automated:
+
+- **Known-CVE scanning is wired** (ADR-0083, `docs/specs/npm-sca-gate/`).
+  `tools/audit-npm.py` runs `npm audit --audit-level=high` over this lockfile as
+  a leg of `make sast`, so it gates locally and in `build-check.yml`. Both npm
+  lockfiles are in the Makefile's `SAST_CONFIG`, so a lockfile-only diff still
+  triggers the gate. Fix a finding with `npm audit fix --package-lock-only`;
+  suppress one only when there is no fix, via a reasoned entry in
+  `tools/npm-audit-allowlist.toml`.
+- **Install-script vetting is by hand, and this lockfile already diverges.**
+  `package.json` `allowScripts` vets `esbuild@0.28.1` and `fsevents@2.3.3`, but
+  the lockfile also carries `playwright/node_modules/fsevents@2.3.2`, which is
+  outside those keys — hence the `npm warn allow-scripts` on install. It is
+  accepted as-is (a Playwright transitive on a devDependency path); machine
+  enforcement is deferred under `workspace.toml [backlog]` slug
+  `npm-allowscripts-enforcement`, which is also where closing this divergence
+  belongs. Check the set by eye when the lockfile moves.
+
 ## Build
 
 - `npm run build` emits into `../build/` (repo root), NOT `web/dist/`

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "astro": "7.1.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "1.62.0",
         "@vitest/ui": "4.1.10",
         "axe-core": "4.12.1",
         "jsdom": "30.0.0",
@@ -3452,9 +3452,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3962,9 +3962,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4221,9 +4221,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4240,7 +4240,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/workspace.toml
+++ b/workspace.toml
@@ -935,13 +935,38 @@ open = [
   {slug = "packs-agents-normative-pointer", source = "spec/contracts-readme-governance-sweep AC6"},
 
 
-  # docs-site-design-refresh deferrals (spec Assumptions). SCA: no npm audit/
-  # Dependabot wiring exists repo-wide; docs-site now vendors mermaid's transitive
-  # tree (previously CDN-loaded), so the unscanned-code surface is net-new — wire a
-  # scanner or record acceptance. Print: docs-site print rendering left at
-  # Starlight defaults (accent/hairlines untuned for paper).
-  {slug = "docs-site-npm-sca-gap", source = "spec/docs-site-design-refresh"},
+  # docs-site-design-refresh deferral (spec Assumptions). The SCA half
+  # (docs-site-npm-sca-gap) was discharged by spec/npm-sca-gate + ADR-0083 —
+  # `tools/audit-npm.py` now runs as a leg of `make sast`. Print: docs-site print
+  # rendering left at Starlight defaults (accent/hairlines untuned for paper).
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
+
+  # npm-sca-gate deferrals (spec Assumptions).
+  #
+  # Dependabot: the npm SCA gate blocks merges on known CVEs, but nothing opens
+  #   the bump PRs — remediation is hand-driven (`npm audit fix
+  #   --package-lock-only`). Dependabot is the complementary automation. Left to
+  #   the repo owner because it changes weekly PR volume and review workload,
+  #   not because it is technically hard: it is one `.github/dependabot.yml`
+  #   with an `npm` ecosystem entry per project directory.
+  # Unblocks when: the repo owner decides the PR volume is wanted.
+  {slug = "npm-dependabot-wiring", summary = "Add .github/dependabot.yml with npm ecosystem entries for docs-site/ and web/ so transitive advisory bumps arrive as PRs instead of waiting for someone to run npm audit fix", source = "spec/npm-sca-gate"},
+
+  # allowScripts enforcement: both docs-site/AGENTS.md and web/AGENTS.md document
+  #   an invariant — the lockfile's `"hasInstallScript": true` entries must stay
+  #   within the versioned `allowScripts` keys in package.json — and *nothing
+  #   checks it*. It is prose. Distinct from the SCA gate: SCA scans for known
+  #   CVEs, allowScripts governs arbitrary code execution at install time.
+  #   Blocked on a disposition, not on effort: web/package-lock.json already
+  #   carries `playwright/node_modules/fsevents@2.3.2`, outside web's
+  #   allowScripts keys (`esbuild@0.28.1`, `fsevents@2.3.3`) — hence the
+  #   `npm warn allow-scripts` on every web install. A checker written today
+  #   lands CI red on arrival, so that entry needs an accept-or-fix decision
+  #   first. Note npm 11 ships `npm approve-scripts`, which may make the checker
+  #   unnecessary — check that before writing one.
+  # Unblocks when: web's fsevents@2.3.2 divergence is dispositioned (add to
+  #   allowScripts, or repin so it dedupes to 2.3.3).
+  {slug = "npm-allowscripts-enforcement", summary = "Make the documented allowScripts install-script invariant machine-checked for both npm projects, after dispositioning web's pre-existing playwright/fsevents@2.3.2 divergence", source = "spec/npm-sca-gate"},
 
   # The credential-brokers pack's shipped .apm/** carries RFC-0023/RFC-0006 citations
   # in credential-setup/scripts/setup.py and user-libs/credbroker/ (files:

--- a/workspace.toml
+++ b/workspace.toml
@@ -968,6 +968,34 @@ open = [
   #   allowScripts, or repin so it dedupes to 2.3.3).
   {slug = "npm-allowscripts-enforcement", summary = "Make the documented allowScripts install-script invariant machine-checked for both npm projects, after dispositioning web's pre-existing playwright/fsevents@2.3.2 divergence", source = "spec/npm-sca-gate"},
 
+  # Unrelated finds from spec/npm-sca-gate — both cost that loop real time.
+  #
+  # Self-test mutates a tracked file: tools/test-lint-pack-test-boundary.py
+  #   appends a deliberately-violating `lint-selftest-scratch` target to the
+  #   REAL Makefile to prove the boundary linter fires, then restores it
+  #   (~lines 560-610). Any `git add -A` during that window commits the
+  #   injected violation, and the local re-run then passes because the file was
+  #   restored — so it only fails in CI, against a tree the developer cannot
+  #   reproduce. That happened on PR #961. Fix: build the fixture in a tmpdir
+  #   copy, or drive the linter with a --makefile argument, so no tracked file
+  #   is ever mid-mutation. Same pattern is worth auditing across tools/test-*.
+  # Unblocks when: picked up — no dependency.
+  {slug = "selftest-mutates-tracked-makefile", summary = "Stop tools/test-lint-pack-test-boundary.py from mutating the real Makefile in place; a concurrent git add -A commits its injected violation and the failure surfaces only in CI", source = "spec/npm-sca-gate (unrelated find)"},
+
+  # project-knowledge --capture refuses: a well-formed capture request built
+  #   against the contract in packs/core/tests/skills/project-knowledge/
+  #   knowledge_test_support.py `valid_capture_request` is rejected with
+  #   {"reason_code": "staged_dual_writer", "recovery_action": "fix_request",
+  #   "retryable": false}. The store appears to be sitting in a staged
+  #   lifecycle state from the project-knowledge foundation work (#952), so
+  #   `--activate-staged` is likely the missing maintainer step. This matters
+  #   because work-loop's finish checklist *mandates* routing learnings through
+  #   this seam — every loop currently has to record a named skip instead.
+  # Unblocks when: a core maintainer confirms whether --activate-staged is the
+  #   intended one-time transition, and runs it (or the diagnostic is corrected
+  #   to say what the producer should actually fix).
+  {slug = "project-knowledge-capture-staged-dual-writer", summary = "project-knowledge --capture rejects contract-valid requests with staged_dual_writer, blocking the work-loop's mandated learning-capture step", source = "spec/npm-sca-gate (unrelated find)"},
+
   # The credential-brokers pack's shipped .apm/** carries RFC-0023/RFC-0006 citations
   # in credential-setup/scripts/setup.py and user-libs/credbroker/ (files:
   # __init__.py, _core.py, _vault.py). The pack is frozen by RFC-0013 (§4/§4d);

--- a/workspace.toml
+++ b/workspace.toml
@@ -968,6 +968,16 @@ open = [
   #   allowScripts, or repin so it dedupes to 2.3.3).
   {slug = "npm-allowscripts-enforcement", summary = "Make the documented allowScripts install-script invariant machine-checked for both npm projects, after dispositioning web's pre-existing playwright/fsevents@2.3.2 divergence", source = "spec/npm-sca-gate"},
 
+  # The npm allowlist's `unblocked_when` is prose tools/audit-npm.py never
+  #   reads, so a suppression can sit forever with a stale justification.
+  #   ADR-0017's .snyk policy carries a machine-checked `expires`; mirroring it
+  #   here would make a rotting suppression fail the gate rather than ride
+  #   along. Deliberately not built while tools/npm-audit-allowlist.toml is
+  #   empty — there is nothing to expire yet, and the shape should be decided
+  #   against a real first entry rather than guessed.
+  # Unblocks when: the allowlist gains its first entry.
+  {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
+
   # Unrelated finds from spec/npm-sca-gate — both cost that loop real time.
   #
   # Self-test mutates a tracked file: tools/test-lint-pack-test-boundary.py


### PR DESCRIPTION
## What does this change?

Extends the repo's existing SAST/**SCA** gate (`make sast`, ADR-0017) to the npm
ecosystem, and remediates the advisories it immediately found. `pip-audit` audits
every Python dependency in the tree and no JavaScript; the repo has two npm
projects whose committed lockfiles were scanned by nothing.

## Why?

- Implements: `docs/specs/npm-sca-gate/spec.md`
- Follows from: **ADR-0083** (new), extending **ADR-0017**
- Discharges: `workspace.toml [backlog].open` slug `docs-site-npm-sca-gap`,
  deferred by `spec/docs-site-design-refresh` when AC9 replaced mermaid's CDN
  script with a bundled dependency and vendored its transitive tree into shipped
  output.

The gap was not theoretical. Both lockfiles carried two unremediated **high**
advisories, and `web/` a third at moderate:

| Project | Package | → | Severity | Advisory |
|---|---|---|---|---|
| both | `js-yaml` | 4.3.0 → 4.3.1 | high | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) |
| both | `nanoid` | 3.3.16 → 3.3.18 | high | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) |
| `web/` | `postcss` | 8.5.19 → 8.5.26 | moderate | `sourceMappingURL` arbitrary `.map` read |

The gate blocks at **`moderate`** and above. It was drafted at `high`; fixing
`web/`'s `postcss` finding left both lockfiles clean at moderate, so the bar was
raised for free. A threshold is cheapest to raise while you are already above it
— defer, and the tightening lands on a day something is failing it.

**Not an incident** — checked, not assumed. Tracing each lockfile's dependency
edges, `js-yaml` is reached only via `astro`/`@astrojs/starlight`, `nanoid` only
via `postcss`, and `postcss` only via `vite`/`@expressive-code/core`. All
build-time toolchain, none in a shipped page bundle, and notably *not* pulled in
by the bundled `mermaid`. Lockfile hygiene, hence no changelog `Security` entry.

### Four decisions worth reviewing

**1. Why a leg on `make sast`, not a job in `ci-security.yml`.** `make sast` is
chained into `build-check`, and `build-check.yml` is the **one** workflow inside
`tools/lint-ci-parity.py`'s `WORKFLOW_SCOPE`. A gate added there is locally
reproducible and drift-checked by construction. `ci-security.yml` is explicitly
out of parity scope — putting it there reproduces the exact defect
`spec/local-gate-ci-parity` was written to close.

**2. The verdict comes from the payload, never the exit code.** `npm audit`
exits non-zero for *both* "found advisories" and "could not reach the registry".
Reading the exit code would make a registry outage, a proxy returning HTML, or a
corporate MITM indistinguishable from a clean tree — failing **open** exactly
when the environment is degraded. Exit 0 is reachable only from a parsed report
carrying `auditReportVersion`; everything else is exit 2, distinct from exit 1.
Fixtures pin those paths, because a healthy CI run never reaches them.

**3. A canary probe, because reading the payload is *still* not enough.**
Decision 2 catches every loud failure. It does not catch a registry or mirror
answering the bulk-advisory endpoint with 200 and an empty body. Measured
against a local stub, that returns `auditReportVersion: 2`, `vulnerabilities:
{}`, no `error` key, and a full `metadata.dependencies` block — the last because
npm computes dependency counts *locally* and never receives them from the
registry. Byte-identical to a genuinely clean audit; no payload inspection
separates them, which also rules out cross-checking audited-count against
lockfile-count. So the gate audits `lodash@4.17.11` (GHSA-jf85-cpcp-j695) first.
No canary report → exit 2. Verified both ways: real registry exits 0 with the
canary confirmed; the stub exits 2, where before this change it exited 0 and
said "no blocking advisories".

**4. An empty, reasoned allowlist ships with it.** `npm audit` has no
per-advisory ignore — its only lever is `--audit-level`, which is repo-wide.
The sibling `pip-audit` leg already runs with four `--ignore-vuln` suppressions,
so suppressions are this control's observed steady state here, not a hypothesis.
The hatch is built now rather than designed under the pressure of a wedged merge
queue. Every entry must carry `id`, `reason`, and `unblocked_when`; a blank one
is a tool error, not a silent pass.

**One easily-missed dependency:** both lockfiles are added to `SAST_CONFIG`.
Neither project is under `SAST_DIRS`, so without that a dependency-bump PR —
a diff whose only changed file is a lockfile — would set `SKIP_SAST=1` and skip
the one gate written to check it.

## How do I verify it?

```bash
python3 tools/test-audit-npm.py          # 32 cases, no network, no npm
python3 tools/audit-npm.py --root .      # live: exits 0 over both lockfiles
make -s print-sast-config                # names both lockfiles + the allowlist
make ci                                  # full local gate, SAST leg included
```

To see the gate is not a no-op, revert either lockfile and re-run
`tools/audit-npm.py` — it exits 1 and names both GHSAs per project. That was its
observed state before the remediation commit.

To see the canary is not a no-op, point it at a stub that answers the advisory
endpoint with 200 and an empty body — the gate must exit **2**, not 0:

```bash
python3 - <<'EOF' &
import http.server, json
class H(http.server.BaseHTTPRequestHandler):
    def do_POST(self):
        self.rfile.read(int(self.headers.get('Content-Length') or 0))
        b = json.dumps({}).encode()
        self.send_response(200); self.send_header('Content-Length', str(len(b))); self.end_headers()
        self.wfile.write(b)
    do_GET = do_POST
    def log_message(self, *a): pass
http.server.HTTPServer(('127.0.0.1', 8788), H).serve_forever()
EOF
npm_config_registry=http://127.0.0.1:8788 python3 tools/audit-npm.py --root .   # exit 2
```

Also verified: neither `package.json` changed, and the `"hasInstallScript": true`
set is byte-identical to the pre-change baseline in both lockfiles.

## What did you not change that you considered?

- **Dependabot.** Would answer a different question ("should we bump?") than a
  gate ("may this merge?"), and it changes weekly PR volume and review workload
  — a repo-owner call, not one a build loop should impose. Backlogged as
  `npm-dependabot-wiring`.
- **Enforcing the `allowScripts` invariant.** Both `AGENTS.md` files document it
  as prose and nothing checks it. Deliberately not built: `web/`'s lockfile
  already carries `playwright/node_modules/fsevents@2.3.2` outside its
  `allowScripts` keys, so a checker lands CI red on arrival. That pre-existing
  divergence needs a disposition first — and npm 11 now ships
  `npm approve-scripts`, which may make a bespoke checker unnecessary.
  Backlogged as `npm-allowscripts-enforcement`. Note this is a *different*
  control from SCA: known-CVE scanning vs. arbitrary code execution at install
  time. Neither substitutes for the other.
- **JavaScript SAST.** Different lens from SCA; already owned by
  `sast-javascript-coverage`.
- **`packs/converters/**/package.json`.** No lockfiles, so `npm audit` has
  nothing to read. Owned by `pack-evals-npm-lockfile-integrity`.
- **`--allowlist` CLI flag.** Written, then removed in the simplify pass — zero
  callers.
- **Cross-checking `metadata.dependencies.total` against the lockfile's package
  count** as the positive control. This was my first proposal and it is *wrong*:
  that number is computed locally, so it stays correct precisely when the
  advisory data is missing. Replaced by the canary. Recorded because the wrong
  version is the intuitive one.
- **Machine-checked allowlist expiry.** `.snyk` has `expires`; our
  `unblocked_when` is prose the gate never reads. Not built while the allowlist
  is empty — the shape should be decided against a real first entry. Backlogged
  as `npm-allowlist-expiry-enforcement`.
- **Tightening to `low`.** `moderate` maps most nearly onto Bandit's `medium`;
  lower would gate noise the Python half of the same gate ignores.

## Bundled fixes

None.

## Deferred

- `npm-dependabot-wiring` — bump automation; changes team PR volume, repo-owner call.
- `npm-allowscripts-enforcement` — blocked on dispositioning `web/`'s pre-existing
  `fsevents@2.3.2` divergence, which would otherwise land the checker CI-red.

## Unrelated finds (recorded, not fixed here)

Two repo hazards this loop tripped over. Both are in `[backlog].open`; neither is
in this PR's scope.

- **`selftest-mutates-tracked-makefile`** — `tools/test-lint-pack-test-boundary.py`
  appends a deliberately-violating `lint-selftest-scratch` target to the **real**
  `Makefile` to prove the boundary linter fires, then restores it. A `git add -A`
  inside that window commits the injected violation — and the local re-run then
  *passes*, because the file has since been restored. So it fails only in CI,
  against a tree the developer cannot reproduce. This reddened the first CI run
  on this PR (commit `eb64a88` removes it). Worth fixing at the source: build the
  fixture in a tmpdir copy rather than mutating a tracked file.
- **`project-knowledge-capture-staged-dual-writer`** — `project-knowledge
  --capture` rejects a request built directly against the contract in
  `knowledge_test_support.valid_capture_request` with
  `{"reason_code": "staged_dual_writer", "recovery_action": "fix_request",
  "retryable": false}`. Since work-loop's finish checklist *mandates* routing
  learnings through that seam, every loop currently has to record a named skip.
  `--activate-staged` looks like the missing maintainer step, but running a
  repo-wide knowledge-lifecycle transition as a side effect of an unrelated PR
  would be the wrong call, so it is recorded instead. **The learning from this
  loop is therefore written into `[backlog].open` and this description rather
  than the knowledge journal.**

---

## Checklist

- [x] Tests pass locally (`python3 tools/test-audit-npm.py`, `make ci`)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy`)
- [ ] **Self-review — read this one.** Reviewer subagents were unavailable in the
      session that produced this PR (operator configuration), so the
      `adversarial-reviewer` and `security-reviewer` passes were run **inline**
      against the `security-checklists` `supply-chain` and `config-misconfig`
      modules rather than dispatched. Recording it as a **named skip, not a
      silent one**. Findings that pass produced, all applied:
      spec-stage — the fail-open-on-registry-error hole (now AC1a); an AC5 that
      was false on arrival for `web/`'s pre-existing `fsevents` entry; a plan
      risk-mitigation claiming this PR tests its own `SAST_CONFIG` predicate
      when it cannot. Implementation-stage — symlinked *files* being skipped
      alongside symlinked directories; a silent `except OSError` in the walk;
      a blocking-severity entry with no `via` reading as clean; the unused
      `--allowlist` flag. **A second pair of eyes on the fail-closed paths in
      `evaluate()` is the highest-value thing a reviewer can do here.**
- [x] Spec and code agree (spec updated in this PR as findings landed)
- [x] Living docs match reality:
  - [x] `docs/product/changelog.md` — N/A: repo-internal gate; the advisories are
        build-time toolchain, not shipped behaviour (traced above)
  - [x] `guides/` — N/A: no user-facing behaviour, config, or interface change
  - [x] `docs/architecture/` — N/A; the decision is recorded in ADR-0083 instead
  - [x] `docs/product/roadmap.md` — N/A
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — `docs-site/AGENTS.md` and `web/AGENTS.md` both now
      state what scans these lockfiles and what does not; ADR-0017 gained a
      forward pointer so a reader landing on the Python-only gate finds the npm
      extension. **Named skip:** the `project-knowledge --capture` seam is
      refusing contract-valid requests (see § Unrelated finds), so the
      journal-bound learning went to `[backlog].open` instead.
