### PR TITLE
docs(conventions): write down how a frozen document is superseded

### DIFF
--- a/.agents/skills/new-spec/assets/plan.md
+++ b/.agents/skills/new-spec/assets/plan.md
@@ -4,9 +4,11 @@
 - **Status:** Drafting <!-- Drafting | Approved | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
-> document is allowed to change as you learn. When it changes substantially
-> (a different approach, not just a re-ordering), note why in the changelog
-> at the bottom.
+> document is allowed to change as you learn — while its Status is `Drafting`
+> or `Executing`. When it changes substantially (a different approach, not just
+> a re-ordering), note why in the changelog at the bottom. Once it is `Done`
+> and the spec is `Shipped`, the directory freezes as a unit
+> (`docs/CONVENTIONS.md` § Document lifecycle).
 
 <!-- **Light-mode lean fill.** For low-risk work running the `work-loop`
 skill's light mode, only Approach + a short Tasks list are required.

--- a/.claude/skills/new-spec/assets/plan.md
+++ b/.claude/skills/new-spec/assets/plan.md
@@ -4,9 +4,11 @@
 - **Status:** Drafting <!-- Drafting | Approved | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
-> document is allowed to change as you learn. When it changes substantially
-> (a different approach, not just a re-ordering), note why in the changelog
-> at the bottom.
+> document is allowed to change as you learn — while its Status is `Drafting`
+> or `Executing`. When it changes substantially (a different approach, not just
+> a re-ordering), note why in the changelog at the bottom. Once it is `Done`
+> and the spec is `Shipped`, the directory freezes as a unit
+> (`docs/CONVENTIONS.md` § Document lifecycle).
 
 <!-- **Light-mode lean fill.** For low-risk work running the `work-loop`
 skill's light mode, only Approach + a short Tasks list are required.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -108,6 +108,84 @@ gives you decision history *without* the burden of keeping it in sync.
 Living docs can be honest about the present because they don't have to
 also be a record of how we got here. That's what ADRs are for.
 
+### A spec directory freezes as a unit, when the spec ships
+
+`shipped specs/*` above means the whole directory — `spec.md` **and** `plan.md`.
+This needs saying because the plan template's own contract line reads "Unlike
+the spec, this document is allowed to change as you learn", which sounds like a
+standing exemption and is not one. That licence is **phase-scoped**: it holds
+while the plan is `Drafting` or `Executing` — while there is still something to
+learn. Once the plan is `Done` and the spec is `Shipped`, the work is over and
+both documents are history. A plan that stayed editable forever would be a
+second, unversioned account of what we did, competing with the ADR that records
+why.
+
+So: before ship, the plan is Living and you edit it freely. After ship, it is
+Frozen and gets exactly the same treatment as its spec.
+
+### Superseding a frozen document
+
+A later decision often reverses part of an earlier one. The earlier document
+still describes what was true when it shipped, so it is not wrong — but a
+reader who starts there must not be left following a rule we no longer keep.
+
+**The pointer goes in the `Status` field, and only there.** That is the one
+field this table already makes mutable on a frozen document, so no new
+exemption is needed. Form:
+
+```
+- **Status:** Shipped (superseded in part by ADR-NNNN — <what changed>; everything else stands)
+- **Status:** Done (superseded in part by ADR-NNNN — <what changed>; everything else stands)   # plan.md
+```
+
+Four rules, each earning its place:
+
+1. **Say "in part" and say which part.** A bare "superseded" invites a reader
+   to discard a document that is mostly still correct.
+2. **Point at the ADR, not at the spec that implemented it.** The ADR is the
+   decision record and is where the reasoning lives.
+3. **Annotate both ends — between ADRs.** The superseding ADR names what it
+   supersedes; the superseded ADR points forward. A one-way pointer only helps
+   readers who already arrived from the right side.
+
+   The **spec end is deliberately one-way**: ADRs do not cite specs (see
+   § *Cite upward*), so a superseded spec points at the ADR and the ADR does not
+   point back. That is the intended asymmetry, not a gap to close.
+4. **Do not change the body's meaning — including "just adding a line".** An
+   append is a body edit. The residue is real and accepted: someone who greps
+   mid-file still lands on the old rule with no pointer in view. The mitigation
+   is that the *operative* instruction lives in a Living file at the point of
+   use (a config header, a linter's message), not that the frozen record is
+   patched.
+
+   **Carve-out: meaning-preserving mechanical rewrites are allowed** — a path
+   or link rename, a moved file's reference, a repo-wide identifier change.
+   `84d79223` ("lift `docs/guides/` to `guides/`") rewrote references across
+   156 files under `docs/specs/`, shipped specs included, and was right to.
+   What freezes is the *record of the decision*, not the spelling of a path
+   that has since moved; a frozen document with dangling links is a worse
+   record, not a purer one. The test is whether a reader's understanding of
+   what was decided changes. If it does, it is not mechanical.
+
+These four rules are **convention-enforced, not machine-enforced**: the linter
+checks the status token's vocabulary and nothing else. A reviewer is the only
+thing standing between a supersession and a one-way, unscoped, or body-editing
+annotation.
+
+**Not `Constrained by:`.** It is the better semantic fit — it is the field that
+cites governing decisions — but it is a record of what governed the spec *at
+ship time*, and that record is still accurate. Editing it would rewrite history
+rather than annotate it, and would extend mutability to a second field for no
+gain. (`Constrained by:` *can* carry a supersession clause —
+`docs/specs/copilot-full-parity/spec.md` does exactly that — so the argument is
+that `Status` is the shorter carrier already licensed here, not that it is the
+only one capable of it.)
+
+The work-loop's `lint-spec-status.py` reads only the leading token (it
+truncates at the delimiters listed in § *Spec metadata contract*), so the
+annotated form still satisfies invariant (i). Confirm that by running it against
+the edited file, not by trusting this paragraph.
+
 ---
 
 ## 1. Charter — `docs/CHARTER.md`
@@ -266,14 +344,18 @@ on, so the criteria pin what's actually intended.)
 **`plan.md` is the implementation strategy.** It enumerates the changes —
 "add a `<thing>` to package X, modify `<other thing>` in package Y, write tests
 for cases A, B, C". It's the work-breakdown for the spec. It is allowed to
-change as you learn things.
+change as you learn things — **while the plan is `Drafting` or `Executing`**.
+Once it is `Done` and the spec `Shipped`, the directory freezes as a unit; see
+§ *A spec directory freezes as a unit, when the spec ships*.
 
 **Lifecycle:** specs are **living documents** for the duration of a feature's
 implementation. If implementation diverges from the spec, the spec is wrong;
-update it in the same PR. After the feature ships, the spec stays as
-documentation of the feature's contract — but at that point the *code is the
-truth*, and the spec is reference material that should be updated alongside
-behavior changes.
+update it in the same PR. After the feature ships the spec **freezes**: at that
+point the *code is the truth*, and the spec becomes the record of what was
+agreed, not a description of current behaviour. A later behaviour change is
+recorded where it belongs — in the code, and in an ADR if it reverses a
+decision — never by rewriting the shipped spec. When a later decision reverses
+part of one, annotate its Status field; see § *Superseding a frozen document*.
 
 Guards, pre-checks, and invariant-enforcement added during implementation are
 ACs, not implementation details — if they affect observable behavior (exit
@@ -300,6 +382,14 @@ mechanical rule.
   `Draft | Approved | Implementing | Shipped | Archived`. (Plans carry their own
   vocabulary, `Drafting | Approved | Executing | Done` — a separate field, separate set.)
   Approved means the spec/plan contract has received human approval. In `spec.md` it means the scope is accepted; in `plan.md` it means the implementation strategy is accepted. Before code changes begin, an implementation run moves `spec.md` to `Implementing`.
+  There is **no `Superseded` token**, and `Archived` is not a substitute — a
+  superseded spec usually shipped and is still live. A supersession is recorded
+  as a parenthetical *annotation* on the existing token
+  (`Shipped (superseded in part by ADR-NNNN — …)`), which is the only edit a
+  frozen spec accepts. Form and rules:
+  [§ Superseding a frozen document](#superseding-a-frozen-document).
+  The linter reads only the leading token — it truncates at the first ` (`,
+  ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
 - **Deferral token.** A criterion that ships *unmet on purpose* is not left

--- a/docs/specs/frozen-spec-supersession/spec.md
+++ b/docs/specs/frozen-spec-supersession/spec.md
@@ -1,0 +1,227 @@
+# Spec: frozen-spec-supersession
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — see § Named deviation
+- **Mode:** full (governance surface — it writes a rule into
+  `docs/CONVENTIONS.md`, the repo's source of truth for document lifecycle, and
+  annotates two frozen documents)
+- **Constrained by:**
+[ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md)
+  (the supersession being recorded);
+  [ADR-0027](../../adr/0027-adr-format-is-madr-aligned-but-lean.md)
+- **Contract:** none
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Named deviation from full mode
+
+The `loop-engine` / `loop-cohort` state machine was not run, and there is no
+`plan.md`. The two human approval gates it sequences were **granted up front by the
+requester** as a standing instruction to carry this through to merge.
+`adversarial-reviewer`
+was run.
+
+## Objective
+
+ADR-0084 reversed ADR-0017's Bandit suppression-comment form. ADR-0017's Status
+line already carries a partial-amendment pointer to it. Its **implementing
+spec** does not — and that spec and plan are where the old form is actually
+taught, at nine sites — three in `spec.md`, six in `plan.md`. A reader who
+starts there follows a rule the repo no
+longer keeps.
+
+The two file edits are the trivial half. The durable half is writing down the
+mechanism, so the next frozen-doc supersession is not decided from scratch.
+
+## Decision 1 — the carrier is the `Status` field, not `Constrained by:`
+
+`Constrained by:` is the better *semantic* fit: it is the field that cites the
+ADRs governing a spec, and ADR-0084 now governs this one. It was still
+rejected, for four reasons:
+
+1. **No new exemption is needed.** `CONVENTIONS.md` § Document lifecycle already
+   makes `Status` mutable on a frozen document ("Status fields can change
+   (Accepted → Superseded), bodies cannot"). Using `Constrained by:` would
+   extend body-mutability to a second field — an extension of the rule rather
+   than an application of it, to say something `Status` already says.
+2. **It matches the precedent at the other end of the pointer.** ADR-0017 itself
+   was annotated on its Status line, as were ADR-0001, 0013, 0015 and 0016. One
+   mechanism at both ends beats two.
+3. **`Status` is the shorter carrier for "in part".** Not the only one —
+   `docs/specs/copilot-full-parity/spec.md:6` carries a `supersedes-in-part`
+   clause inside its `Constrained by:` field, so the field demonstrably can
+   express it. But it does so in a long parenthetical inside a citation list,
+   where `Status` says it in five words at the top of the document. (An earlier
+   draft of this spec claimed only `Status` *could*; that was wrong, and is
+   corrected here rather than quietly dropped.)
+4. **`Constrained by: ADR-0017` is still true.** It records what governed the
+   spec when it shipped. Amending it would rewrite history; annotating `Status`
+   adds to it.
+
+## Decision 2 — a shipped `plan.md` is frozen, and the ambiguity was the defect
+
+`CONVENTIONS.md:103` puts "shipped `specs/*`" in the Frozen class, which reads
+as the whole directory. The plan template's own contract line says "Unlike the
+spec, this document is allowed to change as you learn." Those appear to
+conflict, and an agent resolving it in the moment could go either way.
+
+**Resolution: the licence is phase-scoped, not standing.** "As you learn" holds
+while the plan is `Drafting` or `Executing` — while there is still something to
+learn. Once the plan is `Done` and the spec `Shipped`, the work is over and both
+are history. A plan editable forever would be a second, unversioned account of
+what we did, competing with the ADR that records why.
+
+So the plan is Living before ship and Frozen after, and gets the same Status
+annotation as its spec. Both readings are now written into `CONVENTIONS.md`,
+which is Living — **the ambiguity itself was the real defect**, and fixing it
+there is the durable half of this change.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the spec carries the pointer.**
+      `docs/specs/sast-sca-tooling/spec.md`'s Status line reads
+      `Shipped (superseded in part by ADR-0084 — …; everything else stands)`,
+      linking the ADR. No body line changes.
+
+- [x] **AC2 — the plan carries it too.** Same *form* of annotation (its own
+      wording, naming task T3) on
+      `docs/specs/sast-sca-tooling/plan.md`'s `Done` status, per Decision 2. No
+      body line changes.
+
+- [x] **AC3 — the status token still parses.** `parse_status` from
+      `lint-spec-status.py`, run against the *edited* file, returns exactly
+      `Shipped` — confirmed by construction, not inferred from the docstring —
+      and `lint-spec-status.py --root . --base-ref origin/main` exits 0 with
+      invariant (i) clean.
+
+- [x] **AC4 — the general rule is written down.** `docs/CONVENTIONS.md`
+      § Document lifecycle gains § *Superseding a frozen document*: the Status
+      carrier, the form for both `spec.md` and `plan.md`, the four rules
+      (say "in part"; point at the ADR; annotate both ends; never touch the
+      body), and the explicit rejection of `Constrained by:` with its reason.
+
+- [x] **AC5 — the freeze unit is disambiguated.** The same section states that a
+      spec directory freezes as a unit and that the plan's "allowed to change"
+      licence is phase-scoped, so the two statements no longer appear to
+      conflict.
+
+- [x] **AC6 — § Spec metadata contract points at it.** The status-vocabulary
+      bullet records that there is no `Superseded` token, that `Archived` is not
+      a substitute, and that a supersession is an annotation on the existing
+      token — with a link to the lifecycle section.
+
+- [x] **AC7 — the projected copy matches its source.** `docs/CONVENTIONS.md` is
+      a projection of `packs/core/seeds/docs/CONVENTIONS.md`; both carry the
+      change byte-identically, so `catalogue verify`'s drift check passes.
+
+- [x] **AC4b — the rule does not forbid maintenance the repo performs.** Rule 4
+      carves out meaning-preserving mechanical rewrites (path/link renames).
+      Without it the convention would have forbidden `84d79223`, which rewrote
+      references across 156 files under `docs/specs/` including shipped ones,
+      and would block fixing `lint-spec-status.py`'s current invariant-(iii)
+      warnings on a frozen spec.
+
+- [x] **AC4c — the file no longer contradicts itself.** Two other sentences in
+      `CONVENTIONS.md` carried the same ambiguity and are amended with it: the
+      unconditional plan licence, and "the spec is reference material that
+      should be updated alongside behavior changes" — which flatly contradicted
+      the Frozen row. Fixing one copy and leaving two would have left the defect
+      Decision 2 exists to remove.
+
+- [x] **AC4d — the template is fixed at source.** The plan template's contract
+      line — the text an author actually reads — now carries the phase scope, in
+      `packs/core/.apm/skills/new-spec/assets/plan.md` and both projections.
+
+- [x] **AC8 — gates pass.** `SKIP_SAST=1 make build-check` exits 0 and
+      `lint-spec-status.py` reports `spec metadata clean`.
+
+- [x] **AC9 — other candidates are surveyed, not fixed.** § Survey below records
+      every shipped spec that cites a superseded ADR and carries no pointer.
+
+## Survey — other frozen documents in the same position
+
+Asked for as a sanity check; **deliberately not fixed here**.
+
+**Teaching reversed content: only this one.** Grepping every `docs/**.md` for
+the reversed suppression form finds it in four locations
+(`sast-sca-tooling/` counted as one, since it spans spec and plan): ADR-0017 and
+ADR-0084 (which quote it while explaining the reversal — correct usage),
+`bandit-nosec-comment-hygiene/spec.md` (same), and
+`docs/specs/sast-sca-tooling/`. Note the brief listed one occurrence in
+`spec.md`; there are three (`:44`, `:147`, `:154`), plus six in `plan.md`
+(`:146`, `:151`, `:154`, `:159`, `:161`, `:164` — all inside task T3).
+That does not change the work — bodies stay frozen and one Status annotation
+covers the document — but the annotation covers more than expected.
+
+**Citing a superseded ADR without a pointer: 12 specs.** Scan scope matters:
+this counts the `- **Constrained by:**` header only, not body mentions — a
+plain grep returns roughly twice as many. A weaker signal, since
+citing ADR-0017 does not mean a spec teaches the reversed spelling — most cite
+it for the gate itself, which stands. Recorded for whoever picks this up:
+
+| Superseded → by | Specs citing it with no pointer |
+| --- | --- |
+| ADR-0017 → ADR-0084 | `infra-aware-work-loop`, `local-gate-ci-parity`, `npm-sca-gate`, `operational-safety-checklists`, `security-reviewer-shift-left` |
+| ADR-0023 → ADR-0042 | `architect-design-reviewer`, `infra-grounding`, `operational-safety-checklists` |
+| ADR-0013/0015/0016 → ADR-0040 | `copilot-full-parity`, `copilot-skills-and-web`, `cursor-full-parity`, `gemini-full-parity` |
+
+Not fixed here because the fix is **not** identical: each needs a judgment about
+whether the superseded sub-decision is one that spec relied on, and ADR-0040 and
+ADR-0042 supersede different sub-decisions than ADR-0084 does. Doing them
+mechanically would stamp "superseded in part" onto specs that are wholly
+unaffected, which is worse than no annotation. Recorded as
+`frozen-spec-supersession-survey`.
+
+## Boundaries
+
+### Always do
+
+- Always annotate both ends: the superseding ADR names what it supersedes, and
+  the superseded document points forward.
+- Always keep the projected `docs/CONVENTIONS.md` byte-identical to its seed.
+
+### Ask first
+
+- Ask before annotating a frozen document whose superseded sub-decision it may
+  not actually rely on. A false "superseded in part" is worse than silence.
+
+### Never do
+
+- Never edit the body of a frozen document, including an "additive" append.
+- Never introduce a `Superseded` status token; the vocabulary is closed and the
+  linter enforces it.
+- Never use `Archived` for a superseded spec — the feature shipped and is live.
+
+## Testing Strategy
+
+Goal-based; the linter is the gate:
+
+- `parse_status` run against the edited `spec.md` returns `Shipped`. Executed,
+  not inferred — the brief asked for confirmation by construction and the
+  docstring alone would not have proven the annotation's link syntax is safe.
+- `lint-spec-status.py --root . --base-ref origin/main` → exit 0,
+  `spec metadata clean`.
+- `SKIP_SAST=1 make build-check` → exit 0, including `catalogue verify`'s
+  seed↔projection drift check, which is what caught the first attempt editing
+  only the projection.
+
+## Assumptions
+
+- `plan.md` status is out of `lint-spec-status.py`'s v1 scope, so the plan
+  annotation is unenforced by the linter. Stated rather than relied on: the
+  plan's form matches the spec's so that a future v2 extension needs no
+  migration.
+
+## Declined
+
+- **Adding a `Superseded` token to the status vocabulary.** It would need a
+  linter change, a migration of the existing annotated statuses, and a decision
+  about what "superseded in part" means as a single token. The annotation
+  carries strictly more information for no schema change.
+- **Amending the frozen bodies at their nine sites.** Forbidden, and the
+  operative instruction already lives in `bandit.yaml`'s header — a Living file,
+  at the point of use.
+- **Fixing the 12 surveyed specs.** See § Survey.

--- a/docs/specs/sast-sca-tooling/plan.md
+++ b/docs/specs/sast-sca-tooling/plan.md
@@ -1,7 +1,7 @@
 # Plan: SAST/SCA tooling (Bandit + pip-audit + Semgrep)
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Done <!-- Drafting | Executing | Done -->
+- **Status:** Done (superseded in part by [ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md) — the Bandit suppression-comment form used throughout task T3's Approach was reversed; everything else stands) <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/sast-sca-tooling/spec.md
+++ b/docs/specs/sast-sca-tooling/spec.md
@@ -1,6 +1,6 @@
 # Spec: SAST/SCA tooling (Bandit + pip-audit + Semgrep)
 
-- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (superseded in part by [ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md) — the Bandit suppression-comment form this spec teaches was reversed; everything else stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0017

--- a/packs/core/.apm/skills/new-spec/assets/plan.md
+++ b/packs/core/.apm/skills/new-spec/assets/plan.md
@@ -4,9 +4,11 @@
 - **Status:** Drafting <!-- Drafting | Approved | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
-> document is allowed to change as you learn. When it changes substantially
-> (a different approach, not just a re-ordering), note why in the changelog
-> at the bottom.
+> document is allowed to change as you learn — while its Status is `Drafting`
+> or `Executing`. When it changes substantially (a different approach, not just
+> a re-ordering), note why in the changelog at the bottom. Once it is `Done`
+> and the spec is `Shipped`, the directory freezes as a unit
+> (`docs/CONVENTIONS.md` § Document lifecycle).
 
 <!-- **Light-mode lean fill.** For low-risk work running the `work-loop`
 skill's light mode, only Approach + a short Tasks list are required.

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -108,6 +108,84 @@ gives you decision history *without* the burden of keeping it in sync.
 Living docs can be honest about the present because they don't have to
 also be a record of how we got here. That's what ADRs are for.
 
+### A spec directory freezes as a unit, when the spec ships
+
+`shipped specs/*` above means the whole directory — `spec.md` **and** `plan.md`.
+This needs saying because the plan template's own contract line reads "Unlike
+the spec, this document is allowed to change as you learn", which sounds like a
+standing exemption and is not one. That licence is **phase-scoped**: it holds
+while the plan is `Drafting` or `Executing` — while there is still something to
+learn. Once the plan is `Done` and the spec is `Shipped`, the work is over and
+both documents are history. A plan that stayed editable forever would be a
+second, unversioned account of what we did, competing with the ADR that records
+why.
+
+So: before ship, the plan is Living and you edit it freely. After ship, it is
+Frozen and gets exactly the same treatment as its spec.
+
+### Superseding a frozen document
+
+A later decision often reverses part of an earlier one. The earlier document
+still describes what was true when it shipped, so it is not wrong — but a
+reader who starts there must not be left following a rule we no longer keep.
+
+**The pointer goes in the `Status` field, and only there.** That is the one
+field this table already makes mutable on a frozen document, so no new
+exemption is needed. Form:
+
+```
+- **Status:** Shipped (superseded in part by ADR-NNNN — <what changed>; everything else stands)
+- **Status:** Done (superseded in part by ADR-NNNN — <what changed>; everything else stands)   # plan.md
+```
+
+Four rules, each earning its place:
+
+1. **Say "in part" and say which part.** A bare "superseded" invites a reader
+   to discard a document that is mostly still correct.
+2. **Point at the ADR, not at the spec that implemented it.** The ADR is the
+   decision record and is where the reasoning lives.
+3. **Annotate both ends — between ADRs.** The superseding ADR names what it
+   supersedes; the superseded ADR points forward. A one-way pointer only helps
+   readers who already arrived from the right side.
+
+   The **spec end is deliberately one-way**: ADRs do not cite specs (see
+   § *Cite upward*), so a superseded spec points at the ADR and the ADR does not
+   point back. That is the intended asymmetry, not a gap to close.
+4. **Do not change the body's meaning — including "just adding a line".** An
+   append is a body edit. The residue is real and accepted: someone who greps
+   mid-file still lands on the old rule with no pointer in view. The mitigation
+   is that the *operative* instruction lives in a Living file at the point of
+   use (a config header, a linter's message), not that the frozen record is
+   patched.
+
+   **Carve-out: meaning-preserving mechanical rewrites are allowed** — a path
+   or link rename, a moved file's reference, a repo-wide identifier change.
+   `84d79223` ("lift `docs/guides/` to `guides/`") rewrote references across
+   156 files under `docs/specs/`, shipped specs included, and was right to.
+   What freezes is the *record of the decision*, not the spelling of a path
+   that has since moved; a frozen document with dangling links is a worse
+   record, not a purer one. The test is whether a reader's understanding of
+   what was decided changes. If it does, it is not mechanical.
+
+These four rules are **convention-enforced, not machine-enforced**: the linter
+checks the status token's vocabulary and nothing else. A reviewer is the only
+thing standing between a supersession and a one-way, unscoped, or body-editing
+annotation.
+
+**Not `Constrained by:`.** It is the better semantic fit — it is the field that
+cites governing decisions — but it is a record of what governed the spec *at
+ship time*, and that record is still accurate. Editing it would rewrite history
+rather than annotate it, and would extend mutability to a second field for no
+gain. (`Constrained by:` *can* carry a supersession clause —
+`docs/specs/copilot-full-parity/spec.md` does exactly that — so the argument is
+that `Status` is the shorter carrier already licensed here, not that it is the
+only one capable of it.)
+
+The work-loop's `lint-spec-status.py` reads only the leading token (it
+truncates at the delimiters listed in § *Spec metadata contract*), so the
+annotated form still satisfies invariant (i). Confirm that by running it against
+the edited file, not by trusting this paragraph.
+
 ---
 
 ## 1. Charter — `docs/CHARTER.md`
@@ -266,14 +344,18 @@ on, so the criteria pin what's actually intended.)
 **`plan.md` is the implementation strategy.** It enumerates the changes —
 "add a `<thing>` to package X, modify `<other thing>` in package Y, write tests
 for cases A, B, C". It's the work-breakdown for the spec. It is allowed to
-change as you learn things.
+change as you learn things — **while the plan is `Drafting` or `Executing`**.
+Once it is `Done` and the spec `Shipped`, the directory freezes as a unit; see
+§ *A spec directory freezes as a unit, when the spec ships*.
 
 **Lifecycle:** specs are **living documents** for the duration of a feature's
 implementation. If implementation diverges from the spec, the spec is wrong;
-update it in the same PR. After the feature ships, the spec stays as
-documentation of the feature's contract — but at that point the *code is the
-truth*, and the spec is reference material that should be updated alongside
-behavior changes.
+update it in the same PR. After the feature ships the spec **freezes**: at that
+point the *code is the truth*, and the spec becomes the record of what was
+agreed, not a description of current behaviour. A later behaviour change is
+recorded where it belongs — in the code, and in an ADR if it reverses a
+decision — never by rewriting the shipped spec. When a later decision reverses
+part of one, annotate its Status field; see § *Superseding a frozen document*.
 
 Guards, pre-checks, and invariant-enforcement added during implementation are
 ACs, not implementation details — if they affect observable behavior (exit
@@ -300,6 +382,14 @@ mechanical rule.
   `Draft | Approved | Implementing | Shipped | Archived`. (Plans carry their own
   vocabulary, `Drafting | Approved | Executing | Done` — a separate field, separate set.)
   Approved means the spec/plan contract has received human approval. In `spec.md` it means the scope is accepted; in `plan.md` it means the implementation strategy is accepted. Before code changes begin, an implementation run moves `spec.md` to `Implementing`.
+  There is **no `Superseded` token**, and `Archived` is not a substitute — a
+  superseded spec usually shipped and is still live. A supersession is recorded
+  as a parenthetical *annotation* on the existing token
+  (`Shipped (superseded in part by ADR-NNNN — …)`), which is the only edit a
+  frozen spec accepts. Form and rules:
+  [§ Superseding a frozen document](#superseding-a-frozen-document).
+  The linter reads only the leading token — it truncates at the first ` (`,
+  ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
 - **Deferral token.** A criterion that ships *unmet on purpose* is not left

--- a/workspace.toml
+++ b/workspace.toml
@@ -1615,6 +1615,19 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
+  # 12 shipped specs cite an ADR that a later ADR superseded, with no forward
+  # pointer on their Status line. Surveyed in docs/specs/frozen-spec-supersession
+  # (see its Survey table) and deliberately NOT fixed there, because the fix is
+  # not mechanical: citing ADR-0017 does not mean a spec taught the reversed
+  # nosec spelling -- most cite it for the gate itself, which stands. Each needs
+  # a judgment about whether the superseded SUB-decision is one that spec relied
+  # on, and ADR-0040/0042 supersede different sub-decisions than ADR-0084 does.
+  # Stamping "superseded in part" onto specs that are wholly unaffected is worse
+  # than no annotation.
+  # The mechanism to apply is now written down: CONVENTIONS.md
+  # "Superseding a frozen document". Work is the judgment, not the edit.
+  {slug = "frozen-spec-supersession-survey", summary = "Decide, per spec, whether each of the 12 shipped specs citing a superseded ADR relied on the superseded sub-decision, and annotate only those", source = "spec/frozen-spec-supersession"},
+
   # The publication-control evidence artifact records NO repository field:
   # build_evidence emits version, branch, app, environment, identities_agree,
   # canary, observed_at, observation_source -- and the committed


### PR DESCRIPTION
## What does this change?

Two Status annotations on `docs/specs/sast-sca-tooling/` (spec and plan), and a new `docs/CONVENTIONS.md` § *Superseding a frozen document* that says how the next one is done. The two file edits are the trivial half; the convention is the point.

## Why?

ADR-0084 reversed ADR-0017's Bandit suppression-comment form. ADR-0017's Status line already points forward. Its **implementing spec** does not — and that spec and plan are where the old form is actually taught, at nine sites (three in `spec.md`, six in `plan.md`, all inside task T3). A reader who starts there follows a rule we no longer keep.

Spec: `docs/specs/frozen-spec-supersession/spec.md`

### The three decisions, as asked

**1. Carrier: the `Status` field, not `Constrained by:`.**
- `CONVENTIONS.md`'s Frozen row already makes `Status` mutable — no new exemption.
- It matches the precedent at the other end: ADR-0001, 0013, 0015, 0016 and 0017 are all annotated on Status.
- `Constrained by: ADR-0017` is still a *true* record of what governed the spec at ship time; amending it would rewrite history rather than annotate it.
- Note one reason I had to **withdraw**: an earlier draft claimed only `Status` *could* express "in part". `docs/specs/copilot-full-parity/spec.md:6` carries a `supersedes-in-part` clause inside `Constrained by:`, so the field demonstrably can. The honest claim is that `Status` is the shorter carrier already licensed here.

**2. Is a shipped `plan.md` frozen? Yes — and the ambiguity was the real defect.**
The plan template said "Unlike the spec, this document is allowed to change as you learn", which reads as a standing exemption against the Frozen row. Resolved as **phase-scoped**: the licence holds while the plan is `Drafting` or `Executing`, and ends when it is `Done` and the spec `Shipped`. A plan editable forever would be a second, unversioned account of what we did, competing with the ADR that records why.

Fixed in three places, not one — leaving copies of an ambiguity is how it survives:
- the new lifecycle section;
- `CONVENTIONS.md`'s own unconditional copy of the plan licence;
- `CONVENTIONS.md`'s "the spec is reference material that should be updated alongside behavior changes", which **flatly contradicted** the Frozen row;
- and the plan template itself (`packs/core/.apm/skills/new-spec/assets/plan.md` + both projections) — the text an author actually reads.

**3. The general rule** is four numbered rules plus an explicit carve-out. Review made me add the carve-out and it matters: **meaning-preserving mechanical rewrites are allowed**. Without it the convention would have forbidden `84d79223` ("lift `docs/guides/` to `guides/`"), which rewrote references across 156 files under `docs/specs/` including shipped ones, and would block fixing `lint-spec-status.py`'s current invariant-(iii) warnings on a frozen spec. What freezes is the record of the decision, not the spelling of a path that has since moved.

## How do I verify it?

```
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root . --base-ref origin/main
SKIP_SAST=1 make build-check    # includes the seed↔projection drift check
```

Confirmed **by construction**, not from the docstring: `parse_status` run against the edited `spec.md` returns exactly `Shipped`, and invariant (i) is clean. `docs/CONVENTIONS.md` is projected from `packs/core/seeds/docs/CONVENTIONS.md` — the first attempt edited only the projection and `catalogue verify` caught it.

## What did you not change that you considered?

- **The frozen bodies at their nine sites.** Forbidden, and the operative instruction already lives in `bandit.yaml`'s header — a Living file, at the point of use.
- **A `Superseded` status token.** It would need a linter change and a migration; the annotation carries strictly more information for no schema change.
- **The 12 surveyed specs.** See below.

## Deferred

- `frozen-spec-supersession-survey` — 12 shipped specs cite an ADR a later ADR superseded, with no forward pointer. **Deliberately not fixed here**, because the fix is *not* identical: citing ADR-0017 does not mean a spec taught the reversed spelling (most cite it for the gate itself, which stands), and ADR-0040/0042 supersede different sub-decisions. Stamping them mechanically would put "superseded in part" on specs that are wholly unaffected — worse than silence. The survey table is in the spec, and the scan is `Constrained by:`-scoped (a plain grep returns roughly twice as many).

## Note on this file being wrong

Per AGENTS.md § *When this file is wrong*: the four new rules are **convention-enforced, not machine-enforced** — the linter checks the status token's vocabulary and nothing else. That is stated in the section rather than left implied.