### PR TITLE
chore(workspace): record that work-loop's learning capture has no writer

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -64,6 +64,27 @@ backlog = [
   # site-design-system-spec, and P5's Astro project index; reference those owners.
   # Blocked until the contract is ratified and all three pilots complete.
   {slug = "portfolio-outcome-entry-surfaces", type = "design", needs = ["work:spec/portfolio-pack-first-value-contract", "work:spec/portfolio-first-run-pilot-architect", "work:spec/portfolio-first-run-pilot-figma", "work:spec/portfolio-first-run-pilot-governance-extras"]},
+  # TRANSITION-STATE DEFECT, observed 2026-08-16 while a work-loop run tried to
+  # record two learnings. The work-loop's mandated "Capture learnings" step has
+  # no working writer today, and both halves fail quietly enough to look fine:
+  #   - packs/core/.apm/skills/work-loop/scripts/append-knowledge.py prints
+  #     "retired writer; use project-knowledge --capture" and EXITS 0. A caller
+  #     that does not read stdout believes it wrote.
+  #   - `project-knowledge --capture` refuses `staged_dual_writer`.
+  #     knowledge_store.py `_assert_v1_writer_allowed` refuses while no committed
+  #     v1 map exists AND the legacy source is present — exactly this repo:
+  #     docs/knowledge/patterns.jsonl is still there, the v1 store is not active.
+  # So every work-loop run in this window completes its finish checklist with the
+  # learning silently dropped. This is the transition, not the destination — but
+  # the transition has no stated end date and the failure is invisible.
+  # Fix (either order): finish the migration (`--migrate-legacy` then
+  #   `--activate-staged`), and INDEPENDENTLY make the retired writer exit
+  #   non-zero so a caller cannot mistake its notice for a successful write. The
+  #   second half is worth doing even if the migration is weeks away.
+  # Unblocks when: picked up. The exit-code half has no dependency; the migration
+  #   rewrites the knowledge store, so it is not a ride-along.
+  {slug = "knowledge-capture-has-no-working-writer", source = "pre-flight/2026-08-16"},
+
   # Project knowledge measured-scale follow-on. Slice 1 deliberately retains closed
   # classification/month journals unchanged; deleting individual observations would
   # break the append-only evidence model and Git would retain the history anyway.


### PR DESCRIPTION
## What does this change?

One `workspace.toml` entry recording a transition-state defect found while trying to use the work-loop's own "Capture learnings" step.

## Why?

Both writers fail, and **both fail quietly enough to look like success**:

- `packs/core/.apm/skills/work-loop/scripts/append-knowledge.py` prints `append-knowledge: retired writer; use project-knowledge --capture` and **exits 0**. A caller that does not read stdout believes it wrote.
- `project-knowledge --capture` refuses with `staged_dual_writer`. `knowledge_store.py`'s `_assert_v1_writer_allowed` declines while no committed v1 map exists *and* the legacy source is present — exactly this repo's state: `docs/knowledge/patterns.jsonl` is still there and the v1 store is not active.

So every work-loop run in this window completes its finish checklist with the learning silently dropped. `K-0064`, written earlier in this same session before the writer was retired on main, looks like the last entry that landed.

That is the transition rather than the destination, and I am not proposing to force the migration — it rewrites the knowledge store and belongs to `project-knowledge-adoption-closeout`, which is queued but not yet written. What is worth separating out is the **exit code**: making the retired writer exit non-zero needs no migration and no decision, and it converts a silent drop into a visible one.

## How do I verify it?

```bash
python3 packs/core/.apm/skills/work-loop/scripts/append-knowledge.py --kind gotcha \
  --scope 'x/**' --title t --body b --source s; echo "exit=$?"   # prints the notice, exits 0
```

## What did you not change that you considered?

- **Running `--migrate-legacy` / `--activate-staged`.** It rewrites the knowledge store — a governance action belonging to the tracked closeout work, not a ride-along in a backlog-clearing session.
- **Fixing the exit code here.** It lives in a protected pack tree and deserves its own change with the migration decision visible alongside it; recording it is the honest first step.

## Checklist

- [x] Lint passes — `lint-spec-status` clean
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents.
- [x] Spec and code agree — no code changed
- [x] No new top-level directories
- [x] Conventional commit format