### PR TITLE
fix(sast): stop feeding nosec reasons to bandit's test-id parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,15 @@ sast:
 	@command -v pip-audit >/dev/null 2>&1 || { echo "make sast: pip-audit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v semgrep   >/dev/null 2>&1 || { echo "make sast: semgrep not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v npm       >/dev/null 2>&1 || { echo "make sast: npm not found — install Node.js (>=24, per docs-site/package.json engines) for the npm SCA leg" >&2; exit 1; }
-	bandit -r $(SAST_DIRS) -c bandit.yaml --severity-level medium --confidence-level medium -q
+	# Bandit's stderr is a gate signal, not chatter (ADR-0084): under -q it
+	# carries only diagnostics about the scan's own integrity — a `# nosec` it
+	# could not parse, one that matched no finding, a file it could not read —
+	# and none of those move its exit code. run-bandit-gate.py fails on any of
+	# them. The self-test below proves it, for the same reason the two
+	# self-tests further down exist: this gate is silent when it works and
+	# would be just as silent if it were simplified back into a no-op.
+	python3 tools/test-sast-stderr-gate.py
+	python3 tools/run-bandit-gate.py $(SAST_DIRS)
 	# The filter below stands in front of pip-audit, so a bug that drops a
 	# *third-party* pin would take this gate green over an unaudited dependency.
 	# Prove it before trusting it.

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,13 +1,45 @@
 # Bandit configuration — the repo's Python SAST gate (ADR-0017).
 #
-# Invoked by `make sast` as:
-#   bandit -r tools packs packages -c bandit.yaml \
-#          --severity-level medium --confidence-level medium
+# Invoked by `make sast` as `python3 tools/run-bandit-gate.py $(SAST_DIRS)`.
+# The Makefile's SAST_DIRS is the one canonical statement of the scanned roots;
+# run-bandit-gate.py holds the floor flags and shells out to:
+#   bandit -r <SAST_DIRS> -c bandit.yaml \
+#          --severity-level medium --confidence-level medium -q
 #
 # The medium+ severity / medium+ confidence floor is set on the CLI (above),
 # not here: it filters out the large low-severity tail (subprocess imports,
 # partial-path process starts) that is noise for an attack-surface gate while
 # keeping the findings an org-grade scan would block on.
+#
+# Bandit's STDERR fails the gate (ADR-0084). Under -q it carries only
+# diagnostics about the scan's own integrity — a suppression bandit could not
+# parse, a suppression that matched no finding, a file it could not read — and
+# none of those move bandit's exit code, so the wrapper moves it for them. If
+# a scan is red with no findings printed, read stderr: something about a
+# `# nosec` below is wrong, not something about the code.
+#
+# Inline suppression form — `# nosec <ID>  # <reason>`, reason after a SECOND
+# `#`. Bandit's parser reads the test-id list up to the next `#`
+# (`NOSEC_COMMENT` in bandit/core/manager.py), so a reason written after a dash
+# or em dash is tokenised and each word looked up as a test name. That is
+# usually just noise ("Test in comment: shell is not a test name or id"), but a
+# reason word colliding with a real test *name* would silently widen the
+# suppression past the ID you wrote. The second `#` terminates the list, so the
+# reason is never parsed. (ADR-0017 § suppression policy predates this and
+# still shows the em-dash form; the ADR is frozen, this file is the live rule.)
+#
+# The ID is MANDATORY, and this is why the form above matters more than tidy
+# output. A `# nosec` whose id list resolves to NO id — a bare `# nosec`, an
+# ID-less `# nosec  # reason`, or a prose sentence in which no word happens to
+# name a test — is treated as a blanket suppression and skips *every* test on
+# that statement. Under the two-`#` form it does so silently. Fail-open either
+# way: always write the ID, and never open a comment with `nosec` unless you
+# mean it as a directive.
+#
+# Suppressions also apply to the whole *statement's* linerange, not just the
+# commented line, so a nosec on a multi-value statement warns "nosec
+# encountered, but no failed test" for every sibling value the rule skips.
+# Bind the offending value to its own name and put the nosec on that statement.
 
 skips:
   # B101 assert_used — test suites (pytest and the standalone tools/test-*.py

--- a/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
+++ b/docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md
@@ -1,6 +1,6 @@
 # ADR-0017: Adopt Bandit + pip-audit + Semgrep as the repo's SAST/SCA gate
 
-- **Status:** Accepted <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
+- **Status:** Accepted — **partially amended:** the `# nosec <ID> — <reason>` **spelling** in the suppression-policy sub-decision is **superseded by [ADR-0084](0084-nosec-reason-delimiter-and-stderr-as-a-gate.md)** (the reason moves behind a second `#`, because Bandit parses the text after `# nosec` as a list of test ids, 2026-08-16); every other decision in this ADR — the three-way real-fix-first ladder itself, the tool choices, the severity floor — stands. <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
 - **Date:** 2026-06-12
 - **Deciders:** eugenelim
 - **Supersedes:** none

--- a/docs/adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md
+++ b/docs/adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md
@@ -1,0 +1,153 @@
+# ADR-0084: Bandit suppression reasons move behind a second `#`, and its stderr becomes a gate
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+- **Decision-makers:** eugenelim
+- **Consulted:** security review, quality review
+- **Supersedes:** the **`# nosec <ID> — <reason>` spelling** in [ADR-0017](0017-adopt-bandit-pip-audit-semgrep-sast-gate.md)'s suppression-policy sub-decision only — that ADR's three-way real-fix-first ladder, tool choices, and severity floor all stand
+- **Related:** the implementing spec `docs/specs/bandit-nosec-comment-hygiene/`; `bandit.yaml` and `tools/run-bandit-gate.py` carry the operative rules
+
+## Decision summary
+
+- **Decision:** A Bandit suppression is written `# nosec <ID>  # <reason>` — the
+  reason after a **second** `#`, never after a dash — and `make sast` fails if
+  Bandit writes anything to stderr.
+- **Because:** Bandit parses the text after `# nosec` as a list of test ids, so
+  a prose reason is a suppression input, not a comment.
+- **Applies to:** every `# nosec` in the repo's scanned roots (`SAST_DIRS`), and
+  the `sast` recipe.
+- **Tradeoff accepted:** ADR-0017's form is now wrong in two frozen documents we
+  cannot rewrite, so a reader who starts there needs this pointer to find the
+  live rule.
+- **Revisit if:** Bandit changes `NOSEC_COMMENT` so the id list no longer runs
+  to the next `#`, or starts emitting routine stderr chatter under `-q`.
+
+## Context
+
+ADR-0017 adopted Bandit and prescribed `# nosec <ID> — <reason>`: a suppression
+scoped to one test id, carrying its justification on the same line. That reads
+well and was implemented faithfully across five sites.
+
+It is also, as written, a suppression input. `bandit/core/manager.py` parses a
+suppression with
+
+```python
+NOSEC_COMMENT = re.compile(r"#\s*nosec:?\s*(?P<tests>[^#]+)?#?")
+```
+
+The captured id list runs to the **next `#`** — so with a dash or em dash as the
+delimiter, the whole reason is captured, tokenised, and each word looked up as a
+Bandit test name. Two ways that fails open:
+
+1. **Widening.** A reason word colliding with a real test *name* (`assert_used`,
+   `weak_cryptographic_key`, …) adds that test to the suppression. Nobody wrote
+   it; nothing reports it.
+2. **Blanket.** A `# nosec` whose id list resolves to *no* id — a bare
+   `# nosec`, an id-less `# nosec  # reason`, or a prose sentence in which no
+   word names a test — is treated by `core/tester.py` as "nosec without test
+   number" and skips **every** test on the statement.
+
+Neither had fired: an audit of every suppression at `origin/main` found each
+resolving to exactly the one id its author wrote, and no blanket suppressions.
+The exposure was latent, and the only thing standing between the repo and it was
+Bandit's stderr — 39 `Test in comment: … is not a test name or id` lines on a
+clean scan, which `make sast` printed and then ignored, because warnings do not
+move Bandit's exit code.
+
+That is the shape this repo has twice refused elsewhere in the same recipe:
+`tools/test-audit-requirements.py` and `tools/test-semgrep-argv-boundary.py`
+exist because a scanner that is silent when it works and silent when it has been
+broken into a no-op is not a gate.
+
+## Decision
+
+**The reason goes after a second `#`.** `# nosec B603  # list argv, no shell`.
+The second `#` terminates the id list, so the reason is never parsed. The id is
+**mandatory** — an id-less suppression is a blanket suppression.
+
+**`make sast` fails on non-empty Bandit stderr.** Under `-q` Bandit's stderr
+carries only diagnostics about the scan's own integrity: unparsed suppressions,
+suppressions that matched no finding, file-level errors. A clean repo produces
+none. Treating any of them as a gate failure is what keeps the first half of
+this decision true a year from now.
+
+The wrapper is `tools/run-bandit-gate.py` — a script rather than a recipe line,
+because a rule this quiet needs a test, and `tools/test-sast-stderr-gate.py`
+drives it against a stub `bandit` to prove it. A gate that is silent when it
+works and equally silent when it has been simplified back into a no-op is the
+shape this recipe already refuses twice.
+
+Where each rule is written: this ADR is the decision record; `bandit.yaml`'s
+header comment is the instruction, sited where the next person writing a
+suppression will be; `run-bandit-gate.py` is the enforcement.
+
+## Decision drivers
+
+- A suppression comment is a security control's audit trail. If the reader and
+  the parser disagree about what it says, it is not an audit trail.
+- ADR-0017's remediation ladder is real-fix-first; a suppression that quietly
+  covers more than it claims corrupts the ladder's bottom rung.
+- The fix had to survive the next contributor, who will read `bandit.yaml` or
+  ADR-0017 and not this spec.
+
+## Consequences
+
+- Every existing suppression that carried a prose reason was rewritten. Two
+  complementary checks confirm the rewrite changed nothing, because neither is
+  sufficient alone:
+  - A before/after scan at `--severity-level low --confidence-level low` gives
+    an identical *reported-finding* set. That catches a suppression that
+    weakened or widened onto a test which fires somewhere in the repo.
+  - Running every suppression comment at both revisions through Bandit's own
+    `_parse_nosec_comment` gives an identical *resolved-id* set — one id per
+    directive, no blanket suppressions, at either revision. That catches the
+    case the scan cannot see: a suppression widened onto a test that fires
+    nowhere today.
+- `make sast` is now stricter than Bandit's own exit code. A future Bandit
+  release that adds routine stderr chatter under `-q` would turn the gate red on
+  no real finding — that is the `Revisit if` trigger.
+- ADR-0017:107 and the shipped `docs/specs/sast-sca-tooling/` spec and plan still
+  spell the old form. Both are frozen. ADR-0017's Status line points here; the
+  shipped spec cannot be annotated at all, which is the accepted cost.
+- The form is documented and now partially self-enforcing (any malformed
+  suppression Bandit *warns* about fails the gate), but an id-less suppression
+  is silent to Bandit and so still invisible. A grep-shaped form lint closes
+  that residue and is tracked as `bandit-nosec-form-lint`.
+- **Revisit if:** Bandit changes `NOSEC_COMMENT` so the id list no longer runs to
+  the next `#`, or starts emitting routine stderr chatter under `-q`.
+
+## Confirmation
+
+- **Mode:** gate-enforced, with a self-test
+- **Signal:** `tools/run-bandit-gate.py` exits non-zero on any Bandit stderr
+  line, so a suppression Bandit cannot parse fails CI rather than printing into
+  a scrollback; `tools/test-sast-stderr-gate.py` proves that against a stub
+  `bandit`, so the rule cannot be simplified away unnoticed.
+- **Owner:** repo maintainers
+
+## Alternatives considered
+
+- **Leave the form and filter the warnings out of the recipe.** Rejected: it
+  hides the signal rather than fixing the comments producing it, and leaves both
+  fail-open paths intact.
+- **Put the reason on the preceding line instead.** Works, and is what the one
+  multi-line rationale in `capture-publish-control-evidence.py` does. Rejected as
+  the general rule because ADR-0017's same-line requirement is worth keeping —
+  a suppression and its justification should not drift apart.
+- **Pin or downgrade Bandit so the warnings stop.** Rejected: the warnings are
+  correct, and the parse behaviour they report predates the version that started
+  reporting it.
+- **Amend ADR-0017 in place.** Rejected: ADR bodies are immutable once Accepted
+  (`docs/CONVENTIONS.md` § Document lifecycle). Only its Status line moves, and
+  it moves to point here.
+- **Ship the form with no enforcement at all.** Rejected: the new spelling is
+  *quieter* than the old one when it is malformed, so documenting it without a
+  gate would trade a noisy foot-gun for a silent one.
+
+## References
+
+- Bandit 1.9.4 `core/manager.py` (`NOSEC_COMMENT`, `_parse_nosec_comment`),
+  `core/tester.py` (empty-id-set handling), `core/utils.py` (`get_nosec`, which
+  matches a suppression against the whole statement's linerange).
+- [ADR-0017](0017-adopt-bandit-pip-audit-semgrep-sast-gate.md) — the SAST gate
+  and its suppression ladder.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,6 +88,8 @@
 | 0080 | [Generic headed SSO capture remains operator-only](0080-generic-headed-sso-capture-remains-operator-only.md) | Accepted |
 | 0081 | [Canonical project knowledge uses per-topic JSON](0081-canonical-project-knowledge-uses-per-topic-json.md) | Accepted |
 | 0082 | [Project-knowledge modes separate capture, distillation, and enquiry authority](0082-project-knowledge-modes-separate-authority.md) | Accepted |
+| 0083 | [Extend the SAST/SCA gate to npm with audit and allowlist](0083-extend-sast-sca-gate-to-npm-with-audit-and-allowlist.md) | Accepted |
+| 0084 | [Bandit suppression reasons move behind a second `#`, and its stderr becomes a gate](0084-nosec-reason-delimiter-and-stderr-as-a-gate.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/specs/bandit-nosec-comment-hygiene/spec.md
+++ b/docs/specs/bandit-nosec-comment-hygiene/spec.md
@@ -1,0 +1,311 @@
+---
+title: Silence Bandit's nosec-parsing warnings without weakening any suppression
+slug: bandit-nosec-comment-hygiene
+---
+
+# Spec: Bandit stops parsing suppression reasons as test ids, and its stderr becomes a gate
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — see § Named deviation
+- **Mode:** full (governance surface — this edits `bandit.yaml`, which
+  `Makefile`'s `SAST_CONFIG` names as the config governing the SAST gate; the
+  `sast` recipe itself; and a shipped pack script installed into adopter repos.
+  Behaviour-equivalence does not clear the trigger; the trigger reads *touches*,
+  not *changes the behaviour of*. Same reading as the sibling
+  `pack-script-root-boundary-validation` spec.)
+- **Constrained by:** [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md)
+  § suppression policy, whose `# nosec <ID> — <reason>` spelling this spec
+  reverses — recorded as
+  [ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md)
+- **Contract:** none (comment form + a gate wrapper; no published interface)
+- **Shape:** service
+
+## Named deviation from full mode
+
+Three full-mode elements were not run. Naming all three, because a partial
+disclosure is worse than none:
+
+1. **The `loop-engine` / `loop-cohort` state machine.** Its primary job is to
+   sequence the two human approval gates, and the requester granted both up
+   front as a standing instruction to carry this change autonomously through to
+   merge. Its state files are gitignored, so it would also have left no record.
+2. **`loop-cohort`'s iteration-cap accounting** (`record-attempt`, `check
+   --phase gates-failed|review`) rides on that same machine, so it is skipped
+   too. This is a real loss, not a nil one: the loop ran three review rounds
+   and one gate failure with no mechanical retry ceiling. It stayed bounded by
+   judgment, which is weaker than a counter.
+3. **A `plan.md` with per-task `Tests:`, verification mode, and `Depends on:`.**
+   The task list below is inline and unannotated. Defensible only because every
+   task is goal-based against a command that already exists — there is no task
+   whose verification had to be invented — but it is a deviation, not a trim.
+
+What full mode required and *was* run: `adversarial-reviewer` to Clean,
+`security-reviewer` (warranted — the suppressions sit on `subprocess` and
+JWT-bearing `urllib` sinks), and the `quality-engineer` floor.
+
+## Objective
+
+`make sast`'s Bandit leg emits 54 `WARNING` lines on a clean run. None is a
+finding — the gate still exits 0 — but the noise buries any warning that
+*would* matter, and one class of it is a live foot-gun. Remove every warning
+by fixing the comments Bandit is complaining about, changing no suppression
+and no runtime behaviour — then make the resulting silence load-bearing by
+failing the gate on any future Bandit stderr, so the next malformed
+suppression is a red build rather than two more lines of scrollback.
+
+Two classes, both diagnosed against Bandit 1.9.4:
+
+1. **`Test in comment: <word> is not a test name or id, ignoring`** (50 lines).
+   `bandit/core/manager.py` parses a nosec comment with
+   `NOSEC_COMMENT = re.compile(r"#\s*nosec:?\s*(?P<tests>[^#]+)?#?")` — the
+   test-id list runs to the *next `#`*, so the whole prose reason in the
+   repo's documented `# nosec <ID> — <reason>` form is tokenised and looked up
+   as test names. Today every lookup misses and only warns. It is a foot-gun
+   because a reason word that happens to collide with a Bandit test *name*
+   (`assert_used`, `weak_cryptographic_key`, …) would silently widen the
+   suppression beyond the ID the author wrote — and because a comment that
+   *opens* with `nosec` and resolves to no id at all is treated as a blanket
+   suppression of every test on the statement. Fix: `# nosec <ID>  # <reason>`
+   — the second `#` terminates the id list, so the reason is never parsed.
+
+2. **`nosec encountered (B104), but no failed test`** (4 lines, all
+   `tier3.py:43`). `utils.get_nosec` matches a nosec against the whole
+   *statement* linerange, so the one-line `frozenset({"", "*", ".", "0.0.0.0",
+   "::"})` runs B104 over five string nodes; four produce no finding and each
+   warns that the nosec went unused. Splitting the literal across lines does
+   not help (the linerange still spans the nosec). Fix: hoist `"0.0.0.0"` to
+   its own single-statement constant carrying the nosec.
+
+## Boundaries
+
+**Never do:** change `bandit.yaml`'s `skips` / `exclude_dirs`; change which test
+ids any line suppresses; filter or `grep -v` the diagnostics out of the `make
+sast` recipe (the whole point is to promote them, not hide them); edit **the
+body of** ADR-0017 or of the shipped `sast-sca-tooling` spec and plan (frozen —
+`docs/CONVENTIONS.md` § Document lifecycle); change any runtime behaviour beyond
+the `tier3.py` constant hoist, which is value-identical.
+
+**Always do:** prove suppression equivalence before claiming the rewrite was
+safe — the reported-finding diff *and* the resolved-id inventory, because
+neither alone can see a suppression widened onto a test that fires nowhere. Give
+any new gate a self-test that fails when the gate is removed; that is why
+`tools/test-sast-stderr-gate.py` exists rather than a bare recipe line.
+
+**Ask first:** before adding a `# nosec` this change did not already have, or
+before widening `exclude_dirs` to quiet a diagnostic. Both move the gate's
+coverage rather than its noise floor, and neither is in scope here.
+
+ADR-0017's **Status line** is a third case, and *is* amended: that field stays
+mutable on a frozen ADR, and four ADRs (0001, 0013, 0015, 0016) already carry
+the same partial-amendment pointer. Without it a reader who starts at the ADR —
+the documented source of truth for *why* — never learns the spelling changed.
+
+## Testing Strategy
+
+Goal-based check — the gate is the test:
+
+- `bandit -r tools packs packages tests -c bandit.yaml --severity-level medium
+  --confidence-level medium -q` emits zero output and exits 0.
+- **Suppression-equivalence check.** The load-bearing one. Base is the pinned
+  SHA `1f6b2d2f`, not the moving `origin/main`, so this stays re-runnable after
+  merge:
+
+  ```sh
+  for ref in 1f6b2d2f HEAD; do
+    git worktree add -q --detach "/tmp/wt-$ref" "$ref"
+    ( cd "/tmp/wt-$ref" && bandit -r tools packs packages tests -c bandit.yaml \
+        --severity-level low --confidence-level low -f json \
+        -q -o "/tmp/$ref.json" 2>"/tmp/$ref.warn" )   # exits 1 — findings expected
+  done
+  python3 - <<'PY'
+  import json
+  key = lambda p, tag: {(r['filename'].split('wt-%s/' % tag)[-1], r['test_id'],
+                         r['issue_text']) for r in json.load(open(p))['results']}
+  b, h = key('/tmp/1f6b2d2f.json', '1f6b2d2f'), key('/tmp/HEAD.json', 'HEAD')
+  print(len(b), len(h), b ^ h)     # -> 239 239 set()
+  PY
+  wc -l /tmp/1f6b2d2f.warn /tmp/HEAD.warn   # -> 54 and 0
+  ```
+
+  A weakened suppression appears only on the HEAD side, an over-broad one only
+  on the base side; the symmetric difference must be empty. Four traps, each of
+  which gave a wrong answer when first skipped:
+  - **Rows are not keys.** Each side has 362 raw result rows collapsing to 239
+    distinct `(filename, test_id, issue_text)` keys. Quote which one you mean.
+  - **Both sides must be clean worktrees**, not "a worktree vs. the working
+    tree". A development tree carries gitignored build output
+    (`packages/agentbundle/build/lib/…`) the worktree does not; scanning one of
+    each inflated both totals and produced a 27-key phantom delta.
+  - **Relative roots** (`tools packs packages tests`) from each worktree root.
+    Absolute paths stop `exclude_dirs: '*/tests/*'` matching, so the two scans
+    diff different file sets.
+  - **Both scans exit 1** at this floor (findings are expected), so `set -e`
+    will abort the loop above if you add it.
+
+  Line numbers are excluded from the key because the `tier3.py` edit shifts
+  them.
+- **Mutation check on the one runtime change.** Deleting `_REJECT_ANY_IPV4`
+  from `_REJECT_LITERALS` must fail
+  `test_rejects_wildcard_and_catchall_endpoints`. It did not before this
+  change: `"0.0.0.0"` and `"::"` are also caught by the downstream
+  `ip.is_unspecified` branch, so a bare `pytest.raises(DeclarationError)`
+  stayed green with the constant deleted. The `match="wildcard"` added here
+  pins the literal-set branch specifically; verified by re-running the mutation.
+- **Gate self-test on the new stderr rule.** `python3
+  tools/test-sast-stderr-gate.py` — five cases against a stub `bandit`: clean
+  scan passes; one stderr line fails the gate *even though bandit exited 0*;
+  findings still fail with bandit's own status; whitespace-only stderr does not
+  fail; no scan roots is a usage error. Separately, end-to-end: reintroducing
+  the dash form on one real suppression makes `python3
+  tools/run-bandit-gate.py tools packs packages tests` exit 1, and the
+  unmodified tree exits 0. Both were run.
+- **Resolved-id inventory.** Complementary to the equivalence check above and
+  necessary because that check only sees *reported* findings: running every
+  suppression comment at both revisions through Bandit's own
+  `_parse_nosec_comment` must give the same result — one resolved id per
+  directive, no blanket suppressions, at either revision. It does, which is
+  what rules out a suppression widened onto a test that fires nowhere today.
+- `python3 tools/lint-ruff.py`, `make lint-mypy`, and `SKIP_SAST=1 make
+  build-check` pass.
+- `python3 -m pytest packages/agentbundle/tests/unit/test_system_trust.py
+  packs/converters/tests/skills/file-to-markdown/ -q` passes (the two edited
+  runtime files are covered there).
+
+## Acceptance Criteria
+
+- [x] Every `# nosec` comment that carries a prose reason uses the
+      `# nosec <ID>  # <reason>` form; no reason text reaches Bandit's test-id
+      parser. That includes `tools/audit-npm.py` ×2, which landed on `main`
+      while this branch was in review — not a drive-by: the stderr gate below
+      fails on them, so converting them is what makes the gate green on the
+      tree it lands in
+- [x] The explanatory block above `_app_api`'s opener in
+      `tools/capture-publish-control-evidence.py` no longer begins with
+      `# nosec` (it is prose, not a directive; the real directive is on the
+      `opener.open` line)
+- [x] `"0.0.0.0"` in `tier3.py` is a single-statement constant carrying
+      `# nosec B104`, and `_REJECT_LITERALS` references it. It is named
+      `_REJECT_ANY_IPV4`, not `_ANY_IPV4`: the constant is pre-suppressed for
+      B104, so a name that reads as a reusable bind address would let a future
+      `bind` use in this module escape the check entirely
+- [x] `bandit … --severity-level medium --confidence-level medium -q` produces
+      no output and exits 0
+- [x] The suppression-equivalence check above reports identical finding sets on
+      both sides — 362 raw result rows collapsing to 239 distinct
+      `(filename, test_id, issue_text)` keys each way, empty symmetric
+      difference — while the warning count goes 54 → 0
+- [x] `make sast`'s Bandit leg fails on non-empty stderr, so the silence this
+      change buys is enforced rather than merely achieved (ADR-0084). Verified
+      both ways: clean tree exits 0, one reintroduced dash-form suppression
+      exits 1
+- [x] That gate has a self-test that fails if the gate is removed —
+      `tools/test-sast-stderr-gate.py`, driven against a stub `bandit`, running
+      ahead of the scan in the `sast` recipe alongside the two self-tests
+      already there
+- [x] `_REJECT_ANY_IPV4` is pinned by an assertion that fails when it is
+      removed from `_REJECT_LITERALS` (`match="wildcard"` in
+      `test_rejects_wildcard_and_catchall_endpoints`)
+- [x] ADR-0084 records the form change and the stderr rule; ADR-0017's Status
+      line points at it, so a reader starting from the frozen ADR finds the
+      live rule
+- [x] `bandit.yaml` documents the required `# nosec <ID>  # <reason>` form and
+      why, so the fix does not regress on the next suppression added — including
+      that the ID is mandatory, because a `# nosec` whose id list resolves to
+      nothing suppresses every test on the statement and, under the two-`#`
+      form, does so silently. The id-less case is the one shape Bandit never
+      warns about, so it stays unenforced — see § Deferred
+- [x] No suppression rationale overstates its guarantee: `diagnose-tls-trust.py`
+      says `list argv` rather than `fixed argv`, since `argv[0]` at both call
+      sites comes from `shutil.which`
+- [x] `python3 tools/lint-ruff.py`, `make lint-mypy`, `SKIP_SAST=1 make
+      build-check`, and the touched packages' tests pass
+
+## Tasks
+
+1. Rewrite the seven prose-carrying nosec comments to the `# nosec <ID>  #
+   <reason>` form (`tools/diagnose-tls-trust.py` ×2, `tools/audit-npm.py` ×2,
+   `packages/agentbundle/agentbundle/system_trust.py` ×2, and the block comment
+   in `tools/capture-publish-control-evidence.py`)
+2. Hoist `"0.0.0.0"` in `packs/converters/.apm/skills/file-to-markdown/scripts/tier3.py`
+   to its own constant carrying the B104 nosec
+3. Document the comment form in `bandit.yaml`
+4. Run the gates (bandit at both floors, ruff, mypy, build-check, tests)
+5. Review (`adversarial-reviewer`, `security-reviewer`, `quality-engineer`),
+   apply findings, re-run the gates, then PR and merge
+6. From review: record the reversal as ADR-0084 and point ADR-0017's Status
+   line at it; pin the `tier3.py` hoist with `match="wildcard"`
+7. From review: promote Bandit's stderr to a gate failure — `tools/run-bandit-gate.py`
+   replaces the bare recipe line, and `tools/test-sast-stderr-gate.py` proves it
+   against a stub `bandit` so the rule cannot be simplified away unnoticed
+
+## Deferred
+
+- `bandit-nosec-form-lint` — a `tools/` check that enforces the form (ID
+  mandatory; reason only after a second `#`), wired into `make build-check`.
+  Recorded in `workspace.toml [backlog].open`.
+- `capture-evidence-repo-dot-segments` — `_validate_repo` accepts `..` path
+  segments, so a `--repo` value can reach an endpoint other than the one named.
+  Pre-existing, no privilege gain, and the JWT still cannot leave
+  `api.github.com`; a behaviour change with its own test belongs in its own PR.
+  Recorded in `workspace.toml [backlog].open`.
+
+## Bundled fixes
+
+- `bandit.yaml`'s invocation comment duplicated the Makefile's scanned-roots
+  list and had already drifted (missing `tests`). It now points at `SAST_DIRS`
+  — one line, in a file this change already edits, three lines above the block
+  it adds.
+- `docs/adr/README.md` was missing its row for ADR-0083 (the npm SCA gate),
+  which landed without one; added while adding ADR-0084's row directly below
+  it. Same shape as the earlier `docs(adr): add the missing ADR-0074 row`.
+- `tools/diagnose-tls-trust.py`'s B603/B404 reasons claimed "fixed argv", but
+  `argv[0]` at both call sites comes from `shutil.which`; corrected to "list
+  argv" while rewriting those same two comments. (`system_trust.py`'s "argv is
+  constant" is accurate and stands — every element there is a module constant.)
+
+## Assumptions
+
+- Bandit's `NOSEC_COMMENT` / `get_nosec` behaviour is stable across the 1.9.x
+  line the repo pins in `tools/requirements-sast.txt`; both were read from the
+  installed 1.9.4 source and confirmed empirically in a scratch file before
+  planning.
+- Warnings go to stderr and never affect the gate's exit code, so this change
+  cannot make CI redder — only quieter.
+
+## Declined
+
+- **A repo policy gate rejecting prose-after-`# nosec`.** A new `tools/` check
+  plus a CI wiring for a five-site problem; the `bandit.yaml` comment carries
+  the same information at the point of use. Deferred, not dismissed.
+- **Amending the *bodies* of the three frozen documents that still teach the
+  old form** — `docs/adr/0017-…:107`, `docs/specs/sast-sca-tooling/spec.md:44`
+  and its `plan.md:146,151,154,159,161,164,166`. Bodies are immutable. What is
+  done instead: ADR-0084 records the reversal, ADR-0017's *Status* line points
+  at it (a field that stays mutable), and `bandit.yaml` carries the operative
+  instruction. The shipped `sast-sca-tooling` spec and plan cannot be annotated
+  at all — an accepted cost, flagged in the PR description per `AGENTS.md` §
+  When this file is wrong.
+- **A `tools/` script for the equivalence check** (a
+  `compare-bandit-suppressions` shape). The
+  check is needed whenever a suppression is touched, which argues for a script,
+  but its shape is still settling — this run changed the procedure twice. The
+  literal commands are pasted into Testing Strategy against a pinned SHA so the
+  next person can run it; promoting it to a tool rides with
+  `bandit-nosec-form-lint`.
+- **Fixing `packs/converters/tests/skills/file-to-markdown/test_tier3.py:40`.**
+  Same shape, but the test tree is excluded by `bandit.yaml`, so it emits no
+  warning — out of scope for "fix the warnings".
+- **Pinning or bumping Bandit, or filtering the recipe's output.** Both hide
+  the signal rather than fix the comments producing it.
+
+## Known skip
+
+`make ci` is red on `origin/main` as of `1f6b2d2f`, independently of this
+change: `tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels`
+asserts every canonical outcome title from the docs-site navigation appears
+verbatim in each markdown entry point, and `guides/README.md` no longer carries
+"Build and review software". Reproduced on a clean `origin/main` worktree;
+`guides/README.md` is not in this diff. Treated as a known skip and recorded as
+`pre-existing-guides-readme-outcome-label-drift` in `workspace.toml
+[backlog].open`. Every other leg of `make ci` is green on this branch.

--- a/packages/agentbundle/agentbundle/system_trust.py
+++ b/packages/agentbundle/agentbundle/system_trust.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 import contextlib
 import os
 import ssl
-import subprocess  # nosec B404 - fixed argv to /usr/bin/security, no shell
+import subprocess  # nosec B404  # fixed argv to /usr/bin/security, no shell
 import sys
 from pathlib import Path
 
@@ -107,7 +107,7 @@ def _default_runner(argv: list[str]) -> str:
     Seam: tests replace ``_RUNNER`` so no assertion depends on the developer's
     own keychain contents.
     """
-    proc = subprocess.run(  # nosec B603 - fixed binary, no shell, argv is constant
+    proc = subprocess.run(  # nosec B603  # fixed binary, no shell, argv is constant
         argv,
         capture_output=True,
         text=True,

--- a/packs/converters/.apm/skills/file-to-markdown/scripts/tier3.py
+++ b/packs/converters/.apm/skills/file-to-markdown/scripts/tier3.py
@@ -39,8 +39,11 @@ import safe_io
 _ALLOWED_KEYS = frozenset({"endpoint-allowlist", "residency-region"})
 
 # Wildcard / scheme-less catch-alls rejected outright. (B104 false positive:
-# `0.0.0.0` here is a value we REJECT from the egress allowlist, not a bind.)
-_REJECT_LITERALS = frozenset({"", "*", ".", "0.0.0.0", "::"})  # nosec B104
+# `0.0.0.0` here is a value we REJECT from the egress allowlist, not a bind —
+# hence the name. Bound to its own statement so the nosec covers one value;
+# see this repo's `bandit.yaml` for why.)
+_REJECT_ANY_IPV4 = "0.0.0.0"  # nosec B104
+_REJECT_LITERALS = frozenset({"", "*", ".", _REJECT_ANY_IPV4, "::"})
 
 # Metadata / loopback hostnames rejected in disguise. NON-EXHAUSTIVE — the
 # connect-time block in the adopter transport is authoritative; this only reduces

--- a/packs/converters/tests/skills/file-to-markdown/test_tier3.py
+++ b/packs/converters/tests/skills/file-to-markdown/test_tier3.py
@@ -40,7 +40,11 @@ def test_valid_declaration_returns_cleaned_endpoints_and_residency():
 @pytest.mark.parametrize("bad", ["", " ", "*", ".", "0.0.0.0", "::"])  # nosec B104
 def test_rejects_wildcard_and_catchall_endpoints(bad):
     decl = {"endpoint-allowlist": [bad], "residency-region": "eu"}
-    with pytest.raises(tier3.DeclarationError):
+    # `match=` pins the *literal-set* branch specifically. Without it the two
+    # unspecified addresses ("0.0.0.0", "::") also fall through to the
+    # IP-classification branch below, so dropping them from _REJECT_LITERALS
+    # left this test green — the assertion could not see the set it names.
+    with pytest.raises(tier3.DeclarationError, match="wildcard"):
         tier3.validate_declaration(decl)
 
 

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess  # nosec B404 - invokes `npm` with a fixed, non-shell argv
+import subprocess  # nosec B404  # invokes `npm` with a list argv, no shell
 import sys
 import tempfile
 import tomllib
@@ -337,7 +337,7 @@ def run_audit(project_dir: Path) -> object:
         f"--audit-level={AUDIT_LEVEL}",
     ]
     try:
-        completed = subprocess.run(  # nosec B603 - fixed argv, shell=False, no user input
+        completed = subprocess.run(  # nosec B603  # list argv of constants, no shell
             argv,
             cwd=project_dir,
             capture_output=True,

--- a/tools/capture-publish-control-evidence.py
+++ b/tools/capture-publish-control-evidence.py
@@ -260,11 +260,14 @@ def _app_api(path: str, jwt: str) -> object:
         },
     )
     try:
-        # nosec B310 — the scheme is a fixed literal above, every interpolated
-        # path segment is a constant or a `--repo` value already constrained by
-        # _validate_repo, and redirects are refused outright. That last point
-        # matters: the default opener copies request headers across a redirect,
-        # which would forward this JWT to another host.
+        # Why B310 is suppressed on the `open` call below: the scheme is a
+        # fixed literal above, every interpolated path segment is a constant or
+        # a `--repo` value already constrained by _validate_repo, and redirects
+        # are refused outright. That last point matters: the default opener
+        # copies request headers across a redirect, which would forward this
+        # JWT to another host. (Prose only — the directive is on the `open`
+        # call below; see `bandit.yaml` for why a reason never precedes the
+        # second `#`.)
         opener = urllib.request.build_opener(_NoRedirect)
         with opener.open(request, timeout=30) as response:  # nosec B310
             return json.loads(response.read())

--- a/tools/diagnose-tls-trust.py
+++ b/tools/diagnose-tls-trust.py
@@ -36,7 +36,7 @@ import re
 import shutil
 import socket
 import ssl
-import subprocess  # nosec B404 - fixed argv, no shell, read-only diagnostics
+import subprocess  # nosec B404  # list argv, no shell, read-only diagnostics
 import sys
 import urllib.error
 import urllib.request
@@ -98,7 +98,9 @@ def fetch(url: str, context: ssl.SSLContext | None = None) -> tuple[bool, str]:
 def run(argv: list[str], timeout: int = 60) -> str:
     """Run *argv*, returning stdout, or "" if it fails."""
     try:
-        proc = subprocess.run(  # nosec B603 - fixed argv, no shell
+        # argv[0] comes from shutil.which at both call sites, not a literal;
+        # the remaining args are constants and there is no shell.
+        proc = subprocess.run(  # nosec B603  # list argv, no shell
             argv, capture_output=True, text=True, timeout=timeout, check=False
         )
     except (OSError, subprocess.SubprocessError, ValueError):

--- a/tools/run-bandit-gate.py
+++ b/tools/run-bandit-gate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Run Bandit as a gate, treating its stderr as a failure (ADR-0084).
+
+Bandit's exit code answers "did I find anything?". It does not answer "was my
+own input sound?" — that goes to stderr and is then discarded by a plain
+`bandit …` recipe line. Under `-q` that stderr carries exactly the diagnostics
+a suppression author needs to see:
+
+  * ``Test in comment: <word> is not a test name or id`` — a suppression whose
+    reason leaked into the test-id list. The words that *do* resolve join the
+    suppression; a word colliding with a real test name widens it silently.
+  * ``nosec encountered (BNNN), but no failed test`` — a suppression covering a
+    statement the test never fires on, i.e. stale or misplaced.
+  * file-level read/parse errors — a file that was never actually scanned.
+
+None of those move the exit code, so this wrapper does: any stderr output fails
+the gate. Findings still go to stdout and still set the exit status.
+
+Run: python3 tools/run-bandit-gate.py <scan-root> [<scan-root> …]
+Exit 0 = clean, 1 = findings or diagnostics, 2 = usage/tool error.
+Proven by tools/test-sast-stderr-gate.py.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is the literal "bandit"
+import sys
+from pathlib import Path
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG = "bandit.yaml"
+
+# The floor lives here and in bandit.yaml's header comment, not on the recipe
+# line, so the two cannot drift apart silently.
+FLOOR = ["--severity-level", "medium", "--confidence-level", "medium", "-q"]
+
+HINT = (
+    "make sast: bandit wrote diagnostics to stderr — that is a gate failure, not\n"
+    "make sast: chatter. A `# nosec` bandit cannot parse can suppress more than\n"
+    "make sast: its author wrote. See ADR-0084 and bandit.yaml's header comment."
+)
+
+
+def main(argv: list[str]) -> int:
+    roots = argv[1:]
+    if not roots:
+        print(f"usage: {Path(argv[0]).name} <scan-root> [<scan-root> ...]", file=sys.stderr)
+        return 2
+
+    cmd = ["bandit", "-r", *roots, "-c", CONFIG, *FLOOR]
+    print(" ".join(cmd))
+    try:
+        # stdout inherited so findings stream as they would from a bare recipe
+        # line; only stderr is captured, because only stderr is being judged.
+        proc = subprocess.run(  # nosec B603  # list argv, no shell; roots are the Makefile's SAST_DIRS
+            cmd,
+            cwd=REPO_ROOT,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        print(f"run-bandit-gate: could not run bandit: {exc}", file=sys.stderr)
+        return 2
+
+    if proc.stderr.strip():
+        sys.stderr.write(proc.stderr if proc.stderr.endswith("\n") else proc.stderr + "\n")
+        print(HINT, file=sys.stderr)
+        return 1
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/test-sast-stderr-gate.py
+++ b/tools/test-sast-stderr-gate.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Self-test for tools/run-bandit-gate.py — the stderr-fails-the-gate rule.
+
+ADR-0084 makes any Bandit stderr line a `make sast` failure. That rule is
+invisible on a healthy repo: a clean scan and a scan whose diagnostics were
+accidentally dropped look identical. Without this file the gate would be
+exactly the shape ADR-0084 § Context refuses — silent when it works and silent
+when it has been broken into a no-op — which is why tools/test-audit-requirements.py
+and tools/test-semgrep-argv-boundary.py already sit in the same recipe.
+
+Drives the wrapper against a stub `bandit` placed first on PATH, so the
+assertions are about the wrapper's contract and never about the repo's current
+findings:
+
+  1. Clean scan (exit 0, no stderr)                       -> gate exits 0.
+  2. Clean scan carrying ONE stderr diagnostic (exit 0)   -> gate exits 1.
+     The load-bearing case: bandit itself says "fine", the wrapper says no.
+  3. Findings (exit 1, no stderr)                         -> gate exits 1,
+     i.e. the wrapper still passes bandit's own verdict through.
+  4. Whitespace-only stderr                               -> gate exits 0,
+     so a stray newline cannot red the build.
+  5. No scan roots                                        -> usage error, 2.
+
+Run: python3 tools/test-sast-stderr-gate.py
+Exit 0 = all pass; non-zero = at least one failure.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is sys.executable
+import sys
+import tempfile
+from pathlib import Path
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE = REPO_ROOT / "tools" / "run-bandit-gate.py"
+
+STUB = """#!/usr/bin/env python3
+import sys
+err = {stderr!r}
+if err:
+    sys.stderr.write(err)
+sys.stdout.write("stub bandit ran\\n")
+sys.exit({code})
+"""
+
+
+def _run_gate(stderr_text: str, code: int, roots: list[str]) -> int:
+    """Run the gate with a stub `bandit` that emits *stderr_text* and *code*."""
+    with tempfile.TemporaryDirectory() as tmp:
+        shim = Path(tmp) / "bandit"
+        shim.write_text(STUB.format(stderr=stderr_text, code=code), encoding="utf-8")
+        shim.chmod(0o700)
+        env = dict(os.environ, PATH=f"{tmp}{os.pathsep}{os.environ.get('PATH', '')}")
+        proc = subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+            [sys.executable, str(GATE), *roots],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        return proc.returncode
+
+
+CASES = [
+    ("clean scan passes", "", 0, ["tools"], 0),
+    (
+        "one stderr diagnostic fails the gate even though bandit exited 0",
+        "[manager]\tWARNING\tTest in comment: shell is not a test name or id, ignoring\n",
+        0,
+        ["tools"],
+        1,
+    ),
+    ("findings still fail, with bandit's own status", "", 1, ["tools"], 1),
+    ("whitespace-only stderr does not fail the gate", "\n  \n", 0, ["tools"], 0),
+    ("no scan roots is a usage error", "", 0, [], 2),
+]
+
+
+def main() -> int:
+    if not GATE.is_file():
+        print(f"test-sast-stderr-gate: missing {GATE}", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for name, stderr_text, code, roots, expected in CASES:
+        got = _run_gate(stderr_text, code, roots)
+        if got == expected:
+            print(f"  ok   {name}")
+        else:
+            print(f"  FAIL {name}: expected exit {expected}, got {got}", file=sys.stderr)
+            failures += 1
+
+    if failures:
+        print(f"\ntest-sast-stderr-gate: {failures} failure(s).", file=sys.stderr)
+        return 1
+    print(f"\ntest-sast-stderr-gate: all {len(CASES)} cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -1651,6 +1651,39 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
+  # Bandit's `# nosec` form is documented in bandit.yaml's header comment but
+  # enforced nowhere, and ADR-0017:107 -- frozen, so it cannot be amended --
+  # still teaches the superseded `# nosec <ID> - <reason>` form. Two failure
+  # modes a lint would catch: (a) a prose reason after the ID is tokenised and
+  # each word looked up as a Bandit test NAME, so a word colliding with a real
+  # test name silently widens the suppression; (b) a `# nosec` with no
+  # resolvable ID (bare, or an ID-less `# nosec  # reason`) suppresses EVERY
+  # test on the statement and, in the two-`#` form, prints no warning at all.
+  # Both fail open. A grep-shaped tools/ check wired into build-check would
+  # close them; deliberately not bundled into the bandit-nosec-comment-hygiene
+  # PR, which was comment-format-only and added no gate.
+  {slug = "bandit-nosec-form-lint", summary = "Add a tools/ check enforcing the `# nosec <ID>  # <reason>` form -- ID mandatory, reason only after a second `#` -- and wire it into make build-check", source = "spec/bandit-nosec-comment-hygiene"},
+
+  # tools/capture-publish-control-evidence.py:_validate_repo accepts
+  # `[A-Za-z0-9._-]+/[A-Za-z0-9._-]+`, which matches `../..`; urllib sends the
+  # selector unnormalised, so `--repo ../../app` reaches a different
+  # api.github.com endpoint than the caller named. No privilege gain (the
+  # operator already holds the App private key) and the JWT still cannot leave
+  # api.github.com -- the scheme and host are fixed literals and _NoRedirect
+  # refuses redirects outright -- so this is hygiene, not a live hole. Fix is a
+  # dot-segment reject in _validate_repo plus a case in its test.
+  # PRE-EXISTING on origin/main as of 1f6b2d2f, not caused by any branch:
+  # tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels
+  # fails because guides/README.md no longer carries the "Build and review
+  # software" outcome label that docs-site navigation still declares. The test
+  # asserts every canonical outcome title appears verbatim in each markdown
+  # entry point, so the two drifted apart when one side was reworded. `make ci`
+  # is red on main until this is reconciled -- decide which side is canonical
+  # (the navigation source or the README wording) and align the other.
+  {slug = "pre-existing-guides-readme-outcome-label-drift", summary = "Reconcile guides/README.md with the docs-site navigation's canonical outcome labels so test_markdown_entry_points_keep_canonical_outcome_labels passes", source = "pre-flight/2026-08-16"},
+
+  {slug = "capture-evidence-repo-dot-segments", summary = "Reject `.` and `..` path segments in capture-publish-control-evidence.py's _validate_repo so a --repo value cannot redirect the App-authenticated read to another endpoint", source = "spec/bandit-nosec-comment-hygiene"},
+
   # test-loop-cohort.sh is 493 lines / 51 cases of bash and uses ~20 bash-isms
   # ([[, local, $(), declare). AGENTS.md's "New tool scripts: Python, not bash"
   # rule grandfathers existing .sh, but this one is a portability dead end: a


### PR DESCRIPTION
## What does this change?

`make sast`'s Bandit leg printed 54 `WARNING` lines on a clean scan and then
exited 0. This rewrites the suppression comments Bandit was complaining about so
it prints nothing, and makes that silence load-bearing: the leg now fails if
Bandit writes anything to stderr at all.

No suppression changed what it suppresses, and no runtime behaviour changed —
the one code edit is a value-identical constant hoist in `tier3.py`.

## Why?

The warnings were not cosmetic. Bandit reads a suppression's test-id list up to
the *next* `#` (`NOSEC_COMMENT` in `bandit/core/manager.py`), so the form
ADR-0017 prescribes — `# nosec <ID> — <reason>` — hands the whole prose reason to
the parser, which tokenises it and looks each word up as a test **name**. Two
fail-open paths follow:

- **Widening** — a reason word colliding with a real test name (`assert_used`,
  `weak_cryptographic_key`, …) joins the suppression. Nobody wrote it; nothing
  reports it.
- **Blanket** — a suppression whose id list resolves to *no* id is treated as
  "nosec without test number" and skips **every** test on the statement.

Neither had fired. An inventory of every suppression on `main`, run through
Bandit's own `_parse_nosec_comment`, resolves to exactly the one id its author
wrote, with no blanket suppressions — the exposure was latent. Moving the reason
behind a second `#` closes both.

The four remaining warnings were `nosec encountered (B104), but no failed test`
at `tier3.py:43`: a suppression matches the whole *statement's* linerange, so
B104 ran over all five strings in the one-line frozenset and reported the
suppression unused for the four it skipped.

Then the awkward part. The new spelling is *quieter* than the old one when it is
malformed — an id-less `# nosec  # reason` blanket-suppresses in total silence,
where the dash form at least emitted warnings. Documenting the rule without
enforcing it would trade a noisy foot-gun for a silent one at exactly the moment
the gate's stderr went clean. So the leg is now `tools/run-bandit-gate.py`, which
fails on any Bandit stderr, with `tools/test-sast-stderr-gate.py` driving it
against a stub `bandit` to prove the rule. That is the same reasoning that
already puts `tools/test-audit-requirements.py` and
`tools/test-semgrep-argv-boundary.py` in that recipe: a scanner that is silent
when it works and silent when it has been broken into a no-op is not a gate.

- Spec: [`docs/specs/bandit-nosec-comment-hygiene/spec.md`](docs/specs/bandit-nosec-comment-hygiene/spec.md)
- Decision: [ADR-0084](docs/adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md), superseding the spelling in ADR-0017's suppression-policy sub-decision. ADR-0017's Status line points at it; the ladder itself, the tool choices, and the severity floor all stand.

## How do I verify it?

```sh
make sast                     # bandit leg: silent, exit 0
make ci                       # build-check + lint + test
```

> **Known skip.** `make ci` is red on `origin/main` itself as of `1f6b2d2f`:
> `tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels`
> fails because `guides/README.md` no longer carries the "Build and review
> software" outcome label the docs-site navigation declares. Reproduced on a
> clean `origin/main` worktree; `guides/README.md` is not in this diff.
> Recorded as `pre-existing-guides-readme-outcome-label-drift` in
> `workspace.toml [backlog].open`. Every other leg of `make ci` is green here.

**Suppression equivalence** — the load-bearing check, since "quieter" must not
mean "suppressing more". Two checks, because neither is sufficient alone.

Reported findings, base pinned at `1f6b2d2f` so this stays re-runnable after
merge:

```sh
for ref in 1f6b2d2f HEAD; do
  git worktree add -q --detach "/tmp/wt-$ref" "$ref"
  ( cd "/tmp/wt-$ref" && bandit -r tools packs packages tests -c bandit.yaml \
      --severity-level low --confidence-level low -f json \
      -q -o "/tmp/$ref.json" 2>"/tmp/$ref.warn" )   # exits 1 — findings expected
done
```

362 raw result rows collapsing to 239 distinct `(filename, test_id,
issue_text)` keys on each side, empty symmetric difference; 54 stderr warnings
on the base, 0 on HEAD.

That check only sees *reported* findings, so it cannot observe a suppression
that widened onto a test firing nowhere. The complement is a **resolved-id
inventory**: every suppression comment at both revisions through Bandit's own
`_parse_nosec_comment` gives the same answer — one id per directive, zero
blanket suppressions, zero multi-id suppressions.

The spec's Testing Strategy carries the full snippet and the four traps that
give a wrong answer if skipped — chiefly: compare two clean worktrees, never a
worktree against a development tree, because gitignored build output skews it.

**The gate itself, both ways** — `python3 tools/test-sast-stderr-gate.py` runs
five cases against a stub `bandit`, including the load-bearing one: bandit exits
0 with a single stderr line, and the gate still fails. End-to-end, reintroducing
the dash form on one real suppression makes the leg exit 1; reverting it exits 0.

**The one runtime change** — delete `_REJECT_ANY_IPV4` from `_REJECT_LITERALS`
and `test_rejects_wildcard_and_catchall_endpoints` now fails. It did not before
this PR; `"0.0.0.0"` and `"::"` are also caught by the downstream
`ip.is_unspecified` branch, so a bare `pytest.raises(DeclarationError)` stayed
green with the constant deleted. `match="wildcard"` pins the literal-set branch.

## What did you not change that you considered?

- **Filtering the warnings out of the recipe.** The obvious route to a clean
  scan, and the wrong one — it hides the signal instead of fixing the comments
  producing it, and leaves both fail-open paths intact.
- **The bodies of the three frozen documents that still teach the old form** —
  ADR-0017:107, `docs/specs/sast-sca-tooling/spec.md:44` and its `plan.md` (×7).
  Bodies are immutable (`docs/CONVENTIONS.md` § Document lifecycle). ADR-0017's
  *Status* line is amended instead, following the partial-amendment precedent in
  ADRs 0001/0013/0015/0016. **Flagged drift:** the shipped `sast-sca-tooling`
  spec and plan cannot be annotated at all, so they will keep teaching the
  em-dash form. `bandit.yaml` is the live rule.
- **A `tools/` lint enforcing the form.** The stderr gate now catches every
  malformed suppression Bandit *warns* about — which is all of them except the
  id-less case, the one shape Bandit is silent about. Closing that residue needs
  a grep-shaped check; deferred.
- **`packs/converters/tests/…/test_tier3.py:40`'s `# nosec B104`.** Same shape,
  but the test tree is excluded by `bandit.yaml`, so it emits no warning.
- **Pinning or bumping Bandit.** The warnings are correct; the parse behaviour
  they report predates the version that started reporting it.
- **The full-mode `loop-engine` state machine.** The trigger fires (this touches
  the SAST governance surface), so the spec declares full mode and the
  `security-reviewer` and `quality-engineer` passes both ran. Three full-mode
  elements were skipped and all three are named in the spec's § Named deviation
  rather than passed over: the state machine, its iteration-cap accounting, and
  a `plan.md` with per-task `Tests:`.

Note on `tools/audit-npm.py`: its two suppressions landed on `main` while this
branch was in review and use the old form. They are converted here — not a
drive-by, but a precondition: the stderr gate this PR adds fails on them.

Bundled fixes:
- `bandit.yaml`'s invocation comment duplicated the Makefile's scanned-roots list
  and had already drifted (missing `tests`); it now points at `SAST_DIRS`.
- `docs/adr/README.md` was missing its row for ADR-0083 (the npm SCA gate), which
  landed without one; added while adding ADR-0084's row directly below it. Same
  shape as the earlier `docs(adr): add the missing ADR-0074 row`.
- `tools/diagnose-tls-trust.py`'s B603/B404 reasons claimed "fixed argv", but
  `argv[0]` at both call sites comes from `shutil.which` — corrected to "list
  argv". (`system_trust.py`'s "argv is constant" is accurate and stands: every
  element there is a module constant.)

Deferred:
- `bandit-nosec-form-lint` — a `tools/` check making the form mandatory (id
  required; reason only after a second `#`), plus promoting the equivalence check
  to a `compare-bandit-suppressions`-shaped script.
- `capture-evidence-repo-dot-segments` — `_validate_repo` accepts `..` path
  segments, so a `--repo` value can reach an endpoint other than the one named.
  Pre-existing, no privilege gain, and the JWT still cannot leave
  `api.github.com` (fixed scheme and host, `_NoRedirect` refuses redirects); a
  behaviour change with its own test belongs in its own PR.

Both recorded in `workspace.toml [backlog].open`.
