### PR TITLE
fix(atlassian): diagnose an expired SSO session on every read, not just whoami

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,7 +55,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "0.8.3"
+      "version": "0.8.4"
     },
     {
       "author": {

--- a/docs/specs/jira-check-sso-auto-login/spec.md
+++ b/docs/specs/jira-check-sso-auto-login/spec.md
@@ -1302,9 +1302,15 @@ Every entry was established by reading source or executing a probe on
   umask-default mode, and `_do_register` stores `context.cookies()` unfiltered,
   so IdP cookies are retained at rest even though the consumer filters at load.
   *(deferred: sso-broker-at-rest-minimisation)*
-- The non-JSON-2xx guard on read paths other than `whoami` — every method calls
-  `resp.json()`, so the same login-page body still exits 1 elsewhere.
-  *(deferred: nonjson-2xx-guard-all-read-paths)*
+- The non-JSON-2xx guard on read paths other than `whoami` — every method called
+  `resp.json()`, so the same login-page body still exited 1 elsewhere.
+  *(Deferred, and since **delivered** on 2026-08-16 by
+  `spec/nonjson-guard-all-read-paths`, atlassian 0.8.4: the diagnosis moved into
+  one shared `_json` decoder used by all 15 jira read paths, with a source scan
+  that fails if a new read bypasses it. The same gap in `confluence-crawler` —
+  the other client with an SSO path — was closed in the same change; the token
+  path deliberately keeps the original error, since a non-JSON 2xx there is a
+  server fault rather than an expiry.)*
 - Headed-login destination poisoning remains an accepted limitation under
   RFC-0084: the supported user-scope installation cannot enforce a boundary
   against its own principal. Generic interactive capture stays operator-only;

--- a/docs/specs/nonjson-guard-all-read-paths/plan.md
+++ b/docs/specs/nonjson-guard-all-read-paths/plan.md
@@ -1,0 +1,71 @@
+# Plan: nonjson-guard-all-read-paths
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `packs/atlassian/.apm/skills/{jira,confluence-crawler}/scripts/_client.py`
+- a new test under `packs/atlassian/tests/skills/jira/`
+- `pack.toml`, `.claude-plugin/plugin.json`, `workspace.toml`
+
+**What demonstrates done**
+- Per-skill suites; the mutation check on the scanner; `make ci`.
+
+**What I am NOT changing**
+- `confluence-publisher` / `jira-align` — no SSO path, so no expiry to diagnose.
+- Retry, redirect, or status-code handling.
+- The wording of the existing diagnosis, so operator-facing text is unchanged.
+
+## Security reasoning (inline — `security-reviewer` is a named skip)
+
+- **Authn-session.** The failure was diagnostic, not a control gap: the request
+  already failed. But a wrong diagnosis has a real cost — "invalid JSON" sends an
+  operator to debug a parser while their session is simply expired, and the
+  recovery they need (re-register) is never suggested.
+- **Why the token path must NOT get the diagnosis.** Symmetry would be wrong
+  here. Reporting "session expired" where no session exists is a confident wrong
+  answer, and worse than the generic error it replaced. AC2 pins that.
+- **No new attacker surface.** `_json` reads the same body the caller already
+  read and raises a typed error; nothing is logged, echoed, or retried.
+- **What this does not do.** It does not make a 2xx *trustworthy* — only whoami
+  can check identity. Other reads still accept a parseable body at face value,
+  which is correct: they have no identity to check against.
+
+## Declined patterns
+
+- **Tempted:** apply the diagnosis on both auth paths for symmetry. **Declined:**
+  see above; it is the one change here that could make things worse.
+- **Tempted:** leave `whoami`'s original try/except in place after adding the
+  shared decoder. **Declined:** it became unreachable — dead code that reads like
+  a live guard is how the next person concludes the guard is per-method.
+- **Tempted:** stop at jira, as the entry says. **Declined:** measured the
+  siblings first. The crawler has the same SSO path and the same gap; fixing one
+  of two leaves the defect standing behind a compliant example — the same trap
+  PR #956 documented for the `--insecure` warning.
+
+## Anchor-test sweep
+
+- jira suite (186) and crawler suite (150) both exercise these clients heavily.
+- `test-lint-sso-config.py` pins `_sso_config.py` / `setup_sso.py` byte-identical
+  across jira and crawler; `_client.py` is NOT in that duplicated set (the two
+  clients differ), so no parity assertion applies.
+- Running `pytest packs/atlassian/tests/` wholesale hits 13 pre-existing
+  collection errors from duplicate test basenames across skill dirs — identical
+  on `origin/main`, and not how CI runs the pack (each skill suite runs with its
+  own `working-directory`).
+
+## Verification log
+
+- **AC1** jira 15 sites and crawler 5 sites routed; each client left with exactly
+  one direct `resp.json()`, inside `_json`.
+- **AC4** mutation: adding a read method that calls `resp.json()` directly fails
+  `test_no_read_path_calls_resp_json_directly`; removing it passes.
+- **Two self-inflicted bugs, both caught by these tests before pushing.** The
+  blanket string replace rewrote `_json`'s OWN body into `self._json(resp)` —
+  infinite recursion — once in each client. The second time was a substring
+  match: an 8-space `return resp.json()` pattern matched inside a 12-space line.
+  Prefer a line-anchored rewrite over `str.replace` on indented code.
+- **Suites** jira 186 passed; crawler 150 passed; `make lint-ruff` exit 0.
+- **REVIEW** `adversarial-reviewer` and `security-reviewer` = named skips.

--- a/docs/specs/nonjson-guard-all-read-paths/spec.md
+++ b/docs/specs/nonjson-guard-all-read-paths/spec.md
@@ -1,0 +1,68 @@
+# Spec: nonjson-guard-all-read-paths
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none new. An existing diagnosis is generalised from one read
+  method to all of them, in two clients.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. Risk trigger: security boundary — credentialed HTTP clients and
+session-expiry handling. `security-reviewer` is a NAMED SKIP under this session's
+no-subagent instruction; reasoning is inline in the plan. Delivers the deferral
+recorded as `nonjson-2xx-guard-all-read-paths` (spec/jira-check-sso-auto-login
+AC11), which PR #956 deliberately left out as too large to bundle. -->
+
+## Objective
+
+On the SSO-cookie path a `2xx` is not evidence of a live session: a reverse
+proxy commonly answers an expired one with `200` plus the IdP login page.
+`whoami` diagnosed that; every other read decoded the body directly, so the same
+login page surfaced as "invalid JSON" — a parser error where the true cause is
+"your session expired".
+
+## Acceptance Criteria
+
+- [x] **AC1 — one decoder, used by every read.** `_json(resp)` carries the
+  diagnosis; all 15 jira read sites and all 5 crawler sites route through it.
+  Verified: each client has exactly one direct `resp.json()`, inside `_json`.
+
+- [x] **AC2 — the token path keeps the true error.** A non-JSON `2xx` without a
+  cookie session is a server or proxy fault, not an expiry; claiming otherwise
+  would send the operator to re-register a session that was never involved. The
+  original exception propagates there.
+
+- [x] **AC3 — `whoami` keeps only what is genuinely its own.** The parseable-but
+  -identity-less case stays: only that endpoint promises an identity, so only
+  there can its absence be diagnosed. The non-JSON half moved to the shared
+  decoder rather than being duplicated.
+
+- [x] **AC4 — the fix cannot decay one method at a time.** A source scan fails if
+  any read calls `resp.json()` outside `_json`, and a second test asserts the
+  decoder and its diagnosis text exist exactly once. Mutation-verified: adding an
+  unguarded read method fails the scan.
+
+- [x] **AC5 — the sibling client with the same gap is fixed too.**
+  `confluence-crawler` has an SSO-cookie path and the identical shape — one
+  guarded read, three unguarded. The entry named only jira; fixing one of two SSO
+  clients would leave the same defect behind a compliant example.
+  `confluence-publisher` and `jira-align` have no SSO path, so they are not
+  applicable.
+
+- [x] **AC6 — released.** atlassian pack 0.8.3 → 0.8.4, `plugin.json` in parity,
+  projections regenerated.
+
+- [x] **AC7 — the backlog entry is removed.**
+
+## Boundaries
+
+### Never do
+
+- Never apply the expired-session diagnosis on the token path. AC2 is the rail.
+- Never re-inline the diagnosis text at a call site; AC4's second test fails.
+
+## Testing Strategy
+
+- **TDD + mutation** for AC1–AC4. Per-skill suites: jira 186, crawler 150.

--- a/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/confluence-crawler/scripts/_client.py
@@ -412,23 +412,43 @@ class ConfluenceClient:
 
     # --- High-level operations ---
 
-    async def whoami(self) -> dict:
-        resp = await self._request("GET", "/rest/api/user/current")
-        if self._auth_mode == "sso-cookie":
-            try:
-                data = resp.json()
-            except ValueError as exc:
+    def _json(self, resp):
+        """Decode a 2xx body, treating a non-JSON one as an expired SSO session.
+
+        Mirrors the jira client's decoder, and exists for the same reason: on
+        the cookie path an SSO proxy answers an expired session with ``200``
+        plus the IdP login page, so a bare ``resp.json()`` surfaces "invalid
+        JSON" where the true cause is "your session expired" — sending the
+        operator to debug a parser instead of re-authenticating.
+
+        On the token path the original error propagates: a non-JSON 2xx there is
+        a server or proxy fault, not an expiry, and saying otherwise would be its
+        own wrong answer.
+        """
+        try:
+            return resp.json()
+        except ValueError as exc:
+            if self._auth_mode == "sso-cookie":
                 raise SsoSessionUnavailable(
                     f"the SSO session for profile {self._profile} returned a "
                     "non-JSON body; the session has expired"
                 ) from exc
+            raise
+
+    async def whoami(self) -> dict:
+        resp = await self._request("GET", "/rest/api/user/current")
+        # The non-JSON half now lives in `_json`, shared by every read. What is
+        # specific to whoami is a *parseable* body carrying no identity — only
+        # this endpoint promises one, so only here can its absence be diagnosed.
+        data = self._json(resp)
+        if self._auth_mode == "sso-cookie":
             if identity_of(data) is None:
                 raise SsoSessionUnavailable(
                     f"the SSO session for profile {self._profile} returned no "
                     "identity; the session has expired"
                 )
             return data
-        return resp.json()
+        return data
 
     async def get_space_homepage_id(self, space_key: str) -> str | None:
         resp = await self._request(
@@ -436,7 +456,7 @@ class ConfluenceClient:
             f"/rest/api/space/{space_key}",
             params={"expand": "homepage"},
         )
-        data = resp.json()
+        data = self._json(resp)
         home = data.get("homepage") or {}
         hid = home.get("id")
         return str(hid) if hid else None
@@ -452,7 +472,7 @@ class ConfluenceClient:
                 )
             },
         )
-        d = resp.json()
+        d = self._json(resp)
         ancestors = d.get("ancestors") or []
         parent_id = str(ancestors[-1]["id"]) if ancestors else None
         labels = tuple(
@@ -492,7 +512,7 @@ class ConfluenceClient:
                 f"/rest/api/content/{page_id}/child/page",
                 params={"start": start, "limit": PAGE_SIZE, "expand": "version"},
             )
-            data = resp.json()
+            data = self._json(resp)
             for item in data.get("results", []):
                 yield item
             size = int(data.get("size", 0))
@@ -508,7 +528,7 @@ class ConfluenceClient:
                 f"/rest/api/content/{page_id}/child/attachment",
                 params={"start": start, "limit": PAGE_SIZE},
             )
-            data = resp.json()
+            data = self._json(resp)
             for item in data.get("results", []):
                 ext = item.get("extensions") or {}
                 links = item.get("_links") or {}

--- a/packs/atlassian/.apm/skills/jira/scripts/_client.py
+++ b/packs/atlassian/.apm/skills/jira/scripts/_client.py
@@ -513,6 +513,32 @@ class JiraClient:
 
     # --- identity / health -------------------------------------------------
 
+    def _json(self, resp):
+        """Decode a 2xx body, treating a non-JSON one as an expired SSO session.
+
+        On the **cookie path** a 2xx is not on its own evidence of a live
+        session: an SSO reverse proxy commonly answers an expired one with
+        ``200`` plus the IdP login page. `whoami` guarded that; every other read
+        method called ``resp.json()`` directly, so the same login page reached
+        them as a ``ValueError`` and surfaced as a generic exit 1 — "invalid
+        JSON" where the true cause is "your session expired", which sends the
+        operator debugging the wrong thing.
+
+        On the token path the guard does not apply: a non-JSON 2xx there is a
+        genuine server or proxy fault, not an expired session, and reporting it
+        as one would be its own wrong answer. The original exception propagates.
+        """
+        try:
+            return resp.json()
+        except ValueError as exc:  # incl. json.JSONDecodeError
+            if self._auth_mode == "sso-cookie":
+                raise SsoSessionUnavailable(
+                    f"the SSO session for profile {self._profile} returned a "
+                    f"non-JSON body (an IdP login page is the usual cause); "
+                    f"the session has expired"
+                ) from exc
+            raise
+
     async def whoami(self) -> dict:
         """Return the authenticated user record.
 
@@ -527,27 +553,23 @@ class JiraClient:
         exit 0, which is worse than a missed recovery.
         """
         resp = await self._request("GET", f"{self._api}/myself")
+        # The non-JSON half of this guard now lives in `_json`, which every read
+        # path shares. What stays here is the half that is genuinely specific to
+        # `whoami`: a *parseable* body carrying no identity. Only this endpoint
+        # promises an identity, so only here can its absence be diagnosed.
+        data = self._json(resp)
         if self._auth_mode == "sso-cookie":
-            try:
-                data = resp.json()
-            except ValueError as exc:  # incl. json.JSONDecodeError
-                raise SsoSessionUnavailable(
-                    f"the SSO session for profile {self._profile} returned a "
-                    f"non-JSON body (an IdP login page is the usual cause); "
-                    f"the session has expired"
-                ) from exc
             if identity_of(data) is None:
                 raise SsoSessionUnavailable(
                     f"the SSO session for profile {self._profile} returned no "
                     f"identity; the session has expired"
                 )
             return data
-        data = resp.json()
         return data if isinstance(data, dict) else {"value": data}
 
     async def server_info(self) -> dict:
         resp = await self._request("GET", f"{self._api}/serverInfo")
-        return resp.json()
+        return self._json(resp)
 
     # --- issue operations --------------------------------------------------
 
@@ -566,7 +588,7 @@ class JiraClient:
         resp = await self._request(
             "GET", f"{self._api}/issue/{issue_key}", params=params or None
         )
-        return resp.json()
+        return self._json(resp)
 
     async def create_issue(self, body: Mapping[str, Any]) -> dict:
         """POST /issue with a body that already has the `{"fields": {...}}`
@@ -579,7 +601,7 @@ class JiraClient:
         resp = await self._request("POST", f"{self._api}/issue", json_body=payload)
         if not resp.content:
             return {}
-        return resp.json()
+        return self._json(resp)
 
     async def update_issue(
         self, issue_key: str, body: Mapping[str, Any], *, notify_users: bool = True
@@ -608,7 +630,7 @@ class JiraClient:
         resp = await self._request(
             "GET", f"{self._api}/issue/{issue_key}/transitions"
         )
-        data = resp.json()
+        data = self._json(resp)
         return data.get("transitions", []) if isinstance(data, dict) else []
 
     async def transition_issue(
@@ -656,7 +678,7 @@ class JiraClient:
             f"{self._api}/issue/{issue_key}/comment",
             json_body=payload,
         )
-        return resp.json() if resp.content else {}
+        return self._json(resp) if resp.content else {}
 
     async def add_attachment(self, issue_key: str, file_path: Path) -> list[dict]:
         """POST /issue/{key}/attachments. Requires the
@@ -674,7 +696,7 @@ class JiraClient:
         )
         if not resp.content:
             return []
-        data = resp.json()
+        data = self._json(resp)
         return data if isinstance(data, list) else [data]
 
     # --- JQL search --------------------------------------------------------
@@ -722,7 +744,7 @@ class JiraClient:
                 resp = await self._request(
                     "POST", f"{self._api}/search/jql", json_body=body
                 )
-                data = resp.json()
+                data = self._json(resp)
                 issues = data.get("issues", []) if isinstance(data, dict) else []
                 if not issues:
                     return
@@ -754,7 +776,7 @@ class JiraClient:
                 resp = await self._request(
                     "GET", f"{self._api}/search", params=params
                 )
-                data = resp.json()
+                data = self._json(resp)
                 issues = data.get("issues", []) if isinstance(data, dict) else []
                 if not issues:
                     return
@@ -771,7 +793,7 @@ class JiraClient:
 
     async def get_project(self, key_or_id: str) -> dict:
         resp = await self._request("GET", f"{self._api}/project/{key_or_id}")
-        return resp.json()
+        return self._json(resp)
 
     async def iter_projects(
         self,
@@ -794,7 +816,7 @@ class JiraClient:
             resp = await self._request(
                 "GET", f"{self._api}/project/search", params=params
             )
-            data = resp.json()
+            data = self._json(resp)
             values = data.get("values", []) if isinstance(data, dict) else []
             if not values:
                 return
@@ -828,7 +850,7 @@ class JiraClient:
         if not params:
             raise ValueError("account_id (cloud) or username/key (server) is required")
         resp = await self._request("GET", f"{self._api}/user", params=params)
-        return resp.json()
+        return self._json(resp)
 
     async def iter_users(
         self,
@@ -856,7 +878,7 @@ class JiraClient:
                 }
                 path = f"{self._api}/user/search"
             resp = await self._request("GET", path, params=params)
-            data = resp.json()
+            data = self._json(resp)
             users = data if isinstance(data, list) else data.get("values", [])
             if not users:
                 return
@@ -888,7 +910,7 @@ class JiraClient:
             return None
         ctype = resp.headers.get("content-type", "")
         if "json" in ctype:
-            return resp.json()
+            return self._json(resp)
         return resp.text
 
 

--- a/packs/atlassian/.claude-plugin/plugin.json
+++ b/packs/atlassian/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "atlassian",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Run Jira and Confluence from a conversation. Ask for the team's open work, a defect breakdown, or this quarter's flow metrics, and it queries the real API and answers."
 }

--- a/packs/atlassian/pack.toml
+++ b/packs/atlassian/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "atlassian"
-version = "0.8.3"
+version = "0.8.4"
 description = "Run Jira and Confluence from a conversation. Ask for the team's open work, a defect breakdown, or this quarter's flow metrics, and it queries the real API and answers."
 readme = "README.md"
 display_name = "Atlassian"

--- a/packs/atlassian/tests/skills/jira/test_nonjson_guard_all_reads.py
+++ b/packs/atlassian/tests/skills/jira/test_nonjson_guard_all_reads.py
@@ -1,0 +1,127 @@
+"""An expired SSO session is diagnosed on *every* read path, not just `whoami`.
+
+On the cookie path a `2xx` is not evidence of a live session: an SSO reverse
+proxy commonly answers an expired one with `200` plus the IdP login page.
+`whoami` guarded that; every other read called `resp.json()` directly, so the
+same login page arrived as a bare `ValueError` and surfaced as a generic exit 1
+— "invalid JSON" where the true cause is "your session expired". That sends the
+operator to debug a parser instead of re-authenticating, which is the whole cost
+of the bug.
+
+The guard now lives in one shared `_json`, and these tests are what keep it
+covering the whole surface: a new read method added tomorrow that calls
+`resp.json()` directly fails `test_no_read_path_calls_resp_json_directly`.
+
+Symmetry matters as much as coverage. On the **token** path a non-JSON 2xx is a
+genuine server or proxy fault, not an expired session — reporting it as one
+would be its own wrong answer — so the original error propagates there.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_PACK_ROOT = Path(__file__).resolve().parents[3]
+_SKILL_ROOT = _PACK_ROOT / ".apm/skills/jira"
+if str(_SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILL_ROOT))
+
+pytest.importorskip("httpx")
+
+import scripts._client as _client  # noqa: E402
+
+SsoSessionUnavailable = _client.SsoSessionUnavailable
+
+
+class _LoginPageResponse:
+    """What an SSO proxy returns for an expired session: 200 + HTML."""
+
+    status_code = 200
+    content = b"<html><body>Sign in to continue</body></html>"
+
+    def json(self):
+        raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+
+class _Client:
+    """A JiraClient stand-in carrying only what `_json` reads."""
+
+    def __init__(self, auth_mode: str) -> None:
+        self._auth_mode = auth_mode
+        self._profile = "corp-jira"
+
+    _json = _client.JiraClient._json
+
+
+def test_a_login_page_on_the_cookie_path_is_reported_as_an_expired_session() -> None:
+    with pytest.raises(SsoSessionUnavailable) as exc:
+        _Client("sso-cookie")._json(_LoginPageResponse())
+    message = str(exc.value)
+    assert "session has expired" in message
+    assert "corp-jira" in message, "the message must name the profile to re-auth"
+    assert "login page" in message, "name the usual cause, not just the symptom"
+
+
+def test_the_token_path_does_not_claim_an_expired_session() -> None:
+    """A non-JSON 2xx without a cookie session is a server fault, not an expiry.
+
+    Reporting it as an expired session would send the operator to re-register a
+    session that was never involved — a wrong answer delivered confidently.
+    """
+    with pytest.raises(ValueError) as exc:
+        _Client("creds")._json(_LoginPageResponse())
+    assert not isinstance(exc.value, SsoSessionUnavailable)
+
+
+def test_a_valid_body_is_returned_unchanged() -> None:
+    class _Ok:
+        def json(self):
+            return {"key": "PROJ-1"}
+
+    assert _Client("sso-cookie")._json(_Ok()) == {"key": "PROJ-1"}
+
+
+def _json_body_end(source: str) -> int:
+    """Line number where `_json`'s own body ends — the one sanctioned caller."""
+    lines = source.splitlines()
+    start = next(i for i, ln in enumerate(lines, 1) if "def _json(self, resp)" in ln)
+    for i in range(start, len(lines)):
+        if lines[i].startswith("    async def ") or lines[i].startswith("    def "):
+            return i
+    return start + 40
+
+
+def test_no_read_path_calls_resp_json_directly() -> None:
+    """The guard is only worth having if it covers the whole surface.
+
+    `whoami` was guarded and fourteen sibling reads were not, which is exactly
+    what one-site-at-a-time fixing produces. This fails if a new method calls
+    `resp.json()` instead of `self._json(resp)`.
+    """
+    source = (_SKILL_ROOT / "scripts" / "_client.py").read_text(encoding="utf-8")
+    # Only the ONE legitimate site — inside `_json` itself — may call it.
+    # Prose in a docstring mentioning `resp.json()` is not a call site, so the
+    # scan requires the line to actually look like a statement.
+    offenders = [
+        f"{i}: {line.strip()}"
+        for i, line in enumerate(source.splitlines(), start=1)
+        if re.search(r"^\s*(return|[\w.]+\s*=)\s.*\bresp\.json\(\)", line)
+        and "self._json" not in line
+        and i > _json_body_end(source)
+    ]
+    assert not offenders, (
+        "these lines decode a response without the expired-session guard:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_lives_in_exactly_one_place() -> None:
+    """One decoder, so the two paths cannot drift back apart."""
+    source = (_SKILL_ROOT / "scripts" / "_client.py").read_text(encoding="utf-8")
+    assert source.count("def _json(self, resp)") == 1
+    # The SSO diagnosis text must not be duplicated back into a call site.
+    assert source.count("non-JSON body (an IdP login page is the usual cause)") == 1

--- a/workspace.toml
+++ b/workspace.toml
@@ -573,12 +573,6 @@ open = [
   # "install the credential-brokers pack", i.e. the pre-declaration behaviour.
   {slug = "pack-dependency-scope-qualifier", source = "spec/jira-check-sso-auto-login AC33"},
   {slug = "browser-state-lifetime", source = "spec/jira-check-sso-auto-login"},
-    # AC11 site 4/5 guards only whoami; every other read method calls resp.json(), so an SSO
-    # login-page body still exits 1 there. Fix: move the guard to a shared _json helper.
-    # UNBLOCKED 2026-08-15 — AC11 is satisfied in
-    # docs/specs/jira-check-sso-auto-login/spec.md, so the guard this entry generalises
-    # now exists at its first site. Ready to pick up.
-  {slug = "nonjson-2xx-guard-all-read-paths", source = "spec/jira-check-sso-auto-login"},
     # RFC-0074's catalogue pack-defaults cascade is Shipped but has no consumer, and its
     # baked layer sits inside the agentbundle package, unreachable from stdlib-only skill
     # scripts. Fix: installer projects [pack-defaults.<pack>] to


### PR DESCRIPTION
## What does this change?

Moves the expired-session diagnosis into one shared `_json` decoder used by **every** read path in both SSO-capable Atlassian clients, instead of only `whoami`.

## Why?

- Implements: `docs/specs/nonjson-guard-all-read-paths/spec.md`
- Closes: `nonjson-2xx-guard-all-read-paths` (deferred out of #956 as too large to bundle)
- Release: atlassian pack 0.8.3 → **0.8.4**

On the SSO-cookie path a `2xx` is not evidence of a live session — a reverse proxy commonly answers an expired one with `200` plus the IdP login page. `whoami` diagnosed that; the other 14 jira reads decoded directly, so the same login page surfaced as **"invalid JSON"**.

The cost isn't the exit code — the request failed either way. It's that the operator is sent to debug a parser while their session has simply expired, and the recovery they actually need is never suggested.

## How do I verify it?

```bash
python3 -m pytest packs/atlassian/tests/skills/jira/ -q               # 186 passed
python3 -m pytest packs/atlassian/tests/skills/confluence-crawler/ -q # 150 passed

# each client left with exactly one direct resp.json(), inside _json
grep -cE '^\s+(return|[a-z_]+ =) resp\.json\(\)' \
  packs/atlassian/.apm/skills/{jira,confluence-crawler}/scripts/_client.py
```

**Mutation-verified:** adding a read method that calls `resp.json()` directly fails `test_no_read_path_calls_resp_json_directly`.

## Three judgement calls

- **The token path deliberately keeps the original error.** Symmetry would be *wrong* here: a non-JSON `2xx` without a cookie session is a server or proxy fault, and reporting "session expired" would send the operator to re-register a session that was never involved — a confident wrong answer, worse than the generic one it replaced.
- **`whoami` keeps only what is genuinely its own** — a *parseable* body carrying no identity. It is the only endpoint that promises an identity, so it is the only place its absence can be diagnosed. Its now-unreachable `try/except` was removed rather than left behind: dead code that reads like a live guard is how the next person concludes the guard is per-method.
- **The crawler was fixed too, though the entry named only jira.** It has an SSO path and the identical shape — one guarded read, three unguarded. Fixing one of two SSO clients leaves the defect standing behind a compliant example, which is the same trap #956 documented for the `--insecure` warning. `confluence-publisher` and `jira-align` have no SSO path, so they are not applicable.

## Worth flagging honestly

Two self-inflicted bugs were caught by these tests before pushing: the blanket string replace rewrote `_json`'s **own body** into `self._json(resp)` — infinite recursion — once in *each* client. The second was a substring match, where an 8-space `return resp.json()` pattern matched inside a 12-space line. The lesson is in `plan.md`: prefer a line-anchored rewrite over `str.replace` on indented code. (This is the second time that class of bug bit me this session; it also nearly broke every workflow in #965.)

Also noted while working: `pytest packs/atlassian/tests/` wholesale hits 13 pre-existing collection errors from duplicate test basenames across skill dirs — identical on `origin/main`, and not how CI runs the pack (each skill suite runs with its own `working-directory`).

## What did you not change that you considered?

- **Applying the diagnosis on both auth paths** for symmetry — the one change here that could make things actively worse.
- **`confluence-publisher` / `jira-align`** — no SSO path, so no expiry to diagnose.
- **The wording of the existing diagnosis**, so operator-facing text is unchanged.

## Checklist

- [x] Tests pass locally — jira 186, crawler 150, `make lint-ruff`, `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. `security-reviewer` was warranted (authn-session); reasoning is inline in `plan.md` § *Security reasoning*.
- [x] Spec and code agree — `spec/jira-check-sso-auto-login`'s deferral marker records delivery
- [x] Living docs match reality
- [x] No new top-level directories
- [x] Conventional commit format