### PR TITLE
fix(tools): reject dot path segments in capture-evidence --repo

### DIFF
--- a/docs/specs/capture-evidence-repo-dot-segments/spec.md
+++ b/docs/specs/capture-evidence-repo-dot-segments/spec.md
@@ -1,0 +1,229 @@
+# Spec: capture-evidence-repo-dot-segments
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — see § Named deviation
+- **Mode:** full (security boundary — `_validate_repo` is input validation on
+  an operator-supplied value that is interpolated into JWT-authenticated API
+  paths)
+- **Constrained by:** none. Recorded as a deferral of
+  [`bandit-nosec-comment-hygiene`](../bandit-nosec-comment-hygiene/spec.md)
+  § Deferred.
+- **Contract:** none (an internal operator script; no published interface)
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Named deviation from full mode
+
+The `loop-engine` / `loop-cohort` state machine was not run, and there is no
+`plan.md`. The two human approval gates it sequences were **granted up front by the
+requester** as a standing instruction to carry this through to merge.
+`adversarial-reviewer`
+and `security-reviewer` were both run, and both produced findings that are
+applied here.
+
+Every AC below is met and both gates are granted, so the spec is `Shipped`. It
+was held at `Implementing` until the grant rather than flipped by the author.
+
+## Objective
+
+`_validate_repo` in `tools/capture-publish-control-evidence.py` accepts
+`[A-Za-z0-9._-]+/[A-Za-z0-9._-]+`. `.` and `..` are built entirely from that
+character set, so the pattern admits RFC 3986 dot-segments, and `urllib` sends
+the selector it is handed without normalising it. A `--repo` value can therefore
+reach an `api.github.com` endpoint other than the one the operator named.
+
+Success: dot-segments are rejected, legitimate dotted repository names still
+work, and a test pins both directions.
+
+## What is actually reachable — and what the register entry got wrong
+
+The backlog entry and the originating spec both cite `--repo ../../app`. That
+value is **already rejected**: it has three segments, and the pattern is
+`fullmatch` over exactly two. Verified by construction.
+
+The values that *do* get through are the two-segment ones:
+
+| `--repo` | admitted today | resulting path | transport of that path |
+| --- | --- | --- | --- |
+| `../..` | yes | `repos/../../environments/…` | `gh api` |
+| `owner/..` | yes | `/repos/owner/../installation` | `_app_api` (urllib) |
+| `./name` | yes | `/repos/./name/installation` | `_app_api` (urllib) |
+| `../name` | yes | `/repos/../name/installation` | `_app_api` (urllib) |
+| `owner/.` | yes | `/repos/owner/./installation` | `_app_api` (urllib) |
+| `../../app` | **no** — three segments | n/a | n/a |
+
+Every admitted value flows through *both* legs — the column names the
+transport of the example path shown, not the only one reached. Five of the six
+`--repo`-interpolated reads go through `_gh_api` → `gh api`; only the
+installation read goes through `_app_api`. For the urllib rows,
+`urllib.request.Request("https://api.github.com/repos/../../app/installation")`
+reports `selector == "/repos/../../app/installation"` — unnormalised. Whether
+GitHub resolves the dot-segments or 404s on them is unverified and does not
+change the point: it is not the read the operator named.
+
+## Honest scope — this is hygiene, not a live hole
+
+Stated plainly because the fix looks scarier than it is:
+
+- **No privilege is gained.** Whoever passes `--repo` already holds the App
+  private key the script requires; they can already read anything the App can.
+- **The JWT cannot leave `api.github.com`** — but this covers only one of the
+  two transports. `_app_api` (the JWT-bearing leg) hard-codes the scheme and
+  host and installs `_NoRedirect`, which matters because urllib's default
+  handler copies the `Authorization` header across an origin change. The other
+  five reads go through `gh api`, which carries the operator's OAuth token, not
+  the JWT, and whose confinement rests on `gh`'s own client and its configured
+  host — nothing in this file. Say that plainly rather than letting the
+  `_NoRedirect` sentence stand for both.
+- **What is actually wrong** is narrower than "the artifact lies about its
+  subject", and the honest version is less flattering to this fix: the evidence
+  document records no repository field at all (`build_evidence` emits `version`,
+  `branch`, `app`, `environment`, `identities_agree`, `canary`, `observed_at`,
+  `observation_source`). So nothing binds the evidence to a subject, and
+  `--repo other-org/well-configured-repo` still produces a byte-indistinguishable
+  artifact. Dot-segments were one route to a wrong-subject capture; this closes
+  that route and does **not** make the artifact trustworthy about its subject.
+  Binding the artifact to its repository is the real fix, and is recorded as
+  `publish-control-evidence-not-repo-bound`.
+
+## Why not "each segment must start alphanumeric"
+
+`lint-spec-status.py` guards its contract paths that way, and copying it here
+would be wrong: **`owner/.github` is a real GitHub repository**, and a leading
+dot is legal in a repository name. Narrowing the charset would reject a valid
+target in the name of safety. The dot-segments are therefore rejected by name,
+leaving every other dotted name (`.github`, `a.b`, `..x`, `x..`) working.
+
+## Acceptance Criteria
+
+- [x] **AC1 — dot-segments are rejected.** `../..`, `owner/..`, `./name`,
+      `../name`, and `owner/.` each raise `CaptureError`.
+
+- [x] **AC2 — legitimate dotted names still work.** `owner/.github`,
+      `my-org/my.repo`, `a_b/c-d.e`, `owner/..x`, and `owner/x..` are accepted
+      and returned unchanged. AC2 is the reason AC1 is implemented as a
+      segment-equality check rather than a charset narrowing.
+
+- [x] **AC3 — the existing shape checks are unchanged.** `owner`,
+      `owner/name/extra`, `""`, `owner/`, `/name`, and values containing a
+      space are still rejected. The new rule is additive.
+
+- [x] **AC4 — the two failures are distinguishable.** A dot-segment value
+      raises the dot-segment message, not the generic shape message, so the
+      operator is not sent looking for the wrong defect.
+
+- [x] **AC5 — the guard is on the live path.** `_validate_repo(args.repo)` runs
+      in `main` before `build_evidence`, which is the only caller that reaches
+      `_gh_api` / `_app_api`. Confirmed by reading the call graph, not assumed.
+
+- [x] **AC6 — a self-test exists and is gated.**
+      `tools/test-capture-publish-control-evidence.py` covers AC1–AC4 and is a
+      step in `tools/repo/build_gate_chain.py`'s `build-check` chain, beside the
+      linter for the artifact this script produces. The script is operator-run
+      and never executes in CI, so without this the guard has no exercise at all.
+
+- [x] **AC7 — the suppression rationale it cites stays true, pinned by
+      behaviour.** The `# nosec B310` on `opener.open` gives two reasons, and
+      the self-test observes both on the *production* path rather than grepping
+      the source: it spies `urllib.request.Request` to assert every URL
+      `_app_api` builds starts `https://api.github.com/`, and spies
+      `build_opener` to assert `_app_api` passes `_NoRedirect`. Re-deriving an
+      opener locally would only have tested urllib.
+
+- [x] **AC7b — the cited control is pinned by behaviour, not by grep.**
+      `_NoRedirect().redirect_request(...)` raises `CaptureError`; every one of
+      `redirect_request` is defined on `_NoRedirect` itself rather than
+      inherited — a `getattr` loop over `http_error_30x` would not show that,
+      since the class subclasses `HTTPRedirectHandler` and every one of those is
+      non-`None` by inheritance. Verified by mutation: deleting
+      `redirect_request` fails the self-test, where the previous substring check
+      passed green while the bearer JWT would have been forwarded across an
+      origin change.
+
+- [x] **AC7c — `gh api` cannot read a path as a flag.** The call passes `--`
+      before `path`. A leading-dash owner (`-h/name`) satisfies the charset
+      guard, so this is what keeps that from mattering to the five reads that
+      go through `gh`. Pinned behaviourally — `subprocess.run` is spied and
+      `argv[:3]` asserted — because a source substring is exactly what this
+      spec's `Always do` boundary rules out. Mutation-verified.
+
+- [x] **AC8 — gates pass.** `python3 tools/lint-ruff.py`, `make lint-mypy`,
+      `SKIP_SAST=1 make build-check`, and `make sast`.
+
+- [x] **AC9 — the register is dispositioned.** `capture-evidence-repo-dot-segments`
+      is removed from `workspace.toml [backlog].open`.
+
+## Boundaries
+
+### Always do
+
+- Always keep the two rejection reasons distinguishable, so an operator is not
+  sent looking for the wrong defect.
+- Always pin a cited control by behaviour. The `# nosec B310` rationale names
+  `_NoRedirect`; a substring match on the source is not a pin.
+
+### Ask first
+
+- Ask before changing `_gh_api`'s transport or `_app_api`'s opener — the B310
+  suppression's rationale depends on both, and this spec only guards the input.
+- Ask before adding a repository field to the evidence artifact; that changes
+  the schema the linter compares against.
+
+### Never do
+
+- Never narrow the character class to exclude a leading dot. See § Why not.
+- Never change the request construction, the `_NoRedirect` opener, or the B310
+  suppression. They are cited as context here; this change is the input guard
+  only.
+- Never make the script reachable from CI. It reads a private key and live org
+  settings; only its guard is gated.
+
+## Testing Strategy
+
+Goal-based, against the real function:
+
+- `python3 tools/test-capture-publish-control-evidence.py` → all cases pass.
+  Counts live in the test, not here, so adding a case cannot silently drift this
+  document.
+- The reachability table's `admitted today` column came from running
+  `re.fullmatch`; the urllib rows' selectors from
+  `urllib.request.Request(...).selector`. The `gh api` row is not a urllib
+  selector and is labelled as such.
+- **Mutation check on the redirect control.** Deleting `redirect_request` from
+  `_NoRedirect` must fail the self-test. Before review it did not: the case
+  grepped the source for `build_opener(_NoRedirect)`, which survives the
+  deletion, while the resulting handler would forward the bearer JWT to another
+  origin. Re-run after the fix — the mutation now fails one case.
+- `SKIP_SAST=1 make build-check` runs the self-test as a chain step.
+
+## Assumptions
+
+- GitHub normalises `..` server-side rather than 404ing on it. Not verified
+  against the live API — doing so would require the App key and would issue real
+  authenticated reads. The fix does not depend on it: an unnormalised selector
+  that 404s is still a request for an endpoint the operator did not name.
+
+## Declined
+
+- **Percent-encoding the segments instead of rejecting them.** It would make
+  `owner/..` a literal path segment rather than a traversal, but a repository
+  named `..` does not exist, so the only thing that behaviour buys is a
+  confusing 404 in place of a clear error.
+- **Validating inside `_gh_api` / `_app_api` instead.** Two call sites, one
+  entry point; the guard belongs where the operator's value enters, and moving
+  it would leave `build_evidence`'s signature accepting an unvalidated repo.
+- **Amending `bandit-nosec-comment-hygiene`'s § Deferred**, which says this
+  deferral is "Recorded in `workspace.toml [backlog].open`" — a statement this
+  PR makes false. That spec is **Frozen**, and `docs/CONVENTIONS.md`
+  § *Superseding a frozen document* is explicit that an append is a body edit,
+  however additive it reads. The forward pointer is this spec's `Constrained
+  by:` line; the parent's stale sentence is the accepted residue of the freeze
+  rule, not an oversight.
+- **Using the return value of `_validate_repo` at the call site.** `main`
+  discards it and passes `args.repo` on. Threading the return value through
+  would be tidier but changes nothing — the function raises on every rejected
+  value, so the guard is total either way. Left alone to keep the diff to the
+  guard.

--- a/tools/capture-publish-control-evidence.py
+++ b/tools/capture-publish-control-evidence.py
@@ -60,15 +60,43 @@ class CaptureError(RuntimeError):
     """A live observation could not be made or did not match the contract."""
 
 
+# Two segments of the GitHub-legal character set. Note this admits a leading
+# dot: `owner/.github` is a real repository and must keep working, so the
+# charset is NOT narrowed to "must start alphanumeric" the way
+# lint-spec-status.py's contract-path token is.
+_REPO_RE = re.compile(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+")
+
+# ...which is why the dot-segments are rejected by name instead. These are the
+# RFC 3986 relative segments; every other dotted name (`.github`, `a.b`, `..x`)
+# is a legitimate repository.
+_DOT_SEGMENTS = frozenset({".", ".."})
+
+
 def _validate_repo(repo: str) -> str:
     """Return `repo` if it is a bare `owner/name`, else raise.
 
     Keeps a stray path segment out of the API URLs assembled below, so the
     fixed-scheme guarantee those calls rely on is actually true.
+
+    The charset alone does not do that. `.` and `..` are built from legal
+    characters, so `../..`, `owner/..`, and `./name` all satisfy the two-segment
+    pattern — and `urllib` sends the selector it is given without normalising
+    it, so `f"repos/{repo}/installation"` is sent verbatim — the request is
+    then not for the endpoint the operator named. (Whether GitHub resolves the
+    dot-segments or 404s on them is unverified and does not matter: either way
+    it is not the named read.) No privilege is gained — whoever passes `--repo`
+    already holds the App private key — and the JWT cannot leave
+    `api.github.com`, because the scheme and host are fixed literals and
+    `_NoRedirect` refuses redirects outright. This is hygiene: the evidence
+    artifact should describe the repository it claims to describe.
     """
-    if not re.fullmatch(r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+", repo):
+    if not _REPO_RE.fullmatch(repo):
         raise CaptureError(
             f"--repo must be a bare owner/name, got {repo!r}"
+        )
+    if any(segment in _DOT_SEGMENTS for segment in repo.split("/")):
+        raise CaptureError(
+            f"--repo must not contain a `.` or `..` path segment, got {repo!r}"
         )
     return repo
 
@@ -77,7 +105,12 @@ def _gh_api(path: str) -> object:
     """Return parsed JSON from `gh api <path>`, or raise CaptureError."""
     try:
         completed = subprocess.run(
-            ["gh", "api", path],
+            # `--` terminates flag parsing. Today every caller prefixes the
+            # literal `repos/`, so `path` never starts with `-` and this is
+            # belt-and-braces — but `_validate_repo` does admit a leading-dash
+            # owner (`-h/name` is legal under the charset), so a future caller
+            # passing a bare repo would hand `gh` something it reads as a flag.
+            ["gh", "api", "--", path],
             check=False,
             capture_output=True,
             text=True,

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -334,6 +334,16 @@ def build_check(args: argparse.Namespace) -> int:
             "lint-claude-plugin-publish-control",
             "tools", "lint-claude-plugin-publish-control.py",
         ),
+        # The capture script that produces the evidence the linter above checks
+        # is operator-run, so nothing else exercises its `--repo` guard. That
+        # guard is the only constraint on a value interpolated into the API
+        # paths, and urllib does not normalise the selector it is handed — so
+        # it is worth a gate even though the script itself never runs in CI.
+        # Placed after the self-test/linter pair above, not between them.
+        _script_step(
+            "test-capture-publish-control-evidence",
+            "tools", "test-capture-publish-control-evidence.py",
+        ),
         # Per-site `(path, pattern, expected)` — the sites do not share a
         # pattern, so one repo-wide grep would pass green on most of them.
         _script_step(

--- a/tools/test-capture-publish-control-evidence.py
+++ b/tools/test-capture-publish-control-evidence.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Self-test for tools/capture-publish-control-evidence.py's `--repo` guard.
+
+`_validate_repo` is the only thing standing between an operator-supplied
+`--repo` and the API paths the capture assembles, and `urllib` sends the
+selector it is handed without normalising it. So the guard has to reject RFC
+3986 dot-segments, not merely constrain the character set — `.` and `..` are
+built entirely from legal characters.
+
+The accept cases matter as much as the reject cases, and are the reason this
+guard is not simply "each segment must start alphanumeric": `owner/.github` is
+a real GitHub repository, and a leading dot is legal in a repository name. A
+tightening that broke it would be a regression, not extra safety.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import sys
+import urllib.request
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "capture_publish_control_evidence", _HERE / "capture-publish-control-evidence.py"
+)
+assert _SPEC and _SPEC.loader
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+    else:
+        FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+        print(f"  FAIL {label} {detail}")
+
+
+def rejects(value: str) -> bool:
+    try:
+        _MOD._validate_repo(value)
+    except _MOD.CaptureError:
+        return True
+    return False
+
+
+def main() -> int:
+    print("capture-publish-control-evidence --repo guard self-test")
+
+    # 1. Dot-segments. Each of these satisfies the two-segment character
+    #    pattern, which is exactly why the charset alone was not enough.
+    for value in ("../..", "owner/..", "./name", "../name", "owner/."):
+        check(f"rejects dot-segment {value!r}", rejects(value))
+
+    # 2. The accept set. A leading dot is legal in a GitHub repository name;
+    #    `owner/.github` is the common real case. Rejecting these would be a
+    #    regression introduced in the name of hardening.
+    for value in ("owner/name", "owner/.github", "my-org/my.repo", "a_b/c-d.e", "owner/..x", "owner/x.."):
+        try:
+            check(f"accepts {value!r}", _MOD._validate_repo(value) == value)
+        except _MOD.CaptureError as exc:
+            check(f"accepts {value!r}", False, str(exc))
+
+    # 3. The pre-existing shape checks still hold — the dot-segment rule is
+    #    additive, not a replacement.
+    for value in ("owner", "owner/name/extra", "", "owner/", "/name", "own er/name", "owner/na me"):
+        check(f"rejects malformed {value!r}", rejects(value))
+
+    # 4. The two rules are distinguishable. A dot-segment value must fail with
+    #    the dot-segment message, not the generic shape message, or the
+    #    operator is sent looking for the wrong defect.
+    try:
+        _MOD._validate_repo("owner/..")
+    except _MOD.CaptureError as exc:
+        check("dot-segment error names the real cause", "path segment" in str(exc), str(exc))
+    else:
+        check("dot-segment error names the real cause", False, "did not raise")
+
+    # 5. Scheme/host confinement is not this guard's job, but the capture's
+    #    B310 suppression cites it as its reason, so the reason has to be
+    #    pinned by BEHAVIOUR, not by a substring match on the source. An
+    #    earlier version of this file grepped for `build_opener(_NoRedirect)`
+    #    and passed green with `redirect_request` deleted — at which point
+    #    urllib's default handler forwards the `Authorization: Bearer <jwt>`
+    #    header across an origin change. A gate that cannot detect the removal
+    #    of the control it names is not a gate.
+    request = urllib.request.Request("https://api.github.com/repos/o/n")
+    try:
+        _MOD._NoRedirect().redirect_request(
+            request, None, 302, "Found", {}, "https://evil.example/x"
+        )
+    except _MOD.CaptureError:
+        check("a redirect is refused, not followed", True)
+    except Exception as exc:  # noqa: BLE001
+        check("a redirect is refused, not followed", False, f"raised {type(exc).__name__}")
+    else:
+        check("a redirect is refused, not followed", False, "returned a request")
+
+    # The override must be defined on _NoRedirect itself, not inherited. The
+    # getattr-per-code loop this replaced was a tautology: _NoRedirect
+    # subclasses HTTPRedirectHandler, so every http_error_30x is non-None by
+    # inheritance and the loop stayed green with redirect_request deleted.
+    check("redirect_request is defined on _NoRedirect, not inherited",
+          "redirect_request" in _MOD._NoRedirect.__dict__)
+
+    # ...and the production call site must actually install it. Asserting on a
+    # locally-built opener only tests urllib's handler substitution; changing
+    # _app_api to build_opener() would leave that green while the bearer JWT
+    # follows a 302 to another origin. So capture what _app_api really passes.
+    captured: list = []
+    real_build_opener = _MOD.urllib.request.build_opener
+
+    def _spy(*handlers):
+        captured.extend(handlers)
+        return real_build_opener(*handlers)
+
+    _MOD.urllib.request.build_opener = _spy
+    try:
+        # The network call is expected to fail; only the spy's capture matters.
+        with contextlib.suppress(Exception):
+            _MOD._app_api("repos/o/n/installation", "not-a-real-jwt")
+    finally:
+        _MOD.urllib.request.build_opener = real_build_opener
+    check("_app_api installs _NoRedirect", _MOD._NoRedirect in captured, str(captured))
+
+    # The other half of the B310 rationale: the API base is a fixed literal.
+    # Captured from the Request _app_api actually constructs.
+    seen: list = []
+    real_request = _MOD.urllib.request.Request
+
+    def _request_spy(url, *a, **kw):
+        seen.append(url)
+        return real_request(url, *a, **kw)
+
+    _MOD.urllib.request.Request = _request_spy
+    try:
+        with contextlib.suppress(Exception):
+            _MOD._app_api("repos/o/n/installation", "not-a-real-jwt")
+    finally:
+        _MOD.urllib.request.Request = real_request
+    check("the API base is a fixed https://api.github.com literal",
+          bool(seen) and all(u.startswith("https://api.github.com/") for u in seen), str(seen))
+
+    # 6. `gh api` gets `--`, so a path can never be read as a flag. A
+    #    leading-dash owner passes the charset guard, so this is the control
+    #    that keeps that from mattering. Pinned behaviourally: the spec's own
+    #    Always-do boundary rules out a substring match on the source.
+    argv_seen: list = []
+    real_run = _MOD.subprocess.run
+
+    def _run_spy(argv, *a, **kw):
+        argv_seen.append(argv)
+        return real_run([sys.executable, "-c", "raise SystemExit(1)"], *a, **kw)
+
+    _MOD.subprocess.run = _run_spy
+    try:
+        with contextlib.suppress(_MOD.CaptureError):
+            _MOD._gh_api("repos/o/n")
+    finally:
+        _MOD.subprocess.run = real_run
+    check("gh api terminates flag parsing",
+          bool(argv_seen) and argv_seen[0][:3] == ["gh", "api", "--"], str(argv_seen))
+    try:
+        _MOD._validate_repo("-h/name")
+    except _MOD.CaptureError:
+        check("leading-dash owner is rejected outright", False,
+              "if this ever starts rejecting, drop the `--` rationale above")
+    else:
+        check("leading-dash owner is accepted (hence the `--`)", True)
+
+    print()
+    if FAILURES:
+        print(f"capture-publish-control-evidence self-test: {len(FAILURES)} case(s) failed.")
+        return 1
+    print("capture-publish-control-evidence self-test: all cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -214,6 +214,7 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-publish-claude-plugins.py",
     "tools/test-lint-claude-plugin-publish-control.py",
     "tools/lint-claude-plugin-publish-control.py",
+    "tools/test-capture-publish-control-evidence.py",
     "tools/test-lint-plugin-route-docs.py",
     "tools/lint-plugin-route-docs.py",
     "tools/test-lint-site-scope-parity.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -720,7 +720,6 @@ open = [
   # Unblocks when: picked up — needs a decision on amending a Shipped spec.
   {slug = "phase4b-docsurl-instruction-stale", source = "spec/marketing-docs-link-repair (out of scope)"},
 
-
   # Three XD-chain structural invariants lost their only implementation. The
   # deterministic checker `tools/check-xd-chain.py` and its `xd-chain-gate.yml`
   # workflow are absent from main (readable only from the unreachable commit
@@ -772,7 +771,6 @@ open = [
   #   are the bulk of the work), so this is not a one-line change.
   # Unblocks when: picked up — no dependency.
   {slug = "ci-parity-docs-yml-out-of-scope", source = "spec/local-gate-ci-parity (scope)"},
-
 
   # `tools/lint-catalogue-curation-guard.py`'s path-gate layer exits 0 with only a
   # stderr note when git or the `--base` ref is unavailable. It is now wired into
@@ -845,7 +843,6 @@ open = [
   # wants its own PR. Unblocks when: picked up.
   {slug = "adr-errata-convention", source = "spec/pack-test-boundary-remaining-packs review"},
 
-
   # The repo has no CI for JavaScript that lives in a pack. `web/` and
   # `docs-site/` are covered — pages.yml and pack-evals.yml run npm, and both
   # ship committed lockfiles — but `packs/converters/.apm/skills/render-proof/`
@@ -873,7 +870,6 @@ open = [
   #   the copytree to prune too.
   {slug = "pack-js-ci-workflow", source = "spec/pack-test-boundary-remaining-packs disposition"},
 
-
   # Phase-1 residue from the packages/ marker sweep: the marker sites that are
   # asserted on verbatim. The set itself is enumerated once, in
   # docs/specs/packages-governance-marker-sweep/spec.md AC5 — do not restate it
@@ -898,7 +894,6 @@ open = [
   {slug = "spec-missing-ac-section-policy", source = "spec/spec-ac-gate-and-fixture-domains"},
 
 {slug = "packages-marker-sweep-pinned-strings", source = "spec/packages-governance-marker-sweep AC5"},
-
 
   # workspace-mcp Stage 1 deferred AC. agentbundle Claude adapter additive-merge
   # `permissions.allow` projection for the 6 workspace-mcp MCP tool ids. If the
@@ -927,8 +922,6 @@ open = [
 
   # ── local-scope-install deferred ACs ────────────────────────────────────────
 
-
-
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)
 
@@ -946,7 +939,6 @@ open = [
   #   150-line subdirectory AGENTS.md cap.
   # Unblocks when: picked up — no dependency.
   {slug = "packs-agents-normative-pointer", source = "spec/contracts-readme-governance-sweep AC6"},
-
 
   # docs-site-design-refresh deferral (spec Assumptions). The SCA half
   # (docs-site-npm-sca-gap) was discharged by spec/npm-sca-gate + ADR-0083 —
@@ -1075,7 +1067,6 @@ open = [
   # ── High severity ────────────────────────────────────────────────────────────
   # (security findings or concretely broken behavior with a known internal fix path)
 
-
   # Security (HIGH). NARROWED 2026-08-16 by spec/install-symlink-hardening. The
   # exfiltration primitive itself is closed:
   #   1. `_collect_tree` no longer reads through a symlink. `Path.is_file()`
@@ -1096,7 +1087,6 @@ open = [
   # Unblocks when: picked up — no dependency.
   {slug = "untrusted-catalogue-symlink-exfiltration"},
 
-
   # CI security. spec/pack-activation-evals introduces the repo's first long-lived
   # API-key workflow secret (ANTHROPIC_API_KEY for pack-evals.yml). No secret scanner
   # is wired today (only CodeQL + Bandit/Semgrep). Adjacent gaps: actionlint + zizmor
@@ -1109,7 +1099,6 @@ open = [
   # File: .github/workflows/pack-evals.yml
   # Unblocks when: a concrete path to npm global-install integrity verification is found.
   {slug = "pack-evals-npm-lockfile-integrity", source = "spec/secret-scanner-for-api-key-workflows AC Assumption 5"},
-
 
   # spec/shared-prefix-aware-multi-adapter-install follow-on (reviewer Concern).
   # install routes state RMW through statelock.persist_state_locked (concurrency AC).
@@ -1143,7 +1132,6 @@ open = [
   #   and flag the missing hash field as the AST09 closure condition in agentic-skills.md.
   # Unblocks when: a governance RFC or install-marker schema extension closes the gap.
   {slug = "skill-governance-inventory-gap"},
-
 
   # ── Medium effort, internal ──────────────────────────────────────────────────
   # (no external environment; needs a focused session or an RFC decision)
@@ -1234,7 +1222,6 @@ open = [
   #   generated: true and must not be edited directly).
   # Unblocks when: spec/product-engineering-shaping-doctrine is Shipped.
   {slug = "digital-experience-contract-pe-journey-xref", source = "spec/digital-experience-contract AC15", needs = "ini-003:work:spec/product-engineering-shaping-doctrine"},
-
 
   # ini-003 follow-on. After the Digital Experience Doctrine initiative ships, the four
   # packs (product-strategy, product-engineering, experience-design, core) form a coherent
@@ -1628,6 +1615,20 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
+  # The publication-control evidence artifact records NO repository field:
+  # build_evidence emits version, branch, app, environment, identities_agree,
+  # canary, observed_at, observation_source -- and the committed
+  # docs/specs/claude-plugin-hook-parity/publish-control-evidence.json has no
+  # repo. So nothing binds the evidence to a subject, and running the capture
+  # against a different, well-configured repo yields a byte-indistinguishable
+  # artifact. capture-evidence-repo-dot-segments closed ONE route to a
+  # wrong-subject capture (dot-segment traversal); this is the wider gap it
+  # deliberately did not close, surfaced in that spec's Honest scope section.
+  # Fix: record the observed repo in the evidence document and have
+  # lint-claude-plugin-publish-control.py compare it against the repository the
+  # artifact is committed in. That is a schema change, hence its own PR.
+  {slug = "publish-control-evidence-not-repo-bound", summary = "Record the observed repository in the publish-control evidence artifact and have the linter check it matches the committing repo", source = "spec/capture-evidence-repo-dot-segments"},
+
   # build-check.yml installs tools/requirements-sast.txt only when
   # skip_sast != 'true', so on a SKIP_SAST PR bandit is absent and
   # lint-nosec-form's unknown-id check (a well-formed but nonexistent ID like a
@@ -1689,16 +1690,6 @@ open = [
   # this spec is then its first caller.
   {slug = "bandit-hygiene-known-skip-dangling-pointer", summary = "Annotate bandit-nosec-comment-hygiene's § Known skip to record that its register entry was closed, using the frozen-doc mechanism from frozen-spec-supersession-convention", source = "spec/guides-readme-outcome-label-drift"},
 
-  # tools/capture-publish-control-evidence.py:_validate_repo accepts
-  # `[A-Za-z0-9._-]+/[A-Za-z0-9._-]+`, which matches `../..`; urllib sends the
-  # selector unnormalised, so `--repo ../../app` reaches a different
-  # api.github.com endpoint than the caller named. No privilege gain (the
-  # operator already holds the App private key) and the JWT still cannot leave
-  # api.github.com -- the scheme and host are fixed literals and _NoRedirect
-  # refuses redirects outright -- so this is hygiene, not a live hole. Fix is a
-  # dot-segment reject in _validate_repo plus a case in its test.
-  {slug = "capture-evidence-repo-dot-segments", summary = "Reject `.` and `..` path segments in capture-publish-control-evidence.py's _validate_repo so a --repo value cannot redirect the App-authenticated read to another endpoint", source = "spec/bandit-nosec-comment-hygiene"},
-
   # test-loop-cohort.sh is 493 lines / 51 cases of bash and uses ~20 bash-isms
   # ([[, local, $(), declare). AGENTS.md's "New tool scripts: Python, not bash"
   # rule grandfathers existing .sh, but this one is a portability dead end: a
@@ -1718,8 +1709,6 @@ open = [
   # the port -- it spawns a Python subprocess per case and invokes the
   # large test_loop_cohort.py suite as one of them.
   {slug = "loop-cohort-shell-suite-to-python", summary = "Port test-loop-cohort.sh (493 lines, 51 sequential cases) to pure-stdlib Python so it runs on Windows, decoupling the shared-counter fixtures and profiling its >10min runtime", source = "spec/pack-script-root-boundary-validation"},
-
-
 
   # Deliberately NOT backlogged: extending SAST_DIRS to web/ (62 JS/TS/Astro
   # files). Decided 2026-08-07 — web/ is the platform site, built and deployed
@@ -1815,7 +1804,6 @@ open = [
   # documentation-entry-navigation work: changing the allowlist is an engine
   # and release-boundary decision. Unblocks: now; no tracked prerequisite.
   {slug = "catalogue-package-guides", source = "spec/documentation-entry-navigation"},
-
 
   # A full generated-HTML crawl performed after the documentation-entry
   # navigation build found 67 older unresolved internal targets across 53,871


### PR DESCRIPTION
## What does this change?

`_validate_repo` in `tools/capture-publish-control-evidence.py` now rejects `.` and `..` path segments. Adds `tools/test-capture-publish-control-evidence.py` (the script had no test at all) and wires it into the `build-check` chain.

## Why?

The guard accepted `[A-Za-z0-9._-]+/[A-Za-z0-9._-]+`. `.` and `..` are built entirely from that character set, and `urllib` sends the selector unnormalised — `Request("https://api.github.com/repos/../../app/installation").selector` is that string verbatim. So a `--repo` value could make the capture read an endpoint other than the one the operator named.

Spec: `docs/specs/capture-evidence-repo-dot-segments/spec.md`

### Scoped honestly — this is hygiene, not a live hole

- **No privilege is gained.** Whoever passes `--repo` already holds the App private key the script requires.
- **The JWT cannot leave `api.github.com`** — but that covers only one of two transports. `_app_api` (the JWT leg) hard-codes scheme and host and installs `_NoRedirect`. The other **five** reads go through `gh api` with the operator's OAuth token, where confinement rests on `gh`'s own client, not on anything in this file.
- **What is actually wrong is narrower than it looks.** The evidence document records **no repository field at all**, so nothing binds it to a subject — `--repo other-org/well-configured-repo` still yields a byte-indistinguishable artifact. This closes one wrong-subject route; it does not make the artifact trustworthy about its subject. Recorded as `publish-control-evidence-not-repo-bound`.

### Two corrections to the brief

- **`--repo ../../app` was already rejected** — three segments, and the pattern is a two-segment `fullmatch`. The reachable values are `../..`, `owner/..`, `./name`, `../name`, `owner/.`. The spec carries a corrected table produced by running `re.fullmatch` and `.selector`, not by reading.
- **Not "each segment must start alphanumeric"** (as `lint-spec-status.py` guards its contract paths): **`owner/.github` is a real GitHub repository**. Narrowing the charset would reject a valid target in the name of hardening. Dot-segments are rejected by name; `.github`, `a.b`, `..x`, `x..` all keep working, and the test asserts that as hard as it asserts the rejections.

## How do I verify it?

```
python3 tools/test-capture-publish-control-evidence.py   # all cases
SKIP_SAST=1 make build-check && make sast                # both exit 0
```

**Mutation-tested — and this is the finding I'd most want reviewed.** The first version pinned the `# nosec B310` rationale with substring greps over the source. Deleting `redirect_request` from `_NoRedirect` left the self-test fully green *while urllib's default handler would forward `Authorization: Bearer <jwt>` across an origin change*. A gate that cannot detect removal of the control it names is not a gate. All three pins are now behavioural and each fails its mutation:

| mutation | now caught by |
| --- | --- |
| `redirect_request` deleted | `redirect_request` must raise, and be in `_NoRedirect.__dict__` (not inherited) |
| `build_opener(_NoRedirect)` → `build_opener()` | `build_opener` is spied; `_app_api` must pass `_NoRedirect` |
| API base → `evil.example` | `Request` is spied; every URL must start `https://api.github.com/` |
| `"gh", "api", path` (no `--`) | `subprocess.run` is spied; `argv[:3]` asserted |

## What did you not change that you considered?

- **Amending `bandit-nosec-comment-hygiene`'s § Deferred**, which now says something false. That spec is **Frozen** (`CONVENTIONS.md` § Document lifecycle: bodies cannot change), and an append is a body edit. The sibling PR `eugenelim/frozen-spec-supersession` makes that explicit.
- **Percent-encoding the segments** instead of rejecting them — a repository named `..` does not exist, so it buys a confusing 404 in place of a clear error.

## Bundled fixes

- `gh api` gains `--` before the path. Every caller prefixes `repos/`, so nothing is exploitable today, but a leading-dash owner (`-h/name`) **does** pass the charset guard, and a future caller passing a bare repo would hand `gh` something it reads as a flag.