### PR TITLE
feat(agentbundle): refuse local installs that cannot be cleanly undone

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -116,6 +116,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead — "Adapt to Project" now reads "How to adapt a freshly installed pack
   to your project". No page moved and no link changed. No pack version changes.
 
+### [agentbundle][0.37.0] — 2026-08-16
+
+#### Changed
+
+- **A local-scope install now stops rather than quietly taking over a file that
+  is not its own.** It refuses when a target is already committed to git, when a
+  file is sitting there that no install created, or when another installed pack
+  already owns that path — and it stops before writing anything, so a refusal
+  leaves your tree untouched. This protects the promise local scope makes:
+  uninstalling puts everything back exactly as it was. Reinstalling over files
+  it already owns still works as before.
+
 ### [agentbundle][0.36.2] — 2026-08-16
 
 #### Fixed

--- a/docs/specs/local-scope-install-guards/plan.md
+++ b/docs/specs/local-scope-install-guards/plan.md
@@ -1,0 +1,71 @@
+# Plan: local-scope-install-guards
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `agentbundle/local_exclude.py` — `tracked_paths` helper (git already lives here).
+- `agentbundle/commands/install.py` — `_local_preflight_refusal` + its call site.
+- `tests/integration/test_local_scope_install.py` — seven new tests.
+- `docs/specs/local-scope-install/spec.md`, version, both changelogs, `workspace.toml`.
+
+**What demonstrates done**
+- 16 integration tests; mutation revert; `make ci`.
+
+**What I am NOT changing**
+- The pack-level mutual exclusion (AC11/AC12) — still correct, just insufficient.
+- Uninstall, or the exclude-block mechanics.
+- Repo- or user-scope install behaviour.
+
+## Security reasoning (inline — `security-reviewer` is a named skip)
+
+- **Ownership / destructive-operation boundary.** Every case here ends in
+  `uninstall` deleting a file this tool did not create. The guard is what makes
+  the exact-restoration guarantee true rather than aspirational.
+- **`path-and-file`.** AC2 is the subtle one: `git ls-files` without
+  `--literal-pathspecs` interprets its arguments as pathspecs, so a projected
+  path carrying a glob metacharacter silently checks the wrong thing. A guard
+  that fails open on a crafted filename is worse than none, because callers stop
+  looking.
+- **Fail-closed ordering.** The pre-flight runs before the exclude block and
+  before any write, so refusal is atomic by construction rather than by rollback.
+  Rollback is the thing that goes wrong under a crash.
+- **Not in scope.** This does not detect a path collision with a *user*-scope
+  pack: RFC-0080 explicitly permits user/local coexistence, because user-scope
+  files land in `~/.claude/` outside the working tree.
+
+## Declined patterns
+
+- **Tempted:** call `git ls-files --error-unmatch` per path, as the AC's
+  parenthetical suggests. **Declined:** it exits non-zero on the first untracked
+  path, so it cannot report the set, and it costs one subprocess per file. One
+  batch `ls-files` and an intersection gives the whole answer.
+- **Tempted:** treat byte-identical content as ownership, so reinstalls over a
+  hand-copied file "just work". **Declined:** that is precisely the case AC10b
+  calls out — uninstall would delete a file the user placed.
+- **Tempted:** also refuse on user-scope path collisions, for symmetry.
+  **Declined:** RFC-0080 permits user/local coexistence by design.
+- **Tempted:** write first and roll back on conflict, reusing the existing
+  rollback machinery. **Declined:** the no-footprint promise is strongest when
+  nothing is written at all.
+
+## Anchor-test sweep
+
+- `tests/integration/test_local_scope_install.py` — nine existing tests, all
+  still pass unchanged.
+- Release-surface pins under `tests/roster/` — re-run after the bump.
+- No test pinned `install.py`'s pre-flight ordering by line number.
+
+## Verification log
+
+- **AC1–AC8** 16 integration tests green against a real git repo.
+- **AC9** mutation: replacing the refusal branch with `if False:` fails all four
+  AC10 tests; restoring passes all 16.
+- **AC11** 0.36.2 -> 0.37.0; both changelogs.
+- One test bug found and fixed during the run: the no-footprint helper asserted
+  the projected path was absent, but several cases refuse *because* a file is
+  already there and it belongs to someone else. It now asserts only that nothing
+  of ours was created.
+- **REVIEW** `adversarial-reviewer` and `security-reviewer` = named skips.

--- a/docs/specs/local-scope-install-guards/spec.md
+++ b/docs/specs/local-scope-install-guards/spec.md
@@ -1,0 +1,83 @@
+# Spec: local-scope-install-guards
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** `install --scope local` refuses three previously-accepted cases.
+  Behaviour change; released as a minor.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. Two risk triggers: security boundary (file I/O, ownership) and
+public-interface change (installs that used to succeed now refuse).
+`security-reviewer` is a NAMED SKIP under this session's no-subagent
+instruction; reasoning is inline in the plan. Delivers AC10 and AC12b of
+spec/local-scope-install, which shipped with both deferred. -->
+
+## Objective
+
+Local scope promises to leave no trace: files are git-invisible via an exclude
+block, and uninstall restores the tree exactly. Three cases broke that promise
+silently. Close them, and refuse before writing anything.
+
+## Acceptance Criteria
+
+- [x] **AC1 — a git-tracked target is refused (AC10a).** Writing over it makes
+  the file dirty in git while the exclude block claims it is invisible, and
+  uninstall would delete a file the repository owns.
+
+- [x] **AC2 — the tracked check cannot be fooled by a glob metacharacter.**
+  `git ls-files` runs with `--literal-pathspecs`. Without it a projected path
+  containing `*`, `?` or `[` is read as a pathspec pattern, so `a[0].md` could
+  match nothing while a real tracked file of that name exists — a false negative
+  on a guard whose only job is to refuse.
+
+- [x] **AC3 — an untracked, unowned target is refused (AC10b).** A file that
+  exists and has no ownership record in the repo, user, or local state.
+
+- [x] **AC4 — identical content does not grant ownership.** The case the
+  original AC names explicitly, and the one most likely to be "simplified" away
+  later: a pre-existing file whose bytes match the projection is still not ours,
+  and uninstall would delete it. Tested by installing once to capture the exact
+  projected bytes, uninstalling, planting those bytes, and asserting the refusal.
+
+- [x] **AC5 — a path owned by a different repo-scope pack is refused (AC12b).**
+  The existing mutual exclusion is pack-level, so it only catches the same pack
+  at both scopes. Two *different* packs colliding on one projected path passed,
+  and the local install silently took ownership of the repo pack's file.
+
+- [x] **AC6 — all three refusals are `--force`-immune.** `--force` cannot make a
+  deletion reversible. Asserted for the tracked case; the messages say so.
+
+- [x] **AC7 — a refusal leaves no footprint.** It runs before the exclude block
+  and before any file write. Asserted: no exclude block, no local state file,
+  and the pre-existing file is byte-unchanged.
+
+- [x] **AC8 — the guards do not refuse the ordinary cases.** A clean repo still
+  installs and stays git-invisible; reinstalling over files this tool owns is
+  not refused. Without this pair, AC3 would reject every legitimate reinstall —
+  the files it inspects are the ones we put there.
+
+- [x] **AC9 — mutation-verified.** Disabling the refusal branch fails all four
+  AC10 tests; restoring passes all sixteen.
+
+- [x] **AC10 — the deferred ACs are closed at source.** `spec/local-scope-install`
+  AC10 and AC12b are checked, and both backlog entries removed.
+
+- [x] **AC11 — released.** 0.36.2 → 0.37.0 (minor: installs that used to
+  succeed now refuse), with an entry in both changelogs.
+
+## Boundaries
+
+### Never do
+
+- Never treat content equality as ownership. AC4 is the rail.
+- Never drop `--literal-pathspecs`. AC2 is the rail.
+- Never let a refusal write first and roll back. Refuse before the exclude block.
+
+## Testing Strategy
+
+- **TDD + mutation**, integration-level against a real git repo and the fixture
+  catalogue — these guards are about git and filesystem state, so a unit test
+  with a mocked git would prove nothing.

--- a/docs/specs/local-scope-install/spec.md
+++ b/docs/specs/local-scope-install/spec.md
@@ -119,7 +119,7 @@ they don't own or haven't permanently adopted it.
   outside a git working tree.
 - [x] AC9: `agentbundle install --scope local --emit-install-routes` is refused with
   an error that references RFC-0008 for the plugins route's own local-scope behaviour.
-- [ ] AC10 (deferred: local-scope-install-ac10-tracked-unowned-file-guards): `agentbundle install --scope local` fails (no partial writes) when:
+- [x] AC10: `agentbundle install --scope local` fails (no partial writes) when:
   (a) any target file is already tracked by git (checked via
   `git --literal-pathspecs ls-files --error-unmatch <path>`); or
   (b) any target file exists as an untracked file that has **no ownership record**
@@ -139,7 +139,7 @@ they don't own or haven't permanently adopted it.
   (`--scope user` coexists with a local install — user-scope files land in `~/.claude/`
   outside the working tree and are unaffected by the exclude block; user/local
   coexistence is explicitly permitted by RFC-0080.)
-- [ ] AC12b (deferred: local-scope-install-ac12b-path-collision-detection): Cross-scope path collision (not just same-pack) is detected and refused:
+- [x] AC12b: Cross-scope path collision (not just same-pack) is detected and refused:
   if a local install's projected paths overlap with any path owned by a repo-scope
   pack (or vice versa), the install is refused with a `--force`-immune error naming
   the colliding path and its owner.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.37.0] — 2026-08-16
+
+### Changed
+
+- **`install --scope local` now refuses three cases it used to accept.** Local
+  scope promises to leave no trace: files are git-invisible via an exclude
+  block, and uninstall restores the tree exactly. Each case below is one where
+  that promise cannot be kept, so the install stops **before writing anything**.
+  All three are `--force`-immune — `--force` cannot make a deletion reversible.
+
+  - **A target already tracked by git.** Writing over it makes the file dirty
+    while the exclude block claims it is invisible, and uninstall would delete a
+    file the repository owns.
+  - **A target that exists, untracked, owned by no agentbundle install.**
+    Identical content does not grant ownership: uninstall would delete a file
+    this tool never created.
+  - **A projected path already owned by a repo-scope pack**, including a
+    *different* pack. The existing mutual exclusion only caught the same pack at
+    both scopes; two different packs colliding on one path slipped through, and
+    the second install silently took ownership of the first's file.
+
+  Reinstalling over files this tool owns is unaffected — the guard keys on
+  ownership, not on the file merely existing.
+
 ## [0.36.2] — 2026-08-16
 
 ### Fixed

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -127,6 +127,86 @@ def _check_source_conflict(
     return "\n".join(lines)
 
 
+def _owner_of(relpath: str, states: list[tuple[str, object]]) -> str | None:
+    """Return "<scope>:<pack>" if any state records ownership of *relpath*."""
+    for scope_name, state in states:
+        if state is None:
+            continue
+        for (pack, _adapter), pack_state in getattr(state, "packs", {}).items():
+            if relpath in getattr(pack_state, "files", {}):
+                return f"{scope_name}:{pack}"
+    return None
+
+
+def _local_preflight_refusal(
+    *,
+    root: Path,
+    pack_name: str,
+    relpaths: list[str],
+    repo_state: object,
+    user_state: object,
+    local_state: object,
+) -> str | None:
+    """Reasons a local-scope install must refuse, or ``None`` to proceed.
+
+    Local scope promises to leave no trace: files are git-invisible via an
+    exclude block, and uninstall restores the tree exactly. Each check below is
+    a case where that promise cannot be kept, so refusing is the only honest
+    outcome — and all three are ``--force``-immune, because ``--force`` cannot
+    make a deletion reversible.
+    """
+    from agentbundle.local_exclude import tracked_paths
+
+    # AC10a — a tracked target. Writing over it would make the file dirty in
+    # git while the exclude block claims it is invisible, and uninstall would
+    # delete a file the repository owns.
+    tracked = tracked_paths(root, relpaths)
+    if tracked:
+        listed = "\n  ".join(tracked[:10])
+        more = f"\n  … and {len(tracked) - 10} more" if len(tracked) > 10 else ""
+        return (
+            f"refusing --scope local: {len(tracked)} target path(s) are already "
+            f"tracked by git:\n  {listed}{more}\n"
+            "A local install must leave no trace, and it cannot delete a tracked "
+            "file on uninstall. This refusal is not overridable with --force."
+        )
+
+    # AC10b — an untracked file with no ownership record anywhere. Matching
+    # content does NOT grant ownership: uninstall would delete a file this tool
+    # never created, which is the exact-restoration guarantee broken.
+    states = [("repo", repo_state), ("user", user_state), ("local", local_state)]
+    unowned = [
+        rel for rel in relpaths
+        if (root / rel).exists() and _owner_of(rel, states) is None
+    ]
+    if unowned:
+        listed = "\n  ".join(unowned[:10])
+        more = f"\n  … and {len(unowned) - 10} more" if len(unowned) > 10 else ""
+        return (
+            f"refusing --scope local: {len(unowned)} target path(s) already exist "
+            f"and are not owned by any agentbundle install:\n  {listed}{more}\n"
+            "Identical content would not make them ours — uninstall would delete "
+            "a file this tool did not create. Move or remove them first. This "
+            "refusal is not overridable with --force."
+        )
+
+    # AC12b — path-level collision with the opposing scope, across ANY pack.
+    # The pack-level mutual exclusion upstream only catches the same pack
+    # installed at both scopes; two DIFFERENT packs projecting the same path
+    # slipped through, and the second install would silently take ownership of
+    # the first's file.
+    for rel in relpaths:
+        owner = _owner_of(rel, [("repo", repo_state)])
+        if owner is not None:
+            return (
+                f"refusing --scope local: {rel} is already owned by "
+                f"{owner} at repo scope. Local and repo installs cannot share a "
+                "projected path — uninstalling either would delete the other's "
+                "file. This refusal is not overridable with --force."
+            )
+    return None
+
+
 def run(args: argparse.Namespace) -> int:
     """Entry point for ``agentbundle install``.
 
@@ -1242,6 +1322,22 @@ def run(args: argparse.Namespace) -> int:
                     "companion.",
                     file=sys.stderr,
                 )
+                return 1
+
+        # ── Local-scope pre-flight: refuse before writing anything ────────────
+        # Runs BEFORE the exclude block and before any file write, so a refusal
+        # leaves no footprint at all — which is the guarantee local scope sells.
+        if plan.scope == "local":
+            _refusal = _local_preflight_refusal(
+                root=plan.root,
+                pack_name=pack_name,
+                relpaths=sorted(projection.keys()),
+                repo_state=repo_state,
+                user_state=user_state,
+                local_state=local_state,
+            )
+            if _refusal is not None:
+                print(f"install: {_refusal}", file=sys.stderr)
                 return 1
 
         # ── Local-scope: write exclude block before files (commit order) ───────

--- a/packages/agentbundle/agentbundle/local_exclude.py
+++ b/packages/agentbundle/agentbundle/local_exclude.py
@@ -91,6 +91,36 @@ def is_git_repo(repo_root: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
+def tracked_paths(repo_root: Path, relpaths: list[str]) -> list[str]:
+    """Return the subset of *relpaths* that git already tracks.
+
+    ``--error-unmatch`` makes git exit non-zero on the first untracked path, so
+    it cannot report the whole set in one call. Paths are therefore checked in
+    one batch WITHOUT that flag: ``ls-files`` lists exactly the tracked ones,
+    and the answer is the intersection.
+
+    ``--literal-pathspecs`` is not optional. Without it a projected path
+    containing a glob metacharacter (``*``, ``?``, ``[``) would be interpreted
+    as a pathspec pattern, so `a[0].md` could match nothing while a real file of
+    that name is tracked — a false negative on a guard whose entire job is to
+    refuse.
+
+    Returns an empty list if git is unavailable; the caller has already
+    established this is a work tree.
+    """
+    if not relpaths:
+        return []
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "--literal-pathspecs", "ls-files", "-z", "--", *relpaths],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    listed = {entry for entry in result.stdout.split("\0") if entry}
+    return sorted(set(relpaths) & listed)
+
+
 def derive_worktree_id(repo_root: Path) -> str:
     """Derive a stable worktree identifier for this clone.
 

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.36.2"
+CLI_VERSION = "0.37.0"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.36.2"
+version = "0.37.0"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_local_scope_install.py
+++ b/packages/agentbundle/tests/integration/test_local_scope_install.py
@@ -375,3 +375,191 @@ def test_rollback_on_write_failure(git_repo: Path) -> None:
         assert current_exclude == prior_exclude, (
             "Exclude block should be restored to pre-install state after rollback"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC10 / AC12b — local-scope pre-flight refusals
+#
+# Local scope promises to leave no trace: files are git-invisible via an
+# exclude block, and uninstall restores the tree exactly. Each case below is
+# one where that promise cannot be kept, so the install must refuse BEFORE
+# writing anything. All three are --force-immune: --force cannot make a
+# deletion reversible.
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_footprint(repo: Path) -> None:
+    """A refusal must leave nothing of *ours* behind.
+
+    Deliberately does not assert the projected path is absent: several of these
+    cases refuse precisely because a file is already sitting there, and that
+    file belongs to someone else. What must be absent is anything this tool
+    would have created — the exclude block and the local state file.
+    """
+    assert "agentbundle:local" not in _exclude_content(repo), (
+        "a refusal left an exclude block behind"
+    )
+    assert not (repo / ".agentbundle-local-state.toml").exists(), (
+        "a refusal left a state file behind"
+    )
+
+
+def test_ac10a_refuses_when_a_target_is_tracked_by_git(tmp_path, capsys) -> None:
+    """A tracked target cannot be taken over.
+
+    Writing over it makes the file dirty in git while the exclude block claims
+    it is invisible, and uninstall would delete a file the repository owns.
+    """
+    from agentbundle.commands.install import run as install_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    target = repo / _EXPECTED_SKILL_RELPATH
+    target.parent.mkdir(parents=True)
+    target.write_text("committed content\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "seed"],
+        check=True,
+    )
+
+    assert install_run(_install_args(repo)) == 1
+    err = capsys.readouterr().err
+    assert "tracked by git" in err
+    assert "--force" in err, "the message must say the refusal is not forceable"
+    assert target.read_text(encoding="utf-8") == "committed content\n", (
+        "the tracked file was modified by a run that refused"
+    )
+
+
+def test_ac10a_refusal_is_force_immune(tmp_path, capsys) -> None:
+    from agentbundle.commands.install import run as install_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    target = repo / _EXPECTED_SKILL_RELPATH
+    target.parent.mkdir(parents=True)
+    target.write_text("committed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "seed"],
+        check=True,
+    )
+
+    args = _install_args(repo)
+    args.force = True
+    assert install_run(args) == 1
+    assert "tracked by git" in capsys.readouterr().err
+
+
+def test_ac10b_refuses_an_untracked_unowned_target(tmp_path, capsys) -> None:
+    from agentbundle.commands.install import run as install_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    target = repo / _EXPECTED_SKILL_RELPATH
+    target.parent.mkdir(parents=True)
+    target.write_text("someone else's file\n", encoding="utf-8")
+
+    assert install_run(_install_args(repo)) == 1
+    err = capsys.readouterr().err
+    assert "not owned by any agentbundle install" in err
+    assert target.read_text(encoding="utf-8") == "someone else's file\n"
+    _assert_no_footprint(repo)
+
+
+def test_ac10b_identical_content_does_not_grant_ownership(tmp_path, capsys) -> None:
+    """The case the AC calls out by name.
+
+    A pre-existing file whose bytes happen to match the projection is still not
+    ours. Treating content equality as ownership would delete it on uninstall,
+    breaking exact restoration for a file this tool never created.
+    """
+    from agentbundle.commands.install import run as install_run
+    from agentbundle.commands.uninstall import run as uninstall_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    # Install once to learn the exact projected bytes, then start clean.
+    assert install_run(_install_args(repo)) == 0
+    projected = (repo / _EXPECTED_SKILL_RELPATH).read_text(encoding="utf-8")
+    assert uninstall_run(_uninstall_args(repo)) == 0
+
+    target = repo / _EXPECTED_SKILL_RELPATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(projected, encoding="utf-8")  # byte-identical, still not ours
+
+    assert install_run(_install_args(repo)) == 1
+    assert "Identical content would not make them ours" in capsys.readouterr().err
+    assert target.exists(), "the unowned file was removed by a refusing run"
+
+
+def test_a_clean_repo_still_installs(tmp_path) -> None:
+    """The guards must not refuse the ordinary case."""
+    from agentbundle.commands.install import run as install_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    assert install_run(_install_args(repo)) == 0
+    assert (repo / _EXPECTED_SKILL_RELPATH).exists()
+    assert _git_status(repo) == "", "a local install must stay git-invisible"
+
+
+def test_reinstalling_over_our_own_files_is_not_refused(tmp_path) -> None:
+    """Ownership is what the guard keys on, not mere existence.
+
+    Without this, AC10b would refuse every legitimate reinstall — the files it
+    is looking at are the ones we put there.
+    """
+    from agentbundle.commands.install import run as install_run
+    from agentbundle.commands.uninstall import run as uninstall_run
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    assert install_run(_install_args(repo)) == 0
+    assert uninstall_run(_uninstall_args(repo)) == 0
+    assert install_run(_install_args(repo)) == 0, "a clean reinstall was refused"
+
+
+def test_ac12b_refuses_a_path_owned_by_a_different_repo_scope_pack(
+    tmp_path, capsys
+) -> None:
+    """Path-level cross-scope collision, across DIFFERENT packs.
+
+    The pack-level mutual exclusion upstream (AC11/AC12) only catches the *same*
+    pack installed at both scopes. Two different packs projecting the same path
+    slipped through entirely, and the local install would silently take
+    ownership of a file the repo-scope pack owns — so uninstalling either would
+    delete the other's file.
+    """
+    from agentbundle.commands.install import run as install_run
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    # A *different* pack already owns the path this install would project.
+    (repo / ".agentbundle-state.toml").write_text(
+        'schema-version = "0.4"\n\n'
+        '[pack.some-other-pack.adapters.claude-code]\n'
+        'installed-version = "1.0.0"\n'
+        'source = "/nonexistent"\n'
+        'install-route = "cli"\n'
+        'scope = "repo"\n'
+        'user-root = "~/.agentbundle"\n'
+        'primitives = ["skill"]\n\n'
+        '[pack.some-other-pack.adapters.claude-code.files]\n'
+        f'"{_EXPECTED_SKILL_RELPATH}" = {{ from-pack-version = "1.0.0", sha = "x" }}\n',
+        encoding="utf-8",
+    )
+
+    assert install_run(_install_args(repo)) == 1
+    err = capsys.readouterr().err
+    assert "already owned by" in err
+    assert "some-other-pack" in err, "the message must name the colliding owner"
+    assert _EXPECTED_SKILL_RELPATH in err, "the message must name the colliding path"
+    assert "--force" in err
+    _assert_no_footprint(repo)

--- a/workspace.toml
+++ b/workspace.toml
@@ -914,25 +914,7 @@ open = [
 
   # ── local-scope-install deferred ACs ────────────────────────────────────────
 
-  # AC10a: install --scope local should abort when any target file is already
-  # tracked by git (checked via git --literal-pathspecs ls-files --error-unmatch).
-  # AC10b: install --scope local should abort when any target file exists as an
-  # untracked file with no ownership record in any agentbundle state (regardless
-  # of content match — same-content unowned files are not implicitly owned).
-  # Fix: add a per-file pre-flight loop in install.py before the write loop;
-  #   add unit tests for both cases (tracked file, untracked unowned file).
-  # Deferred from: spec/local-scope-install PR (wave 5 adversarial review).
-  {slug = "local-scope-install-ac10-tracked-unowned-file-guards", source = "spec/local-scope-install AC10a/AC10b"},
 
-  # AC12b: install --scope local should refuse when any projected path overlaps
-  # with a path owned by a repo-scope pack (and vice versa). Current code only
-  # does pack-level mutual exclusion (same pack, same pair). The path-level
-  # cross-scope collision between DIFFERENT packs is undetected.
-  # Fix: before the write loop, intersect the new projection's paths with all
-  #   paths in the opposing scope's state; refuse with a force-immune error
-  #   naming the colliding path and its owner.
-  # Deferred from: spec/local-scope-install PR (wave 5 adversarial review).
-  {slug = "local-scope-install-ac12b-path-collision-detection", source = "spec/local-scope-install AC12b"},
 
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)


### PR DESCRIPTION
## What does this change?

`install --scope local` now refuses three cases it used to accept, each of which ended with `uninstall` deleting a file this tool never created. Delivers **AC10** and **AC12b** of `spec/local-scope-install`, which shipped with both deferred.

## Why?

- Implements: `docs/specs/local-scope-install-guards/spec.md`
- Closes: `local-scope-install-ac10-tracked-unowned-file-guards`, `local-scope-install-ac12b-path-collision-detection`
- Release: agentbundle 0.36.2 → **0.37.0** (minor — installs that used to succeed now refuse)

Local scope promises to leave no trace: files are git-invisible via an exclude block, and uninstall restores the tree exactly. These three broke that promise silently.

| Case | Why it must refuse |
|---|---|
| Target already **tracked by git** | Writing over it makes the file dirty while the exclude block claims it is invisible; uninstall would delete a file the repo owns |
| Target exists, **untracked and unowned** | Identical content does not grant ownership — uninstall would delete a user's file |
| Path owned by a **different repo-scope pack** | The existing exclusion is pack-level, so two different packs colliding on one path passed straight through |

## How do I verify it?

```bash
python3 -m pytest packages/agentbundle/tests/integration/test_local_scope_install.py -q   # 16 passed
make ci
```

**Mutation-verified:** replacing the refusal branch with `if False:` fails all four AC10 tests; restoring passes all sixteen.

### Two details worth a reviewer's eye

- **`--literal-pathspecs` is load-bearing, not decoration.** Without it `git ls-files` reads its arguments as *pathspecs*, so a projected path containing a glob metacharacter — `a[0].md` — could match nothing while a real tracked file of that name exists. A guard that fails open on a crafted filename is worse than no guard, because callers stop looking. I also batched one `ls-files` rather than the AC's suggested per-path `--error-unmatch`, which exits non-zero on the first untracked path and therefore cannot report the set at all.
- **Refusal happens before the exclude block and before any write**, so it is atomic by construction rather than by rollback — rollback is the thing that goes wrong under a crash. Asserted: no exclude block, no state file, and the pre-existing file byte-unchanged.

Two tests pin that the guards do **not** refuse the ordinary cases (clean repo installs git-invisibly; reinstalling over our own files works). Without that pair, the ownership guard would reject every legitimate reinstall — the files it inspects are the ones we put there.

## What did you not change that you considered?

- **Treating byte-identical content as ownership**, so a reinstall over a hand-copied file "just works". That is exactly the case AC10b calls out — uninstall would delete a file the user placed. It has its own test precisely because it is the one most likely to be simplified away later.
- **Refusing on user-scope path collisions, for symmetry.** RFC-0080 permits user/local coexistence by design: user-scope files land in `~/.claude/`, outside the working tree and the exclude block.
- **Writing first and rolling back on conflict**, reusing the existing rollback machinery. The no-footprint promise is strongest when nothing is written at all.

## Checklist

- [x] Tests pass locally — 16 integration tests, `make ci`
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. `security-reviewer` was warranted (ownership/destructive boundary, pathspec fail-open, fail-closed ordering); reasoning is inline in `plan.md` § *Security reasoning*.
- [x] Spec and code agree — `spec/local-scope-install` AC10 and AC12b now checked at source
- [x] Living docs match reality — both changelogs
- [x] No new top-level directories
- [x] Conventional commit format