### PR TITLE
feat(sast): gate the one nosec shape bandit is silent about

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -36,6 +36,23 @@
 # way: always write the ID, and never open a comment with `nosec` unless you
 # mean it as a directive.
 #
+# `tools/lint-nosec-form.py` enforces the ID-mandatory and second-`#` rules
+# above — not the linerange guidance below, and not the severity floor. It runs
+# in `make build-check`, deliberately NOT in `make sast`: it needs no scanner,
+# and SKIP_SAST turns `sast` off for exactly the diffs where a stray
+# suppression would otherwise go unscanned. This paragraph is the canonical
+# statement of that placement; the script and the chain step point here.
+#
+# It reproduces bandit's own tokenize + NOSEC_COMMENT detection rather than
+# grepping, so it sees what bandit sees: a directive inside a string literal is
+# not one, and `# noseclike` IS one. It also rejects two shapes that look fine
+# — `Bnnn,Bnnn` with no space (bandit keeps only the last id) and an ID that
+# does not exist, e.g. a typo'd `B999` (resolves to nothing, so it blankets).
+#
+# The string-literal point applies to prose as well: a comment *quoting* the
+# directive form is a directive. Describe the form, or point at this file; do
+# not spell it out in a Python comment.
+#
 # Suppressions also apply to the whole *statement's* linerange, not just the
 # commented line, so a nosec on a multi-value statement warns "nosec
 # encountered, but no failed test" for every sibling value the rule skips.

--- a/docs/specs/bandit-nosec-form-lint/spec.md
+++ b/docs/specs/bandit-nosec-form-lint/spec.md
@@ -1,0 +1,326 @@
+# Spec: bandit-nosec-form-lint
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — see § Named deviation
+- **Mode:** full (governance surface — it adds a gate to the `build-check`
+  chain and edits `bandit.yaml`, which `Makefile`'s `SAST_CONFIG` names as the
+  config governing the SAST gate. Same reading as the sibling
+  `bandit-nosec-comment-hygiene` spec, which called the same two surfaces
+  full-mode.)
+- **Constrained by:**
+[ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md)
+- **Contract:** none (a repo gate; no published interface)
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Named deviation from full mode
+
+The `loop-engine` / `loop-cohort` state machine was not run, and there is no
+`plan.md` with per-task `Tests:`. The two human approval gates it
+sequences were **granted up front by the requester** as a standing instruction
+to carry this through to merge.
+Everything else full mode requires was run:
+`adversarial-reviewer` (iterated), and `security-reviewer` (warranted — the
+change adds a gate over a security control's audit trail and the linter itself
+shells out). Both produced findings that are applied here.
+
+**Why no `plan.md` is a judgement, not an omission.** A plan's per-task
+`Tests:` and `Depends on:` exist to sequence multiple interdependent tasks;
+this is a single task whose verification mode is named in § Testing Strategy
+and whose gate is the self-test. There is no task ordering for a plan to carry.
+
+**Status ownership.** Every AC below is met and both gates are granted, so the
+spec is `Shipped`. It was held at `Implementing` until the grant rather than
+flipped by the author.
+
+## Objective
+
+`tools/run-bandit-gate.py` fails `make sast` on any Bandit stderr, which catches
+every malformed suppression Bandit *warns* about. One shape produces no warning
+at all:
+
+```python
+x = eval(s)  # nosec           <- resolves to no test id
+x = eval(s)  # nosec  # reason <- same, and the second `#` makes it look correct
+```
+
+Bandit's `core/tester.py` treats an empty resolved-id set as "nosec without test
+number" and skips **every** test on that statement. Nothing reaches stderr, so
+the gate stays green over it. Fail-open and silent — ADR-0084 recorded this as
+the residue its stderr rule cannot reach and named a form lint as the closer.
+
+Success: that shape fails `make build-check`, with a message that says which of
+the two consequences applies and how to fix it.
+
+## Why `build-check` and not `make sast`
+
+Two reasons, both load-bearing:
+
+1. **It needs no scanner.** Pure stdlib, offline, sub-second. Nothing about it
+   belongs behind the ~76k-LOC scanner pass.
+2. **`make sast` would not catch it anyway.** This is the reason that actually
+   carries the decision. The blanket shape produces *no bandit output at all* —
+   that is its whole nature — so running it behind the scanners would add
+   nothing whether they are skipped or not.
+
+   An earlier draft argued instead that `SKIP_SAST` leaves a window. That
+   argument does not hold and is recorded here so it is not re-derived:
+   `skip_sast` is true only when the diff touches nothing in
+   `SAST_DIRS ∪ SAST_CONFIG`, and this linter's scope *is* `SAST_DIRS` — so any
+   diff that can introduce an in-scope violation is by construction
+   SAST-relevant. The `SKIP_SAST` point survives only for *pre-existing*
+   violations, which a skipped run would leave unexamined.
+
+## How it detects — parity with Bandit, not a grep
+
+The linter reproduces Bandit's own detection rather than searching for the word
+`nosec`. `core/manager.py` tokenises each file and hands every `COMMENT` token
+to `_parse_nosec_comment`, which runs
+
+```python
+NOSEC_COMMENT = re.compile(r"#\s*nosec:?\s*(?P<tests>[^#]+)?#?")
+```
+
+as a `search`. Both halves are copied deliberately:
+
+- **`tokenize`, not lines.** A `# nosec` inside a string literal or docstring is
+  not a directive, and must not be reported. Line-based grepping cannot tell.
+- **`search` with no word boundary.** `# noseclike` **is** a directive to
+  Bandit: the pattern matches its prefix and captures `like` as the id list,
+  which resolves to nothing — a blanket suppression nobody wrote. A linter that
+  "helpfully" required a word boundary would be quieter than Bandit and miss it.
+
+The consequence cuts both ways, and this change hit it: prose *quoting* the
+required form inside a Python comment is itself a directive. The comment
+introduced in `tools/repo/build_gate_chain.py` to explain this gate spelled the
+form out, and Bandit's parser read it as an id-less suppression of that very
+line. Confirmed by construction — `_parse_nosec_comment` on that text returns
+`set()`. The linter caught it on its first real run. The comment now names
+`bandit.yaml` instead of quoting the form.
+
+## The two gates caught each other
+
+Worth recording, because it is the argument for having both. This change was
+caught twice by the machinery it extends:
+
+1. **The new linter caught its own explanatory comment.** The note added to
+   `build_gate_chain.py` spelled out the directive form, and bandit's parser
+   read it as an id-less suppression of that line. Confirmed by construction:
+   `_parse_nosec_comment` on that text returns `set()`.
+2. **The existing stderr gate caught the new self-test.** An early draft drove
+   `git` through the real repo's index and carried `# nosec B603` on those
+   calls. The calls also trip B607 (partial executable path), and at the gate's
+   medium severity floor neither finding survives, so both suppressions were
+   unused — `run-bandit-gate.py` failed the build on
+   `nosec encountered … but no failed test`. The fix was not to add ids: it was
+   to stop mutating the real repo at all. The self-test now runs the linter
+   inside a throwaway git repo carrying its own `Makefile` and copy of the
+   script, so `REPO_ROOT` resolves there. That removed the subprocess calls,
+   removed the suppressions, and made the case exercise Makefile parsing too.
+
+A test that writes to the real index would also have left it dirty had it
+crashed between setup and teardown. The gate found a correctness problem by
+complaining about a comment.
+
+## Deliberate narrowing, and one optional import
+
+Bandit accepts a test *name* (`assert_used`) as well as an id (`B101`).
+ADR-0084 and `bandit.yaml` require the numeric ID, so only `B<digits>` is
+accepted here.
+
+`classify` resolves stray tokens **before** consulting any registry, and that
+ordering is why the `not-an-id` message stays hedged: at that point the linter
+genuinely cannot tell whether `assert_used` names a real test, so it states the
+form violation as fact and both consequences — silent widening, or
+full-statement suppression — conditionally. A test pins that phrasing.
+
+**Deviation from AGENTS.md's pure-stdlib rule, named rather than buried.**
+`id_checker()` imports `bandit.core.extension_loader` when it is available, to
+catch a well-formed id that does not exist (`# nosec B999`). The base path is
+still pure stdlib — the import is optional, guarded, and its failure degrades
+the scan rather than breaking it (any exception, not just `ImportError`:
+importing builds the plugin registry from entry points). `check_id` and not
+`plugins_by_id`: the B3xx range is bandit's *blacklist* registry, so a
+plugins-only lookup reports every `# nosec B310` in this repo as unknown.
+
+## Scope
+
+Git-tracked `*.py` under the Makefile's `SAST_DIRS`, **read from the Makefile at
+runtime rather than copied**. `Makefile:185` exists so consumers read that
+variable "instead of hard-coding the lists, so the workflow predicate can't
+drift from them and silently skip the scan on a newly-added scannable dir"; a
+second copy in this script would be that exact drift. Parsed rather than shelled
+out to `make`, because this chain is deliberately make-free for Windows.
+
+**Wider than bandit's own scan, deliberately.** `bandit.yaml` excludes
+`*/tests/*`; this gate does not. A malformed suppression in a test tree is
+still a malformed suppression, and `exclude_dirs` is configuration that can
+change — a directive that is inert today becomes live the moment a tree stops
+being excluded. The cost is a possible red build over a directive bandit never
+evaluates; the repo's one such site
+(`packs/converters/tests/skills/file-to-markdown/test_tier3.py:40`) is
+well-formed, so nothing is red today. If that trade ever bites, honour
+`exclude_dirs` here rather than deleting the suppression.
+
+Tracked-only because `packages/agentbundle/build/lib/` holds gitignored copies
+of tracked modules. Bandit *does* read them when they exist (`bandit -r
+packages` walks the filesystem, and `bandit.yaml` excludes only `*/tests/*`), so
+the reason is not "no scanner reads it" — it is that a report there duplicates
+one already raised against the real file.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the id-less shapes fail.** A bare `# nosec` and an id-less
+      `# nosec  # reason` are each reported, with the message stating plainly
+      that they suppress every test on the statement and that Bandit reports
+      nothing.
+
+- [x] **AC2 — the reversed form still fails here.** `# nosec B307 — reason`,
+      `# nosec B307 - reason`, and bare prose after the id are reported. Bandit
+      warns about these and the stderr gate already catches them; this catches
+      them without a scan, on diffs where `SKIP_SAST` is set.
+
+- [x] **AC3 — Bandit parity, both directions.** `# noseclike` is reported
+      (Bandit treats it as an id-less directive). A `# nosec` inside a string
+      literal or docstring, and prose merely containing the word `nosec`
+      mid-sentence, are **not** reported — the last is real text from
+      `packs/converters/.apm/skills/file-to-markdown/scripts/tier3.py:43`, which
+      a word-grep linter would fire on.
+
+- [x] **AC4 — no overclaiming on the name form.** `# nosec assert_used` is
+      reported, and its message does not assert that the statement is fully
+      suppressed. A test pins that phrasing, so a future "simplification" of the
+      message into a flat claim fails.
+
+- [x] **AC4b — two more shapes that read as correct are rejected.** Both were
+      found by review, and both resolve to a blanket suppression in bandit:
+      - `# nosec B404,B603` — a comma with no following space. Bandit's
+        `NOSEC_COMMENT_TESTS` keeps only the last capture of a comma run, so it
+        suppresses `B603` alone. Measured on 1.9.4; `# nosec B404, B603`
+        resolves to both and stays silent.
+      - `# nosec B999` — an ID that does not exist. It has an ID's shape, so it
+        reads as correct, but resolves to nothing. A one-character typo is the
+        likeliest real instance of this gate's whole failure class. Requires
+        bandit's registry (`extension_loader.MANAGER.check_id`, which covers the
+        blacklist B3xx range that `plugins_by_id` alone misses), so it is
+        skipped with a printed notice where bandit is absent. **Its CI reach is
+        currently nil, stated plainly:** `build-check.yml` installs
+        `requirements-sast.txt` only when `skip_sast != 'true'`, so on a
+        SKIP_SAST PR bandit is absent and this check no-ops; where bandit *is*
+        installed, `make sast` also runs and `run-bandit-gate.py` already fails
+        on bandit's own `Test in comment: B999 …` stderr. So it earns its place
+        locally and as defence-in-depth, not as new CI coverage. Making the
+        bandit install unconditional would change that, and is recorded as
+        `build-check-installs-bandit-unconditionally`.
+
+- [x] **AC5b — the gate cannot be neutered silently.** Two mutations were run
+      against the real tree and both now fail the self-test: (a) `main` unable
+      to return 1, and (b) the scan scope collapsed to a root matching nothing.
+      Before review both passed with every case green, which is what made the
+      original AC7 claim false. A scan matching no files now exits 2 — a silent
+      no-op is not a pass.
+
+- [x] **AC5 — silent on the tree it lands in.** `python3
+      tools/lint-nosec-form.py` exits 0 across every git-tracked file in
+      `SAST_DIRS`, and says how many it read.
+
+- [x] **AC6 — wired into `make build-check`.** `tools/lint-nosec-form.py` and
+      its self-test are steps in `tools/repo/build_gate_chain.py`'s `build-check`
+      chain, self-test first, matching the surrounding `_script_step` pairs. It
+      is reachable with `SKIP_SAST=1`.
+
+- [x] **AC7 — the gate has a self-test that fails if the gate is removed.**
+      `tools/test-lint-nosec-form.py`, in the shape
+      `tools/test-sast-stderr-gate.py` and `tools/test-audit-requirements.py`
+      set. Its firing cases assert the *kind* of violation reported, not merely
+      a non-zero exit, so a linter simplified into something that never fires
+      still fails it.
+
+- [x] **AC8 — ADR-0084's `Revisit if` is mechanical.** A case asserts the
+      linter's `NOSEC_COMMENT` is byte-identical to Bandit's, so a Bandit
+      upgrade that changes the pattern turns the build red instead of silently
+      un-syncing the two. Skipped with a printed notice when Bandit is absent.
+
+- [x] **AC9 — `bandit.yaml` names its enforcer.** Its header comment already
+      states the form and that the ID is mandatory; it gains a pointer to the
+      linter, so the file that carries the instruction also says what checks it.
+
+- [x] **AC10 — the register is dispositioned.** `bandit-nosec-form-lint` is
+      removed from `workspace.toml [backlog].open`, and the
+      `compare-bandit-suppressions` decision below is recorded there.
+
+- [x] **AC11 — gates pass.** `python3 tools/lint-ruff.py`, `make lint-mypy`,
+      `SKIP_SAST=1 make build-check`, `make sast` (unskipped, so the new gate
+      and the scanners are both proven on this diff), and `python3 -m pytest
+      tools/test_build_gate_chain.py` — named explicitly because the chain's
+      ordered `EXPECTED_SCRIPT_STEPS` manifest is not run by `make build-check`,
+      only by `make test` and `build-check.yml`. Omitting it is how this PR
+      first shipped two red CI jobs while `make build-check` reported green.
+
+## Boundaries
+
+### Always do
+
+- Always derive the scanned file set from the Makefile's `SAST_DIRS`. A widened
+  `SAST_DIRS` must widen this gate in the same commit, with no edit here.
+- Always keep the self-test's firing cases asserting the *kind* of violation and
+  the process exit code, not merely "something was reported".
+
+### Ask first
+
+- Ask before widening the accepted id grammar beyond `B<digits>` — accepting
+  bandit's test-*name* form would re-open the narrowing § Deliberate narrowing
+  argues for.
+- Ask before adding any exemption mechanism (a pragma, an allowlist). The gate's
+  value is that it has none, exactly as bandit has none.
+
+### Never do
+
+- Never add an escape hatch for prose that quotes the form. Bandit has none —
+  an exemption here would make the linter quieter than the tool it models, which
+  is the one failure mode it cannot afford.
+- Never widen it to a word-boundary or line-based match to reduce noise. Parity
+  with `NOSEC_COMMENT` is the whole design.
+- Never change any existing suppression. This change adds a gate; it moves no
+  suppression's coverage. The tree is already clean under it.
+
+## Testing Strategy
+
+Goal-based, and verified against real fixtures both ways:
+
+- **Silent half, real tree:** `python3 tools/lint-nosec-form.py` → exit 0 over
+  all git-tracked `*.py` in `SAST_DIRS`.
+- **Firing half:** `python3 tools/test-lint-nosec-form.py` → every case passes,
+  covering the bad shapes and the silent ones, plus the process-level exit contract.
+- **End-to-end through the chain:** the linter and its self-test appear in
+  `SKIP_SAST=1 make build-check` output and block it on failure. Demonstrated
+  live, not reasoned about: the `build_gate_chain.py` comment described above
+  made the chain red until it was fixed.
+- **Independent confirmation of the hazard:** Bandit's own
+  `_parse_nosec_comment`, run against that comment's text, returns `set()`.
+
+## Assumptions
+
+- Bandit's `NOSEC_COMMENT` and the tokenize-driven `COMMENT` walk are stable
+  across the 1.9.x line pinned in `tools/requirements-sast.txt`. AC8 converts
+  this from an assumption into a gate.
+
+## Declined
+
+- **A `compare-bandit-suppressions` tool in this PR.** It earns being a
+  tool: the four traps in `bandit-nosec-comment-hygiene`'s § Testing Strategy
+  are durable knowledge, and their current carrier is prose inside a **Frozen**
+  spec — so when the procedure improves, the record cannot. That is a real
+  defect, not a style preference. But it is a different concern from this gate
+  (a manual before/after harness, not a build-check step), it would roughly
+  double this diff, and this PR changes no suppression, so it would ship
+  unexercised. Recorded as `compare-bandit-suppressions-tool`.
+- **Scanning untracked files.** `git ls-files` is the file set on purpose; see
+  § Scope.
+- **Accepting Bandit's test-name form.** See § Deliberate narrowing.
+- **Adding the self-test to `tools/test-all.py`'s `TESTS`.** That umbrella is a
+  curated hand-run list; this gate runs in `build-check`, so an entry there
+  would be a second, weaker copy of an enforcement that already blocks.

--- a/tools/lint-nosec-form.py
+++ b/tools/lint-nosec-form.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Enforce the bandit suppression-comment form. Rules and rationale: bandit.yaml.
+
+`tools/run-bandit-gate.py` fails `make sast` on any bandit stderr, which catches
+every malformed suppression bandit *warns* about. It cannot catch a directive
+that resolves to no test id: bandit's `core/tester.py` treats an empty resolved
+set as "nosec without test number" and skips **every** test on the statement,
+printing nothing. Fail-open and silent — this linter is that backstop.
+
+It reproduces bandit's own detection rather than grepping, because only parity
+is safe in both directions. `core/manager.py` tokenises each file and hands
+every COMMENT token to `_parse_nosec_comment`, which runs
+
+    NOSEC_COMMENT = re.compile(r"#\\s*nosec:?\\s*(?P<tests>[^#]+)?#?")
+
+as a `search`. So a directive inside a string literal is not one (tokenize),
+and `# noseclike` IS one (no word boundary — the captured id list is `like`,
+which resolves to nothing). The same applies to prose: a comment *quoting* the
+directive form is a directive.
+
+Four violation kinds, each a distinct way a suppression covers more than it says:
+
+  blanket      no id at all -> skips every test on the statement, silently.
+  not-an-id    prose or a test *name* reached the id list.
+  lossy-comma  `B404,B603` -> bandit keeps only `B603` (see _COMMA_RUN).
+  unknown-id   `B999` has an id's shape but resolves to nothing -> blanket.
+
+Run: python3 tools/lint-nosec-form.py [<root> ...]
+Exit 0 = every suppression well-formed, 1 = violations, 2 = usage/tool error
+(including a scan that matched no files — a silent no-op is not a pass).
+Proven by tools/test-lint-nosec-form.py.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is the literal "git"
+import sys
+import tokenize
+from pathlib import Path
+from typing import Callable
+
+# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Kept byte-identical to bandit/core/manager.py's NOSEC_COMMENT (1.9.4). A
+# bandit upgrade that changes it must change this too — ADR-0084's `Revisit if`
+# trigger, pinned by a self-test case rather than left to memory.
+NOSEC_COMMENT = re.compile(r"#\s*nosec:?\s*(?P<tests>[^#]+)?#?")
+
+# The repo's documented id form. Narrower than bandit's, which also accepts a
+# test *name* (`assert_used`); bandit.yaml requires the numeric ID.
+TEST_ID = re.compile(r"^B\d+$")
+
+# How the captured id list is broken into tokens. Bandit does NOT split: it runs
+# NOSEC_COMMENT_TESTS = r"(?:(B\d+|[a-z\d_]+),?)+" as a `finditer`, whose
+# repeated group keeps only its LAST capture per match — so `B404,B603` yields
+# `{'B603'}` (measured on 1.9.4) while `B404, B603` yields both. Splitting on
+# whitespace-or-comma here is deliberately *wider* than bandit's matcher: it
+# must see every token bandit could, plus the ones it cannot.
+_ID_SEPARATOR = re.compile(r"[,\s]+")
+
+# Two ids joined by a bare comma — the shape bandit's repeated capture group
+# collapses. Deliberately NOT `,\S`: measured on 1.9.4, `B404,,B603` and
+# `,B404` both resolve fully, so reporting them as lossy would be false.
+_COMMA_RUN = re.compile(r"B\d+,B\d+")
+
+# The scanned roots are the Makefile's SAST_DIRS, read at runtime rather than
+# copied. Makefile:185 exists so consumers read that variable "instead of
+# hard-coding the lists, so the workflow predicate can't drift from them and
+# silently skip the scan on a newly-added scannable dir" — a second copy here
+# would be the exact drift it warns about. Parsed rather than shelled out to
+# `make`, because this chain is deliberately make-free (Windows).
+_SAST_DIRS_RE = re.compile(r"^SAST_DIRS\s*[:+?]*=\s*(.+)$", re.MULTILINE)
+
+BLANKET = "blanket"
+NOT_AN_ID = "not-an-id"
+LOSSY_COMMA = "lossy-comma"
+UNKNOWN_ID = "unknown-id"
+
+
+class LintError(RuntimeError):
+    """A tool-level failure: the scan could not be performed as specified."""
+
+
+def sast_dirs(root: Path | None = None) -> list[str]:
+    """Return the Makefile's SAST_DIRS as a list of roots."""
+    makefile = (root or REPO_ROOT) / "Makefile"
+    try:
+        text = makefile.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise LintError(f"could not read {makefile}: {exc}") from None
+    matches = _SAST_DIRS_RE.findall(text)
+    if not matches:
+        raise LintError(f"no `SAST_DIRS :=` assignment in {makefile}")
+    if len(matches) > 1:
+        # A later `SAST_DIRS +=` would be invisible to a first-match parse, and
+        # invisible means a NARROWER gate than the scan — the exact drift this
+        # derivation exists to prevent. Fail loudly instead.
+        raise LintError(
+            f"{len(matches)} `SAST_DIRS` assignments in {makefile}; expected exactly one"
+        )
+    roots = matches[0].split("#", 1)[0].split()
+    if not roots:
+        raise LintError(f"`SAST_DIRS` in {makefile} is empty")
+    return roots
+
+
+def id_checker() -> Callable[[str], bool] | None:
+    """Return bandit's own `check_id`, or None when bandit is absent.
+
+    `check_id` rather than `plugins_by_id`: the B3xx range is bandit's
+    *blacklist* registry, not its plugin registry, so a plugins-only lookup
+    reports every `# nosec B310` in this repo as unknown. `check_id` consults
+    plugins, blacklist and builtins — it is the same predicate bandit applies
+    when resolving a directive, which is the only thing worth matching.
+
+    Optional by design. AGENTS.md requires this script to be pure stdlib, so it
+    must do its job with no third-party import — but where bandit *is* installed
+    (any environment that runs `make sast`) its registry is the only way to
+    catch a well-formed id that does not exist. `# nosec B999  # typo` has the
+    shape of an id, resolves to nothing, and is therefore a blanket
+    suppression; a one-character typo is the likeliest real instance of exactly
+    the failure class this gate exists for.
+    """
+    try:
+        from bandit.core import extension_loader  # noqa: PLC0415
+
+        return extension_loader.MANAGER.check_id
+    except Exception:  # noqa: BLE001
+        # Not just ImportError: importing builds MANAGER from installed entry
+        # points, so a broken plugin distribution or an API move raises
+        # something else. Falling back to "registry unavailable" keeps that a
+        # degraded scan rather than a traceback with exit 1 — a status this
+        # tool's contract reserves for "violations found".
+        return None
+
+
+class Violation:
+    """One malformed suppression, with the text needed to fix it."""
+
+    def __init__(self, path: str, line: int, kind: str, comment: str, detail: str):
+        self.path = path
+        self.line = line
+        self.kind = kind
+        self.comment = comment
+        self.detail = detail
+
+    def render(self) -> str:
+        return f"  {self.path}:{self.line}: {self.detail}\n      {self.comment.strip()}"
+
+
+def classify(
+    comment: str, known_ids: Callable[[str], bool] | None = None
+) -> tuple[str, str] | None:
+    """Return `(kind, detail)` for a malformed suppression, or None if fine.
+
+    None covers both "well-formed directive" and "not a directive at all"; the
+    caller does not need to tell those apart, only whether to report.
+    """
+    match = NOSEC_COMMENT.search(comment)
+    if not match:
+        return None
+
+    tests = (match.group("tests") or "").strip()
+    if not tests:
+        return (
+            BLANKET,
+            "`# nosec` with no test ID suppresses EVERY test on this statement, "
+            "and bandit reports nothing. Write the ID, reason after a second `#`",
+        )
+
+    tokens = [token for token in _ID_SEPARATOR.split(tests) if token]
+
+    if not tokens:
+        # `tests` was non-empty but held only separators: a directive whose id
+        # list is nothing but commas and whitespace. Bandit resolves every such
+        # form to an empty set (measured on 1.9.4), so they are blanket
+        # suppressions — and the earlier `not tests` guard does not see them,
+        # because `.strip()` removes the whitespace but leaves the comma.
+        # (Spelled in prose, not quoted: a comment quoting a directive is one.)
+        return (
+            BLANKET,
+            "the id list is punctuation only, which bandit resolves to no test "
+            "— so this suppresses EVERY test on the statement, silently. Write "
+            "the ID, reason after a second `#`",
+        )
+
+    stray = [token for token in tokens if not TEST_ID.match(token)]
+
+    if stray:
+        # Deliberately does not claim which consequence follows. Bandit also
+        # resolves test *names* (`assert_used` -> B101), and a stdlib-only
+        # linter cannot know that registry, so `assert_used` is certainly a form
+        # violation but is NOT a blanket one. Naming both outcomes and asserting
+        # neither is the only honest message.
+        return (
+            NOT_AN_ID,
+            f"{', '.join(stray)} reached bandit's test-id parser — text after "
+            "`# nosec` is read as a list of test IDs up to the next `#`. A word "
+            "that collides with a real test name silently widens the "
+            "suppression; if no word resolves at all, bandit suppresses EVERY "
+            "test on the statement. Put the reason after a SECOND `#`",
+        )
+
+    if _COMMA_RUN.search(tests):
+        return (
+            LOSSY_COMMA,
+            "a comma with no following space drops every id but the last — "
+            "bandit keeps only the final capture of a comma run, so `B404,B603` "
+            "suppresses B603 alone. Separate ids with `, ` (comma AND space)",
+        )
+
+    if known_ids is not None:
+        unknown = [token for token in tokens if not known_ids(token)]
+        if unknown:
+            return (
+                UNKNOWN_ID,
+                f"{', '.join(unknown)} is not a bandit test ID. It has the shape "
+                "of one, so it reads as correct, but bandit resolves it to "
+                "nothing — and a directive resolving to no id suppresses EVERY "
+                "test on the statement",
+            )
+
+    return None
+
+
+def scan_source(
+    source: str, path: str, known_ids: Callable[[str], bool] | None = None
+) -> list[Violation]:
+    """Return every malformed suppression in `source`.
+
+    Tokenises as bandit does, so a `# nosec` inside a string literal is not a
+    directive. `io.StringIO(...).readline` rather than `str.splitlines`: the
+    latter also breaks on \\v, \\f, \\x1c-\\x1e, \\x85, \\u2028 and \\u2029,
+    which desynchronises the token stream from real line numbers and can abort
+    a file bandit tokenises cleanly.
+    """
+    violations: list[Violation] = []
+    for token in tokenize.generate_tokens(io.StringIO(source).readline):
+        if token.type != tokenize.COMMENT:
+            continue
+        verdict = classify(token.string, known_ids)
+        if verdict is None:
+            continue
+        kind, detail = verdict
+        violations.append(Violation(path, token.start[0], kind, token.string, detail))
+    return violations
+
+
+def tracked_python_files(roots: list[str], root: Path | None = None) -> list[Path]:
+    """Return git-tracked `*.py` under `roots`, repo-relative, sorted.
+
+    Tracked-only because `packages/agentbundle/build/lib/` holds gitignored
+    copies of tracked modules: bandit does read them when they exist, so a
+    report there is a duplicate of one already raised against the real file.
+    """
+    completed = subprocess.run(  # nosec B603, B607  # list argv, no shell; "git" from PATH, roots from the Makefile
+        ["git", "ls-files", "-z", "--", *roots],
+        cwd=root or REPO_ROOT,
+        capture_output=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise LintError(completed.stderr.strip() or "git ls-files failed")
+    return sorted(Path(name) for name in completed.stdout.split("\0") if name.endswith(".py"))
+
+
+def main(argv: list[str]) -> int:
+    base = REPO_ROOT
+    try:
+        roots = argv[1:] or sast_dirs(base)
+        files = tracked_python_files(roots, base)
+    except (LintError, OSError, UnicodeDecodeError) as exc:
+        print(f"lint-nosec-form: {exc}", file=sys.stderr)
+        return 2
+
+    if not files:
+        # A scan that reads nothing must not look like a scan that found
+        # nothing: a typo'd or renamed root is the cheapest way to turn this
+        # gate into a silent no-op.
+        print(
+            f"lint-nosec-form: no tracked *.py under {' '.join(roots)} — "
+            "refusing to report success on an empty scan",
+            file=sys.stderr,
+        )
+        return 2
+
+    known_ids = id_checker()
+    caveat = "" if known_ids is not None else " (bandit absent: IDs not resolved)"
+    violations: list[Violation] = []
+    scanned = 0
+    for relative in files:
+        absolute = base / relative
+        if not absolute.exists():
+            # Tracked in the index but absent from the worktree (mid-rebase,
+            # partial checkout). Skipping beats aborting the whole gate.
+            continue
+        try:
+            # tokenize.open honours the BOM and PEP 263 coding cookies, as
+            # bandit's own reader does; read_text(encoding="utf-8") would
+            # reject a file bandit scans cleanly.
+            with tokenize.open(absolute) as handle:
+                source = handle.read()
+        except (OSError, UnicodeDecodeError, SyntaxError) as exc:
+            print(f"lint-nosec-form: could not read {relative}: {exc}", file=sys.stderr)
+            return 2
+        try:
+            violations.extend(scan_source(source, relative.as_posix(), known_ids))
+        except (tokenize.TokenError, IndentationError, SyntaxError) as exc:
+            print(f"lint-nosec-form: could not tokenise {relative}: {exc}", file=sys.stderr)
+            return 2
+        scanned += 1
+
+    if scanned == 0:
+        # `files` being non-empty is not enough: every listed file can be absent
+        # from the worktree, and the skip below would then report a clean scan
+        # of nothing. This guard and the `not files` one above look redundant
+        # and are not — the skip re-opened exactly the hole that one closes.
+        print(
+            f"lint-nosec-form: {len(files)} file(s) tracked under "
+            f"{' '.join(roots)} but none present on disk — refusing to report "
+            "success on an empty scan",
+            file=sys.stderr,
+        )
+        return 2
+
+    if violations:
+        print(
+            f"lint-nosec-form: FAIL — {len(violations)} malformed suppression(s) "
+            f"in {scanned} tracked file(s){caveat}:",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(violation.render(), file=sys.stderr)
+        print(
+            "\nThe ID is mandatory and any reason goes after a second `#`.\n"
+            "See bandit.yaml's header comment and ADR-0084.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"lint-nosec-form: OK — every suppression in {scanned} tracked file(s) "
+        f"carries a test ID, with any reason behind a second `#`{caveat}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -374,6 +374,24 @@ def build_check(args: argparse.Namespace) -> int:
             "lint-pack-descriptions",
             "tools", "lint-pack-descriptions.py",
         ),
+        # The bandit suppression-comment form (ADR-0084). bandit.yaml's header
+        # is the canonical statement of the rule and of why this runs here
+        # rather than in `make sast`; the short version is that it needs no
+        # scanner and SKIP_SAST would disable it on exactly the diffs where a
+        # stray suppression goes unscanned.
+        #
+        # The form is not spelled out in this comment on purpose: bandit
+        # tokenises this file too, so a comment quoting the literal directive IS
+        # one to its parser. Writing it out here blanket-suppressed this very
+        # line until lint-nosec-form caught it.
+        _script_step(
+            "test-lint-nosec-form",
+            "tools", "test-lint-nosec-form.py",
+        ),
+        _script_step(
+            "lint-nosec-form",
+            "tools", "lint-nosec-form.py",
+        ),
         # The standing check that the repo-lint steps above do not become stale
         # again: lint-ci-parity fails when build-check.yml gains a gate with no
         # local counterpart and no declared exemption.

--- a/tools/test-lint-nosec-form.py
+++ b/tools/test-lint-nosec-form.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Self-test for tools/lint-nosec-form.py.
+
+The risk this guards is not "does it spot a bare `# nosec`" — that is the easy
+half. It is that a linter written to catch malformed suppressions goes quiet:
+by drifting off bandit's detection, by having its scan scope collapse, or by
+being simplified until no input can make it fail. A gate that is silent when it
+works and equally silent when it has been broken into a no-op is the shape
+ADR-0084 and tools/test-sast-stderr-gate.py exist to refuse.
+
+So the cases below come in three layers:
+
+  * `classify` / `scan_source` — the detection contract, asserted on the *kind*
+    of violation, never merely on "something was reported".
+  * `main` as a process, against a throwaway git repo — the exit contract
+    (0/1/2). Two mutations that a pure-function suite cannot see are covered
+    here: a collapsed scan scope reporting success, and a `main` that can never
+    return 1.
+  * parity with the installed bandit, so an upgrade that moves the parser turns
+    the build red instead of silently un-syncing the two.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is sys.executable or "git"
+import sys
+import tempfile
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_HERE = Path(__file__).resolve().parent
+_LINTER = _HERE / "lint-nosec-form.py"
+_SPEC = importlib.util.spec_from_file_location("lint_nosec_form", _LINTER)
+assert _SPEC and _SPEC.loader
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+    else:
+        FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+        print(f"  FAIL {label} {detail}")
+
+
+def kinds(source: str, known=None) -> list[str]:
+    return [v.kind for v in _MOD.scan_source(source, "f.py", known)]
+
+
+def run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+        [sys.executable, str(_LINTER), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _git_repo(tmp: Path, files: dict[str, str]) -> Path:
+    """Create a throwaway git repo containing `files`, and track them."""
+    for name, body in files.items():
+        target = tmp / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    for argv in (["git", "init", "-q"], ["git", "add", "-A"]):
+        subprocess.run(argv, cwd=tmp, check=True, capture_output=True)  # nosec B603  # list argv, no shell; argv[0] is "git"
+    return tmp
+
+
+def main() -> int:
+    print("lint-nosec-form self-test")
+
+    # ---- detection contract -------------------------------------------------
+
+    # The hole this linter exists for. Bandit treats both as "nosec without
+    # test number", skips every test on the statement, and prints nothing — so
+    # the stderr gate cannot see them.
+    check("bare `# nosec` fires", kinds("x = eval(s)  # nosec\n") == [_MOD.BLANKET])
+    check(
+        "id-less `# nosec  # reason` fires",
+        kinds("x = eval(s)  # nosec  # trusted input\n") == [_MOD.BLANKET],
+        "this is the shape the two-`#` form makes look well-formed",
+    )
+
+    # The form ADR-0084 reversed. Bandit warns about these, so the stderr gate
+    # catches them too — this catches them without a scan, on diffs where
+    # SKIP_SAST is set.
+    check("em-dash reason fires", kinds("x = eval(s)  # nosec B307 — t\n") == [_MOD.NOT_AN_ID])
+    check("hyphen reason fires", kinds("x = eval(s)  # nosec B307 - t\n") == [_MOD.NOT_AN_ID])
+    check("bare prose reason fires", kinds("x = eval(s)  # nosec trusted\n") == [_MOD.NOT_AN_ID])
+
+    # Bandit's regex has no word boundary, so this IS a directive with an id
+    # list of `like`, resolving to nothing. Parity beats intuition.
+    check("`# noseclike` fires", kinds("x = eval(s)  # noseclike\n") == [_MOD.NOT_AN_ID])
+
+    # A test *name* is a form violation but NOT a blanket one — bandit resolves
+    # `assert_used` to B101. The message must not claim otherwise.
+    name_form = _MOD.scan_source("assert x  # nosec assert_used\n", "f.py")
+    check("test-name form fires", [v.kind for v in name_form] == [_MOD.NOT_AN_ID])
+    check(
+        "test-name message does not overclaim",
+        bool(name_form) and "if no word resolves at all" in name_form[0].detail,
+        "must state the blanket consequence conditionally",
+    )
+
+    # `B404,B603` resolves to {'B603'} alone in bandit 1.9.4 — the comma run
+    # collapses to its last capture. Legal-looking and lossy.
+    check(
+        "comma with no space fires",
+        kinds("import subprocess  # nosec B404,B603  # list argv\n") == [_MOD.LOSSY_COMMA],
+    )
+    check(
+        "comma WITH space is silent",
+        kinds("import subprocess  # nosec B404, B603  # list argv\n") == [],
+    )
+
+    # A separator-only id list. `.strip()` leaves the comma, so the
+    # empty-`tests` guard does not see these — bandit resolves all four to an
+    # empty set, i.e. blanket. The last is the spec's own dangerous example
+    # with one stray comma added.
+    for text in ("x = eval(s)  # nosec,\n", "x = eval(s)  # nosec ,\n",
+                 "x = eval(s)  # nosec,,\n", "x = eval(s)  # nosec,  # trusted\n"):
+        check(f"separator-only id list fires: {text.split('#', 1)[1].strip()!r}",
+              kinds(text) == [_MOD.BLANKET], str(kinds(text)))
+
+    # A well-formed id that does not exist resolves to nothing -> blanket.
+    # Needs bandit's registry, so it is conditional on bandit being installed.
+    ids = _MOD.id_checker()
+    if ids is None:
+        print("  skip unknown-id cases (bandit not installed)")
+    else:
+        check("`# nosec B999` fires", kinds("x = eval(s)  # nosec B999  # typo\n", ids) == [_MOD.UNKNOWN_ID])
+        check("real id is silent", kinds("x = eval(s)  # nosec B307  # ok\n", ids) == [])
+
+    # Well-formed shapes stay silent.
+    check("id alone is silent", kinds("x = eval(s)  # nosec B307\n") == [])
+    check("id + second-# reason is silent", kinds("x = eval(s)  # nosec B307  # t\n") == [])
+    check("bandit's colon form is silent", kinds("x = eval(s)  # nosec: B307  # ok\n") == [])
+
+    # Not directives. The first is verbatim from tier3.py:43; a word-grep
+    # linter would fire on it.
+    check(
+        "prose mentioning nosec is silent",
+        kinds("# hence the name. Bound to its own statement so the nosec covers one value;\nx = 1\n") == [],
+    )
+    check("`# nosec` inside a string is silent", kinds("s = '# nosec'\n") == [])
+    check("`# nosec` inside a docstring is silent", kinds('"""See # nosec."""\nx = 1\n') == [])
+
+    # A form feed is a str.splitlines boundary but not a tokenize one; line
+    # numbers must follow tokenize, or the report points at the wrong line.
+    located = _MOD.scan_source("x = 1\n\f\ny = eval(s)  # nosec\n", "f.py")
+    check("line number survives a form feed", bool(located) and located[0].line == 3,
+          str(located[0].line) if located else "no violation")
+
+    # ---- exit contract, as a process ---------------------------------------
+
+    # A scan matching no files must not report success. This is the mutation
+    # "collapse DEFAULT_ROOTS to something that matches nothing", which a
+    # pure-function suite cannot see at all.
+    empty = run(["definitely-not-a-root"])
+    check("empty scan exits 2, not 0", empty.returncode == 2,
+          f"rc={empty.returncode} {empty.stdout.strip()[:120]}")
+    check("empty scan says why", "refusing to report success" in empty.stderr, empty.stderr[:160])
+
+    # A tracked-but-deleted file is skipped, not fatal: `git ls-files` reads the
+    # index, and a mid-rebase worktree is not a reason to abort the gate.
+    with tempfile.TemporaryDirectory() as raw:
+        repo = _git_repo(Path(raw), {"Makefile": "SAST_DIRS := src\n",
+                                     "src/a.py": "x = 1  # nosec B101  # fine\n"})
+        (repo / "src" / "a.py").unlink()
+        listed = _MOD.tracked_python_files(["src"], repo)
+        check("a deleted tracked file is still listed by git", listed == [Path("src/a.py")], str(listed))
+
+    # ...and skipping it must not turn the scan into a silent success. `files`
+    # is non-empty here while `scanned` falls to 0, which is how the skip
+    # re-opened the empty-scan hole the case above guards.
+    with tempfile.TemporaryDirectory() as raw:
+        gone = _git_repo(Path(raw) / "gone", {
+            "Makefile": "SAST_DIRS := src\n",
+            "src/only.py": "x = 1  # nosec B101  # fine\n",
+            "tools/lint-nosec-form.py": _LINTER.read_text(encoding="utf-8"),
+        })
+        (gone / "src" / "only.py").unlink()
+        result = subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+            [sys.executable, str(gone / "tools" / "lint-nosec-form.py")],
+            capture_output=True, text=True, check=False,
+        )
+        check("all-files-deleted scan exits 2, not 0", result.returncode == 2,
+              f"rc={result.returncode} {result.stdout.strip()[:120]}")
+
+    # A surviving file is still scanned when a sibling is missing.
+    with tempfile.TemporaryDirectory() as raw:
+        partial = _git_repo(Path(raw) / "partial", {
+            "Makefile": "SAST_DIRS := src\n",
+            "src/missing.py": "x = 1\n",
+            "src/bad.py": "y = 1  # nosec\n",
+            "tools/lint-nosec-form.py": _LINTER.read_text(encoding="utf-8"),
+        })
+        (partial / "src" / "missing.py").unlink()
+        result = subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+            [sys.executable, str(partial / "tools" / "lint-nosec-form.py")],
+            capture_output=True, text=True, check=False,
+        )
+        check("a missing sibling does not abort the scan", result.returncode == 1,
+              f"rc={result.returncode} {(result.stderr or result.stdout)[:160]}")
+        check("the surviving file is the one reported", "src/bad.py" in result.stderr,
+              result.stderr[:160])
+
+    # A real violation must exit 1. Run against a throwaway repo carrying its
+    # own copy of the linter, so REPO_ROOT resolves there: this exercises the
+    # whole path — Makefile parsing, `git ls-files`, tokenising, the exit code —
+    # without writing to the real repo's index, which a crash between setup and
+    # teardown would otherwise leave dirty.
+    with tempfile.TemporaryDirectory() as raw:
+        sandbox = _git_repo(Path(raw) / "violation", {
+            "Makefile": "SAST_DIRS := src\n",
+            "src/bad.py": "x = 1  # nosec\n",
+            "tools/lint-nosec-form.py": _LINTER.read_text(encoding="utf-8"),
+        })
+        dirty = subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+            [sys.executable, str(sandbox / "tools" / "lint-nosec-form.py")],
+            capture_output=True, text=True, check=False,
+        )
+        check("a real violation exits 1", dirty.returncode == 1,
+              f"rc={dirty.returncode} — a linter that cannot fail is not a gate")
+        check("the violation is named on stderr", "src/bad.py" in dirty.stderr,
+              dirty.stderr[:200])
+        check("the sandbox roots came from its own Makefile",
+              _MOD.sast_dirs(sandbox) == ["src"], str(_MOD.sast_dirs(sandbox)))
+
+    # ---- scope and parity ---------------------------------------------------
+
+    # The scan scope is read from the Makefile, not copied. If that ever
+    # regresses to a literal, this case is what notices.
+    # `SAST_DIRS +=` must be SEEN, so the multiple-assignment guard fires. An
+    # earlier pattern missed `+=` entirely, which silently NARROWED the gate
+    # relative to the scan — the drift this derivation exists to prevent.
+    with tempfile.TemporaryDirectory() as raw:
+        appended = Path(raw)
+        (appended / "Makefile").write_text("SAST_DIRS := tools packs\nSAST_DIRS += web\n",
+                                           encoding="utf-8")
+        try:
+            _MOD.sast_dirs(appended)
+        except _MOD.LintError as exc:
+            check("`SAST_DIRS +=` fails loudly", "expected exactly one" in str(exc), str(exc))
+        else:
+            check("`SAST_DIRS +=` fails loudly", False, "silently ignored the append")
+
+    # Deliberately NOT asserted against a literal list — a third copy of
+    # SAST_DIRS is the drift this derivation exists to prevent, and widening
+    # the Makefile would red an unrelated file. The sandbox case above proves
+    # the derivation; this proves it resolves against the real Makefile.
+    roots = _MOD.sast_dirs()
+    check("roots derive from the real Makefile", bool(roots) and all(
+        (_MOD.REPO_ROOT / r).is_dir() for r in roots), str(roots))
+
+    # ADR-0084's `Revisit if` made mechanical: a bandit upgrade that moves
+    # either pattern turns the build red rather than silently un-syncing.
+    try:
+        from bandit.core import manager  # noqa: PLC0415
+    except ImportError:
+        print("  skip bandit regex parity (bandit not installed)")
+    else:
+        check("regex matches bandit's NOSEC_COMMENT",
+              _MOD.NOSEC_COMMENT.pattern == manager.NOSEC_COMMENT.pattern,
+              f"ours={_MOD.NOSEC_COMMENT.pattern!r} bandit={manager.NOSEC_COMMENT.pattern!r}")
+        # The comma-run finding depends on this second pattern; pin it too.
+        check("bandit still collapses a comma run",
+              manager._parse_nosec_comment("# nosec B404,B603") == {"B603"},
+              str(manager._parse_nosec_comment("# nosec B404,B603")))
+
+    # The clean tree passes, and reports a plausible file count — a scope
+    # collapse that still finds *some* files would slip past the empty check.
+    clean = run([])
+    check("clean repo exits 0", clean.returncode == 0, (clean.stderr or clean.stdout)[:300])
+    digits = [int(s) for s in clean.stdout.replace("(", " ").split() if s.isdigit()]
+    # 500, not 100: the tree has ~790 tracked .py under SAST_DIRS and the
+    # largest single root (`packages`) holds ~407, so a collapse to any one
+    # root fails this. A floor of 100 would have passed a collapse to `tools`.
+    check("clean run scanned a plausible number of files", bool(digits) and max(digits) >= 500,
+          clean.stdout.strip()[:160])
+
+    print()
+    if FAILURES:
+        print(f"lint-nosec-form self-test: {len(FAILURES)} case(s) failed.")
+        return 1
+    print("lint-nosec-form self-test: all cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -221,6 +221,8 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-check-site-plugin-offers.py",
     "tools/test-lint-pack-descriptions.py",
     "tools/lint-pack-descriptions.py",
+    "tools/test-lint-nosec-form.py",
+    "tools/lint-nosec-form.py",
     "tools/test-lint-ci-parity.py",
     "tools/test-build-check-windows-workflow.py",
     "tools/lint-ci-parity.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -1628,18 +1628,32 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
-  # Bandit's `# nosec` form is documented in bandit.yaml's header comment but
-  # enforced nowhere, and ADR-0017:107 -- frozen, so it cannot be amended --
-  # still teaches the superseded `# nosec <ID> - <reason>` form. Two failure
-  # modes a lint would catch: (a) a prose reason after the ID is tokenised and
-  # each word looked up as a Bandit test NAME, so a word colliding with a real
-  # test name silently widens the suppression; (b) a `# nosec` with no
-  # resolvable ID (bare, or an ID-less `# nosec  # reason`) suppresses EVERY
-  # test on the statement and, in the two-`#` form, prints no warning at all.
-  # Both fail open. A grep-shaped tools/ check wired into build-check would
-  # close them; deliberately not bundled into the bandit-nosec-comment-hygiene
-  # PR, which was comment-format-only and added no gate.
-  {slug = "bandit-nosec-form-lint", summary = "Add a tools/ check enforcing the `# nosec <ID>  # <reason>` form -- ID mandatory, reason only after a second `#` -- and wire it into make build-check", source = "spec/bandit-nosec-comment-hygiene"},
+  # build-check.yml installs tools/requirements-sast.txt only when
+  # skip_sast != 'true', so on a SKIP_SAST PR bandit is absent and
+  # lint-nosec-form's unknown-id check (a well-formed but nonexistent ID like a
+  # typo'd B999, which bandit resolves to nothing and so treats as a blanket
+  # suppression) silently no-ops. Where bandit IS installed, make sast runs too
+  # and run-bandit-gate.py already fails on bandit's own stderr for that case --
+  # so the check currently adds zero CI coverage, only local and defence-in-depth
+  # value. Surfaced in spec/bandit-nosec-form-lint AC4b rather than hidden.
+  # Fix: drop the `if:` on that install step, or add an unconditional bandit-only
+  # install, so the registry is present on every build-check run. Weigh against
+  # the install cost on diffs that scan nothing.
+  {slug = "build-check-installs-bandit-unconditionally", summary = "Install bandit on every build-check run so lint-nosec-form's unknown-ID check is not inert on SKIP_SAST PRs", source = "spec/bandit-nosec-form-lint"},
+
+  # The suppression-equivalence procedure in bandit-nosec-comment-hygiene's
+  # Testing Strategy (two clean worktrees, pinned base SHA, relative scan
+  # roots, distinct (filename,test_id,issue_text) keys -- four traps that each
+  # gave a wrong answer once) is needed every time a `# nosec` is touched, but
+  # lives as prose inside a FROZEN spec, so it cannot be corrected as the
+  # procedure improves. Judged in bandit-nosec-form-lint to earn being a tool;
+  # kept out of that PR because it is a manual before/after harness rather than
+  # a build-check gate, would roughly double the diff, and that PR changes no
+  # suppression so it would have shipped unexercised.
+  # Fix: tools/compare-bandit-suppressions.py taking base and head refs (not a
+  # hardcoded SHA), encoding all four traps, plus the resolved-id inventory
+  # half that the reported-finding diff cannot see.
+  {slug = "compare-bandit-suppressions-tool", summary = "Promote the two-worktree bandit suppression-equivalence procedure to tools/compare-bandit-suppressions.py, encoding the four traps and the resolved-id inventory", source = "spec/bandit-nosec-form-lint"},
 
   # 7 of the 13 pytest files named on Makefile:349 (`make test`) are a run step
   # in NO workflow: test_validate_guides, test_check_guide_index,


### PR DESCRIPTION
## What does this change?

Adds `tools/lint-nosec-form.py` and its self-test, wired into `make build-check` via `tools/repo/build_gate_chain.py`. It enforces the Bandit suppression-comment form from `bandit.yaml`'s header: the ID is mandatory, any reason goes after a second `#`.

## Why?

`tools/run-bandit-gate.py` fails `make sast` on any Bandit stderr, catching every malformed suppression Bandit *warns* about. It cannot catch a directive that resolves to **no test id** — `core/tester.py` treats an empty resolved set as "nosec without test number" and skips **every** test on the statement, printing nothing. Fail-open and silent. ADR-0084 recorded this residue and named a form lint as its closer.

**It reproduces Bandit's detection rather than grepping**, because only parity is safe in both directions. `tokenize` means a directive inside a string literal is not one; `NOSEC_COMMENT`'s lack of a word boundary means `# noseclike` **is** one (Bandit captures `like`, resolves nothing, blankets the statement).

Four violation kinds, three of them found by review:
- `blanket` — no id, or an id list of only separators. `# nosec,` resolves to `set()` in Bandit 1.9.4.
- `not-an-id` — prose or a test *name* reached the id list.
- `lossy-comma` — `B404,B603` with no space. Bandit keeps only `{'B603'}`; a comma **with** a space resolves both.
- `unknown-id` — `B999` has an id's shape and resolves to nothing.

Spec: `docs/specs/bandit-nosec-form-lint/spec.md` · ADR-0084

**Why `build-check` and not `make sast`:** the blanket shape produces no Bandit output at all, so running it behind the scanners would add nothing. (An earlier draft argued `SKIP_SAST` leaves a window; that argument does not hold — `skip_sast` is true only when the diff touches nothing in `SAST_DIRS ∪ SAST_CONFIG`, and this linter's scope *is* `SAST_DIRS`. Recorded in the spec so it is not re-derived.)

## How do I verify it?

```
python3 tools/lint-nosec-form.py            # OK across 793 tracked files
python3 tools/test-lint-nosec-form.py       # all cases
python3 -m pytest tools/test_build_gate_chain.py -q
SKIP_SAST=1 make build-check && make sast   # both exit 0
```

**Mutation-tested.** Four ways to neuter the gate now fail the self-test: `main` unable to return 1; scan scope collapsed to a root matching nothing; every tracked file absent from the worktree; and a `SAST_DIRS +=` that would silently narrow the scan.

**The gates caught each other, twice.** The comment added to `build_gate_chain.py` to explain this gate spelled the directive form out — and Bandit's parser read it as an id-less suppression of that very line (`_parse_nosec_comment` returns `set()`). Later, the self-test drove `git` through the real repo's index carrying `# nosec B603`; those calls also trip B607, and at the medium floor neither survives, so `run-bandit-gate.py` failed on unused suppressions. The fix was not more ids — it was to stop mutating the real repo. The self-test now runs inside a throwaway git repo carrying its own `Makefile` and copy of the script.

## What did you not change that you considered?

- **Accepting Bandit's test-name form.** `bandit.yaml` requires the numeric ID.
- **An escape hatch for prose quoting the form.** Bandit has none; an exemption would make this quieter than the tool it models.
- **Honouring `bandit.yaml`'s `*/tests/*` exclusion.** Deliberately wider — a malformed suppression in a test tree is still malformed, and `exclude_dirs` is configuration that can change. Recorded in § Scope.

## Bundled fixes

- `bandit.yaml`'s header gains a pointer to its enforcer, and says why the form must not be spelled out in a Python comment.

## Deferred

- `compare-bandit-suppressions-tool` — **superseded by PR for `eugenelim/compare-bandit-suppressions`**, which builds it. Whichever of the two merges second removes this entry.
- `build-check-installs-bandit-unconditionally` — `build-check.yml` installs `requirements-sast.txt` only when `skip_sast != 'true'`, so the `unknown-id` check is inert on exactly the PRs that motivate it, and redundant where Bandit *is* installed (`make sast` catches it via stderr). Its CI reach today is nil; stated plainly in AC4b rather than hidden.