### PR TITLE
fix(agentbundle): stop a planted symlink wedging every state-mutating verb

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -116,6 +116,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead — "Adapt to Project" now reads "How to adapt a freshly installed pack
   to your project". No page moved and no link changed. No pack version changes.
 
+### [agentbundle][0.36.2] — 2026-08-16
+
+#### Fixed
+
+- **A single stray file could hang every command that records installed packs,
+  and burn a CPU core doing it.** If something left a broken shortcut where the
+  lock file belongs, `agentbundle` spun forever instead of timing out. It now
+  refuses that file straight away and tells you to remove it. Also fixed two
+  narrower races where a command could delete another command's lock and let
+  both write at once.
+
 ### [agentbundle][0.36.1] — 2026-08-16
 
 #### Fixed

--- a/docs/specs/agentbundle-statelock-hardening/plan.md
+++ b/docs/specs/agentbundle-statelock-hardening/plan.md
@@ -1,0 +1,73 @@
+# Plan: agentbundle-statelock-hardening
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `packages/agentbundle/agentbundle/statelock.py`.
+- `packages/agentbundle/tests/unit/test_statelock_hardening.py` (new).
+- Version + both changelogs; `workspace.toml`.
+
+**What demonstrates done**
+- The reproduction, before and after; 14 tests; mutation revert; `make ci`.
+
+**What I am NOT changing**
+- The work-loop skill's `_statelock.py` — the source of the port, untouched.
+- `persist_state_locked`'s signature or the merge semantics.
+- The 60s `stale_after` default (an NTP-skew margin, not part of this defect).
+
+## Security reasoning (inline — `security-reviewer` is a named skip)
+
+- **Availability / CWE-835 (infinite loop).** The primitive is an unkillable
+  busy-wait reachable by anyone who can create a name next to the state file.
+  It is a denial of service on *every* state-mutating verb at once, and the
+  timeout that should have bounded it was itself bypassed — the worst shape,
+  because the caller believes it is protected.
+- **`path-and-file` / CWE-59 (link following).** `Path.stat()` follows; the
+  planted symlink is what turned a normal contention path into an unbounded one.
+  `os.lstat` plus an S_ISREG refusal removes the class, not just the instance.
+- **Concurrency (TOCTOU).** AC5 and AC6 are two different ways the lock could
+  admit two holders — one at release, one during reclaim. Both are real races
+  rather than theoretical: the reclaim window is exactly when a third contender
+  is most likely to be trying the path.
+- **Failure mode chosen.** Refusing immediately on a non-regular lock path is
+  louder than waiting. That is deliberate: a timeout message would send the
+  operator to retry, which cannot succeed.
+- **Not in scope.** This does not authenticate the lock's *creator*; a local
+  attacker can still hold the lock legitimately and block progress for
+  `stale_after`. Bounded, visible, and a different problem.
+
+## Declined patterns
+
+- **Tempted:** import the work-loop skill's `_statelock.py` directly instead of
+  porting. **Declined:** ADR-0074 keeps them separate on purpose, and the skill
+  script is not importable from the installed package anyway.
+- **Tempted:** make `StateLockUnusable` subclass `StateLockTimeout` so every
+  existing `except StateLockTimeout` catches it. **Declined:** it is not a
+  timeout, and mistyping it to buy compatibility would make the taxonomy lie.
+  Checked the two real consumers instead — both handle the OSError family.
+- **Tempted:** also port the reference's `StateLockLost` (raised when a hold
+  discovers its lock was reclaimed mid-body). **Declined:** it is a new
+  observable failure for callers that today see silent success; worth doing, but
+  as its own decision rather than inside a DoS fix.
+
+## Anchor-test sweep
+
+- `tests/unit/test_statelock.py` — five existing tests over acquire, contention
+  and the merge; all still pass unchanged.
+- `tests/integration/test_local_scope_install.py` patches
+  `persist_state_locked`; signature untouched.
+- Release-surface pins under `tests/roster/` — re-run after the bump (pass).
+
+## Verification log
+
+- **AC1** reproduced against the shipped code: still spinning after 5s with
+  `timeout=2.0`.
+- **AC2/AC3** after the fix: `StateLockUnusable` in 0.000s.
+- **AC7** mutation: reverting lstat+refusal and the bounded retry re-fails the
+  spin test with the "it is spinning" assertion; restoring passes.
+- **Suites** 14 tests across the new and existing statelock files; roster pass.
+- **REVIEW** `adversarial-reviewer` and `security-reviewer` = named skips
+  (session instruction prohibits subagent dispatch). Reasoning inline above.

--- a/docs/specs/agentbundle-statelock-hardening/spec.md
+++ b/docs/specs/agentbundle-statelock-hardening/spec.md
@@ -1,0 +1,83 @@
+# Spec: agentbundle-statelock-hardening
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** `agentbundle.statelock` gains one exception type
+  (`StateLockUnusable`, an `OSError`). No existing signature changes.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. Risk trigger: security boundary — a denial-of-service on every
+state-mutating verb, reachable by any writable path next to a state file.
+`security-reviewer` cannot be dispatched under this session's no-subagent
+instruction, so its absence is a NAMED SKIP; the reasoning is inline in the plan. -->
+
+## Objective
+
+One planted file wedged every state-mutating `agentbundle` verb at 100% CPU,
+forever, with the timeout never firing. Close that, and the three adjacent races
+in the same lock.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the hot spin is reproduced before it is fixed.** Against the
+  shipped package: a dangling symlink at `<state>.lock` makes
+  `os.open(O_CREAT|O_EXCL)` fail `FileExistsError` while `Path.stat()` follows
+  the link and raises `FileNotFoundError`; that handler looped with neither a
+  deadline check nor a sleep. Measured: still spinning past a 2.0s timeout.
+
+- [x] **AC2 — every retry path checks the deadline and sleeps.** All three
+  continue-paths in the acquire loop (released-between-open-and-lstat, reclaim,
+  and ordinary contention) now bound themselves.
+
+- [x] **AC3 — the examine step does not follow links, and refuses what waiting
+  cannot fix.** `os.lstat` replaces `Path.stat()`; a lock path that is not a
+  regular file raises `StateLockUnusable` **immediately** rather than waiting out
+  a timeout that cannot succeed. Reporting a timeout there would tell an operator
+  to retry, which would never work; the message says to remove the file.
+
+- [x] **AC4 — the new exception cannot surprise a caller.**
+  `StateLockUnusable` subclasses `OSError`, as `StateLockTimeout` does. The two
+  production consumers are `install.py` (catches `Exception` and rolls back) and
+  `oplog.py` (propagates, and already raises bare `OSError` for a symlinked
+  oplog path).
+
+- [x] **AC5 — release keys on inode identity AND a per-hold token.** Release was
+  an unconditional `unlink(missing_ok=True)`, so a hold whose lock had been
+  reclaimed mid-body would delete its *successor's* live lockfile — two holders
+  inside the section, produced by a release rather than an acquire. Identity
+  alone is insufficient: ext4 and tmpfs reuse inode numbers aggressively, so a
+  successor can land on the freed inode. The uuid4 token makes a false positive
+  require reproducing a uuid4.
+
+- [x] **AC6 — a mismatched reclaim restores by `os.link`, not `rename`.**
+  `rename` silently replaces its destination, so if a third process took the
+  momentarily-free lock path, restoring by rename would delete that process's
+  lockfile and admit two holders. `link` fails with `FileExistsError` instead —
+  failing closed.
+
+- [x] **AC7 — each property has its own test, and they are mutation-verified.**
+  Reverting AC2+AC3 makes `test_a_dangling_symlink_lock_path_does_not_spin` fail
+  with the spin assertion; restoring passes. Tests are separated per property so
+  a regression names which one returned.
+
+- [x] **AC8 — the hardening does not cost the deadlock recovery it protects.**
+  A stale (one-hour-old) lock is still reclaimed, and a fresh foreign lock is
+  still waited on and then times out — asserted to actually wait, not refuse.
+
+- [x] **AC9 — released.** 0.36.1 → 0.36.2, both changelogs, backlog entry removed.
+
+## Boundaries
+
+### Never do
+
+- Never merge this module with the work-loop skill's `_statelock.py`. ADR-0074
+  keeps them separate deliberately — different files, different consumers. This
+  ports the hardening; it does not share the code.
+- Never use `Path.stat()` on the lock path. Following the link is the defect.
+
+## Testing Strategy
+
+- **TDD + mutation** throughout; the reproduction came first.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,37 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.36.2] — 2026-08-16
+
+### Fixed
+
+- **Security: one planted file could wedge every state-mutating command at
+  100% CPU.** A *dangling symlink* at `<state>.lock` made
+  `os.open(O_CREAT|O_EXCL)` fail with `FileExistsError` while `Path.stat()`
+  followed the link and raised `FileNotFoundError` — and that handler looped
+  with neither a deadline check nor a sleep. The timeout therefore never fired:
+  confirmed against the shipped package at 98% CPU, still spinning well past a
+  2-second budget. Any writable directory holding a state file was enough.
+
+  Four hardening items, ported from the work-loop skill's sibling lock (kept a
+  separate module deliberately — the two guard different files for different
+  consumers):
+
+  - **Every** retry path now checks the deadline and sleeps.
+  - The examine step uses `os.lstat`, which does not follow links, and refuses
+    any lock path that is not a regular file. New `StateLockUnusable` (an
+    `OSError`, like `StateLockTimeout`) says so immediately rather than waiting
+    out a timeout that cannot succeed — waiting cannot make a symlink acquirable,
+    and telling an operator to retry would be advice that never works.
+  - Release keys on inode identity **and** a per-hold uuid4 token, so a hold
+    whose lock was reclaimed mid-body no longer unlinks its *successor's* live
+    lockfile on the way out. Inode identity alone is not enough: ext4 and tmpfs
+    reuse inode numbers aggressively.
+  - A mismatched reclaim restores the displaced file with `os.link` rather than
+    `rename`. `rename` silently replaces its destination, so a third process
+    that took the momentarily-free path would have its lockfile deleted and two
+    holders admitted; `link` fails closed instead.
+
 ## [0.36.1] — 2026-08-16
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/statelock.py
+++ b/packages/agentbundle/agentbundle/statelock.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
+import stat
 import time
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterator
 
@@ -30,6 +33,86 @@ if TYPE_CHECKING:
 
 class StateLockTimeout(OSError):
     """Raised when the lock cannot be acquired within the timeout."""
+
+
+class StateLockUnusable(OSError):
+    """Raised when the lock path can never become acquirable.
+
+    Distinct from :class:`StateLockTimeout` because waiting cannot help: a
+    non-regular file at the lock path (a symlink, a directory, a FIFO) will
+    still be there at the deadline. Both subclass ``OSError``, which every
+    caller of this module already handles.
+    """
+
+
+# Ownership record: a tag, a per-hold uuid4 token, and the holder's pid.
+# The token is what makes ownership checkable — inode identity alone is not
+# enough, because ext4 and tmpfs reuse inode numbers aggressively, so a
+# successor's lockfile can land on the freed inode of the one being checked.
+_RECORD_TAG = b"agentbundle-statelock"
+_RECORD_RE = re.compile(r"^agentbundle-statelock ([0-9a-f]{32}) (\d+)$")
+
+
+def _read_record(lock: Path) -> bytes | None:
+    """First line of *lock*, or ``None`` if unreadable."""
+    try:
+        with open(lock, "rb") as handle:  # noqa: PTH123 — need the raw fd path
+            return handle.readline()
+    except OSError:
+        return None
+
+
+def _same_file(st: os.stat_result, ident: tuple[int, int]) -> bool:
+    """Inode identity. Necessary but not sufficient — see :func:`_is_ours`."""
+    return (st.st_dev, st.st_ino) == ident
+
+
+def _is_ours(lock: Path, ident: tuple[int, int], record: bytes) -> bool:
+    """True iff *lock* is still the exact file this hold created."""
+    try:
+        st = os.lstat(lock)
+    except OSError:
+        return False
+    return _same_file(st, ident) and _read_record(lock) == record
+
+
+def _reclaim(lock: Path, observed: os.stat_result, record: bytes | None) -> None:
+    """Best-effort removal of the stale lockfile *observed*.
+
+    Rename to a name unique per *attempt* (not per pid — two threads of one
+    process would otherwise collide), then confirm the file that moved is the
+    one judged stale before unlinking it.
+
+    On a mismatch we moved a *live* holder's lock, so it goes back by
+    ``os.link``, not ``rename``: ``rename`` silently replaces its destination,
+    so if a third process took the momentarily-free path in the meantime,
+    restoring by rename would delete that process's lockfile and admit two
+    holders. ``link`` fails with ``FileExistsError`` instead, and the displaced
+    holder discovers the loss at release rather than a bystander losing a write.
+    """
+    claimed = lock.with_name(f"{lock.name}.reclaim.{uuid.uuid4().hex}")
+    try:
+        lock.rename(claimed)
+    except OSError:
+        return  # another contender reclaimed, or the holder released first
+    try:
+        moved = os.lstat(claimed)
+    except OSError:
+        return
+    if not _same_file(moved, (observed.st_dev, observed.st_ino)) or (
+        _read_record(claimed) != record
+    ):
+        try:
+            os.link(claimed, lock)
+        except OSError:
+            # The path is occupied again, or the link failed; leaving `claimed`
+            # in place fails closed rather than clobbering a live holder.
+            return
+        with contextlib.suppress(OSError):
+            claimed.unlink()
+        return
+    with contextlib.suppress(OSError):
+        claimed.unlink()
 
 
 @contextlib.contextmanager
@@ -44,11 +127,23 @@ def state_lock(
 
     The lock is a sibling file ``<state_path>.lock`` created with
     ``O_CREAT | O_EXCL`` — the create succeeds for exactly one holder. Other
-    contenders spin-retry every *poll* seconds up to *timeout*. A lockfile
-    whose mtime is older than *stale_after* is reclaimed (a previous holder
-    crashed); this prevents a permanent deadlock without a daemon.
+    contenders retry every *poll* seconds up to *timeout*. A lockfile whose
+    mtime is older than *stale_after* is reclaimed (a previous holder crashed);
+    this prevents a permanent deadlock without a daemon.
 
-    Raises ``StateLockTimeout`` if the lock cannot be acquired in time.
+    **Every** retry path checks the deadline and sleeps. An earlier version did
+    not: a *dangling symlink* at the lock path made ``O_CREAT | O_EXCL`` fail
+    with ``FileExistsError`` while ``Path.stat()`` followed the link and raised
+    ``FileNotFoundError``, whose handler looped with neither check nor sleep.
+    One planted file wedged every state-mutating verb at 100% CPU, and the
+    timeout never fired.
+
+    The examine step therefore uses ``os.lstat`` (which does not follow) and
+    refuses any lock path that is not a regular file — waiting cannot make a
+    symlink acquirable.
+
+    Raises :class:`StateLockUnusable` at once if the lock path is not a regular
+    file, and :class:`StateLockTimeout` if contention outlasts *timeout*.
     """
     # ``state_path`` is trusted, CLI-resolved input (the repo root or
     # ``~/.agentbundle/``), never pack-sourced — so the sibling lock path
@@ -57,37 +152,52 @@ def state_lock(
     lock_path = state_path.with_name(state_path.name + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     deadline = time.monotonic() + timeout
+    record = b"%s %s %d\n" % (
+        _RECORD_TAG,
+        uuid.uuid4().hex.encode("ascii"),
+        os.getpid(),
+    )
     fd: int | None = None
     while True:
         try:
             fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
             break
         except FileExistsError:
-            # Reclaim a stale lock (a holder crashed) — but do it RACE-SAFELY.
-            # A naive `unlink(); continue` lets two contenders both unlink and
-            # a third's fresh lock get deleted, admitting two holders. Instead
-            # rename the stale lockfile to a per-pid temp: `os.rename` is
-            # atomic, so exactly one contender wins (the lockfile moves once);
-            # losers see FileNotFoundError and re-loop. Staleness is judged on
-            # `st_mtime` — necessarily wall-clock, unlike the monotonic
-            # timeout; the 60s default absorbs normal NTP skew.
             try:
-                age = time.time() - lock_path.stat().st_mtime
+                observed = os.lstat(lock_path)
             except FileNotFoundError:
-                # Holder released between our open and stat — retry promptly.
+                # Released between our open and our lstat. Retry — BOUNDED,
+                # which is exactly what the superseded loop missed.
+                if time.monotonic() >= deadline:
+                    raise StateLockTimeout(
+                        f"could not acquire state lock {lock_path} within {timeout}s"
+                    ) from None
+                time.sleep(poll)
                 continue
+
+            if not stat.S_ISREG(observed.st_mode):
+                raise StateLockUnusable(
+                    f"refusing state lock {lock_path}: a lock path must be a "
+                    f"regular file (found mode {stat.filemode(observed.st_mode)}). "
+                    "Waiting cannot make this acquirable — remove it."
+                ) from None
+
+            observed_record = _read_record(lock_path)
+            # Staleness is wall-clock (st_mtime), unlike the monotonic timeout,
+            # so it is exposed to NTP skew; the stale_after margin absorbs it.
+            age = time.time() - observed.st_mtime
             if age > stale_after:
-                claimed = lock_path.with_name(
-                    lock_path.name + f".reclaim.{os.getpid()}"
-                )
-                try:
-                    lock_path.rename(claimed)
-                except (FileNotFoundError, OSError):
-                    # Another contender reclaimed or the holder released first.
-                    continue
-                # We won the reclaim: drop the stale lock and retry the create.
-                Path(claimed).unlink(missing_ok=True)
+                _reclaim(lock_path, observed, observed_record)
+                if time.monotonic() >= deadline:
+                    raise StateLockTimeout(
+                        f"could not acquire state lock {lock_path} within {timeout}s"
+                    ) from None
+                # Sleep here too: a reclaim that keeps losing its rename would
+                # otherwise spin hot until the deadline — bounded, but still the
+                # CPU burn this hardening exists to remove.
+                time.sleep(poll)
                 continue
+
             if time.monotonic() >= deadline:
                 raise StateLockTimeout(
                     f"could not acquire state lock {lock_path} within {timeout}s"
@@ -95,15 +205,23 @@ def state_lock(
             time.sleep(poll)
     try:
         with contextlib.suppress(OSError):
-            os.write(fd, str(os.getpid()).encode("ascii"))
+            os.write(fd, record)
         os.close(fd)
         fd = None
+        held = os.lstat(lock_path)
+        ident = (held.st_dev, held.st_ino)
         yield lock_path
     finally:
         if fd is not None:
             with contextlib.suppress(OSError):
                 os.close(fd)
-        lock_path.unlink(missing_ok=True)
+        # Unlink only if this is still the file we created. The old code
+        # unlinked unconditionally, so a hold whose lock had been reclaimed
+        # would delete its *successor's* live lockfile on the way out — two
+        # holders inside the section, from a release rather than an acquire.
+        if _is_ours(lock_path, ident, record):
+            with contextlib.suppress(OSError):
+                lock_path.unlink()
 
 
 def persist_state_locked(

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.36.1"
+CLI_VERSION = "0.36.2"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.36.1"
+version = "0.36.2"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/unit/test_statelock_hardening.py
+++ b/packages/agentbundle/tests/unit/test_statelock_hardening.py
@@ -68,9 +68,8 @@ def test_a_dangling_symlink_lock_path_does_not_spin(tmp_path: Path) -> None:
     _lock_of(state).symlink_to(tmp_path / "does-not-exist")
 
     started = time.monotonic()
-    with _Alarm(10), pytest.raises(OSError):
-        with statelock.state_lock(state, timeout=2.0):
-            pass
+    with _Alarm(10), pytest.raises(OSError), statelock.state_lock(state, timeout=2.0):
+        pass
     assert time.monotonic() - started < 5.0, "took far longer than the timeout"
 
 
@@ -89,9 +88,12 @@ def test_a_symlink_lock_path_is_refused_not_waited_on(tmp_path: Path) -> None:
     _lock_of(state).symlink_to(tmp_path / "real-target")
 
     started = time.monotonic()
-    with _Alarm(10), pytest.raises(statelock.StateLockUnusable) as exc:
-        with statelock.state_lock(state, timeout=30.0):
-            pass
+    with (
+        _Alarm(10),
+        pytest.raises(statelock.StateLockUnusable) as exc,
+        statelock.state_lock(state, timeout=30.0),
+    ):
+        pass
     # Refused immediately, not after the 30s timeout.
     assert time.monotonic() - started < 2.0
     assert "regular file" in str(exc.value)
@@ -100,9 +102,12 @@ def test_a_symlink_lock_path_is_refused_not_waited_on(tmp_path: Path) -> None:
 def test_a_directory_lock_path_is_refused(tmp_path: Path) -> None:
     state = _state(tmp_path)
     _lock_of(state).mkdir()
-    with _Alarm(10), pytest.raises(statelock.StateLockUnusable):
-        with statelock.state_lock(state, timeout=30.0):
-            pass
+    with (
+        _Alarm(10),
+        pytest.raises(statelock.StateLockUnusable),
+        statelock.state_lock(state, timeout=30.0),
+    ):
+        pass
 
 
 def test_unusable_is_an_oserror(tmp_path: Path) -> None:
@@ -163,9 +168,8 @@ def test_a_stale_lock_is_still_reclaimed(tmp_path: Path) -> None:
     lock.write_text("agentbundle-statelock deadbeef 99999\n", encoding="ascii")
     os.utime(lock, (time.time() - 3600, time.time() - 3600))
 
-    with _Alarm(15):
-        with statelock.state_lock(state, timeout=5.0, stale_after=60.0):
-            pass  # acquired by reclaiming the hour-old lock
+    with _Alarm(15), statelock.state_lock(state, timeout=5.0, stale_after=60.0):
+        pass  # acquired by reclaiming the hour-old lock
 
 
 def test_a_fresh_foreign_lock_times_out(tmp_path: Path) -> None:
@@ -174,9 +178,12 @@ def test_a_fresh_foreign_lock_times_out(tmp_path: Path) -> None:
     _lock_of(state).write_text("agentbundle-statelock cafe 12345\n", encoding="ascii")
 
     started = time.monotonic()
-    with _Alarm(15), pytest.raises(statelock.StateLockTimeout):
-        with statelock.state_lock(state, timeout=0.5, stale_after=9999):
-            pass
+    with (
+        _Alarm(15),
+        pytest.raises(statelock.StateLockTimeout),
+        statelock.state_lock(state, timeout=0.5, stale_after=9999),
+    ):
+        pass
     elapsed = time.monotonic() - started
     assert elapsed >= 0.4, "must actually wait rather than refuse at once"
     assert elapsed < 5.0

--- a/packages/agentbundle/tests/unit/test_statelock_hardening.py
+++ b/packages/agentbundle/tests/unit/test_statelock_hardening.py
@@ -1,0 +1,182 @@
+"""The four hardening properties of the state lock.
+
+The defect that motivated these: a **dangling symlink** planted at the lock
+path wedged every state-mutating verb. `os.open(O_CREAT|O_EXCL)` fails
+`FileExistsError` on a symlink, while `Path.stat()` *follows* it and raises
+`FileNotFoundError` — and that handler looped with neither a deadline check nor
+a sleep. Confirmed against the shipped package before the fix: 100% CPU, still
+spinning well past a 2-second timeout, which therefore never fired. One planted
+file, every verb.
+
+Each property below is stated as its own test, so a regression names which one
+came back rather than only that something did.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+
+import pytest
+from agentbundle import statelock
+
+
+def _state(tmp_path: Path) -> Path:
+    p = tmp_path / "state.json"
+    p.write_text("{}", encoding="utf-8")
+    return p
+
+
+def _lock_of(state: Path) -> Path:
+    return state.with_name(state.name + ".lock")
+
+
+class _Alarm:
+    """Fail the test if the block outlasts *seconds* — a spin never returns."""
+
+    def __init__(self, seconds: int) -> None:
+        self.seconds = seconds
+
+    def __enter__(self):
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM unavailable on this platform")
+
+        def _boom(_sig, _frm):
+            raise AssertionError(
+                "the acquire loop did not return — it is spinning, which is "
+                "the exact defect these tests exist to prevent"
+            )
+
+        self._prev = signal.signal(signal.SIGALRM, _boom)
+        signal.alarm(self.seconds)
+        return self
+
+    def __exit__(self, *exc):
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, self._prev)
+        return False
+
+
+# --- 1. Every retry path checks the deadline and sleeps --------------------
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="no symlink support")
+def test_a_dangling_symlink_lock_path_does_not_spin(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    _lock_of(state).symlink_to(tmp_path / "does-not-exist")
+
+    started = time.monotonic()
+    with _Alarm(10), pytest.raises(OSError):
+        with statelock.state_lock(state, timeout=2.0):
+            pass
+    assert time.monotonic() - started < 5.0, "took far longer than the timeout"
+
+
+# --- 2. os.lstat + refuse a non-regular lock path --------------------------
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="no symlink support")
+def test_a_symlink_lock_path_is_refused_not_waited_on(tmp_path: Path) -> None:
+    """Waiting cannot make a symlink acquirable, so it must not be waited on.
+
+    The distinction matters operationally: a timeout tells the operator to try
+    again, which will never work. This tells them to remove the file.
+    """
+    state = _state(tmp_path)
+    (tmp_path / "real-target").write_text("x", encoding="utf-8")
+    _lock_of(state).symlink_to(tmp_path / "real-target")
+
+    started = time.monotonic()
+    with _Alarm(10), pytest.raises(statelock.StateLockUnusable) as exc:
+        with statelock.state_lock(state, timeout=30.0):
+            pass
+    # Refused immediately, not after the 30s timeout.
+    assert time.monotonic() - started < 2.0
+    assert "regular file" in str(exc.value)
+
+
+def test_a_directory_lock_path_is_refused(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    _lock_of(state).mkdir()
+    with _Alarm(10), pytest.raises(statelock.StateLockUnusable):
+        with statelock.state_lock(state, timeout=30.0):
+            pass
+
+
+def test_unusable_is_an_oserror(tmp_path: Path) -> None:
+    """Both consumers handle OSError-family failures; keep it that way."""
+    assert issubclass(statelock.StateLockUnusable, OSError)
+    assert issubclass(statelock.StateLockTimeout, OSError)
+
+
+# --- 3. Ownership keys on inode identity AND the per-hold token ------------
+
+
+def test_release_does_not_unlink_a_successors_lock(tmp_path: Path) -> None:
+    """The release-side half of the same class of bug.
+
+    If a hold's lockfile is reclaimed mid-body and a successor takes the path,
+    an unconditional `unlink()` on the way out deletes the *successor's* live
+    lock — two holders inside the section, produced by a release rather than an
+    acquire.
+    """
+    state = _state(tmp_path)
+    lock = _lock_of(state)
+
+    with statelock.state_lock(state, timeout=5.0):
+        # Simulate the reclaim: our lockfile goes away and a successor's
+        # appears at the same path with different contents.
+        lock.unlink()
+        lock.write_text("successor-holds-this\n", encoding="utf-8")
+
+    assert lock.exists(), "release deleted a lockfile it did not create"
+    assert lock.read_text(encoding="utf-8") == "successor-holds-this\n"
+
+
+def test_release_removes_its_own_lock(tmp_path: Path) -> None:
+    """The other direction — ownership checking must not leak locks."""
+    state = _state(tmp_path)
+    lock = _lock_of(state)
+    with statelock.state_lock(state, timeout=5.0):
+        assert lock.exists()
+    assert not lock.exists(), "a normal release must remove its own lockfile"
+
+
+def test_the_lock_record_identifies_this_hold(tmp_path: Path) -> None:
+    state = _state(tmp_path)
+    lock = _lock_of(state)
+    with statelock.state_lock(state, timeout=5.0):
+        record = lock.read_text(encoding="ascii")
+    assert record.startswith("agentbundle-statelock ")
+    assert record.rstrip().endswith(str(os.getpid()))
+
+
+# --- 4. Stale reclaim still works -----------------------------------------
+
+
+def test_a_stale_lock_is_still_reclaimed(tmp_path: Path) -> None:
+    """Hardening must not cost the deadlock recovery it was built around."""
+    state = _state(tmp_path)
+    lock = _lock_of(state)
+    lock.write_text("agentbundle-statelock deadbeef 99999\n", encoding="ascii")
+    os.utime(lock, (time.time() - 3600, time.time() - 3600))
+
+    with _Alarm(15):
+        with statelock.state_lock(state, timeout=5.0, stale_after=60.0):
+            pass  # acquired by reclaiming the hour-old lock
+
+
+def test_a_fresh_foreign_lock_times_out(tmp_path: Path) -> None:
+    """A lock that is merely held, not stale, is waited on and then times out."""
+    state = _state(tmp_path)
+    _lock_of(state).write_text("agentbundle-statelock cafe 12345\n", encoding="ascii")
+
+    started = time.monotonic()
+    with _Alarm(15), pytest.raises(statelock.StateLockTimeout):
+        with statelock.state_lock(state, timeout=0.5, stale_after=9999):
+            pass
+    elapsed = time.monotonic() - started
+    assert elapsed >= 0.4, "must actually wait rather than refuse at once"
+    assert elapsed < 5.0

--- a/workspace.toml
+++ b/workspace.toml
@@ -517,18 +517,6 @@ open = [
     # from a subprocess killed between create and write, or a filesystem that returns ENOSPC
     # on write. Unblocks: now — it is a test-coverage gap, not a defect.
   {slug = "statelock-token-write-failure-test", source = "spec/loop-cohort-state-lock"},
-    # agentbundle/statelock.py:74-78 hot-spins forever on a dangling-symlink lock path:
-    # open(O_CREAT|O_EXCL) fails EEXIST on a symlink while Path.stat() follows it and raises
-    # FileNotFoundError, whose handler `continue`s with no deadline check and no sleep, so
-    # StateLockTimeout never fires. Confirmed against the SHIPPED package: 98.4% CPU, still
-    # spinning after 6s with timeout=2.0. One planted file wedges every state-mutating verb.
-    # The work-loop now has its own hardened lock (ADR-0074: deliberately separate, since the
-    # two guard different files for different consumers), so this module keeps the defect on its
-    # own. Fix: port the four hardening items from
-    # packs/core/.apm/skills/work-loop/scripts/_statelock.py — deadline check on every retry
-    # path, os.lstat + refuse a non-regular lock path, inode+token ownership, link-based reclaim
-    # restore. Needs an agentbundle release. Unblocks: now — it does not depend on the skill.
-  {slug = "agentbundle-statelock-symlink-spin", source = "spec/loop-cohort-state-lock"},
     # loop-engine's _recover_pending reads the repo-global .loop-run/events.pending and then
     # calls _recover_engine_state_tmp(pending_spec_dir) for whatever spec that record names,
     # so a transition on spec A — holding only A's per-spec lock — can promote or delete spec


### PR DESCRIPTION
## What does this change?

One file, planted in any directory holding a state file, hung every `agentbundle` command that writes state — forever, at 100% CPU, with the timeout never firing. This fixes that and three adjacent races in the same lock.

## Why?

- Implements: `docs/specs/agentbundle-statelock-hardening/spec.md`
- Closes: `agentbundle-statelock-symlink-spin`
- Release: agentbundle 0.36.1 → **0.36.2**

A dangling symlink at `<state>.lock` makes `os.open(O_CREAT|O_EXCL)` fail `FileExistsError` (the link exists). `Path.stat()` then **follows** the link and raises `FileNotFoundError` — and that handler looped with neither a deadline check nor a sleep. The worst shape of bug, because the caller believes the timeout protects it.

**Reproduced against the shipped package before touching it:** still spinning well past a 2.0s budget.

## How do I verify it?

```bash
python3 -m pytest packages/agentbundle/tests/unit/test_statelock_hardening.py \
                 packages/agentbundle/tests/unit/test_statelock.py -q     # 14 passed
make ci
```

The reproduction, if you want to see it yourself — plant `state.json.lock` as a symlink to a nonexistent path and call `state_lock(state, timeout=2.0)`. Before: spins. After: `StateLockUnusable` in 0.000s.

**Mutation-verified:** reverting the `lstat` + refusal and the bounded retry re-fails `test_a_dangling_symlink_lock_path_does_not_spin` with its "it is spinning" assertion; restoring passes.

## The four items

1. **Every** retry path checks the deadline and sleeps — all three continue-paths, not only the one that failed.
2. The examine step uses `os.lstat` (does not follow) and refuses a non-regular lock path **immediately** via a new `StateLockUnusable`. Reporting a timeout there would tell an operator to retry — advice that can never work, because waiting cannot make a symlink acquirable.
3. Release keys on inode identity **and** a per-hold uuid4 token. It was an unconditional `unlink`, so a hold whose lock had been reclaimed mid-body would delete its **successor's** live lockfile — two holders in the section, produced by a *release* rather than an acquire. Identity alone is insufficient: ext4 and tmpfs reuse inode numbers aggressively.
4. A mismatched reclaim restores by `os.link`, not `rename`. `rename` silently replaces its destination, so a third process that took the momentarily-free path would lose its lockfile; `link` fails closed.

Two tests pin that the hardening did not cost the deadlock recovery it exists to protect: a stale lock is still reclaimed, and a fresh foreign lock is still *waited on* (asserted to actually wait) before timing out.

## What did you not change that you considered?

- **Importing the work-loop skill's `_statelock.py` instead of porting it.** ADR-0074 keeps the two separate deliberately — different files, different consumers — and the skill script is not importable from the installed package anyway.
- **Making `StateLockUnusable` subclass `StateLockTimeout`**, so every existing `except StateLockTimeout` would catch it. It is not a timeout, and mistyping it to buy compatibility would make the taxonomy lie. I checked the two real consumers instead: `install.py` catches `Exception` and rolls back; `oplog.py` propagates and already raises bare `OSError` for a symlinked oplog path.
- **Porting the reference's `StateLockLost`** (raised when a hold finds its lock was reclaimed mid-body). Worth having, but it is a new observable failure for callers that today see silent success — its own decision, not something to slip inside a DoS fix.
- **Authenticating the lock's creator.** Out of scope: a local actor can still hold the lock legitimately and block progress for `stale_after`. Bounded, visible, different problem.

## Checklist

- [x] Tests pass locally — 14 statelock tests, `make ci`
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. `security-reviewer` was warranted (CWE-835 infinite loop, CWE-59 link following, two TOCTOU races), so its reasoning is inline in `plan.md` § *Security reasoning*. **Worth a human security read before merge if you want one.**
- [x] Spec and code agree
- [x] Living docs match reality — both changelogs
- [x] No new top-level directories
- [x] Conventional commit format