### PR TITLE
fix(agentbundle): one symlink policy for every direct-directory adapter

### DIFF
--- a/docs/specs/install-symlink-hardening/spec.md
+++ b/docs/specs/install-symlink-hardening/spec.md
@@ -51,8 +51,11 @@ disk under the link's own, innocent-looking relpath.
   six adapters. It failed `test_symlink_pass_through`, which surfaced AC2's
   invariant. The entry's premise was inverted: the four adapters that drop every
   symlink are the ones diverging from the spec, not the two that preserve them.
-  Recorded as `adapter-symlink-policy-divergence`, which needs a ruling on which
-  policy the invariant should state before any code moves.
+
+  **Ruled and resolved 2026-08-16** by `spec/unify-adapter-symlink-policy`: the
+  invariant stands, and the four strict adapters moved TO pass-through, with one
+  shared definition in `direct_directory.py`. The read-side fix this spec landed
+  is what makes that safe — a preserved link cannot be read through.
 
 - [x] **AC5 — released.** 0.36.0 → 0.36.1 with an entry in both changelogs.
 

--- a/docs/specs/unify-adapter-symlink-policy/plan.md
+++ b/docs/specs/unify-adapter-symlink-policy/plan.md
@@ -1,0 +1,71 @@
+# Plan: unify-adapter-symlink-policy
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `build/projections/direct_directory.py` (the one definition).
+- The six adapters.
+- `tests/unit/test_adapter_symlink_policy.py` (new).
+- `docs/specs/install-symlink-hardening/spec.md`, `workspace.toml`.
+
+**What demonstrates done**
+- Existing adapter + hardening suites unchanged and green; new tests;
+  mutation on the guard; `make ci`.
+
+**What I am NOT changing**
+- `render._collect_tree` — already correct, and it is what makes this safe.
+- `build/main.py`'s `.apm`/`seeds` copytrees — same invariant, already right.
+- `lint_packs.py`'s refusal of packs that ship symlinks.
+
+## Security reasoning (inline — `security-reviewer` is a named skip)
+
+- **The direction of this change is toward *more* preserved symlinks**, which
+  looks like the wrong direction until you separate the two operations.
+  *Resolving* a link materialises its target's bytes into the projection — that
+  is the exfiltration. *Preserving* it copies a pointer. The invariant forbids
+  the first, and this change makes all six adapters obey it.
+- **Defence in depth is intact and now correctly layered.** Projection preserves
+  (never materialises); the install-side read refuses to follow (never
+  materialises either). Both layers now decline to produce out-of-tree bytes,
+  where before four adapters solved it by deletion and two by preservation.
+- **What a preserved relative link can still do:** appear in an adopter's tree as
+  a dangling or upward-pointing link. It carries no content, `_collect_tree` will
+  not read it, and `lint_packs` refuses any first-party pack that ships one. The
+  residual is a visible artefact, not a disclosure.
+- **Order mattered.** Doing this before `install-symlink-hardening` closed the
+  read would have widened a live hole. That is why the first attempt was reverted
+  rather than pushed through.
+
+## Declined patterns
+
+- **Tempted:** keep the strict policy and amend the invariant instead — it is the
+  simpler rule and nothing ships symlinks. **Declined:** the operator ruled for
+  consistency with the stated invariant, and the invariant's reasoning is sound
+  once resolve-vs-preserve is separated. Amending a Shipped spec's security
+  invariant to match four files that drifted is the wrong direction of fit.
+- **Tempted:** assert `"symlinks=True" in source` per adapter. **Declined:** it
+  passes while a specific call has lost the flag. Verified by mutation, twice —
+  the first version of my own guard had this bug.
+
+## Anchor-test sweep
+
+- `tests/build_pipeline/test_adapter_codex.py::test_symlink_pass_through` — the
+  test that caught the first attempt; passes unchanged, as it must.
+- `tests/unit/test_nested_symlink_hardening.py` — pins the absolute case for four
+  adapters; passes unchanged (its fixture is `/etc/passwd`).
+- `tests/build_pipeline/test_adapter_cursor.py::test_nested_symlink_not_reproduced`
+  — asserts the target is not copied; still true, since preservation copies no
+  content.
+
+## Verification log
+
+- **AC1–AC3** six adapters import one definition; each direct-directory
+  `copytree` carries `symlinks=True`.
+- **AC4** `tests/build_pipeline/` + `test_nested_symlink_hardening.py` green with
+  no edits — the evidence the change is behaviour-preserving under existing cover.
+- **AC5/AC6** 5 new tests; mutation on the guard fails as intended after the fix
+  and (revealingly) passed before it.
+- **REVIEW** `adversarial-reviewer` and `security-reviewer` = named skips.

--- a/docs/specs/unify-adapter-symlink-policy/spec.md
+++ b/docs/specs/unify-adapter-symlink-policy/spec.md
@@ -1,0 +1,75 @@
+# Spec: unify-adapter-symlink-policy
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none new. Six private copies of one policy become one shared
+  definition, and the four that had drifted move back to the specified rule.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full. Two risk triggers: security boundary (symlink handling on the
+untrusted-catalogue install path) and structural (a shared definition replacing
+six private ones). `security-reviewer` is a NAMED SKIP under this session's
+no-subagent instruction; reasoning is inline in the plan. -->
+
+## Objective
+
+Six direct-directory adapters each carried a private symlink callback, and the
+copies had drifted into two policies. Settle on the one the repo already
+specified, and put it in one place so it cannot drift again.
+
+## Acceptance Criteria
+
+- [x] **AC1 — pass-through is the policy, and it is the specified one.**
+  `docs/specs/codex-native-skills/spec.md`: *"the symlink-pass-through is the
+  path-traversal-safety invariant; never resolve a symlink to its target at
+  projection time."* `cursor`, `copilot`, `gemini` and `kiro` were dropping every
+  symlink; they now drop absolute targets and preserve relative ones, matching
+  `claude_code` and `codex`.
+
+- [x] **AC2 — one definition.** `ignore_absolute_symlinks` lives in
+  `build/projections/direct_directory.py`, the module whose stated job is shared
+  helpers for direct-directory projections. No adapter defines its own.
+
+- [x] **AC3 — `symlinks=True` on every direct-directory `copytree`.** Without it
+  the callback is moot: `copytree` dereferences, and preservation silently
+  becomes resolution — the exact failure the invariant names.
+
+- [x] **AC4 — the change is behaviour-preserving under existing coverage.**
+  Every existing symlink fixture uses an ABSOLUTE target (`/etc/passwd`, or a
+  resolved `tmp_path`), which both policies drop. `tests/build_pipeline/` and
+  `test_nested_symlink_hardening.py` pass unchanged. The only behaviour that
+  moves is the relative case, which no test exercised and no pack ships.
+
+- [x] **AC5 — the newly-uniform guarantee is pinned.** A test asserts an absolute
+  link is dropped, a relative in-tree link survives *as a link*, and a relative
+  upward link survives with its target unresolved — the distinction the invariant
+  turns on. A second asserts no regular file in the output carries the
+  out-of-tree bytes, which is what would happen if `symlinks=True` were lost.
+
+- [x] **AC6 — a seventh private policy cannot appear, and neither can a lost
+  `symlinks=True`.** A guard inspects each adapter's `copytree` **call**, not the
+  file. Mutation-verified twice: a file-level check passed while one call had lost
+  the flag (these modules contain other `copytree` calls); the call-level check
+  fails.
+
+- [x] **AC7 — safe because the read is already closed.** `spec/install-symlink-
+  hardening` made `render._collect_tree` skip symlinked entries, so a preserved
+  link cannot become a file on an adopter's disk. Re-admitting relative links to
+  projections without that fix would have been the wrong order.
+
+- [x] **AC8 — the backlog entry is closed and the sibling spec updated.**
+
+## Boundaries
+
+### Never do
+
+- Never drop `symlinks=True` from a direct-directory `copytree`. AC3/AC6.
+- Never resolve a symlink at projection time. That is the invariant itself.
+
+## Testing Strategy
+
+- **TDD + mutation** for AC5/AC6; **regression** for AC4 (existing suites must
+  pass untouched — that is the evidence the change is behaviour-preserving).

--- a/packages/agentbundle/agentbundle/build/adapters/claude_code.py
+++ b/packages/agentbundle/agentbundle/build/adapters/claude_code.py
@@ -24,7 +24,10 @@ from typing import Iterator
 # keeps the phases predictable, which the spec calls for.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
 from agentbundle.build.projection_io import copy_projected_file, ensure_directory_no_follow
-from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 from agentbundle.build.projections.merge_json import project_merge_json
 
 
@@ -197,23 +200,6 @@ def _project_single(
             raise ValueError(f"claude-code: unhandled mode {mode!r} for {primitive_name}")
 
 
-def _ignore_absolute_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: drop symlinks with absolute targets
-    and Python bytecode cache directories.
-
-    Relative symlinks (intra-skill cross-references) are preserved as
-    symlinks. Absolute symlinks always escape the tree and are a path-escape
-    vector. __pycache__ directories are excluded because .pyc files embed
-    absolute source paths and can never be byte-identical across machines.
-    """
-    base = Path(directory)
-    return {
-        name for name in names
-        if name == "__pycache__"
-        or ((base / name).is_symlink() and (base / name).readlink().is_absolute())
-    }
-
-
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         # Defense-in-depth — `lint-packs` rejects packs that ship
@@ -233,11 +219,11 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
             elif destination.exists():
                 shutil.rmtree(destination)
             # symlinks=True preserves relative nested symlinks; absolute
-            # targets are filtered out by _ignore_absolute_symlinks.
+            # targets are filtered out by ignore_absolute_symlinks.
             shutil.copytree(
                 entry, destination,
                 symlinks=True,
-                ignore=_ignore_absolute_symlinks,
+                ignore=ignore_absolute_symlinks,
             )
 
 

--- a/packages/agentbundle/agentbundle/build/adapters/codex.py
+++ b/packages/agentbundle/agentbundle/build/adapters/codex.py
@@ -25,7 +25,10 @@ from agentbundle.build.projection_io import copy_projected_file, ensure_director
 from agentbundle.build.projections.codex_agent_toml import (
     project_codex_agent_toml,
 )
-from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 from agentbundle.build.projections.merge_json import project_merge_json
 
 
@@ -181,11 +184,11 @@ def project_packs(
                         elif destination.exists():
                             shutil.rmtree(destination)
                         # symlinks=True preserves relative nested symlinks;
-                        # absolute targets are filtered by _ignore_absolute_symlinks.
+                        # absolute targets are filtered by ignore_absolute_symlinks.
                         shutil.copytree(
                             entry, destination,
                             symlinks=True,
-                            ignore=_ignore_absolute_symlinks,
+                            ignore=ignore_absolute_symlinks,
                         )
             # Bound to `skill` only per spec § Never do. Other
             # direct-directory primitives opt in explicitly.
@@ -210,23 +213,6 @@ def project_packs(
                 project_codex_agent_toml(source_dir, output_root, rule, mapping)
         else:
             raise ValueError(f"codex: unhandled mode {mode!r} for {primitive_name}")
-
-
-def _ignore_absolute_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: drop symlinks with absolute targets
-    and Python bytecode cache directories.
-
-    Relative symlinks (intra-skill cross-references) are preserved.
-    Absolute symlinks always escape the tree and are a path-escape vector.
-    __pycache__ directories are excluded because .pyc files embed absolute
-    source paths and can never be byte-identical across machines.
-    """
-    base = Path(directory)
-    return {
-        name for name in names
-        if name == "__pycache__"
-        or ((base / name).is_symlink() and (base / name).readlink().is_absolute())
-    }
 
 
 def _project_direct_file(

--- a/packages/agentbundle/agentbundle/build/adapters/copilot.py
+++ b/packages/agentbundle/agentbundle/build/adapters/copilot.py
@@ -31,20 +31,10 @@ from agentbundle.build.projections.copilot_agent_md import (
 from agentbundle.build.projections.copilot_hooks_json import (
     project_copilot_hooks_json,
 )
-from agentbundle.build.projections.direct_directory import sweep_orphans
-
-
-def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member and
-    Python bytecode cache directories.
-
-    Drops nested symlinks so they are never reproduced in the output
-    tree. The top-level `is_symlink()` skip in `_project_direct_directory`
-    covers the skill root; this covers the subtree. __pycache__ is excluded
-    because .pyc files embed absolute source paths and would cause drift.
-    """
-    base = Path(directory)
-    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 
 
 def _iter_primitives(contract: dict) -> Iterator[str]:
@@ -165,7 +155,7 @@ def _project_direct_directory(
 
     A symlink at the entry root is skipped (defense-in-depth — `lint-packs`
     already refuses symlinked packs, but a direct `project()` caller bypasses
-    that gate). `ignore=_ignore_symlinks` drops nested symlinks so they are
+    that gate). `ignore=ignore_absolute_symlinks` drops nested symlinks so they are
     never reproduced in the output tree. A destination symlink is `unlink`ed
     (never `rmtree`d) before the copy. ``primitive_name`` retains the helper's
     established call contract; the pack-union orphan sweep now runs once after
@@ -183,7 +173,14 @@ def _project_direct_directory(
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
+            # `symlinks=True` is the invariant, not an optimisation: it is what
+            # keeps a relative link a LINK rather than resolving it to its
+            # target's bytes at projection time.
+            shutil.copytree(
+                entry, destination,
+                symlinks=True,
+                ignore=ignore_absolute_symlinks,
+            )
 
 
 def _sweep_skill_orphans(

--- a/packages/agentbundle/agentbundle/build/adapters/cursor.py
+++ b/packages/agentbundle/agentbundle/build/adapters/cursor.py
@@ -42,7 +42,10 @@ from typing import Any, Iterator
 # Build-pipeline ordering invariant — uniform across adapters.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
 from agentbundle.build.projection_io import copy_projected_file, ensure_directory_no_follow
-from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 
 _ADAPTER = "cursor"
 
@@ -167,25 +170,6 @@ def _project_single(
 # ---------------------------------------------------------------------------
 
 
-def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member and
-    Python bytecode cache directories.
-
-    Drops **nested** symlinks during the copy so they are never reproduced in
-    the output tree. Without this, a symlink inside a skill subdir would be
-    copied as a symlink (`symlinks=True`) and later dereferenced by the
-    install walker's `read_bytes()`, embedding out-of-tree content (e.g. a
-    secret the symlink points at) into the projection. The top-level
-    `is_symlink()` skip in `_project_direct_directory` only covers the skill
-    root; this covers the subtree. (Build runs on trusted `packs/`; this is
-    the install-from-untrusted-catalogue defense — mirrored in all five
-    direct-directory adapters.) __pycache__ is excluded because .pyc files
-    embed absolute source paths and would cause drift on any other machine.
-    """
-    base = Path(directory)
-    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
-
-
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         # Defense-in-depth: `lint-packs` rejects symlink-bearing packs, but a
@@ -198,9 +182,16 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            # `ignore=_ignore_symlinks` drops nested symlinks (see above);
+            # `ignore=ignore_absolute_symlinks` drops nested symlinks (see above);
             # `symlinks` is then moot since none survive the filter.
-            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
+            # `symlinks=True` is the invariant, not an optimisation: it is what
+            # keeps a relative link a LINK rather than resolving it to its
+            # target's bytes at projection time.
+            shutil.copytree(
+                entry, destination,
+                symlinks=True,
+                ignore=ignore_absolute_symlinks,
+            )
 
 
 def _project_direct_file(

--- a/packages/agentbundle/agentbundle/build/adapters/gemini.py
+++ b/packages/agentbundle/agentbundle/build/adapters/gemini.py
@@ -45,7 +45,10 @@ from typing import Any, Iterator
 # Build-pipeline ordering invariant — uniform across adapters.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
 from agentbundle.build.projection_io import copy_projected_file, ensure_directory_no_follow
-from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 from agentbundle.build.projections.gemini_command_toml import (
     project_gemini_command_toml,
 )
@@ -166,16 +169,6 @@ def _project_single(
 # ---------------------------------------------------------------------------
 
 
-def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member and
-    Python bytecode cache directories (drops nested symlinks so the install
-    walker can't read through them to embed out-of-tree content; drops
-    __pycache__ because .pyc files embed absolute source paths and drift).
-    The cursor.py precedent."""
-    base = Path(directory)
-    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
-
-
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         if entry.is_symlink():
@@ -186,7 +179,14 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
+            # `symlinks=True` is the invariant, not an optimisation: it is what
+            # keeps a relative link a LINK rather than resolving it to its
+            # target's bytes at projection time.
+            shutil.copytree(
+                entry, destination,
+                symlinks=True,
+                ignore=ignore_absolute_symlinks,
+            )
 
 
 def _project_direct_file(

--- a/packages/agentbundle/agentbundle/build/adapters/kiro.py
+++ b/packages/agentbundle/agentbundle/build/adapters/kiro.py
@@ -39,7 +39,10 @@ from typing import Any, Iterator
 # uniform across adapters.
 from agentbundle.build.phase_order import PHASE_ORDER as _PHASE_ORDER
 from agentbundle.build.projection_io import copy_projected_file, ensure_directory_no_follow
-from agentbundle.build.projections.direct_directory import sweep_orphans
+from agentbundle.build.projections.direct_directory import (
+    ignore_absolute_symlinks,
+    sweep_orphans,
+)
 from agentbundle.build.projections.kiro_ide_hook import (
     project as kiro_ide_hook_project,
 )
@@ -458,19 +461,6 @@ def _project_hook_wiring_to_agent_json(
 # ---------------------------------------------------------------------------
 
 
-def _ignore_symlinks(directory: str, names: list[str]) -> set[str]:
-    """`shutil.copytree` ignore callback: skip every symlink member and
-    Python bytecode cache directories.
-
-    Drops nested symlinks so they are never reproduced in the output
-    tree. The top-level `is_symlink()` skip in `_project_direct_directory`
-    covers the skill root; this covers the subtree. __pycache__ is excluded
-    because .pyc files embed absolute source paths and would cause drift.
-    """
-    base = Path(directory)
-    return {name for name in names if name == "__pycache__" or (base / name).is_symlink()}
-
-
 def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
     for entry in sorted(source_dir.iterdir()):
         # Defense-in-depth — `lint-packs` rejects packs that ship
@@ -488,9 +478,16 @@ def _project_direct_directory(source_dir: Path, target_dir: Path) -> None:
                 destination.unlink()
             elif destination.exists():
                 shutil.rmtree(destination)
-            # `ignore=_ignore_symlinks` drops nested symlinks so they are
+            # `ignore=ignore_absolute_symlinks` drops nested symlinks so they are
             # never reproduced in the output tree.
-            shutil.copytree(entry, destination, ignore=_ignore_symlinks)
+            # `symlinks=True` is the invariant, not an optimisation: it is what
+            # keeps a relative link a LINK rather than resolving it to its
+            # target's bytes at projection time.
+            shutil.copytree(
+                entry, destination,
+                symlinks=True,
+                ignore=ignore_absolute_symlinks,
+            )
 
 
 def _project_direct_file(

--- a/packages/agentbundle/agentbundle/build/projections/direct_directory.py
+++ b/packages/agentbundle/agentbundle/build/projections/direct_directory.py
@@ -1,4 +1,4 @@
-"""Shared post-pass helper for `direct-directory` skill projections.
+"""Shared helpers for `direct-directory` skill projections.
 
 After every multi-pack `project_packs(...)` call, the orphan sweep
 removes child directories of the projected skill target whose names
@@ -13,6 +13,40 @@ from __future__ import annotations
 import shutil
 import sys
 from pathlib import Path
+
+
+def ignore_absolute_symlinks(directory: str, names: list[str]) -> set[str]:
+    """`shutil.copytree` ignore callback: drop absolute-target symlinks and
+    `__pycache__`, and PRESERVE relative ones as symlinks.
+
+    One definition for all six direct-directory adapters. They previously
+    carried six private copies that had drifted into two policies — four
+    dropping every symlink, two dropping only absolute targets — which is what
+    six copies of one rule does.
+
+    The surviving policy is pass-through, because
+    `docs/specs/codex-native-skills/spec.md` states it as the invariant:
+    "the symlink-pass-through is the path-traversal-safety invariant; never
+    resolve a symlink to its target at projection time". Resolving is what
+    materialises a target's bytes into the output; preserving the link does not,
+    and `render._collect_tree` refuses to read through a link, so a preserved
+    link cannot become a file on an adopter's disk either.
+
+    Absolute targets are still dropped: they always escape the tree and carry no
+    meaning once the tree is copied elsewhere. A relative link survives as a
+    link — including one that traverses upward, which is safe for the same
+    reason the invariant gives, and visible as a link to anything that inspects
+    the output.
+
+    `__pycache__` is excluded because `.pyc` files embed absolute source paths
+    and can never be byte-identical across machines.
+    """
+    base = Path(directory)
+    return {
+        name for name in names
+        if name == "__pycache__"
+        or ((base / name).is_symlink() and (base / name).readlink().is_absolute())
+    }
 
 
 def sweep_orphans(target_dir: Path, expected_names: set[str]) -> None:

--- a/packages/agentbundle/tests/unit/test_adapter_symlink_policy.py
+++ b/packages/agentbundle/tests/unit/test_adapter_symlink_policy.py
@@ -1,0 +1,127 @@
+"""One symlink policy, shared by every direct-directory adapter.
+
+Six adapters project a skill directory with `shutil.copytree`, and each used to
+carry its own ignore callback. Six copies of one rule did what six copies do:
+they drifted into two policies — `cursor`, `copilot`, `gemini` and `kiro`
+dropping every symlink, `claude_code` and `codex` dropping only absolute
+targets and preserving relative ones.
+
+Pass-through is the surviving policy, and it is the one the repo already
+specified. `docs/specs/codex-native-skills/spec.md`: *"the symlink-pass-through
+is the path-traversal-safety invariant; never resolve a symlink to its target at
+projection time."* Resolving is what materialises a target's bytes into the
+output. Preserving the link does not — and `render._collect_tree` refuses to
+read through a link, so a preserved link cannot become a file on an adopter's
+disk by that route either.
+
+What the existing suites already cover is the ABSOLUTE case, because every one
+of their fixtures uses `/etc/passwd` or a resolved tmp path. This file covers
+what those cannot see: that a *relative* link survives as a link, uniformly,
+and that no adapter has grown a seventh private policy.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+import pytest
+from agentbundle.build.projections.direct_directory import ignore_absolute_symlinks
+
+_ADAPTERS = ("cursor", "copilot", "gemini", "kiro", "claude_code", "codex")
+
+
+def _tree(root: Path) -> Path:
+    skill = root / "skill"
+    (skill / "nested").mkdir(parents=True)
+    (skill / "real.md").write_text("real\n", encoding="utf-8")
+    (skill / "nested" / "keep.md").write_text("keep\n", encoding="utf-8")
+
+    outside = root / "outside-secret.txt"
+    outside.write_text("SECRET\n", encoding="utf-8")
+
+    (skill / "abs.md").symlink_to(outside)                       # absolute — dropped
+    (skill / "intra.md").symlink_to(Path("real.md"))             # relative in-tree — kept
+    (skill / "up.md").symlink_to(Path("..") / "outside-secret.txt")  # relative up — kept
+    return skill
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="no symlink support")
+def test_absolute_links_are_dropped_and_relative_ones_preserved(tmp_path) -> None:
+    skill = _tree(tmp_path)
+    dest = tmp_path / "out"
+    shutil.copytree(skill, dest, symlinks=True, ignore=ignore_absolute_symlinks)
+
+    assert not (dest / "abs.md").exists(), "an absolute-target symlink must be dropped"
+    assert (dest / "intra.md").is_symlink(), "a relative symlink must survive AS a link"
+    assert (dest / "up.md").is_symlink()
+    # Preserved, never resolved — that distinction is the invariant. If these
+    # were resolved, the out-of-tree bytes would be sitting in the projection.
+    assert (dest / "up.md").readlink() == Path("..") / "outside-secret.txt"
+    assert (dest / "real.md").read_text() == "real\n"
+    assert (dest / "nested" / "keep.md").read_text() == "keep\n"
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="no symlink support")
+def test_no_regular_file_carries_out_of_tree_bytes(tmp_path) -> None:
+    """Preserving a link must not become copying its target.
+
+    The failure this guards is the whole reason the invariant exists: a
+    `copytree` without `symlinks=True` dereferences, and the secret lands as a
+    regular file under an innocent name.
+    """
+    skill = _tree(tmp_path)
+    dest = tmp_path / "out"
+    shutil.copytree(skill, dest, symlinks=True, ignore=ignore_absolute_symlinks)
+
+    for path in dest.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            assert "SECRET" not in path.read_text(encoding="utf-8", errors="replace"), path
+
+
+def test_pycache_is_still_excluded(tmp_path) -> None:
+    """Unrelated to symlinks and load-bearing: `.pyc` files embed absolute
+    source paths, so they can never be byte-identical across machines."""
+    (tmp_path / "__pycache__").mkdir()
+    assert "__pycache__" in ignore_absolute_symlinks(str(tmp_path), ["__pycache__", "a.py"])
+
+
+def test_every_adapter_uses_the_shared_policy() -> None:
+    """No adapter may keep a private symlink policy.
+
+    Six private copies is how the two policies diverged; this fails if a seventh
+    appears, or if one stops passing `symlinks=True` (which would silently turn
+    preservation back into resolution).
+    """
+    import agentbundle.build.adapters as adapters_pkg
+
+    adapters_dir = Path(adapters_pkg.__file__).parent
+    offenders: list[str] = []
+    for name in _ADAPTERS:
+        src = (adapters_dir / f"{name}.py").read_text(encoding="utf-8")
+        if "def _ignore_symlinks" in src or "def _ignore_absolute_symlinks" in src:
+            offenders.append(f"{name}: defines a private symlink policy")
+        # Check the CALL, not the file. A whole-file `"symlinks=True" in src`
+        # passes while the direct-directory copytree has lost it, because these
+        # modules contain other copytree calls — verified by mutation: dropping
+        # it from one call left a file-level check green.
+        for call in re.finditer(r"shutil\.copytree\((?:[^()]|\([^()]*\))*\)", src):
+            text = call.group(0)
+            if "ignore_absolute_symlinks" not in text:
+                continue  # a different copytree, not the direct-directory one
+            if "symlinks=True" not in text:
+                offenders.append(
+                    f"{name}: direct-directory copytree without symlinks=True — "
+                    "it would resolve links instead of preserving them"
+                )
+        if "ignore=ignore_absolute_symlinks" not in src:
+            offenders.append(f"{name}: does not use the shared policy")
+    assert not offenders, offenders
+
+
+def test_the_policy_is_defined_exactly_once() -> None:
+    from agentbundle.build.projections import direct_directory
+
+    src = Path(direct_directory.__file__).read_text(encoding="utf-8")
+    assert src.count("def ignore_absolute_symlinks") == 1

--- a/tools/lint-ci-parity.py
+++ b/tools/lint-ci-parity.py
@@ -295,14 +295,16 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
         LOCAL("test"),
     "pytest credential-setup skill (RFC-0023 T8 + missing-credbroker guard)":
         CI_ONLY(
-            "PROVISIONING, not step vocabulary — the chain grew "
-            "`_pytest_step_cwd` and this step still cannot move. The suite "
+            "PROVISIONING, and DECIDED to stay here (2026-08-16). The suite "
             "spawns setup.py as a subprocess, and that script hard-exits 3 when "
             "credbroker is not INSTALLED; a source path on PYTHONPATH does not "
             "satisfy it (verified in CI, twice). Moving it would mean "
-            "`pip install -e ./packages/credbroker` inside build-check, which is "
-            "a decision about what that target provisions — see backlog "
-            "`gate-chain-credential-setup-provisioning`."
+            "`pip install -e ./packages/credbroker` inside `make build-check`, "
+            "which is already heavy and is otherwise install-free and offline. "
+            "The suite's subject is installed-package behaviour, so running it "
+            "against a source path would test something no adopter experiences "
+            "— CI is its honest home, not a compromise. Do not re-open this as "
+            "a step-vocabulary gap: the chain has `_pytest_step_cwd`."
         ),
     "pip install httpx for the atlassian SSO suites (RFC-0035)":
         CI_ONLY(

--- a/workspace.toml
+++ b/workspace.toml
@@ -774,21 +774,6 @@ open = [
   # Unblocks when: picked up — no dependency.
   {slug = "ci-parity-docs-yml-out-of-scope", source = "spec/local-gate-ci-parity (scope)"},
 
-  # Split out of gate-chain-step-vocabulary 2026-08-16 (spec/gate-chain-cwd-steps).
-  # The chain gained `_pytest_step_cwd` with a collected-count floor, and the
-  # catalogue-curation suites moved from CI-only to locally covered. The
-  # credential-setup step did NOT move, and its blocker was never the step
-  # vocabulary — that was the entry's premise and it was wrong.
-  # It spawns setup.py as a SUBPROCESS, and that script hard-exits 3 unless
-  # credbroker is INSTALLED. A source path on PYTHONPATH does not satisfy it —
-  # verified twice in CI, once at collection and once at the spawn.
-  # Fix: decide whether `make build-check` should run
-  #   `pip install -e ./packages/credbroker`. That is a question about what that
-  #   target provisions, not about the chain: build-check is otherwise
-  #   install-free and offline, and adding a pip install changes its character.
-  #   The alternative is leaving this gate CI-only on purpose and saying so.
-  # Unblocks when: someone rules on build-check's provisioning posture.
-  {slug = "gate-chain-credential-setup-provisioning", source = "spec/gate-chain-cwd-steps"},
 
   # `tools/lint-catalogue-curation-guard.py`'s path-gate layer exits 0 with only a
   # stderr note when git or the `--base` ref is unavailable. It is now wired into
@@ -1091,32 +1076,6 @@ open = [
   # ── High severity ────────────────────────────────────────────────────────────
   # (security findings or concretely broken behavior with a known internal fix path)
 
-  # NARROWED and RE-SCOPED 2026-08-16 by spec/install-symlink-hardening, which
-  # attempted this and reverted the attempt. Recording why, because the entry as
-  # written points at a fix the repo's own spec forbids.
-  # The entry proposed lifting cursor's symlink-skipping helper into
-  # direct_directory.py and adopting it in the other adapters. Two findings:
-  #   1. STALE TARGET LIST. copilot, gemini and kiro already drop every symlink.
-  #      Only claude_code and codex differ, and they use a DIFFERENT rule: drop
-  #      absolute-target symlinks, preserve relative ones.
-  #   2. THAT DIFFERENCE IS SPECIFIED, NOT DRIFT.
-  #      docs/specs/codex-native-skills/spec.md:92 requires
-  #      `copytree(..., symlinks=True)` for every direct-directory projection and
-  #      states "the symlink-pass-through IS the path-traversal-safety invariant;
-  #      never resolve a symlink to its target at projection time".
-  #      tests/build_pipeline/test_adapter_codex.py::test_symlink_pass_through
-  #      pins it. Adopting the strict helper everywhere fails that test and
-  #      violates the stated invariant.
-  # So the four strict adapters are the ones diverging from the spec, not the two
-  # permissive ones — the inverse of the entry's premise. Nothing is unsafe today:
-  # the exfiltration this guarded against is closed at the read (`_collect_tree`
-  # no longer follows links), so the projection-layer difference is now a
-  # consistency question, not a vulnerability.
-  # Fix: decide ONE policy across all six adapters and make the spec and the
-  #   adapters agree — either amend the codex-native-skills invariant, or bring
-  #   the four strict adapters back to pass-through. Needs the decision first.
-  # Unblocks when: someone rules on which policy the invariant should state.
-  {slug = "adapter-symlink-policy-divergence", source = "spec/install-symlink-hardening"},
 
   # Security (HIGH). NARROWED 2026-08-16 by spec/install-symlink-hardening. The
   # exfiltration primitive itself is closed:


### PR DESCRIPTION
## What does this change?

Six direct-directory adapters each carried a private symlink callback, and the copies had drifted into two policies. This settles on the one the repo already specified and puts it in one place.

Also closes `gate-chain-credential-setup-provisioning` as a **decision** (your ruling: keep it CI-only).

## Why?

- Implements: `docs/specs/unify-adapter-symlink-policy/spec.md`
- Closes: `adapter-symlink-policy-divergence`, `gate-chain-credential-setup-provisioning`

| Before | Adapters |
|---|---|
| drop **every** symlink | `cursor`, `copilot`, `gemini`, `kiro` |
| drop **absolute** only | `claude_code`, `codex` |

`docs/specs/codex-native-skills/spec.md`: *"the symlink-pass-through is the path-traversal-safety invariant; never resolve a symlink to its target at projection time."* The four strict adapters were the ones diverging.

## The direction looks wrong, and here is why it isn't

This change **preserves more symlinks**. That reads as a step backwards until the two operations are separated:

- **Resolving** a link materialises its target's bytes into the projection. That is the exfiltration.
- **Preserving** it copies a pointer.

The invariant forbids the first. `symlinks=True` is therefore not an optimisation but the invariant itself — without it `copytree` dereferences, and preservation silently becomes resolution.

**Safe because the read is already closed.** #962 made `_collect_tree` skip symlinked entries, so a preserved link cannot become a file on an adopter's disk. Doing this *before* that fix would have widened a live hole — which is exactly why my first attempt was reverted rather than pushed through.

## How do I verify it?

```bash
cd packages/agentbundle
python3 -m pytest tests/build_pipeline/ tests/unit/test_nested_symlink_hardening.py -q  # unchanged, green
python3 -m pytest tests/unit/test_adapter_symlink_policy.py -q                          # new
python3 tools/lint-ci-parity.py     # 31 local / 25 CI-only
make ci
```

**The existing suites passing untouched is the evidence, not a formality.** Every existing symlink fixture uses an **absolute** target (`/etc/passwd`, or a resolved `tmp_path`) — which *both* policies drop. So the only behaviour that moves is the relative case, which no test exercised and no pack ships.

The new tests cover what those cannot see: a relative in-tree link survives *as a link*, a relative upward link survives *with its target unresolved*, and no regular file in the output carries the out-of-tree bytes.

## One thing I got wrong first

My guard originally asserted `"symlinks=True" in source` per adapter. That **passed** while `gemini`'s direct-directory `copytree` had lost the flag — these modules contain other `copytree` calls, so a file-level check is satisfied by any of them. Mutation caught it; the guard now inspects the **call**.

## Item 2 — decision, not a gap

`gate-chain-credential-setup-provisioning` is closed rather than deferred. That suite's subject is *installed-package* behaviour, so running it against a source path would test something no adopter experiences — CI is its honest home. `make build-check` stays install-free and offline. The exemption reason now records the decision and says not to re-open it as a step-vocabulary gap.

## Checklist

- [x] Tests pass locally — existing adapter/hardening suites unchanged, 5 new tests, `make ci`
- [x] Lint and typecheck pass — `make lint-ruff`, `lint-spec-status`, `lint-ci-parity`
- [ ] ~~Self-review via reviewer subagent~~ — **named skip:** session instruction prohibits dispatching subagents. `security-reviewer` was warranted; reasoning is inline in `plan.md` § *Security reasoning*, including why the ordering against #962 mattered.
- [x] Spec and code agree — `spec/install-symlink-hardening` AC4 records the ruling
- [x] Living docs match reality
- [x] No new top-level directories
- [x] Conventional commit format