### PR TITLE
ci(build-check): gate seven ungated tests and install bandit unconditionally

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -97,6 +97,9 @@ jobs:
         if: steps.changes.outputs.skip_sast != 'true'
         run: pip install -r tools/requirements-sast.txt
 
+      - name: Install agentbundle (editable) + pytest
+        run: python -m pip install -e packages/agentbundle/ pytest
+
       - name: Install bandit unconditionally (lint-nosec-form's ID registry)
         # Deliberately NOT behind the skip_sast condition above, and deliberately
         # not the whole of requirements-sast.txt.
@@ -115,10 +118,29 @@ jobs:
         # The pin is READ, not restated — a second copy of the version range can
         # drift from the canonical one in requirements-sast.txt; deriving it
         # cannot.
-        run: pip install "$(grep -E '^bandit' tools/requirements-sast.txt)"
-
-      - name: Install agentbundle (editable) + pytest
-        run: python -m pip install -e packages/agentbundle/ pytest
+        #
+        # LAST step before `make build-check`, and it asserts its own success.
+        # Both matter, because a provisioning step that quietly does nothing
+        # would leave the required check green with the gate it enables inert —
+        # the exact shape this whole step exists to remove. Three routes, all
+        # measured rather than assumed:
+        #   (a) a grep that matches nothing yields `pip install ""`, which exits
+        #       0 with no output; `set -e` on the assignment is what stops it.
+        #   (b) a bandit whose registry import raises — an API move inside the
+        #       >=1.9,<2 range, a broken plugin entry point — leaves
+        #       id_checker() returning None, and lint-nosec-form then degrades
+        #       to a caveat and exit 0. The python assertion below reaches for
+        #       the same API and both directions of its answer.
+        #   (c) a later pip resolution replacing a shared transitive dep of
+        #       bandit; running last leaves nothing between here and the gate.
+        run: |
+          set -euo pipefail
+          pin="$(grep -E '^bandit([^A-Za-z0-9._-]|$)' tools/requirements-sast.txt)"
+          echo "installing pinned: $pin"
+          pip install "$pin"
+          python -c "from bandit.core import extension_loader as e; \
+            assert e.MANAGER.check_id('B307'), 'bandit registry did not resolve a real test id'; \
+            assert not e.MANAGER.check_id('B999'), 'bandit registry resolved a nonexistent test id'"
 
       - name: Run make build-check
         # Pass SKIP_SAST=1 only when the diff touches no SAST-relevant file; the

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -133,14 +133,30 @@ jobs:
         #       the same API and both directions of its answer.
         #   (c) a later pip resolution replacing a shared transitive dep of
         #       bandit; running last leaves nothing between here and the gate.
+        #
+        # The registry probe raises rather than asserting: a bare `assert` is
+        # compiled out under PYTHONOPTIMIZE, which would restore the silent pass
+        # this probe exists to remove.
+        #
+        # tools/test_build_gate_chain.py pins this step's existence, its lack of
+        # an `if:`, and its position — extracting this very body and running it
+        # against two mutated inputs. Nothing else does: lint-ci-parity's roster
+        # only demands a disposition for steps that exist, so deleting this step
+        # and its row would leave both gates green.
         run: |
           set -euo pipefail
           pin="$(grep -E '^bandit([^A-Za-z0-9._-]|$)' tools/requirements-sast.txt)"
           echo "installing pinned: $pin"
           pip install "$pin"
-          python -c "from bandit.core import extension_loader as e; \
-            assert e.MANAGER.check_id('B307'), 'bandit registry did not resolve a real test id'; \
-            assert not e.MANAGER.check_id('B999'), 'bandit registry resolved a nonexistent test id'"
+          python - <<'PROBE'
+          from bandit.core import extension_loader as loader
+          if not loader.MANAGER.check_id("B307") or loader.MANAGER.check_id("B999"):
+              raise SystemExit(
+                  "bandit's registry did not resolve as lint-nosec-form's "
+                  "id_checker() expects; its unknown-id check would silently "
+                  "no-op behind a green gate"
+              )
+          PROBE
 
       - name: Run make build-check
         # Pass SKIP_SAST=1 only when the diff touches no SAST-relevant file; the

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -97,6 +97,26 @@ jobs:
         if: steps.changes.outputs.skip_sast != 'true'
         run: pip install -r tools/requirements-sast.txt
 
+      - name: Install bandit unconditionally (lint-nosec-form's ID registry)
+        # Deliberately NOT behind the skip_sast condition above, and deliberately
+        # not the whole of requirements-sast.txt.
+        #
+        # `make build-check` chains tools/lint-nosec-form.py on every run. One of
+        # its checks — a well-formed but nonexistent test id, which bandit
+        # resolves to nothing and so treats as a blanket suppression — needs
+        # bandit's own registry and silently no-ops without it. Behind the
+        # condition it was inert on exactly the PRs it exists for: a SKIP_SAST
+        # diff, where `make sast` does not run and nothing else catches the
+        # shape. See docs/specs/bandit-nosec-form-lint/spec.md AC4b.
+        #
+        # semgrep and pip-audit stay conditional: they are the expensive half of
+        # that install and no gate running under SKIP_SAST needs them.
+        #
+        # The pin is READ, not restated — a second copy of the version range can
+        # drift from the canonical one in requirements-sast.txt; deriving it
+        # cannot.
+        run: pip install "$(grep -E '^bandit' tools/requirements-sast.txt)"
+
       - name: Install agentbundle (editable) + pytest
         run: python -m pip install -e packages/agentbundle/ pytest
 
@@ -220,6 +240,31 @@ jobs:
       # navigation. make build-check runs no pytest — wire them explicitly.
       - name: pytest guides sidebar generation
         run: python -m pytest tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py
+
+      # Seven of the thirteen tools/ suites `make test` runs were a run step in
+      # NO workflow — they gated `make ci` locally and nothing on the way to
+      # main. That is how #958 merged green while leaving main red on
+      # test_catalogue_navigation. Wired here as two grouped steps, split by what
+      # they gate. Counted per file across all of .github/workflows/: two
+      # siblings on the same Makefile line (test_catalogue_tooling_rewire,
+      # test_catalogue_tooling_docs) ARE run, by Gate F of
+      # catalogue-tooling-ci-gates.yml, so they are deliberately absent here.
+      - name: pytest guides + catalogue navigation
+        run: >-
+          python -m pytest
+          tools/test_validate_guides.py
+          tools/test_check_guide_index.py
+          tools/test_catalogue_navigation.py
+          tools/test_documentation_entry_links.py
+
+      # test_check_rendered_site_links.py appears in pages.yml as a `paths:`
+      # trigger and never as a run step — easy to miscount as covered.
+      - name: pytest site build + link rewriting
+        run: >-
+          python -m pytest
+          tools/test_build_site_link_rewrites.py
+          tools/test_check_rendered_site_links.py
+          tools/test_build_site_routing.py
 
       - name: Install credbroker (editable, with crypto extra)
         # Installing the [crypto] extra verifies it resolves (spec credbroker AC1)

--- a/docs/specs/bandit-nosec-form-lint/spec.md
+++ b/docs/specs/bandit-nosec-form-lint/spec.md
@@ -1,6 +1,6 @@
 # Spec: bandit-nosec-form-lint
 
-- **Status:** Shipped
+- **Status:** Shipped (AC4b's deferral `build-check-installs-bandit-unconditionally` was closed by [`build-check-coverage-gaps`](../build-check-coverage-gaps/spec.md), so that register anchor no longer resolves; not a supersession — every decision here stands)
 - **Owner:** eugenelim
 - **Plan:** none — see § Named deviation
 - **Mode:** full (governance surface — it adds a gate to the `build-check`

--- a/docs/specs/build-check-coverage-gaps/spec.md
+++ b/docs/specs/build-check-coverage-gaps/spec.md
@@ -98,13 +98,10 @@ body exits non-zero. An unmutated assertion is an unverified one.
 Seven separate steps would put seven near-identical rows in `STEP_DISPOSITION`
 for no gain. One step would merge two unrelated concerns behind a single
 disposition, which is the residual `lint-ci-parity` documents and does not need
-feeding. Two steps, grouped by what they gate:
-
-- **guides and catalogue navigation** — `test_validate_guides`,
-  `test_check_guide_index`, `test_catalogue_navigation`,
-  `test_documentation_entry_links`
-- **site build and link rewriting** — `test_build_site_link_rewrites`,
-  `test_check_rendered_site_links`, `test_build_site_routing`
+feeding. Two steps, grouped by what they gate — `pytest guides + catalogue
+navigation` and `pytest site build + link rewriting`. **AC1 is the canonical
+list of which file goes where; this section does not restate it**, so a
+regrouping cannot leave two lists disagreeing.
 
 This follows the existing `pytest guides sidebar generation` step, which already
 groups three related `tools/test_build_site_*.py` files under one disposition.
@@ -162,6 +159,38 @@ not something to paper over by adding a second runner in `build-check.yml`.
       results differ — one `unknown-id` violation versus none. Measured by
       running it, not read off the docstring.
 
+- [x] **AC4b — the install step itself is pinned, and the pin is verified by
+      deletion.** `tools/test_build_gate_chain.py` gains
+      `BanditRegistryProvisioningTest`: it parses `build-check.yml`, asserts the
+      step exists, carries no `if:`, and is the step immediately before `Run
+      make build-check` — then **extracts and executes that step's real body**
+      with `pip` stubbed, once against the tree (passes) and twice against
+      mutated input (fails). Four mutations of the workflow — delete the step,
+      restore its `if:`, insert a step before the gate, drop the registry probe
+      — each turn the suite red; the restored control is green. Two further
+      mutations cover the probe's own halves: deleting either
+      `check_id("B307")` or `check_id("B999")` reddens the suite, so neither
+      direction can be dropped unnoticed. Without any of this, deleting the step
+      *and its roster row* passes `lint-ci-parity` in both directions and the
+      gate is silently inert again.
+
+      The test parses `build-check.yml` with a **stdlib** line-structured scan,
+      not PyYAML: this module is pure stdlib per `AGENTS.md`, and it also runs
+      in Gate F of `catalogue-tooling-ci-gates.yml`, whose job installs only
+      `agentbundle` (which declares no dependencies) — so a `yaml` import would
+      fail at collection there. A pin that cannot run in one of the two jobs
+      that run it is not a pin. Verified by running the suite with `yaml` made
+      unimportable.
+
+- [x] **AC4c — closing the two register entries leaves no dangling pointer.**
+      `bandit-nosec-form-lint/spec.md` (AC4b names
+      `build-check-installs-bandit-unconditionally`) and
+      `guides-readme-outcome-label-drift/spec.md` (names
+      `catalogue-site-tests-absent-from-ci`) each carry a `Status`-line
+      annotation recording that the anchor was closed and by what. Both are
+      Frozen; no body line changes; the carrier is the one `CONVENTIONS.md`
+      § *Superseding a frozen document* licenses.
+
 - [x] **AC5 — every new step carries a disposition.** `STEP_DISPOSITION` in
       `tools/lint-ci-parity.py` gains one entry per new step: `LOCAL("test")`
       for the two pytest steps (the `Makefile`'s `test` target runs all seven
@@ -217,6 +246,8 @@ Goal-based, plus one measured before/after.
 | AC1, AC2 | The workflow scan described in AC2, run on the base and on the change. |
 | AC3, AC3a | Read the edited workflow; assert the new step has no `if:` and is the last step before `Run make build-check`. Then run the step body verbatim against three mutated inputs and assert each exits non-zero. |
 | AC4 | `scan_source(src, path, id_checker())` vs `scan_source(src, path, None)` on a `B`-shaped nonexistent ID. |
+| AC4b | `pytest tools/test_build_gate_chain.py -k Bandit`, then the same against four mutated copies of `build-check.yml`; assert red each time and green on restore. |
+| AC4c | `parse_status` on both edited files; `git diff --unified=0` showing only `- **Status:**` lines. |
 | AC5, AC6 | `python3 tools/lint-ci-parity.py`; exit code and summary line. |
 | AC7 | The four gate commands. |
 | AC8 | `tomllib.load` on `workspace.toml`; assert neither slug is present. |
@@ -233,15 +264,22 @@ Four findings from `security-reviewer`, each recorded in `workspace.toml
 
 | Slug | Why not here |
 | --- | --- |
-| `lint-nosec-form-require-id-registry` | The tool degrades to an exit-0 caveat when the registry is unreachable. **Every route to that is closed in CI by this change**; what remains is a local `SKIP_SAST=1 make build-check` without bandit. Fixing it in the linter makes bandit a hard prerequisite for every contributor — a real cost, and its own decision. |
+| `lint-nosec-form-require-id-registry` | The tool degrades to an exit-0 caveat when the registry is unreachable. In CI that is now closed on three counts — the step fails if the pin is unresolvable, fails if the registry is unusable, and AC4b's test fails if the step is deleted, made conditional, or displaced. What remains is a **local** `SKIP_SAST=1 make build-check` without bandit. Fixing that in the linter makes bandit a hard prerequisite for every contributor — a real cost, and its own decision. |
 | `build-check-yml-no-permissions-block` | Adding `permissions: contents: read` changes the job's token scope. That is a behaviour change, which the bundled-fixes carve-out fails closed on, and it applies to three other workflows too. |
 | `sast-requirements-hash-locked` | Needs a generated locked file and a refresh procedure. |
 | `sast-requirements-not-audited` | `pip-audit` covers `tools/requirements.txt` and the pack files, not the CI-tooling ones. Confirmed by reading the `Makefile` invocations. A different file set and a different decision (audit vs. Dependabot). |
 
+Two more from `adversarial-reviewer`:
+
+| Slug | Why not here |
+| --- | --- |
+| `tools-test-runner-boundary` | Closing the **class** means extending `lint-pack-test-boundary.py`'s runner discipline from `packs/**/tests` to `tools/`. Eight `tools/` test files are invoked by nothing at all today — two of them landed in the last two merges — so it is worth doing and is its own change. |
+| `site-test-source-substring-assertions` | Re-expressing two suites' substring assertions against parsed structure. Needed, but it is a rewrite of tests this change only *wires up*. |
+
 ## Honest scope
 
 The seven tests now gate `main`, and bandit's registry is now present — and
-proven present — on every run. Two things this does **not** do:
+proven present — on every run. Four things this does **not** do:
 
 1. **Gate F's `paths-ignore` still excludes doc surfaces.** A PR touching only
    `docs/**` does not run `test_catalogue_tooling_rewire` or
@@ -249,3 +287,21 @@ proven present — on every run. Two things this does **not** do:
 2. **`lint-nosec-form`'s unknown-ID check gains CI reach, not novelty.** Where
    `make sast` runs, `run-bandit-gate.py` already catches the same shape via
    bandit's stderr. What changes is that a `SKIP_SAST` PR is now covered too.
+3. **The recurrence class stays open.** Nothing stops the *next* `tools/` test
+   from landing gated by nothing — `lint-ci-parity` only enforces
+   workflow-step → local-target, never the reverse, and the reverse discipline
+   exists only for `packs/**/tests`. Measured: **eight** `tools/test*.py` files
+   are invoked by no `Makefile` target, no workflow, and no tool script, two of
+   them arriving in the last four merges (#980, #982). The measurement and its
+   method live in the register entry `tools-test-runner-boundary`; this bullet
+   points at it rather than restating the list.
+4. **This couples every PR to formatting elsewhere.** Two of the seven suites
+   assert on raw substrings of `pages.yml`, `web/src/lib/catalogue-navigation.ts`
+   and two `.astro` files — including occurrence *counts* of quoted `paths:`
+   entries. `build-check.yml` has no `paths:` filter, so a cosmetic requote in
+   `pages.yml` now reddens the required check for an unrelated PR. The coupling
+   already existed in `make ci`; wiring the suites makes it block merges. Those
+   assertions are also the shape
+   `docs/knowledge/observations/antipattern/2026-08.jsonl` names — they do not
+   detect removal of what they pin. Registered as
+   `site-test-source-substring-assertions`.

--- a/docs/specs/build-check-coverage-gaps/spec.md
+++ b/docs/specs/build-check-coverage-gaps/spec.md
@@ -1,0 +1,216 @@
+---
+title: Close two build-check coverage gaps — seven ungated tests and a missing bandit registry
+slug: build-check-coverage-gaps
+---
+
+# Spec: build-check closes two coverage gaps
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** none — see § Named deviation
+- **Mode:** full (governance surface — it edits `.github/workflows/build-check.yml`,
+  the one workflow `tools/lint-ci-parity.py` holds in scope, and changes which
+  gates block a merge. A change to what CI proves is a CI-integrity change even
+  when every line of it is additive.)
+- **Constrained by:**
+  [ADR-0017](../../adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md)
+  (the SAST gate whose tooling install this makes partly unconditional);
+  [ADR-0084](../../adr/0084-nosec-reason-delimiter-and-stderr-as-a-gate.md)
+  (bandit's stderr as a gate — the mechanism `lint-nosec-form`'s unknown-ID
+  check is defence-in-depth for);
+  [`local-gate-ci-parity`](../local-gate-ci-parity/spec.md)
+  (the `STEP_DISPOSITION` roster every new step must join)
+- **Contract:** none (CI wiring; no published interface)
+- **Shape:** integration
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Named deviation from full mode
+
+The `loop-engine` / `loop-cohort` state machine was not run, and there is no
+`plan.md`. The two human approval gates it sequences — **spec-approved** and
+**plan-approved** — were **granted up front by the requester**, as a standing
+instruction to carry this through to merge. The merge decision itself was
+explicitly retained. `adversarial-reviewer` and `security-reviewer` were run.
+Same deviation shape as the sibling specs of this batch
+(`bandit-nosec-form-lint`, `frozen-spec-supersession`).
+
+## Objective
+
+Two independent holes in `build-check.yml`, bundled because the fix to each is
+an edit to that file plus a `tools/lint-ci-parity.py` disposition, and because
+reviewing one CI-coverage change is cheaper than reviewing two.
+
+**Gap 1 — seven tests gate nothing remotely.** `make test` runs thirteen
+`tools/test_*.py` files on one line of the `Makefile`. Seven of them are a
+`run:` step in **no** workflow under `.github/workflows/`. They gate `make ci`
+on a contributor's machine and nothing on the way to `main`.
+
+This is not hypothetical. It is exactly how #958 merged green while leaving
+`main` red on `test_catalogue_navigation` — a failure PR #967 then had to record
+as a known skip, and a later spec had to fix.
+
+**Gap 2 — `lint-nosec-form`'s unknown-ID check is inert where it matters.**
+`build-check.yml` installs `tools/requirements-sast.txt` only when
+`skip_sast != 'true'`. `tools/lint-nosec-form.py` runs in `make build-check`
+unconditionally, but its unknown-ID check needs bandit's test registry, so on a
+`SKIP_SAST` PR it silently no-ops. Where bandit *is* installed, `make sast` runs
+too and `run-bandit-gate.py` already fails on bandit's own stderr for the same
+shape — so the check's CI reach today is nil, on exactly the PRs it was written
+for. `bandit-nosec-form-lint` AC4b states this and defers the fix here.
+
+## Decision 1 — install bandit unconditionally, the rest of the SAST tools conditionally
+
+The register entry offered two shapes: drop the `if:` on the existing install
+step, or add an unconditional bandit-only install. The second wins on cost.
+`tools/requirements-sast.txt` pins three tools; `semgrep` and `pip-audit` are
+the expensive half of that install and neither is needed by any gate that runs
+under `SKIP_SAST`. Bandit alone is what `lint-nosec-form` needs.
+
+**The pin is read, not restated.** The new step installs
+`$(grep -E '^bandit' tools/requirements-sast.txt)` rather than naming a version.
+A second copy of `bandit>=1.9,<2` is a thing that can drift from the canonical
+one; deriving it cannot. Same principle `lint-ci-parity.py` applies to its own
+reachable-target set ("*derived* from the Makefile, never declared").
+
+The conditional full-SAST install stays exactly as it is. When it runs, pip
+finds bandit already satisfied and moves on.
+
+## Decision 2 — two grouped steps, not seven, and not one
+
+Seven separate steps would put seven near-identical rows in `STEP_DISPOSITION`
+for no gain. One step would merge two unrelated concerns behind a single
+disposition, which is the residual `lint-ci-parity` documents and does not need
+feeding. Two steps, grouped by what they gate:
+
+- **guides and catalogue navigation** — `test_validate_guides`,
+  `test_check_guide_index`, `test_catalogue_navigation`,
+  `test_documentation_entry_links`
+- **site build and link rewriting** — `test_build_site_link_rewrites`,
+  `test_check_rendered_site_links`, `test_build_site_routing`
+
+This follows the existing `pytest guides sidebar generation` step, which already
+groups three related `tools/test_build_site_*.py` files under one disposition.
+
+## Decision 3 — the count is seven, and it is counted per file across every workflow
+
+Stated because getting it wrong is the easy path, and two specific shapes make
+it easy:
+
+1. `test_check_rendered_site_links.py` appears in `pages.yml` twice — as a
+   `paths:` trigger, never as a `run:` step. A grep for the filename finds it
+   and reports it covered.
+2. `test_catalogue_tooling_rewire.py` and `test_catalogue_tooling_docs.py`
+   **are** run, by Gate F of `catalogue-tooling-ci-gates.yml`. They are
+   therefore **not** in the seven. Wiring them here would duplicate Gate F.
+
+Neither is fixed here. Gate F's own `paths-ignore` covers `docs/**`,
+`guides/**`, `docs-site/**` and `web/**`, so it does not gate doc-surface PRs
+either — but that is Gate F's gap to close, in `catalogue-tooling-ci-gates.yml`,
+not something to paper over by adding a second runner in `build-check.yml`.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the seven run in CI.** `build-check.yml` gains two `run:` steps
+      that between them invoke exactly
+      `tools/test_validate_guides.py`, `tools/test_check_guide_index.py`,
+      `tools/test_catalogue_navigation.py`,
+      `tools/test_documentation_entry_links.py`,
+      `tools/test_build_site_link_rewrites.py`,
+      `tools/test_check_rendered_site_links.py`, and
+      `tools/test_build_site_routing.py`.
+
+- [x] **AC2 — the count is verified by construction, not by grep.** A scan that
+      parses every `.github/workflows/*.yml`, walks it for `run:` scalars, and
+      tests each of the thirteen `Makefile` filenames against them reports
+      exactly these seven as absent from every workflow — before the change.
+      After it, zero. `test_check_rendered_site_links.py`'s `pages.yml`
+      appearance is classified non-`run:` by that scan, not by reading the YAML.
+
+- [x] **AC3 — bandit is present on every build-check run.** A new,
+      unconditional install step precedes `Run make build-check` and installs
+      the `bandit` line read out of `tools/requirements-sast.txt`. The existing
+      conditional `Install SAST/SCA tools` step is unchanged.
+
+- [x] **AC4 — the unknown-ID check is demonstrably live, and demonstrably was
+      not.** `lint-nosec-form.scan_source` is run against a well-formed but
+      nonexistent ID both with `id_checker()` and with `None`, and the two
+      results differ — one `unknown-id` violation versus none. Measured by
+      running it, not read off the docstring.
+
+- [x] **AC5 — every new step carries a disposition.** `STEP_DISPOSITION` in
+      `tools/lint-ci-parity.py` gains one entry per new step: `LOCAL("test")`
+      for the two pytest steps (the `Makefile`'s `test` target runs all seven
+      and is reachable from `make ci`), `CI_ONLY(...)` for the install step,
+      with a reason that names *why* it is unconditional rather than saying
+      "Provisioning."
+
+- [x] **AC6 — the parity gate agrees.** `python3 tools/lint-ci-parity.py` exits
+      0 and its summary count rises by three steps.
+
+- [x] **AC7 — gates pass.** `python3 tools/lint-ruff.py`, `make lint-mypy`,
+      `SKIP_SAST=1 make build-check`, `make sast`, and
+      `lint-spec-status.py --root . --base-ref origin/main` all exit 0.
+
+- [x] **AC8 — both register entries are closed.**
+      `catalogue-site-tests-absent-from-ci` and
+      `build-check-installs-bandit-unconditionally` are removed from
+      `workspace.toml [backlog].open`, verified with `tomllib` rather than by
+      reading the diff.
+
+## Boundaries
+
+### Always do
+
+- Always count CI coverage per file across every workflow in
+  `.github/workflows/`, and only against `run:` scalars.
+- Always give a new `build-check.yml` step a `STEP_DISPOSITION` entry in the
+  same commit; the gate fails closed if you do not, and that is the point.
+
+### Ask first
+
+- Ask before pulling `catalogue-tooling-ci-gates.yml` Gate F's `paths-ignore`
+  gap into this change. It is a real gap and a different workflow's.
+
+### Never do
+
+- Never restate the `bandit` version pin. Read it from
+  `tools/requirements-sast.txt`.
+- Never widen the unconditional install to the whole of
+  `requirements-sast.txt`; `semgrep` and `pip-audit` are the cost this decision
+  exists to avoid paying on every PR.
+- Never spell a bandit suppression directive out inside a Python comment, in
+  this change or any other. A comment quoting the form **is** the form —
+  `bandit.yaml` says so and `lint-nosec-form.py` enforces it. Describe it, or
+  point at `bandit.yaml`.
+
+## Testing Strategy
+
+Goal-based, plus one measured before/after.
+
+| What | How |
+| --- | --- |
+| AC1, AC2 | The workflow scan described in AC2, run on the base and on the change. |
+| AC3 | Read the edited workflow; assert the new step has no `if:` and precedes `Run make build-check`. |
+| AC4 | `scan_source(src, path, id_checker())` vs `scan_source(src, path, None)` on a `B`-shaped nonexistent ID. |
+| AC5, AC6 | `python3 tools/lint-ci-parity.py`; exit code and summary line. |
+| AC7 | The four gate commands. |
+| AC8 | `tomllib.load` on `workspace.toml`; assert neither slug is present. |
+
+No new unit test file. `tools/test-lint-ci-parity.py` already pins the roster
+invariants in both directions — a step without a disposition and a disposition
+without a step both fail — so the roster edit is covered by an existing gate
+rather than a new one.
+
+## Honest scope
+
+The seven tests now gate `main`, and bandit's registry is now present on every
+run. Two things this does **not** do:
+
+1. **Gate F's `paths-ignore` still excludes doc surfaces.** A PR touching only
+   `docs/**` does not run `test_catalogue_tooling_rewire` or
+   `test_catalogue_tooling_docs`. Out of scope, and left in the register.
+2. **`lint-nosec-form`'s unknown-ID check gains CI reach, not novelty.** Where
+   `make sast` runs, `run-bandit-gate.py` already catches the same shape via
+   bandit's stderr. What changes is that a `SKIP_SAST` PR is now covered too.

--- a/docs/specs/build-check-coverage-gaps/spec.md
+++ b/docs/specs/build-check-coverage-gaps/spec.md
@@ -68,14 +68,30 @@ step, or add an unconditional bandit-only install. The second wins on cost.
 the expensive half of that install and neither is needed by any gate that runs
 under `SKIP_SAST`. Bandit alone is what `lint-nosec-form` needs.
 
-**The pin is read, not restated.** The new step installs
-`$(grep -E '^bandit' tools/requirements-sast.txt)` rather than naming a version.
-A second copy of `bandit>=1.9,<2` is a thing that can drift from the canonical
-one; deriving it cannot. Same principle `lint-ci-parity.py` applies to its own
+**The pin is read, not restated.** The new step greps the `bandit` line out of
+`tools/requirements-sast.txt` rather than naming a version. A second copy of
+`bandit>=1.9,<2` is a thing that can drift from the canonical one; deriving it
+cannot. The pattern is anchored `^bandit([^A-Za-z0-9._-]|$)` so a future
+`bandit-extras` line cannot be picked up instead. Same principle `lint-ci-parity.py` applies to its own
 reachable-target set ("*derived* from the Makefile, never declared").
 
 The conditional full-SAST install stays exactly as it is. When it runs, pip
 finds bandit already satisfied and moves on.
+
+**The step asserts its own success, and runs last.** A provisioning step that
+quietly does nothing would leave the required check green with the gate it
+enables inert — the exact shape this change exists to remove, reintroduced one
+level up. Security review found three routes to that, all since measured:
+
+| Route | Measured | Closed by |
+| --- | --- | --- |
+| The grep matches nothing → `pip install ""` exits **0 with no output**, and a failing command substitution inside a `run:` block does not fail the step on its own | Confirmed against pip and `bash -e` | `set -euo pipefail` with the substitution in an *assignment*, whose status `set -e` does honour |
+| bandit installs but its registry import raises — an API move inside `>=1.9,<2`, a broken plugin entry point — so `id_checker()` returns `None` and `lint-nosec-form` degrades to a caveat and exit 0 | Confirmed by reading `id_checker`'s `except Exception: return None` | A `python -c` assertion reaching for the same API, checking **both** directions: a real id resolves, a nonexistent one does not |
+| A later `pip install` replaces a shared transitive dep of bandit, exiting 0 while breaking it | Standard pip resolver behaviour | Moving the step to **last before `Run make build-check`**, so nothing runs in between |
+
+Each is mutation-tested: with no bandit line in the requirements file, with the
+registry import broken, and with a `check_id` that resolves everything, the step
+body exits non-zero. An unmutated assertion is an unverified one.
 
 ## Decision 2 — two grouped steps, not seven, and not one
 
@@ -128,10 +144,17 @@ not something to paper over by adding a second runner in `build-check.yml`.
       After it, zero. `test_check_rendered_site_links.py`'s `pages.yml`
       appearance is classified non-`run:` by that scan, not by reading the YAML.
 
-- [x] **AC3 — bandit is present on every build-check run.** A new,
-      unconditional install step precedes `Run make build-check` and installs
-      the `bandit` line read out of `tools/requirements-sast.txt`. The existing
-      conditional `Install SAST/SCA tools` step is unchanged.
+- [x] **AC3 — bandit is present on every build-check run, and the step fails
+      when it is not.** A new, unconditional install step is the **last** step
+      before `Run make build-check`; it installs the `bandit` line read out of
+      `tools/requirements-sast.txt`, and asserts the registry resolved by
+      calling the same API `id_checker()` reaches for, in both directions. The
+      existing conditional `Install SAST/SCA tools` step is unchanged.
+
+- [x] **AC3a — the fail-closed path is mutation-tested, not asserted.** With
+      (i) no `bandit` line in the requirements file, (ii) the registry import
+      broken, and (iii) a `check_id` that resolves every id, the step body exits
+      non-zero. Run, not reasoned about.
 
 - [x] **AC4 — the unknown-ID check is demonstrably live, and demonstrably was
       not.** `lint-nosec-form.scan_source` is run against a well-formed but
@@ -192,7 +215,7 @@ Goal-based, plus one measured before/after.
 | What | How |
 | --- | --- |
 | AC1, AC2 | The workflow scan described in AC2, run on the base and on the change. |
-| AC3 | Read the edited workflow; assert the new step has no `if:` and precedes `Run make build-check`. |
+| AC3, AC3a | Read the edited workflow; assert the new step has no `if:` and is the last step before `Run make build-check`. Then run the step body verbatim against three mutated inputs and assert each exits non-zero. |
 | AC4 | `scan_source(src, path, id_checker())` vs `scan_source(src, path, None)` on a `B`-shaped nonexistent ID. |
 | AC5, AC6 | `python3 tools/lint-ci-parity.py`; exit code and summary line. |
 | AC7 | The four gate commands. |
@@ -203,10 +226,22 @@ invariants in both directions — a step without a disposition and a disposition
 without a step both fail — so the roster edit is covered by an existing gate
 rather than a new one.
 
+## Deferred
+
+Four findings from `security-reviewer`, each recorded in `workspace.toml
+[backlog].open` with a cold-start-sufficient comment:
+
+| Slug | Why not here |
+| --- | --- |
+| `lint-nosec-form-require-id-registry` | The tool degrades to an exit-0 caveat when the registry is unreachable. **Every route to that is closed in CI by this change**; what remains is a local `SKIP_SAST=1 make build-check` without bandit. Fixing it in the linter makes bandit a hard prerequisite for every contributor — a real cost, and its own decision. |
+| `build-check-yml-no-permissions-block` | Adding `permissions: contents: read` changes the job's token scope. That is a behaviour change, which the bundled-fixes carve-out fails closed on, and it applies to three other workflows too. |
+| `sast-requirements-hash-locked` | Needs a generated locked file and a refresh procedure. |
+| `sast-requirements-not-audited` | `pip-audit` covers `tools/requirements.txt` and the pack files, not the CI-tooling ones. Confirmed by reading the `Makefile` invocations. A different file set and a different decision (audit vs. Dependabot). |
+
 ## Honest scope
 
-The seven tests now gate `main`, and bandit's registry is now present on every
-run. Two things this does **not** do:
+The seven tests now gate `main`, and bandit's registry is now present — and
+proven present — on every run. Two things this does **not** do:
 
 1. **Gate F's `paths-ignore` still excludes doc surfaces.** A PR touching only
    `docs/**` does not run `test_catalogue_tooling_rewire` or

--- a/docs/specs/build-check-coverage-gaps/spec.md
+++ b/docs/specs/build-check-coverage-gaps/spec.md
@@ -69,9 +69,8 @@ the expensive half of that install and neither is needed by any gate that runs
 under `SKIP_SAST`. Bandit alone is what `lint-nosec-form` needs.
 
 **The pin is read, not restated.** The new step greps the `bandit` line out of
-`tools/requirements-sast.txt` rather than naming a version. A second copy of
-`bandit>=1.9,<2` is a thing that can drift from the canonical one; deriving it
-cannot. The pattern is anchored `^bandit([^A-Za-z0-9._-]|$)` so a future
+`tools/requirements-sast.txt` rather than naming a version. A second copy of the version range is a thing
+that can drift from the canonical one; deriving it cannot. The pattern is anchored `^bandit([^A-Za-z0-9._-]|$)` so a future
 `bandit-extras` line cannot be picked up instead. Same principle `lint-ci-parity.py` applies to its own
 reachable-target set ("*derived* from the Makefile, never declared").
 
@@ -88,10 +87,13 @@ level up. Security review found three routes to that, all since measured:
 | The grep matches nothing → `pip install ""` exits **0 with no output**, and a failing command substitution inside a `run:` block does not fail the step on its own | Confirmed against pip and `bash -e` | `set -euo pipefail` with the substitution in an *assignment*, whose status `set -e` does honour |
 | bandit installs but its registry import raises — an API move inside `>=1.9,<2`, a broken plugin entry point — so `id_checker()` returns `None` and `lint-nosec-form` degrades to a caveat and exit 0 | Confirmed by reading `id_checker`'s `except Exception: return None` | A `python -c` assertion reaching for the same API, checking **both** directions: a real id resolves, a nonexistent one does not |
 | A later `pip install` replaces a shared transitive dep of bandit, exiting 0 while breaking it | Standard pip resolver behaviour | Moving the step to **last before `Run make build-check`**, so nothing runs in between |
+| `continue-on-error: true` on the step — it fails, the job does not, and neither `lint-ci-parity` nor a position check notices | Confirmed by adding it | AC4b's test reads the key and asserts it absent |
+| The body reformatted from `\|` to a folded `>-` scalar — the file's dominant style for multi-token commands — so what runs is one line and `bash` rejects it | Confirmed by reformatting it | AC4b's test records the scalar style and asserts `\|`, because the body it executes must be the body GitHub runs |
 
-Each is mutation-tested: with no bandit line in the requirements file, with the
-registry import broken, and with a `check_id` that resolves everything, the step
-body exits non-zero. An unmutated assertion is an unverified one.
+Every row is mutation-tested. AC4b is the single canonical statement of the
+mutation set — the workflow-level and body-level cases and their counts live
+there, and nothing else restates them, so the number cannot drift. An unmutated
+assertion is an unverified one.
 
 ## Decision 2 — two grouped steps, not seven, and not one
 
@@ -188,8 +190,18 @@ not something to paper over by adding a second runner in `build-check.yml`.
       `guides-readme-outcome-label-drift/spec.md` (names
       `catalogue-site-tests-absent-from-ci`) each carry a `Status`-line
       annotation recording that the anchor was closed and by what. Both are
-      Frozen; no body line changes; the carrier is the one `CONVENTIONS.md`
-      § *Superseding a frozen document* licenses.
+      Frozen and no body line changes.
+
+      **Both the carrier and this second *shape* of it are licensed.**
+      `CONVENTIONS.md` § *Superseding a frozen document* makes the `Status`
+      parenthetical the one edit a frozen spec accepts, and — since
+      [`frozen-doc-supersession-annotations`](../frozen-doc-supersession-annotations/spec.md)
+      landed — names two shapes for it: the supersession pointer, and this one,
+      a pointer recording that a `[backlog].open` anchor the body names has been
+      closed. Rules 3 and 4 hold (one-way, no body line moves); rules 1 and 2 do
+      not apply, because nothing was superseded and there is no ADR to point at.
+      That sequencing was deliberate: this spec was written while the rule was
+      still in flight and said so, and the sibling merged first.
 
 - [x] **AC5 — every new step carries a disposition.** `STEP_DISPOSITION` in
       `tools/lint-ci-parity.py` gains one entry per new step: `LOCAL("test")`
@@ -203,7 +215,9 @@ not something to paper over by adding a second runner in `build-check.yml`.
 
 - [x] **AC7 — gates pass.** `python3 tools/lint-ruff.py`, `make lint-mypy`,
       `SKIP_SAST=1 make build-check`, `make sast`, and
-      `lint-spec-status.py --root . --base-ref origin/main` all exit 0.
+      `python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .
+      --base-ref origin/main` all exit 0. (That script lives under the skill,
+      not in `tools/`.)
 
 - [x] **AC8 — both register entries are closed.**
       `catalogue-site-tests-absent-from-ci` and
@@ -291,10 +305,11 @@ proven present — on every run. Four things this does **not** do:
    from landing gated by nothing — `lint-ci-parity` only enforces
    workflow-step → local-target, never the reverse, and the reverse discipline
    exists only for `packs/**/tests`. Measured: **eight** `tools/test*.py` files
-   are invoked by no `Makefile` target, no workflow, and no tool script, two of
-   them arriving in the last four merges (#980, #982). The measurement and its
-   method live in the register entry `tools-test-runner-boundary`; this bullet
-   points at it rather than restating the list.
+   are invoked by no `Makefile` target, no workflow, and no tool script — two of
+   them arrivals from this same batch. The count, the file list, the method and
+   the dated measurement live in the register entry
+   `tools-test-runner-boundary`; this bullet points at it rather than restating
+   them, because a "last N merges" figure decays on every merge.
 4. **This couples every PR to formatting elsewhere.** Two of the seven suites
    assert on raw substrings of `pages.yml`, `web/src/lib/catalogue-navigation.ts`
    and two `.astro` files — including occurrence *counts* of quoted `paths:`

--- a/docs/specs/guides-readme-outcome-label-drift/spec.md
+++ b/docs/specs/guides-readme-outcome-label-drift/spec.md
@@ -1,6 +1,6 @@
 # Spec: guides-readme-outcome-label-drift
 
-- **Status:** Shipped
+- **Status:** Shipped (its deferral `catalogue-site-tests-absent-from-ci` was closed by [`build-check-coverage-gaps`](../build-check-coverage-gaps/spec.md), so that register anchor no longer resolves; not a supersession — every decision here stands)
 - **Owner:** eugenelim
 - **Plan:** none — light mode, single task
 - **Contract:** none. One documentation table cell; no schema, code, or

--- a/tools/lint-ci-parity.py
+++ b/tools/lint-ci-parity.py
@@ -239,6 +239,16 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
         CI_ONLY(
             "Provisioning."
         ),
+    "Install bandit unconditionally (lint-nosec-form's ID registry)":
+        CI_ONLY(
+            "Provisioning — but not interchangeable with the conditional step "
+            "above, which is why it is a separate row. `make build-check` "
+            "chains lint-nosec-form.py on every run, and its unknown-test-id "
+            "check reads bandit's registry; without bandit that check silently "
+            "no-ops. Behind the skip_sast condition it was inert on exactly the "
+            "diffs it exists for. Locally the contributor already has bandit "
+            "(tools/requirements-sast.txt), so there is no make target to name."
+        ),
     "Run make build-check":
         CI_ONLY(
             "Invokes the local gate itself — this is the parity anchor, not a "
@@ -281,6 +291,13 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
     "pytest make-free gate chains (windows-build-gate-chain)":
         LOCAL("test"),
     "pytest guides sidebar generation":
+        LOCAL("test"),
+    # Both wired by docs/specs/build-check-coverage-gaps. The seven files these
+    # two steps run were on `make test`'s Makefile line and in no workflow's
+    # run: steps — locally gated, remotely not.
+    "pytest guides + catalogue navigation":
+        LOCAL("test"),
+    "pytest site build + link rewriting":
         LOCAL("test"),
     # RFC-0082 export boundary. The gate itself runs in release-agentbundle.yml;
     # this step runs the gate's own tests, so a regression to always-exit-0 goes

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -92,17 +92,20 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
     `STEP_DISPOSITION` row passes the parity gate in both directions.
 
     The step body is **executed**, not pattern-matched: `pip` is stubbed so the
-    run is offline, and the two mutations below are the negative controls. An
-    assertion never seen to fail is an unverified one, and this file's older
-    `workflow.index(...)` cases are exactly the source-substring shape
+    run is offline, and the cases below are its negative controls. The full
+    mutation set — body-level and workflow-level — is enumerated once, in
+    `docs/specs/build-check-coverage-gaps/spec.md` AC4b; it is not restated
+    here, so the number cannot drift between the two. An assertion never seen to
+    fail is an unverified one, and this file's older `workflow.index(...)` cases
+    are exactly the source-substring shape
     `docs/knowledge/observations/antipattern/2026-08.jsonl` warns about.
     """
 
     STEP = "Install bandit unconditionally (lint-nosec-form's ID registry)"
     GATE = "Run make build-check"
 
-    @staticmethod
-    def _parse_steps(text: str) -> list[dict]:
+    @classmethod
+    def _parse_steps(cls, text: str) -> list[dict]:
         """Return `build-check.yml`'s steps as {name, has_if, run} dicts.
 
         Hand-parsed rather than PyYAML on purpose. This module is pure stdlib
@@ -129,7 +132,10 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
             if line and not line.startswith("      ") and stripped:
                 break  # dedented out of the steps list
             if line.startswith("      - "):
-                current = {"name": None, "has_if": False, "run": None}
+                current = {
+                    "name": None, "has_if": False, "run": None,
+                    "style": None, "continue_on_error": False,
+                }
                 steps.append(current)
                 run_indent = None
                 # Re-indent the first key onto the eight-space level the rest of
@@ -143,7 +149,7 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
                 if not stripped or len(line) - len(line.lstrip(" ")) >= run_indent:
                     current["run"].append(line[run_indent:])
                     continue
-                current["run"] = "\n".join(current["run"]).rstrip("\n")
+                current["run"] = cls._join(current["run"], current["style"])
                 run_indent = None
             if line.startswith("        ") and not line.startswith("         "):
                 key, _, value = stripped.partition(":")
@@ -151,15 +157,41 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
                     current["name"] = value.strip()
                 elif key == "if":
                     current["has_if"] = True
+                elif key == "continue-on-error":
+                    current["continue_on_error"] = value.strip() not in ("false", "")
                 elif key == "run" and value.strip() in ("|", "|-", ">-", ">"):
                     current["run"] = []
+                    current["style"] = value.strip()
                     run_indent = 10
                 elif key == "run":
                     current["run"] = value.strip()
+                    current["style"] = "plain"
         for step in steps:
             if isinstance(step["run"], list):
-                step["run"] = "\n".join(step["run"]).rstrip("\n")
+                step["run"] = cls._join(step["run"], step["style"])
         return steps
+
+    @staticmethod
+    def _join(body: list[str], style: str | None) -> str:
+        """Join a block scalar's lines the way YAML would, per its style.
+
+        `|` keeps newlines; `>` folds a single newline to a space (blank lines
+        stay newlines). Getting this wrong is not cosmetic: a folded body run as
+        if it were literal is a different script — `set -euo pipefail pin=…` on
+        one line, which bash rejects — so a test that "executes the real body"
+        would be executing something GitHub never runs.
+        """
+        if style in (">", ">-"):
+            out: list[str] = []
+            for line in body:
+                if not line.strip():
+                    out.append("\n")
+                elif out and out[-1] != "\n":
+                    out[-1] = out[-1] + " " + line.strip()
+                else:
+                    out.append(line.strip())
+            return "".join(out).strip()
+        return "\n".join(body).rstrip("\n")
 
     def setUp(self):
         self.root = Path(__file__).resolve().parents[1]
@@ -211,6 +243,16 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
             "first place; the whole point is that it is not",
         )
         self.assertIn(self.GATE, self.names)
+        self.assertFalse(
+            self._step()["continue_on_error"],
+            "continue-on-error neuters the step as completely as deleting it, "
+            "and neither lint-ci-parity nor the position check notices",
+        )
+        self.assertEqual(
+            self._step()["style"], "|",
+            "the body below is executed verbatim; a folded scalar would run as "
+            "one line and is a different script",
+        )
         self.assertEqual(
             self.names[index + 1], self.GATE,
             "another step between the install and the gate can replace a shared "
@@ -235,7 +277,12 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
         (fake / "tools/requirements-sast.txt").write_text(
             "pip-audit>=2.10,<3\nsemgrep>=1.166,<2\n", encoding="utf-8"
         )
-        self.assertNotEqual(self._run_body(fake).returncode, 0)
+        result = self._run_body(fake)
+        self.assertNotEqual(result.returncode, 0)
+        # Assert the cause, not just the exit code: with bandit absent (Gate F's
+        # env, where the positive control skips) a step that can never succeed
+        # for an unrelated reason would satisfy a bare non-zero check.
+        self.assertNotIn("installing pinned:", result.stdout)
 
     def _bandit_shim(self, extension_loader_source: str) -> str:
         holder = tempfile.TemporaryDirectory()
@@ -258,6 +305,9 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
         (shim / "bandit/__init__.py").write_text("", encoding="utf-8")
         result = self._run_body(self.root, {"PYTHONPATH": str(shim)})
         self.assertNotEqual(result.returncode, 0, result.stdout)
+        # It got past the grep and the install, and died on the import.
+        self.assertIn("installing pinned:", result.stdout)
+        self.assertIn("bandit.core", result.stderr)
 
     def test_step_body_fails_when_the_registry_resolves_every_id(self):
         """The probe's second direction, which the other cases cannot reach.
@@ -276,6 +326,7 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
         )
         result = self._run_body(self.root, {"PYTHONPATH": shim})
         self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("did not resolve as lint-nosec-form", result.stderr)
 
     def test_step_body_fails_when_the_registry_resolves_nothing(self):
         """The probe's first direction, so neither half can be deleted unnoticed.
@@ -293,6 +344,7 @@ class BanditRegistryProvisioningTest(unittest.TestCase):
         )
         result = self._run_body(self.root, {"PYTHONPATH": shim})
         self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertIn("did not resolve as lint-nosec-form", result.stderr)
 
 
 class CiPytestProvisioningTest(unittest.TestCase):

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -11,6 +11,9 @@ import argparse
 import ast
 import contextlib
 import io
+import os
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -73,6 +76,223 @@ class PackSkillPytestShapeTest(unittest.TestCase):
             if legacy:
                 failures.append(f"{path.relative_to(root)}: undiscoverable cases {legacy}")
         self.assertEqual(failures, [], "\n".join(failures))
+
+
+class BanditRegistryProvisioningTest(unittest.TestCase):
+    """`build-check` installs bandit unconditionally, last, and proves it worked.
+
+    `make build-check` chains `tools/lint-nosec-form.py`, whose unknown-test-id
+    check reads bandit's registry through `id_checker()` and **degrades to an
+    exit-0 caveat** when it cannot. So a provisioning step that quietly does
+    nothing leaves the required check green with that check inert — which is the
+    defect `docs/specs/build-check-coverage-gaps` exists to remove.
+
+    Nothing else pins the step. `tools/lint-ci-parity.py`'s roster only demands
+    a disposition for steps that *exist*, so deleting the step together with its
+    `STEP_DISPOSITION` row passes the parity gate in both directions.
+
+    The step body is **executed**, not pattern-matched: `pip` is stubbed so the
+    run is offline, and the two mutations below are the negative controls. An
+    assertion never seen to fail is an unverified one, and this file's older
+    `workflow.index(...)` cases are exactly the source-substring shape
+    `docs/knowledge/observations/antipattern/2026-08.jsonl` warns about.
+    """
+
+    STEP = "Install bandit unconditionally (lint-nosec-form's ID registry)"
+    GATE = "Run make build-check"
+
+    @staticmethod
+    def _parse_steps(text: str) -> list[dict]:
+        """Return `build-check.yml`'s steps as {name, has_if, run} dicts.
+
+        Hand-parsed rather than PyYAML on purpose. This module is pure stdlib
+        (AGENTS.md § New tool scripts) AND runs in Gate F of
+        catalogue-tooling-ci-gates.yml, whose job installs only agentbundle —
+        which declares no dependencies — so importing yaml here fails at
+        collection there. A pin that cannot run in one of the two jobs that run
+        it is not a pin.
+
+        Only the fixed shape of a steps list is read: a step opens at six
+        spaces + "- ", its keys sit at eight, and a block scalar's body sits
+        deeper. That is structure, not a substring search for the control.
+        """
+        steps: list[dict] = []
+        lines = text.splitlines()
+        index = 0
+        while index < len(lines) and lines[index] != "    steps:":
+            index += 1
+        index += 1
+        current: dict | None = None
+        run_indent: int | None = None
+        for line in lines[index:]:
+            stripped = line.strip()
+            if line and not line.startswith("      ") and stripped:
+                break  # dedented out of the steps list
+            if line.startswith("      - "):
+                current = {"name": None, "has_if": False, "run": None}
+                steps.append(current)
+                run_indent = None
+                # Re-indent the first key onto the eight-space level the rest of
+                # the step's keys sit at, and re-strip: `stripped` above still
+                # carries the "- " that would otherwise land in the key name.
+                line = "        " + line[8:]
+                stripped = line.strip()
+            if current is None:
+                continue
+            if run_indent is not None:
+                if not stripped or len(line) - len(line.lstrip(" ")) >= run_indent:
+                    current["run"].append(line[run_indent:])
+                    continue
+                current["run"] = "\n".join(current["run"]).rstrip("\n")
+                run_indent = None
+            if line.startswith("        ") and not line.startswith("         "):
+                key, _, value = stripped.partition(":")
+                if key == "name":
+                    current["name"] = value.strip()
+                elif key == "if":
+                    current["has_if"] = True
+                elif key == "run" and value.strip() in ("|", "|-", ">-", ">"):
+                    current["run"] = []
+                    run_indent = 10
+                elif key == "run":
+                    current["run"] = value.strip()
+        for step in steps:
+            if isinstance(step["run"], list):
+                step["run"] = "\n".join(step["run"]).rstrip("\n")
+        return steps
+
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[1]
+        self.steps = self._parse_steps(
+            (self.root / ".github/workflows/build-check.yml").read_text(encoding="utf-8")
+        )
+        self.names = [step["name"] for step in self.steps]
+        # The parse itself must not be the thing that silently breaks: if the
+        # workflow's shape ever stops matching, this fails loudly here rather
+        # than reporting an absent step.
+        self.assertGreater(len(self.steps), 30, "step parse collapsed")
+        self.assertIn(self.GATE, self.names, "step parse lost a known step")
+
+    def _step(self):
+        self.assertIn(
+            self.STEP, self.names,
+            "the unconditional bandit install is gone; lint-nosec-form's "
+            "unknown-id check is inert again and no other gate notices",
+        )
+        return self.steps[self.names.index(self.STEP)]
+
+    def _run_body(self, cwd: Path, extra_env: dict[str, str] | None = None):
+        """Run the real step body with `pip` stubbed out. Returns CompletedProcess."""
+        bash = shutil.which("bash")
+        if bash is None:  # pragma: no cover - POSIX runners always have it
+            self.skipTest("bash unavailable; the step body is a bash script")
+        holder = tempfile.TemporaryDirectory()
+        self.addCleanup(holder.cleanup)
+        stub = Path(holder.name) / "bin"
+        stub.mkdir()
+        (stub / "pip").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (stub / "pip").chmod(0o755)
+        (stub / "python").write_text(
+            f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8"
+        )
+        (stub / "python").chmod(0o755)
+        env = dict(os.environ, PATH=f"{stub}{os.pathsep}{os.environ.get('PATH', '')}")
+        env.update(extra_env or {})
+        return subprocess.run(  # noqa: S603
+            [bash, "-c", self._step()["run"]],
+            cwd=cwd, env=env, capture_output=True, text=True, check=False,
+        )
+
+    def test_step_is_unconditional_and_immediately_precedes_the_gate(self):
+        index = self.names.index(self._step()["name"])
+        self.assertFalse(
+            self._step()["has_if"],
+            "an `if:` here is what made the bandit install skippable in the "
+            "first place; the whole point is that it is not",
+        )
+        self.assertIn(self.GATE, self.names)
+        self.assertEqual(
+            self.names[index + 1], self.GATE,
+            "another step between the install and the gate can replace a shared "
+            "transitive dependency of bandit while exiting 0",
+        )
+
+    def test_step_body_passes_against_the_real_tree(self):
+        try:
+            import bandit.core.extension_loader  # noqa: F401,PLC0415
+        except Exception:  # noqa: BLE001 - a broken plugin raises more than ImportError
+            self.skipTest("bandit not installed; the positive control needs it")
+        result = self._run_body(self.root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("bandit", result.stdout)
+
+    def test_step_body_fails_when_the_requirements_file_names_no_bandit(self):
+        """`pip install ""` exits 0 with no output — the substitution must fail first."""
+        holder = tempfile.TemporaryDirectory()
+        self.addCleanup(holder.cleanup)
+        fake = Path(holder.name)
+        (fake / "tools").mkdir()
+        (fake / "tools/requirements-sast.txt").write_text(
+            "pip-audit>=2.10,<3\nsemgrep>=1.166,<2\n", encoding="utf-8"
+        )
+        self.assertNotEqual(self._run_body(fake).returncode, 0)
+
+    def _bandit_shim(self, extension_loader_source: str) -> str:
+        holder = tempfile.TemporaryDirectory()
+        self.addCleanup(holder.cleanup)
+        shim = Path(holder.name)
+        (shim / "bandit" / "core").mkdir(parents=True)
+        (shim / "bandit/__init__.py").write_text("", encoding="utf-8")
+        (shim / "bandit/core/__init__.py").write_text("", encoding="utf-8")
+        (shim / "bandit/core/extension_loader.py").write_text(
+            extension_loader_source, encoding="utf-8"
+        )
+        return str(shim)
+
+    def test_step_body_fails_when_the_bandit_registry_is_unusable(self):
+        """`id_checker()` swallows every exception, so an API move must fail here."""
+        holder = tempfile.TemporaryDirectory()
+        self.addCleanup(holder.cleanup)
+        shim = Path(holder.name)
+        (shim / "bandit").mkdir()
+        (shim / "bandit/__init__.py").write_text("", encoding="utf-8")
+        result = self._run_body(self.root, {"PYTHONPATH": str(shim)})
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_step_body_fails_when_the_registry_resolves_every_id(self):
+        """The probe's second direction, which the other cases cannot reach.
+
+        A `check_id` that says yes to everything satisfies the real-id half and
+        would leave `lint-nosec-form` reporting no unknown ids while resolving
+        `B999` — the same silent pass, from the opposite direction. Without this
+        case, deleting ` or loader.MANAGER.check_id("B999")` from the probe
+        leaves the suite green; measured.
+        """
+        shim = self._bandit_shim(
+            "class _Manager:\n"
+            "    def check_id(self, test_id):\n"
+            "        return True\n"
+            "MANAGER = _Manager()\n"
+        )
+        result = self._run_body(self.root, {"PYTHONPATH": shim})
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_step_body_fails_when_the_registry_resolves_nothing(self):
+        """The probe's first direction, so neither half can be deleted unnoticed.
+
+        An importable registry that resolves no id is not the silent-pass shape
+        — `lint-nosec-form` would flag every valid suppression instead — but
+        without this case the `check_id("B307")` half of the probe can be
+        removed and the suite stays green. Both halves get a negative control.
+        """
+        shim = self._bandit_shim(
+            "class _Manager:\n"
+            "    def check_id(self, test_id):\n"
+            "        return False\n"
+            "MANAGER = _Manager()\n"
+        )
+        result = self._run_body(self.root, {"PYTHONPATH": shim})
+        self.assertNotEqual(result.returncode, 0, result.stdout)
 
 
 class CiPytestProvisioningTest(unittest.TestCase):

--- a/workspace.toml
+++ b/workspace.toml
@@ -1683,6 +1683,43 @@ open = [
   # cost and deserves its own decision, not a ride-along.
   {slug = "lint-nosec-form-require-id-registry", summary = "Add --require-id-registry to lint-nosec-form.py so an unreachable bandit registry exits 2 instead of degrading to an exit-0 caveat, and decide whether bandit becomes a hard build-check prerequisite", source = "spec/build-check-coverage-gaps security review"},
 
+  # Nothing stops the NEXT tools/ test from landing gated by nothing.
+  # lint-ci-parity enforces workflow-step -> local-make-target and never the
+  # reverse; lint-pack-test-boundary.py enforces the reverse direction only for
+  # packs/**/tests (its _RUNNER_FILES / _NO_RUNNER tables), not for tools/.
+  # That asymmetry is the defect that produced #958, and spec/
+  # build-check-coverage-gaps fixed the instance without closing the class.
+  # Measured 2026-08-17 by scanning Makefile + .github/workflows/ + every
+  # non-test tools/**/*.py and packages/agentbundle/**/*.py for each of the 65
+  # tools/test*.py filenames: EIGHT are invoked by nothing at all --
+  # test-check-atlassian-phase3-readiness, test-check-contract-drift,
+  # test-compare-bandit-suppressions, test_build_site_dry_run,
+  # test_enterprise_rollout_playbook, test_export_work_index,
+  # test_guide_typed_asides, test_live_demo_guide. Two of those arrived in the
+  # last two merges (#980, #982), so this is an active leak, not a backlog.
+  # Note the scan must include tools/catalogue/ and tools/hooks/ as invocation
+  # sources: an earlier pass over Makefile + workflows alone reported 14 and was
+  # wrong, because pre_pr_catalogue.py invokes several directly.
+  # Fix: extend the _RUNNER_FILES/_NO_RUNNER discipline to tools/test*.py -- a
+  # test file must name a runner or carry an explicit no-runner disposition.
+  {slug = "tools-test-runner-boundary", summary = "Extend lint-pack-test-boundary's runner/no-runner discipline to tools/test*.py; eight are invoked by nothing today", source = "spec/build-check-coverage-gaps review"},
+  # Wiring the seven guides/site suites into build-check.yml (spec/
+  # build-check-coverage-gaps) couples EVERY PR to the formatting of files those
+  # tests substring-assert against. test_check_rendered_site_links.py's
+  # test_pages_gate_runs_after_both_builds_before_upload_and_has_path_filters
+  # asserts on raw text of pages.yml including exact single-quoted `paths:`
+  # entries and their occurrence COUNTS; test_catalogue_navigation.py does the
+  # same against web/src/lib/catalogue-navigation.ts and two .astro files.
+  # build-check.yml has no `paths:` filter, so a cosmetic requote in pages.yml
+  # now reddens the required check for an unrelated PR. Worse, per the
+  # antipattern recorded in docs/knowledge/observations/antipattern/2026-08.jsonl
+  # those assertions do not detect REMOVAL of what they claim to pin -- they are
+  # the source-substring shape that register entry exists to name.
+  # Fix: re-express both against parsed YAML / a parsed module graph, then
+  # confirm each goes red when the pinned control is deleted. Do not simply
+  # loosen them; the ordering they assert is real.
+  {slug = "site-test-source-substring-assertions", summary = "Re-express test_check_rendered_site_links' pages.yml ordering assertion and test_catalogue_navigation's web/src assertions against parsed structure, and verify each by deletion", source = "spec/build-check-coverage-gaps review"},
+
   # docs/specs/distribution-adapters/spec.md carries `- **Status:** Shipped`,
   # which CONVENTIONS.md's lifecycle table puts in the Frozen class ("bodies
   # cannot change") -- yet every adapter PR amends it: each one's Constrained-by

--- a/workspace.toml
+++ b/workspace.toml
@@ -1669,42 +1669,6 @@ open = [
   # passing is the false positive that spec exists to avoid.
   {slug = "adr-0050-supersession-body-survey", summary = "Body-survey the ADR-0050 -> ADR-0055 chain; platform-site/spec.md still documents a MkDocs route for a build that no longer exists and cites no ADR, so no header scan reaches it", source = "spec/frozen-doc-supersession-annotations review"},
 
-  # build-check.yml installs tools/requirements-sast.txt only when
-  # skip_sast != 'true', so on a SKIP_SAST PR bandit is absent and
-  # lint-nosec-form's unknown-id check (a well-formed but nonexistent ID like a
-  # typo'd B999, which bandit resolves to nothing and so treats as a blanket
-  # suppression) silently no-ops. Where bandit IS installed, make sast runs too
-  # and run-bandit-gate.py already fails on bandit's own stderr for that case --
-  # so the check currently adds zero CI coverage, only local and defence-in-depth
-  # value. Surfaced in spec/bandit-nosec-form-lint AC4b rather than hidden.
-  # Fix: drop the `if:` on that install step, or add an unconditional bandit-only
-  # install, so the registry is present on every build-check run. Weigh against
-  # the install cost on diffs that scan nothing.
-  {slug = "build-check-installs-bandit-unconditionally", summary = "Install bandit on every build-check run so lint-nosec-form's unknown-ID check is not inert on SKIP_SAST PRs", source = "spec/bandit-nosec-form-lint"},
-
-  # 7 of the 13 pytest files named on Makefile:349 (`make test`) are a run step
-  # in NO workflow: test_validate_guides, test_check_guide_index,
-  # test_catalogue_navigation, test_documentation_entry_links,
-  # test_build_site_link_rewrites, test_check_rendered_site_links,
-  # test_build_site_routing. So they gate `make ci` locally and nothing
-  # remotely. Counted per-file across all of .github/workflows/, not just
-  # build-check.yml -- an earlier draft of this entry said 9 because it grepped
-  # build-check.yml alone and missed Gate F.
-  #   - test_check_rendered_site_links appears in pages.yml:23,45 but only as a
-  #     `paths:` trigger, never as a run step. Easy to miscount as covered.
-  #   - test_catalogue_tooling_rewire and _docs ARE run, by Gate F of
-  #     catalogue-tooling-ci-gates.yml:513,515 -- so they are NOT in this list.
-  #     Note though that workflow's paths-ignore covers docs/**, guides/**,
-  #     docs-site/** and web/**, so it does not gate doc-surface PRs either.
-  #     Do not "fix" those two here; that would duplicate Gate F.
-  # This is not theoretical: it is exactly how #958 merged green while leaving
-  # main red on test_catalogue_navigation, the failure PR #967 recorded as a
-  # known skip and this entry's sibling spec then fixed.
-  # Fix: add the seven as explicit build-check.yml steps (or one grouped step)
-  # and give each its lint-ci-parity disposition. Wiring one alone was declined
-  # in guides-readme-outcome-label-drift -- partial coverage reads as coverage.
-  {slug = "catalogue-site-tests-absent-from-ci", summary = "Wire the 7 catalogue/site pytest files from Makefile:349 that are a run step in no GitHub workflow into build-check.yml, with lint-ci-parity dispositions", source = "spec/guides-readme-outcome-label-drift"},
-
   # test-loop-cohort.sh is 493 lines / 51 cases of bash and uses ~20 bash-isms
   # ([[, local, $(), declare). AGENTS.md's "New tool scripts: Python, not bash"
   # rule grandfathers existing .sh, but this one is a portability dead end: a

--- a/workspace.toml
+++ b/workspace.toml
@@ -1631,6 +1631,58 @@ open = [
   # artifact is committed in. That is a schema change, hence its own PR.
   {slug = "publish-control-evidence-not-repo-bound", summary = "Record the observed repository in the publish-control evidence artifact and have the linter check it matches the committing repo", source = "spec/capture-evidence-repo-dot-segments"},
 
+  # build-check.yml declares no top-level `permissions:` block, so every step --
+  # including three pip installs and an editable install that executes setup.py
+  # -- runs under the repository's DEFAULT GITHUB_TOKEN. The job also runs on
+  # `push: branches: [main]`, where that default may be write-scoped. 10 of the
+  # 14 workflows here already declare one; ci-security.yml:27 documents
+  # `contents: read` as the intended posture, so this is the repo's own pattern
+  # being missed rather than an unconsidered gap. Surfaced by security review on
+  # spec/build-check-coverage-gaps and deliberately NOT bundled there: adding the
+  # block changes the job's token scope, which is a behaviour change and outside
+  # that spec's bundled-fixes carve-out.
+  # Fix: add `permissions: contents: read` at the top of build-check.yml (and
+  # sweep the other three undeclared workflows). zizmor's `excessive-permissions`
+  # audit would own this class going forward, but ci-security.yml:120 filters it
+  # out with --min-severity high -- lower the threshold or add a rule-specific
+  # run in the same change, or the next one lands the same way.
+  {slug = "build-check-yml-no-permissions-block", summary = "Declare `permissions: contents: read` on build-check.yml (and the three other undeclared workflows), and stop zizmor's --min-severity high from filtering out excessive-permissions", source = "spec/build-check-coverage-gaps security review"},
+  # tools/requirements-sast.txt is installed by range (`bandit>=1.9,<2` etc.)
+  # with no hashes, and after spec/build-check-coverage-gaps its bandit line is
+  # fetched on 100% of build-check runs rather than a subset. The repo already
+  # demonstrates the stronger shape one workflow over: ci-security.yml:107 runs
+  # `pip install --require-hashes -r tools/requirements-ci-security-locked.txt`.
+  # Fix: generate a hash-locked tools/requirements-sast-locked.txt from the range
+  # file and install from it with --require-hashes in both the conditional and
+  # the unconditional step, keeping requirements-sast.txt as the canonical input
+  # so nothing restates a pin. Needs a refresh procedure, hence its own PR.
+  {slug = "sast-requirements-hash-locked", summary = "Generate and install a hash-locked tools/requirements-sast-locked.txt with --require-hashes, mirroring the ci-security locked file", source = "spec/build-check-coverage-gaps security review"},
+  # pip-audit covers tools/requirements.txt and every packs/*/requirements.txt
+  # (Makefile:235) and the PEP 517 build-system requirements (Makefile:238). It
+  # does NOT cover tools/requirements-sast.txt or
+  # tools/requirements-ci-security-locked.txt -- the CI tooling itself has no SCA.
+  # Confirmed by reading the audit invocations, not inferred. Adjacent to
+  # npm-dependabot-wiring but a different ecosystem and a different file set.
+  # Fix: add the two CI-tooling requirements files to the audit-requirements.py
+  # invocation, or wire Dependabot for pip so the bumps arrive as PRs. Decide
+  # which, then do one -- doing both duplicates the noise.
+  {slug = "sast-requirements-not-audited", summary = "Give tools/requirements-sast.txt and requirements-ci-security-locked.txt SCA coverage -- pip-audit skips both today", source = "spec/build-check-coverage-gaps security review"},
+  # lint-nosec-form.py's unknown-id check degrades silently when bandit's
+  # registry is unreachable: id_checker() catches Exception and returns None,
+  # and main() then appends " (bandit absent: IDs not resolved)" to an EXIT-0
+  # line. That contradicts the tool's own stated rule two guards above it -- an
+  # empty scan exits 2 precisely because "a silent no-op is not a pass".
+  # spec/build-check-coverage-gaps closed every route to this IN CI (the install
+  # step now asserts the registry resolves, in both directions, and runs last),
+  # but a local `SKIP_SAST=1 make build-check` on a machine without bandit still
+  # reports OK on a degraded scan.
+  # Fix: give the script a --require-id-registry flag that turns
+  # `known_ids is None` into exit 2, and pass it from tools/repo/build_gate_chain.py
+  # so local and CI behave identically. Deferred because it makes bandit a hard
+  # prerequisite of `make build-check` for every contributor -- that is a real
+  # cost and deserves its own decision, not a ride-along.
+  {slug = "lint-nosec-form-require-id-registry", summary = "Add --require-id-registry to lint-nosec-form.py so an unreachable bandit registry exits 2 instead of degrading to an exit-0 caveat, and decide whether bandit becomes a hard build-check prerequisite", source = "spec/build-check-coverage-gaps security review"},
+
   # docs/specs/distribution-adapters/spec.md carries `- **Status:** Shipped`,
   # which CONVENTIONS.md's lifecycle table puts in the Frozen class ("bodies
   # cannot change") -- yet every adapter PR amends it: each one's Constrained-by


### PR DESCRIPTION
## What does this change?

Wires seven `tools/` test suites into `build-check.yml` that were a run step in
no workflow, and makes the bandit install unconditional so
`tools/lint-nosec-form.py`'s unknown-test-id check is not inert on exactly the
PRs it exists for. Both are `build-check.yml` edits with `lint-ci-parity`
dispositions, which is why they are one PR.

## Why?

- Implements: `docs/specs/build-check-coverage-gaps/spec.md`
- Closes: `catalogue-site-tests-absent-from-ci`, `build-check-installs-bandit-unconditionally`
- Follows from: ADR-0017, ADR-0084; `docs/specs/bandit-nosec-form-lint/spec.md` AC4b defers Gap 2 here

**Gap 1** is not hypothetical: it is how #958 merged green while leaving `main`
red on `test_catalogue_navigation` — a failure #967 had to record as a known
skip and a later spec had to fix. Seven of the thirteen suites on `make test`'s
`Makefile` line gated a contributor's machine and nothing on the way to `main`.

**Gap 2**: `build-check.yml` installed `requirements-sast.txt` only when
`skip_sast != 'true'`, so on a `SKIP_SAST` PR bandit was absent and the
unknown-ID check silently no-oped. Where bandit *was* installed, `make sast`
ran too and `run-bandit-gate.py` already caught the same shape — so the check's
CI reach was nil.

**Bundled, and here is the argument against.** Two register entries in one PR
widens the diff. They are bundled because each fix is one edit to
`build-check.yml` plus one `STEP_DISPOSITION` row, and reviewing one
CI-coverage change costs less than reviewing two. If you would rather see them
split, say so and I will.

## How do I verify it?

```bash
python3 tools/lint-ruff.py                 # clean
make lint-mypy                             # clean
SKIP_SAST=1 make build-check               # exit 0
make sast                                  # exit 0
python3 tools/lint-ci-parity.py            # 56 → 59 steps, all dispositioned
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root . --base-ref origin/main
python3 -m pytest tools/test_build_gate_chain.py -q     # 25 passed
```

**The count of seven, by construction.** Parse every `.github/workflows/*.yml`,
walk it for `run:` scalars, test each of the thirteen `Makefile` filenames
against them. Before: exactly these seven absent. After: zero. Two traps that
make a grep get this wrong — `test_check_rendered_site_links.py` appears in
`pages.yml` as a `paths:` trigger and never as a run step; and
`test_catalogue_tooling_rewire`/`_docs` **are** run by Gate F of
`catalogue-tooling-ci-gates.yml`, so they are deliberately not in the seven.

**The bandit step is pinned, and the pin is verified by deletion.**
`BanditRegistryProvisioningTest` parses the workflow, asserts the step exists /
has no `if:` / has no `continue-on-error` / uses a `|` scalar / immediately
precedes the gate — then extracts and **executes** the real step body with
`pip` stubbed. Eight mutations each turn the suite red: delete the step,
restore its `if:`, add `continue-on-error: true`, reformat the body to `>-`,
insert a step before the gate, drop the probe, drop either direction of the
probe's `check_id` call. The restored control is green. Without it, deleting the
step *and its roster row* passes `lint-ci-parity` in both directions.

Each negative control asserts *why* the body failed, not just that it did — with
bandit unimportable (Gate F's environment, where the positive control skips) a
step that could never succeed previously satisfied all of them.

That test parses with a stdlib line scan, not PyYAML: it also runs in Gate F of
`catalogue-tooling-ci-gates.yml`, whose job installs only `agentbundle` (no
dependencies), so a `yaml` import would fail at collection there. The parser is
diffed against PyYAML across all 59 steps — zero mismatches, including folded
`>-` bodies — and the suite is verified with `yaml` made genuinely
unimportable.

## What did you not change that you considered?

- **Gate F's `paths-ignore`** still excludes `docs/**`, `guides/**`,
  `docs-site/**`, `web/**`, so a doc-surface PR does not run
  `test_catalogue_tooling_rewire`/`_docs`. Real, and a different workflow's gap.
- **The recurrence class.** Nothing stops the *next* `tools/` test landing gated
  by nothing — `lint-ci-parity` enforces workflow-step → local-target and never
  the reverse. Measured: **eight** `tools/test*.py` files are invoked by no make
  target, no workflow and no tool script — two of them arrivals from this same
  batch. The count, list, method and dated measurement live in the register
  entry `tools-test-runner-boundary`.
- **Widening the unconditional install to all of `requirements-sast.txt`.**
  `semgrep` and `pip-audit` are the expensive half and no gate running under
  `SKIP_SAST` needs them.
- **Deriving the bandit pin by restating it.** The step greps it out of
  `tools/requirements-sast.txt`, anchored so a future `bandit-extras` line
  cannot be picked up instead.

**Merge-order note — resolved.** The two `Status`-line annotations this PR adds
use the *second* licensed shape of the frozen-doc pointer (a closed register
anchor, not a supersession). That shape is written into `CONVENTIONS.md` by
#987, which merged first, so these annotations arrive under a written rule.
Rebased on top of it; AC4c now reflects the landed state.

Bundled fixes: none.

Deferred:

| Slug | Why not here |
| --- | --- |
| `lint-nosec-form-require-id-registry` | Every route to the silent no-op is closed **in CI**; what remains is a local `SKIP_SAST=1 make build-check` without bandit. Fixing that in the linter makes bandit a hard prerequisite for every contributor — its own decision. |
| `build-check-yml-no-permissions-block` | `permissions: contents: read` changes the job's token scope. A behaviour change, and it applies to three other workflows too. |
| `sast-requirements-hash-locked` | Needs a generated locked file and a refresh procedure. |
| `sast-requirements-not-audited` | `pip-audit` covers `tools/requirements.txt` and the pack files, not the CI-tooling ones. Confirmed by reading the `Makefile` invocations. |
| `tools-test-runner-boundary` | The recurrence class above. |
| `site-test-source-substring-assertions` | Two of the seven suites assert on raw substrings of `pages.yml` and `web/src/`. A rewrite of tests this change only wires up. |

---

## Checklist

- [x] Tests pass locally (`SKIP_SAST=1 make build-check`, `make sast`, `pytest tools/test_build_gate_chain.py`)
- [x] Lint and typecheck pass (`python3 tools/lint-ruff.py`, `make lint-mypy`)
- [x] Self-review run: `adversarial-reviewer` (three passes) and `security-reviewer`; blockers addressed
- [x] Spec and code agree
- [x] Living docs match reality — no user-visible behaviour change, so no `docs/product/changelog.md` or `guides/` entry
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — `docs/knowledge/observations/antipattern/2026-08.jsonl` (via `project-knowledge --capture`, in the sibling PR that shares the lesson)
