### PR TITLE
feat(sast): make the suppression-equivalence check a tool

### DIFF
--- a/docs/specs/compare-bandit-suppressions/spec.md
+++ b/docs/specs/compare-bandit-suppressions/spec.md
@@ -1,0 +1,188 @@
+# Spec: compare-bandit-suppressions
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — single task; verification mode is named in § Testing Strategy
+- **Mode:** full (governance surface — it is the verification procedure for
+  changes to `# nosec` suppressions, which govern what the SAST gate skips)
+- **Constrained by:** [ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md),
+  [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md)
+- **Contract:** none (a manual verification harness; no published interface)
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Named deviation from full mode
+
+No `loop-engine` / `loop-cohort` state machine and no `plan.md` — a single task
+whose verification is the tool's own reproduction of a historical result. The
+two human approval gates were **granted up front by the requester**.
+
+## Objective
+
+Rewriting a `# nosec` comment is supposed to be behaviour-preserving, and the
+only way to know is to compare what Bandit reports before and after. That
+procedure exists — written out in `bandit-nosec-comment-hygiene`'s § Testing
+Strategy — but it lives as **prose inside a Frozen spec**, so when the procedure
+improves the record cannot be corrected. That is the defect this closes.
+
+It earns being a tool for a second reason: the procedure has four traps, and
+each one gave a *wrong answer* the first time it was run by hand. All four fail
+silently — they produce a confident wrong number, not an error.
+
+## The four traps, and where each is encoded
+
+| Trap | What went wrong by hand | Where it lives now |
+| --- | --- | --- |
+| **Rows are not keys** | 362 raw result rows collapse to 239 distinct `(filename, test_id, issue_text)` keys; comparing row counts answers a different question | `scan()` reports both and diffs only the key set |
+| **Two clean worktrees** | A worktree vs. the *dev tree* scanned gitignored build output on one side only, inflating both totals and inventing a 27-key delta | both sides are `git worktree add --detach`; the working tree is never scanned |
+| **Relative scan roots** | Absolute paths stop `bandit.yaml`'s `exclude_dirs: '*/tests/*'` glob matching, so the two scans cover different file sets | roots stay relative, `cwd` is the worktree |
+| **Both scans exit 1** | Findings are expected at the low/low floor, so a non-zero exit aborted the run | the exit code is ignored; a missing report is the only fatal case |
+
+A fifth trap surfaced while building this and is encoded too: **`Path.resolve()`
+anchors a relative path to the calling process's cwd** — the repo, not the
+worktree — silently mixing the two trees. `_worktree_relative` is string-based
+for that reason, and a case pins it.
+
+## Two checks, because neither is sufficient
+
+- **Reported findings.** Catches a suppression that weakened, or widened onto a
+  test that fires somewhere in the repo.
+- **Resolved-id inventory.** Every suppression comment at both revisions run
+  through Bandit's own `_parse_nosec_comment`. Catches what the scan cannot see:
+  a suppression widened onto a test that fires nowhere today, and any directive
+  resolving to no id at all — a blanket suppression of the whole statement.
+
+## A reported-finding difference has two possible causes
+
+The finding diff cannot tell a moved *suppression* from moved *code*: a key on
+one side only means either the suppression changed, or the file did. So the
+rows name both, and the resolved-id inventory is the half that isolates
+suppression changes — it compares only files present at both revisions.
+
+Found by running the tool on this repo's own recent history: three findings
+appeared at head solely because #971 added `tools/export_work_index.py`. An
+earlier message asserted "suppression WEAKENED at head" for exactly those rows,
+which was wrong.
+
+## A difference is a signal, not a verdict
+
+Exit 1 means "these two revisions do not suppress the same things — look". It
+does not mean "you broke something". Proven on the tool's own validation run
+against the change that motivated it (below), where the one reported difference
+was the intended removal of a spurious directive.
+
+Only a file present at **both** revisions can have had its suppressions changed.
+A file added at head brings new suppressions by definition, and a deleted file
+takes its own with it; both are printed as notes, neither fails the run. The
+first version of this script conflated them and reported a false FAIL, because
+the change it was validating against added two files.
+
+## Acceptance Criteria
+
+- [x] **AC1 — it reproduces the historical result exactly.** Run against the
+      pinned base `1f6b2d2f` and the merged `7f186a0b`, it reports **362 rows →
+      239 distinct keys on both sides, empty symmetric difference, and stderr
+      54 → 0** — the numbers `bandit-nosec-comment-hygiene` records. This is the
+      acceptance test: the tool is only worth having if it agrees with the
+      hand-run procedure it replaces.
+
+- [x] **AC2 — it detects the one real suppression change in that diff.** The
+      same run reports `tools/capture-publish-control-evidence.py` as base
+      `[{B310}, {B310}]` → head `[{B310}]`, which is exactly the spurious
+      second directive that spec's AC2 removed (a prose block that *began* with
+      `# nosec`). Detecting an intended change is the tool working.
+
+- [x] **AC3 — added files are notes, not failures.** The same run reports
+      `tools/run-bandit-gate.py` and `tools/test-sast-stderr-gate.py` as new
+      files carrying two suppressions each, without failing on them.
+
+- [x] **AC3b — a finding present on one side only is not attributed to a
+      cause.** The rows name both possibilities (suppression moved, or code
+      moved), because the finding diff cannot distinguish them; the resolved-id
+      inventory is what isolates suppression changes. Verified on real history:
+      `7f186a0b -> main` reports three head-only findings that exist purely
+      because an unrelated PR added a file, alongside `resolved suppression ids:
+      identical across 16 shared file(s)`.
+
+- [x] **AC4 — blanket suppressions at head are called out by name**, separately
+      from the equivalence result, since one is a defect regardless of what the
+      base looked like.
+
+- [x] **AC5 — the four traps are encoded, not documented.** Each has a
+      counterpart in code per the table above, and the ones that are pure
+      functions have self-test cases.
+
+- [x] **AC6 — a ref compared against itself is identical.** `--e2e` runs it and
+      must exit 0; a non-reproducible scan (wrong cwd, leaked absolute path,
+      nondeterministic key) fails here.
+
+- [x] **AC7 — the scan scope is derived, not copied.** Roots come from the
+      Makefile's `SAST_DIRS`, and an appended second assignment fails loudly
+      rather than silently narrowing the comparison.
+
+- [x] **AC8 — it has a self-test with a home.**
+      `tools/test-compare-bandit-suppressions.py`, added to `tools/test-all.py`'s
+      curated manifest (whose entries `test-test-all.py` gates), running the
+      fast cases only.
+
+- [x] **AC9 — gates pass.** `python3 tools/lint-ruff.py`, `make lint-mypy`,
+      `SKIP_SAST=1 make build-check`, `make sast`.
+
+- [x] **AC10 — the register entry is removed, and the ordering it depended on
+      is recorded.** `compare-bandit-suppressions-tool` is *added* by the
+      sibling PR #977 and did not exist on the `origin/main` this branch was
+      first cut from, so the two PRs agreed that whichever merged second would
+      remove it. #977 merged first; this PR merges second and removes it here.
+      Stated rather than silently checked — for most of this branch's life the
+      AC could not be satisfied, and an AC that claims a deletion which never
+      happened is worse than an open one.
+
+## Boundaries
+
+### Always do
+
+- Always scan two clean worktrees. The working tree is never an input.
+- Always keep the roots relative and derived from `SAST_DIRS`.
+
+### Ask first
+
+- Ask before wiring this into `make build-check`. It creates two worktrees and
+  runs two full scans; it is a harness for a human touching a suppression, not
+  a per-PR gate.
+
+### Never do
+
+- Never raise the severity floor. `low/low` is deliberate — a suppression that
+  moved a low-severity finding is still a moved suppression, and the gate's own
+  `medium/medium` floor would hide it.
+- Never compare against a moving branch name in a recorded result. Pin the base
+  to a SHA so the check stays reproducible after the branch advances.
+
+## Testing Strategy
+
+Goal-based, against a known-answer historical comparison:
+
+- `python3 tools/compare-bandit-suppressions.py 1f6b2d2f 7f186a0b` reproduces
+  the numbers in AC1–AC3. Run; output recorded in the PR description.
+- `python3 tools/test-compare-bandit-suppressions.py` — fast trap cases.
+- `python3 tools/test-compare-bandit-suppressions.py --e2e` — adds the same-ref
+  comparison (two full scans). Run once here.
+- `lint-ruff`, `make lint-mypy`, `SKIP_SAST=1 make build-check`, `make sast`.
+
+## Assumptions
+
+- Bandit's `_parse_nosec_comment` stays importable across the 1.9.x line pinned
+  in `tools/requirements-sast.txt`. `tools/lint-nosec-form.py`'s parity case
+  turns a change there into a red build, so this assumption is already gated
+  elsewhere.
+
+## Declined
+
+- **Pure stdlib.** AGENTS.md requires it for new `tools/` scripts; this one is a
+  Bandit *driver* — it shells out to `bandit` and imports its parser — so the
+  rule cannot apply. Named here rather than worked around.
+- **Wiring it into `make build-check`.** See Boundaries § Ask first.
+- **Failing on any inventory difference.** Added and removed files are notes;
+  only a file present at both revisions can have had its suppressions changed.

--- a/tools/compare-bandit-suppressions.py
+++ b/tools/compare-bandit-suppressions.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Prove a `# nosec` edit changed no suppression, by scanning two clean worktrees.
+
+Run this whenever a suppression comment is touched. Rewriting one is supposed to
+be behaviour-preserving, and the only way to know is to compare what bandit
+reports before and after — but the comparison has four traps that each produced
+a *wrong answer* the first time the procedure was run by hand
+(`docs/specs/bandit-nosec-comment-hygiene` § Testing Strategy). This script
+exists so they are encoded once instead of re-derived:
+
+  1. **Rows are not keys.** A scan of this repo yields ~362 raw result rows that
+     collapse to ~239 distinct `(filename, test_id, issue_text)` keys. Comparing
+     row counts answers a different question than comparing key sets. This
+     reports both and diffs the keys.
+  2. **Both sides must be clean worktrees** — never a worktree against the
+     development tree. A dev tree carries gitignored build output
+     (`packages/agentbundle/build/lib/…`) a worktree does not; scanning one of
+     each inflated both totals and produced a 27-key phantom delta.
+  3. **Relative scan roots**, resolved from each worktree's own root. Absolute
+     paths stop `bandit.yaml`'s `exclude_dirs: '*/tests/*'` glob from matching,
+     so the two scans silently cover different file sets.
+  4. **Both scans exit 1** at the low/low floor, because findings are expected
+     there. A non-zero exit is not an error and must not abort the run.
+
+Two complementary checks, because neither is sufficient alone:
+
+  * **Reported findings.** Catches a suppression that weakened, or that widened
+    onto a test which fires somewhere in the repo.
+  * **Resolved-id inventory.** Runs every suppression comment at both revisions
+    through bandit's own `_parse_nosec_comment`. Catches the case the scan
+    cannot see — a suppression widened onto a test that fires nowhere today, and
+    any directive that resolves to no id at all (a blanket suppression).
+
+Line numbers are deliberately excluded from the finding key: a comment edit
+shifts them without changing what is suppressed.
+
+Usage:
+    python3 tools/compare-bandit-suppressions.py <base-ref> [<head-ref>]
+
+`head-ref` defaults to HEAD. Pin `base-ref` to a SHA rather than a branch name
+so the check stays reproducible after the branch moves.
+
+Exit 0 = the two revisions suppress the same things, 1 = they differ,
+2 = the comparison could not be performed.
+
+Requires `bandit` on PATH and importable — this is a bandit driver, so the
+repo's pure-stdlib rule for `tools/` scripts cannot apply to it; that is stated
+rather than worked around.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is "git" or "bandit"
+import sys
+import tempfile
+import tokenize
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Trap 4: findings ARE expected at this floor, so a non-zero exit is normal.
+# The floor is deliberately lower than `make sast`'s medium/medium — a
+# suppression that moved a low-severity finding is still a moved suppression.
+FLOOR = ["--severity-level", "low", "--confidence-level", "low"]
+
+
+class CompareError(RuntimeError):
+    """The comparison could not be performed."""
+
+
+def _run(argv: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is "git" or "bandit"
+        argv, cwd=cwd, capture_output=True, encoding="utf-8",
+        errors="surrogateescape", check=False,
+    )
+
+
+def sast_dirs(root: Path) -> list[str]:
+    """Return the Makefile's SAST_DIRS. Trap 3 — these stay RELATIVE."""
+    import re  # noqa: PLC0415
+
+    text = (root / "Makefile").read_text(encoding="utf-8")
+    matches = re.findall(r"^SAST_DIRS\s*[:+?]*=\s*(.+)$", text, re.MULTILINE)
+    if len(matches) != 1:
+        raise CompareError(f"expected exactly one SAST_DIRS assignment, found {len(matches)}")
+    return matches[0].split("#", 1)[0].split()
+
+
+def scan(worktree: Path, roots: list[str]) -> tuple[set[tuple[str, str, str]], int, str]:
+    """Return `(keys, raw_row_count, stderr)` for a bandit scan of `worktree`.
+
+    Trap 3: `roots` are relative and `cwd` is the worktree, so `exclude_dirs`
+    globs match the same way on both sides. Trap 1: the key drops the line
+    number, because a comment edit shifts lines without changing coverage.
+    """
+    out = worktree / ".bandit-compare.json"
+    completed = _run(
+        ["bandit", "-r", *roots, "-c", "bandit.yaml", *FLOOR, "-f", "json", "-q",
+         "-o", str(out)],
+        cwd=worktree,
+    )
+    # Trap 4: exit 1 means "findings", which is the expected state here. Only a
+    # missing report is fatal.
+    if not out.exists():
+        raise CompareError(
+            f"bandit produced no report in {worktree} (exit {completed.returncode}): "
+            f"{completed.stderr.strip()[:400]}"
+        )
+    results = json.loads(out.read_text(encoding="utf-8"))["results"]
+    keys = {
+        (_worktree_relative(r["filename"], worktree), r["test_id"], r["issue_text"])
+        for r in results
+    }
+    return keys, len(results), completed.stderr
+
+
+def _worktree_relative(filename: str, worktree: Path) -> str:
+    """Return `filename` relative to `worktree`, whatever form bandit reported.
+
+    Deliberately string-based. `Path(...).resolve()` would anchor a *relative*
+    report to this process's cwd — which is the repo, not the worktree — and
+    silently produce paths from the wrong tree. That is trap 2 wearing a
+    different hat, and it raised a confusing `relative_to` error the first time.
+    """
+    text = filename.replace("\\", "/")
+    for prefix in (str(worktree.resolve()) + "/", str(worktree) + "/", "./"):
+        if text.startswith(prefix.replace("\\", "/")):
+            text = text[len(prefix):]
+            break
+    return text
+
+
+def inventory(worktree: Path, roots: list[str]) -> dict[str, set[str]]:
+    """Return `{"<path>:<line>": {resolved ids}}` for every suppression.
+
+    The half the reported-finding diff cannot see. Uses bandit's own parser, so
+    what is recorded is what bandit would actually apply — including an empty
+    set, which is a blanket suppression of the whole statement.
+    """
+    from bandit.core import manager  # noqa: PLC0415
+
+    found: dict[str, set[str]] = {}
+    listing = _run(["git", "ls-files", "-z", "--", *roots], cwd=worktree)
+    if listing.returncode != 0:
+        raise CompareError(f"git ls-files failed in {worktree}: {listing.stderr.strip()}")
+    for name in listing.stdout.split("\0"):
+        if not name.endswith(".py"):
+            continue
+        path = worktree / name
+        if not path.exists():
+            continue
+        try:
+            with tokenize.open(path) as handle:
+                source = handle.read()
+            for token in tokenize.generate_tokens(iter(source.splitlines(True)).__next__):
+                if token.type != tokenize.COMMENT:
+                    continue
+                resolved = manager._parse_nosec_comment(token.string)
+                if resolved is not None:
+                    found[f"{name}:{token.start[0]}"] = set(resolved)
+        except (OSError, UnicodeDecodeError, SyntaxError, tokenize.TokenError):
+            # A file bandit cannot read is a scan-integrity problem the gate
+            # reports; it is not this comparison's business to fail on it.
+            continue
+    return found
+
+
+def compare(base_ref: str, head_ref: str) -> int:
+    for tool in ("git", "bandit"):
+        if shutil.which(tool) is None:
+            raise CompareError(f"`{tool}` is required and not on PATH")
+
+    roots = sast_dirs(REPO_ROOT)
+    print(f"comparing {base_ref} -> {head_ref} over: {' '.join(roots)}\n")
+
+    with tempfile.TemporaryDirectory(prefix="bandit-compare-") as raw:
+        trees: dict[str, Path] = {}
+        try:
+            for label, ref in (("base", base_ref), ("head", head_ref)):
+                # Trap 2: a clean worktree on BOTH sides. Never compare against
+                # the working tree — its gitignored build output is scanned too.
+                path = Path(raw) / label
+                created = _run(
+                    ["git", "worktree", "add", "-q", "--detach", str(path), ref],
+                    cwd=REPO_ROOT,
+                )
+                if created.returncode != 0:
+                    raise CompareError(
+                        f"could not create a worktree for {ref!r}: {created.stderr.strip()}"
+                    )
+                trees[label] = path
+
+            scans = {}
+            invs = {}
+            for label in ("base", "head"):
+                keys, rows, stderr = scan(trees[label], roots)
+                scans[label] = (keys, rows, stderr)
+                invs[label] = inventory(trees[label], roots)
+                warn_lines = len([ln for ln in stderr.splitlines() if ln.strip()])
+                print(f"  {label:4} ({base_ref if label == 'base' else head_ref}): "
+                      f"{rows} rows -> {len(keys)} distinct keys, "
+                      f"{len(invs[label])} suppressions, {warn_lines} stderr line(s)")
+        finally:
+            for path in trees.values():
+                _run(["git", "worktree", "remove", "--force", str(path)], cwd=REPO_ROOT)
+
+    print()
+    failed = False
+
+    base_keys, _, _ = scans["base"]
+    head_keys, _, _ = scans["head"]
+    only_base = sorted(base_keys - head_keys)
+    only_head = sorted(head_keys - base_keys)
+    if only_base or only_head:
+        failed = True
+        print("REPORTED FINDINGS DIFFER:", file=sys.stderr)
+        # Deliberately does not name a cause. A finding present on one side only
+        # has two possible explanations — a suppression moved, or the code did
+        # (a new file, a deleted one, an edit that introduced or removed the
+        # finding). Asserting the first would be wrong every time the second is
+        # true, which this tool's own validation run demonstrated: three
+        # findings appeared at head purely because an unrelated PR added a file.
+        # Read these rows against the resolved-id result below, which is the
+        # half that isolates suppression changes from code changes.
+        for key in only_base:
+            print(f"  - at base only (suppression widened at head, OR the code "
+                  f"stopped producing it): {key}", file=sys.stderr)
+        for key in only_head:
+            print(f"  + at head only (suppression weakened at head, OR the code "
+                  f"newly produces it): {key}", file=sys.stderr)
+    else:
+        print(f"reported findings: identical ({len(base_keys)} distinct keys)")
+
+    # The inventory is keyed by path:line, and a comment edit moves lines — so
+    # compare the multiset of resolved id-sets per file, not per line.
+    def by_file(inv: dict[str, set[str]]) -> dict[str, list[frozenset]]:
+        out: dict[str, list[frozenset]] = {}
+        for locator, ids in inv.items():
+            out.setdefault(locator.rsplit(":", 1)[0], []).append(frozenset(ids))
+        return {k: sorted(v, key=sorted) for k, v in out.items()}
+
+    base_inv, head_inv = by_file(invs["base"]), by_file(invs["head"])
+
+    # Only a file present at BOTH revisions can have had its suppressions
+    # changed. A file added at head brings new suppressions by definition, and
+    # a deleted file takes its own with it — both are worth printing, neither is
+    # an equivalence violation. Conflating them made this script's own first run
+    # report a false FAIL, because the change it was checking added two files.
+    shared = sorted(set(base_inv) & set(head_inv))
+    changed = [name for name in shared if base_inv[name] != head_inv[name]]
+    if changed:
+        failed = True
+        print("\nRESOLVED SUPPRESSION IDS DIFFER:", file=sys.stderr)
+        for name in changed:
+            print(f"  {name}:\n      base {base_inv[name]}\n      head {head_inv[name]}",
+                  file=sys.stderr)
+    else:
+        total = sum(len(base_inv[name]) for name in shared)
+        print(f"resolved suppression ids: identical across {len(shared)} shared "
+              f"file(s) ({total} directives)")
+
+    added = sorted(set(head_inv) - set(base_inv))
+    removed = sorted(set(base_inv) - set(head_inv))
+    for name in added:
+        print(f"  note: new file at head carries {len(head_inv[name])} "
+              f"suppression(s): {name}")
+    for name in removed:
+        print(f"  note: file gone at head, took {len(base_inv[name])} "
+              f"suppression(s) with it: {name}")
+
+    blanket = {k: v for k, v in invs["head"].items() if not v}
+    if blanket:
+        failed = True
+        print("\nBLANKET SUPPRESSIONS AT HEAD (resolve to no test id):", file=sys.stderr)
+        for locator in sorted(blanket):
+            print(f"  {locator}", file=sys.stderr)
+
+    print()
+    if failed:
+        print("compare-bandit-suppressions: FAIL — the two revisions do not "
+              "suppress the same things.", file=sys.stderr)
+        return 1
+    print("compare-bandit-suppressions: OK — identical reported findings and "
+          "identical resolved suppression ids.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Prove a `# nosec` edit changed no suppression.",
+    )
+    parser.add_argument("base_ref", help="pin to a SHA, not a moving branch name")
+    parser.add_argument("head_ref", nargs="?", default="HEAD")
+    args = parser.parse_args(argv[1:])
+    try:
+        return compare(args.base_ref, args.head_ref)
+    except CompareError as exc:
+        print(f"compare-bandit-suppressions: {exc}", file=sys.stderr)
+        return 2
+    except ImportError as exc:
+        print(f"compare-bandit-suppressions: bandit is not importable ({exc}); "
+              "install tools/requirements-sast.txt", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/test-all.py
+++ b/tools/test-all.py
@@ -108,6 +108,10 @@ TESTS: list[tuple[str, list[str]]] = [
     ("lint-knowledge", [sys.executable, "-m", "pytest", "-q",
                         "tests/roster/test_work_loop_lint_knowledge.py"]),
     ("audit-npm", [sys.executable, "tools/test-audit-npm.py"]),
+    # Fast cases only. Its --e2e flag runs two full bandit scans and is for the
+    # human touching a suppression, not for this umbrella.
+    ("compare-bandit-suppressions",
+     [sys.executable, "tools/test-compare-bandit-suppressions.py"]),
     ("lint-sso-config", [sys.executable, "tools/test-lint-sso-config.py"]),
     ("lint-skill-spec", [sys.executable, "-m", "pytest",
                               "packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py",

--- a/tools/test-compare-bandit-suppressions.py
+++ b/tools/test-compare-bandit-suppressions.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Self-test for tools/compare-bandit-suppressions.py.
+
+The comparison's value is entirely in the four traps it encodes, and every one
+of them fails *silently* — a wrong scan scope, a path anchored to the wrong
+tree, or row counts mistaken for key counts all produce a confident, wrong
+answer rather than an error. So the cases below target the trap logic directly.
+
+Two of them exist because this script got them wrong on its first real run:
+
+  * `_worktree_relative` must not use `Path.resolve()`. Bandit reports paths
+    relative to its own cwd, and resolving them anchors to *this* process's cwd
+    — the repo, not the worktree — silently mixing trees.
+  * A file that exists at only one revision is not a changed suppression. The
+    first run reported a false FAIL because the change under test added two
+    files, and every suppression in them looked like a difference.
+
+The end-to-end case (a ref compared against itself, which must be identical by
+construction) runs two full bandit scans and takes minutes, so it is opt-in:
+pass --e2e. Everything else is sub-second.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess  # nosec B404  # list argv, no shell; argv[0] is sys.executable
+import sys
+import tempfile
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_HERE = Path(__file__).resolve().parent
+_TOOL = _HERE / "compare-bandit-suppressions.py"
+_SPEC = importlib.util.spec_from_file_location("compare_bandit_suppressions", _TOOL)
+assert _SPEC and _SPEC.loader
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+    else:
+        FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+        print(f"  FAIL {label} {detail}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--e2e", action="store_true",
+                        help="also run a same-ref comparison (slow: two full scans)")
+    args = parser.parse_args()
+
+    print("compare-bandit-suppressions self-test")
+
+    # Trap 3 / trap 2: path handling must never anchor to this process's cwd.
+    # A synthetic path, never touched on disk. Not under /tmp: a literal there
+    # trips B108, and a suppression would be worse than a different fixture.
+    worktree = Path("/scan/base")
+    for reported, expected in (
+        ("/scan/base/packages/agentbundle/x.py", "packages/agentbundle/x.py"),
+        ("./packages/agentbundle/x.py", "packages/agentbundle/x.py"),
+        ("packages/agentbundle/x.py", "packages/agentbundle/x.py"),
+    ):
+        got = _MOD._worktree_relative(reported, worktree)
+        check(f"path {reported!r} -> {expected!r}", got == expected, got)
+
+    # A path from a DIFFERENT tree must not silently reduce to a repo-relative
+    # one — that is the failure that mixes the two sides together.
+    other = _MOD._worktree_relative("/somewhere/else/packages/x.py", worktree)
+    check("a foreign absolute path is left absolute", other.startswith("/somewhere/else"), other)
+
+    # Scan scope comes from the Makefile, and an appended assignment must fail
+    # loudly rather than silently narrowing the comparison.
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        (root / "Makefile").write_text("SAST_DIRS := tools packs\n", encoding="utf-8")
+        check("SAST_DIRS parses", _MOD.sast_dirs(root) == ["tools", "packs"],
+              str(_MOD.sast_dirs(root)))
+
+        (root / "Makefile").write_text(
+            "SAST_DIRS := tools packs  # trailing comment\n", encoding="utf-8")
+        check("a trailing comment is stripped", _MOD.sast_dirs(root) == ["tools", "packs"],
+              str(_MOD.sast_dirs(root)))
+
+        (root / "Makefile").write_text("SAST_DIRS := tools\nSAST_DIRS += web\n",
+                                       encoding="utf-8")
+        try:
+            _MOD.sast_dirs(root)
+        except _MOD.CompareError as exc:
+            check("`SAST_DIRS +=` fails loudly", "exactly one" in str(exc), str(exc))
+        else:
+            check("`SAST_DIRS +=` fails loudly", False, "silently ignored the append")
+
+    # Trap 1: the finding key drops the line number, because a comment edit
+    # shifts lines without changing what is suppressed. Two rows that differ
+    # only by line must collapse to one key.
+    rows = [
+        {"filename": "a.py", "test_id": "B310", "issue_text": "t", "line_number": 10},
+        {"filename": "a.py", "test_id": "B310", "issue_text": "t", "line_number": 99},
+    ]
+    keys = {(_MOD._worktree_relative(r["filename"], worktree), r["test_id"], r["issue_text"])
+            for r in rows}
+    check("rows differing only by line collapse to one key", len(keys) == 1 and len(rows) == 2,
+          f"{len(rows)} rows -> {len(keys)} keys")
+
+    if args.e2e:
+        # Identical by construction. Catches a scan that is not reproducible —
+        # a wrong cwd, a leaked absolute path, a nondeterministic key.
+        print("  .... running same-ref comparison (two full scans, slow)")
+        result = subprocess.run(  # nosec B603  # list argv, no shell; argv[0] is sys.executable
+            [sys.executable, str(_TOOL), "HEAD", "HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+        check("a ref compared against itself is identical", result.returncode == 0,
+              (result.stderr or result.stdout)[-300:])
+    else:
+        print("  skip same-ref comparison (pass --e2e to run it)")
+
+    print()
+    if FAILURES:
+        print(f"compare-bandit-suppressions self-test: {len(FAILURES)} case(s) failed.")
+        return 1
+    print("compare-bandit-suppressions self-test: all cases passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspace.toml
+++ b/workspace.toml
@@ -1655,20 +1655,6 @@ open = [
   # the install cost on diffs that scan nothing.
   {slug = "build-check-installs-bandit-unconditionally", summary = "Install bandit on every build-check run so lint-nosec-form's unknown-ID check is not inert on SKIP_SAST PRs", source = "spec/bandit-nosec-form-lint"},
 
-  # The suppression-equivalence procedure in bandit-nosec-comment-hygiene's
-  # Testing Strategy (two clean worktrees, pinned base SHA, relative scan
-  # roots, distinct (filename,test_id,issue_text) keys -- four traps that each
-  # gave a wrong answer once) is needed every time a `# nosec` is touched, but
-  # lives as prose inside a FROZEN spec, so it cannot be corrected as the
-  # procedure improves. Judged in bandit-nosec-form-lint to earn being a tool;
-  # kept out of that PR because it is a manual before/after harness rather than
-  # a build-check gate, would roughly double the diff, and that PR changes no
-  # suppression so it would have shipped unexercised.
-  # Fix: tools/compare-bandit-suppressions.py taking base and head refs (not a
-  # hardcoded SHA), encoding all four traps, plus the resolved-id inventory
-  # half that the reported-finding diff cannot see.
-  {slug = "compare-bandit-suppressions-tool", summary = "Promote the two-worktree bandit suppression-equivalence procedure to tools/compare-bandit-suppressions.py, encoding the four traps and the resolved-id inventory", source = "spec/bandit-nosec-form-lint"},
-
   # 7 of the 13 pytest files named on Makefile:349 (`make test`) are a run step
   # in NO workflow: test_validate_guides, test_check_guide_index,
   # test_catalogue_navigation, test_documentation_entry_links,


### PR DESCRIPTION
## What does this change?

Adds `tools/compare-bandit-suppressions.py <base-ref> [<head-ref>]` and its self-test. Run it whenever a `# nosec` is touched.

## Why?

Rewriting a suppression is supposed to be behaviour-preserving, and the only way to know is to compare what Bandit reports before and after. That procedure exists — in `bandit-nosec-comment-hygiene`'s § Testing Strategy — but it lives as **prose inside a Frozen spec**, so when the procedure improves the record cannot be corrected. That is the defect this closes.

It earns being a tool for a second reason: the procedure has four traps, and **each gave a wrong answer the first time it was run by hand**. All four fail *silently* — a confident wrong number, not an error.

| Trap | What went wrong | Where it lives now |
| --- | --- | --- |
| Rows are not keys | 362 rows collapse to 239 distinct keys | `scan()` reports both, diffs only keys |
| Two clean worktrees | worktree vs. *dev tree* scanned gitignored build output on one side, inventing a 27-key delta | both sides `git worktree add --detach` |
| Relative scan roots | absolute paths stop `exclude_dirs` matching, so the scans cover different file sets | roots relative, `cwd` is the worktree |
| Both scans exit 1 | findings are expected at low/low, so a non-zero exit aborted the run | exit code ignored; only a missing report is fatal |

A **fifth** surfaced while building it: `Path.resolve()` anchors a relative path to the calling process's cwd — the repo, not the worktree — silently mixing trees. `_worktree_relative` is string-based for that reason.

Two checks, because neither suffices alone: the reported-finding diff catches a suppression that weakened or widened onto a test that fires somewhere; the resolved-id inventory (through Bandit's own `_parse_nosec_comment`) catches what the scan cannot see — widened onto a test that fires nowhere, or resolving to no id at all.

Spec: `docs/specs/compare-bandit-suppressions/spec.md`

## How do I verify it?

Validated against the change that motivated it, which is the acceptance test — the tool is only worth having if it agrees with the hand-run procedure it replaces:

```
python3 tools/compare-bandit-suppressions.py 1f6b2d2f 7f186a0b
```

```
  base (1f6b2d2f): 362 rows -> 239 distinct keys, 20 suppressions, 54 stderr line(s)
  head (7f186a0b): 362 rows -> 239 distinct keys, 23 suppressions, 0 stderr line(s)

reported findings: identical (239 distinct keys)
  note: new file at head carries 2 suppression(s): tools/run-bandit-gate.py
  note: new file at head carries 2 suppression(s): tools/test-sast-stderr-gate.py

RESOLVED SUPPRESSION IDS DIFFER:
  tools/capture-publish-control-evidence.py:
      base [frozenset({'B310'}), frozenset({'B310'})]
      head [frozenset({'B310'})]
```

Every number matches what the spec records — **362 → 239 both sides, empty symmetric difference, stderr 54 → 0**. The one reported difference is exactly the spurious prose-block directive that spec's AC2 removed. **Detecting an intended change is the tool working**: exit 1 means "look", not "you broke it".

```
python3 tools/test-compare-bandit-suppressions.py         # fast trap cases
python3 tools/test-compare-bandit-suppressions.py --e2e   # + same-ref comparison, exits 0
```

That validation run also **found a flaw in the first version**: it counted suppressions in files present at only one revision as differences, and reported a false FAIL because the change under test added two files. Only a file present at both revisions can have had its suppressions changed; added and removed files are now notes.

## What did you not change that you considered?

- **Wiring it into `make build-check`.** It creates two worktrees and runs two full scans. It is a harness for the human touching a suppression, not a per-PR gate. Its self-test's fast cases join `tools/test-all.py`'s curated manifest instead.
- **Pure stdlib.** AGENTS.md requires it for new `tools/` scripts; this one is a Bandit *driver* — it shells out to `bandit` and imports its parser — so the rule cannot apply. Named in § Declined rather than worked around.
- **Raising the severity floor to match the gate's.** `low/low` is deliberate: a suppression that moved a low-severity finding is still a moved suppression, and `medium/medium` would hide it.

## Note on ordering

`compare-bandit-suppressions-tool` is added to `workspace.toml [backlog].open` by the sibling PR #977 and does not exist on the `origin/main` this branch is cut from, so this PR cannot remove it. **Whichever of the two merges second removes it.** Stated rather than silently checked — an AC claiming a deletion that never happened is worse than an open one.