### PR TITLE
fix(guides): realign the build outcome label with the canonical map

### DIFF
--- a/docs/specs/guides-readme-outcome-label-drift/spec.md
+++ b/docs/specs/guides-readme-outcome-label-drift/spec.md
@@ -1,0 +1,126 @@
+# Spec: guides-readme-outcome-label-drift
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — light mode, single task
+- **Contract:** none. One documentation table cell; no schema, code, or
+  behaviour change.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (no risk trigger fired). Checked the published-interface
+trigger explicitly: it does NOT fire. `guides/` ships to adopters, but this
+restores a label to the value the canonical map already publishes on every
+other surface — it removes a divergence rather than introducing one. -->
+
+## Objective
+
+`tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels`
+fails on a clean `origin/main`, so `make ci` is red for everyone. The test
+asserts every canonical outcome title appears verbatim in each markdown entry
+point; `guides/README.md` carries `Start, remember, build, and review software`
+where the canonical map says `Build and review software`.
+
+Success: the two sides agree again, `make ci`'s catalogue-navigation leg is
+green, and the capability #958 was describing survives.
+
+## Which side is canonical
+
+The navigation source, `web/src/lib/catalogue-navigation.ts`. Three independent
+reasons:
+
+1. **It says so, and the wiring backs it.** Its own header calls it the
+   "Canonical outcome and role routes"; `PackCatalogue.astro` and
+   `catalogue/index.astro` import it rather than restating it, and
+   `test_marketing_surfaces_import_the_canonical_map` fails if either declares
+   its own list. The markdown entry points are aligned consumers — the test
+   docstring calls them "authored for their medium".
+2. **The drift is one-sided.** `Start, remember, build, and review software`
+   occurs exactly once repo-wide (`guides/README.md:11`). #958
+   (`feat(core): add canonical work-intake routing`) reworded that one cell and
+   left the source, `docs-site/src/content/docs/index.mdx`, and both marketing
+   surfaces on the canonical wording. One consumer moved; the source did not.
+3. **Register.** Every other title names an outcome the reader wants — *Decide
+   what to build*, *Document what ships*, *Provision and release safely*. The
+   README's column header is `I need to…`, and "I need to start, remember,
+   build, and review software" enumerates the pack's verbs instead of naming
+   the job. Work intake is part of building, not a fourth peer outcome.
+
+So `guides/README.md` is realigned to the source, not the reverse.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the title cell matches the canonical map.**
+  `guides/README.md`'s third outcome row reads `**Build and review software**`,
+  byte-identical to `catalogue-navigation.ts`'s `build` outcome `title`.
+
+- [x] **AC2 — #958's actual contribution survives.** The row's *description*
+  cell keeps `[`core`](core/) to route work into a durable artifact and
+  supervised loop`. Work-intake routing is a fact about what `core` does; it
+  belongs in the cell that describes the pack, not in the outcome label. Only
+  the title cell changes.
+
+- [x] **AC3 — the assertion is untouched.** No edit to
+  `tools/test_catalogue_navigation.py`, and no edit to
+  `web/src/lib/catalogue-navigation.ts` or
+  `docs-site/src/content/docs/index.mdx`. The gate is not moved to meet the
+  code.
+
+- [x] **AC4 — the full navigation contract passes.**
+  `python3 -m pytest tools/test_catalogue_navigation.py -q` reports 4 passed —
+  not just the one previously-failing case, since the pack-membership and
+  role-route cases read the same source.
+
+- [x] **AC5 — the pack-link contract still holds.**
+  `python3 tools/check-guide-index.py` exits 0. It verifies every active pack
+  has a guide-home link in this file; the edited row carries three of them.
+
+- [x] **AC6 — the backlog entry is dispositioned.**
+  `pre-existing-guides-readme-outcome-label-drift` is removed from
+  `workspace.toml [backlog].open`, and the known-skip paragraph in
+  `docs/specs/bandit-nosec-comment-hygiene/spec.md` is left alone — it is a
+  Shipped spec recording what was true when it shipped.
+
+## Boundaries
+
+### Never do
+
+- Never weaken or delete the assertion. The test caught a real divergence
+  between a published label and its source; that is the test working.
+- Never edit the canonical map to match the consumer. That inverts the
+  direction the whole navigation contract is built around.
+- Never touch the other five outcome rows, the role list, or the flagship
+  paragraph below the table.
+
+## Testing Strategy
+
+Goal-based check — the failing gate is the test:
+
+- `python3 -m pytest tools/test_catalogue_navigation.py -q` → 4 passed
+  (currently 1 failed, 3 passed).
+- `python3 tools/check-guide-index.py` → exit 0.
+- `SKIP_SAST=1 make build-check` → the repo policy gates that read `guides/`.
+
+## Assumptions
+
+- #958 intended to advertise work-intake routing, not to rename the outcome.
+  Supported by the diff: it changed the title and description cells of one row
+  in one file, in a PR whose subject is `add canonical work-intake routing`,
+  and touched no navigation source. Had a rename been intended, the canonical
+  map and the docs-site LinkCard were the files to edit.
+
+## Declined
+
+- **Promoting #958's wording to canonical.** It would change the marketing
+  homepage, the catalogue page, and the docs-site featured LinkCard for a label
+  that names the pack's mechanism rather than the reader's outcome. A bigger
+  diff, on the surface adopters see first, to publish the worse of the two
+  strings.
+- **A new lint that pins markdown labels to the source automatically.**
+  `test_markdown_entry_points_keep_canonical_outcome_labels` already is that
+  lint. It fired correctly and was skipped, not missing.
+- **Fixing the known-skip paragraph in the `bandit-nosec-comment-hygiene`
+  spec.** That spec is Shipped; its § Known skip is an accurate record of the
+  tree it shipped against. Editing it would rewrite history to describe a
+  present that spec never saw.

--- a/docs/specs/guides-readme-outcome-label-drift/spec.md
+++ b/docs/specs/guides-readme-outcome-label-drift/spec.md
@@ -9,10 +9,12 @@
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.
 
-<!-- Mode: light (no risk trigger fired). Checked the published-interface
-trigger explicitly: it does NOT fire. `guides/` ships to adopters, but this
-restores a label to the value the canonical map already publishes on every
-other surface — it removes a divergence rather than introducing one. -->
+<!-- Mode: light. Routed by AGENTS.md § How we work's cosmetic/tightly-local
+carve-out: one table cell, behaviour-preserving, verified by a named test that
+already exists. Not by an exception to the published-interface trigger — that
+trigger is stated unconditionally and `guides/` is shipped adopter copy this
+diff changes visibly, so claiming it "does not fire" would be inventing an
+exception the trigger list does not contain. -->
 
 ## Objective
 
@@ -30,14 +32,22 @@ green, and the capability #958 was describing survives.
 The navigation source, `web/src/lib/catalogue-navigation.ts`. Three independent
 reasons:
 
-1. **It says so, and the wiring backs it.** Its own header calls it the
-   "Canonical outcome and role routes"; `PackCatalogue.astro` and
-   `catalogue/index.astro` import it rather than restating it, and
-   `test_marketing_surfaces_import_the_canonical_map` fails if either declares
-   its own list. The markdown entry points are aligned consumers — the test
-   docstring calls them "authored for their medium".
+1. **A test contract binds the markdown surfaces to it.** The binding authority
+   is `tools/test_catalogue_navigation.py` (added by #927), which names
+   `NAVIGATION_SOURCE` and asserts its titles appear in both
+   `MARKDOWN_SURFACES`. Its docstring frames the split: the marketing surfaces
+   "import one outcome map", while the markdown entry points "remain authored
+   for their medium, so this test keeps their labels aligned". Aligned to what
+   is not symmetric — the map is the source, the markdown is the consumer.
+
+   Note the source's own header is narrower than this and cannot carry the
+   argument alone: it reads "Canonical outcome and role routes **for the
+   marketing site**", and its second paragraph binds only "those two entry
+   surfaces". It claims no authority over the adopter-facing `guides/` tree.
+   The test does.
 2. **The drift is one-sided.** `Start, remember, build, and review software`
-   occurs exactly once repo-wide (`guides/README.md:11`). #958
+   occurred exactly once repo-wide before this change (`guides/README.md:11`);
+   after it, only this spec quotes the string. #958
    (`feat(core): add canonical work-intake routing`) reworded that one cell and
    left the source, `docs-site/src/content/docs/index.mdx`, and both marketing
    surfaces on the canonical wording. One consumer moved; the source did not.
@@ -67,14 +77,14 @@ So `guides/README.md` is realigned to the source, not the reverse.
   `docs-site/src/content/docs/index.mdx`. The gate is not moved to meet the
   code.
 
-- [x] **AC4 — the full navigation contract passes.**
-  `python3 -m pytest tools/test_catalogue_navigation.py -q` reports 4 passed —
-  not just the one previously-failing case, since the pack-membership and
+- [x] **AC4 — the full navigation contract passes**, not just the
+  previously-failing case: § Testing Strategy's pytest run reports zero
+  failures across every case in the file, since the pack-membership and
   role-route cases read the same source.
 
-- [x] **AC5 — the pack-link contract still holds.**
-  `python3 tools/check-guide-index.py` exits 0. It verifies every active pack
-  has a guide-home link in this file; the edited row carries three of them.
+- [x] **AC5 — the pack-link contract still holds.** § Testing Strategy's
+  `check-guide-index.py` run exits 0. It verifies every active pack has a
+  guide-home link in this file; the edited row carries three of them.
 
 - [x] **AC6 — the backlog entry is dispositioned.**
   `pre-existing-guides-readme-outcome-label-drift` is removed from
@@ -90,17 +100,18 @@ So `guides/README.md` is realigned to the source, not the reverse.
   between a published label and its source; that is the test working.
 - Never edit the canonical map to match the consumer. That inverts the
   direction the whole navigation contract is built around.
-- Never touch the other five outcome rows, the role list, or the flagship
+- Never touch the other six outcome rows, the role list, or the flagship
   paragraph below the table.
 
 ## Testing Strategy
 
 Goal-based check — the failing gate is the test:
 
-- `python3 -m pytest tools/test_catalogue_navigation.py -q` → 4 passed
-  (currently 1 failed, 3 passed).
+- `python3 -m pytest tools/test_catalogue_navigation.py -q` → zero failures
+  (was 1 failed, 3 passed).
 - `python3 tools/check-guide-index.py` → exit 0.
 - `SKIP_SAST=1 make build-check` → the repo policy gates that read `guides/`.
+- `SKIP_SAST=1 make ci` → exit 0, which is the claim this PR actually makes.
 
 ## Assumptions
 
@@ -119,8 +130,34 @@ Goal-based check — the failing gate is the test:
   strings.
 - **A new lint that pins markdown labels to the source automatically.**
   `test_markdown_entry_points_keep_canonical_outcome_labels` already is that
-  lint. It fired correctly and was skipped, not missing.
-- **Fixing the known-skip paragraph in the `bandit-nosec-comment-hygiene`
-  spec.** That spec is Shipped; its § Known skip is an accurate record of the
-  tree it shipped against. Editing it would rewrite history to describe a
-  present that spec never saw.
+  lint, and it is correct. What it is not is *enforced*: it is named only at
+  `Makefile:349`, inside `make test`, and appears in no workflow under
+  `.github/workflows/`. So it never ran on #958's PR — which is why that PR
+  merged green and left `main` red for everyone who ran `make ci` locally. A
+  second copy of the same lint would inherit the same gap; wiring is the fix,
+  and it is deferred below rather than half-done here.
+- **Wiring the test into `build-check.yml` in this PR.** The gap is not one
+  test: 7 of the 13 files on `Makefile:349` are a run step in no workflow
+  (`test_validate_guides`, `test_check_guide_index`, `test_catalogue_navigation`,
+  `test_documentation_entry_links`, `test_build_site_link_rewrites`,
+  `test_check_rendered_site_links`, `test_build_site_routing`). Wiring one and
+  leaving six would read as coverage that is not there, and every added step
+  needs a `lint-ci-parity` disposition. Deferred as
+  `catalogue-site-tests-absent-from-ci` so the recurrence risk is registered
+  rather than lost with the entry this PR closes.
+
+  Counted per-file across all of `.github/workflows/`. Two traps, both of which
+  produced a wrong count on the first pass: `test_check_rendered_site_links`
+  appears in `pages.yml` only as a `paths:` trigger, never as a run step; and
+  `test_catalogue_tooling_rewire` / `_docs` *are* run, by Gate F of
+  `catalogue-tooling-ci-gates.yml`, so they are not in the list — though that
+  workflow's `paths-ignore` covers `docs/**`, `guides/**`, `docs-site/**` and
+  `web/**`, so it does not gate doc-surface PRs either.
+- **Appending a resolution line to the `bandit-nosec-comment-hygiene` spec's
+  § Known skip**, which points at the register entry this PR removes. That
+  spec is Frozen (`docs/CONVENTIONS.md` § Document lifecycle: "Status fields
+  can change …, bodies cannot"), and appending to a body is a body edit however
+  additive it reads. The legal mechanism for annotating a frozen spec is
+  exactly what `frozen-spec-supersession-convention` is deciding; pre-empting
+  it with a one-off body edit here would prejudge that decision. Deferred, with
+  that spec named as a caller once the convention lands.

--- a/guides/README.md
+++ b/guides/README.md
@@ -8,7 +8,7 @@ Use this catalogue to add repeatable, supervised ways of working to your agent. 
 | --- | --- | --- |
 | **Decide what to build** | [`product-strategy`](product-strategy/) for strategic choices | [`desk-research`](desk-research/) for evidence, then [`product-engineering`](product-engineering/) to shape a build-ready bet |
 | **Design the product and system** | [`experience-design`](experience-design/) for journeys and surfaces | [`architect`](architect/), [`contracts`](contracts/), and [`frontend-engineering`](frontend-engineering/) for the system, interfaces, and implementation |
-| **Start, remember, build, and review software** | [`core`](core/) to route work into a durable artifact and supervised loop | [`governance-extras`](governance-extras/) for durable decisions and [`monorepo-extras`](monorepo-extras/) for package scaffolding |
+| **Build and review software** | [`core`](core/) to route work into a durable artifact and supervised loop | [`governance-extras`](governance-extras/) for durable decisions and [`monorepo-extras`](monorepo-extras/) for package scaffolding |
 | **Provision and release safely** | [`iac-terraform`](iac-terraform/) for reviewable infrastructure plans | [`release-engineering`](release-engineering/) for deployed validation and the human production gate, supervised by [`core`](core/) |
 | **Work with team systems and evidence** | [`atlassian`](atlassian/), [`github`](github/), [`linear`](linear/), or [`figma`](figma/) | [`converters`](converters/) for source material and [`credential-brokers`](credential-brokers/) for credential-safe access |
 | **Document what ships** | [`product-documentation`](product-documentation/) | [`converters`](converters/) and the guide for the pack whose behavior you are documenting |

--- a/workspace.toml
+++ b/workspace.toml
@@ -1641,6 +1641,40 @@ open = [
   # PR, which was comment-format-only and added no gate.
   {slug = "bandit-nosec-form-lint", summary = "Add a tools/ check enforcing the `# nosec <ID>  # <reason>` form -- ID mandatory, reason only after a second `#` -- and wire it into make build-check", source = "spec/bandit-nosec-comment-hygiene"},
 
+  # 7 of the 13 pytest files named on Makefile:349 (`make test`) are a run step
+  # in NO workflow: test_validate_guides, test_check_guide_index,
+  # test_catalogue_navigation, test_documentation_entry_links,
+  # test_build_site_link_rewrites, test_check_rendered_site_links,
+  # test_build_site_routing. So they gate `make ci` locally and nothing
+  # remotely. Counted per-file across all of .github/workflows/, not just
+  # build-check.yml -- an earlier draft of this entry said 9 because it grepped
+  # build-check.yml alone and missed Gate F.
+  #   - test_check_rendered_site_links appears in pages.yml:23,45 but only as a
+  #     `paths:` trigger, never as a run step. Easy to miscount as covered.
+  #   - test_catalogue_tooling_rewire and _docs ARE run, by Gate F of
+  #     catalogue-tooling-ci-gates.yml:513,515 -- so they are NOT in this list.
+  #     Note though that workflow's paths-ignore covers docs/**, guides/**,
+  #     docs-site/** and web/**, so it does not gate doc-surface PRs either.
+  #     Do not "fix" those two here; that would duplicate Gate F.
+  # This is not theoretical: it is exactly how #958 merged green while leaving
+  # main red on test_catalogue_navigation, the failure PR #967 recorded as a
+  # known skip and this entry's sibling spec then fixed.
+  # Fix: add the seven as explicit build-check.yml steps (or one grouped step)
+  # and give each its lint-ci-parity disposition. Wiring one alone was declined
+  # in guides-readme-outcome-label-drift -- partial coverage reads as coverage.
+  {slug = "catalogue-site-tests-absent-from-ci", summary = "Wire the 7 catalogue/site pytest files from Makefile:349 that are a run step in no GitHub workflow into build-check.yml, with lint-ci-parity dispositions", source = "spec/guides-readme-outcome-label-drift"},
+
+  # docs/specs/bandit-nosec-comment-hygiene/spec.md § Known skip points at the
+  # register entry `pre-existing-guides-readme-outcome-label-drift`, which
+  # guides-readme-outcome-label-drift closed -- so that prose pointer now
+  # dangles. lint-spec-status.py invariant (iv) only checks `(deferred: <slug>)`
+  # markers, so nothing catches it. The spec is Frozen (CONVENTIONS § Document
+  # lifecycle: bodies cannot change), so the annotation has to use whatever
+  # mechanism frozen-spec-supersession-convention settles -- almost certainly a
+  # status-line annotation rather than a body append. Unblocks when that lands;
+  # this spec is then its first caller.
+  {slug = "bandit-hygiene-known-skip-dangling-pointer", summary = "Annotate bandit-nosec-comment-hygiene's § Known skip to record that its register entry was closed, using the frozen-doc mechanism from frozen-spec-supersession-convention", source = "spec/guides-readme-outcome-label-drift"},
+
   # tools/capture-publish-control-evidence.py:_validate_repo accepts
   # `[A-Za-z0-9._-]+/[A-Za-z0-9._-]+`, which matches `../..`; urllib sends the
   # selector unnormalised, so `--repo ../../app` reaches a different

--- a/workspace.toml
+++ b/workspace.toml
@@ -1649,16 +1649,6 @@ open = [
   # api.github.com -- the scheme and host are fixed literals and _NoRedirect
   # refuses redirects outright -- so this is hygiene, not a live hole. Fix is a
   # dot-segment reject in _validate_repo plus a case in its test.
-  # PRE-EXISTING on origin/main as of 1f6b2d2f, not caused by any branch:
-  # tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels
-  # fails because guides/README.md no longer carries the "Build and review
-  # software" outcome label that docs-site navigation still declares. The test
-  # asserts every canonical outcome title appears verbatim in each markdown
-  # entry point, so the two drifted apart when one side was reworded. `make ci`
-  # is red on main until this is reconciled -- decide which side is canonical
-  # (the navigation source or the README wording) and align the other.
-  {slug = "pre-existing-guides-readme-outcome-label-drift", summary = "Reconcile guides/README.md with the docs-site navigation's canonical outcome labels so test_markdown_entry_points_keep_canonical_outcome_labels passes", source = "pre-flight/2026-08-16"},
-
   {slug = "capture-evidence-repo-dot-segments", summary = "Reject `.` and `..` path segments in capture-publish-control-evidence.py's _validate_repo so a --repo value cannot redirect the App-authenticated read to another endpoint", source = "spec/bandit-nosec-comment-hygiene"},
 
   # test-loop-cohort.sh is 493 lines / 51 cases of bash and uses ~20 bash-isms


### PR DESCRIPTION
## What does this change?

`guides/README.md`'s third outcome row goes back to **Build and review software**, matching `web/src/lib/catalogue-navigation.ts`. One table cell.

## Why?

`tools/test_catalogue_navigation.py::test_markdown_entry_points_keep_canonical_outcome_labels` fails on a clean `origin/main`, so **`make ci` is red for everyone**. It asserts every canonical outcome title appears verbatim in each markdown entry point, and the README carried `Start, remember, build, and review software`.

**The navigation source is canonical**, so the README moves — three independent reasons:

1. **A test contract binds them.** `tools/test_catalogue_navigation.py` (added by #927) names the source and asserts its titles appear in both markdown surfaces. Its docstring frames the split: marketing surfaces "import one outcome map", markdown entry points "remain authored for their medium". *Aligned to what* is not symmetric.
2. **The drift is one-sided.** The reworded string occurs exactly once repo-wide. #958 (`feat(core): add canonical work-intake routing`) changed that one cell and left the source, the docs-site LinkCard, and both marketing surfaces alone.
3. **Register.** Every other title names an outcome the reader wants — *Document what ships*, *Provision and release safely* — under a column headed `I need to…`. The replacement enumerated the pack's verbs.

**#958's actual contribution survives**: the row's description cell still reads "`core` to route work into a durable artifact and supervised loop". Work intake is a fact about what the pack does, so it belongs in the cell that describes the pack.

Spec: `docs/specs/guides-readme-outcome-label-drift/spec.md`

## How do I verify it?

```
python3 -m pytest tools/test_catalogue_navigation.py -q   # 4 passed (was 1 failed, 3 passed)
python3 tools/check-guide-index.py                        # exit 0
SKIP_SAST=1 make ci                                       # exit 0 — the actual claim
```

## What did you not change that you considered?

- **Promoting #958's wording to canonical.** It would change the marketing homepage, the catalogue page, and the docs-site featured LinkCard to publish the worse of the two strings.
- **The assertion.** It caught a real divergence between a published label and its source. That is the test working.

## Deferred

- `catalogue-site-tests-absent-from-ci` — **the reason this reached `main` at all.** The test is named only at `Makefile:349` and is a run step in **no** workflow, so it never ran on #958's PR. It is not one test: 7 of the 13 files on that line are unwired (counted per-file across all of `.github/workflows/`; `test_check_rendered_site_links` appears in `pages.yml` only as a `paths:` trigger, and `test_catalogue_tooling_rewire`/`_docs` *are* run by Gate F, so they are excluded). Wiring one and leaving six would read as coverage that is not there.
- `bandit-hygiene-known-skip-dangling-pointer` — closing this register entry leaves a prose pointer in the Frozen `bandit-nosec-comment-hygiene` spec dangling. The legal mechanism for annotating a frozen spec is what the sibling PR `eugenelim/frozen-spec-supersession` decides; pre-empting it with a body edit would prejudge that.