### PR TITLE
feat(frontend-engineering): record security and reliability status at production tier

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -240,7 +240,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "0.1.4"
+      "version": "0.2.0"
     },
     {
       "author": {

--- a/docs/specs/frontend-engineering-doctrine-update/spec.md
+++ b/docs/specs/frontend-engineering-doctrine-update/spec.md
@@ -85,6 +85,15 @@ than an unsupported adopter-facing claim.
   skill or reviewer body changes; the only authorized `.apm` change is
   `packs/frontend-engineering/.apm/skills/frontend-engineering/evals/eval_queries.json`.
 
+  **Both behaviour gaps this AC recorded are now closed** (2026-08-16,
+  `spec/frontend-manifest-production-fields`, pack 0.2.0). The narrowing was the
+  right call at the time — claiming coverage FE did not have would have been
+  worse — but it left the Digital Experience Contract asking at production tier
+  for evidence nothing collected. The evidence manifest now carries
+  `security/privacy review status` and `reliability/recovery status`, recording
+  review state and handoff rather than a verdict, so FE still performs neither
+  review.
+
 - [x] AC3: `web/src/content/packs/frontend-engineering.md` presents create,
   retrofit, audit, and verify as four adopter jobs with their expected outputs;
   a five-second scan answers what the pack is, who it serves, and which job to

--- a/docs/specs/frontend-manifest-production-fields/plan.md
+++ b/docs/specs/frontend-manifest-production-fields/plan.md
@@ -1,0 +1,53 @@
+# Plan: frontend-manifest-production-fields
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md`
+- `packs/frontend-engineering/JOURNEY.md`, `pack.toml`, `.claude-plugin/plugin.json`
+- `docs/specs/frontend-engineering-doctrine-update/spec.md`, `workspace.toml`
+
+**What demonstrates done**
+- `catalogue lint` clean for the pack; `make build-self FORCE=1`; `make ci`.
+
+**What I am NOT changing**
+- The frontend reviewer's lens, or any reviewer's scope.
+- The other eleven manifest fields.
+- The Digital Experience Contract — this makes FE meet it, not redefine it.
+
+## Declined patterns
+
+- **Tempted:** make FE actually assess security and reliability, since it is
+  already looking at the surface. **Declined:** that is what the two backlog
+  entries explicitly ruled out, and it would put an unqualified verdict in front
+  of a ship decision. Recording the handoff is the useful half.
+- **Tempted:** require both fields at every tier. **Declined:** the contract
+  annotates them `production+`, and requiring production ceremony on an explore
+  surface is the thing the tiering exists to prevent.
+- **Tempted:** leave them blank when unknown. **Declined:** a blank field cannot
+  be distinguished from an unasked question. AC3 makes the "not at this tier"
+  answer explicit.
+- **Tempted:** skip the pack version bump — it is only prose. **Declined:** two
+  new required fields change what an adopter's completion check demands.
+
+## Anchor-test sweep
+
+- `JOURNEY.md:161` enumerates the eleven fields in prose — updated (AC5).
+- `pack.toml` ↔ `.claude-plugin/plugin.json` version parity is now enforced by
+  CAT-L009, which I turned on in #953. It fired on the bump, exactly as intended,
+  and the manifest was synced.
+- `evals/eval_queries.json` references the manifest by name only, so no eval
+  pins the field list.
+- `dist/` is gitignored; projection is regenerated, not committed.
+
+## Verification log
+
+- **AC1–AC5** applied to SKILL.md (manifest table + verify mode) and JOURNEY.md.
+- **AC6** pack 0.1.4 -> 0.2.0; plugin.json synced; `make build-self FORCE=1` ok.
+- **Lint** `lint_catalogue(pack='frontend-engineering')` -> CAT-L007/8/9 clean.
+- **AC8** two entries removed (125 -> 123).
+- **REVIEW** `adversarial-reviewer` = named skip (session instruction prohibits
+  subagent dispatch). Self-reviewed against the spec-less checklist.

--- a/docs/specs/frontend-manifest-production-fields/spec.md
+++ b/docs/specs/frontend-manifest-production-fields/spec.md
@@ -1,0 +1,70 @@
+# Spec: frontend-manifest-production-fields
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** the frontend-engineering evidence manifest gains two
+  production-tier fields. Pack minor release.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light. Checked the security-boundary trigger explicitly: it does NOT
+fire. Nothing here performs, gates, or relaxes a security or reliability review —
+the change adds two *record-what-happened* fields and states, twice, that FE
+must not render a verdict. -->
+
+## Objective
+
+The Digital Experience Contract asks a production surface for Security and
+Privacy and for Reliability. The frontend-engineering evidence manifest required
+neither, so the contract asked for evidence nothing collected.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the manifest carries both fields at production tier.**
+  `security/privacy review status` and `reliability/recovery status`, mirroring
+  the contract's own `Required: production+` annotation.
+
+- [x] **AC2 — they record status and handoff, never a verdict.** Stated twice in
+  the skill body, because this is the failure the change could introduce: FE does
+  not own security review or reliability engineering, and a field that reads like
+  a sign-off would be worse than the gap it closes. A field whose honest value is
+  "routed to `security-reviewer`, outstanding" is doing its job — it makes the
+  gap visible while someone is deciding whether to ship.
+
+- [x] **AC3 — blank is not an option below production tier.** On an explore- or
+  pilot-tier surface they are recorded as not-applicable-at-this-tier, so a
+  reader can distinguish "not needed yet" from "nobody looked".
+
+- [x] **AC4 — verify mode emits them.** The mode that runs the gate suite and
+  produces a manifest now names them, so a run cannot report four green gates
+  while saying nothing about either.
+
+- [x] **AC5 — the enumeration in `JOURNEY.md` matches.** It listed the eleven
+  fields in prose; a stale enumeration is how the manifest and its adopter-facing
+  description drift apart.
+
+- [x] **AC6 — released and projected.** Pack 0.1.4 → 0.2.0 (minor: production
+  surfaces gain two required fields), `.claude-plugin/plugin.json` kept in
+  parity, and `make build-self FORCE=1` re-projected.
+
+- [x] **AC7 — the originating AC records the follow-through.**
+  `spec/frontend-engineering-doctrine-update` AC2 narrowed adopter-facing prose
+  rather than claiming coverage. That was right at the time; the note records
+  that both gaps it opened are now closed.
+
+- [x] **AC8 — both backlog entries removed.**
+
+## Boundaries
+
+### Never do
+
+- Never let these fields imply FE performed the review. AC2 is the rail.
+- Never move security review into the frontend reviewer. `security-reviewer`
+  keeps auth, secrets, and user-input boundaries.
+
+## Testing Strategy
+
+- **Goal-based**: `catalogue lint` clean for the pack (including CAT-L009
+  pack.toml ↔ plugin.json parity), `make build-self` clean, `make ci`.

--- a/packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md
+++ b/packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md
@@ -331,7 +331,7 @@ Run the full GATES suite in order:
 3. **CSS token enforcement** (GATES phase step 3, if stylelint is configured)
 4. **Visual QA checklist** (GATES phase step 4) — confirm all 18 applicable states are present
 
-After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results.
+After running all four gates, generate the evidence manifest (see Evidence manifest section below) with the results. On a production-tier surface, the manifest's two production fields are part of that output: record the security/privacy and reliability review status, routing anything you cannot answer to `security-reviewer` or `quality-engineer` and recording that it is outstanding. A gate run that reports four green gates while saying nothing about either is the shape this manifest exists to prevent.
 
 ---
 
@@ -602,6 +602,30 @@ FE cannot claim completion (create or retrofit) or a passing gate run (verify) w
 | analytics events | Confirmation of measurement events firing on primary action completion |
 | known exceptions | Documented, accepted gaps with rationale and owner — not a place to hide problems |
 | unverified items | Items that could not be verified in this session with reason (no Chromium, no network, etc.) |
+
+**Additional fields for a production surface (2 more, 13 in total):**
+
+The Digital Experience Contract carries a *Security and Privacy* and a
+*Reliability* field at production tier, and this manifest did not require the
+evidence behind either. The gap showed up as adopter-facing prose being narrowed
+to avoid claiming coverage FE does not have — the honest short-term fix, but it
+left the contract asking for something nothing collected.
+
+**Record status and handoff. Do not perform the review.** FE does not own
+security review or reliability engineering, and these fields must not read as a
+claim that it does. A field whose honest value is "not reviewed — routed to
+`security-reviewer`, outstanding" is doing its job: it makes the gap visible at
+the moment someone is deciding whether to ship.
+
+| Field | What to record |
+|---|---|
+| security/privacy review status | What user data this surface handles (inputs, storage, third-party calls) and the state of its security review: reviewed and by whom, routed and outstanding, or explicitly not applicable with a reason. Auth, secrets, and user-input boundaries stay `security-reviewer`'s call — record the handoff and its outcome, never a verdict of your own. |
+| reliability/recovery status | The surface's error-handling and recovery path: what the user sees when a request fails, whether errors are monitored and by whom, and any SLO or alerting owner. Where FE cannot answer — error rates, alerting thresholds — name the `quality-engineer` or platform owner the question went to, and whether it is answered. |
+
+Both are required only for **production**-tier surfaces, matching the contract's
+own `Required: production+` annotation. On an explore- or pilot-tier surface,
+record them as not-applicable-at-this-tier rather than leaving them blank, so a
+reader can tell the difference between "not needed yet" and "nobody looked".
 
 ---
 

--- a/packs/frontend-engineering/.claude-plugin/plugin.json
+++ b/packs/frontend-engineering/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-engineering",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Build the web surface, then prove it holds up. HTML, CSS, and JS with a real token system, WCAG 2.2 AA, and Core Web Vitals measured rather than asserted. A reviewer reads the diff for the regressions those three tend to hide."
 }

--- a/packs/frontend-engineering/JOURNEY.md
+++ b/packs/frontend-engineering/JOURNEY.md
@@ -158,7 +158,7 @@ Common requests:
 ### 5. Produce the evidence manifest
 
 - **You provide:** screenshots, field data, analytics-event proof, or known-exception decisions that are not available from local gates.
-- **Agent does:** assembles the evidence manifest with routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, and unverified items.
+- **Agent does:** assembles the evidence manifest with routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, and unverified items. For a production surface it also records security/privacy review status and reliability/recovery status — the state of those reviews and who they were routed to, not a verdict of its own.
 - **You do:** inspect the unverified items and known exceptions instead of treating them as noise.
 - **You decide:** accept the known exceptions, require fixes, or defer the surface.
 - **Output:** a completion-ready evidence manifest for create, retrofit, or verify mode.

--- a/packs/frontend-engineering/pack.toml
+++ b/packs/frontend-engineering/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "frontend-engineering"
-version = "0.1.4"
+version = "0.2.0"
 description = "Build the web surface, then prove it holds up. HTML, CSS, and JS with a real token system, WCAG 2.2 AA, and Core Web Vitals measured rather than asserted. A reviewer reads the diff for the regressions those three tend to hide."
 readme = "README.md"
 display_name = "Frontend Engineering"

--- a/web/src/content/journeys/frontend-engineering.md
+++ b/web/src/content/journeys/frontend-engineering.md
@@ -159,7 +159,7 @@ Common requests:
 ### 5. Produce the evidence manifest
 
 - **You provide:** screenshots, field data, analytics-event proof, or known-exception decisions that are not available from local gates.
-- **Agent does:** assembles the evidence manifest with routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, and unverified items.
+- **Agent does:** assembles the evidence manifest with routes, viewports, browsers, states, screenshots, a11y result, perf result, console/network result, analytics events, known exceptions, and unverified items. For a production surface it also records security/privacy review status and reliability/recovery status — the state of those reviews and who they were routed to, not a verdict of its own.
 - **You do:** inspect the unverified items and known exceptions instead of treating them as noise.
 - **You decide:** accept the known exceptions, require fixes, or defer the surface.
 - **Output:** a completion-ready evidence manifest for create, retrofit, or verify mode.

--- a/workspace.toml
+++ b/workspace.toml
@@ -516,6 +516,22 @@ open = [
     # deliberately lacks (a fault-injection hook in a lock is its own hazard). Fix: drive it
     # from a subprocess killed between create and write, or a filesystem that returns ENOSPC
     # on write. Unblocks: now — it is a test-coverage gap, not a defect.
+  # FLAKY GATE, observed 2026-08-16 on PR #966 (a docs-and-pack change touching
+  # nothing related). test_concurrent_reclaimers_yield_one_holder failed on
+  # ubuntu py3.12 while py3.11 passed on the same commit, and it passed 3/3
+  # locally and on a plain re-run of the same job. Reported: two holders after a
+  # reclaim race, with one of them raising StateLockLost — i.e. the module's own
+  # loss detection fired, which is the designed behaviour, so the ASSERTION may
+  # be what is wrong rather than the lock.
+  # Why it matters beyond the noise: this is a concurrency gate. A test that
+  # fails ~sometimes trains everyone to re-run it, and the next real regression
+  # gets re-run too. It is also on a security-relevant control.
+  # Fix: decide whether "one holder entered and a second was told it lost" is a
+  #   pass (the lock behaved) or a fail (two ENTERs happened at all), then make
+  #   the assertion say that. If it is a genuine race, it needs its own spec.
+  # Unblocks when: picked up — no dependency.
+  {slug = "statelock-concurrent-reclaimers-test-flake", source = "pre-flight/2026-08-16"},
+
   {slug = "statelock-token-write-failure-test", source = "spec/loop-cohort-state-lock"},
     # loop-engine's _recover_pending reads the repo-global .loop-run/events.pending and then
     # calls _recover_engine_state_tmp(pending_spec_dir) for whatever spec that record names,

--- a/workspace.toml
+++ b/workspace.toml
@@ -1661,38 +1661,7 @@ open = [
   # large test_loop_cohort.py suite as one of them.
   {slug = "loop-cohort-shell-suite-to-python", summary = "Port test-loop-cohort.sh (493 lines, 51 sequential cases) to pure-stdlib Python so it runs on Windows, decoupling the shared-counter fixtures and profiling its >10min runtime", source = "spec/pack-script-root-boundary-validation"},
 
-  # Frontend-engineering doctrine benchmark follow-ons — 2026-08-08.
-  # The shipped Digital Experience Contract includes a production Frontend
-  # Engineering Security and Privacy field for data handled, privacy controls,
-  # and security review status, but the frontend-engineering evidence manifest
-  # does not require that evidence. The frontend-reviewer correctly routes
-  # security findings to security-reviewer, so adopter-facing publication prose
-  # was narrowed instead of claiming coverage. Fix: update the main skill's
-  # evidence-manifest requirements and create/retrofit/verify guidance to record
-  # security/privacy review status for production surfaces without making the FE
-  # skill perform security review. Affected file:
-  # packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md.
-  # Decision: security-reviewer remains responsible for auth, secrets, and user-
-  # input boundaries; FE records status and handoff evidence. Unblocks: now; no
-  # tracked prerequisite. Completion includes projected/eval/docs synchronization.
-  # Cold-start: add security/privacy review-status fields and handoff evidence to the main FE manifest without moving security review into the frontend reviewer.
-  {slug = "frontend-engineering-security-privacy-manifest-field", source = "spec/frontend-engineering-doctrine-update AC2"},
 
-  # The shipped Digital Experience Contract includes a production Frontend
-  # Engineering Reliability field for error rates, SLOs, monitoring/alerting,
-  # and recovery path, but the frontend-engineering evidence manifest records
-  # only console/network result, known exceptions, and unverified items.
-  # Adopter-facing prose was narrowed so FE does not claim full reliability
-  # coverage. Fix: update the main skill's create/retrofit/verify evidence-
-  # manifest guidance to require reliability/recovery status for production
-  # surfaces, with explicit quality-engineer or platform-owner handoff where
-  # needed. Affected file:
-  # packs/frontend-engineering/.apm/skills/frontend-engineering/SKILL.md.
-  # Decision: reliability is not a frontend-reviewer lens today; FE records
-  # status and recovery evidence rather than claiming broader review. Unblocks:
-  # now; no tracked prerequisite. Completion includes projected/eval/docs sync.
-  # Cold-start: add reliability/recovery status and owner handoff evidence to the main FE manifest without claiming broader reliability review.
-  {slug = "frontend-engineering-reliability-manifest-field", source = "spec/frontend-engineering-doctrine-update AC2"},
 
   # Deliberately NOT backlogged: extending SAST_DIRS to web/ (62 JS/TS/Astro
   # files). Decided 2026-08-07 — web/ is the platform site, built and deployed


### PR DESCRIPTION
## What does this change?

The frontend-engineering evidence manifest gains two production-tier fields — `security/privacy review status` and `reliability/recovery status` — so a production surface collects the evidence the Digital Experience Contract already asks it for.

## Why?

- Implements: `docs/specs/frontend-manifest-production-fields/spec.md`
- Closes: `frontend-engineering-security-privacy-manifest-field`, `frontend-engineering-reliability-manifest-field`
- Release: frontend-engineering pack 0.1.4 → **0.2.0**

The contract carries both fields at production tier; the manifest required neither. `spec/frontend-engineering-doctrine-update` AC2 handled that by *narrowing the adopter-facing prose* rather than claiming coverage FE does not have — right at the time, since the alternative was a false claim, but it described the gap instead of closing it.

## The thing to check in review

**These fields record status and handoff, never a verdict** — and the skill body says so twice, because that is exactly the failure this change could introduce. FE does not own security review or reliability engineering, and a field that reads like a sign-off would be worse than the gap it closes.

A field whose honest value is *"not reviewed — routed to `security-reviewer`, outstanding"* is doing its job: it makes the gap visible at the moment someone is deciding whether to ship. `security-reviewer` keeps auth, secrets, and user-input boundaries; `quality-engineer` or the platform owner keeps error rates and alerting.

## How do I verify it?

```bash
# the pack lints clean, including the pack.toml ↔ plugin.json parity check
cd packages/agentbundle && python3 -c "
from pathlib import Path
from agentbundle.catalogue_tooling.lint import lint_catalogue
r = lint_catalogue(Path('../..'), pack='frontend-engineering')
print([d.code for d in r.diagnostics if d.code.startswith('CAT-L00')] or 'clean')"

make build-self FORCE=1     # projections in sync
make ci
```

A nice bit of self-validation: bumping the pack version tripped **CAT-L009**, the `pack.toml` ↔ `plugin.json` parity check I turned on in #953. First real catch, and it was right — the manifest was out of sync and is now fixed.

## What did you not change that you considered?

- **Making FE actually assess security and reliability**, since it is already looking at the surface. Both backlog entries ruled this out explicitly, and it would put an unqualified verdict in front of a ship decision.
- **Requiring both fields at every tier.** The contract annotates them `production+`; requiring production ceremony on an explore surface is what the tiering exists to prevent.
- **Allowing blank when unknown.** A blank field cannot be distinguished from an unasked question, so below production tier they are recorded as not-applicable-at-this-tier.
- **Skipping the version bump** on the grounds that it is only prose. Two new required fields change what an adopter's completion check demands.

## Checklist

- [x] Tests pass locally — `make ci`, catalogue lint clean for the pack
- [x] Lint and typecheck pass — `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. Self-reviewed against the work-loop's spec-less checklist.
- [x] Spec and code agree — `spec/frontend-engineering-doctrine-update` AC2 records that both gaps it opened are now closed
- [x] Living docs match reality — `JOURNEY.md`'s field enumeration updated
- [x] No new top-level directories
- [x] Conventional commit format