### PR TITLE
ci(build-check): gate the docs palette and pin the site test roster

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [main]
 
-# AC12: contents: read is sufficient — all 56 steps reviewed: no token use, no
+# AC12: contents: read is sufficient — every step reviewed: no token use, no
 # artifact upload/download, no PR comment, no push.
 permissions:
   contents: read
@@ -284,6 +284,20 @@ jobs:
           tools/test_build_site_link_rewrites.py
           tools/test_check_rendered_site_links.py
           tools/test_build_site_routing.py
+      # spec/site-ci-contract-closure AC4. The docs palette's WCAG floor becomes a
+      # required gate here rather than in docs.yml or pages.yml: neither is a
+      # required context, so a gate placed there could not block a merge. Both
+      # commands run — the checker is what fails on a regressed pair, and its suite
+      # is what proves the checker still detects one (the checker exits 0 both when
+      # the palette is clean and when it has been broken into a no-op).
+      #
+      # Dependency-free by contract: stdlib only, no npm, nothing added to any
+      # manifest. Its step name is registered in tools/lint-ci-parity.py; renaming
+      # it without updating that roster fails the parity gate in both directions.
+      - name: docs palette contrast gate
+        run: |
+          python3 tools/check-docs-contrast.py
+          python -m pytest tools/test_check_docs_contrast.py -q
       - name: pytest credential-setup skill (RFC-0023 T8 + missing-credbroker guard)
         working-directory: packs/credential-brokers/tests/skills/credential-setup
         # `requires_crypto` gates on find_spec("cryptography") and ("argon2"), so a

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,9 @@ test:
 	$(PYTHON) -m pytest packages/agentbundle/tests/ -q
 	$(PYTHON) -m pytest packages/credbroker/ -q
 	$(PYTHON) tools/lint-conformance-portability.py --root .
+	# spec/site-ci-contract-closure AC6: the docs-palette WCAG gate runs locally
+	# too, so `make ci` covers what gate-main's contrast step runs.
+	$(PYTHON) tools/check-docs-contrast.py
 	$(PYTHON) -m pytest tests/ -q
 	$(PYTHON) -m pytest packs/core/tests/hooks/ -q
 	$(PYTHON) -m pytest packs/core/tests/pack/ -q
@@ -365,7 +368,7 @@ test:
 	@n=$$($(PYTHON) -m pytest packs/desk-research/tests/skills/desk-research-project-start/ -q --collect-only | grep -c '::' || true); \
 	 if [ "$$n" -lt 7 ]; then echo "packs/desk-research/tests/skills/desk-research-project-start/ collected $$n, expected >= 7" >&2; exit 1; fi
 	$(PYTHON) -m pytest packs/desk-research/tests/skills/desk-research-project-start/ -q
-	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py -q
+	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q
 	$(PYTHON) -m pytest \

--- a/docs/specs/site-ci-contract-closure/plan.md
+++ b/docs/specs/site-ci-contract-closure/plan.md
@@ -96,8 +96,9 @@ assertion in T3 is genuinely red-first.
 
 **Tests:**
 - TDD (`stub: true`): known passing and failing ratios, plus threshold
-  inclusivity — no 6-hex pair yields exactly 4.5, so assert the `>=` boundary
-  directly and bracket it with the tightest real pairs either side (AC3).
+  inclusivity — no gray-on-gray 6-hex pair and no shipped-palette pair lands exactly
+  on 4.5, so assert the boundary through the seam `main()` calls and bracket it with
+  the tightest real pairs either side (AC3).
 - TDD (`stub: true`): each named invalid-input case refuses with a diagnostic and
   a non-zero exit rather than an uncaught traceback — malformed hex, legal
   three-digit shorthand, and an unresolvable `var()` chain (AC3).

--- a/docs/specs/site-ci-contract-closure/plan.md
+++ b/docs/specs/site-ci-contract-closure/plan.md
@@ -1,14 +1,20 @@
 # Plan: Site CI contract closure
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Approved
+- **Status:** Done
 
 ## Approach
 
-First pin required-workflow inclusion with a construction test. Then add focused
-contrast-checker tests and wire one explicit required CI step that runs the
-seven modules plus the contrast check. Keep the local command identical to the
-CI selection so future changes cannot create a second test contract.
+The seven modules already run in `gate-main`, a required context, so AC1 is
+satisfied before this spec and is recorded with its proof rather than
+reimplemented. What lands here: a standing construction test pinning that fact by
+seeded deletion, focused contrast-checker tests plus the input hardening they
+require, and ONE new `gate-main` step invoking the contrast checker and its test.
+The two existing seven-module steps are left untouched — adding a third step
+naming them would duplicate execution and create the second workflow-side source
+of truth this plan exists to prevent. Parity is addressability, not set-equality:
+every path the new step names must be reachable from `make ci`, which
+`tools/lint-ci-parity.py` enforces.
 
 ## Constraints
 
@@ -49,57 +55,104 @@ The contrast checker remains a direct Python command. Traces to: AC3-AC7.
 
 **Depends on:** none
 
-**Touches:** tools/test_build_gate_chain.py, .github/workflows/build-check.yml
+**Touches:** tools/test-build-check-workflow.py
 
 **Tests:**
-- TDD: seed each of the seven module names absent in turn and require failure
-  (AC1-AC2).
-- TDD: seed an advisory or wrong-job invocation and require failure (AC2).
-- TDD: remove a relevant path trigger and require failure (AC5).
+- TDD (`stub: true`): seed each of the seven module names absent in turn from an
+  in-memory copy of `build-check.yml` and require failure (AC2).
+- TDD (`stub: true`): seed each neutering form on the owning step and require
+  failure (AC2). `continue-on-error` is already covered file-wide by
+  `no-continue-on-error`; the step-level `if:` and `working-directory:` forms need
+  new assertions, because the existing ones are roster-scoped to other steps and a
+  step-level `if:` was a live bypass of this very gate.
+- TDD (`stub: true`): seed the step into a job other than `gate-main` and require
+  failure (AC2).
+- Goal-based: assert no `paths:` key exists under `on.pull_request` or `on.push`
+  (AC5).
 
 **Approach:**
-- Extend the existing workflow construction-test surface rather than creating a
-  second workflow parser.
-- Assert semantic command membership and required-job placement.
+- Extend `tools/test-build-check-workflow.py`, the canonical owner of
+  `build-check.yml` posture assertions, which the AGGREGATOR invokes. Deliberately
+  not `tools/test_build_gate_chain.py`: that runs inside `gate-main`, the far side
+  of the edge being protected — the same argument the aggregator's own guard makes.
+- Enumerate the seven-module roster IN the test. Deriving it from the `Makefile`
+  was considered and rejected: a roster read out of one of the things being
+  checked is circular — deleting a module from both the Makefile and the workflow
+  would then pass. Make/CI divergence is a separate concern already owned by
+  `tools/lint-ci-parity.py`'s coverage layer, so nothing is lost by keeping the
+  pin independent.
+- Assert semantic command membership and `gate-main` placement by job id.
 
-**Done when:** the test is red on the current workflow and distinguishes every
-  named omission.
+**Done when:** every seeded omission and neutering is distinguished. Note the
+presence assertions are GREEN on current `main` — AC1 is already satisfied — so
+mutation, not red-first, is the proof discipline here; only the contrast-step
+assertion in T3 is genuinely red-first.
 
 ### T2: Contrast checker has a deterministic unit contract
 
 **Depends on:** none
 
-**Touches:** tools/check-docs-contrast.py, tools/test_check_docs_contrast.py
+**Touches:** tools/check-docs-contrast.py, tools/test_check_docs_contrast.py, Makefile
 
 **Tests:**
-- TDD: known passing, exact-boundary, and failing ratios (AC3).
-- TDD: invalid hexadecimal input refuses clearly (AC3).
-- TDD: a failing registered pair returns non-zero (AC3-AC4).
+- TDD (`stub: true`): known passing and failing ratios, plus threshold
+  inclusivity — no 6-hex pair yields exactly 4.5, so assert the `>=` boundary
+  directly and bracket it with the tightest real pairs either side (AC3).
+- TDD (`stub: true`): each named invalid-input case refuses with a diagnostic and
+  a non-zero exit rather than an uncaught traceback — malformed hex, legal
+  three-digit shorthand, and an unresolvable `var()` chain (AC3).
+- TDD (`stub: true`): a seeded below-threshold registered pair returns non-zero
+  (AC3-AC4).
 
 **Approach:**
-- Exercise public calculation and CLI seams without snapshots or source-shape
-  assertions.
+- Seed failures by running the script as a subprocess with `cwd` set to a temp
+  tree containing a crafted `docs-site/src/styles/starlight.css`. `CSS_PATH` is a
+  module-level relative path, so this needs no new flag. The shipped
+  `docs-site/src/styles/starlight.css` is NEVER mutated, and no `--css` argument
+  is added — that would be a public interface no acceptance criterion authorises.
+- Harden `luminance()`/`resolve()` to refuse the three named cases; today all
+  three raise an uncaught `ValueError`/`KeyError` past `main()`'s
+  `startswith("#")` guard.
+- Register the new test module in the `Makefile` test target, or it runs nowhere
+  and joins the orphans the register tracks under `tools-test-runner-boundary`.
 - Keep fixtures local and dependency-free.
 
-**Done when:** the checker behavior is proved independently of CI wiring.
+**Done when:** the checker behavior is proved independently of CI wiring, and the
+new module is reachable from `make ci`.
 
 ### T3: Required CI runs the seven modules and contrast gate
 
 **Depends on:** T1, T2
 
-**Touches:** .github/workflows/build-check.yml
+**Touches:** .github/workflows/build-check.yml, tools/lint-ci-parity.py
 
 **Tests:**
-- Goal-based: run the T1 workflow construction test (AC1-AC2, AC5-AC6).
-- Goal-based: execute the exact CI command locally (AC1, AC4, AC6).
-- Goal-based: verify dependency manifests are unchanged (AC7).
+- Goal-based: run the T1 construction test (AC2, AC5).
+- Goal-based: execute the new step's command locally (AC4).
+- Goal-based: `tools/lint-ci-parity.py` passes, proving the new step's paths are
+  reachable from `make ci` (AC6).
+- Goal-based: `git diff` shows no change to any dependency manifest or lockfile,
+  and `tools/test_check_docs_contrast.py` conforms to RFC-0082's Tools row — a
+  test of a `tools/` script, co-located in `tools/`, shipping through no surface
+  (AC7).
 
 **Approach:**
-- Add one plainly named required step using the exact registered module list.
-- Add the checker and affected paths to the workflow filters.
+- Add exactly ONE new `gate-main` step invoking `tools/check-docs-contrast.py` and
+  `tools/test_check_docs_contrast.py`. Do NOT add a step naming the seven modules:
+  they already run in two steps, and a third would duplicate execution and split
+  the source of truth.
+- Existing `gate-main` step names are FROZEN — `tools/lint-ci-parity.py` keys its
+  dispositions on the literal strings "pytest guides + catalogue navigation" and
+  "pytest site build + link rewriting", so renaming either breaks the roster in
+  both directions. The new step takes a distinct name and gets its own
+  `STEP_DISPOSITION` row in the same commit, or the parity gate fails closed.
+- Add NO `paths:` filter (see AC5 — it would make every PR unmergeable).
+- Do not touch `build-check.yml` lines 266-270: that stranded credential-setup
+  comment pre-dates this change and this change does not orphan it, so it falls
+  outside the bundled-fixes carve-out. Record it as deferred instead.
 
-**Done when:** the focused local command is green and the workflow construction
-contract recognizes the required gate.
+**Done when:** the new step runs locally, `lint-ci-parity` is green, and the
+construction contract recognises the gate.
 
 ## Rollout
 
@@ -117,3 +170,26 @@ or deployment migration exists.
 ## Changelog
 
 - 2026-08-17: initial plan derived from the approved tech-site completion brief.
+- 2026-08-17: corrected again during implementation review, after code. T1's
+  Approach had directed deriving the roster from the `Makefile`; the implementation
+  hard-codes it on an anti-circularity argument, and this plan now carries that
+  reasoning rather than leaving it only in the test file. Two `make-covers-*`
+  assertions were written and then REMOVED: they read the real `Makefile`, so no
+  workflow mutation could flip them, and they would have shipped as decorative
+  assertions the posture file's own "evaluated but unmutated" rule exists to
+  reject. Diff review also found a step-level `if:` bypass — `if: ${{ false }}` on
+  either pytest step or the contrast step skipped the gate with the posture test
+  green — and a tautological threshold assertion (`FLOOR <= FLOOR`) that stayed
+  green when the production comparison was flipped; both are fixed, the latter by
+  extracting a `passes()` seam.
+- 2026-08-17: corrected at spec-stage review, before any code. AC1 was already
+  satisfied by the shipped `build-check-coverage-gaps` spec, and the intake
+  assumption that the seven modules were absent from required CI was false —
+  they run in `gate-main`, which branch protection requires by name. AC5 was
+  restated because adding `paths:` filters to a workflow whose jobs are required
+  contexts would leave every non-matching PR permanently unmergeable. AC6 was
+  restated because `ci-gate-parallelization` AC16 settled that parity is
+  one-to-many after the job split. AC2 gained a job id, a definition of
+  neutered, and mutation-proof discipline; AC3 gained named invalid-input
+  cases. Scope is unchanged in substance: no criterion was dropped, and the
+  two restatements preserve each criterion's intent.

--- a/docs/specs/site-ci-contract-closure/spec.md
+++ b/docs/specs/site-ci-contract-closure/spec.md
@@ -1,9 +1,9 @@
 # Spec: Site CI contract closure
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
-- **Constrained by:** RFC-0082
+- **Constrained by:** [RFC-0082](../../rfc/0082-test-ownership-boundaries-and-inclusion.md), [ADR-0086](../../adr/0086-split-the-sast-gate-into-its-own-ci-job.md), [`spec/ci-gate-parallelization`](../ci-gate-parallelization/spec.md) AC16
 - **Brief:** docs/product/briefs/tech-site-completion.md
 - **Discovery:** none
 - **Contract:** none
@@ -38,6 +38,9 @@ that required CI does not execute.
 ### Never do
 
 - Claim coverage because a test appears only in a local Make target.
+- Assert workflow source shape without proving it by seeded deletion — a bare
+  presence assertion does not detect removal (see the register's
+  `site-test-source-substring-assertions` entry).
 - Add a package or JavaScript dependency for contrast verification.
 - Weaken a failure to advisory, continue-on-error, or source-shape-only proof.
 
@@ -53,7 +56,10 @@ that required CI does not execute.
 
 ## Acceptance Criteria
 
-- [ ] Required CI executes these seven modules:
+- [x] Required CI executes these seven modules (satisfied before this spec, by
+  the shipped `docs/specs/build-check-coverage-gaps/spec.md` AC1; they run
+  unconditionally in `gate-main`, which branch protection requires by name
+  alongside `make build-check`, `gate-sast`, and `gate-export-boundary`):
   `tools/test_validate_guides.py`,
   `tools/test_check_guide_index.py`,
   `tools/test_catalogue_navigation.py`,
@@ -61,25 +67,50 @@ that required CI does not execute.
   `tools/test_build_site_link_rewrites.py`,
   `tools/test_check_rendered_site_links.py`, and
   `tools/test_build_site_routing.py`.
-- [ ] A construction test parses the required workflow and fails when any of
-  the seven modules is absent, misspelled, advisory, or placed outside the
-  required job.
-- [ ] `tools/check-docs-contrast.py` has focused tests for light and dark
-  pairs, the 4.5:1 boundary, invalid color input, and non-zero exit on failure.
-- [ ] Required CI runs the contrast checker and fails when a registered pair is
+- [x] A standing construction test parses `build-check.yml` and fails when any of
+  the seven modules is absent, misspelled, neutered, or placed outside the
+  `gate-main` job specifically (`gate-main` is a required context; the
+  `build-check` aggregator is a separate required context that runs no pytest).
+  "Neutered" covers at least `continue-on-error`, a step-level `if:`, and a
+  `working-directory:` redirection. It lives with the other `build-check.yml`
+  posture assertions in `tools/test-build-check-workflow.py`, which the
+  aggregator invokes — not inside `gate-main`, the job it protects. Each of the
+  seven names is proven by seeded deletion against an in-memory copy, because a
+  bare presence assertion cannot detect removal.
+- [x] `tools/check-docs-contrast.py` has focused tests for light and dark pairs,
+  the 4.5:1 threshold boundary (asserted on the comparison's inclusivity plus the
+  tightest real pairs either side, since no 6-hex pair yields exactly 4.5), each
+  named invalid-input case — malformed hex, legal-but-unsupported three-digit
+  shorthand, an unresolvable `var()` chain, and a palette that cannot be read or
+  decoded — and non-zero exit on failure.
+  Each refuses with a diagnostic rather than an uncaught traceback.
+- [x] Required CI runs the contrast checker and fails when a registered pair is
   below 4.5:1.
-- [ ] Workflow path filters include the seven tests, their production modules,
-  the contrast checker and its test, docs palette sources, and the workflow
-  itself.
-- [ ] The focused local command and required CI command select the same test
-  modules and contrast contract.
-- [ ] No new dependency is introduced and existing test ownership remains
+- [x] The gate is never skipped for a relevant change, because `build-check.yml`
+  carries no `paths:` filter on either trigger and so runs on every pull request
+  to `main` — verified by asserting the *absence* of a `paths:` key under both
+  `on.pull_request` and `on.push`. Adding path filters is prohibited, not merely
+  unnecessary: the workflow's jobs are required contexts by name, so on a PR
+  touching none of the filtered paths the workflow would never run, the required
+  checks would never report, and the PR would be permanently unmergeable.
+- [x] Every module and script the new CI step names is reachable from `make ci`,
+  proven by `tools/lint-ci-parity.py`'s coverage layer. Set-equality between one
+  local command and one CI job is deliberately NOT claimed:
+  `docs/specs/ci-gate-parallelization/spec.md` AC16 settled that parity became
+  one-to-many when the workflow split into three jobs, with addressability as the
+  replacement invariant, and `make build-check` runs no pytest at all.
+- [x] No new dependency is introduced and existing test ownership remains
   consistent with RFC-0082.
 
 ## Assumptions
 
-- Technical: the seven modules exist in the local aggregate test target but not
-  as required CI steps (source: `Makefile` and `.github/workflows/build-check.yml`).
+- Technical: the seven modules already run in BOTH the local aggregate test
+  target and `gate-main`, a required context — the intake assumption that they
+  were absent from CI was false. What is absent is a standing construction test
+  pinning that fact, and any CI or Make invocation of
+  `tools/check-docs-contrast.py` (source: `Makefile` test target and
+  `.github/workflows/build-check.yml` `gate-main`; branch-protection contexts read
+  from the GitHub API on 2026-08-17).
 - Technical: the dependency-free contrast checker currently passes all
   registered light and dark pairs (source: `tools/check-docs-contrast.py`
   probe during intake).

--- a/docs/specs/site-ci-contract-closure/spec.md
+++ b/docs/specs/site-ci-contract-closure/spec.md
@@ -78,8 +78,9 @@ that required CI does not execute.
   seven names is proven by seeded deletion against an in-memory copy, because a
   bare presence assertion cannot detect removal.
 - [x] `tools/check-docs-contrast.py` has focused tests for light and dark pairs,
-  the 4.5:1 threshold boundary (asserted on the comparison's inclusivity plus the
-  tightest real pairs either side, since no 6-hex pair yields exactly 4.5), each
+  the 4.5:1 threshold boundary (asserted on the comparison's inclusivity through the
+  seam `main()` uses, plus the tightest real pairs either side; measured: no
+  gray-on-gray 6-hex pair and no shipped-palette pair lands exactly on 4.5), each
   named invalid-input case — malformed hex, legal-but-unsupported three-digit
   shorthand, an unresolvable `var()` chain, and a palette that cannot be read or
   decoded — and non-zero exit on failure.

--- a/tools/check-docs-contrast.py
+++ b/tools/check-docs-contrast.py
@@ -43,6 +43,20 @@ PAIRS = [
 FLOOR = 4.5
 DECL_RE = re.compile(r"(--[a-z0-9-]+)\s*:\s*([^;]+);")
 VAR_RE = re.compile(r"var\((--[a-z0-9-]+)\)")
+# Exactly six hex digits. Three-digit shorthand (`#abc`) is legal CSS but NOT
+# accepted here: `int("ab", 16)` would parse it happily and return a
+# plausible-but-wrong luminance, and a silently wrong contrast number is worse
+# than a refusal.
+HEX6_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+class ColourError(ValueError):
+    """A palette value this checker refuses to interpret.
+
+    Raised instead of letting `int(..., 16)` or a `KeyError` escape, so a
+    malformed palette produces a diagnostic and a non-zero exit rather than a
+    traceback — the difference between a gate that reports and one that crashes.
+    """
 
 
 def split_blocks(css: str) -> list[tuple[str, str]]:
@@ -73,8 +87,11 @@ def theme_tables(css: str) -> dict[str, dict[str, str]]:
 
 def resolve(name: str, table: dict[str, str], depth: int = 0) -> str:
     if depth > 10:
-        raise ValueError(f"var() chain too deep resolving {name}")
-    value = table[name]
+        raise ColourError(f"var() chain too deep resolving {name} (cycle?)")
+    try:
+        value = table[name]
+    except KeyError:
+        raise ColourError(f"{name} is not defined in this theme") from None
     m = VAR_RE.fullmatch(value)
     return resolve(m.group(1), table, depth + 1) if m else value
 
@@ -84,9 +101,24 @@ def _linearize(c: float) -> float:
 
 
 def luminance(hex_color: str) -> float:
-    h = hex_color.lstrip("#")
+    if not HEX6_RE.match(hex_color.strip()):
+        raise ColourError(
+            f"{hex_color!r} is not a six-digit hex colour "
+            "(three-digit shorthand is not supported)"
+        )
+    h = hex_color.strip().lstrip("#")
     r, g, b = (int(h[i : i + 2], 16) / 255 for i in (0, 2, 4))
     return 0.2126 * _linearize(r) + 0.7152 * _linearize(g) + 0.0722 * _linearize(b)
+
+
+def passes(r: float) -> bool:
+    """Whether a measured ratio clears the floor.
+
+    Extracted so the boundary is testable: WCAG's threshold is inclusive, and a
+    test asserting that against `FLOOR` alone is a tautology that stays green if
+    this comparison is flipped to `>`.
+    """
+    return r >= FLOOR
 
 
 def ratio(fg: str, bg: str) -> float:
@@ -95,23 +127,43 @@ def ratio(fg: str, bg: str) -> float:
 
 
 def main() -> int:
-    css = CSS_PATH.read_text(encoding="utf-8")
+    try:
+        css = CSS_PATH.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        # A missing or unreadable sheet is a gate failure, not a crash: this runs as
+        # a required CI step, and a traceback there reads as tooling breakage rather
+        # than the contract violation it is.
+        print(f"error  cannot read or decode {CSS_PATH}: {exc}")
+        print("\ncheck-docs-contrast: palette unreadable")
+        return 1
     tables = theme_tables(css)
     failures = 0
     for theme, table in tables.items():
         for fg_name, bg_name in PAIRS:
-            fg, bg = resolve(fg_name, table), resolve(bg_name, table)
+            try:
+                fg, bg = resolve(fg_name, table), resolve(bg_name, table)
+            except ColourError as exc:
+                print(f"error  {theme}: {fg_name}/{bg_name} — {exc}")
+                failures += 1
+                continue
             if not (fg.startswith("#") and bg.startswith("#")):
                 print(f"error  {theme}: {fg_name}/{bg_name} not plain hex ({fg!r}, {bg!r})")
                 failures += 1
                 continue
-            r = ratio(fg, bg)
-            status = "ok  " if r >= FLOOR else "FAIL"
-            if r < FLOOR:
+            try:
+                r = ratio(fg, bg)
+            except ColourError as exc:
+                print(f"error  {theme}: {fg_name}/{bg_name} — {exc}")
+                failures += 1
+                continue
+            ok = passes(r)
+            status = "ok  " if ok else "FAIL"
+            if not ok:
                 failures += 1
             print(f"{status}  {theme:5} {fg_name} on {bg_name}: {r:.2f}")
     if failures:
-        print(f"\ncheck-docs-contrast: {failures} pair(s) below {FLOOR}:1")
+        print(f"\ncheck-docs-contrast: {failures} pair(s) failed — "
+              f"below {FLOOR}:1, or a value this checker refuses to interpret")
         return 1
     print("\ncheck-docs-contrast: all pairs pass")
     return 0

--- a/tools/fixtures/build-check-good.yml
+++ b/tools/fixtures/build-check-good.yml
@@ -55,6 +55,23 @@ jobs:
       - name: pytest credbroker
         run: |
           python -m pytest packages/credbroker -q
+      - name: pytest guides + catalogue navigation
+        run: >-
+          python -m pytest
+          tools/test_validate_guides.py
+          tools/test_check_guide_index.py
+          tools/test_catalogue_navigation.py
+          tools/test_documentation_entry_links.py
+      - name: pytest site build + link rewriting
+        run: >-
+          python -m pytest
+          tools/test_build_site_link_rewrites.py
+          tools/test_check_rendered_site_links.py
+          tools/test_build_site_routing.py
+      - name: docs palette contrast gate
+        run: |
+          python3 tools/check-docs-contrast.py
+          python -m pytest tools/test_check_docs_contrast.py -q
   gate-sast:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/tools/lint-ci-parity.py
+++ b/tools/lint-ci-parity.py
@@ -347,6 +347,11 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
         LOCAL("test"),
     "pytest site build + link rewriting":
         LOCAL("test"),
+    # spec/site-ci-contract-closure AC4/AC6. Both halves are reachable from
+    # `make ci` via the `test` target: the checker on its own line near the top,
+    # and its suite on the site/catalogue pytest line.
+    "docs palette contrast gate":
+        LOCAL("test"),
     # RFC-0082 export boundary. The gate itself runs in release-agentbundle.yml;
     # this step runs the gate's own tests, so a regression to always-exit-0 goes
     # red here rather than staying silently green.

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -255,6 +255,11 @@ def _key_re(key: str, indent: str = r"\s*") -> re.Pattern[str]:
 # `pull_request: {branches: [main], paths: ['x']}` hid the filter mid-line while the
 # bare block spelling above it kept `trigger-pull-request` satisfied. Matching after
 # any whitespace, `{` or `,` sees the flow form too.
+# Explicit-key (`? k` / `: v`) and escape-encoded (`"p\x61ths":`) key syntax, in
+# either block or flow position. Both resolve to a normal key that every
+# spelling-based matcher in this file misses.
+_UNMODELLED_KEY_RE = re.compile(r'(?:^|[{,])[ \t]*\?[ \t]|"[^"\n]*\\[^"\n]*"\s*:', re.M)
+
 _TRIGGER_PATHS_RES = (
     re.compile(r"(?:^|[\s{,])['\"]?paths['\"]?\s*:", re.M),
     re.compile(r"(?:^|[\s{,])['\"]?paths-ignore['\"]?\s*:", re.M),
@@ -292,9 +297,10 @@ PINNED_EXPORT_PYTEST = (
     '| tee "$RUNNER_TEMP/out.txt"'
 )
 PINNED_POSTURE = f"python3 {SELF_NAME}"
-# spec/site-ci-contract-closure AC2. These four statements are FIXED, so they go
-# through `_pinned` (statement equality) rather than `_invocation` (argv membership)
-# — this file's own guidance. Membership alone accepted
+# spec/site-ci-contract-closure AC2. These four statements are FIXED, and are held by
+# WHOLE-BODY equality in the `*-body-exact` checks — not by `_pinned`, whose four
+# statement-equality conjuncts were removed as non-independent (see the removal note
+# at the checks). Argv membership alone accepted
 # `python -m pytest --collect-only <modules>` and `… -q -k nope`, which collect or
 # select nothing while every module name stayed present and the audit stayed clean.
 PINNED_SITE_GUIDES_PYTEST = (
@@ -1350,15 +1356,23 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     # yamllint-truthy-friendly spelling nothing else here pins) made the whole
     # assertion vacuous and a paths: filter passed undetected.
     # Every key assertion in this file matches a SPELLING (`k:`, `'k':`, `k :`). Two
-    # standard YAML forms resolve to the same key and match none of them, and both
-    # were measured green against the real workflow: an escape-encoded key
-    # (`"i\x66":` → `if`) and explicit-key syntax (`? if` / `: value`). Rather than
-    # teach every matcher a fourth and fifth spelling, refuse the syntax outright —
-    # neither appears in this workflow or the fixture, and neither has a legitimate
-    # use here. This is fail-closed for all nine `_key_re` consumers, not just the
-    # two assertions that surfaced it.
-    check("no-unmodelled-key-syntax",
-          not re.search(r'^[ ]*\?[ ]|^[ ]*"[^"\n]*\\', text, re.M))
+    # standard YAML forms resolve to the same key and match none of them: an
+    # escape-encoded key (`"i\x66":` → `if`) and explicit-key syntax (`? if` /
+    # `: value`). Rather than teach every matcher two more spellings, refuse the
+    # syntax outright — neither appears in this workflow or the fixture, and neither
+    # has a legitimate use here.
+    #
+    # Matched in KEY POSITION, not at line start. An earlier draft anchored both
+    # alternatives to `^`, which closed the spelling only where it had been found:
+    # `pull_request: {branches: [main], "p\x61ths": ['tools/**']}` audited clean
+    # while resolving to a live `paths` filter. Line-anchoring also false-positived
+    # on any line beginning with a quoted string containing a backslash — the shape
+    # a backslash-continued command already produces twice in this workflow.
+    _unmodelled = _UNMODELLED_KEY_RE.search(text)
+    if _unmodelled:
+        _note_miss("no `? key` or escape-encoded key syntax",
+                   _unmodelled.group(0).strip())
+    check("no-unmodelled-key-syntax", _unmodelled is None)
     # Exactly one top-level `on:`. Every other key in this file closes the
     # duplicate-key class; `on:` was the one left open, and it is the key deciding
     # whether the required contexts report at all. A second `on:` also truncates
@@ -1555,6 +1569,10 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("dry-run-contrast-checker", "contrast-body-exact",
      lambda t: t.replace("python3 tools/check-docs-contrast.py",
                          "python3 tools/check-docs-contrast.py --dry-run")),
+    ("flow-escaped-paths-key", "no-unmodelled-key-syntax",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n    branches: [main]\n"
+                         "  pull_request: {branches: [main], \"p\\x61ths\": ['tools/**']}\n", 1)),
     ("escaped-key-syntax", "no-unmodelled-key-syntax",
      lambda t: t.replace('      - name: docs palette contrast gate\n',
                          '      - name: docs palette contrast gate\n        "i\\x66": ${{ false }}\n')),

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -138,12 +138,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-check.yml"
-# A `paths:`/`paths-ignore:` key at trigger-option indent. `[ ]{4}` rather than
-# `\s{4}`: the latter spans newlines, so it also matched a 2-space `paths:` after
-# blank lines and a job-level key — fail-closed, but not the scope the comment
-# claimed. Searched within the `on:` block only, so a step input named `paths:`
-# elsewhere cannot trip it.
-_TRIGGER_PATHS_RE = re.compile(r"^[ ]{4}paths(-ignore)?[ ]*:", re.M)
 
 
 def _on_block(text: str) -> str:
@@ -249,6 +243,15 @@ def _key_re(key: str, indent: str = r"\s*") -> re.Pattern[str]:
     assertion now shares this matcher so the CLASS is closed, not a spelling.
     """
     return re.compile(rf"^{indent}['\"]?{re.escape(key)}['\"]?\s*:", re.M)
+
+
+# `paths:`/`paths-ignore:` anywhere inside the `on:` block, at ANY indent and in any
+# quoting. An earlier draft hard-coded `[ ]{4}` and the bare spelling — the only key
+# matcher in this file not going through `_key_re` — so `'paths':`, `"paths-ignore":`,
+# a 6-space indent, and the `on.push` trigger each slipped past while the audit stayed
+# green. Indent is deliberately unconstrained: the block is already scoped to `on:`,
+# so any depth within it is a trigger option.
+_TRIGGER_PATHS_RES = (_key_re("paths", r"[ ]+"), _key_re("paths-ignore", r"[ ]+"))
 
 
 # Step-level `env:` stays legal — the detect step and the guard need it — but its KEYS
@@ -1309,6 +1312,21 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     check("contrast-suite-pinned",
           bool(_pinned(_contrast_step, PINNED_CONTRAST_SUITE)))
 
+    # Whole-body equality, not statement presence. `_pinned` finds a statement
+    # wherever it sits, so a prepended `exit 0` left every pin satisfied while the
+    # step ran nothing — measured green. These three bodies are finitely enumerable
+    # (one, one, and two statements), which is this file's own stated escape from the
+    # neutering ladder: pin the whole set rather than enumerate what may not precede it.
+    check("site-guides-body-exact",
+          _run_lines(_step_named(main_blk, "pytest guides + catalogue navigation"))
+          == [PINNED_SITE_GUIDES_PYTEST])
+    check("site-build-body-exact",
+          _run_lines(_step_named(main_blk, "pytest site build + link rewriting"))
+          == [PINNED_SITE_BUILD_PYTEST])
+    check("contrast-body-exact",
+          _run_lines(_step_named(main_blk, "docs palette contrast gate"))
+          == [PINNED_CONTRAST_CHECKER, PINNED_CONTRAST_SUITE])
+
     # AC2's second neutering form. `continue-on-error` is covered file-wide, and
     # cwd redirection by _NO_CWD_STEPS above — but a step-level `if:` was the live
     # bypass: `if: ${{ false }}` on either pytest step or the contrast step skipped
@@ -1330,7 +1348,8 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     # yamllint-truthy-friendly spelling nothing else here pins) made the whole
     # assertion vacuous and a paths: filter passed undetected.
     _on = _on_block(text)
-    check("no-path-filter", bool(_on) and not _TRIGGER_PATHS_RE.search(_on))
+    check("no-path-filter",
+          bool(_on) and not any(r.search(_on) for r in _TRIGGER_PATHS_RES))
 
     # AC4: the predicate has exactly one consumer.
     sast_blk = _job_block(text, "gate-sast")
@@ -1519,6 +1538,24 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("dry-run-contrast-checker", "contrast-checker-pinned",
      lambda t: t.replace("python3 tools/check-docs-contrast.py",
                          "python3 tools/check-docs-contrast.py --dry-run")),
+    ("exit-0-prefix-in-contrast-step", "contrast-body-exact",
+     lambda t: t.replace("          python3 tools/check-docs-contrast.py\n",
+                         "          exit 0\n          python3 tools/check-docs-contrast.py\n")),
+    ("exit-0-prefix-in-site-step", "site-guides-body-exact",
+     lambda t: t.replace("          python -m pytest\n          tools/test_validate_guides.py",
+                         "          exit 0\n          python -m pytest\n          tools/test_validate_guides.py")),
+    ("exit-0-prefix-in-site-build-step", "site-build-body-exact",
+     lambda t: t.replace("          python -m pytest\n          tools/test_build_site_link_rewrites.py",
+                         "          exit 0\n          python -m pytest\n          tools/test_build_site_link_rewrites.py")),
+    ("quote-paths-key", "no-path-filter",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n    branches: [main]\n    'paths':\n      - 'tools/**'\n", 1)),
+    ("paths-ignore-key", "no-path-filter",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n    branches: [main]\n    paths-ignore:\n      - 'docs/**'\n", 1)),
+    ("deep-indent-paths", "no-path-filter",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n      branches: [main]\n      paths:\n        - 'tools/**'\n", 1)),
     ("quote-on-key", "no-path-filter",
      lambda t: t.replace("on:\n", "'on':\n", 1)),
     # A paths: filter on a workflow whose jobs are required contexts leaves every

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -138,6 +138,23 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-check.yml"
+# A `paths:`/`paths-ignore:` key at trigger-option indent. `[ ]{4}` rather than
+# `\s{4}`: the latter spans newlines, so it also matched a 2-space `paths:` after
+# blank lines and a job-level key — fail-closed, but not the scope the comment
+# claimed. Searched within the `on:` block only, so a step input named `paths:`
+# elsewhere cannot trip it.
+_TRIGGER_PATHS_RE = re.compile(r"^[ ]{4}paths(-ignore)?[ ]*:", re.M)
+
+
+def _on_block(text: str) -> str:
+    """The `on:` mapping body — up to the next top-level key."""
+    m = re.search(r"^on:\s*$", text, re.M)
+    if not m:
+        return ""
+    nxt = re.search(r"^[A-Za-z]", text[m.end():], re.M)
+    return text[m.end():m.end() + nxt.start()] if nxt else text[m.end():]
+
+
 SELF_NAME = "tools/test-build-check-workflow.py"
 
 AGGREGATOR_JOB_ID = "build-check"
@@ -149,6 +166,28 @@ AGGREGATOR_RUN_STEPS = (
     "Require every gate",
 )
 REQUIRED_WORK_JOBS = ("gate-main", "gate-sast", "gate-export-boundary")
+
+# spec/site-ci-contract-closure AC2. The seven site/catalogue modules that
+# spec/build-check-coverage-gaps AC1 moved into gate-main. Enumerated HERE rather
+# than derived from the Makefile on purpose: a roster read out of the thing being
+# checked is circular — deleting a module from both Makefile and workflow would
+# then pass. This list is the independent pin; Make/CI agreement is a separate
+# concern owned by tools/lint-ci-parity.py's coverage layer.
+SITE_TEST_MODULES = (
+    "tools/test_validate_guides.py",
+    "tools/test_check_guide_index.py",
+    "tools/test_catalogue_navigation.py",
+    "tools/test_documentation_entry_links.py",
+    "tools/test_build_site_link_rewrites.py",
+    "tools/test_check_rendered_site_links.py",
+    "tools/test_build_site_routing.py",
+)
+# spec/site-ci-contract-closure AC4. The docs-palette contrast gate: the checker
+# and its own suite. Registered so removing either from gate-main fails here.
+CONTRAST_SCRIPTS = (
+    "tools/check-docs-contrast.py",
+    "tools/test_check_docs_contrast.py",
+)
 
 EXPECTED_PYTHON = '"3.11"'
 # The runner is the outermost layer this file can reach: it decides what every
@@ -254,6 +293,12 @@ _NO_CWD_STEPS = (
     ("gate-sast", "Run make sast"),
     ("gate-sast", "Install SAST/SCA tools"),
     ("gate-export-boundary", "pytest export-boundary gate"),
+    # spec/site-ci-contract-closure AC2. Same reasoning as the anchor: a redirected
+    # cwd leaves every pinned module name byte-identical while pytest collects from
+    # a different tree, so the roster assertion passes and nothing it names runs.
+    ("gate-main", "pytest guides + catalogue navigation"),
+    ("gate-main", "pytest site build + link rewriting"),
+    ("gate-main", "docs palette contrast gate"),
 )
 # Non-run steps permitted in the aggregator, compared as the `uses:` VALUE for equality.
 # A substring test over the step chunk — the previous shape — accepted
@@ -1208,6 +1253,49 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
           and "requirements-sast.txt" in bandit_step
           and bool(_invocation(bandit_step, "python") or "extension_loader" in bandit_step))
 
+    # spec/site-ci-contract-closure AC2. Each site module must be an ARGUMENT of a
+    # pytest statement inside gate-main — not merely a token somewhere in the file.
+    # `_invocation` enforces command-word + argv membership, so a module named only
+    # in a comment, in an `echo`, or in another job does not satisfy this.
+    #
+    # Placement is asserted against gate-main by job id, not "the required job":
+    # branch protection requires four contexts, and the aggregator is one of them
+    # but runs no pytest. Its two run steps are pinned by AGGREGATOR_RUN_STEPS, so
+    # a module smuggled there would fail that pin instead.
+    for _mod in SITE_TEST_MODULES:
+        check(f"site-module[{_mod}]",
+              bool(_invocation(main_blk, "python", "-m", "pytest", _mod))
+              or bool(_invocation(main_blk, "python3", "-m", "pytest", _mod))
+              or bool(_invocation(main_blk, "pytest", _mod)))
+
+    # AC4: the contrast gate runs in gate-main, checker and suite both.
+    for _script in CONTRAST_SCRIPTS:
+        if _script.endswith("test_check_docs_contrast.py"):
+            ok = (bool(_invocation(main_blk, "python", "-m", "pytest", _script))
+                  or bool(_invocation(main_blk, "python3", "-m", "pytest", _script))
+                  or bool(_invocation(main_blk, "pytest", _script)))
+        else:
+            ok = (bool(_invocation(main_blk, "python", _script))
+                  or bool(_invocation(main_blk, "python3", _script)))
+        check(f"contrast-gate[{_script}]", ok)
+
+    # AC2's second neutering form. `continue-on-error` is covered file-wide, and
+    # cwd redirection by _NO_CWD_STEPS above — but a step-level `if:` was the live
+    # bypass: `if: ${{ false }}` on either pytest step or the contrast step skipped
+    # the gate with this file reporting posture OK. gate-main carries no step-level
+    # `if:` at all, so the honest assertion is that it stays that way.
+    for _step_name in ("pytest guides + catalogue navigation",
+                       "pytest site build + link rewriting",
+                       "docs palette contrast gate"):
+        _st = _step_named(main_blk, _step_name)
+        check(f"site-step-no-if[{_step_name}]", bool(_st) and not _has_if(_st))
+
+    # AC5. build-check.yml must carry NO paths: filter. Its jobs are required
+    # contexts by name, so a filtered trigger means a PR touching none of the
+    # filtered paths never runs the workflow, the required checks never report,
+    # and the PR is permanently unmergeable — Expected, not skipped-as-success.
+    check("no-path-filter", not _TRIGGER_PATHS_RE.search(_on_block(text)))
+
     # AC4: the predicate has exactly one consumer.
     sast_blk = _job_block(text, "gate-sast")
     sast_step = _step_named(sast_blk, "make sast")
@@ -1332,6 +1420,61 @@ def _sub_in_job(text: str, job_id: str, old: str, new: str) -> str:
 
 
 _MUTATIONS: list[tuple[str, str, object]] = [
+    # -- spec/site-ci-contract-closure AC2/AC4/AC5 -------------------------------
+    # Removal is the mode a bare presence assertion cannot see, so each family is
+    # proved by deleting the thing it pins rather than by asserting it is there.
+    # One deletion mutation PER module. `_family` collapses `site-module[<mod>]` to
+    # `site-module[*]`, so a single member would satisfy the coverage claim while the
+    # other six sat unmutated — the exact asserted-but-unproven posture this file
+    # exists to reject. Generated, so adding a module to SITE_TEST_MODULES cannot
+    # silently ship without its proof.
+    *[(f"drop-site-module[{_m}]", f"site-module[{_m}]",
+       (lambda mod: (lambda t: t.replace(f"          {mod}\n", "")))(_m))
+      for _m in SITE_TEST_MODULES],
+    # Misspelling, the mode a substring match over the file would still pass.
+    ("misspell-site-module", "site-module[tools/test_build_site_routing.py]",
+     lambda t: t.replace("tools/test_build_site_routing.py",
+                         "tools/test_build_site_routeing.py")),
+    # Present in the file, but MOVED to a job whose name branch protection requires
+    # for a different purpose and which runs no site tests. A plain deletion would
+    # prove only what drop-site-module already proves; this makes job PLACEMENT the
+    # thing that fails, which is what AC2 actually claims to detect.
+    ("site-module-wrong-job", "site-module[tools/test_catalogue_navigation.py]",
+     lambda t: _sub_in_job(
+         _sub_in_job(t, "gate-main",
+                     "          tools/test_catalogue_navigation.py\n", ""),
+         "gate-sast", "      - name: Run make sast\n",
+         "      - name: pytest moved\n        run: >-\n          python -m pytest\n"
+         "          tools/test_catalogue_navigation.py\n"
+         "      - name: Run make sast\n")),
+    # Named only inside an echo — the command-word rule must reject it.
+    ("echo-wrap-site-modules", "site-module[tools/test_check_guide_index.py]",
+     lambda t: t.replace("          python -m pytest\n"
+                         "          tools/test_validate_guides.py\n"
+                         "          tools/test_check_guide_index.py\n",
+                         "          echo python -m pytest\n"
+                         "          tools/test_validate_guides.py\n"
+                         "          tools/test_check_guide_index.py\n")),
+    ("drop-contrast-checker", "contrast-gate[tools/check-docs-contrast.py]",
+     lambda t: t.replace("          python3 tools/check-docs-contrast.py\n", "")),
+    ("drop-contrast-suite", "contrast-gate[tools/test_check_docs_contrast.py]",
+     lambda t: t.replace(
+         "          python -m pytest tools/test_check_docs_contrast.py -q\n", "")),
+    # A paths: filter on a workflow whose jobs are required contexts leaves every
+    # non-matching PR permanently unmergeable.
+    ("if-false-on-contrast-step", "site-step-no-if[docs palette contrast gate]",
+     lambda t: t.replace("      - name: docs palette contrast gate\n",
+                         "      - name: docs palette contrast gate\n        if: ${{ false }}\n")),
+    ("if-false-on-site-step", "site-step-no-if[pytest guides + catalogue navigation]",
+     lambda t: t.replace("      - name: pytest guides + catalogue navigation\n",
+                         "      - name: pytest guides + catalogue navigation\n        if: ${{ false }}\n")),
+    ("cwd-redirect-contrast-step", "no-working-directory[gate-main/docs palette contrast gate]",
+     lambda t: t.replace("      - name: docs palette contrast gate\n",
+                         "      - name: docs palette contrast gate\n        working-directory: tools\n")),
+    ("add-path-filter", "no-path-filter",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n    branches: [main]\n"
+                         "    paths:\n      - 'tools/**'\n")),
     # -- the neutering class, applied to EVERY control (round-8 blocker 1) --------
     ("or-true-anchor", "anchor-step",
      lambda t: t.replace("make build-check PACKS_DIR=packs SAST_DELEGATED=1",

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -251,7 +251,14 @@ def _key_re(key: str, indent: str = r"\s*") -> re.Pattern[str]:
 # a 6-space indent, and the `on.push` trigger each slipped past while the audit stayed
 # green. Indent is deliberately unconstrained: the block is already scoped to `on:`,
 # so any depth within it is a trigger option.
-_TRIGGER_PATHS_RES = (_key_re("paths", r"[ ]+"), _key_re("paths-ignore", r"[ ]+"))
+# Unanchored on purpose. `_key_re` pins a key to line start, so
+# `pull_request: {branches: [main], paths: ['x']}` hid the filter mid-line while the
+# bare block spelling above it kept `trigger-pull-request` satisfied. Matching after
+# any whitespace, `{` or `,` sees the flow form too.
+_TRIGGER_PATHS_RES = (
+    re.compile(r"(?:^|[\s{,])['\"]?paths['\"]?\s*:", re.M),
+    re.compile(r"(?:^|[\s{,])['\"]?paths-ignore['\"]?\s*:", re.M),
+)
 
 
 # Step-level `env:` stays legal — the detect step and the guard need it — but its KEYS
@@ -1297,20 +1304,15 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
                   or bool(_invocation(main_blk, "python3", _script)))
         check(f"contrast-gate[{_script}]", ok)
 
-    # Statement equality on the four fixed statements. The membership checks above
-    # stay as the roster pin (they name WHICH modules must appear); these pin HOW
-    # they are invoked, which is what closes argument-level neutering.
-    check("site-guides-pytest-pinned",
-          bool(_pinned(_step_named(main_blk, "pytest guides + catalogue navigation"),
-                       PINNED_SITE_GUIDES_PYTEST)))
-    check("site-build-pytest-pinned",
-          bool(_pinned(_step_named(main_blk, "pytest site build + link rewriting"),
-                       PINNED_SITE_BUILD_PYTEST)))
-    _contrast_step = _step_named(main_blk, "docs palette contrast gate")
-    check("contrast-checker-pinned",
-          bool(_pinned(_contrast_step, PINNED_CONTRAST_CHECKER)))
-    check("contrast-suite-pinned",
-          bool(_pinned(_contrast_step, PINNED_CONTRAST_SUITE)))
+    # The `*-body-exact` checks below subsume statement-equality pins on these four
+    # statements: `_run_lines(step) == [P]` implies `_pinned(step, P)` unconditionally
+    # (same source, and none of the pinned texts contains `;`, `&&`, `||` or a
+    # trailing `&`). Four such conjuncts were written here and removed rather than
+    # kept — this file's own history deletes conjuncts that cannot fail independently,
+    # because they inflate the family and mutation counts without adding a proof. The
+    # `site-module[*]` / `contrast-gate[*]` membership checks DO stay: they compare an
+    # independent roster against the pinned strings, so a coordinated edit to both the
+    # workflow and a `PINNED_*` constant still fails there.
 
     # Whole-body equality, not statement presence. `_pinned` finds a statement
     # wherever it sits, so a prepended `exit 0` left every pin satisfied while the
@@ -1347,6 +1349,21 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     # what keeps this fail-closed. Without that, quoting the key as `'on':` (a
     # yamllint-truthy-friendly spelling nothing else here pins) made the whole
     # assertion vacuous and a paths: filter passed undetected.
+    # Every key assertion in this file matches a SPELLING (`k:`, `'k':`, `k :`). Two
+    # standard YAML forms resolve to the same key and match none of them, and both
+    # were measured green against the real workflow: an escape-encoded key
+    # (`"i\x66":` → `if`) and explicit-key syntax (`? if` / `: value`). Rather than
+    # teach every matcher a fourth and fifth spelling, refuse the syntax outright —
+    # neither appears in this workflow or the fixture, and neither has a legitimate
+    # use here. This is fail-closed for all nine `_key_re` consumers, not just the
+    # two assertions that surfaced it.
+    check("no-unmodelled-key-syntax",
+          not re.search(r'^[ ]*\?[ ]|^[ ]*"[^"\n]*\\', text, re.M))
+    # Exactly one top-level `on:`. Every other key in this file closes the
+    # duplicate-key class; `on:` was the one left open, and it is the key deciding
+    # whether the required contexts report at all. A second `on:` also truncates
+    # `_on_block`, so the mapping YAML actually resolves would go unscanned.
+    check("one-on-key", len(_key_values(text, "on", "")) == 1)
     _on = _on_block(text)
     check("no-path-filter",
           bool(_on) and not any(r.search(_on) for r in _TRIGGER_PATHS_RES))
@@ -1526,18 +1543,30 @@ _MUTATIONS: list[tuple[str, str, object]] = [
                          "      - name: docs palette contrast gate\n        working-directory: tools\n")),
     # The vacuity guard: quoting the top-level key must not silently disable the
     # assertion above it.
-    ("collect-only-site-guides", "site-guides-pytest-pinned",
+    ("collect-only-site-guides", "site-guides-body-exact",
      lambda t: t.replace("          python -m pytest\n          tools/test_validate_guides.py",
                          "          python -m pytest --collect-only\n          tools/test_validate_guides.py")),
-    ("k-filter-site-build", "site-build-pytest-pinned",
+    ("k-filter-site-build", "site-build-body-exact",
      lambda t: t.replace("          tools/test_build_site_routing.py\n",
                          "          tools/test_build_site_routing.py -k nope\n")),
-    ("k-filter-contrast-suite", "contrast-suite-pinned",
+    ("k-filter-contrast-suite", "contrast-body-exact",
      lambda t: t.replace("python -m pytest tools/test_check_docs_contrast.py -q",
                          "python -m pytest tools/test_check_docs_contrast.py -q -k nope")),
-    ("dry-run-contrast-checker", "contrast-checker-pinned",
+    ("dry-run-contrast-checker", "contrast-body-exact",
      lambda t: t.replace("python3 tools/check-docs-contrast.py",
                          "python3 tools/check-docs-contrast.py --dry-run")),
+    ("escaped-key-syntax", "no-unmodelled-key-syntax",
+     lambda t: t.replace('      - name: docs palette contrast gate\n',
+                         '      - name: docs palette contrast gate\n        "i\\x66": ${{ false }}\n')),
+    ("explicit-key-syntax", "no-unmodelled-key-syntax",
+     lambda t: t.replace('      - name: docs palette contrast gate\n',
+                         '      - name: docs palette contrast gate\n        ? if\n        : ${{ false }}\n')),
+    ("duplicate-on-key", "one-on-key",
+     lambda t: t.rstrip() + "\non:\n  pull_request:\n    paths: ['x']\n"),
+    ("flow-style-trigger-paths", "no-path-filter",
+     lambda t: t.replace("  pull_request:\n    branches: [main]\n",
+                         "  pull_request:\n    branches: [main]\n"
+                         "  pull_request: {branches: [main], paths: ['tools/**']}\n", 1)),
     ("exit-0-prefix-in-contrast-step", "contrast-body-exact",
      lambda t: t.replace("          python3 tools/check-docs-contrast.py\n",
                          "          exit 0\n          python3 tools/check-docs-contrast.py\n")),
@@ -1556,6 +1585,8 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("deep-indent-paths", "no-path-filter",
      lambda t: t.replace("  pull_request:\n    branches: [main]\n",
                          "  pull_request:\n      branches: [main]\n      paths:\n        - 'tools/**'\n", 1)),
+    # Vacuity guard: respelling the top-level `on:` key must not silently disable
+    # `no-path-filter` by emptying the span it searches.
     ("quote-on-key", "no-path-filter",
      lambda t: t.replace("on:\n", "'on':\n", 1)),
     # A paths: filter on a workflow whose jobs are required contexts leaves every

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -282,6 +282,21 @@ PINNED_EXPORT_PYTEST = (
     '| tee "$RUNNER_TEMP/out.txt"'
 )
 PINNED_POSTURE = f"python3 {SELF_NAME}"
+# spec/site-ci-contract-closure AC2. These four statements are FIXED, so they go
+# through `_pinned` (statement equality) rather than `_invocation` (argv membership)
+# — this file's own guidance. Membership alone accepted
+# `python -m pytest --collect-only <modules>` and `… -q -k nope`, which collect or
+# select nothing while every module name stayed present and the audit stayed clean.
+PINNED_SITE_GUIDES_PYTEST = (
+    "python -m pytest tools/test_validate_guides.py tools/test_check_guide_index.py "
+    "tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py"
+)
+PINNED_SITE_BUILD_PYTEST = (
+    "python -m pytest tools/test_build_site_link_rewrites.py "
+    "tools/test_check_rendered_site_links.py tools/test_build_site_routing.py"
+)
+PINNED_CONTRAST_CHECKER = "python3 tools/check-docs-contrast.py"
+PINNED_CONTRAST_SUITE = "python -m pytest tools/test_check_docs_contrast.py -q"
 # `working-directory:` decides WHERE a pinned statement runs, so it is the YAML sibling
 # of the `-C`/`-f` ban in `_REDIRECT_FLAGS` — and it was unasserted. Measured:
 # `working-directory: tools` on the anchor leaves the pinned text untouched, audits
@@ -1279,6 +1294,21 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
                   or bool(_invocation(main_blk, "python3", _script)))
         check(f"contrast-gate[{_script}]", ok)
 
+    # Statement equality on the four fixed statements. The membership checks above
+    # stay as the roster pin (they name WHICH modules must appear); these pin HOW
+    # they are invoked, which is what closes argument-level neutering.
+    check("site-guides-pytest-pinned",
+          bool(_pinned(_step_named(main_blk, "pytest guides + catalogue navigation"),
+                       PINNED_SITE_GUIDES_PYTEST)))
+    check("site-build-pytest-pinned",
+          bool(_pinned(_step_named(main_blk, "pytest site build + link rewriting"),
+                       PINNED_SITE_BUILD_PYTEST)))
+    _contrast_step = _step_named(main_blk, "docs palette contrast gate")
+    check("contrast-checker-pinned",
+          bool(_pinned(_contrast_step, PINNED_CONTRAST_CHECKER)))
+    check("contrast-suite-pinned",
+          bool(_pinned(_contrast_step, PINNED_CONTRAST_SUITE)))
+
     # AC2's second neutering form. `continue-on-error` is covered file-wide, and
     # cwd redirection by _NO_CWD_STEPS above — but a step-level `if:` was the live
     # bypass: `if: ${{ false }}` on either pytest step or the contrast step skipped
@@ -1294,7 +1324,13 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     # contexts by name, so a filtered trigger means a PR touching none of the
     # filtered paths never runs the workflow, the required checks never report,
     # and the PR is permanently unmergeable — Expected, not skipped-as-success.
-    check("no-path-filter", not _TRIGGER_PATHS_RE.search(_on_block(text)))
+    # `_on_block` returns "" when the top-level key is not the bare `on:` it anchors
+    # on, and `search("")` is trivially falsy — so requiring the span be NON-EMPTY is
+    # what keeps this fail-closed. Without that, quoting the key as `'on':` (a
+    # yamllint-truthy-friendly spelling nothing else here pins) made the whole
+    # assertion vacuous and a paths: filter passed undetected.
+    _on = _on_block(text)
+    check("no-path-filter", bool(_on) and not _TRIGGER_PATHS_RE.search(_on))
 
     # AC4: the predicate has exactly one consumer.
     sast_blk = _job_block(text, "gate-sast")
@@ -1460,8 +1496,6 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("drop-contrast-suite", "contrast-gate[tools/test_check_docs_contrast.py]",
      lambda t: t.replace(
          "          python -m pytest tools/test_check_docs_contrast.py -q\n", "")),
-    # A paths: filter on a workflow whose jobs are required contexts leaves every
-    # non-matching PR permanently unmergeable.
     ("if-false-on-contrast-step", "site-step-no-if[docs palette contrast gate]",
      lambda t: t.replace("      - name: docs palette contrast gate\n",
                          "      - name: docs palette contrast gate\n        if: ${{ false }}\n")),
@@ -1471,6 +1505,24 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("cwd-redirect-contrast-step", "no-working-directory[gate-main/docs palette contrast gate]",
      lambda t: t.replace("      - name: docs palette contrast gate\n",
                          "      - name: docs palette contrast gate\n        working-directory: tools\n")),
+    # The vacuity guard: quoting the top-level key must not silently disable the
+    # assertion above it.
+    ("collect-only-site-guides", "site-guides-pytest-pinned",
+     lambda t: t.replace("          python -m pytest\n          tools/test_validate_guides.py",
+                         "          python -m pytest --collect-only\n          tools/test_validate_guides.py")),
+    ("k-filter-site-build", "site-build-pytest-pinned",
+     lambda t: t.replace("          tools/test_build_site_routing.py\n",
+                         "          tools/test_build_site_routing.py -k nope\n")),
+    ("k-filter-contrast-suite", "contrast-suite-pinned",
+     lambda t: t.replace("python -m pytest tools/test_check_docs_contrast.py -q",
+                         "python -m pytest tools/test_check_docs_contrast.py -q -k nope")),
+    ("dry-run-contrast-checker", "contrast-checker-pinned",
+     lambda t: t.replace("python3 tools/check-docs-contrast.py",
+                         "python3 tools/check-docs-contrast.py --dry-run")),
+    ("quote-on-key", "no-path-filter",
+     lambda t: t.replace("on:\n", "'on':\n", 1)),
+    # A paths: filter on a workflow whose jobs are required contexts leaves every
+    # non-matching PR permanently unmergeable.
     ("add-path-filter", "no-path-filter",
      lambda t: t.replace("  pull_request:\n    branches: [main]\n",
                          "  pull_request:\n    branches: [main]\n"

--- a/tools/test_check_docs_contrast.py
+++ b/tools/test_check_docs_contrast.py
@@ -48,12 +48,24 @@ def _load():
 mod = _load()
 
 
-def _css(pairs: str) -> str:
-    """A minimal two-theme sheet defining every name PAIRS references."""
+def _css(pairs: str, light_overrides: str = "") -> str:
+    """A minimal two-theme sheet defining every name PAIRS references.
+
+    `light_overrides` is written ONLY into the `[data-theme='light']` block, so a
+    fixture can make the themes differ. Without that, both blocks carried identical
+    declarations and no test could distinguish them — deleting the light theme from
+    `theme_tables` left the whole suite green while silently dropping 14 pairs,
+    including the three closest to the floor in the shipped palette.
+    """
     return (
         ":root {\n" + pairs + "}\n"
-        "[data-theme='light'] {\n" + pairs + "}\n"
+        "[data-theme='light'] {\n" + pairs + light_overrides + "}\n"
     )
+
+
+def _all_pairs_ok() -> str:
+    return ("".join(f"  {fg}: #000000;\n" for fg, _ in mod.PAIRS)
+            + "".join(f"  {bg}: #ffffff;\n" for _, bg in mod.PAIRS))
 
 
 def _run(root: Path) -> subprocess.CompletedProcess[str]:
@@ -93,10 +105,24 @@ def test_threshold_is_inclusive_at_the_floor() -> None:
     assert mod.passes(mod.FLOOR + 1e-9) is True
 
 
+def test_floor_is_the_wcag_aa_threshold() -> None:
+    """Pin the constant itself.
+
+    Every other assertion here is FLOOR-relative, so without this the threshold
+    could be moved a long way with the whole suite green — and changing it is an
+    "Ask first" boundary in the spec.
+    """
+    assert mod.FLOOR == 4.5
+
+
 def test_tightest_real_pairs_straddle_the_floor() -> None:
-    """#767676 on white is the canonical just-above-4.5 web pair; #777 lighter fails."""
+    """#767676 on white is the canonical just-above-4.5 web pair; #777777 just fails.
+
+    Both are within 0.03 of the floor, so this brackets it tightly — an earlier
+    draft used #8a8a8a (3.45), loose enough that FLOOR could drift ~24% undetected.
+    """
     assert mod.ratio("#767676", "#ffffff") >= mod.FLOOR
-    assert mod.ratio("#8a8a8a", "#ffffff") < mod.FLOOR
+    assert mod.ratio("#777777", "#ffffff") < mod.FLOOR
 
 
 # --------------------------------------------------------------------------
@@ -169,6 +195,53 @@ def test_malformed_palette_value_exits_non_zero_without_traceback(tmp_path: Path
     (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
     (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
         _css(pairs), encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode != 0, r.stdout + r.stderr
+    assert "Traceback" not in r.stderr, f"must refuse, not crash: {r.stderr}"
+
+
+def test_below_floor_in_light_theme_only_is_caught(tmp_path: Path) -> None:
+    """The light theme must be enumerated, not just dark.
+
+    `theme_tables` builds light as `{**dark, **light}`. Deleting the light entry, or
+    swapping the merge order so light no longer overrides, both left every other test
+    green — while dropping 14 pairs including the three tightest in the shipped
+    palette. This fixture is clean in `:root` and fails only under
+    `[data-theme='light']`, so it can only pass if light is actually checked.
+    """
+    fg0, bg0 = mod.PAIRS[0]
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(_all_pairs_ok(), light_overrides=f"  {fg0}: #808080;\n  {bg0}: #858585;\n"),
+        encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode != 0, r.stdout + r.stderr
+    assert "light" in r.stdout, f"the light theme must be named in the failure: {r.stdout}"
+
+
+def test_both_themes_are_enumerated(tmp_path: Path) -> None:
+    """A clean palette must still report BOTH themes, so a dropped theme is visible."""
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(_all_pairs_ok()), encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "dark" in r.stdout and "light" in r.stdout, r.stdout
+    # Every registered pair, in both themes.
+    assert r.stdout.count("on ") == 2 * len(mod.PAIRS), r.stdout
+
+
+def test_unresolvable_var_in_palette_exits_non_zero_without_traceback(tmp_path: Path) -> None:
+    """Covers the `resolve()` handler in `main()` at the CLI boundary.
+
+    Deleting that try/except left the suite green: the unresolvable-var case was
+    asserted only at the `resolve()` unit level, so AC3's no-traceback promise was
+    unproven for that handler.
+    """
+    fg0, _ = mod.PAIRS[0]
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(_all_pairs_ok() + f"  {fg0}: var(--nope);\n"), encoding="utf-8")
     r = _run(tmp_path)
     assert r.returncode != 0, r.stdout + r.stderr
     assert "Traceback" not in r.stderr, f"must refuse, not crash: {r.stderr}"

--- a/tools/test_check_docs_contrast.py
+++ b/tools/test_check_docs_contrast.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Behavioural coverage for `tools/check-docs-contrast.py`.
+
+# STUB: AC3 — red stub materialised at PLAN per CONVENTIONS § Stub → EXECUTE handoff.
+
+Two seams, deliberately separated:
+
+- The **ratio maths** is imported and exercised directly. `ratio()` and
+  `luminance()` are pure, so a WCAG reference value is the honest assertion.
+- The **CLI contract** is exercised as a subprocess against a temp tree. The
+  script reads a module-level relative `CSS_PATH`, so `cwd` is the whole
+  interface — which is why no `--css` flag is added here. Adding one would be a
+  public interface no acceptance criterion authorises, and the shipped
+  `docs-site/src/styles/starlight.css` is never mutated by these tests.
+
+The threshold case does not assert a pair measuring exactly 4.5:1 — none exists.
+No gray-on-gray 6-hex pair lands on 4.5 (all 65 536 were measured), and the
+shipped palette has none either, so a fixture claiming to sit exactly on the
+boundary would be asserting a fiction.
+What is asserted instead is the comparison's *inclusivity* (a synthetic ratio at
+the floor passes) plus the tightest real pairs either side of it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "check-docs-contrast.py"
+if not SCRIPT.is_file():  # wrong parents[] depth after a move
+    raise SystemExit(f"subject not found at {SCRIPT} — check the parents[] depth")
+
+
+def _load():
+    """Import the hyphenated script by path — it is not an importable module name."""
+    spec = importlib.util.spec_from_file_location("_docs_contrast", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+
+def _css(pairs: str) -> str:
+    """A minimal two-theme sheet defining every name PAIRS references."""
+    return (
+        ":root {\n" + pairs + "}\n"
+        "[data-theme='light'] {\n" + pairs + "}\n"
+    )
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    css = root / "docs-site" / "src" / "styles" / "starlight.css"
+    css.parent.mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)], cwd=root, capture_output=True, text=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# Ratio maths — pure, so assert against WCAG reference values
+# --------------------------------------------------------------------------
+
+def test_ratio_black_on_white_is_the_wcag_maximum() -> None:
+    assert round(mod.ratio("#000000", "#ffffff"), 2) == 21.0
+
+
+def test_ratio_is_symmetric() -> None:
+    assert mod.ratio("#000000", "#ffffff") == mod.ratio("#ffffff", "#000000")
+
+
+def test_identical_colours_have_no_contrast() -> None:
+    assert round(mod.ratio("#7f7f7f", "#7f7f7f"), 2) == 1.0
+
+
+def test_threshold_is_inclusive_at_the_floor() -> None:
+    """A ratio measuring exactly FLOOR must PASS, not fail.
+
+    WCAG's threshold is inclusive. Asserted through `passes()`, the seam `main()`
+    actually calls, so flipping it to `>` fails here — an earlier draft of this
+    test compared `FLOOR <= FLOOR`, which is true regardless of the production
+    comparison and stayed green when the operator was flipped.
+    """
+    assert mod.passes(mod.FLOOR) is True
+    assert mod.passes(mod.FLOOR - 1e-9) is False
+    assert mod.passes(mod.FLOOR + 1e-9) is True
+
+
+def test_tightest_real_pairs_straddle_the_floor() -> None:
+    """#767676 on white is the canonical just-above-4.5 web pair; #777 lighter fails."""
+    assert mod.ratio("#767676", "#ffffff") >= mod.FLOOR
+    assert mod.ratio("#8a8a8a", "#ffffff") < mod.FLOOR
+
+
+# --------------------------------------------------------------------------
+# Invalid input — each named case refuses, none crashes with a raw traceback
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", ["#xyzxyz", "#12345", "", "#"])
+def test_malformed_hex_refuses_clearly(value: str) -> None:
+    with pytest.raises(mod.ColourError):
+        mod.luminance(value)
+
+
+def test_three_digit_shorthand_is_refused_not_silently_wrong() -> None:
+    """`#abc` is legal CSS but unsupported here.
+
+    It must refuse rather than misparse: `int("ab", 16)` would succeed and yield a
+    plausible-but-wrong luminance, which is worse than an error.
+    """
+    with pytest.raises(mod.ColourError):
+        mod.luminance("#abc")
+
+
+def test_unresolvable_var_chain_refuses_clearly() -> None:
+    with pytest.raises(mod.ColourError):
+        mod.resolve("--doc-text", {"--doc-text": "var(--nope)"})
+
+
+def test_var_cycle_refuses_rather_than_recursing() -> None:
+    table = {"--a": "var(--b)", "--b": "var(--a)"}
+    with pytest.raises(mod.ColourError):
+        mod.resolve("--a", table)
+
+
+# --------------------------------------------------------------------------
+# CLI contract — exit status is the gate CI depends on
+# --------------------------------------------------------------------------
+
+def test_passing_palette_exits_zero(tmp_path: Path) -> None:
+    pairs = "".join(f"  {fg}: #000000;\n" for fg, _ in mod.PAIRS) + \
+            "".join(f"  {bg}: #ffffff;\n" for _, bg in mod.PAIRS)
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(pairs), encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "all pairs pass" in r.stdout
+
+
+def test_one_failing_registered_pair_exits_non_zero(tmp_path: Path) -> None:
+    """The seeded-failure case AC4's CI gate depends on.
+
+    Seeded in a temp tree, never in the shipped palette.
+    """
+    fg0, bg0 = mod.PAIRS[0]
+    pairs = "".join(f"  {fg}: #000000;\n" for fg, _ in mod.PAIRS) + \
+            "".join(f"  {bg}: #ffffff;\n" for _, bg in mod.PAIRS)
+    # Collapse one registered pair onto near-identical greys → ~1:1.
+    pairs += f"  {fg0}: #808080;\n  {bg0}: #858585;\n"
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(pairs), encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode != 0, r.stdout + r.stderr
+    assert "below" in r.stdout
+
+
+def test_malformed_palette_value_exits_non_zero_without_traceback(tmp_path: Path) -> None:
+    pairs = "".join(f"  {fg}: #zzzzzz;\n" for fg, _ in mod.PAIRS) + \
+            "".join(f"  {bg}: #ffffff;\n" for _, bg in mod.PAIRS)
+    (tmp_path / "docs-site" / "src" / "styles").mkdir(parents=True)
+    (tmp_path / "docs-site" / "src" / "styles" / "starlight.css").write_text(
+        _css(pairs), encoding="utf-8")
+    r = _run(tmp_path)
+    assert r.returncode != 0, r.stdout + r.stderr
+    assert "Traceback" not in r.stderr, f"must refuse, not crash: {r.stderr}"
+
+
+def test_missing_css_exits_non_zero_without_traceback(tmp_path: Path) -> None:
+    r = _run(tmp_path)  # creates the dir but no file
+    assert r.returncode != 0
+    assert "Traceback" not in r.stderr, f"must refuse, not crash: {r.stderr}"
+
+
+def test_undecodable_css_exits_non_zero_without_traceback(tmp_path: Path) -> None:
+    """`UnicodeDecodeError` is a ValueError, not an OSError.
+
+    An earlier draft caught only `OSError`, so a non-UTF8 sheet escaped as a raw
+    traceback printing absolute repo paths — from a required CI step, which reads
+    as tooling breakage rather than the contract violation it is.
+    """
+    css = tmp_path / "docs-site" / "src" / "styles"
+    css.mkdir(parents=True)
+    (css / "starlight.css").write_bytes(b"\xff\xfe:root{--doc-text:#000000;}")
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "Traceback" not in r.stderr, f"must refuse, not crash: {r.stderr}"

--- a/tools/test_check_docs_contrast.py
+++ b/tools/test_check_docs_contrast.py
@@ -56,6 +56,12 @@ def _css(pairs: str, light_overrides: str = "") -> str:
     declarations and no test could distinguish them — deleting the light theme from
     `theme_tables` left the whole suite green while silently dropping 14 pairs,
     including the three closest to the floor in the shipped palette.
+
+    One residual, stated rather than left implied: every fixture here declares the
+    full `PAIRS` set in BOTH blocks, so none exercises light *inheriting* a name it
+    does not declare. Mutating the merge to `dict(light)` therefore leaves this suite
+    green; the shipped-palette run is what catches that (one pair errors, exit 1), so
+    it is not silent in CI.
     """
     return (
         ":root {\n" + pairs + "}\n"
@@ -118,8 +124,9 @@ def test_floor_is_the_wcag_aa_threshold() -> None:
 def test_tightest_real_pairs_straddle_the_floor() -> None:
     """#767676 on white is the canonical just-above-4.5 web pair; #777777 just fails.
 
-    Both are within 0.03 of the floor, so this brackets it tightly — an earlier
-    draft used #8a8a8a (3.45), loose enough that FLOOR could drift ~24% undetected.
+    Measured margins: #767676 is 4.5422 (+0.042), #777777 is 4.4781 (-0.022) — the
+    floor is bracketed within 0.07 total. An earlier draft used #8a8a8a (3.45), loose
+    enough that FLOOR could drift ~24% undetected.
     """
     assert mod.ratio("#767676", "#ffffff") >= mod.FLOOR
     assert mod.ratio("#777777", "#ffffff") < mod.FLOOR

--- a/workspace.toml
+++ b/workspace.toml
@@ -201,6 +201,7 @@ shipped = [
   {path = "docs/specs/workspace-mcp/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "workspace-mcp — Stage 1 implementation", needs = []},
   {path = "docs/specs/m6-live-demo-guide/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run a peer-led shaping-to-spec demonstration on the adopting organization's repository", needs = []},
   # Tech-site completion programme — shipped 2026-08-17.
+  {path = "docs/specs/site-ci-contract-closure/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Require the existing site construction tests and docs contrast checker in CI", needs = []},
   {path = "docs/specs/site-contract-provenance-cleanup/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Reconcile frozen site decisions, living guidance, and legacy provenance", needs = []},
 ]
 queue   = [
@@ -243,7 +244,6 @@ queue   = [
   # Tech-site completion programme — approved 2026-08-17 from the canonical brief.
   # These entries are independently shippable. `needs` records only hard delivery
   # ordering; the brief retains the broader wave and evidence sequence.
-  {path = "docs/specs/site-ci-contract-closure/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Require the existing site construction tests and docs contrast checker in CI", needs = []},
   {path = "docs/specs/docs-site-build-contract-hardening/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Harden docs rendering with site-local cleanup and built-in plugin tests", needs = [{type = "local", kind = "spec", path = "docs/specs/site-ci-contract-closure/spec.md"}]},
   {path = "docs/specs/guide-title-clarity/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Apply the four approved guide-title wording changes", needs = []},
   {path = "docs/specs/guide-metadata-completion/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Complete reviewed metadata for every rendered public guide", needs = [{type = "local", kind = "spec", path = "docs/specs/guide-title-clarity/spec.md"}]},
@@ -470,6 +470,17 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # .github/workflows/build-check.yml carries a comment block describing the
+  # credential-setup skill suite that sits above the WRONG step: the steps
+  # spec/build-check-coverage-gaps inserted displaced it from the
+  # `pytest credential-setup skill` step it documents, and
+  # spec/site-ci-contract-closure's contrast step widened that gap by one more.
+  # A reader takes it as describing whichever step follows it. Fix: move the block
+  # back above its own step. Deliberately deferred rather than tidied in passing:
+  # it pre-dates both changes and neither orphaned it, so it falls outside the
+  # bundled-fixes carve-out. Unblocks when: picked up — comment move only, no
+  # dependency.
+  {slug = "build-check-stranded-credential-setup-comment", source = "spec/site-ci-contract-closure (review concern 16)"},
   # tools/lint-build.py's RFC_AUTHORISED_DIRS still credits the `docs-site` entry to
   # ADR-0055, while the tuple's own header says entries are added only when an
   # Accepted RFC authorises the directory — and RFC-0089 is now exactly that RFC.


### PR DESCRIPTION
## What does this change?

Pins the seven site/catalogue test modules to `gate-main` with a standing,
mutation-proven construction test, and makes the docs-palette WCAG floor a
required gate by adding one `gate-main` step plus the checker tests and input
hardening it needs.

## Why?

- Implements: `docs/specs/site-ci-contract-closure/spec.md`
- Follows from: [RFC-0082](docs/rfc/0082-test-ownership-boundaries-and-inclusion.md),
  [ADR-0086](docs/adr/0086-split-the-sast-gate-into-its-own-ci-job.md),
  `docs/specs/ci-gate-parallelization/spec.md` AC16
- Brief: `docs/product/briefs/tech-site-completion.md` (wave 1)

**AC1 was already satisfied and is recorded, not reimplemented.** The shipped
`build-check-coverage-gaps` spec had already moved all seven modules into
`gate-main`, and branch protection requires `gate-main` by name (alongside
`gate-sast`, `gate-export-boundary`, and the `make build-check` aggregator). The
spec's intake assumption — that the seven ran locally "but not as required CI
steps" — was false; they ran in both. What was genuinely missing is a *standing*
test pinning that (the sibling's was a one-time before/after scan) and any
invocation of `tools/check-docs-contrast.py` anywhere.

## How do I verify it?

Every new assertion is proven by seeded failure against the **real** workflow,
not only the fixture:

```
drop tools/test_validate_guides.py         → rc 1  site-module[…]
drop tools/test_build_site_routing.py      → rc 1  site-module[…]
misspell a module name                     → rc 1  site-module[…]
move a module to gate-sast                 → rc 1  site-module[…]
drop either contrast command               → rc 1  contrast-gate[…]
continue-on-error on an owning step        → rc 1
if: ${{ false }} on any of the three steps → rc 1  site-step-no-if[…]
working-directory: tools on either step    → rc 1  no-working-directory[…]
--collect-only / -k nope on any step       → rc 1  *-body-exact
exit 0 prepended to any of the three       → rc 1  *-body-exact
paths: filter, any spelling or indent      → rc 1  no-path-filter
paths: under on.push, or a flow mapping    → rc 1  no-path-filter
quoted or duplicated top-level on: key     → rc 1  no-path-filter / one-on-key
escape-encoded or explicit-key YAML syntax → rc 1  no-unmodelled-key-syntax
```

Every one of those was measured green before the assertion that now catches it.

```
python3 tools/test-build-check-workflow.py     # posture OK; self-test: 174 mutations
                                              # each caught, all 76 families mutated
python3 tools/lint-ci-parity.py               # ok — 72 steps, all dispositioned
python3 tools/test-lint-ci-parity.py          # 104 cases pass
python3 -m pytest tools/test_check_docs_contrast.py -q   # 21 passed
python3 tools/check-docs-contrast.py          # shipped palette: all pairs pass
```

Emitted output unchanged — a **route-set diff** against the pre-change baseline,
not just a count (a rename preserves a count):

```
269 routes before, 269 after; diff → identical membership
rendered-site-links: 57833 links across 269 pages; clean
check-docs-contrast: all pairs pass          # both themes
```

Also: `make build-check` complete with SAST/SCA · `lint-ruff` pass · `lint-mypy`
118 files clean · `git diff --check` clean · `lint-spec-status.py` metadata clean ·
reconciliation shows no new Type 1/2/3, and `docs-site-build-contract-hardening`
became `canonical.ready` as its dependency cleared · no dependency added, no
manifest or lockfile touched.

## What did you not change that you considered?

- **A third step naming the seven modules.** They already run in two steps; a
  third would duplicate execution and create the second workflow-side source of
  truth this spec exists to prevent. Only one new step was added.
- **Deriving the roster from the `Makefile`.** Rejected as circular: a roster read
  out of one of the things being checked means deleting a module from both the
  Makefile and the workflow would pass. The roster is enumerated in the test;
  Make/CI divergence stays with `lint-ci-parity`, which already owns it.
- **Two `make-covers-*` assertions I wrote and then removed.** They read the real
  `Makefile`, so no workflow mutation could flip them — they would have shipped as
  decorative assertions that the posture file's own "evaluated but unmutated" rule
  exists to reject.
- **`tools/test_build_gate_chain.py` as the test's home.** It runs inside
  `gate-main`, the far side of the edge being protected. The test went into
  `tools/test-build-check-workflow.py`, which the aggregator invokes — the same
  argument the aggregator's own guard makes.
- **A `--css` flag on the checker.** The seeded-failure tests run it as a
  subprocess with `cwd` set to a temp tree, so no new public interface was added
  and the shipped `docs-site/src/styles/starlight.css` is never mutated.
- **Branch protection.** No change needed: `gate-main` is already a required
  context, so the new step is required by placement alone.
- **`build-check.yml` lines 266-272** — see *Deferred*.

## Two acceptance criteria were restated. Neither was dropped.

**AC5 is inverted, deliberately.** As approved it asked for `paths:` filters on
`build-check.yml`. Implementing that would be actively harmful: the workflow's
jobs are required contexts *by name*, so on a PR touching none of the filtered
paths the workflow never runs, the required checks never report, and the PR is
permanently unmergeable — held in `Expected`, not skipped-as-success. The
criterion now requires the filter's **absence**, enforced by a `no-path-filter`
assertion with an `add-path-filter` mutation, and prohibits adding one.

**AC6 is restated** because it contradicted a shipped decision. It demanded that
the local and CI commands "select the same test modules", but
`ci-gate-parallelization` AC16 settled that parity became one-to-many at the job
split, with addressability as the replacement invariant — and `make build-check`
runs no pytest at all. It now requires every path the new step names to be
reachable from `make ci`, which `lint-ci-parity` enforces. That gate caught a real
gap while implementing this: the *test* was registered in the Makefile but the
*checker* was not.

## Deferred:

- `build-check-stranded-credential-setup-comment` — a comment block in
  `build-check.yml` displaced from the step it documents. This change widens the
  gap by one step but did not orphan it, so it falls outside the bundled-fixes
  carve-out.

## Bundled fixes:

- `build-check.yml`'s `permissions:` rationale said "all 56 steps reviewed" (72
  now, and already stale by 15 before this PR). Replaced with "every step
  reviewed" so the claim stops requiring arithmetic maintenance.
