### PR TITLE
fix(agentbundle): complete portable catalogue verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -213,7 +213,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "author": {
@@ -293,7 +293,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "0.2.3"
+      "version": "0.2.4"
     },
     {
       "author": {

--- a/docs/guides/how-to/create-external-catalogue.md
+++ b/docs/guides/how-to/create-external-catalogue.md
@@ -72,7 +72,7 @@ Fix any errors before continuing. Add `--format json` to get machine-readable ou
 agentbundle catalogue verify --root my-catalogue/
 ```
 
-This runs the full 18-step pipeline including a build into a temp directory. It must exit 0 before
+This runs the full 19-step pipeline including a build into a temp directory. It must exit 0 before
 you publish or distribute the catalogue.
 
 ## Step 7 — Project to self-host adapters (optional)

--- a/docs/guides/reference/catalogue-commands.md
+++ b/docs/guides/reference/catalogue-commands.md
@@ -20,7 +20,7 @@ Exits 0 when all checks pass; non-zero on any failure. Runs as step 2 of `catalo
 
 ## `agentbundle catalogue verify`
 
-Runs the full 18-step source pipeline: lint, schema validation, contract checks, build (into a temp
+Runs the full 19-step source pipeline: lint, schema validation, contract checks, build (into a temp
 directory), self-host drift check, and more.
 
 ```

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -38,7 +38,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rendered pointer field is authoritative, and `none` values with explanatory
   annotations or ordinary punctuation no longer become dangling pointers when
   a repository adds its first discovery anchor.
+### [agentbundle][0.37.2] — 2026-08-17
 
+#### Added
+
+- **`catalogue verify` now performs all 19 advertised checks.** Profiles are
+  schema-validated and confined to local pack roots; dependencies are checked
+  for structure, supported ranges, required-pack compatibility, and cycles;
+  adapter declarations are checked against the shipped contract; configured
+  output is compared with a fresh confined build; pack manifests receive a
+  narrow preflight; and skill evaluation manifests are validated without
+  parsing opaque payload files.
+- **External catalogue portability has an end-to-end regression fixture.** A
+  synthetic two-pack catalogue verifies successfully through the real CLI,
+  including a portable seed that discusses this repository by name.
+
+#### Changed
+
+- **Dependency range semantics now agree across verify, lint, and install.**
+  Caret, tilde, comparator, compound, and prerelease forms use one
+  dependency-free npm-compatible parser. Below `1.0.0`, caret ranges keep their
+  normal semver meaning, so `^0.2` no longer accepts `0.3.x`.
+- **Host-only catalogue policy moved out of the distributable verifier.** Seed
+  and APM leak checks specific to this repository now run from the local build
+  gate, so external catalogues are not rejected for host vocabulary.
+- **Verifier help and adopter documentation now consistently describe a
+  19-step pipeline.**
+
+#### Fixed
+
+- **Malformed catalogue configuration now returns a bounded, redacted
+  diagnostic instead of leaking exception text.** The existing optional-PyYAML
+  guard remains a structured warning and now has explicit regression coverage.
+
+### [figma][0.3.2] — 2026-08-17
+
+#### Fixed
+
+- **Figma now declares the credential-brokers minor it actually supports.**
+  Dependency validation no longer relies on treating `^0.2` as compatible with
+  `0.3.x`.
+
+### [linear][0.2.4] — 2026-08-17
+
+#### Fixed
+
+- **Linear now declares the credential-brokers minor it actually supports.**
+  Dependency validation no longer relies on treating `^0.2` as compatible with
+  `0.3.x`.
+
+### [iac-terraform][0.1.7] — 2026-08-17
+
+#### Fixed
+
+- **IaC Terraform now declares the governance-extras minor it actually supports.**
+  Dependency validation no longer relies on treating `^0.6` as compatible with
+  `0.9.x`.
 ### [core][2.7.1] — 2026-08-17
 
 #### Added

--- a/docs/specs/catalogue-verifier-correctness/plan.md
+++ b/docs/specs/catalogue-verifier-correctness/plan.md
@@ -1,6 +1,6 @@
 # Plan: catalogue-verifier-correctness
 
-- **Status:** Executing
+- **Status:** Done
 - **Spec:** [`spec.md`](spec.md)
 
 ## Mode and declined patterns
@@ -20,6 +20,9 @@ Declined:
   deterministic projection derived from source, not a subprocess.
 - Tempted to add new verification steps beyond 19; declining — step additions require
   RFC or a separate spec.
+- Tempted to add step-11 validation and projection rules for agentic
+  `metadata.boundaries`; declining — this plan does not change that metadata contract,
+  and adding public verifier behavior would violate the spec's correctness-only boundary.
 - Tempted to emit `return []` with a docstring comment for steps that cannot be
   implemented in this PR; declining — every step must either implement or return a
   single `NotImplemented`-typed finding with a description, never a silent empty list.
@@ -36,8 +39,9 @@ Declined:
   spec (shipped schema sync for profile.schema.json).
 - Domain claim: `_APM_SKILL_BLOCKLIST` in verify.py contains `agent-ready-repo` by name.
   Confirmed by direct read of verify.py at HEAD.
-- Resolve-vs-surface: no open questions; all 11 defects confirmed (PyYAML guard already
-  correct at HEAD — T10 is regression coverage, not a defect fix). Proceeding to implementation.
+- Resolve-vs-surface: pre-EXECUTE review found contract and construction-test gaps. They
+  are resolved in this PLAN revision; implementation remains blocked until the revised
+  spec and plan pass review and receive fresh human approval.
 
 ## Task list
 
@@ -61,7 +65,7 @@ T12  Version + changelog + closeout               Depends on: T0–T11, T2b
 **Wave note:** T0–T10 and T2b all modify `verify.py` and are NOT parallelizable in supervisor
 mode — parallel implementers would conflict on the same file. Execute all tasks sequentially.
 T11 and T12 depend on all prior tasks and must be last.
-Final sequence: T0–T10, T2b (any order but sequential), then T11, then T12.
+Final sequence: T0, T2, T2b, T3–T10 (sequential), then T11, then T12.
 
 ---
 
@@ -75,6 +79,9 @@ Final sequence: T0–T10, T2b (any order but sequential), then T11, then T12.
 
 **Tests (write red first):**
 
+stub: true — materialized in `test_catalogue_verify_step1.py`; collect passes and the
+red assertion fails on raw diagnostic forwarding.
+
 ```python
 class TestStepConfigValidation:
     def test_malformed_catalogue_toml_returns_structured_diagnostic(self, tmp_path):
@@ -83,29 +90,36 @@ class TestStepConfigValidation:
         # assert result contains at least one Diagnostic, does NOT raise an exception
         # (malformed catalogue.toml must not escape as AttributeError or TOMLDecodeError)
         raise NotImplementedError  # STUB: AC0
-    def test_absent_catalogue_toml_still_ok(self, tmp_path):
+    def test_malformed_catalogue_toml_redacts_sensitive_details(self, tmp_path):
+        # malformed config includes a secret-like value and runs under an identifiable root
+        # assert CAT-V-001 contains neither raw exception text, the value, nor absolute root
+        raise NotImplementedError  # construction stub: config diagnostic redaction
+    def test_absent_catalogue_toml_continues_without_step1_diagnostic(self, tmp_path):
         # empty tmp_path — no catalogue.toml
         # call verify_catalogue(tmp_path)
-        # assert result is ok=True (absent = valid; load_catalogue_config() returns None)
-        # regression guard: test_verify_empty_dir_passes must remain green
-        raise NotImplementedError  # STUB: AC0
+        # assert no CAT-V-001; later CAT-V-002 source-identity lint is allowed
+        raise NotImplementedError  # construction stub: missing config continues
 ```
 
 **Approach:**
 
-`verify_catalogue()` currently calls `load_catalogue_config(root)` before entering
-`_VERIFY_STEPS`. If `catalogue.toml` is present but malformed, the TOML parse exception
-escapes the function entirely (including for `--format json`) — `_step_config_validation`
-is a no-op. Note: a missing `catalogue.toml` returns `None` from `load_catalogue_config()`
-(backward-compatible) — do NOT convert that case into an error.
+`verify_catalogue()` calls `load_catalogue_config(root)` before entering `_VERIFY_STEPS`.
+The current partial guard catches `CatalogueConfigError` and returns CAT-V-001, but it
+forwards `str(exc)` directly. That message is not a stable or safe public diagnostic: it
+can contain parser detail, absolute paths, or sensitive configuration text.
+`_step_config_validation` remains a no-op. A missing `catalogue.toml` returns `None` from
+`load_catalogue_config()`; do not convert that case into CAT-V-001. The remaining pipeline
+still runs and may correctly return CAT-V-002 for a missing source-identity contract.
 
-Fix: wrap the pre-loop `load_catalogue_config(root)` call in a try/except; on failure,
-return a result whose first diagnostic is a structured step-1 failure. Do NOT restructure
+Fix: retain the pre-loop `load_catalogue_config(root)` try/except, but replace raw exception
+forwarding with a bounded step-1 message such as `catalogue.toml is invalid`; use the
+repository-relative diagnostic path `catalogue.toml`. Do NOT restructure
 the step protocol by removing the pre-loop load — every subsequent step receives `config`
 from that pre-loop call, and removing it would pass `None` to valid catalogues, silently
 skipping config-dependent lint, schema, build, and drift checks. The guarded pre-load
 is the only correct approach. Do NOT silently swallow the error — return a structured
-finding per the "Boundaries / Never do" rule.
+finding per the "Boundaries / Never do" rule. Tests, rather than new control flow, are the
+main residual for this partially implemented task.
 
 **Done when:** `python3 -m pytest packages/agentbundle/tests/integration/test_catalogue_verify_step1.py -q` exits 0.
 
@@ -145,14 +159,12 @@ optional. That lint branch is currently unreachable for the same path reason
 argument is a statement of intent for both gates, not an appeal to live
 behaviour; whoever fixes lint should keep the two aligned.
 
-**Release:** shipped as agentbundle **0.35.3** — a patch, mid-plan. Not the minor
-T12 claims: 0.36.0 is reserved for the rest of this plan and Wave 4's AC29, which
-`workspace.toml` flags as a collision hazard. T12 still bumps a minor on top of
-0.35.3, and its changelog entry covers T0 and T2–T11 only — T1 is already
-published in the 0.35.3 sections of `packages/agentbundle/CHANGELOG.md` and
-`docs/product/changelog.md`.
+**Release:** T1 shipped independently as a patch. T12 derives the next available
+version from the package manifest and current workspace collision notes rather than
+reserving a number in this plan. Its changelog entry covers T0 and T2–T11 only —
+T1 already has its own published changelog sections.
 
-Resume this plan at T2. The rest of the task is left below as the record.
+Resume this plan at T0. The rest of the task is left below as the record.
 
 **Verification mode:** TDD
 
@@ -178,8 +190,10 @@ class TestStepPluginValidation:
         raise NotImplementedError  # STUB: AC2
 ```
 
-Note: all TDD task stubs in this plan that use `...` should be materialized as
-`raise NotImplementedError  # STUB: AC<n>` before EXECUTE begins (CONVENTIONS.md:391-396).
+Note: all open TDD task stubs must be materialized as compilable red tests before
+EXECUTE begins and recorded as `stub: true` in their task. Package tests use
+behavior-named construction-stub comments rather than internal AC identifiers, per
+`packages/AGENTS.local.md`.
 
 **Approach:**
 
@@ -217,6 +231,9 @@ Without this second change, a pack that has only `plugin.json` (wrong path) woul
 
 **Tests (write red first):**
 
+stub: true — materialized in `test_catalogue_verify_profile_schema.py`; collect passes
+and schema/reference/confinement assertions are red.
+
 ```python
 class TestStepProfiles:
     def test_valid_profile_passes(self, tmp_path):
@@ -241,6 +258,14 @@ class TestStepProfiles:
         # a missing pack
         # assert: step 6 still emits a pack-ref finding (config-None does not skip this check)
         raise NotImplementedError  # STUB: AC3
+    def test_invalid_or_traversing_pack_reference_emits_finding(self, tmp_path):
+        # schema-valid profile shape whose pack value violates canonical slug grammar
+        # assert: finding is emitted before any path outside packs_dir is read
+        raise NotImplementedError  # construction stub: invalid pack reference
+    def test_symlink_or_junction_escape_emits_finding(self, tmp_path):
+        # packs/<slug> resolves outside the configured packs root
+        # assert: finding is root-relative and the escaped sentinel is never read
+        raise NotImplementedError  # construction stub: confined pack reference
 ```
 
 **Approach:**
@@ -262,7 +287,15 @@ Extend `_step_profiles` in two passes per profile file:
    Note: `contracts/catalogue.schema.json:74-76` defines `[catalogue.paths].packs` as the
    relative packs-dir path and lint.py honors it; use the same derivation here so a
    catalogue with a custom packs path does not produce false "missing pack" findings.
-   A missing pack directory → finding. This check applies whether `config is None` or not.
+   Validate the referenced name against the canonical pack-name grammar before joining it
+   to `packs_dir`. Resolve both the root and candidate and require the candidate to remain
+   beneath the canonical root; reject absolute/traversing values and symlink or Windows
+   junction escapes without reading the escaped target. Detect junctions through
+   `Path.is_junction()` when available (with a false-returning compatibility fallback), so
+   the detector is construction-testable on non-Windows hosts. Use the repository's existing
+   pack-name/path-confinement helpers when available rather than adding a local variant.
+   A missing or escaped pack directory → finding. This check applies whether `config is
+   None` or not.
    Also update test fixtures and comments to use the object form: `{"pack": "nonexistent-pack"}`
    not a bare string in the profile's packs array.
 
@@ -279,6 +312,9 @@ Extend `_step_profiles` in two passes per profile file:
 - `packages/agentbundle/tests/integration/test_catalogue_verify_marketplace.py` (new)
 
 **Tests (write red first):**
+
+stub: true — materialized in `test_catalogue_verify_marketplace.py`; collect passes and
+the source-path assertion is red.
 
 ```python
 class TestStepMarketplace:
@@ -332,6 +368,12 @@ diagnostic code.
 
 **Tests (write red first):**
 
+stub: true — materialized in `test_catalogue_verify_dependencies.py`,
+`test_install_dependencies_gate.py`, and `test_catalogue_tooling_lint.py`; collect passes.
+The red construction suite covers every deterministic AC4 branch, the complete accepted
+range grammar and exclusion boundaries across verify/install/lint, external-catalogue
+profile closure, and traversal/symlink confinement before EXECUTE.
+
 ```python
 class TestStepDependencies:
     def test_no_dependencies_passes(self, tmp_path):
@@ -383,6 +425,14 @@ class TestStepDependencies:
         # run verify --pack A → assert NO finding (B's defect must not surface in A-only mode)
         # (AC4 scoping: check only the selected pack's dependencies)
         raise NotImplementedError  # STUB: AC4
+    def test_invalid_or_traversing_dependency_pack_emits_finding(self, tmp_path):
+        # local dependency pack violates canonical slug grammar
+        # assert: finding is emitted before local path lookup
+        raise NotImplementedError  # construction stub: invalid dependency pack
+    def test_dependency_symlink_or_junction_escape_emits_finding(self, tmp_path):
+        # packs/<dependency> resolves outside packs_dir
+        # assert: finding is root-relative and escaped pack.toml is never read
+        raise NotImplementedError  # construction stub: confined dependency lookup
     def test_config_none_skips_local_check_emits_diagnostic(self, tmp_path):
         # catalogue with NO catalogue.toml (config is None)
         # pack A declares required dep: catalogue = "my-catalogue", pack = "B"; pack B is absent
@@ -426,7 +476,10 @@ dependencies are objects with `catalogue`, `pack`, `version` under
       the RFC-0001 grammar does not accept emits a finding (syntax error) and skips the
       remaining checks for this dependency.
    b. If `dependency.catalogue == current_catalogue_name` (and range syntax is valid),
-      branch by dependency kind per RFC-0001 semantics (§ dependency semantics):
+      validate `dependency.pack` against the canonical pack-name grammar, resolve the
+      candidate beneath `packs_dir.resolve()`, and refuse absolute/traversing values plus
+      symlink or Windows-junction escapes before reading `pack.toml`. Then branch by
+      dependency kind per RFC-0001 semantics (§ dependency semantics):
       - **`required`**: fail-if-unsatisfied. Verify `packs/<dependency.pack>/` exists;
         if not, emit a finding (missing required dependency). If present, read the pack's
         `pack.toml` version field and check it satisfies the declared range; version out
@@ -527,6 +580,9 @@ python3 -m pytest packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
 
 **Tests (write red first):**
 
+stub: true — materialized in `test_catalogue_verify_adapter_compat.py`; collect passes
+and the unknown-adapter assertion is red.
+
 ```python
 class TestStepAdapterCompat:
     def test_no_allowed_adapters_passes(self, tmp_path):
@@ -577,6 +633,9 @@ Unknown adapter → finding. Load adapter keys from `_data/adapter.toml` via
 
 **Tests (write red first):**
 
+stub: true — materialized in `test_catalogue_verify_output_drift.py`; collect passes and
+the confined-tree assertion is red.
+
 ```python
 class TestStepOutputDrift:
     def test_no_generated_projections_passes(self, tmp_path):
@@ -598,6 +657,14 @@ class TestStepOutputDrift:
         # run verify --pack A → fresh tree contains only A; assert no finding
         # for pack B (out-of-scope packs must not produce spurious findings)
         raise NotImplementedError  # STUB: AC6
+    def test_output_symlink_or_junction_escape_is_refused(self, tmp_path):
+        # configured output contains a directory alias to an out-of-root sentinel
+        # assert: root-relative finding; sentinel content is never compared
+        raise NotImplementedError  # construction stub: confined output walk
+    def test_output_resolution_loop_terminates_with_finding(self, tmp_path):
+        # configured output contains a circular symlink/reparse path
+        # assert: verifier catches resolution failure and terminates deterministically
+        raise NotImplementedError  # construction stub: bounded output walk
 ```
 
 **Approach:**
@@ -618,12 +685,19 @@ Algorithm:
    Scope both trees to the same pack's projection paths (`dist/claude-plugins/<pack>/`,
    `dist/apm/<pack>/`) before comparing; otherwise all other packs in configured output
    produce spurious "stale" findings. When no `--pack` is specified, compare full trees.
-3. Compare bidirectionally (scoped as above):
+3. Walk both trees with one confined regular-file iterator. Canonicalize each root; record
+   the resolved current directory before inspecting filenames; reject child directories
+   whose resolved path leaves the root, including Windows junction/reparse points; never
+   follow symlink aliases; call `Path.is_junction()` when available (with a false-returning
+   compatibility fallback); and catch both `OSError` and `RuntimeError` from resolution.
+   Yield only root-relative paths so diagnostics cannot expose checkout paths. A refused
+   path produces a structured finding and its target is never read.
+4. Compare bidirectionally (scoped as above):
    a. For every file in the (scoped) configured output tree: if the file is absent from
       the fresh tree or its contents differ → emit a finding naming the stale path.
    b. For every file in the (scoped) fresh tree: if it is absent from the configured output
       → emit a finding naming the missing path (newly added pack projection not yet built).
-4. Replace `return []` with real implementation.
+5. Replace `return []` with real implementation.
 
 Note: per-pack `.claude-code/`, `.cursor/`, `.kiro/`, `.copilot/`, `.codex/` trees do NOT
 exist in the packs directory layout. Catalogue-level self-host projection drift is covered
@@ -640,14 +714,11 @@ by step 15 (`_step_selfhost_drift`); step 14 targets build-output package projec
 **Touches:**
 - `packages/agentbundle/agentbundle/catalogue_tooling/verify.py`
 - `packages/agentbundle/tests/integration/test_catalogue_verify_package_preflight.py` (new)
-- NOTE: `package.py` is intentionally NOT touched. Full custom-path support for
-  `package_catalogue()` would also require updating `_check_required_files` (still defaults
-  to the literal required path `packs`) and manifest extraction (only recognizes archive keys
-  whose first component is `packs`). That is a packaging-paths fix, not a verifier defect.
-  The verifier must implement its own path-aware traversal for step 17 (see step 3 below)
-  rather than calling the hardcoded helpers from `package.py`.
 
 **Tests (write red first):**
+
+stub: true — materialized in `test_catalogue_verify_package_preflight.py`; collect passes
+and the missing-manifest assertion is red.
 
 ```python
 class TestStepPackagePreflight:
@@ -660,67 +731,26 @@ class TestStepPackagePreflight:
         # A verifier finding for missing README would introduce a new contract rule
         # under a correctness-only spec — not permitted. Assert no finding is emitted.
     def test_config_less_preflight_emits_no_finding(self, tmp_path): ...
-        # verify_catalogue() currently passes config=None to all steps (AC0/T0 not yet
-        # implemented). This test exercises step 17 with config=None and a valid pack;
+        # This test exercises step 17 with config=None and a valid pack;
         # the step must fall back to root/"packs" and emit no finding.
-    def test_custom_packs_dir_used(self, tmp_path): ...
-        # When catalogue.toml specifies paths.packs = "components", step 17 still looks at
-        # root/"packs" — matching package_catalogue() which hardcodes that path.
-        # Packs placed in "components/" are NOT found; step emits a finding for the missing
-        # "packs/" directory. Verifier and packager are consistent: both fail for this config.
-        # (Using config.paths.packs here would create a false-pass — T2 uses it; T6 does not.)
+    def test_catalogue_root_required_paths_are_out_of_scope(self, tmp_path): ...
+        # valid pack.toml without marketplace/license files still passes step 17
+        # because those are packaging-root rules, not pack preflight.
 ```
 
 **Approach:**
 
-Implement `_step_package_preflight` to check:
-0. **Path:** `_step_package_preflight` may be called with `config is None` — AC0's
-   early return (T0) is not yet implemented; the current `verify_catalogue()` passes
-   `config=None` to all steps in `_VERIFY_STEPS`. Derive packs dir as `root / "packs"` —
-   matching `package_catalogue()`'s current behavior, which hardcodes `root / "packs"` for
-   scanning, required-file checks, and manifest extraction. Do NOT use `config.paths.packs`
-   here: packaging does not yet honor custom packs paths; using the configured path in the
-   verifier would create a false-pass (step 17 passes for `components/`, then `catalogue
-   package` immediately fails against `packs/`). T2 (step 6 / profile validation) uses
-   `config.paths.packs` per `lint.py:1801` — that is a different step with a different goal.
-   If `root/"packs"` does not exist AND `config is not None`, emit a diagnostic (CAT-V-NNN
-   "required packs directory 'packs/' is missing") before continuing to step 1. Do NOT emit
-   this diagnostic when `config is None` — a missing `packs/` under config-None is normal
-   for empty-directory catalogues (AC0: ok=True).
-1. `pack.toml` is present and parses as TOML → finding if missing or unparseable.
-2. `pack.toml` validates against `pack.schema.json` → finding if schema violation.
-3. Verify the pack layout. When `config is not None`:
-   Do NOT call `_scan_content()`, `_validate_content()`, or `_check_required_files()` from
-   `package.py` — they all hardcode `root / "packs"` internally, and a full custom-path fix
-   for `package_catalogue()` would require updating those helpers, `_check_required_files`,
-   and manifest extraction (out of scope for this verifier-correctness spec). Instead,
-   implement the equivalent traversal inline in `_step_package_preflight` or via a new
-   helper in `verify.py` that accepts `packs_dir` as a parameter.
-   The traversal must:
-   a. Walk `packs_dir` for pack directories (using `config.package.include` filter if set).
-   b. Mirror the `_REQUIRED_PATHS` check against the catalogue root. `_REQUIRED_PATHS` contains
-      four entries (`package.py:57-61`): `"packs"`, `".claude-plugin/marketplace.json"`,
-      `"LICENSE-APACHE"`, `"LICENSE-MIT"`. Check each as `root / entry`; emit a finding for any
-      that is absent. Since T6 uses `root / "packs"` unconditionally (step 0), the `"packs"`
-      entry maps directly to `root / "packs"` — no substitution needed.
-      `config.package.required or None` correctly handles both absent and `[]` cases: an
-      empty list evaluates falsy → `None` → `_REQUIRED_PATHS` applied (packaging defaults
-      preserved). Only a non-empty list overrides the defaults. Do NOT state that `[]`
-      disables defaults — `[] or None` evaluates to `None`, so defaults are always applied.
-   c. Validate content structure using the packs_dir, not the hardcoded `root / "packs"`.
-   When `config is None`, skip this sub-step — no package config is available to drive it.
-   **Pack-scoped mode (--pack A):** scope BOTH the content collection AND the pack-root
-   walks to the selected pack. `_scan_content()` collects content for all packs by default;
-   `_validate_content()` independently iterates every directory under `packs/`. Adding
-   `pack_filter` only to the pack.toml traversal does not prevent pack B's content from
-   failing the step when only pack A was requested. Fix: scope both `_scan_content()` and
-   `_validate_content()` to the selected pack's directory; all three sub-calls (scan,
-   required-files, validate) must be restricted to the selected pack when `--pack` is used.
-   Do NOT call `_check_required_files` with a `Path` and config object directly —
-   `_check_required_files` immediately iterates `content_paths` and raises `TypeError`
-   on that shape.
-4. `README.md` absence → no finding (not a required contract artifact). Replace `return []`
-   with real implementation.
+Implement `_step_package_preflight` as the narrow pack contract in AC7:
+1. Derive `packs_dir` from `config.paths.packs` when config exists, otherwise
+   `root / "packs"`. A missing packs directory is an empty catalogue, not a step-17 error.
+2. Iterate non-reserved pack directories, honoring `--pack` when supplied.
+3. Require each selected pack's `pack.toml` to exist and parse as TOML; malformed or
+   missing files emit a finding.
+4. Validate the parsed value against bundled `pack.schema.json` using the existing
+   stdlib validator; each schema error emits a finding.
+5. Do not check README, catalogue-root required paths, licenses, marketplace files,
+   package include lists, or packaging-content traversal. Replace `return []` with the
+   implementation above.
 
 **Done when:** `python3 -m pytest packages/agentbundle/tests/integration/test_catalogue_verify_package_preflight.py -q` exits 0.
 
@@ -736,6 +766,9 @@ Implement `_step_package_preflight` to check:
 - `packages/agentbundle/tests/integration/test_catalogue_verify_fixture_checks.py` (new)
 
 **Tests (write red first):**
+
+stub: true — materialized in `test_catalogue_verify_fixture_checks.py`; collect passes
+and the malformed-manifest assertion is red.
 
 ```python
 class TestStepFixtureChecks:
@@ -824,6 +857,11 @@ for that file.
 - `Makefile` or `tools/repo/build_gate_chain.py` (add `tools/catalogue/tests/` to an executed test target)
 
 **Tests (write red first):**
+
+stub: true — materialized in `tools/catalogue/tests/test_verify_host_checks.py`; collect
+passes. The red suite covers pattern detection in both preserved scan scopes, seed opt-in,
+sentinel and fenced-example exemptions, confinement to the core APM tree, checker presence,
+and both test/checker runtime gate registrations.
 
 ```python
 # In test_catalogue_tooling_lint.py — migrate existing assertion:
@@ -1007,6 +1045,8 @@ SKIP_SAST=1 make build-check  # exit 0 with verify_host_checks running as part o
 
 **Verification mode:** goal-based
 
+stub: no stub (goal-based check)
+
 **Touches:**
 - `packages/agentbundle/agentbundle/catalogue_tooling/verify.py` (module docstring, `verify_catalogue` docstring, verification-table comment)
 - `packages/agentbundle/agentbundle/cli.py` (CLI help text at line ~781)
@@ -1045,6 +1085,8 @@ python3 -c "from agentbundle.catalogue_tooling.verify import _VERIFY_STEPS; asse
 
 **Tests:**
 
+stub: n/a — the named regression tests already exist and collect.
+
 **Note:** `packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py` already
 contains `test_step_agent_artifacts_pyyaml_absent` (monkeypatches `import yaml`, asserts
 `CAT-V-011` warning Diagnostic is returned) and its clean-path companion. T10 does NOT
@@ -1064,13 +1106,17 @@ Do NOT create a new test file; do NOT duplicate the existing coverage. Do NOT mo
 
 **Verification mode:** TDD
 
-**Depends on:** T0–T10
+**Depends on:** T0–T10, T2b
 
 **Touches:**
 - `packages/agentbundle/tests/fixtures/external_catalogue/` (new fixture directory)
 - `packages/agentbundle/tests/integration/test_catalogue_verify_external_portability.py` (new; filesystem — uses fixture dir and tmp_path)
 
 **Tests:**
+
+stub: true — materialized with the synthetic `external_catalogue` fixture and
+`test_catalogue_verify_external_portability.py`; collect passes and the host-leak
+assertion is red while the nineteen-step assertion is green.
 
 ```python
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "external_catalogue"
@@ -1112,15 +1158,19 @@ A separate seed fixture at `seeds/AGENTS.md` (recognized path) contains both
 
 **Verification mode:** goal-based
 
-**Depends on:** T0–T11
+stub: no stub (goal-based check)
+
+**Depends on:** T0–T11, T2b
 
 **Touches (this PR):**
-- `packages/agentbundle/pyproject.toml` — already bumped to 0.35.3 at T1; bump again
+- `packages/agentbundle/pyproject.toml` — derive and apply the next available version
 - `packages/agentbundle/agentbundle/version.py` — same
-- `docs/product/changelog.md` — already carries a 0.35.3 section covering T1 only
+- `packages/agentbundle/README-pypi.md` — describe the release-bearing verifier behavior
+- `docs/product/changelog.md` — add the new release section; do not duplicate T1
+- `docs/specs/catalogue-verifier-correctness/spec.md` — check completed ACs and set Shipped
+- `docs/specs/catalogue-verifier-correctness/plan.md` — set Done
 
 **Touches (post-publish follow-on PR):**
-- `docs/specs/catalogue-verifier-correctness/spec.md` (Status: Implementing → Shipped)
 - `workspace.toml` (move verifier-correctness from queue to shipped)
 
 **Tests:** none (goal-based)
@@ -1133,20 +1183,21 @@ A separate seed fixture at `seeds/AGENTS.md` (recognized path) contains both
    implementations; host-only leak extracted to repository-local tooling; all public
    "18-step" references updated to "19-step"; regression coverage added for PyYAML guard
    (was already correct; no behavior change).
-3. Include `Engine-Change-RFC: RFC-0076` in the commit message footer (verify.py
+3. Update `README-pypi.md` so the checked-in package description matches the release.
+4. Include `Engine-Change-RFC: RFC-0076` in the commit message footer (verify.py
    is catalogue tooling infrastructure; D1/D2 authority model).
-4. Run full gates: `SKIP_SAST=1 make build-check`; `python3 -m pytest packages/agentbundle/tests/ -q`.
-5. Tag and publish to PyPI — T3 changes accepted dependency-range semantics for
+5. Check every completed AC, set spec Status to Shipped, and set plan Status to Done.
+6. Run full gates: `SKIP_SAST=1 make build-check`; `python3 -m pytest packages/agentbundle/tests/ -q`.
+7. Tag and publish to PyPI — T3 changes accepted dependency-range semantics for
    `validate_dependencies_required`, which is a public CLI semantic change per
    `packages/AGENTS.local.md:7-13`. After the PR merges: tag `agentbundle-vX.Y.Z` and
    push to PyPI via the standard release process before closing out this spec.
 
 **Post-publish follow-on (separate change, after PyPI release is confirmed):**
-6. Update spec.md Status: Shipped.
-7. Move `spec/catalogue-verifier-correctness` from `queue` to `shipped` in `workspace.toml`.
+8. Move `spec/catalogue-verifier-correctness` from `queue` to `shipped` in `workspace.toml`.
 
-Steps 6–7 cannot land in the same PR as the version bump because the PyPI publication
-occurs post-merge. Mark these as a follow-on change triggered by confirmed publication.
+Only step 8 waits for publication confirmation; package policy permits the release PR to
+close the spec and plan while workspace membership remains active until publication.
 
 **Done when:**
 ```bash
@@ -1158,10 +1209,10 @@ grep "19-step" packages/agentbundle/agentbundle/catalogue_tooling/verify.py   # 
 
 ## Constraints
 
-- T11 may not start until T1–T10 all pass gates — the portability test validates the
+- T11 may not start until T0–T10 and T2b all pass gates — the portability test validates the
   cumulative result of all corrections.
-- T12 must be last; no *further* version bump until T0–T11 pass gates. T1 shipped
-  ahead of the plan and already consumed a patch (0.35.3) — see the T1 record.
+- T12 must be last; derive its version only after T0–T11 and T2b pass gates and re-check
+  current workspace collision notes at execution time.
 - No step may be left returning `return []` without a real implementation or a
   `NotImplemented` finding — silent empty results are the root cause of this spec.
 

--- a/docs/specs/catalogue-verifier-correctness/spec.md
+++ b/docs/specs/catalogue-verifier-correctness/spec.md
@@ -1,6 +1,6 @@
 # Spec: catalogue-verifier-correctness
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [RFC-0076](../../rfc/0076-catalogue-contracts-composition-semantics-discovery.md) (portable verifier is D1/D2 infrastructure); [catalogue-wave2-pack-integrations](../catalogue-wave2-pack-integrations/spec.md) (step 19 defines integration-verification scope)
@@ -15,9 +15,10 @@
 ## Objective
 
 `packages/agentbundle/agentbundle/catalogue_tooling/verify.py` advertises a 19-step
-portable catalogue verification pipeline but has 13 confirmed defects: a no-op step 1
-(`_step_config_validation`) that lets malformed `catalogue.toml` escape as an unhandled
-exception instead of a structured diagnostic, wrong plugin path in steps 4 and 5, wrong
+portable catalogue verification pipeline but has 13 confirmed defects: step 1 originally
+let malformed `catalogue.toml` escape as an unhandled exception instead of a structured
+diagnostic (a partial guard now exists but lacks contract coverage and safe diagnostic
+redaction), wrong plugin path in steps 4 and 5, wrong
 marketplace source path in step 12 (`_step_marketplace` reads `dist/marketplace.json`
 which never exists — source is `config.paths.marketplace`; the step silently returns `[]`
 for every catalogue), five unimplemented steps (7, 8, 14, 17, 18) that return `[]`
@@ -64,6 +65,8 @@ this spec at implementation time.
 - Implement neutral index generation (Wave 4 scope).
 - Implement JOURNEY.md semantic indexing (Wave 4 scope).
 - Implement release integrity or mutation-refusal logic (Wave 5 scope).
+- Extend step 11 with new agentic-skill boundary-metadata validation or projection rules;
+  that is a separate public contract, not a correction to this step's advertised behavior.
 - Add third-party dependencies not already in `agentbundle` or its optional extras.
 - Silently swallow exceptions in corrected steps — correct steps fail openly with a
   structured diagnostic.
@@ -72,25 +75,31 @@ this spec at implementation time.
 
 ## Testing Strategy
 
+- **Config validation (AC0):** TDD — malformed configuration returns a step-1
+  diagnostic without raising; its message is bounded and redacted. Missing
+  `catalogue.toml` reaches the remaining pipeline and produces no step-1 diagnostic.
 - **Plugin path correction (AC1–AC2):** TDD — write fixtures with `pack_dir/.claude-plugin/plugin.json`
   and `pack_dir/plugin.json`; assert correct path is found and wrong path produces a
   finding; assert step 5 version-parity uses the same corrected path.
-- **Profile validation (AC3):** TDD — write profile fixture with known schema violation;
-  assert step 6 emits a finding (not passes silently).
+- **Profile validation (AC3):** TDD — write profile fixtures with a known schema violation,
+  a missing pack, an invalid pack slug, and a symlink/junction escape; assert step 6 emits
+  structured findings and never resolves a reference outside the configured packs root.
 - **Dependency validation (AC4):** TDD — write fixture with missing and present dependency;
   assert step 7 returns findings for missing, empty for present; no `return []`; test
   `--pack` scoped mode confirms unrelated-pack defects produce no finding.
 - **Marketplace source path (AC3a):** TDD — write fixture with malformed source `marketplace.json`
   at `config.paths.marketplace`; assert step 12 emits a finding (not silently passes).
-- **Installer grammar alignment (AC4a):** TDD — update `test_install_dependencies_gate.py:300`
+- **Installer/linter grammar alignment (AC4a):** TDD — update `test_install_dependencies_gate.py:300`
   to split the `~0.1`-rejected assertion into `test_install_valid_tilde_range_passes`
   (positive) and `test_install_malformed_range_rejected` (negative, genuinely invalid
-  string). Run `test_install_dependencies_gate.py` as part of T3 Done-when.
+  string); exercise the same grammar through `catalogue lint`, including cross-catalogue
+  profile closure. Run both suites as part of T3 Done-when.
 - **Adapter compatibility (AC5):** TDD — write fixture with pack declaring an unsupported
   adapter in the `allowed-adapters` list key under `[pack.install]`; assert step 8 emits
   a finding; no `return []`.
-- **Output drift (AC6):** TDD — write fixture with stale generated output; assert step 14
-  emits a finding; no `return []`.
+- **Output drift (AC6):** TDD — write fixtures with stale output plus symlink/junction and
+  loop escapes; assert step 14 emits root-relative findings without reading outside the
+  configured output root or hanging; no `return []`.
 - **Package preflight (AC7):** TDD — write fixture triggering package preflight failure;
   assert step 17 emits a finding; no `return []`.
 - **Fixture checks (AC8):** TDD — write fixture with malformed deterministic fixture;
@@ -111,19 +120,20 @@ this spec at implementation time.
 
 ### Phase AA — Config validation (step 1)
 
-- [ ] AC0: When `catalogue.toml` is **present but contains malformed TOML**, `verify_catalogue()`
+- [x] AC0: When `catalogue.toml` is **present but contains malformed TOML**, `verify_catalogue()`
   returns a result containing at least one structured `Diagnostic` attributed to step 1,
   rather than letting the TOML parse exception escape. Implementation note: the pre-loop
   `load_catalogue_config(root)` call is wrapped in a try/except; on failure the function
   returns early with a step-1 diagnostic (without entering `_VERIFY_STEPS`) — `_step_config_validation`
   itself is therefore not reached in this path. AC0 requires that the caller receives a
-  step-1 diagnostic, not that `_step_config_validation` generates it. `load_catalogue_config()`
-  returns `None` for a missing `catalogue.toml` (backward-compatible: verification proceeds
-  without config), so an absent `catalogue.toml` must NOT produce a diagnostic —
-  `test_verify_empty_dir_passes` must continue to assert `ok=True`. A unit test confirms:
-  calling `verify_catalogue()` against a catalogue with a present malformed `catalogue.toml`
-  returns a result with at least one step-1 diagnostic rather than raising. Calling it
-  against an empty directory still returns `ok=True`.
+  step-1 diagnostic, not that `_step_config_validation` generates it. The diagnostic uses
+  a bounded reason category and the repository-relative path `catalogue.toml`; it never
+  includes a stack trace, an absolute checkout path, URL userinfo/query text, secret-like
+  configuration values, or the raw exception string. `load_catalogue_config()` returns
+  `None` for a missing `catalogue.toml`, so absence must not produce CAT-V-001 and
+  verification continues through the remaining steps. An empty directory may still fail
+  later source-identity lint with CAT-V-002; this criterion does not override that shipped
+  behavior. Unit tests cover malformed, redacted, and missing-config cases.
 
 ### Phase A — Plugin path correction
 
@@ -153,7 +163,7 @@ this spec at implementation time.
 
 ### Phase B — Profile validation
 
-- [ ] AC3: `_step_profiles` (step 6) validates each profile file in two passes:
+- [x] AC3: `_step_profiles` (step 6) validates each profile file in two passes:
   (a) **Schema validation** — validates against `profile.schema.json` using
   `agentbundle.build.validate.validate`. A profile with a deliberate schema violation
   (e.g., missing required `scope` field — `profile.schema.json` requires `scope`,
@@ -163,11 +173,15 @@ this spec at implementation time.
   check that `<packs_dir>/<slug>/` exists, where `packs_dir = root / config.paths.packs if
   config is not None else root / "packs"` (matching `lint.py:1801`). A schema-valid profile
   that references a pack not present in the configured packs directory produces a finding.
-  A unit test covers each pass independently (schema failure, pack-ref missing).
+  Before joining a pack reference to `packs_dir`, validate it against the canonical pack-name
+  grammar and resolve the candidate under `packs_dir.resolve()`. Invalid names, absolute or
+  traversing names, and candidates that escape through a symlink or Windows junction produce
+  a structured finding without reading outside the configured root. A unit test covers each
+  pass independently (schema failure, pack-ref missing, invalid slug, resolved escape).
 
 ### Phase B.5 — Marketplace source path
 
-- [ ] AC3a: `_step_marketplace` (step 12) is corrected to read the marketplace file from
+- [x] AC3a: `_step_marketplace` (step 12) is corrected to read the marketplace file from
   `config.paths.marketplace` (the source path — `config.paths.marketplace` defaults to
   `.claude-plugin/marketplace.json` in the catalogue root; use `root / config.paths.marketplace`
   when config is present, or `root / ".claude-plugin" / "marketplace.json"` when absent).
@@ -180,7 +194,7 @@ this spec at implementation time.
 
 ### Phase C — Dependency validation
 
-- [ ] AC4: `_step_dependencies` (step 7) is implemented. It validates dependency
+- [x] AC4: `_step_dependencies` (step 7) is implemented. It validates dependency
   references as declared in `pack.schema.json`: dependencies are objects with required
   `catalogue`, `pack`, and `version` fields, listed under `[pack.dependencies.required]`,
   `[pack.dependencies.recommended]`, and `[pack.dependencies.conflicts]`. For each
@@ -212,11 +226,15 @@ this spec at implementation time.
   dependencies (including its cycle graph); do not scan unrelated packs — an unrelated
   invalid pack must not produce a finding in `--pack A` mode. A unit test confirms this:
   a catalogue with two packs where pack B has an invalid `required` reference; running
-  with `--pack A` produces no finding.
+  with `--pack A` produces no finding. Before any local dependency lookup, validate the
+  referenced pack against the canonical pack-name grammar and confine the resolved candidate
+  beneath `packs_dir.resolve()`; invalid, traversing, or symlink/junction-escaping references
+  produce a finding without reading the escaped path.
 
 ### Phase C.5 — Installer grammar alignment
 
-- [ ] AC4a: `commands/install.py::validate_dependencies_required` is updated to accept the
+- [x] AC4a: `commands/install.py::validate_dependencies_required` and catalogue profile lint
+  are updated to accept the
   same full RFC-0001 range grammar as the expanded verifier step 7 — `^X.Y`, `~X.Y`,
   `>=X.Y`, compound (`>=A <B`), and prerelease forms. This is required for verify/install
   consistency: if the verifier accepts a range that the installer rejects, a pack passes
@@ -226,11 +244,15 @@ this spec at implementation time.
   this test must be updated: split into `test_install_valid_tilde_range_passes` (positive,
   `~0.1` succeeds) and `test_install_malformed_range_rejected` (negative, a genuinely
   invalid string such as `"not-a-version"` fails). The version grammar is a public contract
-  invariant; `catalogue verify` and `catalogue install` must agree on what is valid.
+  invariant; `catalogue verify`, `catalogue lint`, and `catalogue install` must agree on what
+  is valid. Profile lint carries the dependency's catalogue identity through closure checks
+  and skips external-catalogue dependencies rather than reporting them as missing locally.
+  CLI-level tests cover every accepted grammar form, malformed syntax, boundary-negative
+  versions, and cross-catalogue profile closure.
 
 ### Phase D — Adapter compatibility
 
-- [ ] AC5: `_step_adapter_compat` (step 8) is implemented. For each pack in the catalogue:
+- [x] AC5: `_step_adapter_compat` (step 8) is implemented. For each pack in the catalogue:
   gate the check through the same contract-version-aware logic as
   `_profile_pack_allowed_adapters` — if the pack's `[pack.adapter-contract].version` is
   absent or `"0.1"` (legacy pack), skip the `allowed-adapters` check entirely (the
@@ -248,7 +270,7 @@ this spec at implementation time.
 
 ### Phase E — Output drift
 
-- [ ] AC6: `_step_output_drift` (step 14) is implemented. It compares the configured
+- [x] AC6: `_step_output_drift` (step 14) is implemented. It compares the configured
   build-output directory (`dist/` by default, or the path from `config.paths.build_output`
   in `catalogue.toml`'s `[catalogue.paths]` table) against a deterministic re-derivation
   from current pack source. If no build-output directory exists, the step returns an empty
@@ -257,20 +279,28 @@ this spec at implementation time.
   `dist/apm/`) is stale relative to the freshly generated equivalent, a finding is
   emitted for each differing path. The step no longer returns `[]`. Note: per-pack
   adapter directories are not per-pack subdirectories in this catalogue layout;
-  catalogue-level self-host projection drift is covered by step 15.
+  catalogue-level self-host projection drift is covered by step 15. The comparison walks
+  only regular files confined beneath the canonical configured-output and fresh-output
+  roots. It records each resolved directory before processing children, refuses symlink and
+  Windows-junction/reparse escapes, catches both `OSError` and `RuntimeError` from resolution,
+  terminates on loops, and reports only repository-relative paths. Tests cover each escape
+  and loop behavior without reading an out-of-root sentinel.
 
 ### Phase F — Package preflight
 
-- [ ] AC7: `_step_package_preflight` (step 17) is implemented. At minimum: confirms
+- [x] AC7: `_step_package_preflight` (step 17) is implemented. It confirms
   `pack.toml` is present and parses; confirms `pack.toml` validates against
   `pack.schema.json`. Missing or malformed `pack.toml` produces a finding. `README.md`
   absence does NOT produce a finding — `README.md` is not a required file per the pack
   contract (the builder treats its absence as a no-op; rejecting it here would introduce
-  a new contract rule under a correctness-only spec). The step no longer returns `[]`.
+  a new contract rule under a correctness-only spec). Step 17 does not add catalogue-root
+  required-path checks, license/marketplace checks, packaging traversal, or new custom-path
+  refusal behavior; those are packaging-contract changes outside this correctness fix. The
+  step no longer returns `[]`.
 
 ### Phase G — Fixture checks
 
-- [ ] AC8: `_step_fixture_checks` (step 18) is implemented. It validates the two named eval
+- [x] AC8: `_step_fixture_checks` (step 18) is implemented. It validates the two named eval
   manifest files present under each skill's `.apm/skills/<skill>/evals/` directory:
   `evals.json` and `eval_queries.json`. Only these two files are parsed — `.jsonl` files
   and files under `evals/files/` are not scanned (those are opaque payload inputs that may
@@ -287,7 +317,7 @@ this spec at implementation time.
 
 ### Phase H — Host-only leak
 
-- [ ] AC9: `_APM_SKILL_BLOCKLIST` in `verify.py` and all four host-specific patterns in
+- [x] AC9: `_APM_SKILL_BLOCKLIST` in `verify.py` and all four host-specific patterns in
   `_SEEDS_BLOCKLIST_PATTERNS` in `lint.py` are removed from their respective portable
   modules. The four patterns to remove from `lint.py` are:
   `(r"agent-ready-repo", ...)`, `(r"RFC-00\d\d", ...)`, `(r"K-00\d\d", ...)`, and
@@ -300,13 +330,13 @@ this spec at implementation time.
 
 ### Phase I — Step count and help accuracy
 
-- [ ] AC10: The module-level docstring of `verify.py` is updated to accurately reflect
+- [x] AC10: The module-level docstring of `verify.py` is updated to accurately reflect
   the pipeline: "19-step" (not "18-step"). `len(_VERIFY_STEPS)` equals 19 (confirmed
   by a unit assertion or a `grep`-based goal-based check).
 
 ### Phase J — PyYAML guard regression coverage
 
-- [ ] AC11: Step 11's PyYAML guard returns a structured `Diagnostic` warning via
+- [x] AC11: Step 11's PyYAML guard returns a structured `Diagnostic` warning via
   `_warn()` when `import yaml` fails. This behavior is already correct at HEAD and is
   NOT a defect fix — AC11 exists to establish regression coverage. A unit test confirms:
   with PyYAML absent (monkeypatched `ImportError`), step 11 returns a non-empty
@@ -315,8 +345,10 @@ this spec at implementation time.
 
 ### Phase K — External-catalogue portability
 
-- [ ] AC12: An integration test runs `agentbundle catalogue verify` against a minimal
-  external-catalogue fixture (no agent-ready-repo content, no host-specific skills).
+- [x] AC12: An integration test runs `agentbundle catalogue verify` against a minimal
+  external-catalogue fixture. Its portable seed intentionally mentions
+  `agent-ready-repo` to prove host vocabulary is allowed in ordinary external content;
+  the fixture contains no host-specific skills or repository policy configuration.
   The test asserts: exit code is 0 (no blocker findings); no finding's `message` field
   references `agent-ready-repo` or any host-specific identifier. The step count is
   verified separately by a unit assertion: `len(_VERIFY_STEPS) == 19` (programmatic —
@@ -325,9 +357,12 @@ this spec at implementation time.
 
 ### Regression
 
-- [ ] AC13: `SKIP_SAST=1 make build-check` exits 0.
-- [ ] AC14: `python3 -m pytest packages/agentbundle/tests/ -q` exits 0.
-- [ ] AC15: `wc -l AGENTS.md` ≤ 250; `wc -l packs/AGENTS.md` ≤ 150.
+- [x] AC13: `SKIP_SAST=1 make build-check` exits 0.
+- [ ] AC14 (deferred: pre-existing-enterprise-agentbundle-full-suite):
+  `python3 -m pytest packages/agentbundle/tests/ -q` exits 0. The managed session blocks
+  pip/venv trust-store fixture setup and protected key-material filename globs before the
+  affected tests reach product behavior; the remaining suite passed.
+- [x] AC15: `wc -l AGENTS.md` ≤ 250; `wc -l packs/AGENTS.md` ≤ 150.
 
 ## Assumptions
 

--- a/guides/_reference/catalogue-format.md
+++ b/guides/_reference/catalogue-format.md
@@ -44,7 +44,7 @@ The contracts above define what `schema = 1` means.
 ```bash
 agentbundle catalogue verify --root .
 ```
-Runs the full 18-step pipeline including schema validation, pack lint,
+Runs the full 19-step pipeline including schema validation, pack lint,
 post-build artifact checks, and self-host drift detection.
 
 For CI pipeline patterns using `verify`, `lint`, and `package` — including

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.37.2] — 2026-08-17
+
+### Added
+
+- **`catalogue verify` now performs all 19 advertised checks.** It validates
+  profile schemas and references, dependency ranges and cycles, adapter
+  compatibility, generated-output drift, pack metadata, and skill evaluation
+  manifests. Generated-output comparison is confined to the `claude-plugins/`
+  and `apm/` projection roots, and linked inputs are refused before reading.
+
+### Changed
+
+- **Dependency ranges now use one npm-compatible grammar across verify, lint,
+  and install.** Caret, tilde, comparator, compound, and prerelease forms agree;
+  below `1.0.0`, caret ranges retain normal semver compatibility.
+- **Repository-specific leak checks moved out of the portable verifier** and
+  into the repository-local build gate.
+
+### Fixed
+
+- **Malformed catalogue configuration now returns a bounded, redacted
+  diagnostic.** Verifier help and adopter documentation also consistently
+  describe the 19-step pipeline.
+
 ## [0.37.1] — 2026-08-16
 
 ### Changed

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -14,17 +14,30 @@ python -m pip install agentbundle
 
 Requires Python 3.11+. Runs on macOS, Linux, and Windows.
 
-## What's new in 0.37.1
+## What's new in 0.37.2
 
-**New catalogue scaffolds now document the guide callout contract.** The
-bundled authoring reference distinguishes exact quoted wording, which stays a
+`agentbundle catalogue verify` now performs all 19 advertised checks. It
+validates profile schemas and pack references, dependency ranges and cycles,
+adapter compatibility, generated-output drift, pack preflight metadata, and
+skill evaluation manifests. The verifier remains read-only and portable across
+external catalogues.
+
+Dependency ranges now use the same npm-compatible grammar in verify, lint, and
+install: caret, tilde, comparator, compound, and prerelease forms agree across
+all three commands. In particular, caret ranges below `1.0.0` now use normal
+semver compatibility (`^0.2` does not include `0.3.x`).
+
+## Catalogue authoring
+
+New catalogue scaffolds document the guide callout contract. The bundled
+authoring reference distinguishes exact quoted wording, which stays a
 blockquote, from guidance that should render as a Starlight `note`, `tip`,
 `caution`, or `danger` aside. Existing catalogues remain unchanged until their
 scaffolded authoring reference is refreshed.
 
 ## Contract discovery
 
-The bundled public contract inventory now includes the strict
+The bundled public contract inventory includes the strict
 `knowledge-captured-observation.schema.json` contract used by the core pack's
 project-knowledge capture handoff.
 

--- a/packages/agentbundle/agentbundle/catalogue_tooling/file_safety.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/file_safety.py
@@ -4,22 +4,31 @@ from __future__ import annotations
 
 import os
 import stat
+from contextlib import contextmanager
+from hashlib import sha256
 from pathlib import Path
+from typing import BinaryIO, Iterator
 
 
 class UnsafeContentError(ValueError):
     """A source entry is not a confined, single-link regular file."""
 
 
-def read_confined_regular_file(root: Path, path: Path) -> bytes:
-    """Read *path* only when it is a regular file confined below *root*.
+@contextmanager
+def _open_confined_regular_file(root: Path, path: Path) -> Iterator[BinaryIO]:
+    """Open *path* only when it is a regular file confined below *root*.
 
     The link count is checked both before and after opening so a hard-linked
     file, or a file replaced between discovery and use, cannot be shipped.
     ``O_NOFOLLOW`` closes the final-component symlink race on platforms that
     provide it; the post-open inode comparison supplies the portable fallback.
+    ``O_NONBLOCK`` prevents a FIFO or device replacement from hanging before
+    the post-open regular-file check can reject it.
     """
-    resolved_root = root.resolve()
+    try:
+        resolved_root = root.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise UnsafeContentError("declared root cannot be resolved safely") from exc
     try:
         relative = path.relative_to(root).as_posix()
     except ValueError as exc:
@@ -35,7 +44,7 @@ def read_confined_regular_file(root: Path, path: Path) -> bytes:
         raise UnsafeContentError(f"hard link not allowed: {relative}")
     try:
         path.resolve(strict=True).relative_to(resolved_root)
-    except (OSError, ValueError) as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
         raise UnsafeContentError(f"source path escapes its declared root: {relative}") from exc
 
     flags = os.O_RDONLY
@@ -43,6 +52,8 @@ def read_confined_regular_file(root: Path, path: Path) -> bytes:
         flags |= os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
     try:
         descriptor = os.open(path, flags)
     except OSError as exc:
@@ -57,7 +68,22 @@ def read_confined_regular_file(root: Path, path: Path) -> bytes:
             raise UnsafeContentError(f"source file changed while opening: {relative}")
         with os.fdopen(descriptor, "rb") as handle:
             descriptor = -1
-            return handle.read()
+            yield handle
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+
+
+def read_confined_regular_file(root: Path, path: Path) -> bytes:
+    """Read a confined, no-follow, single-link regular file."""
+    with _open_confined_regular_file(root, path) as handle:
+        return handle.read()
+
+
+def sha256_confined_regular_file(root: Path, path: Path) -> str:
+    """Hash a confined regular file without loading it wholly into memory."""
+    digest = sha256()
+    with _open_confined_regular_file(root, path) as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/lint.py
@@ -17,6 +17,7 @@ import ast
 import json
 import os
 import re
+import stat
 import tomllib
 from pathlib import Path
 
@@ -27,8 +28,18 @@ from agentbundle.catalogue_tooling.config import (
     load_catalogue_config,
 )
 from agentbundle.catalogue_tooling.diagnostics import DiagnosticCode
+from agentbundle.catalogue_tooling.file_safety import (
+    UnsafeContentError,
+    read_confined_regular_file,
+    sha256_confined_regular_file,
+)
 from agentbundle.catalogue_tooling.manifest import plugin_json_path
+from agentbundle.catalogue_tooling.package import _TRANSIENT_DIRS
 from agentbundle.catalogue_tooling.results import Diagnostic, LintResult, Severity
+from agentbundle.catalogue_tooling.version_ranges import (
+    parse_version_range,
+    version_satisfies,
+)
 
 # Frontmatter regex: matches the YAML front-matter block at the top of a file
 _FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
@@ -53,6 +64,75 @@ _MAX_DESC_LEN = 1024
 _PRIM_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 _AGENTBUNDLE_VERSION: str | None = None
+
+
+def _path_is_junction(path: Path) -> bool:
+    """Return whether *path* is a Windows junction when supported."""
+    checker = getattr(path, "is_junction", None)
+    return bool(checker and checker())
+
+
+def _diagnostic_path(root: Path, path: Path) -> str:
+    """Return a catalogue-relative path without exposing an outside target."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return "<outside-root>"
+
+
+def _first_unsafe_pack_entry(pack_dir: Path) -> tuple[Path, str] | None:
+    """Return the first unsafe entry in an authored tree lint will read."""
+    for authored_root in (pack_dir / ".apm", pack_dir / "seeds"):
+        try:
+            root_metadata = authored_root.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return authored_root, "uninspectable entry"
+        if (
+            stat.S_ISLNK(root_metadata.st_mode)
+            or _path_is_junction(authored_root)
+        ):
+            return authored_root, "link-like entry"
+        if not stat.S_ISDIR(root_metadata.st_mode):
+            return authored_root, "non-directory authored root"
+        walk_errors: list[Path] = []
+
+        def _record_walk_error(
+            exc: OSError,
+            errors: list[Path] = walk_errors,
+            fallback: Path = authored_root,
+        ) -> None:
+            """Capture the first directory that os.walk could not enumerate."""
+            errors.append(Path(exc.filename) if exc.filename is not None else fallback)
+
+        for current_text, dirnames, filenames in os.walk(
+            authored_root,
+            topdown=True,
+            onerror=_record_walk_error,
+            followlinks=False,
+        ):
+            if walk_errors:
+                return walk_errors[0], "uninspectable directory"
+            current = Path(current_text)
+            dirnames[:] = [name for name in dirnames if name not in _TRANSIENT_DIRS]
+            for name in sorted([*dirnames, *filenames]):
+                candidate = current / name
+                if candidate.is_symlink() or _path_is_junction(candidate):
+                    return candidate, "link-like entry"
+                if name not in filenames:
+                    continue
+                try:
+                    metadata = candidate.lstat()
+                except OSError:
+                    return candidate, "uninspectable entry"
+                if not stat.S_ISREG(metadata.st_mode):
+                    return candidate, "non-regular entry"
+                if metadata.st_nlink > 1:
+                    return candidate, "hard-linked entry"
+        if walk_errors:
+            return walk_errors[0], "uninspectable directory"
+    return None
 
 
 def _get_agentbundle_version() -> str:
@@ -139,9 +219,6 @@ def _parse_frontmatter(text: str) -> dict[str, str] | None:
 # Profile lint helpers
 # ---------------------------------------------------------------------------
 
-_PROFILE_CARET_RE = re.compile(r"^\^([0-9]+)\.([0-9]+)$")
-
-
 def _profile_allowed_scopes(pack_toml: dict) -> list[str]:
     install = pack_toml.get("pack", {}).get("install")
     if isinstance(install, dict):
@@ -154,30 +231,26 @@ def _profile_allowed_scopes(pack_toml: dict) -> list[str]:
     return ["repo"]
 
 
-def _profile_required_deps(pack_toml: dict) -> list[tuple[str, str]]:
+def _profile_required_deps(pack_toml: dict) -> list[tuple[str, str, str]]:
+    """Return required dependencies as catalogue, pack, and range triples."""
     deps = pack_toml.get("pack", {}).get("dependencies", {})
-    out: list[tuple[str, str]] = []
+    out: list[tuple[str, str, str]] = []
     if isinstance(deps, dict):
         for entry in deps.get("required") or []:
             if isinstance(entry, dict):
-                out.append((entry.get("pack", ""), entry.get("version", "")))
+                out.append(
+                    (
+                        entry.get("catalogue", ""),
+                        entry.get("pack", ""),
+                        entry.get("version", ""),
+                    )
+                )
     return out
 
 
 def _profile_satisfies(installed_version: str, dep_range: str) -> bool | None:
-    """``^X.Y`` caret-minor satisfaction check. None = unsupported range grammar."""
-    m = _PROFILE_CARET_RE.match(dep_range)
-    if m is None:
-        return None
-    req_major, req_minor = int(m.group(1)), int(m.group(2))
-    parts = installed_version.split(".")
-    try:
-        ima = int(parts[0]) if len(parts) > 0 else 0
-        imi = int(parts[1]) if len(parts) > 1 else 0
-        ipa = int(parts[2]) if len(parts) > 2 else 0
-    except (ValueError, IndexError):
-        return False
-    return ima == req_major and (imi > req_minor or (imi == req_minor and ipa >= 0))
+    """Return dependency-range satisfaction using the shared grammar."""
+    return version_satisfies(installed_version, dep_range)
 
 
 def _profile_load_packs(packs_dir: Path) -> dict[str, dict]:
@@ -187,19 +260,28 @@ def _profile_load_packs(packs_dir: Path) -> dict[str, dict]:
     for pack_dir in sorted(packs_dir.iterdir()):
         if pack_dir.name.startswith("_"):
             continue  # reserved authoring asset
+        if pack_dir.is_symlink() or _path_is_junction(pack_dir):
+            continue
         toml_path = pack_dir / "pack.toml"
-        if not toml_path.exists():
+        if not (toml_path.exists() or toml_path.is_symlink() or _path_is_junction(toml_path)):
             continue
         try:
-            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except (tomllib.TOMLDecodeError, OSError):
+            content = read_confined_regular_file(pack_dir, toml_path).decode("utf-8")
+            data = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError):
             continue
         name = data.get("pack", {}).get("name") or pack_dir.name
         out[name] = data
     return out
 
 
-def _profile_lint_one(profile_id: str, raw: dict, packs: dict[str, dict]) -> list[str]:
+def _profile_lint_one(
+    profile_id: str,
+    raw: dict,
+    packs: dict[str, dict],
+    catalogue_name: str | None,
+) -> list[str]:
+    """Validate one profile against local pack and dependency contracts."""
     violations: list[str] = []
     scope = raw.get("scope")
     if scope not in ("user", "repo"):
@@ -226,7 +308,16 @@ def _profile_lint_one(profile_id: str, raw: dict, packs: dict[str, dict]) -> lis
                     f"profile {profile_id!r}: pack {name!r} does not allow scope "
                     f"{scope!r} (allowed-scopes: {allowed})"
                 )
-        for dep_name, dep_range in _profile_required_deps(pack_toml):
+        for dep_catalogue, dep_name, dep_range in _profile_required_deps(pack_toml):
+            if not parse_version_range(dep_range):
+                violations.append(
+                    f"profile {profile_id!r}: pack {name!r} declares an "
+                    f"unsupported version range {dep_range!r} for {dep_name!r} "
+                    "(unsupported dependency range grammar)"
+                )
+                continue
+            if catalogue_name is None or dep_catalogue != catalogue_name:
+                continue
             if dep_name not in index:
                 violations.append(
                     f"profile {profile_id!r}: pack {name!r} requires {dep_name!r} "
@@ -243,13 +334,7 @@ def _profile_lint_one(profile_id: str, raw: dict, packs: dict[str, dict]) -> lis
             if dep_toml is not None:
                 dep_version = dep_toml.get("pack", {}).get("version", "")
                 sat = _profile_satisfies(dep_version, dep_range)
-                if sat is None:
-                    violations.append(
-                        f"profile {profile_id!r}: pack {name!r} declares an "
-                        f"unsupported version range {dep_range!r} for {dep_name!r} "
-                        f"(only ^X.Y is supported)"
-                    )
-                elif sat is False:
+                if sat is not True:
                     violations.append(
                         f"profile {profile_id!r}: pack {name!r} requires "
                         f"{dep_name!r} {dep_range}, but the catalogue ships "
@@ -263,21 +348,7 @@ def _profile_lint_one(profile_id: str, raw: dict, packs: dict[str, dict]) -> lis
 # Seeds lint helpers
 # ---------------------------------------------------------------------------
 
-_SEEDS_BLOCKLIST_PATTERNS: tuple[tuple[str, str], ...] = (
-    (r"agent-ready-repo", "catalogue name 'agent-ready-repo'"),
-    (r"RFC-00\d\d", "catalogue RFC reference (RFC-NNNN)"),
-    (r"K-00\d\d", "catalogue knowledge entry (K-NNNN)"),
-    (
-        r"\b("
-        r"distribution-adapters|self-hosting|agent-spec-cli|"
-        r"user-scope-hooks|converters-pack|"
-        r"claude-plugins-install-route|codex-native-skills|"
-        r"apm-install-route-parity|skill-secrets|wire-session-start-hook|"
-        r"kiro-ide-hook|windows-ci-bundler|windows-hooks-phase3"
-        r")\b",
-        "catalogue spec name",
-    ),
-)
+_SEEDS_BLOCKLIST_PATTERNS: tuple[tuple[str, str], ...] = ()
 _SEEDS_BLOCKLIST_RE = [(re.compile(p), name) for p, name in _SEEDS_BLOCKLIST_PATTERNS]
 
 _SEEDS_REQUIRED_PLACEHOLDERS: dict[str, tuple[str, ...]] = {
@@ -951,20 +1022,37 @@ def _cs_has_scrubbing_parser(py_path: Path) -> bool:
     return False
 
 
-def _cs_is_canonical_shim(py: Path, shim_source_dir: Path) -> bool:
+def _cs_is_canonical_shim(
+    py: Path,
+    shim_source_dir: Path,
+    *,
+    pack_dir: Path | None = None,
+    shim_pack_dir: Path | None = None,
+) -> bool:
+    """Compare a shim only through confined, single-link regular-file reads."""
     if py.name not in _CS_SHIM_BASENAMES:
         return False
     if py.parent.name not in {"scripts", "shared-libs"}:
         return False
+    actual_root = pack_dir if pack_dir is not None else py.parent
+    expected_root = shim_pack_dir if shim_pack_dir is not None else shim_source_dir
+    source_directories = [shim_source_dir]
+    if shim_pack_dir is not None:
+        source_directories = [shim_pack_dir, shim_pack_dir / ".apm", shim_source_dir]
+    for directory in (actual_root, *source_directories):
+        if (
+            directory.is_symlink()
+            or _path_is_junction(directory)
+            or not directory.is_dir()
+        ):
+            return False
     expected_path = shim_source_dir / py.name
     try:
-        expected = expected_path.read_bytes()
-    except OSError:
+        expected = sha256_confined_regular_file(expected_root, expected_path)
+        actual = sha256_confined_regular_file(actual_root, py)
+    except (OSError, UnsafeContentError):
         return False
-    try:
-        return py.read_bytes() == expected
-    except OSError:
-        return False
+    return actual == expected
 
 
 # ---------------------------------------------------------------------------
@@ -1058,10 +1146,14 @@ class _CatalogueRules:
         for entry in sorted(packs_dir.iterdir()):
             if entry.name.startswith("_"):
                 continue  # reserved authoring asset
-            if not entry.is_dir() or not (entry / "pack.toml").exists():
+            if entry.is_symlink() or _path_is_junction(entry) or not entry.is_dir():
+                continue
+            manifest = entry / "pack.toml"
+            if not (manifest.exists() or manifest.is_symlink() or _path_is_junction(manifest)):
                 continue
             try:
-                data = tomllib.loads((entry / "pack.toml").read_text(encoding="utf-8"))
+                content = read_confined_regular_file(entry, manifest).decode("utf-8")
+                data = tomllib.loads(content)
                 pack_name = data.get("pack", {}).get("name", "")
             except Exception:
                 continue
@@ -1093,21 +1185,27 @@ class _CatalogueRules:
         for toml_path in sorted(profiles_dir.glob("*.toml")):
             profile_id = toml_path.stem
             try:
-                raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-            except (tomllib.TOMLDecodeError, OSError) as exc:
+                content = read_confined_regular_file(profiles_dir, toml_path).decode("utf-8")
+                raw = tomllib.loads(content)
+            except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
                 diags.append(_diag(
                     DiagnosticCode.CAT_L028,
                     Severity.ERROR,
                     f"profile {profile_id!r}: cannot parse: {exc}",
-                    path=str(toml_path),
+                    path=_diagnostic_path(self._root, toml_path),
                 ))
                 continue
-            for violation in _profile_lint_one(profile_id, raw, packs):
+            for violation in _profile_lint_one(
+                profile_id,
+                raw,
+                packs,
+                getattr(self._config, "name", None),
+            ):
                 diags.append(_diag(
                     DiagnosticCode.CAT_L028,
                     Severity.ERROR,
                     violation,
-                    path=str(toml_path),
+                    path=_diagnostic_path(self._root, toml_path),
                 ))
         return diags
 
@@ -1132,7 +1230,17 @@ class _CatalogueRules:
             if not val:
                 continue
             try:
-                resolved = (self._root / val).resolve()
+                configured_path = self._root / val
+                if configured_path.is_symlink() or _path_is_junction(configured_path):
+                    self._unsafe_config_paths.add(field)
+                    diags.append(_diag(
+                        DiagnosticCode.CAT_L021,
+                        Severity.ERROR,
+                        f"catalogue.paths.{field} is link-like: {val!r}",
+                        remediation="Use a real path inside the catalogue root.",
+                    ))
+                    continue
+                resolved = configured_path.resolve()
                 if not resolved.is_relative_to(root):
                     self._unsafe_config_paths.add(field)
                     diags.append(_diag(
@@ -1171,9 +1279,10 @@ class _PackRules:
         if not self._pack_toml_loaded:
             self._pack_toml_loaded = True
             toml_path = self._dir / "pack.toml"
-            if toml_path.exists():
+            if toml_path.exists() or toml_path.is_symlink() or _path_is_junction(toml_path):
                 try:
-                    self._pack_toml = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+                    content = read_confined_regular_file(self._dir, toml_path).decode("utf-8")
+                    self._pack_toml = tomllib.loads(content)
                 except Exception:
                     self._pack_toml = None
         return self._pack_toml
@@ -1203,17 +1312,18 @@ class _PackRules:
                 Severity.ERROR,
                 f"directory name {self._name!r} differs from [pack].name {pack_name!r}",
                 pack=self._name,
-                path=str(self._dir / "pack.toml"),
+                path=_diagnostic_path(self._root, self._dir / "pack.toml"),
                 remediation="Rename the directory to match [pack].name, or update [pack].name.",
             )]
         return []
 
     def _check_pack_toml_parseable(self) -> list[Diagnostic]:
         toml_path = self._dir / "pack.toml"
-        if not toml_path.exists():
+        if not (toml_path.exists() or toml_path.is_symlink() or _path_is_junction(toml_path)):
             return []
         try:
-            tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            content = read_confined_regular_file(self._dir, toml_path).decode("utf-8")
+            tomllib.loads(content)
             return []
         except Exception as exc:
             return [_diag(
@@ -1221,7 +1331,7 @@ class _PackRules:
                 Severity.ERROR,
                 f"pack.toml is not valid TOML: {exc}",
                 pack=self._name,
-                path=str(toml_path),
+                path=_diagnostic_path(self._root, toml_path),
                 remediation="Fix the TOML syntax error in pack.toml.",
             )]
 
@@ -1246,24 +1356,29 @@ class _PackRules:
                 Severity.ERROR,
                 f"pack.toml fails schema validation: {errors[0]}",
                 pack=self._name,
-                path=str(self._dir / "pack.toml"),
+                path=_diagnostic_path(self._root, self._dir / "pack.toml"),
                 remediation="Fix the pack.toml field(s) reported by the schema validator.",
             )]
         return []
 
     def _check_plugin_json(self) -> list[Diagnostic]:
         plugin_path = plugin_json_path(self._dir)
-        if not plugin_path.exists():
+        if not (
+            plugin_path.exists()
+            or plugin_path.is_symlink()
+            or _path_is_junction(plugin_path)
+        ):
             return []
         try:
-            data = json.loads(plugin_path.read_text(encoding="utf-8"))
+            content = read_confined_regular_file(self._dir, plugin_path).decode("utf-8")
+            data = json.loads(content)
         except Exception as exc:
             return [_diag(
                 DiagnosticCode.CAT_L007,
                 Severity.ERROR,
                 f"plugin.json is not valid JSON: {exc}",
                 pack=self._name,
-                path=str(plugin_path),
+                path=_diagnostic_path(self._root, plugin_path),
                 remediation="Fix the JSON syntax error in plugin.json.",
             )]
         # Basic schema check: must have name and version
@@ -1275,7 +1390,7 @@ class _PackRules:
                     Severity.ERROR,
                     f"plugin.json missing required key: {key!r}",
                     pack=self._name,
-                    path=str(plugin_path),
+                    path=_diagnostic_path(self._root, plugin_path),
                     remediation=f"Add {key!r} to plugin.json.",
                 ))
         return diags
@@ -1285,10 +1400,15 @@ class _PackRules:
         if pt is None:
             return []
         plugin_path = plugin_json_path(self._dir)
-        if not plugin_path.exists():
+        if not (
+            plugin_path.exists()
+            or plugin_path.is_symlink()
+            or _path_is_junction(plugin_path)
+        ):
             return []
         try:
-            plugin_data = json.loads(plugin_path.read_text(encoding="utf-8"))
+            content = read_confined_regular_file(self._dir, plugin_path).decode("utf-8")
+            plugin_data = json.loads(content)
         except Exception:
             return []
         pack_name = pt.get("pack", {}).get("name", "")
@@ -1329,7 +1449,7 @@ class _PackRules:
                     Severity.ERROR,
                     f"skill directory {skill_dir.name!r} missing SKILL.md",
                     pack=self._name,
-                    path=str(skill_dir),
+                    path=_diagnostic_path(self._root, skill_dir),
                     remediation="Add a SKILL.md with name and description frontmatter.",
                 ))
                 continue
@@ -1341,7 +1461,7 @@ class _PackRules:
                     Severity.ERROR,
                     "SKILL.md missing frontmatter",
                     pack=self._name,
-                    path=str(skill_md),
+                    path=_diagnostic_path(self._root, skill_md),
                     remediation="Add --- frontmatter with name and description.",
                 ))
                 continue
@@ -1352,7 +1472,7 @@ class _PackRules:
                         Severity.ERROR,
                         f"SKILL.md frontmatter missing required key: {key!r}",
                         pack=self._name,
-                        path=str(skill_md),
+                        path=_diagnostic_path(self._root, skill_md),
                         remediation=f"Add {key!r} to the SKILL.md frontmatter.",
                     ))
             # Check description length
@@ -1363,7 +1483,7 @@ class _PackRules:
                     Severity.ERROR,
                     f"SKILL.md description exceeds {_MAX_DESC_LEN} chars ({len(desc)})",
                     pack=self._name,
-                    path=str(skill_md),
+                    path=_diagnostic_path(self._root, skill_md),
                     remediation="Shorten the description field.",
                 ))
         return diags
@@ -1382,7 +1502,7 @@ class _PackRules:
                     Severity.ERROR,
                     f"agent file {agent_file.name!r} missing frontmatter",
                     pack=self._name,
-                    path=str(agent_file),
+                    path=_diagnostic_path(self._root, agent_file),
                     remediation="Add --- frontmatter with name and description.",
                 ))
                 continue
@@ -1393,7 +1513,7 @@ class _PackRules:
                         Severity.ERROR,
                         f"agent file frontmatter missing required key: {key!r}",
                         pack=self._name,
-                        path=str(agent_file),
+                        path=_diagnostic_path(self._root, agent_file),
                         remediation=f"Add {key!r} to the agent frontmatter.",
                     ))
         return diags
@@ -1422,7 +1542,7 @@ class _PackRules:
                         Severity.ERROR,
                         violation,
                         pack=self._name,
-                        path=str(path),
+                        path=_diagnostic_path(self._root, path),
                     ))
         return diags
 
@@ -1441,7 +1561,7 @@ class _PackRules:
                 Severity.ERROR,
                 f"{pack_name}: {msg}",
                 pack=pack_name,
-                path=str(toml_path),
+                path=_diagnostic_path(self._root, toml_path),
             ))
 
         fv = pt.get("pack", {}).get("first-value")
@@ -1557,7 +1677,8 @@ class _PackRules:
         skills_dir = self._dir / ".apm" / "skills"
         if not skills_dir.is_dir():
             return []
-        shim_source_dir = self._root / "packs" / "credential-brokers" / ".apm" / "shared-libs"
+        shim_pack_dir = self._root / "packs" / "credential-brokers"
+        shim_source_dir = shim_pack_dir / ".apm" / "shared-libs"
         diags: list[Diagnostic] = []
 
         def _report(path: Path, message: str) -> None:
@@ -1669,7 +1790,12 @@ class _PackRules:
 
             # D3: dotfile read (AST walk)
             for py in py_files:
-                if _cs_is_canonical_shim(py, shim_source_dir):
+                if _cs_is_canonical_shim(
+                    py,
+                    shim_source_dir,
+                    pack_dir=self._dir,
+                    shim_pack_dir=shim_pack_dir,
+                ):
                     continue
                 for lineno, desc in _cs_check_dotfile_read(py):
                     _report(
@@ -1680,7 +1806,13 @@ class _PackRules:
 
             # Broker-specific checks
             consumer_py_files = [
-                p for p in py_files if not _cs_is_canonical_shim(p, shim_source_dir)
+                p for p in py_files
+                if not _cs_is_canonical_shim(
+                    p,
+                    shim_source_dir,
+                    pack_dir=self._dir,
+                    shim_pack_dir=shim_pack_dir,
+                )
             ]
 
             if auth == "creds":
@@ -1873,12 +2005,76 @@ def lint_catalogue(root: Path, pack: str | None = None, *, deep: bool = False) -
     packs_dir = cat_rules._packs_dir()
 
     # Step 4+5: per-pack rules
+    safe_pack_dirs: list[Path] = []
+    safe_deep_pack_dirs: list[Path] = []
+    unsafe_pack_diagnostics: list[Diagnostic] = []
     if packs_dir is not None and packs_dir.is_dir():
         for pack_dir in sorted(packs_dir.iterdir()):
             if pack_dir.name.startswith("_"):
                 continue  # reserved authoring asset
-            if not pack_dir.is_dir() or not (pack_dir / "pack.toml").exists():
+            if pack_dir.is_symlink() or _path_is_junction(pack_dir):
+                unsafe_pack_diagnostics.append(_diag(
+                    DiagnosticCode.CAT_L005,
+                    Severity.ERROR,
+                    "pack directory is link-like and cannot be read safely",
+                    pack=pack_dir.name,
+                    path=_diagnostic_path(root, pack_dir),
+                    remediation="Replace the link with a real directory inside packs.",
+                ))
                 continue
+            if not pack_dir.is_dir():
+                continue
+            pack_name = pack_dir.name
+
+            unsafe_entry = _first_unsafe_pack_entry(pack_dir)
+            if unsafe_entry is not None:
+                unsafe_path, unsafe_reason = unsafe_entry
+                unsafe_pack_diagnostics.append(_diag(
+                    DiagnosticCode.CAT_L005,
+                    Severity.ERROR,
+                    f"pack contains a {unsafe_reason} and cannot be read safely",
+                    pack=pack_name,
+                    path=_diagnostic_path(root, unsafe_path),
+                    remediation=(
+                        "Use single-link regular files and real directories inside the pack."
+                    ),
+                ))
+                continue
+
+            manifest = pack_dir / "pack.toml"
+            has_manifest = (
+                manifest.exists()
+                or manifest.is_symlink()
+                or _path_is_junction(manifest)
+            )
+            if has_manifest:
+                try:
+                    sha256_confined_regular_file(pack_dir, manifest)
+                except UnsafeContentError as exc:
+                    unsafe_pack_diagnostics.append(_diag(
+                        DiagnosticCode.CAT_L005,
+                        Severity.ERROR,
+                        f"pack manifest cannot be read safely: {exc}",
+                        pack=pack_name,
+                        path=_diagnostic_path(root, manifest),
+                        remediation=(
+                            "Replace pack.toml with a single-link regular file."
+                        ),
+                    ))
+                    continue
+
+            safe_deep_pack_dirs.append(pack_dir)
+            if not has_manifest:
+                continue
+            safe_pack_dirs.append(pack_dir)
+
+        diagnostics.extend(
+            diagnostic
+            for diagnostic in unsafe_pack_diagnostics
+            if pack is None or diagnostic.pack == pack
+        )
+
+        for pack_dir in safe_pack_dirs:
             pack_name = pack_dir.name
             if pack is not None and pack_name != pack:
                 continue
@@ -1895,8 +2091,17 @@ def lint_catalogue(root: Path, pack: str | None = None, *, deep: bool = False) -
     # Deep spec-compliance pass
     if deep:
         from agentbundle.catalogue_tooling.skill_spec_lint import lint_skill_spec
-        deep_diags = lint_skill_spec(root, pack=pack)
-        diagnostics.extend(deep_diags)
+
+        unsafe_in_scope = any(
+            pack is None or diagnostic.pack == pack
+            for diagnostic in unsafe_pack_diagnostics
+        )
+        if unsafe_in_scope:
+            for pack_dir in safe_deep_pack_dirs:
+                if pack is None or pack_dir.name == pack:
+                    diagnostics.extend(lint_skill_spec(root, pack=pack_dir.name))
+        else:
+            diagnostics.extend(lint_skill_spec(root, pack=pack))
 
     diagnostics.sort(key=_sort_key)
     ok = not any(d.severity == Severity.ERROR for d in diagnostics)

--- a/packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py
@@ -20,10 +20,16 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
 import tomllib
 from pathlib import Path
 from typing import Any
 
+from agentbundle.catalogue_tooling.file_safety import (
+    UnsafeContentError,
+    read_confined_regular_file,
+)
+from agentbundle.catalogue_tooling.package import _TRANSIENT_DIRS
 from agentbundle.catalogue_tooling.results import Diagnostic, Severity
 
 # ---------------------------------------------------------------------------
@@ -34,7 +40,7 @@ ALLOWED_SKILL_KEYS = frozenset({"name", "description", "license", "compatibility
                                  "metadata", "allowed-tools"})
 KEBAB = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 BLESSED_SUBDIRS = frozenset({"scripts", "references", "assets", "evals"})
-IGNORED_DEV_DIRS = frozenset({"node_modules", ".venv", "venv", "__pycache__"})
+IGNORED_DEV_DIRS = _TRANSIENT_DIRS
 
 RE_ABS_PATH = re.compile(r"(/Users/|/home/|/opt/|/var/|/etc/|C:\\)")
 RE_INSTALL_PATH = re.compile(
@@ -68,6 +74,17 @@ class _DuplicateKeyError(Exception):
     def __init__(self, key: object, line: int) -> None:
         self.key = key
         self.line = line
+
+
+def _path_is_junction(path: Path) -> bool:
+    """Return whether *path* is a Windows junction, failing closed on errors."""
+    checker = getattr(path, "is_junction", None)
+    if checker is None:
+        return False
+    try:
+        return bool(checker())
+    except OSError:
+        return True
 
 
 def _require_yaml() -> Any:
@@ -171,6 +188,130 @@ def _check_description_source(fm_lines: list[str]) -> tuple[int, str] | None:
     return None
 
 
+def _check_eval_queries(evals_json: Path, *, content: str | None = None) -> list[str]:
+    """Return structural findings for one ``eval_queries.json`` manifest."""
+    try:
+        source = content if content is not None else evals_json.read_text(encoding="utf-8")
+        data = json.loads(source)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return [f"evals/eval_queries.json is not valid JSON: {exc}"]
+    if not isinstance(data, list):
+        return ["evals/eval_queries.json must be a JSON array at top level"]
+    if not data:
+        return ["evals/eval_queries.json must contain at least one query"]
+    findings: list[str] = []
+    for idx, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            findings.append(f"eval_queries[{idx}] must be an object")
+            continue
+        query = entry.get("query")
+        if not isinstance(query, str) or not query:
+            findings.append(f"eval_queries[{idx}].query must be a non-empty string")
+        should_trigger = entry.get("should_trigger")
+        if not isinstance(should_trigger, bool):
+            findings.append(
+                f"eval_queries[{idx}].should_trigger must be a boolean "
+                f"(got {type(should_trigger).__name__})"
+            )
+    return findings
+
+
+def _check_evals_json(
+    skill_dir: Path,
+    evals_json: Path,
+    skill_name: str | None,
+    *,
+    content: str | None = None,
+) -> list[str]:
+    """Return structural and referenced-file findings for one eval manifest."""
+    try:
+        source = content if content is not None else evals_json.read_text(encoding="utf-8")
+        data = json.loads(source)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return [f"evals/evals.json is not valid JSON: {exc}"]
+    if not isinstance(data, dict):
+        return ["evals/evals.json must be a JSON object"]
+    findings: list[str] = []
+    manifest_skill_name = data.get("skill_name")
+    if not isinstance(manifest_skill_name, str) or not manifest_skill_name:
+        findings.append("evals.json 'skill_name' must be a non-empty string")
+    elif skill_name and manifest_skill_name != skill_name:
+        findings.append(
+            f"evals.json skill_name {manifest_skill_name!r} does not match "
+            f"skill name {skill_name!r}"
+        )
+    evals_list = data.get("evals")
+    if not isinstance(evals_list, list):
+        findings.append("evals.json 'evals' must be a list")
+        return findings
+    if not evals_list:
+        findings.append("evals.json 'evals' must contain at least one entry")
+        return findings
+    seen_ids: set[object] = set()
+    for idx, entry in enumerate(evals_list):
+        if not isinstance(entry, dict):
+            findings.append(f"evals[{idx}] must be an object")
+            continue
+        eval_id = entry.get("id")
+        if not isinstance(eval_id, (int, str)) or isinstance(eval_id, bool):
+            findings.append(
+                f"evals[{idx}].id must be int or str (got {type(eval_id).__name__})"
+            )
+        elif eval_id in seen_ids:
+            findings.append(f"evals[{idx}] duplicate id {eval_id!r}")
+        else:
+            seen_ids.add(eval_id)
+        prompt = entry.get("prompt")
+        if not isinstance(prompt, str) or not prompt:
+            findings.append(f"evals[{idx}].prompt must be a non-empty string")
+        expected = entry.get("expected_output")
+        if not isinstance(expected, str) or not expected:
+            findings.append(f"evals[{idx}].expected_output must be a non-empty string")
+        files = entry.get("files")
+        if files is not None:
+            if not isinstance(files, list):
+                findings.append(f"evals[{idx}].files must be a list")
+            else:
+                try:
+                    canonical_skill_dir = skill_dir.resolve()
+                except (OSError, RuntimeError):
+                    canonical_skill_dir = skill_dir
+                for file_ref in files:
+                    if not isinstance(file_ref, str) or not file_ref:
+                        findings.append(
+                            f"evals[{idx}].files entry must be a non-empty string"
+                        )
+                        continue
+                    try:
+                        resolved = (skill_dir / file_ref).resolve()
+                    except (OSError, RuntimeError):
+                        findings.append(
+                            f"evals[{idx}].files entry {file_ref!r} cannot be resolved"
+                        )
+                        continue
+                    if not resolved.is_relative_to(canonical_skill_dir):
+                        findings.append(
+                            f"evals[{idx}].files entry {file_ref!r} resolves outside "
+                            "the skill directory"
+                        )
+                    elif not resolved.exists():
+                        findings.append(
+                            f"evals[{idx}].files entry {file_ref!r} does not exist"
+                        )
+        assertions = entry.get("assertions")
+        if assertions is not None:
+            if not isinstance(assertions, list):
+                findings.append(f"evals[{idx}].assertions must be a list")
+            else:
+                for assertion_index, assertion in enumerate(assertions):
+                    if not isinstance(assertion, str) or not assertion:
+                        findings.append(
+                            f"evals[{idx}].assertions[{assertion_index}] must be a "
+                            "non-empty string"
+                        )
+    return findings
+
+
 # ---------------------------------------------------------------------------
 # Main API
 # ---------------------------------------------------------------------------
@@ -230,8 +371,8 @@ def lint_skill_spec(root: Path, pack: str | None = None) -> list[Diagnostic]:
     def _parse_frontmatter(path: Path):
         """Return (fields, body_start_line, body, error, fm_text)."""
         try:
-            raw = path.read_bytes()
-        except OSError as exc:
+            raw = read_confined_regular_file(path.parent, path)
+        except (OSError, UnsafeContentError) as exc:
             return None, 0, "", f"could not read skill: {exc}", ""
         if raw.startswith(b"\xef\xbb\xbf"):
             return None, 0, "", (
@@ -420,139 +561,100 @@ def lint_skill_spec(root: Path, pack: str | None = None) -> list[Diagnostic]:
                 _warn(path, f"loose file at skill root: {child.name!r}",
                       code=_CODE_LAYOUT, pack_name=pack_name)
 
-    def _check_eval_queries(evals_json: Path, pack_name: str | None) -> None:
+    def _report_eval_queries(
+        skill_dir: Path, evals_json: Path, pack_name: str | None
+    ) -> None:
         try:
-            data = json.loads(evals_json.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            _err(evals_json, f"evals/eval_queries.json is not valid JSON: {exc}",
-                 code=_CODE_EVALS, pack_name=pack_name)
+            content = read_confined_regular_file(skill_dir, evals_json).decode("utf-8")
+        except (OSError, UnicodeDecodeError, UnsafeContentError) as exc:
+            _err(
+                evals_json,
+                f"could not read eval manifest: {exc}",
+                code=_CODE_EVALS,
+                pack_name=pack_name,
+            )
             return
-        if not isinstance(data, list):
-            _err(evals_json, "evals/eval_queries.json must be a JSON array at top level",
-                 code=_CODE_EVALS, pack_name=pack_name)
-            return
-        for idx, entry in enumerate(data):
-            if not isinstance(entry, dict):
-                _err(evals_json, f"eval_queries[{idx}] must be an object",
-                     code=_CODE_EVALS, pack_name=pack_name)
-                continue
-            query = entry.get("query")
-            if not isinstance(query, str) or not query:
-                _err(evals_json,
-                     f"eval_queries[{idx}].query must be a non-empty string",
-                     code=_CODE_EVALS, pack_name=pack_name)
-            st = entry.get("should_trigger")
-            if not isinstance(st, bool):
-                _err(evals_json,
-                     f"eval_queries[{idx}].should_trigger must be a boolean "
-                     f"(got {type(st).__name__})",
-                     code=_CODE_EVALS, pack_name=pack_name)
+        for message in _check_eval_queries(evals_json, content=content):
+            _err(evals_json, message, code=_CODE_EVALS, pack_name=pack_name)
 
-    def _check_evals_json(skill_dir: Path, evals_json: Path,
-                          skill_name: str | None, pack_name: str | None) -> None:
+    def _report_evals_json(
+        skill_dir: Path,
+        evals_json: Path,
+        skill_name: str | None,
+        pack_name: str | None,
+    ) -> None:
         try:
-            data = json.loads(evals_json.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            _err(evals_json, f"evals/evals.json is not valid JSON: {exc}",
-                 code=_CODE_EVALS, pack_name=pack_name)
+            content = read_confined_regular_file(skill_dir, evals_json).decode("utf-8")
+        except (OSError, UnicodeDecodeError, UnsafeContentError) as exc:
+            _err(
+                evals_json,
+                f"could not read eval manifest: {exc}",
+                code=_CODE_EVALS,
+                pack_name=pack_name,
+            )
             return
-        if not isinstance(data, dict):
-            _err(evals_json, "evals/evals.json must be a JSON object",
-                 code=_CODE_EVALS, pack_name=pack_name)
-            return
-        sn = data.get("skill_name")
-        if not isinstance(sn, str) or not sn:
-            _err(evals_json, "evals.json 'skill_name' must be a non-empty string",
-                 code=_CODE_EVALS, pack_name=pack_name)
-        elif skill_name and sn != skill_name:
-            _err(evals_json, f"evals.json skill_name {sn!r} does not match "
-                              f"skill name {skill_name!r}",
-                 code=_CODE_EVALS, pack_name=pack_name)
-        evals_list = data.get("evals")
-        if not isinstance(evals_list, list):
-            _err(evals_json, "evals.json 'evals' must be a list",
-                 code=_CODE_EVALS, pack_name=pack_name)
-            return
-        seen_ids: set = set()
-        for idx, entry in enumerate(evals_list):
-            if not isinstance(entry, dict):
-                _err(evals_json, f"evals[{idx}] must be an object",
-                     code=_CODE_EVALS, pack_name=pack_name)
-                continue
-            eid = entry.get("id")
-            if not isinstance(eid, (int, str)) or isinstance(eid, bool):
-                _err(evals_json, f"evals[{idx}].id must be int or str "
-                                  f"(got {type(eid).__name__})",
-                     code=_CODE_EVALS, pack_name=pack_name)
-            elif eid in seen_ids:
-                _err(evals_json, f"evals[{idx}] duplicate id {eid!r}",
-                     code=_CODE_EVALS, pack_name=pack_name)
-            else:
-                seen_ids.add(eid)
-            prompt = entry.get("prompt")
-            if not isinstance(prompt, str) or not prompt:
-                _err(evals_json, f"evals[{idx}].prompt must be a non-empty string",
-                     code=_CODE_EVALS, pack_name=pack_name)
-            expected = entry.get("expected_output")
-            if not isinstance(expected, str) or not expected:
-                _err(evals_json, f"evals[{idx}].expected_output must be a "
-                                  f"non-empty string",
-                     code=_CODE_EVALS, pack_name=pack_name)
-            files = entry.get("files")
-            if files is not None:
-                if not isinstance(files, list):
-                    _err(evals_json, f"evals[{idx}].files must be a list",
-                         code=_CODE_EVALS, pack_name=pack_name)
-                else:
-                    skill_dir_resolved = skill_dir.resolve()
-                    for fpath in files:
-                        if not isinstance(fpath, str) or not fpath:
-                            _err(evals_json,
-                                 f"evals[{idx}].files entry must be a non-empty string",
-                                 code=_CODE_EVALS, pack_name=pack_name)
-                            continue
-                        resolved = (skill_dir / fpath).resolve()
-                        try:
-                            resolved.relative_to(skill_dir_resolved)
-                        except ValueError:
-                            _err(evals_json, f"evals[{idx}].files entry "
-                                              f"{fpath!r} resolves outside "
-                                              f"the skill directory",
-                                 code=_CODE_EVALS, pack_name=pack_name)
-                            continue
-                        if not resolved.exists():
-                            _err(evals_json, f"evals[{idx}].files entry "
-                                              f"{fpath!r} does not exist",
-                                 code=_CODE_EVALS, pack_name=pack_name)
-            asserts = entry.get("assertions")
-            if asserts is not None:
-                if not isinstance(asserts, list):
-                    _err(evals_json, f"evals[{idx}].assertions must be a list",
-                         code=_CODE_EVALS, pack_name=pack_name)
-                else:
-                    for ai, a in enumerate(asserts):
-                        if not isinstance(a, str) or not a:
-                            _err(evals_json,
-                                 f"evals[{idx}].assertions[{ai}] must be a "
-                                 f"non-empty string",
-                                 code=_CODE_EVALS, pack_name=pack_name)
+        for message in _check_evals_json(
+            skill_dir, evals_json, skill_name, content=content
+        ):
+            _err(evals_json, message, code=_CODE_EVALS, pack_name=pack_name)
 
     def _check_evals(skill_dir: Path, path: Path, skill_name: str | None,
                      pack_name: str | None) -> None:
         evals_dir = skill_dir / "evals"
-        if not evals_dir.exists() or not evals_dir.is_dir():
+        try:
+            evals_metadata = evals_dir.lstat()
+        except FileNotFoundError:
+            return
+        except OSError:
+            _err(
+                evals_dir,
+                "could not inspect evals directory",
+                code=_CODE_EVALS,
+                pack_name=pack_name,
+            )
+            return
+        if (
+            stat.S_ISLNK(evals_metadata.st_mode)
+            or _path_is_junction(evals_dir)
+            or not stat.S_ISDIR(evals_metadata.st_mode)
+        ):
+            _err(
+                evals_dir,
+                "evals entry is not a real directory",
+                code=_CODE_EVALS,
+                pack_name=pack_name,
+            )
             return
         evals_json = evals_dir / "evals.json"
         eval_queries_json = evals_dir / "eval_queries.json"
-        if not evals_json.exists() and not eval_queries_json.exists():
+
+        def _manifest_present(manifest: Path) -> bool | None:
+            """Return no-follow presence, diagnosing inspection failures."""
+            try:
+                manifest.lstat()
+            except FileNotFoundError:
+                return False
+            except OSError:
+                _err(
+                    manifest,
+                    "could not inspect eval manifest",
+                    code=_CODE_EVALS,
+                    pack_name=pack_name,
+                )
+                return None
+            return True
+
+        evals_present = _manifest_present(evals_json)
+        queries_present = _manifest_present(eval_queries_json)
+        if evals_present is False and queries_present is False:
             _err(path, "evals/ directory present but neither evals/evals.json "
                         "nor evals/eval_queries.json is present",
                  code=_CODE_EVALS, pack_name=pack_name)
             return
-        if evals_json.exists():
-            _check_evals_json(skill_dir, evals_json, skill_name, pack_name)
-        if eval_queries_json.exists():
-            _check_eval_queries(eval_queries_json, pack_name)
+        if evals_present:
+            _report_evals_json(skill_dir, evals_json, skill_name, pack_name)
+        if queries_present:
+            _report_eval_queries(skill_dir, eval_queries_json, pack_name)
 
     def _check_skill(path: Path, pack_name: str | None) -> None:
         fields, body_start, body, ferr, fm_text = _parse_frontmatter(path)
@@ -572,100 +674,237 @@ def lint_skill_spec(root: Path, pack: str | None = None) -> list[Diagnostic]:
 
     # ── Build walk roots ──────────────────────────────────────────────────
 
+    def _validate_walk_root(
+        walk_dir: Path,
+    ) -> tuple[bool, tuple[Path, str] | None]:
+        """Validate every directory component without following links."""
+        try:
+            relative = walk_dir.relative_to(root)
+        except ValueError:
+            return False, (walk_dir, "skill walk root is outside catalogue root")
+        if ".." in relative.parts:
+            return False, (walk_dir, "skill walk root contains path traversal")
+        current = root
+        for part in relative.parts:
+            current /= part
+            try:
+                metadata = current.lstat()
+            except FileNotFoundError:
+                return False, None
+            except OSError:
+                return False, (current, "could not inspect skill walk root")
+            if stat.S_ISLNK(metadata.st_mode) or _path_is_junction(current):
+                return False, (current, "linked skill walk root is not allowed")
+            if not stat.S_ISDIR(metadata.st_mode):
+                return False, (current, "skill walk root is not a directory")
+        try:
+            walk_dir.resolve(strict=True).relative_to(root.resolve(strict=True))
+        except (OSError, RuntimeError, ValueError):
+            return False, (walk_dir, "skill walk root escapes catalogue root")
+        return True, None
+
     walk_roots: list[tuple[Path, str | None]] = []  # (walk_dir, pack_name)
+    root_errors: list[tuple[Path, str, str | None]] = []
+    crossref_pack_dirs: list[Path] = []
     packs_root = root / "packs"
 
     if pack is not None:
-        skill_root = packs_root / pack / ".apm" / "skills"
-        if skill_root.exists():
-            walk_roots.append((skill_root, pack))
+        if not KEBAB.fullmatch(pack):
+            root_errors.append(
+                (packs_root, "pack filter is not a safe pack name", None)
+            )
+        else:
+            pack_dir = packs_root / pack
+            walk_roots.append((pack_dir / ".apm" / "skills", pack))
+            pack_present, pack_error = _validate_walk_root(pack_dir)
+            if pack_present and pack_error is None:
+                crossref_pack_dirs.append(pack_dir)
     else:
-        projection = root / ".claude" / "skills"
-        if projection.exists():
-            walk_roots.append((projection, None))
-        if packs_root.exists():
-            for p in sorted(packs_root.glob("*/.apm/skills")):
-                pack_name = p.parent.parent.name
-                if pack_name.startswith("_"):
-                    continue
-                walk_roots.append((p, pack_name))
+        walk_roots.append((root / ".claude" / "skills", None))
+        packs_present, packs_error = _validate_walk_root(packs_root)
+        if packs_error is not None:
+            root_errors.append((*packs_error, None))
+        elif packs_present:
+            try:
+                with os.scandir(packs_root) as it:
+                    pack_entries = sorted(it, key=lambda entry: entry.name)
+            except OSError:
+                root_errors.append(
+                    (packs_root, "could not enumerate packs for deep lint", None)
+                )
+            else:
+                for entry in pack_entries:
+                    if entry.name.startswith("_"):
+                        continue
+                    pack_dir = Path(entry.path)
+                    try:
+                        metadata = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        root_errors.append(
+                            (pack_dir, "could not inspect pack for deep lint", entry.name)
+                        )
+                        continue
+                    if (
+                        stat.S_ISLNK(metadata.st_mode)
+                        or _path_is_junction(pack_dir)
+                    ):
+                        root_errors.append(
+                            (pack_dir, "linked pack is not allowed", entry.name)
+                        )
+                    elif stat.S_ISDIR(metadata.st_mode):
+                        crossref_pack_dirs.append(pack_dir)
+                        walk_roots.append(
+                            (pack_dir / ".apm" / "skills", entry.name)
+                        )
 
     # ── Walk skills ───────────────────────────────────────────────────────
 
-    def _skill_mds(walk_dir: Path) -> list[Path]:
-        """Return all SKILL.md paths under walk_dir, including broken/circular symlinks.
+    def _skill_mds(walk_dir: Path) -> tuple[list[Path], list[tuple[Path, str]]]:
+        """Return skill paths and bounded traversal errors under *walk_dir*.
 
-        Path.glob("*/SKILL.md") silently skips broken/circular symlinks on
-        Python 3.11 Linux (it checks is_file() internally). Using os.scandir
-        with lstat ensures every SKILL.md — even a dangling or looped symlink —
-        is visited so the linter can emit a diagnostic.
+        Directory entries are inspected without following links. Transient
+        directories are skipped before inspection; every other traversal error
+        becomes a catalogue-relative diagnostic instead of silently weakening
+        the deep lint pass.
         """
         result: list[Path] = []
+        errors: list[tuple[Path, str]] = []
+        root_present, root_error = _validate_walk_root(walk_dir)
+        if root_error is not None:
+            return [], [root_error]
+        if not root_present:
+            return [], []
         try:
             with os.scandir(walk_dir) as it:
-                for entry in it:
-                    if not (entry.is_dir(follow_symlinks=True) or
-                            entry.is_dir(follow_symlinks=False)):
-                        continue
-                    skill_md = Path(entry.path) / "SKILL.md"
-                    try:
-                        skill_md.lstat()  # succeeds for real files and any symlink
-                        result.append(skill_md)
-                    except OSError:
-                        pass
+                entries = sorted(it, key=lambda entry: entry.name)
         except OSError:
-            pass
-        return sorted(result)
+            return [], [(walk_dir, "could not enumerate skill directory")]
+        for entry in entries:
+            if entry.name in _TRANSIENT_DIRS:
+                continue
+            entry_path = Path(entry.path)
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError:
+                errors.append((entry_path, "could not inspect skill directory"))
+                continue
+            is_link = stat.S_ISLNK(metadata.st_mode) or _path_is_junction(entry_path)
+            if not (stat.S_ISDIR(metadata.st_mode) or is_link):
+                continue
+            if is_link:
+                errors.append((entry_path, "linked skill directory is not allowed"))
+                continue
+            skill_md = entry_path / "SKILL.md"
+            try:
+                skill_metadata = skill_md.lstat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                errors.append((skill_md, "could not inspect skill entry"))
+                continue
+            if (
+                stat.S_ISLNK(skill_metadata.st_mode)
+                or _path_is_junction(skill_md)
+            ):
+                errors.append((skill_md, "linked skill entry is not allowed"))
+            elif not stat.S_ISREG(skill_metadata.st_mode):
+                errors.append((skill_md, "non-regular skill entry is not allowed"))
+            elif skill_metadata.st_nlink > 1:
+                errors.append((skill_md, "hard-linked skill entry is not allowed"))
+            else:
+                result.append(skill_md)
+        return sorted(result), errors
 
+    for error_path, message, pack_name in root_errors:
+        _err(error_path, message, code=_CODE_PARSE, pack_name=pack_name)
     for walk_dir, pack_name in walk_roots:
-        for skill_md in _skill_mds(walk_dir):
+        skill_mds, walk_errors = _skill_mds(walk_dir)
+        for error_path, message in walk_errors:
+            _err(error_path, message, code=_CODE_PARSE, pack_name=pack_name)
+        for skill_md in skill_mds:
             try:
                 _check_skill(skill_md, pack_name)
-            except (OSError, RuntimeError) as exc:
-                _err(skill_md, f"could not read skill: {exc}",
+            except (OSError, RuntimeError):
+                _err(skill_md, "could not inspect skill contents",
                      code=_CODE_PARSE, pack_name=pack_name)
 
     # ── [pack.evals].skills cross-reference ──────────────────────────────
 
-    if packs_root.exists() and pack is None:
-        for pack_toml in sorted(packs_root.glob("*/pack.toml")):
-            pack_dir = pack_toml.parent
-            pn = pack_dir.name
-            if pn.startswith("_"):
+    for pack_dir in sorted(crossref_pack_dirs):
+        pack_toml = pack_dir / "pack.toml"
+        pn = pack_dir.name
+        try:
+            pack_toml.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            _err(
+                pack_toml,
+                "could not inspect pack.toml",
+                code=_CODE_TOML,
+                pack_name=pn,
+            )
+            continue
+        try:
+            manifest_text = read_confined_regular_file(
+                pack_dir, pack_toml
+            ).decode("utf-8")
+            manifest = tomllib.loads(manifest_text)
+        except (
+            OSError,
+            UnicodeDecodeError,
+            UnsafeContentError,
+            tomllib.TOMLDecodeError,
+        ) as exc:
+            _err(pack_toml, f"could not parse pack.toml: {exc}",
+                 code=_CODE_TOML, pack_name=pn)
+            continue
+        evals_cfg = manifest.get("pack", {}).get("evals")
+        if evals_cfg is None:
+            continue
+        if not isinstance(evals_cfg, dict):
+            _err(pack_toml, "[pack.evals] must be a table",
+                 code=_CODE_TOML, pack_name=pn)
+            continue
+        skills = evals_cfg.get("skills", [])
+        if not isinstance(skills, list):
+            _err(pack_toml, "[pack.evals].skills must be an array of strings",
+                 code=_CODE_TOML, pack_name=pn)
+            continue
+        for entry in skills:
+            if not isinstance(entry, str) or not entry:
+                _err(pack_toml, f"[pack.evals].skills entry must be a "
+                                 f"non-empty string (got {entry!r})",
+                     code=_CODE_TOML, pack_name=pn)
                 continue
+            if not KEBAB.fullmatch(entry):
+                _err(
+                    pack_toml,
+                    f"[pack.evals].skills entry {entry!r} is not a safe skill name",
+                    code=_CODE_TOML,
+                    pack_name=pn,
+                )
+                continue
+            skill_dir = pack_dir / ".apm" / "skills" / entry
+            skill_present, skill_error = _validate_walk_root(skill_dir)
+            if not skill_present or skill_error is not None:
+                _err(pack_toml, f"[pack.evals].skills names {entry!r} but "
+                                 f"it is not a skill directory",
+                     code=_CODE_TOML, pack_name=pn)
+                continue
+            eval_queries = skill_dir / "evals" / "eval_queries.json"
             try:
-                manifest = tomllib.loads(pack_toml.read_text(encoding="utf-8"))
-            except (OSError, tomllib.TOMLDecodeError) as exc:
-                _err(pack_toml, f"could not parse pack.toml: {exc}",
+                eval_metadata = eval_queries.lstat()
+            except OSError:
+                eval_metadata = None
+            if (
+                eval_metadata is None
+                or not stat.S_ISREG(eval_metadata.st_mode)
+                or eval_metadata.st_nlink > 1
+                or _path_is_junction(eval_queries)
+            ):
+                _err(pack_toml, f"[pack.evals].skills names {entry!r} but "
+                                 f"it ships no evals/eval_queries.json",
                      code=_CODE_TOML, pack_name=pn)
-                continue
-            evals_cfg = manifest.get("pack", {}).get("evals")
-            if evals_cfg is None:
-                continue
-            if not isinstance(evals_cfg, dict):
-                _err(pack_toml, "[pack.evals] must be a table",
-                     code=_CODE_TOML, pack_name=pn)
-                continue
-            skills = evals_cfg.get("skills", [])
-            if not isinstance(skills, list):
-                _err(pack_toml, "[pack.evals].skills must be an array of strings",
-                     code=_CODE_TOML, pack_name=pn)
-                continue
-            for entry in skills:
-                if not isinstance(entry, str) or not entry:
-                    _err(pack_toml, f"[pack.evals].skills entry must be a "
-                                     f"non-empty string (got {entry!r})",
-                         code=_CODE_TOML, pack_name=pn)
-                    continue
-                skill_dir = pack_dir / ".apm" / "skills" / entry
-                if not skill_dir.is_dir():
-                    _err(pack_toml, f"[pack.evals].skills names {entry!r} but "
-                                     f"it is not a skill directory",
-                         code=_CODE_TOML, pack_name=pn)
-                    continue
-                if not (skill_dir / "evals" / "eval_queries.json").is_file():
-                    _err(pack_toml, f"[pack.evals].skills names {entry!r} but "
-                                     f"it ships no evals/eval_queries.json",
-                         code=_CODE_TOML, pack_name=pn)
 
     return diags

--- a/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/verify.py
@@ -1,4 +1,4 @@
-"""Catalogue verification engine — 18-step source-checkout pipeline.
+"""Catalogue verification engine — 19-step source-checkout pipeline.
 
 Entry points:
   ``verify_catalogue(root, pack=None) -> VerifyResult``
@@ -13,10 +13,15 @@ import re
 import tempfile
 from pathlib import Path
 
+from agentbundle.catalogue_tooling.file_safety import (
+    UnsafeContentError,
+    read_confined_regular_file,
+)
 from agentbundle.catalogue_tooling.manifest import MANIFEST_NAME, plugin_json_path
 from agentbundle.catalogue_tooling.results import Diagnostic, Severity, VerifyResult
 
 _AGENTBUNDLE_VERSION: str | None = None
+_PACK_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 
 def _get_agentbundle_version() -> str:
@@ -54,6 +59,71 @@ def _warn(code: str, message: str, pack: str | None = None, path: str | None = N
         message=message,
         remediation=None,
     )
+
+
+def _info(code: str, message: str, pack: str | None = None, path: str | None = None) -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        severity=Severity.INFO,
+        pack=pack,
+        path=path,
+        line=None,
+        col=None,
+        message=message,
+        remediation=None,
+    )
+
+
+def _load_bundled_json(name: str) -> dict:
+    """Load a JSON contract through the package's zipapp-safe reader."""
+    from agentbundle.build.main import _read_bundled
+
+    return json.loads(_read_bundled(name))
+
+
+def _path_is_junction(path: Path) -> bool:
+    """Return whether *path* is a Windows junction when the runtime supports it."""
+    checker = getattr(path, "is_junction", None)
+    return bool(checker and checker())
+
+
+def _confined_pack_candidate(packs_dir: Path, slug: object) -> tuple[Path | None, str | None]:
+    """Resolve a pack slug beneath *packs_dir* without following link-like escapes."""
+    if not isinstance(slug, str) or not _PACK_SLUG_RE.fullmatch(slug):
+        return None, "pack reference must use the canonical lowercase slug grammar"
+    candidate = packs_dir / slug
+    try:
+        if candidate.is_symlink() or _path_is_junction(candidate):
+            return None, "pack reference refused: link is outside the packs root"
+        canonical_root = packs_dir.resolve()
+        canonical_candidate = candidate.resolve()
+    except (OSError, RuntimeError):
+        return None, "pack reference refused: path cannot be resolved safely"
+    if not canonical_candidate.is_relative_to(canonical_root):
+        return None, "pack reference refused: path is outside the packs root"
+    return canonical_candidate, None
+
+
+def _confined_directory_issue(root: Path, path: Path) -> str | None:
+    """Describe why *path* is not a real directory confined below *root*."""
+    if path.is_symlink() or _path_is_junction(path):
+        return "link-like"
+    try:
+        canonical_root = root.resolve(strict=True)
+        canonical_path = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return "unresolvable"
+    if not canonical_path.is_relative_to(canonical_root):
+        return "outside its pack root"
+    return None
+
+
+def _diagnostic_path(root: Path, path: Path) -> str:
+    """Return a repository-relative label without exposing an outside path."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return "<outside-root>"
 
 
 # ---------------------------------------------------------------------------
@@ -94,16 +164,23 @@ def _step_pack_schema(
 
     packs_dir_name = getattr(config, "paths", None)
     packs_dir = root / (getattr(packs_dir_name, "packs", "packs") if packs_dir_name else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-003",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
     if not packs_dir.is_dir():
         return []
 
-    # Use the bundled pack.schema.json so validation works both editable and wheel.
-    schema_path = Path(__file__).resolve().parent.parent / "_data" / "pack.schema.json"
-    if not schema_path.exists():
+    try:
+        schema = _load_bundled_json("pack.schema.json")
+    except (OSError, ValueError):
         return []
-
-    import json as _json
-    schema = _json.loads(schema_path.read_text(encoding="utf-8"))
 
     diags: list[Diagnostic] = []
     for pack_dir in sorted(packs_dir.iterdir()):
@@ -113,13 +190,25 @@ def _step_pack_schema(
             continue
         if pack and pack_dir.name != pack:
             continue
+        pack_issue = _confined_directory_issue(packs_dir, pack_dir)
+        if pack_issue is not None:
+            diags.append(
+                _err(
+                    "CAT-V-003",
+                    f"refused {pack_issue} pack directory",
+                    pack=pack_dir.name,
+                    path=_diagnostic_path(root, pack_dir),
+                )
+            )
+            continue
         pack_toml = pack_dir / "pack.toml"
-        if not pack_toml.exists():
+        if not (pack_toml.exists() or pack_toml.is_symlink() or _path_is_junction(pack_toml)):
             continue
         try:
             import tomllib
-            contract = tomllib.loads(pack_toml.read_text(encoding="utf-8"))
-        except Exception as exc:
+            content = read_confined_regular_file(pack_dir, pack_toml).decode("utf-8")
+            contract = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
             diags.append(_err("CAT-V-003", f"pack.toml parse error: {exc}", pack=pack_dir.name))
             continue
         errors = validate_schema(contract, schema)
@@ -143,6 +232,16 @@ def _step_plugin_validation(
     """Step 4: validate plugin.json presence and JSON parse."""
     packs_dir_name = getattr(config, "paths", None)
     packs_dir = root / (getattr(packs_dir_name, "packs", "packs") if packs_dir_name else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-004",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
     if not packs_dir.is_dir():
         return []
 
@@ -153,6 +252,17 @@ def _step_plugin_validation(
         if not pack_dir.is_dir():
             continue
         if pack and pack_dir.name != pack:
+            continue
+        pack_issue = _confined_directory_issue(packs_dir, pack_dir)
+        if pack_issue is not None:
+            diags.append(
+                _err(
+                    "CAT-V-004",
+                    f"refused {pack_issue} pack directory",
+                    pack=pack_dir.name,
+                    path=_diagnostic_path(root, pack_dir),
+                )
+            )
             continue
         # The pack root is not a manifest location. A plugin.json there is
         # invisible to every consumer while looking present in the tree —
@@ -164,11 +274,16 @@ def _step_plugin_validation(
                 pack=pack_dir.name,
             ))
         plugin_json = _plugin_json_path(pack_dir)
-        if not plugin_json.exists():
+        if not (
+            plugin_json.exists()
+            or plugin_json.is_symlink()
+            or _path_is_junction(plugin_json)
+        ):
             continue  # a pack need not ship a manifest; catalogue lint agrees
         try:
-            json.loads(plugin_json.read_text(encoding="utf-8"))
-        except Exception as exc:
+            content = read_confined_regular_file(pack_dir, plugin_json).decode("utf-8")
+            json.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             diags.append(_err("CAT-V-004", f"plugin.json parse error: {exc}", pack=pack_dir.name))
     return diags
 
@@ -179,6 +294,16 @@ def _step_version_parity(
     """Step 5: pack.toml and plugin.json name/version must match."""
     packs_dir_name = getattr(config, "paths", None)
     packs_dir = root / (getattr(packs_dir_name, "packs", "packs") if packs_dir_name else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-005",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
     if not packs_dir.is_dir():
         return []
 
@@ -190,15 +315,50 @@ def _step_version_parity(
             continue
         if pack and pack_dir.name != pack:
             continue
+        pack_issue = _confined_directory_issue(packs_dir, pack_dir)
+        if pack_issue is not None:
+            diags.append(
+                _err(
+                    "CAT-V-005",
+                    f"refused {pack_issue} pack directory",
+                    pack=pack_dir.name,
+                    path=_diagnostic_path(root, pack_dir),
+                )
+            )
+            continue
         pack_toml_path = pack_dir / "pack.toml"
         manifest_path = _plugin_json_path(pack_dir)
-        if not pack_toml_path.exists() or not manifest_path.exists():
+        pack_toml_present = (
+            pack_toml_path.exists()
+            or pack_toml_path.is_symlink()
+            or _path_is_junction(pack_toml_path)
+        )
+        manifest_present = (
+            manifest_path.exists()
+            or manifest_path.is_symlink()
+            or _path_is_junction(manifest_path)
+        )
+        if not pack_toml_present or not manifest_present:
             continue
         try:
             import tomllib
-            pt = tomllib.loads(pack_toml_path.read_text(encoding="utf-8"))
-            pj = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except Exception:
+            pack_content = read_confined_regular_file(pack_dir, pack_toml_path).decode("utf-8")
+            manifest_content = read_confined_regular_file(pack_dir, manifest_path).decode("utf-8")
+            pt = tomllib.loads(pack_content)
+            pj = json.loads(manifest_content)
+        except (
+            UnsafeContentError,
+            UnicodeDecodeError,
+            tomllib.TOMLDecodeError,
+            json.JSONDecodeError,
+        ) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-005",
+                    f"version parity inputs cannot be read safely: {exc}",
+                    pack=pack_dir.name,
+                )
+            )
             continue
         pt_name = (pt.get("pack") or {}).get("name")
         pt_version = (pt.get("pack") or {}).get("version")
@@ -222,40 +382,425 @@ def _step_version_parity(
 def _step_profiles(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 6: profile schema validation (graceful pass when profiles absent)."""
+    """Step 6: validate profile schema and confined local pack references."""
     profiles_dir_name = getattr(config, "paths", None)
     profiles_dir = root / (
         getattr(profiles_dir_name, "profiles", "profiles") if profiles_dir_name else "profiles"
     )
+    profiles_present = (
+        profiles_dir.exists()
+        or profiles_dir.is_symlink()
+        or _path_is_junction(profiles_dir)
+    )
+    profiles_issue = (
+        _confined_directory_issue(root, profiles_dir) if profiles_present else None
+    )
+    if profiles_issue is not None:
+        return [
+            _err(
+                "CAT-V-006",
+                f"refused {profiles_issue} profiles directory",
+                path=_diagnostic_path(root, profiles_dir),
+            )
+        ]
     if not profiles_dir.is_dir():
         return []
+    packs_dir = root / (
+        getattr(profiles_dir_name, "packs", "packs") if profiles_dir_name else "packs"
+    )
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-006",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
+    try:
+        schema = _load_bundled_json("profile.schema.json")
+        from agentbundle.build.validate import validate as validate_schema
+    except (OSError, ValueError, ImportError) as exc:
+        return [_err("CAT-V-006", f"profile schema is unavailable: {exc}")]
+
     diags: list[Diagnostic] = []
     for profile_file in sorted(profiles_dir.iterdir()):
         if profile_file.suffix not in (".toml", ".json"):
             continue
         try:
+            content = read_confined_regular_file(profiles_dir, profile_file).decode("utf-8")
             if profile_file.suffix == ".toml":
                 import tomllib
-                tomllib.loads(profile_file.read_text(encoding="utf-8"))
+                profile_data = tomllib.loads(content)
             else:
-                json.loads(profile_file.read_text(encoding="utf-8"))
-        except Exception as exc:
-            diags.append(_err("CAT-V-006", f"profile {profile_file.name!r} parse error: {exc}"))
+                profile_data = json.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-006",
+                    f"profile {profile_file.name!r} is unsafe: {exc}",
+                    path=_diagnostic_path(root, profile_file),
+                )
+            )
+            continue
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-006",
+                    f"profile {profile_file.name!r} parse error: {exc}",
+                    path=_diagnostic_path(root, profile_file),
+                )
+            )
+            continue
+
+        errors = validate_schema(profile_data, schema)
+        for error in errors:
+            diags.append(
+                _err(
+                    "CAT-V-006",
+                    f"profile {profile_file.name!r} schema: {error}",
+                    path=str(profile_file.relative_to(root)),
+                )
+            )
+        if errors or not isinstance(profile_data, dict):
+            continue
+        for entry in profile_data.get("packs", []):
+            if not isinstance(entry, dict):
+                continue
+            slug = entry.get("pack")
+            candidate, reason = _confined_pack_candidate(packs_dir, slug)
+            if reason:
+                diags.append(
+                    _err(
+                        "CAT-V-006",
+                        f"profile {profile_file.name!r}: {reason}",
+                        path=str(profile_file.relative_to(root)),
+                    )
+                )
+            elif candidate is not None and not candidate.is_dir():
+                diags.append(
+                    _err(
+                        "CAT-V-006",
+                        f"profile {profile_file.name!r}: pack {slug!r} is missing",
+                        path=str(profile_file.relative_to(root)),
+                    )
+                )
     return diags
 
 
 def _step_dependencies(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 7: dependency reference validation (pass-through; complex graph TBD)."""
-    return []
+    """Step 7: validate dependency grammar, local resolution, and required cycles."""
+    import tomllib
+
+    from agentbundle.catalogue_tooling.version_ranges import (
+        parse_version_range,
+        version_satisfies,
+    )
+
+    paths = getattr(config, "paths", None)
+    packs_dir = root / (getattr(paths, "packs", "packs") if paths else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-007",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
+    if not packs_dir.is_dir():
+        return []
+    catalogue_name = getattr(config, "name", None) if config else None
+    diags: list[Diagnostic] = []
+    contracts: dict[str, dict | None] = {}
+
+    def load_pack(name: str) -> dict | None:
+        """Load one safely named pack manifest once."""
+        if name in contracts:
+            return contracts[name]
+        candidate, reason = _confined_pack_candidate(packs_dir, name)
+        if reason or candidate is None or not candidate.is_dir():
+            contracts[name] = None
+            return None
+        manifest = candidate / "pack.toml"
+        if not manifest.is_file():
+            contracts[name] = None
+            return None
+        try:
+            content = read_confined_regular_file(candidate, manifest).decode("utf-8")
+            value = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-007",
+                    f"pack {name!r}: pack.toml cannot be read safely: {exc}",
+                    pack=name,
+                    path=_diagnostic_path(root, manifest),
+                )
+            )
+            contracts[name] = None
+            return None
+        contracts[name] = value
+        return value
+
+    if pack is not None:
+        initial_names = [pack]
+    else:
+        initial_names = [
+            candidate.name
+            for candidate in sorted(packs_dir.iterdir())
+            if candidate.is_dir()
+            and not candidate.name.startswith("_")
+            and not candidate.is_symlink()
+            and not _path_is_junction(candidate)
+        ]
+
+    graph: dict[str, set[str]] = {}
+    queue = list(initial_names)
+    processed: set[str] = set()
+    while queue:
+        owner = queue.pop(0)
+        if owner in processed:
+            continue
+        processed.add(owner)
+        contract = load_pack(owner)
+        if contract is None:
+            continue
+        graph.setdefault(owner, set())
+        dependencies = contract.get("pack", {}).get("dependencies", {})
+        if not isinstance(dependencies, dict):
+            continue
+        has_entries = any(
+            dependencies.get(kind)
+            for kind in ("required", "recommended", "conflicts")
+        )
+        warned_unknown_identity = False
+        for kind in ("required", "recommended", "conflicts"):
+            entries = dependencies.get(kind) or []
+            if not isinstance(entries, list):
+                diags.append(
+                    _err(
+                        "CAT-V-007",
+                        f"pack {owner!r}: dependencies.{kind} must be a list",
+                        pack=owner,
+                    )
+                )
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    diags.append(
+                        _err(
+                            "CAT-V-007",
+                            f"pack {owner!r}: {kind} dependency must be an object",
+                            pack=owner,
+                        )
+                    )
+                    continue
+                dep_catalogue = entry.get("catalogue")
+                dep_name = entry.get("pack")
+                dep_range = entry.get("version")
+                fields = (dep_catalogue, dep_name, dep_range)
+                if not all(isinstance(value, str) and value for value in fields):
+                    diags.append(
+                        _err(
+                            "CAT-V-007",
+                            f"pack {owner!r}: {kind} dependency requires catalogue, "
+                            "pack, and version",
+                            pack=owner,
+                        )
+                    )
+                    continue
+                if not parse_version_range(dep_range):
+                    diags.append(
+                        _err(
+                            "CAT-V-007",
+                            f"pack {owner!r}: dependency {dep_name!r} has invalid "
+                            f"version range {dep_range!r}",
+                            pack=owner,
+                        )
+                    )
+                    continue
+                if catalogue_name is None:
+                    if has_entries and not warned_unknown_identity:
+                        diags.append(
+                            _info(
+                                "CAT-V-007",
+                                "catalogue identity unknown (no catalogue.toml); "
+                                f"local dependency classification skipped for pack {owner!r}",
+                                pack=owner,
+                            )
+                        )
+                        warned_unknown_identity = True
+                    continue
+                if dep_catalogue != catalogue_name:
+                    continue
+
+                candidate, reason = _confined_pack_candidate(packs_dir, dep_name)
+                if _PACK_SLUG_RE.fullmatch(dep_name):
+                    diagnostic_path = str((packs_dir / dep_name).relative_to(root))
+                else:
+                    diagnostic_path = str(packs_dir.relative_to(root) / "<invalid-pack-reference>")
+                if reason:
+                    diags.append(
+                        _err(
+                            "CAT-V-007",
+                            f"pack {owner!r}: {reason}",
+                            pack=owner,
+                            path=diagnostic_path,
+                        )
+                    )
+                    continue
+                if kind == "conflicts":
+                    continue
+                if candidate is None or not candidate.is_dir():
+                    if kind == "required":
+                        diags.append(
+                            _err(
+                                "CAT-V-007",
+                                f"pack {owner!r}: missing required dependency {dep_name!r}",
+                                pack=owner,
+                                path=diagnostic_path,
+                            )
+                        )
+                    continue
+                dep_contract = load_pack(dep_name)
+                if kind == "required":
+                    graph[owner].add(dep_name)
+                    graph.setdefault(dep_name, set())
+                    if pack is not None and dep_name not in processed:
+                        queue.append(dep_name)
+                    dep_version = (
+                        dep_contract.get("pack", {}).get("version")
+                        if dep_contract is not None
+                        else None
+                    )
+                    if version_satisfies(dep_version, dep_range) is not True:
+                        diags.append(
+                            _err(
+                                "CAT-V-007",
+                                f"pack {owner!r}: dependency {dep_name!r} version {dep_version!r} "
+                                f"does not satisfy {dep_range!r}",
+                                pack=owner,
+                                path=diagnostic_path,
+                            )
+                        )
+
+    visited: set[str] = set()
+    reported_cycles: set[frozenset[str]] = set()
+    for start in sorted(graph):
+        if start in visited:
+            continue
+        stack: list[tuple[str, list[str], int]] = [(start, sorted(graph[start]), 0)]
+        active: list[str] = [start]
+        active_set = {start}
+        while stack:
+            node, neighbours, index = stack[-1]
+            if index >= len(neighbours):
+                stack.pop()
+                active_set.discard(node)
+                if active and active[-1] == node:
+                    active.pop()
+                visited.add(node)
+                continue
+            neighbour = neighbours[index]
+            stack[-1] = (node, neighbours, index + 1)
+            if neighbour in active_set:
+                cycle_start = active.index(neighbour)
+                cycle = active[cycle_start:] + [neighbour]
+                cycle_key = frozenset(cycle)
+                if cycle_key not in reported_cycles:
+                    reported_cycles.add(cycle_key)
+                    for cycle_pack in sorted(cycle_key):
+                        diags.append(
+                            _err(
+                                "CAT-V-007",
+                                f"{' -> '.join(cycle)}: circular required dependency",
+                                pack=cycle_pack,
+                            )
+                        )
+                continue
+            if neighbour in visited:
+                continue
+            active.append(neighbour)
+            active_set.add(neighbour)
+            stack.append((neighbour, sorted(graph.get(neighbour, set())), 0))
+    return diags
 
 
 def _step_adapter_compat(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 8: adapter contract compatibility check."""
-    return []
+    """Step 8: reject unknown adapters declared by non-legacy packs."""
+    from agentbundle.config import pack_spec_version
+    from agentbundle.scope import shipped_adapters_from_contract
+
+    try:
+        known_adapters = set(shipped_adapters_from_contract())
+    except (OSError, ValueError) as exc:
+        return [_err("CAT-V-008", f"adapter contract is unavailable: {exc}")]
+    import tomllib
+    paths = getattr(config, "paths", None)
+    packs_dir = root / (getattr(paths, "packs", "packs") if paths else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-008",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
+    if not packs_dir.is_dir():
+        return []
+    diags: list[Diagnostic] = []
+    for pack_dir in sorted(packs_dir.iterdir()):
+        if (
+            not pack_dir.is_dir()
+            or pack_dir.name.startswith("_")
+            or pack_dir.is_symlink()
+            or _path_is_junction(pack_dir)
+            or (pack is not None and pack_dir.name != pack)
+        ):
+            continue
+        manifest = pack_dir / "pack.toml"
+        if not manifest.is_file():
+            continue
+        try:
+            content = read_confined_regular_file(pack_dir, manifest).decode("utf-8")
+            contract = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-008",
+                    f"pack.toml cannot be read safely: {exc}",
+                    pack=pack_dir.name,
+                    path=_diagnostic_path(root, manifest),
+                )
+            )
+            continue
+        version = pack_spec_version(contract)
+        if version is None or version == "0.1":
+            continue
+        install = contract.get("pack", {}).get("install", {})
+        allowed = install.get("allowed-adapters", []) if isinstance(install, dict) else []
+        if not isinstance(allowed, list):
+            continue
+        for adapter in allowed:
+            if isinstance(adapter, str) and adapter not in known_adapters:
+                diags.append(
+                    _err(
+                        "CAT-V-008",
+                        f"unknown allowed adapter {adapter!r}",
+                        pack=pack_dir.name,
+                        path=str(manifest.relative_to(root)),
+                    )
+                )
+    return diags
 
 
 def _step_primitive_layout(
@@ -289,7 +834,7 @@ def _step_build_output(
 def _step_agent_artifacts(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 11: lint .claude/ agent artifact frontmatter and APM skill leak guard.
+    """Step 11: lint portable .claude/ agent artifact contracts.
 
     ALL yaml.* references live inside this function body — none at module scope.
     """
@@ -339,12 +884,6 @@ def _step_agent_artifacts(
     ALLOWED_AUTH_BROKERS = ("env", "cli", "creds", "sso-cookie")
     ALLOWED_AGENT_KEYS = {"name", "description", "tools", "model"}
     ALLOWED_COMMAND_KEYS = {"description", "allowed-tools", "model", "argument-hint"}
-    _APM_SKILL_BLOCKLIST: tuple[tuple[str, str], ...] = (
-        (r"agent-ready-repo", "catalogue name 'agent-ready-repo'"),
-        (r"RFC-00\d\d", "catalogue RFC reference (RFC-NNNN)"),
-        (r"K-00\d\d", "catalogue knowledge entry (K-NNNN)"),
-    )
-
     diags: list[Diagnostic] = []
 
     def _report(path: Path, msg: str) -> None:
@@ -536,18 +1075,6 @@ def _step_agent_artifacts(
             _report(path, "body is empty")
         check_links(path, body, body_start)
 
-    # --- APM leak guard (packs/core/.apm/skills/) — runs unconditionally ---
-
-    apm_skills_dir = root / "packs" / "core" / ".apm" / "skills"
-    if apm_skills_dir.exists():
-        for skill_dir_item in sorted(p for p in apm_skills_dir.iterdir() if p.is_dir()):
-            for target in sorted(skill_dir_item.rglob("*.md")):
-                text = target.read_text(encoding="utf-8")
-                for pat, label in _APM_SKILL_BLOCKLIST:
-                    for _lineno, line in enumerate(text.splitlines(), 1):
-                        if re.search(pat, line):
-                            _report(target, f"leaked {label} in shipped skill body")
-
     # --- Scan .claude/ artifacts ---
 
     claude_dir = root / ".claude"
@@ -587,20 +1114,39 @@ def _step_agent_artifacts(
 def _step_marketplace(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 12: marketplace aggregation check."""
-    # Check that marketplace.json is parseable if present
-    packs_dir_name = getattr(config, "paths", None)
-    build_output_dir = root / (
-        getattr(packs_dir_name, "build_output", "dist") if packs_dir_name else "dist"
+    """Step 12: validate the configured source marketplace when it exists."""
+    paths = getattr(config, "paths", None)
+    marketplace = root / (
+        getattr(paths, "marketplace", ".claude-plugin/marketplace.json")
+        if paths
+        else ".claude-plugin/marketplace.json"
     )
-    marketplace = build_output_dir / "marketplace.json"
-    if not marketplace.exists():
-        # marketplace may be in dist/ from a prior build — skip gracefully
+    marketplace_present = (
+        marketplace.exists()
+        or marketplace.is_symlink()
+        or _path_is_junction(marketplace)
+    )
+    if not marketplace_present:
         return []
     try:
-        json.loads(marketplace.read_text(encoding="utf-8"))
-    except Exception as exc:
-        return [_err("CAT-V-012", f"marketplace.json parse error: {exc}")]
+        content = read_confined_regular_file(root, marketplace).decode("utf-8")
+        json.loads(content)
+    except (UnsafeContentError, UnicodeDecodeError) as exc:
+        return [
+            _err(
+                "CAT-V-012",
+                f"marketplace.json is unsafe: {exc}",
+                path=_diagnostic_path(root, marketplace),
+            )
+        ]
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return [
+            _err(
+                "CAT-V-012",
+                f"marketplace.json parse error: {exc}",
+                path=_diagnostic_path(root, marketplace),
+            )
+        ]
     return []
 
 
@@ -755,8 +1301,185 @@ def _step_plugin_manifests(
 def _step_output_drift(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 14: generated output drift checks (complex; TBD)."""
-    return []
+    """Step 14: compare configured output with a safely confined fresh build."""
+    import os
+
+    from agentbundle.catalogue_tooling.file_safety import (
+        UnsafeContentError,
+        sha256_confined_regular_file,
+    )
+
+    paths = getattr(config, "paths", None)
+    output_dir = root / (getattr(paths, "build_output", "dist") if paths else "dist")
+    if not output_dir.is_dir():
+        return []
+    if output_dir.is_symlink() or _path_is_junction(output_dir):
+        return [
+            _err(
+                "CAT-V-014",
+                f"refused output root {output_dir.relative_to(root).as_posix()}: link-like root",
+                path=output_dir.relative_to(root).as_posix(),
+            )
+        ]
+    fresh_dir = tmpdir / "dist"
+    if not fresh_dir.is_dir():
+        from agentbundle.catalogue_tooling.build import build_catalogue
+
+        fresh_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            build_result = build_catalogue(root, output=fresh_dir, pack=pack)
+        except Exception as exc:
+            return [_err("CAT-V-014", f"fresh output build failed: {exc}")]
+        if not build_result.ok:
+            return [_err("CAT-V-014", "fresh output build failed")]
+
+    diags: list[Diagnostic] = []
+
+    projection_roots = {"claude-plugins", "apm"}
+
+    def in_scope(relative: Path) -> bool:
+        return (
+            len(relative.parts) >= 2
+            and relative.parts[0] in projection_roots
+            and (pack is None or relative.parts[1] == pack)
+        )
+
+    def directory_may_contain_scope(relative: Path) -> bool:
+        if not relative.parts:
+            return True
+        if relative.parts[0] not in projection_roots:
+            return False
+        return pack is None or len(relative.parts) < 2 or relative.parts[1] == pack
+
+    def walk_files(tree: Path, *, source_tree: bool) -> dict[Path, Path]:
+        """Return confined regular files keyed relative to *tree*."""
+        files: dict[Path, Path] = {}
+        if not tree.is_dir():
+            return files
+        try:
+            canonical_tree = tree.resolve()
+        except (OSError, RuntimeError) as exc:
+            diags.append(_err("CAT-V-014", f"output root cannot be resolved: {exc}"))
+            return files
+        visited: set[Path] = set()
+        for current_text, dirnames, filenames in os.walk(tree, topdown=True, followlinks=False):
+            current = Path(current_text)
+            try:
+                resolved_current = current.resolve()
+            except (OSError, RuntimeError):
+                dirnames[:] = []
+                continue
+            if not resolved_current.is_relative_to(canonical_tree) or resolved_current in visited:
+                dirnames[:] = []
+                continue
+            visited.add(resolved_current)
+            safe_directories: list[str] = []
+            for dirname in sorted(dirnames):
+                child = current / dirname
+                if not directory_may_contain_scope(child.relative_to(tree)):
+                    continue
+                rel_to_catalogue = (
+                    child.relative_to(root)
+                    if source_tree
+                    else output_dir.relative_to(root) / child.relative_to(tree)
+                )
+                try:
+                    unsafe_link = child.is_symlink() or _path_is_junction(child)
+                    resolved_child = child.resolve()
+                    unsafe_escape = not resolved_child.is_relative_to(canonical_tree)
+                    repeated = resolved_child in visited
+                except (OSError, RuntimeError):
+                    unsafe_link = True
+                    unsafe_escape = True
+                    repeated = True
+                if unsafe_link or unsafe_escape or repeated:
+                    kind = "junction" if _path_is_junction(child) else "link or loop"
+                    diags.append(
+                        _err(
+                            "CAT-V-014",
+                            f"refused output {kind} {rel_to_catalogue.as_posix()}: "
+                            "target is outside the output root or repeats a visited directory",
+                            path=rel_to_catalogue.as_posix(),
+                        )
+                    )
+                    continue
+                safe_directories.append(dirname)
+            dirnames[:] = safe_directories
+            for filename in sorted(filenames):
+                candidate = current / filename
+                if not in_scope(candidate.relative_to(tree)):
+                    continue
+                if candidate.is_symlink() or _path_is_junction(candidate):
+                    rel_to_catalogue = (
+                        candidate.relative_to(root)
+                        if source_tree
+                        else output_dir.relative_to(root) / candidate.relative_to(tree)
+                    )
+                    diags.append(
+                        _err(
+                            "CAT-V-014",
+                            f"refused output link {rel_to_catalogue.as_posix()}",
+                            path=rel_to_catalogue.as_posix(),
+                        )
+                    )
+                    continue
+                try:
+                    resolved_file = candidate.resolve()
+                except (OSError, RuntimeError):
+                    continue
+                if resolved_file.is_relative_to(canonical_tree) and candidate.is_file():
+                    files[candidate.relative_to(tree)] = candidate
+        return files
+
+    configured = walk_files(output_dir, source_tree=True)
+    fresh = walk_files(fresh_dir, source_tree=False)
+
+    configured = {relative: path for relative, path in configured.items() if in_scope(relative)}
+    fresh = {relative: path for relative, path in fresh.items() if in_scope(relative)}
+    for relative in sorted(configured.keys() | fresh.keys()):
+        diagnostic_path = (output_dir.relative_to(root) / relative).as_posix()
+        if relative not in fresh:
+            diags.append(
+                _err(
+                    "CAT-V-014",
+                    f"stale generated output: {diagnostic_path}",
+                    path=diagnostic_path,
+                )
+            )
+            continue
+        if relative not in configured:
+            diags.append(
+                _err(
+                    "CAT-V-014",
+                    f"missing generated output: {diagnostic_path}",
+                    path=diagnostic_path,
+                )
+            )
+            continue
+        try:
+            configured_digest = sha256_confined_regular_file(
+                output_dir, configured[relative]
+            )
+            fresh_digest = sha256_confined_regular_file(fresh_dir, fresh[relative])
+            differs = configured_digest != fresh_digest
+        except (OSError, UnsafeContentError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-014",
+                    f"cannot compare generated output {diagnostic_path}: {exc}",
+                    path=diagnostic_path,
+                )
+            )
+            continue
+        if differs:
+            diags.append(
+                _err(
+                    "CAT-V-014",
+                    f"generated output differs: {diagnostic_path}",
+                    path=diagnostic_path,
+                )
+            )
+    return diags
 
 
 def _step_selfhost_drift(
@@ -812,15 +1535,277 @@ def _step_sync_defaults(
 def _step_package_preflight(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 17: package preflight (TBD — depends on package-enhanced spec)."""
-    return []
+    """Step 17: parse and schema-check each selected pack manifest."""
+    import tomllib
+
+    from agentbundle.build.validate import validate as validate_schema
+
+    paths = getattr(config, "paths", None)
+    packs_dir = root / (getattr(paths, "packs", "packs") if paths else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-017",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_dir),
+            )
+        ]
+    if not packs_dir.is_dir():
+        return []
+    try:
+        schema = _load_bundled_json("pack.schema.json")
+    except (OSError, ValueError) as exc:
+        return [_err("CAT-V-017", f"pack schema is unavailable: {exc}")]
+    diags: list[Diagnostic] = []
+    for pack_dir in sorted(packs_dir.iterdir()):
+        if (
+            not pack_dir.is_dir()
+            or pack_dir.name.startswith("_")
+            or pack_dir.is_symlink()
+            or _path_is_junction(pack_dir)
+            or (pack is not None and pack_dir.name != pack)
+        ):
+            continue
+        manifest = pack_dir / "pack.toml"
+        diagnostic_path = str(manifest.relative_to(root))
+        if not manifest.is_file():
+            diags.append(
+                _err(
+                    "CAT-V-017",
+                    "pack.toml is missing",
+                    pack=pack_dir.name,
+                    path=diagnostic_path,
+                )
+            )
+            continue
+        try:
+            content = read_confined_regular_file(pack_dir, manifest).decode("utf-8")
+            contract = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            diags.append(
+                _err(
+                    "CAT-V-017",
+                    f"pack.toml parse error: {exc}",
+                    pack=pack_dir.name,
+                    path=diagnostic_path,
+                )
+            )
+            continue
+        for error in validate_schema(contract, schema):
+            diags.append(
+                _err(
+                    "CAT-V-017",
+                    f"pack schema: {error}",
+                    pack=pack_dir.name,
+                    path=diagnostic_path,
+                )
+            )
+    return diags
 
 
 def _step_fixture_checks(
     root: Path, config: object | None, pack: str | None, tmpdir: Path
 ) -> list[Diagnostic]:
-    """Step 18: deterministic fixture checks (TBD)."""
-    return []
+    """Step 18: validate skill eval manifests without parsing opaque payloads."""
+    from agentbundle.catalogue_tooling.skill_spec_lint import (
+        _check_eval_queries,
+        _check_evals_json,
+    )
+
+    paths = getattr(config, "paths", None)
+    packs_dir = root / (getattr(paths, "packs", "packs") if paths else "packs")
+    packs_present = packs_dir.exists() or packs_dir.is_symlink() or _path_is_junction(packs_dir)
+    packs_issue = _confined_directory_issue(root, packs_dir) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-018",
+                f"refused {packs_issue} packs directory",
+                path=str(packs_dir.relative_to(root)),
+            )
+        ]
+    if not packs_dir.is_dir():
+        return []
+    diags: list[Diagnostic] = []
+    for pack_dir in sorted(packs_dir.iterdir()):
+        if (
+            not pack_dir.is_dir()
+            or pack_dir.name.startswith("_")
+            or pack_dir.is_symlink()
+            or _path_is_junction(pack_dir)
+            or (pack is not None and pack_dir.name != pack)
+        ):
+            continue
+        try:
+            canonical_pack = pack_dir.resolve(strict=True)
+        except (OSError, RuntimeError):
+            diags.append(
+                _err(
+                    "CAT-V-018",
+                    "refused unresolvable pack directory",
+                    pack=pack_dir.name,
+                    path=str(pack_dir.relative_to(root)),
+                )
+            )
+            continue
+        apm_dir = pack_dir / ".apm"
+        if apm_dir.is_symlink() or _path_is_junction(apm_dir):
+            diags.append(
+                _err(
+                    "CAT-V-018",
+                    "refused link-like .apm directory",
+                    pack=pack_dir.name,
+                    path=str(apm_dir.relative_to(root)),
+                )
+            )
+            continue
+        if not apm_dir.is_dir():
+            continue
+        apm_issue = _confined_directory_issue(canonical_pack, apm_dir)
+        if apm_issue is not None:
+            diags.append(
+                _err(
+                    "CAT-V-018",
+                    f"refused {apm_issue} .apm directory",
+                    pack=pack_dir.name,
+                    path=str(apm_dir.relative_to(root)),
+                )
+            )
+            continue
+        skills_dir = apm_dir / "skills"
+        if skills_dir.is_symlink() or _path_is_junction(skills_dir):
+            diags.append(
+                _err(
+                    "CAT-V-018",
+                    "refused link-like skills directory",
+                    pack=pack_dir.name,
+                    path=str(skills_dir.relative_to(root)),
+                )
+            )
+            continue
+        if not skills_dir.is_dir():
+            continue
+        skills_issue = _confined_directory_issue(canonical_pack, skills_dir)
+        if skills_issue is not None:
+            diags.append(
+                _err(
+                    "CAT-V-018",
+                    f"refused {skills_issue} skills directory",
+                    pack=pack_dir.name,
+                    path=str(skills_dir.relative_to(root)),
+                )
+            )
+            continue
+        for skill_dir in sorted(skills_dir.iterdir()):
+            if skill_dir.is_symlink() or _path_is_junction(skill_dir):
+                diags.append(
+                    _err(
+                        "CAT-V-018",
+                        "refused link-like skill directory",
+                        pack=pack_dir.name,
+                        path=str(skill_dir.relative_to(root)),
+                    )
+                )
+                continue
+            if not skill_dir.is_dir():
+                continue
+            skill_issue = _confined_directory_issue(canonical_pack, skill_dir)
+            if skill_issue is not None:
+                diags.append(
+                    _err(
+                        "CAT-V-018",
+                        f"refused {skill_issue} skill directory",
+                        pack=pack_dir.name,
+                        path=str(skill_dir.relative_to(root)),
+                    )
+                )
+                continue
+            evals_dir = skill_dir / "evals"
+            if evals_dir.is_symlink() or _path_is_junction(evals_dir):
+                diags.append(
+                    _err(
+                        "CAT-V-018",
+                        "refused link-like evals directory",
+                        pack=pack_dir.name,
+                        path=str(evals_dir.relative_to(root)),
+                    )
+                )
+                continue
+            if not evals_dir.is_dir():
+                continue
+            evals_issue = _confined_directory_issue(canonical_pack, evals_dir)
+            if evals_issue is not None:
+                diags.append(
+                    _err(
+                        "CAT-V-018",
+                        f"refused {evals_issue} evals directory",
+                        pack=pack_dir.name,
+                        path=str(evals_dir.relative_to(root)),
+                    )
+                )
+                continue
+            manifests = (
+                (evals_dir / "evals.json", "evals"),
+                (evals_dir / "eval_queries.json", "queries"),
+            )
+            for manifest, manifest_kind in manifests:
+                if manifest.is_symlink() or _path_is_junction(manifest):
+                    diags.append(
+                        _err(
+                            "CAT-V-018",
+                            "refused link-like eval manifest",
+                            pack=pack_dir.name,
+                            path=str(manifest.relative_to(root)),
+                        )
+                    )
+                    continue
+                try:
+                    manifest.lstat()
+                except FileNotFoundError:
+                    continue
+                except OSError as exc:
+                    diags.append(
+                        _err(
+                            "CAT-V-018",
+                            f"eval manifest cannot be inspected safely: {exc}",
+                            pack=pack_dir.name,
+                            path=str(manifest.relative_to(root)),
+                        )
+                    )
+                    continue
+                try:
+                    content = read_confined_regular_file(pack_dir, manifest).decode("utf-8")
+                except (UnsafeContentError, UnicodeDecodeError) as exc:
+                    diags.append(
+                        _err(
+                            "CAT-V-018",
+                            f"refused unsafe eval manifest: {exc}",
+                            pack=pack_dir.name,
+                            path=str(manifest.relative_to(root)),
+                        )
+                    )
+                    continue
+                if manifest_kind == "evals":
+                    messages = _check_evals_json(
+                        skill_dir,
+                        manifest,
+                        skill_dir.name,
+                        content=content,
+                    )
+                else:
+                    messages = _check_eval_queries(manifest, content=content)
+                for message in messages:
+                    diags.append(
+                        _err(
+                            "CAT-V-018",
+                            message,
+                            pack=pack_dir.name,
+                            path=str(manifest.relative_to(root)),
+                        )
+                    )
+    return diags
 
 
 # ---------------------------------------------------------------------------
@@ -851,8 +1836,8 @@ def _is_valid_semver_range(version: str) -> bool:
     return True
 
 
-def _resolve_primitive_ref(ref: str, pack_dir: Path) -> bool:
-    """Return True if the type-qualified *ref* resolves in *pack_dir*'s .apm tree.
+def _resolve_primitive_ref(ref: object, pack_dir: Path) -> tuple[bool, str | None]:
+    """Resolve a type-qualified primitive ref without following link-like paths.
 
     Mapping:
       skill:<name>   → directory  pack_dir/.apm/skills/<name>/
@@ -860,21 +1845,60 @@ def _resolve_primitive_ref(ref: str, pack_dir: Path) -> bool:
       command:<name> → file       pack_dir/.apm/commands/<name>.md
       hook:<name>    → any file   pack_dir/.apm/hooks/<name>.*  (stem match)
     """
-    if ":" not in ref:
-        return False
+    if not isinstance(ref, str) or ":" not in ref:
+        return False, "reference must be a type-qualified string"
     type_str, name = ref.split(":", 1)
+    if not _PACK_SLUG_RE.fullmatch(name):
+        return False, "primitive name must use the canonical lowercase slug grammar"
+
+    def real_directory(path: Path) -> tuple[bool, str | None]:
+        try:
+            relative = path.relative_to(pack_dir)
+        except ValueError:
+            return False, "primitive path escapes its pack"
+        current = pack_dir
+        for component in relative.parts:
+            current /= component
+            if not current.is_dir():
+                return False, "primitive directory not found"
+            issue = _confined_directory_issue(pack_dir, current)
+            if issue is not None:
+                return False, f"refused {issue} primitive directory"
+        return True, None
+
+    def regular_file(path: Path) -> tuple[bool, str | None]:
+        if not (path.exists() or path.is_symlink() or _path_is_junction(path)):
+            return False, "primitive file not found"
+        parent_ok, parent_reason = real_directory(path.parent)
+        if not parent_ok:
+            return False, parent_reason
+        try:
+            read_confined_regular_file(pack_dir, path)
+        except UnsafeContentError as exc:
+            return False, f"refused unsafe primitive file: {exc}"
+        return True, None
+
     if type_str == "skill":
-        return (pack_dir / ".apm" / "skills" / name).is_dir()
+        return real_directory(pack_dir / ".apm" / "skills" / name)
     if type_str == "agent":
-        return (pack_dir / ".apm" / "agents" / f"{name}.md").exists()
+        return regular_file(pack_dir / ".apm" / "agents" / f"{name}.md")
     if type_str == "command":
-        return (pack_dir / ".apm" / "commands" / f"{name}.md").exists()
+        return regular_file(pack_dir / ".apm" / "commands" / f"{name}.md")
     if type_str == "hook":
         hooks_dir = pack_dir / ".apm" / "hooks"
-        if not hooks_dir.is_dir():
-            return False
-        return any(f.is_file() and f.stem == name for f in hooks_dir.iterdir())
-    return False
+        hooks_ok, hooks_reason = real_directory(hooks_dir)
+        if not hooks_ok:
+            return False, hooks_reason
+        unsafe_reason: str | None = None
+        for candidate in sorted(hooks_dir.iterdir()):
+            if candidate.stem != name:
+                continue
+            candidate_ok, candidate_reason = regular_file(candidate)
+            if candidate_ok:
+                return True, None
+            unsafe_reason = candidate_reason
+        return False, unsafe_reason or "primitive hook not found"
+    return False, f"unsupported primitive type {type_str!r}"
 
 
 def _step_integration_validation(
@@ -890,117 +1914,274 @@ def _step_integration_validation(
       - an absent target pack is not an error (portable across catalogues)
       - provider primitive refs resolve in the target pack when present
     """
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib  # type: ignore[no-redef]
-
-    from agentbundle.catalogue_tooling.results import Severity
+    import tomllib
 
     packs_path = getattr(getattr(config, "paths", None), "packs", None) or "packs"
     packs_root = root / packs_path
-
+    packs_present = (
+        packs_root.exists()
+        or packs_root.is_symlink()
+        or _path_is_junction(packs_root)
+    )
+    packs_issue = _confined_directory_issue(root, packs_root) if packs_present else None
+    if packs_issue is not None:
+        return [
+            _err(
+                "CAT-V-019",
+                f"refused {packs_issue} packs directory",
+                path=_diagnostic_path(root, packs_root),
+            )
+        ]
     if not packs_root.is_dir():
         return []
 
-    def _err(message: str, declaring: str | None = None) -> Diagnostic:
-        return Diagnostic(
-            code="CAT-V-019",
-            severity=Severity.ERROR,
-            pack=declaring,
-            path=None,
-            line=None,
-            col=None,
-            message=message,
-            remediation=None,
-        )
+    diags: list[Diagnostic] = []
+    scan_diags: list[Diagnostic] = []
 
     # Pass 1: build full pack-name → pack-dir map (cross-reference)
-    all_pack_dirs: dict[str, Path] = {}
-    for candidate in packs_root.iterdir():
+    all_packs: dict[str, tuple[Path, dict]] = {}
+    for candidate in sorted(packs_root.iterdir()):
+        if candidate.name.startswith("_"):
+            continue
+        if candidate.is_symlink() or _path_is_junction(candidate):
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    "refused link-like pack directory",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, candidate),
+                )
+            )
+            continue
         if not candidate.is_dir():
             continue
+        candidate_issue = _confined_directory_issue(packs_root, candidate)
+        if candidate_issue is not None:
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    f"refused {candidate_issue} pack directory",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, candidate),
+                )
+            )
+            continue
         toml_path = candidate / "pack.toml"
-        if not toml_path.exists():
+        if not (
+            toml_path.exists()
+            or toml_path.is_symlink()
+            or _path_is_junction(toml_path)
+        ):
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    "pack.toml is missing; integrations cannot be validated",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, toml_path),
+                )
+            )
             continue
         try:
-            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except Exception:
+            content = read_confined_regular_file(candidate, toml_path).decode("utf-8")
+            data = tomllib.loads(content)
+        except (UnsafeContentError, UnicodeDecodeError, tomllib.TOMLDecodeError) as exc:
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    f"pack.toml cannot be read safely: {exc}",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, toml_path),
+                )
+            )
             continue
-        pack_name = data.get("pack", {}).get("name") or candidate.name
-        all_pack_dirs[pack_name] = candidate
+        pack_table = data.get("pack", {})
+        if not isinstance(pack_table, dict):
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    "pack must be a table",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, toml_path),
+                )
+            )
+            continue
+        pack_name = pack_table.get("name") or candidate.name
+        if not isinstance(pack_name, str):
+            scan_diags.append(
+                _err(
+                    "CAT-V-019",
+                    "pack name must be a string",
+                    pack=candidate.name,
+                    path=_diagnostic_path(root, toml_path),
+                )
+            )
+            continue
+        all_packs[pack_name] = (candidate, data)
 
-    diags: list[Diagnostic] = []
+    relevant_packs: set[str] | None = None
+    if pack is not None:
+        relevant_packs = {pack}
+        selected = all_packs.get(pack)
+        if selected is not None:
+            _selected_dir, selected_data = selected
+            selected_table = selected_data.get("pack", {})
+            if isinstance(selected_table, dict):
+                selected_integrations = selected_table.get("integrations") or []
+                if isinstance(selected_integrations, list):
+                    for entry in selected_integrations:
+                        if not isinstance(entry, dict):
+                            continue
+                        target = entry.get("pack")
+                        if isinstance(target, str):
+                            relevant_packs.add(target)
+    diags.extend(
+        diagnostic
+        for diagnostic in scan_diags
+        if relevant_packs is None or diagnostic.pack in relevant_packs
+    )
 
     # Pass 2: validate integrations in each (optionally filtered) pack
-    for pack_name, pack_dir in all_pack_dirs.items():
+    for pack_name, (pack_dir, data) in all_packs.items():
         if pack is not None and pack_name != pack:
             continue
-        toml_path = pack_dir / "pack.toml"
-        try:
-            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except Exception:
-            continue
-        integrations = data.get("pack", {}).get("integrations") or []
+        pack_table = data.get("pack", {})
+        if not isinstance(pack_table, dict):
+            continue  # rejected while building all_packs above
+        integrations = pack_table.get("integrations") or []
         if not integrations:
+            continue
+        if not isinstance(integrations, list):
+            diags.append(
+                _err(
+                    "CAT-V-019",
+                    "pack.integrations must be an array of tables",
+                    pack=pack_name,
+                )
+            )
             continue
 
         seen_ids: set[str] = set()  # reset per declaring pack (scopes to pack)
-        for entry in integrations:
+        for integration_index, entry in enumerate(integrations):
+            if not isinstance(entry, dict):
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration at index {integration_index} must be a table",
+                        pack=pack_name,
+                    )
+                )
+                continue
             entry_id = entry.get("id", "")
+            if not isinstance(entry_id, str):
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration at index {integration_index} has a non-string id",
+                        pack=pack_name,
+                    )
+                )
+                continue
 
             # Duplicate id within this pack
             if entry_id in seen_ids:
-                diags.append(_err(
-                    f"duplicate integration id {entry_id!r} in pack {pack_name!r}",
-                    declaring=pack_name,
-                ))
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"duplicate integration id {entry_id!r} in pack {pack_name!r}",
+                        pack=pack_name,
+                    )
+                )
             seen_ids.add(entry_id)
 
             # Consumer refs must resolve in declaring pack
-            for ref in entry.get("consumers", []):
-                if not _resolve_primitive_ref(ref, pack_dir):
-                    diags.append(_err(
-                        f"integration {entry_id!r}: consumer ref {ref!r} not found"
-                        f" in {pack_name!r}",
-                        declaring=pack_name,
-                    ))
+            consumers = entry.get("consumers", [])
+            if not isinstance(consumers, list):
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration {entry_id!r}: consumers must be an array",
+                        pack=pack_name,
+                    )
+                )
+                consumers = []
+            for ref in consumers:
+                resolved, reason = _resolve_primitive_ref(ref, pack_dir)
+                if not resolved:
+                    diags.append(
+                        _err(
+                            "CAT-V-019",
+                            f"integration {entry_id!r}: consumer ref {ref!r} "
+                            f"is invalid in {pack_name!r}: {reason}",
+                            pack=pack_name,
+                        )
+                    )
 
             # No self-targeting
             target = entry.get("pack", "")
+            if not isinstance(target, str):
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration {entry_id!r}: target pack must be a string",
+                        pack=pack_name,
+                    )
+                )
+                target = ""
             if target == pack_name:
-                diags.append(_err(
-                    f"integration {entry_id!r}: pack {pack_name!r} targets itself"
-                    f" (self-reference not allowed)",
-                    declaring=pack_name,
-                ))
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration {entry_id!r}: pack {pack_name!r} targets itself"
+                        " (self-reference not allowed)",
+                        pack=pack_name,
+                    )
+                )
 
             # Version, if present, must be a valid semver range
             version = entry.get("version")
-            if version is not None and not _is_valid_semver_range(version):
-                diags.append(_err(
-                    f"integration {entry_id!r}: version range {version!r} is not"
-                    f" a valid semver range",
-                    declaring=pack_name,
-                ))
+            if version is not None and (
+                not isinstance(version, str) or not _is_valid_semver_range(version)
+            ):
+                diags.append(
+                    _err(
+                        "CAT-V-019",
+                        f"integration {entry_id!r}: version range {version!r} is not"
+                        " a valid semver range",
+                        pack=pack_name,
+                    )
+                )
 
             # If target is in this catalogue, check provider refs
-            if target in all_pack_dirs:
-                target_dir = all_pack_dirs[target]
-                for ref in entry.get("providers", []):
-                    if not _resolve_primitive_ref(ref, target_dir):
-                        diags.append(_err(
-                            f"integration {entry_id!r}: provider ref {ref!r} not"
-                            f" found in target pack {target!r}",
-                            declaring=pack_name,
-                        ))
+            if target in all_packs:
+                target_dir, _target_data = all_packs[target]
+                providers = entry.get("providers", [])
+                if not isinstance(providers, list):
+                    diags.append(
+                        _err(
+                            "CAT-V-019",
+                            f"integration {entry_id!r}: providers must be an array",
+                            pack=pack_name,
+                        )
+                    )
+                    providers = []
+                for ref in providers:
+                    resolved, reason = _resolve_primitive_ref(ref, target_dir)
+                    if not resolved:
+                        diags.append(
+                            _err(
+                                "CAT-V-019",
+                                f"integration {entry_id!r}: provider ref {ref!r} is invalid"
+                                f" in target pack {target!r}: {reason}",
+                                pack=pack_name,
+                            )
+                        )
             # Target absent → no error (portable across catalogues)
 
     return diags
 
 
 # ---------------------------------------------------------------------------
-# 18-step verification table (plus step 19)
+# 19-step verification table
 # ---------------------------------------------------------------------------
 
 _VERIFY_STEPS = [
@@ -1037,7 +2218,7 @@ def verify_catalogue(
 ) -> VerifyResult:
     """Verify a catalogue at *root* against its contracts.
 
-    Runs the 18-step verification sequence defined in ini-005 Bucket 6.
+    Runs the 19-step verification sequence defined by the catalogue contract.
     Stops at first step failure unless ``continue_on_error=True``.
     Build output (step 10) goes to a temporary directory; the catalogue
     root has zero new or modified files after verify completes.
@@ -1046,10 +2227,12 @@ def verify_catalogue(
 
     try:
         config = load_catalogue_config(root)
-    except CatalogueConfigError as exc:
+    except CatalogueConfigError:
         return VerifyResult(
             ok=False,
-            diagnostics=[_err("CAT-V-001", str(exc), path="catalogue.toml")],
+            diagnostics=[
+                _err("CAT-V-001", "catalogue.toml is invalid", path="catalogue.toml")
+            ],
             schema_version=1,
             command="catalogue verify",
             operation="source-checkout",

--- a/packages/agentbundle/agentbundle/catalogue_tooling/version_ranges.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/version_ranges.py
@@ -1,0 +1,149 @@
+"""Small, dependency-free parser for the catalogue dependency range contract."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import total_ordering
+
+_VERSION_RE = re.compile(
+    r"^(0|[1-9]\d*)"
+    r"(?:\.(0|[1-9]\d*))?"
+    r"(?:\.(0|[1-9]\d*))?"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+_ATOM_RE = re.compile(r"^(\^|~|>=|<=|>|<|=)?(.+)$")
+
+
+@total_ordering
+@dataclass(frozen=True, eq=False)
+class _Version:
+    """Comparable semantic version with missing minor/patch normalized to zero."""
+
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+    components: int
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _Version):
+            return NotImplemented
+        return (
+            self.major,
+            self.minor,
+            self.patch,
+            self.prerelease,
+        ) == (
+            other.major,
+            other.minor,
+            other.patch,
+            other.prerelease,
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, _Version):
+            return NotImplemented
+        release = (self.major, self.minor, self.patch)
+        other_release = (other.major, other.minor, other.patch)
+        if release != other_release:
+            return release < other_release
+        if not self.prerelease:
+            return False
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            left_numeric = left.isdigit()
+            right_numeric = right.isdigit()
+            if left_numeric and right_numeric:
+                left_number = left.lstrip("0") or "0"
+                right_number = right.lstrip("0") or "0"
+                if len(left_number) != len(right_number):
+                    return len(left_number) < len(right_number)
+                return left_number < right_number
+            if left_numeric != right_numeric:
+                return left_numeric
+            return left < right
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def _parse_version(value: object) -> _Version | None:
+    if not isinstance(value, str):
+        return None
+    match = _VERSION_RE.fullmatch(value.strip())
+    if match is None:
+        return None
+    try:
+        components = 1 + int(match.group(2) is not None) + int(match.group(3) is not None)
+        prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+        return _Version(
+            int(match.group(1)),
+            int(match.group(2) or 0),
+            int(match.group(3) or 0),
+            prerelease,
+            components,
+        )
+    except (ValueError, OverflowError):
+        return None
+
+
+def _compare(candidate: _Version, operator: str, boundary: _Version) -> bool:
+    if operator in ("", "="):
+        return candidate == boundary
+    if operator == ">=":
+        return candidate >= boundary
+    if operator == ">":
+        return candidate > boundary
+    if operator == "<=":
+        return candidate <= boundary
+    if operator == "<":
+        return candidate < boundary
+    if operator == "^":
+        if boundary.major:
+            upper = _Version(boundary.major + 1, 0, 0, (), 3)
+        elif boundary.minor:
+            upper = _Version(0, boundary.minor + 1, 0, (), 3)
+        else:
+            upper = _Version(0, 0, boundary.patch + 1, (), 3)
+        return candidate >= boundary and candidate < upper
+    if operator == "~":
+        if boundary.components == 1:
+            upper = _Version(boundary.major + 1, 0, 0, (), 3)
+        else:
+            upper = _Version(boundary.major, boundary.minor + 1, 0, (), 3)
+        return candidate >= boundary and candidate < upper
+    return False
+
+
+def _parse_atoms(expression: object) -> list[tuple[str, _Version]] | None:
+    if not isinstance(expression, str) or not expression.strip():
+        return None
+    atoms: list[tuple[str, _Version]] = []
+    for raw_atom in expression.split():
+        match = _ATOM_RE.fullmatch(raw_atom)
+        if match is None:
+            return None
+        operator = match.group(1) or ""
+        version = _parse_version(match.group(2))
+        if version is None:
+            return None
+        atoms.append((operator, version))
+    if len(atoms) > 1 and any(operator in ("", "^", "~", "=") for operator, _ in atoms):
+        return None
+    return atoms
+
+
+def parse_version_range(expression: object) -> bool:
+    """Return whether *expression* uses the supported dependency range grammar."""
+    return _parse_atoms(expression) is not None
+
+
+def version_satisfies(version: object, expression: object) -> bool | None:
+    """Return range satisfaction, or ``None`` when either input is malformed."""
+    candidate = _parse_version(version)
+    atoms = _parse_atoms(expression)
+    if candidate is None or atoms is None:
+        return None
+    return all(_compare(candidate, operator, boundary) for operator, boundary in atoms)

--- a/packages/agentbundle/agentbundle/cli.py
+++ b/packages/agentbundle/agentbundle/cli.py
@@ -787,7 +787,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _ver_p = cat_subs.add_parser(
         "verify",
         help=(
-            "Verify catalogue against contracts (18-step pipeline, including "
+            "Verify catalogue against contracts (19-step pipeline, including "
             "agent-artifact lint and plugin manifest validation)."
         ),
     )

--- a/packages/agentbundle/agentbundle/commands/install.py
+++ b/packages/agentbundle/agentbundle/commands/install.py
@@ -4370,9 +4370,8 @@ def validate_dependencies_required(
     user_state.packs (key by pack name; a pack at either scope satisfies
     the gate).
 
-    Version-range grammar: exactly ``^X.Y`` (caret-minor). An installed
-    version ``A.B.C`` satisfies ``^X.Y`` when ``A == X AND (B > Y OR (B
-    == Y AND C >= 0))``, i.e. ``>= X.Y.0 AND < (X+1).0.0``.
+    Version ranges use the shared catalogue dependency grammar, including
+    caret, tilde, comparator, compound, and prerelease forms.
 
     ``also_installing`` (pack-profiles) — names of packs being installed in
     the *same batch* as this one (a profile install). A required dep whose name
@@ -4391,9 +4390,10 @@ def validate_dependencies_required(
             Caller is expected to print str(exc) to stderr and exit 1.
     """
     batch = also_installing or set()
-    import re
-
-    _CARET_RE = re.compile(r"^\^([0-9]+)\.([0-9]+)$")
+    from agentbundle.catalogue_tooling.version_ranges import (
+        parse_version_range,
+        version_satisfies,
+    )
 
     pack_name = pack_toml.get("pack", {}).get("name", "<unknown>")
     deps = pack_toml.get("pack", {}).get("dependencies", {})
@@ -4425,15 +4425,11 @@ def validate_dependencies_required(
         dep_range = entry.get("version", "")
 
         # Validate grammar first (even before checking if the dep is installed).
-        m = _CARET_RE.match(dep_range)
-        if m is None:
+        if not parse_version_range(dep_range):
             raise RuntimeError(
                 f"install: unsupported version range {dep_range!r} for required pack "
-                f"{dep_name!r}; only ^X.Y is supported"
+                f"{dep_name!r}"
             )
-
-        req_major = int(m.group(1))
-        req_minor = int(m.group(2))
 
         dep_version = installed.get(dep_name)
         if dep_version is None:
@@ -4454,27 +4450,7 @@ def validate_dependencies_required(
         # gate real: a dep pre-installed (or written earlier in the batch) at a
         # version that does not satisfy the range is refused, not name-bypassed.
 
-        # Parse installed version X.Y.Z (allow fewer components).
-        parts = dep_version.split(".")
-        try:
-            inst_major = int(parts[0]) if len(parts) > 0 else 0
-            inst_minor = int(parts[1]) if len(parts) > 1 else 0
-            inst_patch = int(parts[2]) if len(parts) > 2 else 0
-        except (ValueError, IndexError) as exc:
-            raise RuntimeError(
-                f"install: pack {pack_name!r} requires {dep_name!r} "
-                f"(version {dep_range}); install {dep_name} first"
-            ) from exc
-
-        # Satisfy: major must match AND version >= X.Y.0 AND < (X+1).0.0.
-        satisfies = (
-            inst_major == req_major
-            and (
-                inst_minor > req_minor
-                or (inst_minor == req_minor and inst_patch >= 0)
-            )
-        )
-        if not satisfies:
+        if version_satisfies(dep_version, dep_range) is not True:
             raise RuntimeError(
                 f"install: pack {pack_name!r} requires {dep_name!r} "
                 f"(version {dep_range}); install {dep_name} first"

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.37.1"
+CLI_VERSION = "0.37.2"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.37.1"
+version = "0.37.2"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/fixtures/external_catalogue/.claude-plugin/marketplace.json
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/.claude-plugin/marketplace.json
@@ -1,0 +1,1 @@
+{"name":"example-catalogue","owner":{"name":"Example"},"plugins":[]}

--- a/packages/agentbundle/tests/fixtures/external_catalogue/AGENTS.md
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/AGENTS.md
@@ -1,0 +1,1 @@
+# Example catalogue

--- a/packages/agentbundle/tests/fixtures/external_catalogue/LICENSE-APACHE
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/LICENSE-APACHE
@@ -1,0 +1,1 @@
+Fixture license text.

--- a/packages/agentbundle/tests/fixtures/external_catalogue/LICENSE-MIT
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/LICENSE-MIT
@@ -1,0 +1,1 @@
+Fixture license text.

--- a/packages/agentbundle/tests/fixtures/external_catalogue/agentbundle/_data/install-defaults.toml
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/agentbundle/_data/install-defaults.toml
@@ -1,0 +1,2 @@
+[catalogue]
+source = "git+https://example.com/example/catalogue"

--- a/packages/agentbundle/tests/fixtures/external_catalogue/catalogue.toml
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/catalogue.toml
@@ -1,0 +1,31 @@
+schema = 1
+
+[catalogue]
+name = "example-catalogue"
+display-name = "Example Catalogue"
+description = "Portable verifier fixture"
+minimum-agentbundle-version = "0.37.2"
+
+[catalogue.paths]
+packs = "packs"
+profiles = "profiles"
+contracts = "contracts"
+marketplace = ".claude-plugin/marketplace.json"
+build-output = "dist"
+
+[catalogue.build]
+recipes = ["default"]
+self-host = false
+claude-plugin-branch = "main"
+marketplace-description = "Example Catalogue"
+
+[catalogue.package]
+include = ["packs/alpha", "packs/beta"]
+required = ["packs/alpha", "packs/beta"]
+
+[distribution.agentbundle]
+preferred-adapter = "claude-code"
+default-source = "git+https://example.com/example/catalogue"
+
+[distribution.agentbundle.artifactory]
+enabled = false

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/.apm/skills/example/SKILL.md
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/.apm/skills/example/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: example
+description: Exercise a portable external catalogue fixture.
+---
+
+Use the fixture without relying on repository-specific policy.

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/.claude-plugin/plugin.json
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{"name":"alpha","version":"1.0.0","description":"First fixture pack"}

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/pack.toml
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/pack.toml
@@ -1,0 +1,13 @@
+[pack]
+name = "alpha"
+version = "1.0.0"
+description = "First fixture pack"
+lint-seeds = true
+
+[pack.adapter-contract]
+version = "0.8"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+allowed-adapters = ["claude-code", "codex"]

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/seeds/AGENTS.md
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/alpha/seeds/AGENTS.md
@@ -1,0 +1,3 @@
+# Catalogue instructions
+
+A monorepo for `<project-name>` that may discuss agent-ready-repo as ordinary data.

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/beta/.claude-plugin/plugin.json
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/beta/.claude-plugin/plugin.json
@@ -1,0 +1,1 @@
+{"name":"beta","version":"1.1.0","description":"Second fixture pack"}

--- a/packages/agentbundle/tests/fixtures/external_catalogue/packs/beta/pack.toml
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/packs/beta/pack.toml
@@ -1,0 +1,17 @@
+[pack]
+name = "beta"
+version = "1.1.0"
+description = "Second fixture pack"
+
+[pack.adapter-contract]
+version = "0.8"
+
+[[pack.dependencies.required]]
+catalogue = "example-catalogue"
+pack = "alpha"
+version = "^1.0"
+
+[pack.install]
+default-scope = "repo"
+allowed-scopes = ["repo"]
+allowed-adapters = ["claude-code", "codex"]

--- a/packages/agentbundle/tests/fixtures/external_catalogue/profiles/example.toml
+++ b/packages/agentbundle/tests/fixtures/external_catalogue/profiles/example.toml
@@ -1,0 +1,8 @@
+scope = "repo"
+description = "Both fixture packs"
+
+[[packs]]
+pack = "alpha"
+
+[[packs]]
+pack = "beta"

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_adapter_compat.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_adapter_compat.py
@@ -1,0 +1,53 @@
+"""Adapter compatibility checks in verifier step 8."""
+
+from pathlib import Path
+
+import pytest
+from agentbundle.catalogue_tooling.verify import _step_adapter_compat
+
+
+def _pack(root: Path, name: str, contract: str, adapter: str) -> None:
+    target = root / "packs" / name
+    target.mkdir(parents=True)
+    target.joinpath("pack.toml").write_text(
+        f'[pack]\nname = "{name}"\nversion = "1.0.0"\n'
+        f'[pack.adapter-contract]\nversion = "{contract}"\n'
+        '[pack.install]\ndefault-scope = "repo"\nallowed-scopes = ["repo"]\n'
+        f'allowed-adapters = ["{adapter}"]\n',
+        encoding="utf-8",
+    )
+
+
+def test_known_adapter_passes(tmp_path):
+    _pack(tmp_path, "alpha", "0.8", "codex")
+    assert _step_adapter_compat(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_unknown_adapter_is_reported(tmp_path):
+    _pack(tmp_path, "alpha", "0.8", "unknown-adapter")
+    findings = _step_adapter_compat(tmp_path, None, None, tmp_path / "tmp")
+    assert any("unknown allowed adapter" in item.message for item in findings)
+
+
+def test_legacy_contract_skips_allowed_adapter_check(tmp_path):
+    _pack(tmp_path, "legacy", "0.1", "unknown-adapter")
+    assert _step_adapter_compat(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_pack_selection_skips_unrelated_pack(tmp_path):
+    _pack(tmp_path, "alpha", "0.8", "codex")
+    _pack(tmp_path, "broken", "0.8", "unknown-adapter")
+    assert _step_adapter_compat(tmp_path, None, "alpha", tmp_path / "tmp") == []
+
+
+def test_linked_pack_manifest_is_refused(tmp_path):
+    pack = tmp_path / "packs" / "alpha"
+    pack.mkdir(parents=True)
+    outside = tmp_path / "outside.toml"
+    outside.write_text("not valid TOML", encoding="utf-8")
+    try:
+        (pack / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_adapter_compat(tmp_path, None, None, tmp_path / "tmp")
+    assert any(item.code == "CAT-V-008" and "safely" in item.message for item in findings)

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_dependencies.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_dependencies.py
@@ -1,0 +1,210 @@
+"""Dependency grammar, resolution, and cycle checks in verifier step 7."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from agentbundle.catalogue_tooling import verify
+from agentbundle.catalogue_tooling.verify import _step_dependencies
+
+
+def _config():
+    return SimpleNamespace(name="example", paths=SimpleNamespace(packs="packs"))
+
+
+def _pack(root: Path, name: str, version: str = "1.0.0", dependency: str = "") -> None:
+    target = root / "packs" / name
+    target.mkdir(parents=True)
+    target.joinpath("pack.toml").write_text(
+        f'[pack]\nname = "{name}"\nversion = "{version}"\n{dependency}',
+        encoding="utf-8",
+    )
+
+
+def _required(name: str, version: str) -> str:
+    return _dependency("required", name, version)
+
+
+def _dependency(
+    kind: str, name: str, version: str, *, catalogue: str = "example"
+) -> str:
+    return (
+        f"[[pack.dependencies.{kind}]]\n"
+        f'catalogue = "{catalogue}"\n'
+        f'pack = "{name}"\n'
+        f'version = "{version}"\n'
+    )
+
+
+def test_valid_dependency_and_supported_ranges_pass(tmp_path):
+    _pack(tmp_path, "base", "1.2.3")
+    for index, expression in enumerate(("^1.0", "~1.2", ">=1.0 <2.0", ">=1.2.3")):
+        _pack(tmp_path, f"owner-{index}", dependency=_required("base", expression))
+    assert _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp") == []
+
+
+def test_missing_required_dependency_is_reported(tmp_path):
+    _pack(tmp_path, "owner", dependency=_required("missing", "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert any("missing required" in item.message for item in findings)
+
+
+def test_required_version_mismatch_is_reported(tmp_path):
+    _pack(tmp_path, "base", "2.0.0")
+    _pack(tmp_path, "owner", dependency=_required("base", "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert any("does not satisfy" in item.message for item in findings)
+
+
+def test_zero_minor_caret_rejects_next_minor(tmp_path):
+    _pack(tmp_path, "base", "0.2.0")
+    _pack(tmp_path, "owner", dependency=_required("base", "^0.1"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert any("does not satisfy" in item.message for item in findings)
+
+
+def test_recommended_absence_and_version_mismatch_are_informational(tmp_path):
+    _pack(tmp_path, "base", "2.0.0")
+    _pack(
+        tmp_path,
+        "owner",
+        dependency=(
+            _dependency("recommended", "missing", "^1.0")
+            + _dependency("recommended", "base", "^1.0")
+        ),
+    )
+    assert _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp") == []
+
+
+def test_conflicts_validate_shape_without_treating_source_presence_as_installed(
+    tmp_path,
+):
+    _pack(tmp_path, "present")
+    _pack(
+        tmp_path,
+        "owner",
+        dependency=(
+            _dependency("conflicts", "present", "^1.0")
+            + _dependency("conflicts", "absent", "^1.0")
+        ),
+    )
+    assert _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp") == []
+
+
+def test_valid_cross_catalogue_dependency_skips_local_lookup(tmp_path):
+    _pack(
+        tmp_path,
+        "owner",
+        dependency=_dependency(
+            "required", "remote", ">=1.0 <2.0", catalogue="other"
+        ),
+    )
+    assert _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp") == []
+
+
+def test_malformed_range_is_reported_for_external_dependency(tmp_path):
+    dependency = (
+        "[[pack.dependencies.required]]\n"
+        'catalogue = "other"\npack = "remote"\nversion = "not-a-version"\n'
+    )
+    _pack(tmp_path, "owner", dependency=dependency)
+    assert any(
+        "invalid version range" in item.message
+        for item in _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    )
+
+
+def test_required_cycle_is_reported(tmp_path):
+    _pack(tmp_path, "alpha", dependency=_required("beta", "^1.0"))
+    _pack(tmp_path, "beta", dependency=_required("alpha", "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert any("circular required dependency" in item.message for item in findings)
+
+
+def test_invalid_and_traversing_local_pack_references_are_refused(tmp_path):
+    for index, name in enumerate(("Not_Canonical", "../outside", "/absolute")):
+        _pack(tmp_path, f"owner-{index}", dependency=_required(name, "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert len(findings) == 3
+    assert all("pack reference" in item.message for item in findings)
+    assert all(item.path == "packs/<invalid-pack-reference>" for item in findings)
+
+
+def test_linked_local_pack_reference_is_refused_without_reading_target(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "pack.toml").write_text("not valid TOML", encoding="utf-8")
+    packs = tmp_path / "packs"
+    packs.mkdir()
+    try:
+        (packs / "linked").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    _pack(tmp_path, "owner", dependency=_required("linked", "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert len(findings) == 1
+    assert "pack reference refused" in findings[0].message
+    assert findings[0].path == "packs/linked"
+
+
+def test_junction_local_pack_reference_is_refused(tmp_path, monkeypatch):
+    _pack(tmp_path, "junction")
+    _pack(tmp_path, "owner", dependency=_required("junction", "^1.0"))
+    junction = tmp_path / "packs" / "junction"
+    original = verify._path_is_junction
+    monkeypatch.setattr(
+        verify,
+        "_path_is_junction",
+        lambda path: path == junction or original(path),
+    )
+
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+
+    assert any(
+        item.code == "CAT-V-007"
+        and item.path == "packs/junction"
+        and "pack reference refused" in item.message
+        for item in findings
+    )
+
+
+def test_linked_pack_manifest_is_refused(tmp_path):
+    base = tmp_path / "packs" / "base"
+    base.mkdir(parents=True)
+    outside = tmp_path / "outside.toml"
+    outside.write_text('[pack]\nname = "base"\nversion = "1.0.0"\n', encoding="utf-8")
+    try:
+        (base / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    _pack(tmp_path, "owner", dependency=_required("base", "^1.0"))
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert any(
+        item.code == "CAT-V-007" and "cannot be read safely" in item.message
+        for item in findings
+    )
+
+
+def test_linked_packs_root_is_refused(tmp_path):
+    outside = tmp_path / "outside-packs"
+    outside.mkdir()
+    try:
+        (tmp_path / "packs").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_dependencies(tmp_path, _config(), None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-007"
+    assert "packs directory" in findings[0].message
+
+
+def test_unknown_catalogue_identity_skips_local_classification_with_info(tmp_path):
+    _pack(tmp_path, "owner", dependency=_required("missing", "^1.0"))
+    findings = _step_dependencies(tmp_path, None, None, tmp_path / "tmp")
+    assert len(findings) == 1
+    assert "catalogue identity unknown" in findings[0].message
+
+
+def test_pack_selection_does_not_scan_unrelated_pack(tmp_path):
+    _pack(tmp_path, "alpha")
+    _pack(tmp_path, "broken", dependency=_required("missing", "^1.0"))
+    assert _step_dependencies(tmp_path, _config(), "alpha", tmp_path / "tmp") == []

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_external_portability.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_external_portability.py
@@ -1,0 +1,56 @@
+"""End-to-end portability proof for an external catalogue."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from agentbundle.catalogue_tooling.verify import _VERIFY_STEPS
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "external_catalogue"
+
+
+def _run_verify() -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    package_root = str(Path(__file__).parents[2])
+    env["PYTHONPATH"] = os.pathsep.join(
+        [package_root, *filter(None, env.get("PYTHONPATH", "").split(os.pathsep))]
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agentbundle",
+            "catalogue",
+            "verify",
+            "--root",
+            str(FIXTURE),
+            "--format",
+            "json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_clean_external_catalogue_verifies():
+    result = _run_verify()
+    assert result.returncode == 0, result.stderr + result.stdout
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert payload["ok"] is True
+    assert payload["diagnostics"] == []
+
+
+def test_portable_seed_does_not_create_host_specific_finding():
+    result = _run_verify()
+    payload = json.loads(result.stdout[result.stdout.index("{") :])
+    assert not any(
+        "agent-ready-repo" in item["message"] for item in payload["diagnostics"]
+    )
+
+
+def test_pipeline_has_nineteen_steps():
+    assert len(_VERIFY_STEPS) == 19

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_fixture_checks.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_fixture_checks.py
@@ -1,0 +1,123 @@
+"""Eval-manifest checks in verifier step 18."""
+
+import json
+from pathlib import Path
+
+import pytest
+from agentbundle.catalogue_tooling.verify import _step_fixture_checks
+
+
+def _evals(root: Path, pack: str = "alpha") -> Path:
+    path = root / "packs" / pack / ".apm" / "skills" / "demo" / "evals"
+    path.mkdir(parents=True)
+    return path
+
+
+def test_valid_eval_queries_pass(tmp_path):
+    target = _evals(tmp_path) / "eval_queries.json"
+    target.write_text(
+        json.dumps([{"query": "use demo", "should_trigger": True}]), encoding="utf-8"
+    )
+    assert _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_malformed_eval_queries_json_is_reported(tmp_path):
+    target = _evals(tmp_path) / "eval_queries.json"
+    target.write_text("{", encoding="utf-8")
+    findings = _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-018"
+    assert "not valid JSON" in findings[0].message
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ([], "at least one query"),
+        ([{"should_trigger": True}], "query must be a non-empty string"),
+        ([{"query": "use demo", "should_trigger": "yes"}], "must be a boolean"),
+    ],
+)
+def test_eval_queries_structural_errors_are_reported(tmp_path, content, message):
+    target = _evals(tmp_path) / "eval_queries.json"
+    target.write_text(json.dumps(content), encoding="utf-8")
+    findings = _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-018"
+    assert message in findings[0].message
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("{", "not valid JSON"),
+        ("", "not valid JSON"),
+        (
+            json.dumps({"skill_name": "demo", "evals": []}),
+            "must contain at least one entry",
+        ),
+        (
+            json.dumps({"skill_name": "demo", "evals": [{"id": 1}]}),
+            "prompt must be a non-empty string",
+        ),
+    ],
+)
+def test_evals_json_errors_are_reported(tmp_path, content, message):
+    target = _evals(tmp_path) / "evals.json"
+    target.write_text(content, encoding="utf-8")
+    findings = _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-018"
+    assert message in findings[0].message
+
+
+def test_opaque_payload_is_not_parsed(tmp_path):
+    evals = _evals(tmp_path)
+    payload = evals / "files" / "payload.jsonl"
+    payload.parent.mkdir()
+    payload.write_text("not json\n", encoding="utf-8")
+    (evals / "evals.json").write_text(
+        json.dumps(
+            {
+                "skill_name": "demo",
+                "evals": [
+                    {
+                        "id": 1,
+                        "prompt": "p",
+                        "expected_output": "e",
+                        "files": ["evals/files/payload.jsonl"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_linked_manifest_is_refused(tmp_path):
+    evals = _evals(tmp_path)
+    outside = tmp_path / "outside.json"
+    outside.write_text("[]", encoding="utf-8")
+    try:
+        (evals / "eval_queries.json").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_fixture_checks(tmp_path, None, None, tmp_path / "tmp")
+    assert any("link-like eval manifest" in item.message for item in findings)
+
+
+def test_relative_catalogue_root_is_supported(tmp_path, monkeypatch):
+    target = _evals(tmp_path) / "eval_queries.json"
+    target.write_text(
+        json.dumps([{"query": "use demo", "should_trigger": True}]), encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert _step_fixture_checks(Path(), None, None, Path("tmp")) == []
+
+
+def test_pack_selection_does_not_scan_unrelated_eval_manifests(tmp_path):
+    alpha = _evals(tmp_path, "alpha") / "eval_queries.json"
+    alpha.write_text(
+        json.dumps([{"query": "use demo", "should_trigger": True}]), encoding="utf-8"
+    )
+    beta = _evals(tmp_path, "beta") / "eval_queries.json"
+    beta.write_text("{", encoding="utf-8")
+    assert _step_fixture_checks(tmp_path, None, "alpha", tmp_path / "tmp") == []

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_marketplace.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_marketplace.py
@@ -1,0 +1,49 @@
+"""Configured marketplace source checks in verifier step 12."""
+
+from types import SimpleNamespace
+
+import pytest
+from agentbundle.catalogue_tooling.verify import _step_marketplace
+
+
+def test_absent_marketplace_passes(tmp_path):
+    assert _step_marketplace(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_malformed_marketplace_is_reported(tmp_path):
+    target = tmp_path / ".claude-plugin" / "marketplace.json"
+    target.parent.mkdir()
+    target.write_text("{", encoding="utf-8")
+    findings = _step_marketplace(tmp_path, None, None, tmp_path / "tmp")
+    assert findings and findings[0].code == "CAT-V-012"
+
+
+def test_valid_marketplace_passes(tmp_path):
+    target = tmp_path / ".claude-plugin" / "marketplace.json"
+    target.parent.mkdir()
+    target.write_text('{"plugins": []}', encoding="utf-8")
+    assert _step_marketplace(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_configured_marketplace_path_is_honoured(tmp_path):
+    target = tmp_path / "metadata" / "plugins.json"
+    target.parent.mkdir()
+    target.write_text("{", encoding="utf-8")
+    config = SimpleNamespace(paths=SimpleNamespace(marketplace="metadata/plugins.json"))
+    findings = _step_marketplace(tmp_path, config, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-012"
+    assert findings[0].path == "metadata/plugins.json"
+
+
+def test_linked_marketplace_is_refused(tmp_path):
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"plugins": []}', encoding="utf-8")
+    target = tmp_path / ".claude-plugin" / "marketplace.json"
+    target.parent.mkdir()
+    try:
+        target.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_marketplace(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-012"
+    assert "unsafe" in findings[0].message

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_output_drift.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_output_drift.py
@@ -1,0 +1,149 @@
+"""Generated-output drift checks in verifier step 14."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from agentbundle.catalogue_tooling import verify
+from agentbundle.catalogue_tooling.build import build_catalogue
+from agentbundle.catalogue_tooling.config import load_catalogue_config
+from agentbundle.catalogue_tooling.verify import _step_output_drift
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "external_catalogue"
+
+
+def _built_catalogue(tmp_path: Path) -> tuple[Path, object]:
+    root = tmp_path / "catalogue"
+    shutil.copytree(FIXTURE, root)
+    config = load_catalogue_config(root)
+    assert config is not None
+    result = build_catalogue(root, output=root / "dist")
+    assert result.ok
+    return root, config
+
+
+def test_absent_output_directory_passes(tmp_path):
+    assert _step_output_drift(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_modified_projection_is_reported(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    generated = next((root / "dist" / "apm").rglob("SKILL.md"))
+    generated.write_text("tampered", encoding="utf-8")
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any("generated output differs" in item.message for item in findings)
+
+
+def test_file_only_in_configured_output_is_reported(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    stale = root / "dist" / "apm" / "removed-pack" / "stale.txt"
+    stale.parent.mkdir()
+    stale.write_text("stale", encoding="utf-8")
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any(
+        item.path == "dist/apm/removed-pack/stale.txt"
+        and "stale generated output" in item.message
+        for item in findings
+    )
+
+
+def test_nondefault_configured_output_is_used_and_reported(tmp_path):
+    root = tmp_path / "catalogue"
+    shutil.copytree(FIXTURE, root)
+    config_path = root / "catalogue.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            'build-output = "dist"', 'build-output = "custom-dist"'
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+    config = load_catalogue_config(root)
+    assert config is not None
+    result = build_catalogue(root, output=root / "custom-dist")
+    assert result.ok
+    stale = root / "custom-dist" / "apm" / "removed-pack" / "stale.txt"
+    stale.parent.mkdir()
+    stale.write_text("stale", encoding="utf-8")
+    ignored = root / "dist" / "apm" / "ignored-pack" / "stale.txt"
+    ignored.parent.mkdir(parents=True)
+    ignored.write_text("ignored", encoding="utf-8")
+
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+
+    assert any(
+        item.path == "custom-dist/apm/removed-pack/stale.txt"
+        and "stale generated output" in item.message
+        for item in findings
+    )
+    assert all(not (item.path or "").startswith("dist/") for item in findings)
+
+
+def test_file_only_in_fresh_output_is_reported(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    missing = root / "dist" / "apm" / "alpha" / "pack.toml"
+    missing.unlink()
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any(
+        item.path == "dist/apm/alpha/pack.toml"
+        and "missing generated output" in item.message
+        for item in findings
+    )
+
+
+def test_pack_selection_ignores_unrelated_output_drift(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    unrelated = root / "dist" / "apm" / "beta" / "pack.toml"
+    unrelated.write_text("tampered", encoding="utf-8")
+    assert _step_output_drift(root, config, "alpha", tmp_path / "fresh") == []
+
+
+def test_linked_output_root_is_refused(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (tmp_path / "dist").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_output_drift(tmp_path, None, None, tmp_path / "fresh")
+    assert any("link-like root" in item.message for item in findings)
+
+
+def test_linked_directory_escape_is_refused_without_exposing_sentinel(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "sentinel.txt").write_text("outside-secret", encoding="utf-8")
+    linked = root / "dist" / "apm" / "escape"
+    try:
+        linked.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any(item.path == "dist/apm/escape" for item in findings)
+    assert all("outside-secret" not in item.message for item in findings)
+
+
+def test_linked_directory_loop_terminates_with_finding(tmp_path):
+    root, config = _built_catalogue(tmp_path)
+    loop = root / "dist" / "apm" / "loop"
+    try:
+        loop.symlink_to(root / "dist" / "apm", target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any(item.path == "dist/apm/loop" and "loop" in item.message for item in findings)
+
+
+def test_junction_like_directory_is_refused(tmp_path, monkeypatch):
+    root, config = _built_catalogue(tmp_path)
+    junction = root / "dist" / "apm" / "junction"
+    junction.mkdir()
+    original = verify._path_is_junction
+    monkeypatch.setattr(
+        verify,
+        "_path_is_junction",
+        lambda path: path == junction or original(path),
+    )
+    findings = _step_output_drift(root, config, None, tmp_path / "fresh")
+    assert any(item.path == "dist/apm/junction" and "junction" in item.message for item in findings)

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_package_preflight.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_package_preflight.py
@@ -1,0 +1,74 @@
+"""Pack preflight checks in verifier step 17."""
+
+from types import SimpleNamespace
+
+import pytest
+from agentbundle.catalogue_tooling.verify import _step_package_preflight
+
+
+def test_missing_pack_manifest_is_reported(tmp_path):
+    (tmp_path / "packs" / "alpha").mkdir(parents=True)
+    findings = _step_package_preflight(tmp_path, None, None, tmp_path / "tmp")
+    assert any("pack.toml is missing" in item.message for item in findings)
+
+
+def test_malformed_pack_manifest_is_reported(tmp_path):
+    pack = tmp_path / "packs" / "alpha"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text("[pack", encoding="utf-8")
+    assert _step_package_preflight(tmp_path, None, None, tmp_path / "tmp")
+
+
+def test_schema_invalid_pack_manifest_is_reported(tmp_path):
+    pack = tmp_path / "packs" / "alpha"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "alpha"\nversion = "1.0.0"\nunexpected = true\n',
+        encoding="utf-8",
+    )
+    findings = _step_package_preflight(tmp_path, None, None, tmp_path / "tmp")
+    assert any(item.code == "CAT-V-017" and "pack schema" in item.message for item in findings)
+
+
+def test_minimal_valid_pack_without_readme_passes(tmp_path):
+    pack = tmp_path / "packs" / "alpha"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "alpha"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    assert _step_package_preflight(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_pack_selection_skips_unrelated_missing_manifest(tmp_path):
+    (tmp_path / "packs" / "broken").mkdir(parents=True)
+    selected = tmp_path / "packs" / "alpha"
+    selected.mkdir()
+    (selected / "pack.toml").write_text(
+        '[pack]\nname = "alpha"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    assert _step_package_preflight(tmp_path, None, "alpha", tmp_path / "tmp") == []
+
+
+def test_configured_pack_path_is_honoured(tmp_path):
+    pack = tmp_path / "custom-packs" / "alpha"
+    pack.mkdir(parents=True)
+    (pack / "pack.toml").write_text(
+        '[pack]\nname = "alpha"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    config = SimpleNamespace(paths=SimpleNamespace(packs="custom-packs"))
+    assert _step_package_preflight(tmp_path, config, None, tmp_path / "tmp") == []
+
+
+def test_linked_pack_manifest_is_refused(tmp_path):
+    pack = tmp_path / "packs" / "alpha"
+    pack.mkdir(parents=True)
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        '[pack]\nname = "alpha"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    try:
+        (pack / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_package_preflight(tmp_path, None, None, tmp_path / "tmp")
+    assert any(item.code == "CAT-V-017" and "parse error" in item.message for item in findings)

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_plugin_path.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_plugin_path.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from agentbundle.catalogue_tooling.verify import (
     _step_plugin_validation,
     _step_version_parity,
@@ -116,6 +117,25 @@ def test_step4_reports_malformed_manifest(tmp_path):
     assert any("parse error" in d.message for d in result)
 
 
+def test_step4_refuses_linked_manifest(tmp_path):
+    """Step 4 never follows a plugin manifest link outside its pack."""
+    _make_pack(tmp_path)
+    pack_dir = tmp_path / "packs" / "my-pack"
+    outside = tmp_path / "outside.json"
+    _write(outside, _manifest())
+    plugin_json = pack_dir / ".claude-plugin" / "plugin.json"
+    plugin_json.parent.mkdir(parents=True)
+    try:
+        plugin_json.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_plugin_validation(tmp_path, None, None, tmp_path)
+
+    assert [diagnostic.code for diagnostic in result] == ["CAT-V-004"]
+    assert "source entry is not a regular file" in result[0].message
+
+
 # ---------------------------------------------------------------------------
 # AC2 — step 5 resolves the same path and detects mismatches
 # ---------------------------------------------------------------------------
@@ -162,3 +182,28 @@ def test_step5_clean_when_pair_agrees(tmp_path):
     )
 
     assert _step_version_parity(tmp_path, None, None, tmp_path) == []
+
+
+@pytest.mark.parametrize("linked_manifest", ["pack.toml", "plugin.json"])
+def test_step5_refuses_linked_parity_input(tmp_path, linked_manifest):
+    """Step 5 refuses links for both files in the parity comparison."""
+    _make_pack(tmp_path, plugin_json=_manifest())
+    pack_dir = tmp_path / "packs" / "my-pack"
+    if linked_manifest == "pack.toml":
+        linked_path = pack_dir / "pack.toml"
+        outside = tmp_path / "outside.toml"
+        _write(outside, PACK_TOML)
+    else:
+        linked_path = pack_dir / ".claude-plugin" / "plugin.json"
+        outside = tmp_path / "outside.json"
+        _write(outside, _manifest())
+    linked_path.unlink()
+    try:
+        linked_path.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_version_parity(tmp_path, None, None, tmp_path)
+
+    assert [diagnostic.code for diagnostic in result] == ["CAT-V-005"]
+    assert "source entry is not a regular file" in result[0].message

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_profile_schema.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_profile_schema.py
@@ -1,0 +1,139 @@
+"""Profile schema and reference checks in verifier step 6."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from agentbundle.catalogue_tooling import verify
+from agentbundle.catalogue_tooling.verify import _step_profiles
+
+
+def _profile(root: Path, body: str) -> None:
+    (root / "profiles").mkdir(exist_ok=True)
+    (root / "profiles" / "example.toml").write_text(body, encoding="utf-8")
+
+
+def _config(*, profiles: str = "profiles", packs: str = "packs"):
+    return SimpleNamespace(paths=SimpleNamespace(profiles=profiles, packs=packs))
+
+
+def test_valid_profile_passes(tmp_path):
+    (tmp_path / "packs" / "alpha").mkdir(parents=True)
+    _profile(
+        tmp_path,
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "alpha"\n',
+    )
+    assert _step_profiles(tmp_path, None, None, tmp_path / "tmp") == []
+
+
+def test_configured_profile_and_pack_paths_are_honoured(tmp_path):
+    (tmp_path / "custom-packs" / "alpha").mkdir(parents=True)
+    profiles = tmp_path / "custom-profiles"
+    profiles.mkdir()
+    profiles.joinpath("example.toml").write_text(
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "alpha"\n',
+        encoding="utf-8",
+    )
+    assert (
+        _step_profiles(
+            tmp_path,
+            _config(profiles="custom-profiles", packs="custom-packs"),
+            None,
+            tmp_path / "tmp",
+        )
+        == []
+    )
+
+
+def test_schema_violation_is_reported(tmp_path):
+    _profile(tmp_path, 'description = "Missing scope"\npacks = []\n')
+    assert _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+
+
+def test_missing_pack_reference_is_reported_without_config(tmp_path):
+    (tmp_path / "packs").mkdir()
+    _profile(
+        tmp_path,
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "missing"\n',
+    )
+    findings = _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+    assert any("missing" in item.message for item in findings)
+
+
+def test_traversing_pack_reference_is_reported(tmp_path):
+    (tmp_path / "packs").mkdir()
+    _profile(
+        tmp_path,
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "../escape"\n',
+    )
+    assert _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+
+
+def test_linked_pack_reference_is_refused_without_reading_target(tmp_path):
+    packs = tmp_path / "packs"
+    packs.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "pack.toml").write_text("not valid TOML", encoding="utf-8")
+    try:
+        (packs / "linked").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    _profile(
+        tmp_path,
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "linked"\n',
+    )
+    findings = _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+    assert len(findings) == 1
+    assert "pack reference refused" in findings[0].message
+    assert findings[0].path == "profiles/example.toml"
+
+
+def test_junction_pack_reference_is_refused(tmp_path, monkeypatch):
+    packs = tmp_path / "packs"
+    junction = packs / "junction"
+    junction.mkdir(parents=True)
+    _profile(
+        tmp_path,
+        'scope = "repo"\ndescription = "Example"\n[[packs]]\npack = "junction"\n',
+    )
+    original = verify._path_is_junction
+    monkeypatch.setattr(
+        verify,
+        "_path_is_junction",
+        lambda path: path == junction or original(path),
+    )
+
+    findings = _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+
+    assert len(findings) == 1
+    assert findings[0].code == "CAT-V-006"
+    assert "pack reference refused" in findings[0].message
+
+
+def test_linked_profile_file_is_refused(tmp_path):
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        'scope = "repo"\ndescription = "Outside"\npacks = []\n', encoding="utf-8"
+    )
+    try:
+        profiles.joinpath("example.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-006"
+    assert "unsafe" in findings[0].message
+
+
+def test_linked_profiles_root_is_refused(tmp_path):
+    outside = tmp_path / "outside-profiles"
+    outside.mkdir()
+    try:
+        (tmp_path / "profiles").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks not available")
+    findings = _step_profiles(tmp_path, None, None, tmp_path / "tmp")
+    assert findings[0].code == "CAT-V-006"
+    assert "profiles directory" in findings[0].message

--- a/packages/agentbundle/tests/integration/test_catalogue_verify_step1.py
+++ b/packages/agentbundle/tests/integration/test_catalogue_verify_step1.py
@@ -1,0 +1,21 @@
+"""Step-1 catalogue configuration regressions."""
+
+from agentbundle.catalogue_tooling.verify import verify_catalogue
+
+
+def test_malformed_catalogue_toml_returns_bounded_diagnostic(tmp_path):
+    secret = "sensitive-value"
+    (tmp_path / "catalogue.toml").write_text(
+        f'[catalogue\nname = "{secret}"\n', encoding="utf-8"
+    )
+    result = verify_catalogue(tmp_path)
+    findings = [item for item in result.diagnostics if item.code == "CAT-V-001"]
+    assert findings
+    rendered = " ".join(item.message for item in findings)
+    assert secret not in rendered
+    assert str(tmp_path) not in rendered
+
+
+def test_absent_catalogue_toml_does_not_create_step1_diagnostic(tmp_path):
+    result = verify_catalogue(tmp_path)
+    assert not [item for item in result.diagnostics if item.code == "CAT-V-001"]

--- a/packages/agentbundle/tests/integration/test_install_dependencies_gate.py
+++ b/packages/agentbundle/tests/integration/test_install_dependencies_gate.py
@@ -5,12 +5,12 @@ installing pack's manifest and resolves each entry against the union of
 repo-scope and user-scope state files. Missing or out-of-range required
 packs cause a non-zero exit with spec-mandated stderr.
 
-Six tests, TDD-first:
+Dependency-gate tests, TDD-first:
   1. test_install_refuses_missing_required
   2. test_install_proceeds_when_required_at_repo_scope
   3. test_install_proceeds_when_required_at_user_scope
   4. test_install_refuses_out_of_range_required
-  5. test_install_refuses_unsupported_range_grammar
+  5. Shared dependency range forms and their exclusion boundaries
   6. test_install_no_required_table_proceeds
 """
 
@@ -20,6 +20,8 @@ import argparse
 import contextlib
 import io
 from pathlib import Path
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -97,24 +99,6 @@ pack = "core"
 version = "^0.1"
 """
 
-ADDON_WITH_REQUIRED_UNSUPPORTED_RANGE = """\
-[pack]
-name = "addon"
-version = "0.1.0"
-
-[pack.adapter-contract]
-version = "0.2"
-
-[pack.install]
-default-scope = "repo"
-allowed-scopes = ["repo"]
-
-[[pack.dependencies.required]]
-catalogue = "agent-ready-repo"
-pack = "core"
-version = "~0.1"
-"""
-
 ADDON_NO_DEPENDENCIES = """\
 [pack]
 name = "addon"
@@ -145,6 +129,10 @@ catalogue = "agent-ready-repo"
 pack = "core"
 version = "^0.1"
 """
+
+
+def _addon_with_range(version_range: str) -> str:
+    return ADDON_WITH_REQUIRED.replace('version = "^0.1"', f'version = "{version_range}"')
 
 
 # ---------------------------------------------------------------------------
@@ -281,24 +269,94 @@ def test_install_refuses_out_of_range_required(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Test 5: refuse when version range grammar is unsupported
+# Test 5: use one dependency range grammar across verify and install
 # ---------------------------------------------------------------------------
 
 
-def test_install_refuses_unsupported_range_grammar(tmp_path):
-    """Gate fires with the unsupported-range message when grammar is not ^X.Y."""
+@pytest.mark.parametrize(
+    ("version_range", "installed_version"),
+    [
+        ("^0.1", "0.1.5"),
+        ("~0.1", "0.1.5"),
+        (">=0.1", "0.2.0"),
+        (">=0.1 <1.0", "0.5.0"),
+        (">=0.1.0-alpha.1", "0.1.0-alpha.2"),
+    ],
+)
+def test_install_accepts_rfc_version_range_forms(
+    tmp_path, version_range, installed_version
+):
+    """Every range form accepted by verify is accepted by the installer."""
     cat = tmp_path / "cat"
-    _stage_pack(cat, "addon", ADDON_WITH_REQUIRED_UNSUPPORTED_RANGE)
+    _stage_pack(cat, "addon", _addon_with_range(version_range))
+    target = tmp_path / "repo"
+    target.mkdir()
+    _pre_install_core(cat, target, version=installed_version)
+
+    rc, _, err = _install(
+        {"pack": "addon", "catalogue": str(cat), "output": str(target), "scope": None, "force": False}  # noqa: E501
+    )
+    assert rc == 0, err
+
+
+def test_install_rejects_malformed_range(tmp_path):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "addon", _addon_with_range("not-a-version"))
     target = tmp_path / "repo"
     target.mkdir()
 
     rc, _, err = _install(
         {"pack": "addon", "catalogue": str(cat), "output": str(target), "scope": None, "force": False}  # noqa: E501
     )
-    assert rc != 0, "install must refuse with unsupported range grammar"
-    first_line = err.strip().splitlines()[0] if err.strip() else ""
-    expected = "install: unsupported version range '~0.1' for required pack 'core'; only ^X.Y is supported"  # noqa: E501
-    assert first_line == expected, f"unexpected stderr first line: {first_line!r}"
+
+    assert rc != 0
+    assert "not-a-version" in err
+    assert "unsupported version range" in err
+
+
+def test_install_rejects_oversized_numeric_range_without_traceback(tmp_path):
+    oversized = "1" + "0" * 5000
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "addon", _addon_with_range(oversized))
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    rc, _, err = _install(
+        {"pack": "addon", "catalogue": str(cat), "output": str(target), "scope": None, "force": False}  # noqa: E501
+    )
+
+    assert rc != 0
+    assert "unsupported version range" in err
+    assert "Traceback" not in err
+
+
+@pytest.mark.parametrize(
+    ("version_range", "installed_version"),
+    [
+        ("^0.1", "0.0.9"),
+        ("^0.1", "0.2.0"),
+        ("~0.1", "0.2.0"),
+        (">=0.1", "0.0.9"),
+        (">=0.1 <1.0", "1.0.0"),
+        (">=0.1.0-alpha.1", "0.1.0-alpha.0"),
+    ],
+)
+def test_install_rejects_versions_outside_each_range_form(
+    tmp_path, version_range, installed_version
+):
+    cat = tmp_path / "cat"
+    _stage_pack(cat, "addon", _addon_with_range(version_range))
+    target = tmp_path / "repo"
+    target.mkdir()
+    _pre_install_core(cat, target, version=installed_version)
+
+    rc, _, err = _install(
+        {"pack": "addon", "catalogue": str(cat), "output": str(target), "scope": None, "force": False}  # noqa: E501
+    )
+
+    assert rc != 0
+    assert "requires 'core'" in err
+    assert "unsupported version range" not in err
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/integration/test_install_profile.py
+++ b/packages/agentbundle/tests/integration/test_install_profile.py
@@ -84,7 +84,7 @@ def _stage_profile(cat, name, scope, packs):
 
 def _three_pack_repo_catalogue(cat):
     """pf-core (no deps) + two addons that each require pf-core ^0.1."""
-    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-core", version="0.1.9", scope="repo")
     _stage_pack(cat, "pf-addon-a", scope="repo", deps=[("pf-core", "^0.1")])
     _stage_pack(cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")])
     _stage_profile(cat, "test-bundle", "repo", ["pf-core", "pf-addon-a", "pf-addon-b"])
@@ -173,7 +173,7 @@ def test_profile_skips_already_installed(tmp_path):
     # Pre-seed pf-core at repo scope.
     state = State()
     state.packs[("pf-core", "claude-code")] = PackState(
-        installed_version="0.4.9", scope="repo", adapter="claude-code"
+        installed_version="0.1.9", scope="repo", adapter="claude-code"
     )
     (target / ".agentbundle-state.toml").write_text(
         dump_state(state), encoding="utf-8", newline="\n"
@@ -199,7 +199,7 @@ def test_profile_refuses_when_a_pack_disallows_the_pinned_adapter(tmp_path):
     target = tmp_path / "repo"
     target.mkdir()
     # pf-core legacy (→ claude-code default); pf-addon-b only allows codex.
-    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-core", version="0.1.9", scope="repo")
     _stage_pack(
         cat, "pf-addon-b", scope="repo", deps=[("pf-core", "^0.1")], allowed_adapters=["codex"]
     )
@@ -326,7 +326,7 @@ def test_profile_refuses_when_pack_requires_dep_not_in_batch(tmp_path):
     cat = tmp_path / "cat"
     target = tmp_path / "repo"
     target.mkdir()
-    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-core", version="0.1.9", scope="repo")
     _stage_pack(cat, "pf-addon-a", scope="repo", deps=[("pf-core", "^0.1")])
     # Profile omits pf-core — pf-addon-a's dep is out of the batch.
     _stage_profile(cat, "incomplete", "repo", ["pf-addon-a"])
@@ -343,7 +343,7 @@ def test_profile_refuses_scope_mismatch(tmp_path):
     cat = tmp_path / "cat"
     target = tmp_path / "repo"
     target.mkdir()
-    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")  # repo-only
+    _stage_pack(cat, "pf-core", version="0.1.9", scope="repo")  # repo-only
     _stage_profile(cat, "userbad", "user", ["pf-core"])
 
     rc, out, err = _run_install(["--profile", "userbad", str(cat), "--output", str(target)])
@@ -401,7 +401,7 @@ def test_single_pack_install_still_records_cli_route(tmp_path):
     cat = tmp_path / "cat"
     target = tmp_path / "repo"
     target.mkdir()
-    _stage_pack(cat, "pf-core", version="0.4.9", scope="repo")
+    _stage_pack(cat, "pf-core", version="0.1.9", scope="repo")
 
     rc, out, err = _run_install(["--pack", "pf-core", str(cat), "--output", str(target)])
     assert rc == 0, f"single-pack install failed: {err}"

--- a/packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_skill_spec_lint.py
@@ -24,6 +24,8 @@ import pytest
 
 yaml = pytest.importorskip("yaml", reason="PyYAML not installed; skip deep lint tests")
 
+import agentbundle.catalogue_tooling.skill_spec_lint as _skill_lint_module  # noqa: E402
+from agentbundle.catalogue_tooling.package import _TRANSIENT_DIRS  # noqa: E402
 from agentbundle.catalogue_tooling.results import Severity  # noqa: E402
 from agentbundle.catalogue_tooling.skill_spec_lint import lint_skill_spec  # noqa: E402
 
@@ -776,7 +778,161 @@ def test_tree_e_symlink_loop(tmp_path):
     errors = [d for d in diags if d.severity == Severity.ERROR]
     msg = _messages(diags)
     assert errors, "expected error diagnostic for symlink loop"
-    assert "could not read skill" in msg
+    assert "linked skill entry is not allowed" in msg
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable on this platform")
+def test_linked_skill_directory_is_not_read(tmp_path: Path) -> None:
+    """Deep lint reports a linked skill directory without reading its target."""
+    skills = tmp_path / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    _write(outside / "SKILL.md", "not valid skill frontmatter\n")
+    try:
+        (skills / "linked").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    diagnostics = lint_skill_spec(tmp_path)
+    messages = _messages(diagnostics)
+
+    assert any(
+        diagnostic.code == "CAT-S001"
+        and diagnostic.path == ".claude/skills/linked"
+        and diagnostic.message == "linked skill directory is not allowed"
+        for diagnostic in diagnostics
+    )
+    assert "missing YAML frontmatter" not in messages
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable on this platform")
+def test_linked_projection_walk_root_is_not_read(tmp_path: Path) -> None:
+    """Deep lint rejects a linked projection root before enumeration."""
+    outside = tmp_path / "outside-skills"
+    _write(outside / "outside" / "SKILL.md", "not valid skill frontmatter\n")
+    projection_parent = tmp_path / ".claude"
+    projection_parent.mkdir()
+    try:
+        (projection_parent / "skills").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    diagnostics = lint_skill_spec(tmp_path)
+    messages = _messages(diagnostics)
+
+    assert any(
+        diagnostic.code == "CAT-S001"
+        and diagnostic.path == ".claude/skills"
+        and diagnostic.message == "linked skill walk root is not allowed"
+        for diagnostic in diagnostics
+    )
+    assert "missing YAML frontmatter" not in messages
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable on this platform")
+def test_linked_pack_walk_root_is_not_read(tmp_path: Path) -> None:
+    """Scoped deep lint rejects a linked pack skill root before enumeration."""
+    outside = tmp_path / "outside-skills"
+    _write(outside / "outside" / "SKILL.md", "not valid skill frontmatter\n")
+    apm = tmp_path / "packs" / "example" / ".apm"
+    apm.mkdir(parents=True)
+    try:
+        (apm / "skills").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    diagnostics = lint_skill_spec(tmp_path, pack="example")
+    messages = _messages(diagnostics)
+
+    assert any(
+        diagnostic.code == "CAT-S001"
+        and diagnostic.path == "packs/example/.apm/skills"
+        and diagnostic.message == "linked skill walk root is not allowed"
+        for diagnostic in diagnostics
+    )
+    assert "missing YAML frontmatter" not in messages
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable on this platform")
+def test_linked_eval_manifest_is_not_read(tmp_path: Path) -> None:
+    """Eval manifests use the same confined regular-file reader as skills."""
+    skill = tmp_path / ".claude" / "skills" / "example"
+    _write(
+        skill / "SKILL.md",
+        "---\nname: example\ndescription: A valid fixture skill.\n---\n\nBody.\n",
+    )
+    (skill / "evals").mkdir()
+    outside = tmp_path / "outside-evals.json"
+    outside.write_text("[]\n", encoding="utf-8")
+    try:
+        (skill / "evals" / "eval_queries.json").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation unavailable")
+
+    diagnostics = lint_skill_spec(tmp_path)
+
+    assert any(
+        diagnostic.code == "CAT-S005"
+        and diagnostic.path == ".claude/skills/example/evals/eval_queries.json"
+        and diagnostic.message.startswith("could not read eval manifest:")
+        for diagnostic in diagnostics
+    )
+
+
+@pytest.mark.parametrize("transient_name", sorted(_TRANSIENT_DIRS))
+def test_transient_skill_directory_is_not_read(tmp_path: Path, transient_name: str) -> None:
+    """Packaging-pruned skill directories cannot re-enter through deep lint."""
+    transient_skill = (
+        tmp_path / "packs" / "example" / ".apm" / "skills" / transient_name
+    )
+    transient_skill.mkdir(parents=True)
+    (transient_skill / "SKILL.md").write_text(
+        "not valid skill frontmatter\n", encoding="utf-8"
+    )
+
+    assert lint_skill_spec(tmp_path) == []
+
+
+@pytest.mark.parametrize("transient_name", sorted(_TRANSIENT_DIRS))
+def test_transient_skill_layout_directory_is_ignored(
+    tmp_path: Path, transient_name: str
+) -> None:
+    """Every packager-pruned directory is silent inside a valid skill."""
+    skill = tmp_path / ".claude" / "skills" / "example"
+    _write(
+        skill / "SKILL.md",
+        "---\nname: example\ndescription: A valid fixture skill.\n---\n\nBody.\n",
+    )
+    (skill / transient_name).mkdir()
+
+    messages = _messages(lint_skill_spec(tmp_path))
+
+    assert "non-blessed top-level subdirectory" not in messages
+
+
+def test_unreadable_skill_root_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deep lint fails closed when a non-transient skill root cannot be listed."""
+    skills = tmp_path / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    original_scandir = os.scandir
+
+    def refuse_skill_root(path):
+        if Path(path) == skills:
+            raise PermissionError("fixture directory is unreadable")
+        return original_scandir(path)
+
+    monkeypatch.setattr(_skill_lint_module.os, "scandir", refuse_skill_root)
+
+    diagnostics = lint_skill_spec(tmp_path)
+
+    assert any(
+        diagnostic.code == "CAT-S001"
+        and diagnostic.path == ".claude/skills"
+        and diagnostic.message == "could not enumerate skill directory"
+        for diagnostic in diagnostics
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -887,6 +1043,30 @@ def test_tree_g_pack_evals_coverage(tmp_path):
     msg = _messages(diags)
     _assert_all_in("tree-G", msg, TREE_G_EXPECTED)
     _assert_none_in("tree-G", msg, TREE_G_UNEXPECTED)
+
+
+def test_pack_filter_rejects_path_traversal_before_discovery(tmp_path: Path) -> None:
+    """A scoped pack filter must be a name, never a filesystem path."""
+    diagnostics = lint_skill_spec(tmp_path, pack="../outside")
+
+    assert any(
+        diagnostic.code == "CAT-S001"
+        and diagnostic.path == "packs"
+        and diagnostic.message == "pack filter is not a safe pack name"
+        for diagnostic in diagnostics
+    )
+
+
+def test_pack_evals_rejects_path_traversal_skill_name(tmp_path: Path) -> None:
+    """Cross-reference entries are validated before constructing skill paths."""
+    _write(
+        tmp_path / "packs" / "example" / "pack.toml",
+        '[pack]\nname = "example"\n[pack.evals]\nskills = ["../outside"]\n',
+    )
+
+    messages = _messages(lint_skill_spec(tmp_path))
+
+    assert "entry '../outside' is not a safe skill name" in messages
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_file_safety.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_file_safety.py
@@ -1,0 +1,54 @@
+"""Confined regular-file read and race regressions."""
+
+import os
+
+import pytest
+from agentbundle.catalogue_tooling import file_safety
+from agentbundle.catalogue_tooling.file_safety import (
+    UnsafeContentError,
+    read_confined_regular_file,
+    sha256_confined_regular_file,
+)
+
+
+def test_regular_file_reads_and_hashes(tmp_path):
+    target = tmp_path / "data.txt"
+    target.write_bytes(b"data")
+    assert read_confined_regular_file(tmp_path, target) == b"data"
+    assert len(sha256_confined_regular_file(tmp_path, target)) == 64
+
+
+def test_symlink_and_hardlink_are_refused(tmp_path):
+    target = tmp_path / "data.txt"
+    target.write_bytes(b"data")
+    linked = tmp_path / "linked.txt"
+    try:
+        linked.symlink_to(target)
+    except OSError:
+        pytest.skip("links not available")
+    with pytest.raises(UnsafeContentError):
+        read_confined_regular_file(tmp_path, linked)
+    linked.unlink()
+    os.link(target, linked)
+    with pytest.raises(UnsafeContentError):
+        read_confined_regular_file(tmp_path, target)
+
+
+def test_fifo_replacement_is_nonblocking_and_refused(tmp_path, monkeypatch):
+    if not hasattr(os, "mkfifo") or not hasattr(os, "O_NONBLOCK"):
+        pytest.skip("FIFO nonblocking checks are unavailable")
+    target = tmp_path / "data.txt"
+    target.write_bytes(b"data")
+    original_open = file_safety.os.open
+    observed_flags: list[int] = []
+
+    def replace_with_fifo(path, flags):
+        observed_flags.append(flags)
+        target.unlink()
+        os.mkfifo(target)
+        return original_open(path, flags)
+
+    monkeypatch.setattr(file_safety.os, "open", replace_with_fifo)
+    with pytest.raises(UnsafeContentError, match="not a regular file"):
+        read_confined_regular_file(tmp_path, target)
+    assert observed_flags[0] & os.O_NONBLOCK

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py
@@ -21,6 +21,7 @@ Monkeypatching strategy:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import agentbundle.build.lint_packs as _lp_module
@@ -290,6 +291,168 @@ def test_pack_filter(tmp_path, monkeypatch):
     result = lint_catalogue(tmp_path, pack="pack-a")
     packs_with_diags = {d.pack for d in result.diagnostics if d.pack is not None}
     assert "pack-b" not in packs_with_diags
+
+
+def test_pack_filter_suppresses_unrelated_unsafe_pack_with_relative_path(
+    tmp_path, monkeypatch
+):
+    """Safety discovery is global, but scoped diagnostics remain pack-local."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack(tmp_path, "pack-a", pack_toml=_PACK_A_TOML, plugin_json=_PACK_A_JSON)
+    unsafe = _add_pack(
+        tmp_path,
+        "pack-b",
+        pack_toml='[pack]\nname = "pack-b"\nversion = "0.1.0"\n',
+    )
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    linked = unsafe / ".apm" / "skills" / "linked" / "SKILL.md"
+    linked.parent.mkdir(parents=True)
+    try:
+        linked.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    scoped = lint_catalogue(tmp_path, pack="pack-a")
+    unscoped = lint_catalogue(tmp_path)
+
+    assert not any(diagnostic.pack == "pack-b" for diagnostic in scoped.diagnostics)
+    unsafe_diagnostic = next(
+        diagnostic
+        for diagnostic in unscoped.diagnostics
+        if diagnostic.pack == "pack-b" and diagnostic.code == "CAT-L005"
+    )
+    assert unsafe_diagnostic.path == "packs/pack-b/.apm/skills/linked/SKILL.md"
+
+
+def test_deep_lint_skips_manifestless_pack_with_linked_skill(tmp_path, monkeypatch):
+    """Deep lint cannot bypass preflight through a pack without pack.toml."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack(tmp_path, "pack-a", pack_toml=_PACK_A_TOML, plugin_json=_PACK_A_JSON)
+    unsafe = _add_pack(tmp_path, "pack-b")
+    outside = tmp_path / "outside-skill.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    linked = unsafe / ".apm" / "skills" / "linked" / "SKILL.md"
+    linked.parent.mkdir(parents=True)
+    try:
+        linked.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    calls: list[tuple[Path, str | None]] = []
+
+    def record_deep_lint(root: Path, pack: str | None = None) -> list[Diagnostic]:
+        calls.append((root, pack))
+        return []
+
+    monkeypatch.setattr(
+        "agentbundle.catalogue_tooling.skill_spec_lint.lint_skill_spec",
+        record_deep_lint,
+    )
+
+    result = lint_catalogue(tmp_path, deep=True)
+
+    assert calls == [(tmp_path, "pack-a")]
+    assert any(
+        diagnostic.code == "CAT-L005" and diagnostic.pack == "pack-b"
+        for diagnostic in result.diagnostics
+    )
+
+
+def test_deep_lint_prunes_transient_symlink_tree(tmp_path, monkeypatch):
+    """Packager-pruned dependency trees do not fail authored-content preflight."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    pack_dir = _add_pack(
+        tmp_path,
+        "pack-a",
+        pack_toml=_PACK_A_TOML,
+        plugin_json=_PACK_A_JSON,
+    )
+    dependency_bin = (
+        pack_dir / ".apm" / "skills" / "example" / "node_modules" / ".bin"
+    )
+    dependency_bin.mkdir(parents=True)
+    (dependency_bin.parents[1] / "SKILL.md").write_text(
+        "---\nname: example\ndescription: Use when exercising a lint fixture.\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    outside = tmp_path / "outside-tool"
+    outside.write_text("outside\n", encoding="utf-8")
+    try:
+        (dependency_bin / "example-tool").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+    calls: list[tuple[Path, str | None]] = []
+
+    def record_deep_lint(root: Path, pack: str | None = None) -> list[Diagnostic]:
+        calls.append((root, pack))
+        return []
+
+    monkeypatch.setattr(
+        "agentbundle.catalogue_tooling.skill_spec_lint.lint_skill_spec",
+        record_deep_lint,
+    )
+
+    result = lint_catalogue(tmp_path, deep=True)
+
+    assert result.ok is True
+    assert calls == [(tmp_path, None)]
+    assert not any(diagnostic.code == "CAT-L005" for diagnostic in result.diagnostics)
+
+
+def test_authored_tree_walk_error_is_unsafe(tmp_path, monkeypatch):
+    """Preflight fails closed when a non-transient directory cannot be listed."""
+    pack_dir = tmp_path / "pack-a"
+    authored_root = pack_dir / ".apm"
+    authored_root.mkdir(parents=True)
+    blocked = authored_root / "skills" / "private"
+
+    def refuse_walk(path, *, topdown, onerror, followlinks):
+        assert path == authored_root
+        assert topdown is True
+        assert followlinks is False
+        onerror(PermissionError(13, "permission denied", str(blocked)))
+        return []
+
+    monkeypatch.setattr(_lint_module.os, "walk", refuse_walk)
+
+    assert _lint_module._first_unsafe_pack_entry(pack_dir) == (
+        blocked,
+        "uninspectable directory",
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs unavailable")
+def test_deep_lint_skips_pack_with_fifo_manifest(tmp_path, monkeypatch):
+    """A FIFO pack.toml is diagnosed without being opened by deep lint."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    _setup_markers(tmp_path)
+    pack_dir = tmp_path / "packs" / "pack-a"
+    pack_dir.mkdir()
+    os.mkfifo(pack_dir / "pack.toml")
+    calls: list[tuple[Path, str | None]] = []
+
+    def record_deep_lint(root: Path, pack: str | None = None) -> list[Diagnostic]:
+        calls.append((root, pack))
+        return []
+
+    monkeypatch.setattr(
+        "agentbundle.catalogue_tooling.skill_spec_lint.lint_skill_spec",
+        record_deep_lint,
+    )
+
+    result = lint_catalogue(tmp_path, deep=True)
+
+    assert calls == []
+    diagnostic = next(d for d in result.diagnostics if d.code == "CAT-L005")
+    assert diagnostic.path == "packs/pack-a/pack.toml"
+    assert "not a regular file" in diagnostic.message
 
 
 # ---------------------------------------------------------------------------
@@ -622,10 +785,18 @@ def _add_pack_full(
         install_section = f'\n[pack.install]\nallowed-scopes = [{scopes_str}]'
     deps_section = ""
     if required_deps:
-        deps_lines = "\n".join(
-            f'  {{ pack = "{d["pack"]}", version = "{d["version"]}" }}'
-            for d in required_deps
-        )
+        entries = []
+        for dependency in required_deps:
+            catalogue = (
+                f'catalogue = "{dependency["catalogue"]}", '
+                if "catalogue" in dependency
+                else ""
+            )
+            entries.append(
+                f'  {{ {catalogue}pack = "{dependency["pack"]}", '
+                f'version = "{dependency["version"]}" }}'
+            )
+        deps_lines = "\n".join(entries)
         deps_section = f"\n[pack.dependencies]\nrequired = [\n{deps_lines},\n]"
     (pack_dir / "pack.toml").write_text(
         f'[pack]\nname = "{name}"\nversion = "{version}"\n'
@@ -707,7 +878,9 @@ def test_check_profiles_dependency_incomplete(tmp_path, monkeypatch):
     _setup_markers(tmp_path)
     _add_pack_full(
         tmp_path, "pack-a", allowed_scopes=["repo"],
-        required_deps=[{"pack": "pack-b", "version": "^0.1"}],
+        required_deps=[
+            {"catalogue": "test-catalogue", "pack": "pack-b", "version": "^0.1"}
+        ],
     )
     _setup_profile(
         tmp_path, "missing-dep",
@@ -727,7 +900,13 @@ def test_check_profiles_order_invalid(tmp_path, monkeypatch):
     _add_pack_full(tmp_path, "pack-base", allowed_scopes=["repo"])
     _add_pack_full(
         tmp_path, "pack-ext", allowed_scopes=["repo"],
-        required_deps=[{"pack": "pack-base", "version": "^0.1"}],
+        required_deps=[
+            {
+                "catalogue": "test-catalogue",
+                "pack": "pack-base",
+                "version": "^0.1",
+            }
+        ],
     )
     # pack-ext before pack-base (wrong order)
     _setup_profile(
@@ -748,7 +927,13 @@ def test_check_profiles_unsupported_range_grammar(tmp_path, monkeypatch):
     _add_pack_full(tmp_path, "pack-base", allowed_scopes=["repo"])
     _add_pack_full(
         tmp_path, "pack-ext", allowed_scopes=["repo"],
-        required_deps=[{"pack": "pack-base", "version": "~=0.1"}],
+        required_deps=[
+            {
+                "catalogue": "test-catalogue",
+                "pack": "pack-base",
+                "version": "~=0.1",
+            }
+        ],
     )
     _setup_profile(
         tmp_path, "bad-range",
@@ -758,6 +943,225 @@ def test_check_profiles_unsupported_range_grammar(tmp_path, monkeypatch):
     l028 = [d for d in result.diagnostics if d.code == "CAT-L028"]
     assert l028, "expected CAT-L028 for unsupported range grammar"
     assert any("unsupported version range" in d.message for d in l028)
+
+
+@pytest.mark.parametrize(
+    "version_range",
+    ["^0.1", "~0.1", ">=0.1", ">=0.1 <1.0", ">=0.1.0-alpha.1"],
+)
+def test_check_profiles_accepts_rfc_version_range_forms(
+    tmp_path, monkeypatch, version_range
+):
+    """Profile lint accepts every dependency range form accepted by verify."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack_full(tmp_path, "pack-base", version="0.1.0", allowed_scopes=["repo"])
+    _add_pack_full(
+        tmp_path,
+        "pack-ext",
+        allowed_scopes=["repo"],
+        required_deps=[
+            {
+                "catalogue": "test-catalogue",
+                "pack": "pack-base",
+                "version": version_range,
+            }
+        ],
+    )
+    _setup_profile(
+        tmp_path,
+        "valid-range",
+        'scope = "repo"\n[[packs]]\npack = "pack-base"\n'
+        '[[packs]]\npack = "pack-ext"\n',
+    )
+
+    result = lint_catalogue(tmp_path)
+
+    assert not any(
+        diagnostic.code == "CAT-L028"
+        and "unsupported version range" in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
+
+
+def test_check_profiles_zero_minor_caret_rejects_next_minor(tmp_path, monkeypatch):
+    """Profile lint applies npm's 0.x caret upper bound."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack_full(
+        tmp_path, "pack-base", version="0.2.0", allowed_scopes=["repo"]
+    )
+    _add_pack_full(
+        tmp_path,
+        "pack-ext",
+        allowed_scopes=["repo"],
+        required_deps=[
+            {
+                "catalogue": "test-catalogue",
+                "pack": "pack-base",
+                "version": "^0.1",
+            }
+        ],
+    )
+    _setup_profile(
+        tmp_path,
+        "zero-minor-caret",
+        'scope = "repo"\n[[packs]]\npack = "pack-base"\n'
+        '[[packs]]\npack = "pack-ext"\n',
+    )
+
+    result = lint_catalogue(tmp_path)
+
+    assert any(
+        diagnostic.code == "CAT-L028"
+        and "does not satisfy" in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
+
+
+def test_canonical_shim_comparison_refuses_linked_sibling_source(tmp_path):
+    """Cross-pack shim comparison never follows the sibling source link."""
+    current_pack = tmp_path / "packs" / "consumer"
+    current = current_pack / ".apm" / "skills" / "example" / "scripts" / "credentials_shim.py"
+    current.parent.mkdir(parents=True)
+    current.write_text("VALUE = 1\n", encoding="utf-8")
+    shim_pack = tmp_path / "packs" / "credential-brokers"
+    source = shim_pack / ".apm" / "shared-libs" / "credentials_shim.py"
+    source.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.py"
+    outside.write_text("VALUE = 1\n", encoding="utf-8")
+    try:
+        source.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    assert not _lint_module._cs_is_canonical_shim(
+        current,
+        source.parent,
+        pack_dir=current_pack,
+        shim_pack_dir=shim_pack,
+    )
+
+
+def test_check_profiles_skips_cross_catalogue_dependency_closure(tmp_path, monkeypatch):
+    """An external dependency is not required in a local catalogue profile."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack_full(
+        tmp_path,
+        "pack-ext",
+        allowed_scopes=["repo"],
+        required_deps=[
+            {
+                "catalogue": "external-catalogue",
+                "pack": "external-pack",
+                "version": "^1.0",
+            }
+        ],
+    )
+    _setup_profile(
+        tmp_path,
+        "external-dependency",
+        'scope = "repo"\n[[packs]]\npack = "pack-ext"\n',
+    )
+
+    result = lint_catalogue(tmp_path)
+
+    assert not any(
+        diagnostic.code == "CAT-L028"
+        and "dependency-incomplete" in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
+
+
+def test_check_profiles_rejects_malformed_cross_catalogue_dependency_range(
+    tmp_path, monkeypatch
+):
+    """External dependencies skip closure, not shared range validation."""
+    monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
+    monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
+    _setup_markers(tmp_path)
+    _add_pack_full(
+        tmp_path,
+        "pack-ext",
+        allowed_scopes=["repo"],
+        required_deps=[
+            {
+                "catalogue": "external-catalogue",
+                "pack": "external-pack",
+                "version": "not-a-version",
+            }
+        ],
+    )
+    _setup_profile(
+        tmp_path,
+        "external-dependency",
+        'scope = "repo"\n[[packs]]\npack = "pack-ext"\n',
+    )
+
+    result = lint_catalogue(tmp_path)
+
+    assert any(
+        diagnostic.code == "CAT-L028"
+        and "unsupported version range" in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
+
+
+def test_profile_closure_is_skipped_without_catalogue_identity():
+    pack = {
+        "pack": {
+            "name": "pack-ext",
+            "version": "1.0.0",
+            "dependencies": {
+                "required": [
+                    {
+                        "catalogue": "unknown-without-config",
+                        "pack": "external-pack",
+                        "version": "^1.0",
+                    }
+                ]
+            },
+        }
+    }
+    violations = _lint_module._profile_lint_one(
+        "configless",
+        {"scope": "repo", "packs": [{"pack": "pack-ext"}]},
+        {"pack-ext": pack},
+        None,
+    )
+
+    assert not any("dependency-incomplete" in violation for violation in violations)
+
+
+def test_profile_lint_rejects_unparseable_local_dependency_version():
+    owner = {
+        "pack": {
+            "name": "owner",
+            "version": "1.0.0",
+            "dependencies": {
+                "required": [
+                    {
+                        "catalogue": "example",
+                        "pack": "base",
+                        "version": "^1.0",
+                    }
+                ]
+            },
+        }
+    }
+    base = {"pack": {"name": "base", "version": "not-a-version"}}
+    violations = _lint_module._profile_lint_one(
+        "invalid-provider-version",
+        {"scope": "repo", "packs": [{"pack": "base"}, {"pack": "owner"}]},
+        {"base": base, "owner": owner},
+        "example",
+    )
+
+    assert any("does not satisfy" in violation for violation in violations)
 
 
 def test_check_profiles_parse_failure(tmp_path, monkeypatch):
@@ -842,8 +1246,8 @@ def test_check_seeds_unknown_seed(tmp_path, monkeypatch):
     assert any("declare its expected" in d.message for d in l029)
 
 
-def test_check_seeds_blocklist_hit(tmp_path, monkeypatch):
-    """Seed contains 'agent-ready-repo' → CAT-L029."""
+def test_portable_seed_lint_ignores_repository_specific_names(tmp_path, monkeypatch):
+    """Portable lint leaves repository-specific governance to local tooling."""
     monkeypatch.setattr(_lp_module, "lint_pack", lambda pack_dir: [])
     monkeypatch.setattr(_lint_module, "_load_pack_schema", lambda: None)
     _setup_markers(tmp_path)
@@ -852,8 +1256,7 @@ def test_check_seeds_blocklist_hit(tmp_path, monkeypatch):
         seeds={"AGENTS.md": "This is for agent-ready-repo\n<project-name>"},
     )
     result = lint_catalogue(tmp_path)
-    l029 = [d for d in result.diagnostics if d.code == "CAT-L029"]
-    assert l029, "expected CAT-L029 for blocklist hit"
+    assert not any(diagnostic.code == "CAT-L029" for diagnostic in result.diagnostics)
 
 
 def test_check_seeds_missing_placeholder(tmp_path, monkeypatch):

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_package.py
@@ -65,7 +65,12 @@ def _make_catalogue(
     pack_dir = root / "packs" / "core"
     pack_dir.mkdir(parents=True)
     (pack_dir / "pack.toml").write_text(
-        '[pack]\nname = "core"\nversion = "0.1.0"\n', encoding="utf-8", newline="\n"
+        '[pack]\nname = "core"\nversion = "0.1.0"\n'
+        'description = "Package test fixture."\n'
+        '[pack.adapter-contract]\nversion = "0.2"\n'
+        '[pack.install]\ndefault-scope = "repo"\nallowed-scopes = ["repo"]\n',
+        encoding="utf-8",
+        newline="\n",
     )
     (pack_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8", newline="\n")
     (pack_dir / "tests").mkdir()
@@ -525,8 +530,10 @@ def test_denied_dirs_not_in_archive(tmp_path: Path) -> None:
     separate question — see `test_transient_dirs_pruned_inside_included_roots`.
     """
     root = _make_catalogue(tmp_path)
-    # Add stub files at denied paths
-    for denied in [".git", "tools", "packages", "dist", "__pycache__"]:
+    # Add stub files at denied paths. ``dist/`` is intentionally omitted: the
+    # verifier now treats an existing generated-output tree as a drift contract,
+    # so an arbitrary dist/stub.txt must be refused before packaging begins.
+    for denied in [".git", "tools", "packages", "__pycache__"]:
         d = root / denied
         d.mkdir()
         (d / "stub.txt").write_text("should be excluded\n", encoding="utf-8", newline="\n")
@@ -537,13 +544,13 @@ def test_denied_dirs_not_in_archive(tmp_path: Path) -> None:
             root=root, bundle="b", release="0.1.0", channel="c", output=output
         )
 
-    assert result.ok
+    assert result.ok, [diagnostic.message for diagnostic in result.diagnostics]
 
     archive = output / "catalogues" / "b" / "releases" / "0.1.0" / "catalogue-0.1.0.tar.gz"
     with tarfile.open(fileobj=io.BytesIO(archive.read_bytes()), mode="r:gz") as tf:
         names = tf.getnames()
 
-    for denied in [".git/", "tools/", "packages/", "dist/", "__pycache__/"]:
+    for denied in [".git/", "tools/", "packages/", "__pycache__/"]:
         for name in names:
             assert not name.startswith(denied), f"denied path found in archive: {name}"
 

--- a/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_tooling_verify.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 from agentbundle.catalogue_tooling.results import Diagnostic, LintResult, Severity, VerifyResult
 from agentbundle.catalogue_tooling.toml_emit import emit_catalogue_toml
 from agentbundle.catalogue_tooling.verify import (
@@ -164,6 +165,74 @@ def test_verify_bad_pack_lint_fails_step2(tmp_path, monkeypatch):
 
     assert not result.ok
     assert any("CAT-V-002" in d.code for d in result.diagnostics)
+
+
+def test_verify_refuses_linked_pack_manifest_before_parsing(tmp_path):
+    """The full pipeline refuses a linked pack.toml before lint parses it."""
+    config = emit_catalogue_toml(
+        name="test-catalogue",
+        display_name="Test Catalogue",
+        description="A catalogue fixture with an unsafe pack manifest.",
+        minimum_agentbundle_version="0.33.0",
+        owner_name="Example Maintainer",
+        preferred_adapter="kiro-ide",
+    )
+    (tmp_path / "catalogue.toml").write_text(config, encoding="utf-8", newline="\n")
+    pack_dir = tmp_path / "packs" / "example-pack"
+    pack_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        '[pack]\nname = "example-pack"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    try:
+        (pack_dir / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = verify_catalogue(tmp_path)
+
+    assert result.ok is False
+    assert [diagnostic.code for diagnostic in result.diagnostics] == ["CAT-V-002"]
+    assert "not a regular file" in result.diagnostics[0].message
+    assert result.diagnostics[0].path == "packs/example-pack/pack.toml"
+
+
+def test_verify_refuses_linked_skill_before_lint_reads_it(tmp_path):
+    """Step 2 rejects a linked SKILL.md before parsing its frontmatter."""
+    config = emit_catalogue_toml(
+        name="test-catalogue",
+        display_name="Test Catalogue",
+        description="A catalogue fixture with an unsafe skill file.",
+        minimum_agentbundle_version="0.33.0",
+        owner_name="Example Maintainer",
+        preferred_adapter="kiro-ide",
+    )
+    (tmp_path / "catalogue.toml").write_text(config, encoding="utf-8", newline="\n")
+    pack_dir = tmp_path / "packs" / "example-pack"
+    pack_dir.mkdir(parents=True)
+    pack_dir.joinpath("pack.toml").write_text(
+        '[pack]\nname = "example-pack"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    outside = tmp_path / "outside-skill.md"
+    outside.write_text("---\nname: outside\ndescription: Outside\n---\n", encoding="utf-8")
+    skill_file = pack_dir / ".apm" / "skills" / "example-skill" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    try:
+        skill_file.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = verify_catalogue(tmp_path)
+
+    assert result.ok is False
+    assert any(
+        diagnostic.code == "CAT-V-002" and "link-like entry" in diagnostic.message
+        for diagnostic in result.diagnostics
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/agentbundle/tests/unit/test_catalogue_wave2_validation.py
+++ b/packages/agentbundle/tests/unit/test_catalogue_wave2_validation.py
@@ -257,6 +257,102 @@ def test_verify_no_integrations_passes(tmp_path):
     assert result == []
 
 
+def test_verify_integration_refuses_linked_pack_manifest(tmp_path):
+    pack_dir = _make_pack(tmp_path, "declaring", [])
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        '[pack]\nname = "declaring"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (pack_dir / "pack.toml").unlink()
+    try:
+        (pack_dir / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+
+    assert any(
+        item.code == "CAT-V-019" and "cannot be read safely" in item.message
+        for item in result
+    )
+
+
+def test_verify_integration_refuses_linked_primitive_directory(tmp_path):
+    pack_dir = _make_pack(
+        tmp_path,
+        "declaring",
+        [_valid_entry(pack="absent-pack")],
+    )
+    outside = tmp_path / "outside-skill"
+    outside.mkdir()
+    skills_dir = pack_dir / ".apm" / "skills"
+    skills_dir.mkdir(parents=True)
+    try:
+        (skills_dir / "consumer-skill").symlink_to(
+            outside, target_is_directory=True
+        )
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_integration_validation(tmp_path, None, None, tmp_path)
+
+    assert any(
+        item.code == "CAT-V-019" and "link-like primitive directory" in item.message
+        for item in result
+    )
+
+
+def test_verify_integration_pack_filter_suppresses_unrelated_unsafe_manifest(
+    tmp_path,
+):
+    _make_pack(tmp_path, "selected", [])
+    unrelated = _make_pack(tmp_path, "unrelated", [])
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        '[pack]\nname = "unrelated"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (unrelated / "pack.toml").unlink()
+    try:
+        (unrelated / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_integration_validation(tmp_path, None, "selected", tmp_path)
+
+    assert result == []
+
+
+def test_verify_integration_pack_filter_reports_unsafe_target_manifest(tmp_path):
+    selected = _make_pack(
+        tmp_path,
+        "selected",
+        [_valid_entry(pack="target")],
+    )
+    _add_skill(selected, "consumer-skill")
+    target = _make_pack(tmp_path, "target", [])
+    outside = tmp_path / "outside.toml"
+    outside.write_text(
+        '[pack]\nname = "target"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (target / "pack.toml").unlink()
+    try:
+        (target / "pack.toml").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks not available")
+
+    result = _step_integration_validation(tmp_path, None, "selected", tmp_path)
+
+    assert any(
+        item.code == "CAT-V-019"
+        and item.pack == "target"
+        and "cannot be read safely" in item.message
+        for item in result
+    )
+
+
 # ── Pipeline-level tests (verify_catalogue wiring) ────────────────────────────
 # These tests drive verify_catalogue() directly to confirm step 19 is wired
 # into the pipeline. Deleting or un-registering the step would leave the unit

--- a/packages/agentbundle/tests/unit/test_dependencies_batch.py
+++ b/packages/agentbundle/tests/unit/test_dependencies_batch.py
@@ -67,7 +67,7 @@ def test_default_call_without_batch_is_unchanged_behavior():
 def test_dep_in_state_still_satisfies_with_batch_param():
     state = State(packs={
         ("core", "claude-code"): PackState(
-            installed_version="0.4.9", scope="repo", adapter="claude-code"
+            installed_version="0.1.9", scope="repo", adapter="claude-code"
         ),
     })
     validate_dependencies_required(
@@ -105,7 +105,11 @@ def test_batch_param_does_not_bypass_grammar_check():
             "version": "0.1.0",
             "dependencies": {
                 "required": [
-                    {"catalogue": "agent-ready-repo", "pack": "core", "version": "0.1"}
+                    {
+                        "catalogue": "agent-ready-repo",
+                        "pack": "core",
+                        "version": "not-a-version",
+                    }
                 ]
             },
         }

--- a/packs/figma/.claude-plugin/plugin.json
+++ b/packs/figma/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "figma",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Paste a Figma share URL and the agent can read the file. It pulls nodes, variables, and version history, renders frames as images, leaves comments, and turns a FigJam connector graph into Mermaid."
 }

--- a/packs/figma/pack.toml
+++ b/packs/figma/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "figma"
-version = "0.3.1"
+version = "0.3.2"
 description = "Paste a Figma share URL and the agent can read the file. It pulls nodes, variables, and version history, renders frames as images, leaves comments, and turns a FigJam connector graph into Mermaid."
 readme = "README.md"
 display_name = "Figma"
@@ -19,7 +19,7 @@ version = "0.8"
 [[pack.dependencies.required]]
 catalogue = "agent-ready-repo"
 pack = "credential-brokers"
-version = "^0.2"
+version = "^0.3"
 
 [pack.install]
 default-scope = "user"

--- a/packs/iac-terraform/.claude-plugin/plugin.json
+++ b/packs/iac-terraform/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "iac-terraform",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Describe the infrastructure you want; get Terraform you would be willing to review. Cloud-agnostic, gated on a written decision, and it stops at the plan \u2014 applying is still yours."
 }

--- a/packs/iac-terraform/pack.toml
+++ b/packs/iac-terraform/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "iac-terraform"
-version = "0.1.6"
+version = "0.1.7"
 description = "Describe the infrastructure you want; get Terraform you would be willing to review. Cloud-agnostic, gated on a written decision, and it stops at the plan — applying is still yours."
 readme = "README.md"
 display_name = "IaC (Terraform)"
@@ -25,11 +25,9 @@ version = "^2.0"
 [[pack.dependencies.required]]
 catalogue = "agent-ready-repo"
 pack = "governance-extras"
-# Same-PR dependency: this PR adds the governance-index template + `new-adr` infra
-# mode + the extension-contract convention to governance-extras, so pin the NEW
-# minor those land in (bump governance-extras in the same PR) — never a range that
-# can resolve to a version predating them.
-version = "^0.6"
+# Requires the governance-index template, `new-adr` infrastructure mode, and
+# extension-contract convention introduced in governance-extras 0.9.
+version = "^0.9"
 
 [pack.links]
 homepage = "https://github.com/eugenelim/agent-ready-repo"

--- a/packs/linear/.claude-plugin/plugin.json
+++ b/packs/linear/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "linear",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Read Linear work into the shared content-based repository intake route, with a separate approved delta sync for existing briefs."
 }

--- a/packs/linear/pack.toml
+++ b/packs/linear/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "linear"
-version = "0.2.3"
+version = "0.2.4"
 description = "Read Linear work into the shared content-based repository intake route, with a separate approved delta sync for existing briefs."
 readme = "README.md"
 display_name = "Linear"
@@ -19,7 +19,7 @@ version = "0.8"
 [[pack.dependencies.required]]
 catalogue = "agent-ready-repo"
 pack = "credential-brokers"
-version = "^0.2"
+version = "^0.3"
 
 [pack.install]
 default-scope = "user"

--- a/tests/roster/test_shipped_pack_manifests.py
+++ b/tests/roster/test_shipped_pack_manifests.py
@@ -33,14 +33,15 @@ CORE_DEP_PACKS = ("governance-extras", "monorepo-extras")
 # Every pack shipping a `credentialed: true` skill declares a required dep on
 # `credential-brokers` — the pack that ships the `credbroker` floor and the
 # `sso-broker.py` engine. Ranges differ by need: `atlassian` needs the exit-4
-# `refresh` contract that landed in 0.3.0; the others only need the broker to
-# exist. `credential-brokers` itself is absent because it ships
+# `refresh` contract that landed in 0.3.0. Zero-major caret ranges do not cross
+# a minor boundary, so every current consumer must declare the shipped 0.3 line.
+# `credential-brokers` itself is absent because it ships
 # `credential-setup` (`credentialed: true`) and cannot depend on itself, and
 # `github` because it shells out to `gh`, which owns its own credential chain.
 CREDENTIALED_PACK_BROKER_RANGE = {
     "atlassian": "^0.3",
-    "figma": "^0.2",
-    "linear": "^0.2",
+    "figma": "^0.3",
+    "linear": "^0.3",
 }
 
 
@@ -114,11 +115,11 @@ def test_credentialed_packs_require_credential_brokers(pack_name, expected_range
 def test_the_install_gate_refuses_without_the_broker_and_admits_it_with(pack_name):
     """Drive the real resolver, not a second implementation of its rules.
 
-    `verify.py`'s dependency step is a pass-through, so an unsatisfiable range —
-    declaring `^0.3` while the pack ships `0.2.2` — surfaces only when an
-    adopter tries to install. Re-deriving caret-minor semantics here would be a
-    second copy of the rule this test exists to protect, free to drift from the
-    resolver without either side going red.
+    Every credentialed consumer declares the shipped 0.3 broker line, and the
+    real install resolver must admit that installed broker version. Re-deriving
+    caret-minor semantics here would be a second copy of the rule this test
+    exists to protect, free to drift from the resolver without either side
+    going red.
     """
     from agentbundle.commands.install import validate_dependencies_required
     from agentbundle.config import PackState, State

--- a/tools/catalogue/tests/test_verify_host_checks.py
+++ b/tools/catalogue/tests/test_verify_host_checks.py
@@ -1,0 +1,248 @@
+"""Tests for the repository-local catalogue leak checker."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+TOOLS = Path(__file__).resolve().parents[2]
+REPO = TOOLS.parent
+sys.path.insert(0, str(TOOLS / "catalogue"))
+sys.path.insert(0, str(TOOLS / "repo"))
+
+import build_gate_chain  # noqa: E402
+import verify_host_checks  # noqa: E402
+
+
+class HostCheckFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self._temporary.name)
+        (self.root / "packs").mkdir()
+
+    def tearDown(self) -> None:
+        self._temporary.cleanup()
+
+    def write_seed(
+        self,
+        content: str | bytes,
+        relative_path: str = "AGENTS.md",
+    ) -> Path:
+        pack = self.root / "packs" / "seed-test-pack"
+        (pack / "seeds").mkdir(parents=True, exist_ok=True)
+        (pack / "pack.toml").write_text(
+            '[pack]\nname = "seed-test-pack"\nversion = "0.1.0"\nlint-seeds = true\n',
+            encoding="utf-8",
+        )
+        target = pack / "seeds" / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content, encoding="utf-8")
+        return target
+
+    def write_apm(self, content: str) -> Path:
+        target = self.root / "packs" / "core" / ".apm" / "skills" / "test" / "SKILL.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        return target
+
+    def run_check(self) -> tuple[int, str]:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            result = verify_host_checks.main(["--root", str(self.root)])
+        return result, stderr.getvalue()
+
+
+class TestHostCheckDetectsPattern(HostCheckFixture):
+    def test_seed_patterns_are_detected(self) -> None:
+        for trigger in (
+            "agent-ready-repo",
+            "RFC-0042",
+            "K-0003",
+            "distribution-adapters",
+        ):
+            with self.subTest(trigger=trigger):
+                self.write_seed(
+                    f"# AGENTS.md\nA monorepo for `<project-name>` — contains {trigger}\n"
+                )
+                result, stderr = self.run_check()
+                self.assertEqual(result, 1)
+                self.assertIn("leaked", stderr)
+
+    def test_non_markdown_seed_patterns_are_detected(self) -> None:
+        self.write_seed(
+            'description = "copied from agent-ready-repo"\n',
+            "workspace.toml",
+        )
+
+        result, stderr = self.run_check()
+
+        self.assertEqual(result, 1)
+        self.assertIn("packs/seed-test-pack/seeds/workspace.toml:1", stderr)
+        self.assertIn("leaked catalogue name", stderr)
+
+    def test_core_apm_patterns_are_detected(self) -> None:
+        for trigger in ("agent-ready-repo", "RFC-0042", "K-0003"):
+            with self.subTest(trigger=trigger):
+                self.write_apm(trigger)
+                result, stderr = self.run_check()
+                self.assertEqual(result, 1)
+                self.assertIn("packs/core/.apm/skills", stderr)
+
+    def test_other_pack_apm_is_outside_the_host_scope(self) -> None:
+        target = self.root / "packs" / "other" / ".apm" / "skills" / "test" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("agent-ready-repo", encoding="utf-8")
+        result, _ = self.run_check()
+        self.assertEqual(result, 0)
+
+
+class TestSeedExemptions(HostCheckFixture):
+    def test_fenced_content_is_exempt(self) -> None:
+        self.write_seed("# AGENTS.md\n<project-name>\n```\nagent-ready-repo\n```\n")
+        result, stderr = self.run_check()
+        self.assertEqual(result, 0, stderr)
+
+    def test_sentinel_exempts_next_content_line(self) -> None:
+        self.write_seed(
+            "# AGENTS.md\n<project-name>\n"
+            "<!-- seed-content-lint-ignore: example -->\n"
+            "[RFC-0013](rfc/0013-example.md)\n"
+        )
+        result, stderr = self.run_check()
+        self.assertEqual(result, 0, stderr)
+
+
+class TestHostCheckFilesystemSafety(HostCheckFixture):
+    def test_dangling_packs_root_is_refused(self) -> None:
+        packs = self.root / "packs"
+        packs.rmdir()
+        try:
+            packs.symlink_to("missing-packs", target_is_directory=True)
+        except OSError:
+            self.skipTest("symlinks not available")
+
+        result, stderr = self.run_check()
+
+        self.assertEqual(result, 1)
+        self.assertIn("not a real directory", stderr)
+
+    def test_linked_pack_is_refused(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        try:
+            (self.root / "packs" / "linked").symlink_to(outside)
+        except OSError:
+            self.skipTest("symlinks not available")
+        result, stderr = self.run_check()
+        self.assertEqual(result, 1)
+        self.assertIn("linked pack", stderr)
+
+    def test_linked_skill_root_is_refused(self) -> None:
+        core = self.root / "packs" / "core"
+        core.mkdir()
+        outside = self.root / "outside"
+        outside.mkdir()
+        try:
+            (core / ".apm").symlink_to(outside)
+        except OSError:
+            self.skipTest("symlinks not available")
+        result, stderr = self.run_check()
+        self.assertEqual(result, 1)
+        self.assertIn("not a real directory", stderr)
+
+    def test_dangling_manifest_is_refused(self) -> None:
+        pack = self.root / "packs" / "seed-test-pack"
+        pack.mkdir()
+        try:
+            (pack / "pack.toml").symlink_to("missing.toml")
+        except OSError:
+            self.skipTest("symlinks not available")
+
+        result, stderr = self.run_check()
+
+        self.assertEqual(result, 1)
+        self.assertIn("not a regular file", stderr)
+
+    def test_dangling_seed_root_is_refused(self) -> None:
+        pack = self.root / "packs" / "seed-test-pack"
+        pack.mkdir()
+        (pack / "pack.toml").write_text(
+            '[pack]\nname = "seed-test-pack"\nversion = "0.1.0"\nlint-seeds = true\n',
+            encoding="utf-8",
+        )
+        try:
+            (pack / "seeds").symlink_to("missing-seeds", target_is_directory=True)
+        except OSError:
+            self.skipTest("symlinks not available")
+
+        result, stderr = self.run_check()
+
+        self.assertEqual(result, 1)
+        self.assertIn("not a real directory", stderr)
+
+    def test_hardlinked_seed_is_refused(self) -> None:
+        target = self.write_seed("# AGENTS.md\n<project-name>\n")
+        alias = target.with_name("ALIAS.md")
+        try:
+            os.link(target, alias)
+        except OSError:
+            self.skipTest("hard links not available")
+        result, stderr = self.run_check()
+        self.assertEqual(result, 1)
+        self.assertIn("hard link", stderr)
+
+    def test_invalid_utf8_is_refused(self) -> None:
+        self.write_seed(b"\xff\xfe")
+        result, stderr = self.run_check()
+        self.assertEqual(result, 1)
+        self.assertIn("invalid UTF-8", stderr)
+
+    def test_junction_like_directory_is_refused_before_traversal(self) -> None:
+        seed_root = self.root / "packs" / "seed-test-pack" / "seeds"
+        seed_root.mkdir(parents=True)
+        (self.root / "packs" / "seed-test-pack" / "pack.toml").write_text(
+            '[pack]\nname = "seed-test-pack"\nversion = "0.1.0"\nlint-seeds = true\n',
+            encoding="utf-8",
+        )
+        junction = seed_root / "junction"
+        junction.mkdir()
+        with mock.patch.object(
+            verify_host_checks,
+            "_path_is_junction",
+            side_effect=lambda path: path.name == "junction",
+        ):
+            result, stderr = self.run_check()
+        self.assertEqual(result, 1)
+        self.assertIn("linked entry", stderr)
+
+
+class TestGateChainWiring(unittest.TestCase):
+    def test_checker_and_its_tests_are_runtime_steps(self) -> None:
+        seen: list[list[str]] = []
+
+        def fake_run(argv, check=False, env=None, cwd=None, **kwargs):
+            seen.append(list(argv))
+            return mock.Mock(returncode=0, stdout="t::a\n" * 200, stderr="")
+
+        with mock.patch.object(build_gate_chain.subprocess, "run", fake_run):
+            result = build_gate_chain.build_check(
+                argparse.Namespace(packs_dir="packs", output_dir="dist")
+            )
+        self.assertEqual(result, 0)
+        rendered = [" ".join(argv) for argv in seen]
+        self.assertTrue(any("test_verify_host_checks.py" in argv for argv in rendered))
+        self.assertTrue(any("verify_host_checks.py" in argv for argv in rendered))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/catalogue/verify_host_checks.py
+++ b/tools/catalogue/verify_host_checks.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Run repository-specific catalogue leak checks outside AgentBundle."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import stat
+import sys
+import tomllib
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_APM_PATTERNS = (
+    (re.compile(r"agent-ready-repo"), "catalogue name 'agent-ready-repo'"),
+    (re.compile(r"RFC-00\d\d"), "catalogue RFC reference (RFC-NNNN)"),
+    (re.compile(r"K-00\d\d"), "catalogue knowledge entry (K-NNNN)"),
+)
+_SEED_PATTERNS = (
+    *_APM_PATTERNS,
+    (
+        re.compile(
+            r"\b(distribution-adapters|self-hosting|agent-spec-cli|"
+            r"user-scope-hooks|converters-pack|claude-plugins-install-route|"
+            r"codex-native-skills|apm-install-route-parity|skill-secrets|"
+            r"wire-session-start-hook|kiro-ide-hook|windows-ci-bundler|"
+            r"windows-hooks-phase3)\b"
+        ),
+        "catalogue spec name",
+    ),
+)
+_SENTINEL_RE = re.compile(
+    r"^\s*<!--\s*seed-content-lint-ignore:\s*([^>]+?)\s*-->\s*$"
+)
+
+
+class UnsafeTreeError(ValueError):
+    """A scanned entry cannot be proven to be a confined regular file."""
+
+
+def _path_is_junction(path: Path) -> bool:
+    """Return whether *path* is a Windows junction, failing closed on errors."""
+    checker = getattr(path, "is_junction", None)
+    if checker is None:
+        return False
+    try:
+        return bool(checker())
+    except OSError:
+        return True
+
+
+def _relative(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return "<outside-root>"
+
+
+def _entry_present(root: Path, path: Path, label: str) -> bool:
+    """Return presence without following links; fail closed on inspection errors."""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise UnsafeTreeError(
+            f"cannot inspect {label}: {_relative(root, path)}"
+        ) from exc
+    return True
+
+
+def _read_confined_utf8(root: Path, path: Path) -> str:
+    """Read one confined single-link regular file without following links."""
+    relative = _relative(root, path)
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise UnsafeTreeError(f"cannot inspect {relative}") from exc
+    if not stat.S_ISREG(before.st_mode):
+        raise UnsafeTreeError(f"not a regular file: {relative}")
+    if before.st_nlink > 1:
+        raise UnsafeTreeError(f"hard link not allowed: {relative}")
+    try:
+        path.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise UnsafeTreeError(f"path escapes its scan root: {relative}") from exc
+
+    flags = os.O_RDONLY
+    for name in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
+        flags |= getattr(os, name, 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise UnsafeTreeError(f"cannot open safely: {relative}") from exc
+    try:
+        after = os.fstat(descriptor)
+        if not stat.S_ISREG(after.st_mode):
+            raise UnsafeTreeError(f"not a regular file: {relative}")
+        if after.st_nlink > 1:
+            raise UnsafeTreeError(f"hard link not allowed: {relative}")
+        if (before.st_dev, before.st_ino) != (after.st_dev, after.st_ino):
+            raise UnsafeTreeError(f"file changed while opening: {relative}")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            raw = handle.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise UnsafeTreeError(f"invalid UTF-8: {relative}") from exc
+
+
+def _require_real_directory(root: Path, path: Path) -> None:
+    relative = _relative(root, path)
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise UnsafeTreeError(f"cannot inspect directory: {relative}") from exc
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or _path_is_junction(path)
+        or not stat.S_ISDIR(metadata.st_mode)
+    ):
+        raise UnsafeTreeError(f"not a real directory: {relative}")
+    try:
+        path.resolve(strict=True).relative_to(root.resolve(strict=True))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise UnsafeTreeError(f"directory escapes repository root: {relative}") from exc
+
+
+def _walk_files(repository_root: Path, scan_root: Path) -> list[Path]:
+    """Return confined files beneath *scan_root*, refusing linked traversal."""
+    _require_real_directory(repository_root, scan_root)
+    files: list[Path] = []
+    pending = [scan_root]
+    while pending:
+        directory = pending.pop()
+        try:
+            entries = sorted(os.scandir(directory), key=lambda entry: entry.name)
+        except OSError as exc:
+            raise UnsafeTreeError(
+                f"cannot enumerate directory: {_relative(repository_root, directory)}"
+            ) from exc
+        for entry in entries:
+            path = Path(entry.path)
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError as exc:
+                raise UnsafeTreeError(
+                    f"cannot inspect entry: {_relative(repository_root, path)}"
+                ) from exc
+            if stat.S_ISLNK(metadata.st_mode) or _path_is_junction(path):
+                raise UnsafeTreeError(
+                    f"linked entry not allowed: {_relative(repository_root, path)}"
+                )
+            if stat.S_ISDIR(metadata.st_mode):
+                pending.append(path)
+            elif stat.S_ISREG(metadata.st_mode):
+                files.append(path)
+            else:
+                raise UnsafeTreeError(
+                    f"special entry not allowed: {_relative(repository_root, path)}"
+                )
+    return sorted(files)
+
+
+def _scan_lines(
+    repository_root: Path,
+    scan_root: Path,
+    patterns: tuple[tuple[re.Pattern[str], str], ...],
+    *,
+    markdown_only: bool,
+    seed_exemptions: bool,
+) -> list[str]:
+    """Scan eligible UTF-8 files without weakening tree-safety checks."""
+    findings: list[str] = []
+    for path in _walk_files(repository_root, scan_root):
+        if markdown_only and path.suffix.lower() != ".md":
+            continue
+        text = _read_confined_utf8(scan_root, path)
+        in_fence = False
+        ignore_next_content = False
+        for line_number, line in enumerate(text.splitlines(), 1):
+            stripped = line.strip()
+            if seed_exemptions and stripped.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if seed_exemptions and _SENTINEL_RE.fullmatch(line):
+                ignore_next_content = True
+                continue
+            if seed_exemptions and (in_fence or not stripped):
+                continue
+            if seed_exemptions and ignore_next_content:
+                ignore_next_content = False
+                continue
+            for pattern, label in patterns:
+                if pattern.search(line):
+                    findings.append(
+                        f"{_relative(repository_root, path)}:{line_number}: leaked {label}"
+                    )
+    return findings
+
+
+def verify_host_checks(root: Path) -> list[str]:
+    """Return host-policy findings for *root*."""
+    root = root.resolve(strict=True)
+    findings: list[str] = []
+    packs_root = root / "packs"
+    try:
+        if not _entry_present(root, packs_root, "packs root"):
+            return findings
+        _require_real_directory(root, packs_root)
+        for entry in sorted(os.scandir(packs_root), key=lambda item: item.name):
+            pack_dir = Path(entry.path)
+            metadata = entry.stat(follow_symlinks=False)
+            if stat.S_ISLNK(metadata.st_mode) or _path_is_junction(pack_dir):
+                raise UnsafeTreeError(f"linked pack not allowed: {_relative(root, pack_dir)}")
+            if not stat.S_ISDIR(metadata.st_mode) or entry.name.startswith("_"):
+                continue
+            manifest = pack_dir / "pack.toml"
+            if not _entry_present(root, manifest, "manifest"):
+                continue
+            contract = tomllib.loads(_read_confined_utf8(pack_dir, manifest))
+            pack_table = contract.get("pack", {})
+            if not isinstance(pack_table, dict) or pack_table.get("lint-seeds") is not True:
+                continue
+            seeds = pack_dir / "seeds"
+            if _entry_present(root, seeds, "seed root"):
+                findings.extend(
+                    _scan_lines(
+                        root,
+                        seeds,
+                        _SEED_PATTERNS,
+                        markdown_only=False,
+                        seed_exemptions=True,
+                    )
+                )
+
+        core = packs_root / "core"
+        apm = core / ".apm"
+        apm_skills = apm / "skills"
+        if _entry_present(root, apm, "core .apm root"):
+            _require_real_directory(root, core)
+            _require_real_directory(root, apm)
+        if _entry_present(root, apm_skills, "core skills root"):
+            _require_real_directory(root, apm_skills)
+            findings.extend(
+                _scan_lines(
+                    root,
+                    apm_skills,
+                    _APM_PATTERNS,
+                    markdown_only=True,
+                    seed_exemptions=False,
+                )
+            )
+    except (OSError, RuntimeError, tomllib.TOMLDecodeError, UnsafeTreeError) as exc:
+        findings.append(f"unsafe catalogue tree: {exc}")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args(argv)
+    try:
+        findings = verify_host_checks(args.root)
+    except (OSError, RuntimeError) as exc:
+        findings = [f"cannot inspect catalogue root: {exc}"]
+    for finding in findings:
+        print(f"host catalogue check: {finding}", file=sys.stderr)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -266,6 +266,14 @@ def build_check(args: argparse.Namespace) -> int:
             "test-workspace-status-cli",
             "tools", "test_workspace_status_cli.py",
         ),
+        _pytest_step(
+            "test-verify-host-checks",
+            "tools", "catalogue", "tests", "test_verify_host_checks.py",
+        ),
+        _script_step(
+            "verify-host-checks",
+            "tools", "catalogue", "verify_host_checks.py",
+        ),
         # Repo-own lints that build-check.yml ran and no local chain did, so a
         # green `make ci` said nothing about them (spec/local-gate-ci-parity).
         # Both default to `--root .` (the guard also to `--base origin/main`),

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -478,6 +478,8 @@ EXPECTED_SCRIPT_STEPS = [
     ".claude/skills/work-loop/scripts/lint-traceability.py",
     "tools/test_workspace_status.py",
     "tools/test_workspace_status_cli.py",
+    "tools/catalogue/tests/test_verify_host_checks.py",
+    "tools/catalogue/verify_host_checks.py",
     "tools/test-lint-catalogue-curation-guard.py",
     "tools/lint-catalogue-curation-guard.py",
     "tools/test-lint-experience-agnostic.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -653,6 +653,42 @@ open = [
   # lock acquire or a filesystem walk, not git) and either speed it up or raise
   # script_seconds for capture.
   {slug = "project-knowledge-capture-times-out", source = "spec/ci-gate-parallelization Capture learnings"},
+
+  # Pre-flight 2026-08-16: the managed enterprise runtime blocks two classes of
+  # package-suite fixture setup. First, pip/ensurepip cannot create its temporary
+  # trust-store CA file:
+  # test_credentials_wheel.py::test_agentbundle_credentials_is_removed_from_installed_wheel
+  # and test_editable_source_detection.py::test_editable_detection_against_real_install.
+  # Second, protected key-material globs (*.pem and *.key) cannot be read even under
+  # approved temporary roots. Affected files:
+  # integration/test_trust_fallback_tls.py, unit/test_system_trust.py, and
+  # unit/test_https_catalogue.py::test_build_opener_custom_ca_bundle.
+  # These failures reproduce outside this initiative's diff and occur before the
+  # behavior under test. Fix: run the full suite in CI or a managed profile that
+  # permits both isolated fixture classes; do not weaken production credential policy.
+  # Unblocks when: that supported verification environment is available.
+  {slug = "pre-existing-enterprise-agentbundle-full-suite", source = "pre-flight/2026-08-16"},
+
+  # Security review 2026-08-17: validate_dependencies_required() has always
+  # satisfied required dependencies by installed pack name + version only.
+  # PackState records a credential-free source URI, while dependency entries
+  # declare a logical catalogue name; no canonical mapping currently proves
+  # those identities match. A same-name pack from another source can therefore
+  # satisfy the gate. Fix: define and persist a canonical catalogue identity on
+  # installed rows, migrate existing state, then require identity + name + range
+  # before writes. Files: commands/install.py, config.py, state migrations/tests.
+  # Unblocks when: the provenance contract and migration ship through a new spec.
+  {slug = "pre-existing-install-dependency-source-provenance", source = "pre-flight/2026-08-17"},
+
+  # Security review 2026-08-17: catalogue verify step 3 predates the verifier
+  # correctness initiative and returns no diagnostic when its validator import
+  # or bundled pack.schema.json load fails, presenting an unperformed schema
+  # check as clean. Fix: make validator/resource unavailability a bounded
+  # CAT-V-003 error and add wheel/zipapp failure-path tests. File:
+  # packages/agentbundle/agentbundle/catalogue_tooling/verify.py::_step_pack_schema.
+  # Unblocks when: a step-3 behavior-change spec defines the public diagnostic.
+  {slug = "pre-existing-pack-schema-validator-fail-open", source = "pre-flight/2026-08-17"},
+
   # The publish job's environment gate asks a human to release executable plugin
   # code adopters install, but GitHub's approval UI shows only the environment
   # name and a comment box — nothing about what is being published. A summary
@@ -2327,7 +2363,8 @@ backlog = []
 
 ["ini-007".work]
 active  = [
-
+]
+shipped = [
   # Catalogue verifier correctness. Independent (no unsatisfied predecessor). Gated on
   # Wave 2 (already shipped). Serialized AFTER Wave 3 to avoid concurrent agentbundle
   # version-bump conflicts (both Wave 3 and verifier-correctness bump the agentbundle
@@ -2351,8 +2388,6 @@ active  = [
   # Wave 3's need uses its canonical path: `work:` needs match shipped entry paths by
   # exact string, and Wave 3 is registered (and will ship) under the canonical form.
   {path = "docs/specs/catalogue-verifier-correctness/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "catalogue-verifier-correctness", needs = [{type = "local", kind = "spec", path = "docs/specs/catalogue-wave2-pack-integrations/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/catalogue-wave3-enterprise-authoring-discovery/spec.md"}]},
-]
-shipped = [
   {path = "docs/specs/governance-guides-cleanup/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Governance guide reference cleanup", needs = []},
   {path = "docs/specs/catalogue-verify-classification/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "catalogue verify classification", needs = []},
   {path = "docs/specs/pack-test-boundary-remaining-packs/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "pack-test-boundary-remaining-packs", needs = []},


### PR DESCRIPTION
## What does this change?

  Completes all 19 advertised `agentbundle catalogue verify` checks, replacing
  silent stubs and correcting configuration, plugin, marketplace, profile,
  dependency, adapter, output-drift, package-preflight, and fixture validation.
  It also unifies npm-compatible dependency ranges across verify, lint, and
  install; moves repository-only policy into local build gates; adds external-
  catalogue coverage; and updates the 0.37.2 changelog and PyPI README.

  ## Why?

  The portable verifier had 13 confirmed defects across 11 steps, allowing
  incomplete verification to appear successful and applying host-specific policy
  to external catalogues.

  - Spec: [`docs/specs/catalogue-verifier-correctness/spec.md`](docs/specs/
  catalogue-verifier-correctness/spec.md)
  - Plan: [`docs/specs/catalogue-verifier-correctness/plan.md`](docs/specs/
  catalogue-verifier-correctness/plan.md)
  - RFC: [`docs/rfc/0076-catalogue-contracts-composition-semantics-
  discovery.md`](docs/rfc/0076-catalogue-contracts-composition-semantics-
  discovery.md)

  ## How do I verify it?

  ```bash
  SKIP_SAST=1 make build-check

  python3 -m pytest \
    packages/agentbundle/tests/integration/test_catalogue_verify_*.py \
    packages/agentbundle/tests/unit/test_catalogue_tooling_*.py \
    tools/catalogue/tests/test_verify_host_checks.py \
    -q

  env PYTHONPATH=packages/agentbundle \
    python3 -m agentbundle catalogue verify --root .

  make lint-ruff
  make lint-mypy

  The focused verifier, installer, and host-policy tests pass. Ruff, mypy,
  Bandit, catalogue verification, and the non-SAST build gate are clean.

  ## What did you not change that you considered?

  - No new verifier flags, exit codes, output formats, or step numbers.
  - No Wave 4 indexing, JOURNEY.md semantics, or other new verification steps.
  - No weakening of credential or key-material policy to make environment-
    blocked tests pass.

  - Dependency source provenance remains deferred as pre-existing-install-
    dependency-source-provenance; it requires a canonical identity and state-
    migration contract.

  - Step 3 validator/resource fail-closed behavior remains deferred as pre-
    existing-pack-schema-validator-fail-open; changing its public diagnostic
    requires a separate behavior-change spec.