### PR TITLE
docs(governance): correct four stale references; defer the fifth on evidence

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -270,11 +270,6 @@ jobs:
         # it stays.
         run: python -m pip install -e './packages/credbroker[crypto]'
 
-      # The credential-setup skill's own suite (RFC-0023 T8 + the
-      # missing-credbroker guard) lives under packs/credential-brokers/tests/skills/credential-setup/ (ADR-0071), which
-      # neither `make build-check` nor any package pytest discovers. Wire it
-      # explicitly or it never gates. Placed after the credbroker[crypto]
-      # install above so the in-process import + crypto-extra cases resolve.
       - name: pytest guides + catalogue navigation
         run: >-
           python -m pytest
@@ -313,6 +308,11 @@ jobs:
       # collection would silently run nothing.
       - name: pages.yml deploy-gate posture
         run: python3 tools/test-pages-workflow.py
+      # The credential-setup skill's own suite (RFC-0023 T8 + the
+      # missing-credbroker guard) lives under packs/credential-brokers/tests/skills/credential-setup/ (ADR-0071), which
+      # neither `make build-check` nor any package pytest discovers. Wire it
+      # explicitly or it never gates. Placed after the credbroker[crypto]
+      # install above so the in-process import + crypto-extra cases resolve.
       - name: pytest credential-setup skill (RFC-0023 T8 + missing-credbroker guard)
         working-directory: packs/credential-brokers/tests/skills/credential-setup
         # `requires_crypto` gates on find_spec("cryptography") and ("argon2"), so a

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,8 @@ sast:
 	# mcp CVEs requires a Semgrep backend compromise + targeted CI attack; the click CVE
 	# requires controlling semgrep's CLI args (i.e. write access to this repo).
 	# Suppression is unblocked once semgrep ships mcp>=1.28.1 + click>=8.3.3 deps.
-	# Full diagnosis and unblock condition: docs/backlog.md § semgrep-mcp-cve-allowlist.
+	# Full diagnosis and unblock condition: workspace.toml [backlog].open, entry
+	# `semgrep-mcp-cve-allowlist` — the suppressions' only recorded expiry.
 	@echo "pip-audit -r tools/requirements-sast.txt (semgrep transitive-dep CVE allowlist applied)"
 	@pip-audit -r tools/requirements-sast.txt \
 		--ignore-vuln CVE-2026-52870 \

--- a/docs/specs/stale-reference-corrections/plan.md
+++ b/docs/specs/stale-reference-corrections/plan.md
@@ -1,0 +1,111 @@
+# Plan: stale-reference-corrections
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `.github/workflows/build-check.yml` — one comment block relocated (AC1).
+- `web/src/design-system.md` — § 6 and § 8 prose plus § 6's resolved-value table (AC2).
+- `tools/lint-build.py` — one trailing comment (AC3).
+- `Makefile` — one comment line in the `sast` target (AC4.1).
+- `workspace.toml` — `[backlog].open` only: one entry widened (AC4.2), five deleted (AC6).
+- `docs/specs/stale-reference-corrections/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- Goal-based throughout. No behavior changes, so no new test earns its place: a
+  test asserting a comment's line number would pin formatting, which is the exact
+  antipattern `site-test-source-substring-assertions` is open against.
+- `python3 tools/test-build-check-workflow.py` and `python3 tools/lint-ci-parity.py` green (AC1).
+- `python3 tools/lint-build.py` green (AC3).
+- `make sast` pip-audit leg green with the four suppressions byte-identical (AC4).
+- `workspace-status status --root .` exits 0, five fewer open entries (AC6).
+- `python3 .claude/skills/work-loop/scripts/lint-spec-status.py` green (deferral anchors intact).
+- `make ci` green before the PR opens.
+
+**What I am NOT changing**
+- No executable line anywhere. Every edit is a comment, a prose sentence, a
+  markdown table cell, or a `[backlog].open` array member.
+- Not the `--ignore-vuln` suppressions, the manifest they scan, or their four CVE ids.
+- Not `contracts`/`guides` in `RFC_AUTHORISED_DIRS` — no authorising RFC exists.
+- Not § 8's known-deviations table in `design-system.md`. It is a separate claim
+  about two `#ffffff` literals and needs its own verification pass; AC2 is scoped
+  to the import claim and the dark-mode mechanism stated in the same sentences.
+- Not `docs/backlog.md`. AC4 repoints away from the tombstone; adding a section
+  to it would re-establish the split registry the tombstone exists to end.
+
+## Declined patterns
+
+- **Tempted:** fix § 8's two `#ffffff` known-deviation rows while the file is
+  open. **Declined:** they are a different claim (token-compliance deviations,
+  not the import mechanism), and I have not verified whether
+  `.site-footer__brand` still sets `color` at all. An unverified "correction" is
+  how this class of drift got here.
+- **Tempted:** re-attribute `contracts` and `guides` in `RFC_AUTHORISED_DIRS`
+  too, since they carry the same ADR-cited-as-RFC shape. **Declined:** RFC-0089
+  exists and names `docs-site`; nothing authorises the other two, so the honest
+  edit is unavailable and inventing an attribution is worse than the status quo.
+  Recorded as a deferral.
+- **Tempted:** add a lint asserting every `RFC_AUTHORISED_DIRS` comment cites an
+  `RFC-` number, so AC3's class cannot recur. **Declined:** it would fail on
+  `contracts` and `guides` immediately — a checker that lands red is the
+  `npm-allowscripts-enforcement` trap, already open for exactly this reason.
+- **Tempted:** while removing five entries, also delete the three anchor-only
+  entries (`ci-gate-*-branch-protection-widening`, `starlight-migration-rfc`)
+  whose work is done. **Declined:** each is retained deliberately because a
+  frozen spec's `(deferred: <slug>)` marker must resolve; removing one reddens
+  `lint-spec-status` invariant (iv). Their own comments say so.
+- **Tempted:** convert the 150-line `packs/AGENTS.md` cap problem into a
+  restructure that frees several lines. **Declined:** the pointer fits as an
+  in-place word swap; reorganising a capped context file to make room for one
+  sentence is a change nobody asked for.
+
+## Tasks
+
+### T1 — Verify every claim (no writes)
+- **Mode:** goal-based. `Done when:` each of the five entries' defect claims has
+  been re-checked against the tree and the evidence recorded in `spec.md`.
+- **Tests:** no stub (goal-based).
+- **Status:** done. All five confirmed; AC2 found the defect wider than the entry
+  described (the mechanism claim and the hex table, not just the import sentence)
+  and the spec records the measurement.
+
+### T2 — AC1: relocate the build-check comment block
+- **Mode:** goal-based. `Done when:` `test-build-check-workflow.py` and
+  `lint-ci-parity.py` are green and the block precedes its own step.
+- **Tests:** no stub (goal-based) — see the trio's note on line-number assertions.
+- **Touches:** `.github/workflows/build-check.yml`.
+
+### T3 — AC2: correct the docs-palette claims
+- **Mode:** goal-based. `Done when:` the four greps in AC2 return the stated
+  results and every token/hex pair in the corrected table resolves in `starlight.css`.
+- **Tests:** no stub (goal-based).
+- **Touches:** `web/src/design-system.md`.
+
+### T4 — AC3 + AC4.1: re-point two stale citations
+- **Mode:** goal-based. `Done when:` `lint-build.py` green and
+  `grep -n "docs/backlog.md" Makefile` returns nothing.
+- **Tests:** no stub (goal-based).
+- **Touches:** `tools/lint-build.py`, `Makefile`.
+
+### T5 — AC5: name the pack schema — ATTEMPTED, REVERTED, DEFERRED
+- **Mode:** goal-based. `Done when:` `lint-agents-md.py` green,
+  `test_catalogue_tooling_docs.py` green, `wc -l packs/AGENTS.md` = 150.
+- **Tests:** no stub (goal-based) — `test_line_count` already covers the cap.
+- **Touches:** none in the final diff.
+- **Outcome:** the edit landed and `make ci` failed on
+  `test_scaffold_projection.py::test_packs_agents_md_cites_only_paths_it_ships` —
+  the authoring scaffold ships no `contracts/` directory, so the pointer dangles
+  in every adopter's tree. Reverted (source files, projection, and manifest), and
+  the backlog entry rewritten with the constraint and three options. The gate the
+  entry did not know about is the one that decided this.
+
+### T6 — AC4.2 + AC6: reconcile `[backlog].open`
+- **Mode:** goal-based. `Done when:` `workspace-status status` exits 0 with four
+  fewer open entries than the base ref, `lint-spec-status.py` green, and `git diff workspace.toml`
+  shows hunks inside `[backlog]` only.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml`.
+- **Depends on:** none of T2-T5 functionally; sequenced last so the entries are
+  removed only after their fixes are in the same diff.

--- a/docs/specs/stale-reference-corrections/spec.md
+++ b/docs/specs/stale-reference-corrections/spec.md
@@ -1,0 +1,212 @@
+# Spec: stale-reference-corrections
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — every change is a comment or a prose sentence. No
+  executable behavior, no gate outcome, and no public interface moves.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (work-loop). No risk trigger fired. Two conditional triggers were
+checked and did NOT fire. (1) Security boundary: the Makefile edit is the COMMENT
+above the `--ignore-vuln` block, not the block — the four suppressed CVE ids, the
+manifest, and the invocation are byte-identical after this change. (2) Governance
+boundary: `[backlog].open` is a display projection the dispatch classifiers never
+read (`workspace_status_engine.py` `extract_repo_backlog`), and no `(deferred: <slug>)`
+anchor in any spec resolves against the five slugs removed here — verified by grep.
+Lean fill: Objective + Acceptance Criteria + Boundaries + Assumptions. -->
+
+## Objective
+
+Five `[backlog].open` entries record the same defect class: a comment or a
+documented claim that was true when written and is false now. Each entry's own
+`Fix:` line is fully determined — none needs a decision, a measurement, or an
+environment — and each says in so many words that it was left out of its parent
+PR because it fell outside that PR's touched area, not because it was hard.
+
+They are corrected together because a reader who trusts any one of them is
+misled in the same way, and because a single-item PR for a one-line comment
+costs more review attention than the correction is worth.
+
+Success: every corrected claim is verifiable by a command recorded beside it in
+this spec, and the five entries leave `[backlog].open`.
+
+## Acceptance Criteria
+
+- [x] **AC1 — `build-check.yml`'s credential-setup comment block sits above the
+  step it documents.** The five-line block that opens "The credential-setup
+  skill's own suite (RFC-0023 T8 + the missing-credbroker guard)" moves from
+  above `pytest guides + catalogue navigation` to immediately above
+  `pytest credential-setup skill (RFC-0023 T8 + missing-credbroker guard)`.
+
+  Evidence of the defect: the block's own subject line names the
+  `credential-setup` step, and four unrelated steps
+  (`pytest guides + catalogue navigation`, `pytest site build + link rewriting`,
+  `docs palette contrast gate`, `pages.yml deploy-gate posture`) sit between the
+  two. A reader takes a leading comment as describing the step that follows it.
+
+  Verification: `python3 tools/test-build-check-workflow.py` and
+  `python3 tools/lint-ci-parity.py` both stay green — the block is a comment, so
+  no assertion family, no `PINNED_JOB_STATEMENTS` entry, and no parity roster
+  entry reads it. No step name, `run:` body, `working-directory:`, or step order
+  changes.
+
+- [x] **AC2 — `web/src/design-system.md` stops claiming the docs CSS imports
+  `tokens.css`.** Both passages are corrected: § 6 Dark mode and § 8 Starlight
+  CSS audit.
+
+  Evidence of the defect: `docs-site/src/styles/starlight.css` says so itself at
+  its compatibility-layer header — "tokens.css is no longer imported; these
+  definitions re-derive exactly the consumed names onto the doc palette" — and
+  the file contains zero `@import`. The docs palette is self-contained per
+  ADR-0085; `--ds-*` names survive only as a re-derivation for the shared
+  primitive components.
+
+  In the same § 6 passage, and corrected with it because they are the same
+  claim about the same mechanism, not a second subject: the section says dark
+  mode is applied "via `[data-theme='dark']`", and its resolved-value table
+  cites `--prim-dark-950` → `#0b0e12`, `--prim-dark-900` → `#111520`,
+  `--ds-accent` → `#e8952b`, `--prim-amber-300` → `#f5bc6a`. Measured: the docs
+  sheet carries **no** `[data-theme='dark']` selector and **no** `--prim-*`
+  token, and none of those four hex values appears anywhere under
+  `docs-site/src/styles/`. The surface is dark-**first** — `:root` is the dark
+  theme and `:root[data-theme='light']` overrides it — so the stated direction
+  is inverted as well as the values being wrong.
+
+  Also in § 8, and corrected with it for the same reason: its known-deviations
+  table asserted two raw `#ffffff` literals against a "Closest `--ds-*` token"
+  of `--ds-hero-fg`. Measured: `--ds-hero-fg` does not exist in `starlight.css`
+  at all, so the comparison column named a token the sheet does not carry; and
+  the `.site-footer__brand { color }` row is simply resolved — that rule now
+  reads `color: var(--doc-heading)`. One deviation survives
+  (`--sl-color-text-invert`'s light-theme assignment, `starlight.css:124`) and
+  the table is narrowed to it.
+
+  Verification: `grep -c '@import' docs-site/src/styles/starlight.css` returns
+  `0`; `grep -c -- '--prim-' docs-site/src/styles/starlight.css` returns `0`;
+  `grep -c "data-theme='dark'" docs-site/src/styles/starlight.css` returns `0`;
+  `grep -n -- '--ds-hero-fg' docs-site/src/styles/starlight.css` returns
+  nothing; every token/hex pair in both corrected tables resolves in
+  `starlight.css`. The four `--prim-*` hexes that remain in `design-system.md`
+  are § 1's `web/` primitive table and are correct against
+  `web/src/styles/tokens.css` — they were never the defect.
+
+- [x] **AC3 — `lint-build.py`'s `docs-site` entry is attributed to the RFC that
+  authorises it.** The trailing comment on the `"docs-site"` member of
+  `RFC_AUTHORISED_DIRS` cites RFC-0089 rather than ADR-0055.
+
+  Evidence of the defect: the tuple's own header (`tools/lint-build.py:31-32`)
+  reads "Top-level directories explicitly authorised by an Accepted RFC. Add
+  entries only when an Accepted RFC authorises the new directory." ADR-0055 is
+  an ADR. `docs/rfc/0089-starlight-docs-boundary.md` is Accepted, is titled
+  "Starlight docs boundary", and its decision weight names ratifying the
+  permanent top-level project as its subject.
+
+  Verification: `python3 tools/lint-build.py` stays green; the tuple's
+  membership is unchanged (comment only).
+
+- [x] **AC4 — the semgrep suppression's recorded expiry resolves, and the SCA
+  gap it points at names every uncovered file.** Two edits:
+
+  1. `Makefile` — the comment above the four `--ignore-vuln` flags cites
+     "docs/backlog.md § semgrep-mcp-cve-allowlist" as the diagnosis and unblock
+     condition. `docs/backlog.md` is an anchor tombstone whose own header says
+     "All open work has migrated to `workspace.toml [backlog].open`", and it
+     carries no semgrep section — `grep -i semgrep docs/backlog.md` returns
+     nothing. The citation is repointed at `workspace.toml [backlog].open`.
+     This was the suppressions' only recorded expiry.
+  2. `workspace.toml` — `sast-requirements-not-audited` names only
+     `tools/requirements-sast.txt` and `tools/requirements-ci-security-locked.txt`.
+     `tools/requirements-evals-locked.txt` exists, is equally unaudited, and
+     falls outside every other entry. Its comment and `summary` are widened to
+     name it.
+
+  The suppression itself does not lift: measured this session, semgrep 1.166.0
+  still requires `mcp==1.23.3` and `click~=8.1.8`, so the unblock condition the
+  comment states is unmet and all four `--ignore-vuln` flags stay.
+
+  Verification: `grep -n "docs/backlog.md" Makefile` returns nothing;
+  `make sast`'s pip-audit leg still passes the same four suppressions; the four
+  CVE ids are byte-identical in the diff.
+
+- [ ] (deferred: packs-agents-normative-pointer) **AC5 — `packs/` names its machine source of truth.** Attempted and reverted; the entry's premise does not survive the repository's own contract.
+
+  The gap is real: `grep -n "pack.schema.json" packs/AGENTS.md packs/README.md`
+  returns nothing, while `profiles/AGENTS.md:18` names
+  `contracts/profile.schema.json`.
+
+  Why the edit was reverted. Both files are projected into the authoring
+  scaffold (`tools/catalogue/sync_authoring_scaffold.py` `_SYNC_PAIRS`), and that
+  scaffold is what `catalogue init` writes into an adopter's catalogue root. The
+  scaffold ships `guides/ packs/ profiles/ tests/` and **no `contracts/`
+  directory**, so the pointer is true here and false in every adopter's tree.
+  `test_scaffold_projection.py::test_packs_agents_md_cites_only_paths_it_ships`
+  exists precisely to catch that and did — measured: the edit reddens `make ci`
+  on arrival with "State the rule without the citation, or ship the file." The
+  current path-free wording is deliberate, not an oversight.
+
+  `packs/README.md` carries no equivalent assertion, so the same pointer lands
+  green there — and is equally false for the adopter. It was reverted too rather
+  than shipped on the strength of an absent test.
+
+  Second instance, found the same way and the reason the entry's premise
+  inverts: `profiles/AGENTS.md` already carries the dangling form, and
+  `test_scaffold_projection.py` asserts only that it exists and is non-empty. The
+  file the entry named as the precedent to mirror is a second occurrence of the
+  same defect.
+
+  Closing it needs a decision — ship the schemas in the scaffold, keep the
+  wording path-free and close the entry as won't-fix, or build a repo-only
+  projection carve-out that `_SYNC_PAIRS` byte-identity does not offer. The
+  rewritten `[backlog].open` entry carries all three options and the
+  recommendation.
+
+- [x] **AC6 — four entries leave `[backlog].open`; the fifth is rewritten.**
+  `packs-agents-normative-pointer` stays open, its comment replaced with what
+  AC5 measured, so the next author does not repeat the attempt. The other four
+  are deleted, not
+  moved to `[backlog].closed`: that collection admits only `kind = "defect"`
+  backed by a real artifact carrying `Status: Closed`, and fabricating one is
+  what this repository's own remediation forbids. Deletion is the established
+  practice — `[backlog].closed` has stayed empty across the project's history.
+
+  No `(deferred: <slug>)` anchor resolves against any of the five (verified by
+  `grep -rn "deferred: <slug>" docs/`), so `lint-spec-status.py` invariant (iv)
+  is unaffected. The two prose mentions in
+  `docs/specs/pip-audit-batching/spec.md` (Archived) are registered-deferral
+  narrative, not anchors, and are left alone — it is a frozen record and its
+  account of what was deferred at the time stays true.
+
+  Verification: `workspace-status status --root .` exits 0 and reports four
+  fewer open entries than the base ref. Deliberately stated as a delta, not an
+  absolute: `[backlog].open` grows on other branches, and this spec was rebased
+  once onto four intervening merges that added entries of their own.
+
+## Boundaries
+
+**Never do**
+
+- Lift the four `--ignore-vuln` suppressions. Their stated condition is unmet
+  (semgrep 1.166.0 still pins `mcp==1.23.3`), so removing them would redden
+  `make sast` on arrival.
+- Re-attribute the `contracts` or `guides` members of `RFC_AUTHORISED_DIRS`.
+  Both cite ADR-0055 and neither has an authorising RFC to point at; inventing
+  one is the fabrication AC6 refuses elsewhere.
+- Edit `docs/specs/pip-audit-batching/spec.md` or any other frozen spec body.
+- Change a step name, `run:` body, `working-directory:`, or step order in
+  `build-check.yml`.
+- Touch `[work]`, `[shaping_queue]`, `[brief_queue]`, or initiative membership
+  in `workspace.toml`.
+
+## Assumptions
+
+1. `docs/backlog.md` remains a tombstone. Confirmed by its own header; AC4
+   repoints away from it rather than adding a section to it.
+2. `contracts/pack.schema.json` and the wheel's `_data/` copy stay identical.
+   Confirmed byte-identical this session; AC5 names the repo-root path because
+   that is the one an author edits.
+3. Comments in `build-check.yml` are not asserted by the posture test. Confirmed
+   by reading `PINNED_JOB_STATEMENTS` and `_NO_CWD_STEPS`, and re-confirmed by
+   running the suite after the move (AC1).

--- a/tools/lint-build.py
+++ b/tools/lint-build.py
@@ -37,7 +37,7 @@ RFC_AUTHORISED_DIRS = (
     "governance",  # RFC-0065 D16 — governance-index template seed projection (governance-extras)
     "contracts",  # ADR-0055 — wave1 docs restructure: lift docs/contracts/ to repo root
     "guides",  # ADR-0055 — wave1 docs restructure: lift docs/guides/ to repo root
-    "docs-site",  # ADR-0055 — Starlight replaces MkDocs: Astro+Node.js docs-site pipeline
+    "docs-site",  # RFC-0089 — Starlight docs boundary ratifies the top-level project
     "tests",  # RFC-0082 — catalogue conformance and non-shipping roster suites
 )
 

--- a/web/src/design-system.md
+++ b/web/src/design-system.md
@@ -451,20 +451,23 @@ not toggled by user setting. Exception: `web/public/favicon.svg` does include a
 `@media (prefers-color-scheme: dark)` rule to adjust the favicon fill in dark OS mode — this is
 a standalone SVG asset and does not affect page or component CSS.
 
-Dark mode equivalents exist only in the **Starlight docs-site** (`docs-site/src/styles/starlight.css`
-via `[data-theme='dark']`, toggled by the Starlight theme switcher). The Starlight CSS imports
-`tokens.css` at build time (`@import './tokens.css'`), so dark-mode color overrides use
-`--prim-*` and `--ds-*` tokens directly rather than raw hex values.
+Dark mode exists only in the **Starlight docs-site** (`docs-site/src/styles/starlight.css`,
+toggled by the Starlight theme switcher) — and that sheet is dark-**first**: the dark palette
+is declared on bare `:root`, and `:root[data-theme='light']` overrides it. There is no
+`[data-theme='dark']` selector. The docs palette is also self-contained per ADR-0085:
+`starlight.css` carries no `@import` and does not read `web/src/styles/tokens.css`. It
+declares its own `--doc-*` tokens and re-derives the `--ds-*` names that the shared
+`primitives/` components consume, so no `--prim-*` token reaches the docs surface.
 
-Dark-mode resolved values (token → hex):
+Docs dark-theme resolved values (token → hex), read from `starlight.css`:
 
 | Role | Token reference | Hex |
 | --- | --- | --- |
-| Docs surface background | `var(--prim-dark-950)` | `#0b0e12` |
-| Sidebar / elevated surface | `var(--prim-dark-900)` | `#111520` |
-| Accent / icon highlight | `var(--ds-accent)` | `#e8952b` |
-| Link color | `var(--prim-amber-300)` | `#f5bc6a` |
-| Inline code background | `var(--ds-accent-subtle-dk)` | `rgba(232,149,43,0.15)` |
+| Docs surface background | `var(--doc-ground)` | `#0c111c` |
+| Sidebar / elevated surface | `var(--doc-surface)` | `#111726` |
+| Accent — fills, large marks | `var(--doc-accent)` | `#4f7df0` |
+| Link color — text-safe on dark (8.68:1) | `var(--doc-accent-strong)` | `#8ab0f9` |
+| Inline code background | `var(--doc-tint)` | `rgba(138,176,249,0.12)` |
 
 ## 7. Card icon parity decision
 
@@ -489,20 +492,21 @@ closes the question so it is not re-litigated in future PRs.
 previously planned audit of Material-injected raw-hex deviations (`.md-header`, `.md-tabs`,
 etc.) no longer applies — those component classes do not exist in the current codebase.
 
-The Starlight CSS (`docs-site/src/styles/starlight.css`) imports `tokens.css` at build time
-(`@import './tokens.css'`) and maps Starlight's slot variables (`--sl-*`) to design-system
-tokens. It is predominantly token-compliant. Known deviations:
+The Starlight CSS (`docs-site/src/styles/starlight.css`) is a self-contained token sheet per
+ADR-0085: it imports nothing, declares its own `--doc-*` palette, and maps Starlight's slot
+variables (`--sl-*`) onto that palette. A compatibility layer at the foot of the file
+re-derives the `--ds-*` names that the shared `src/components/primitives/` components consume
+in scoped styles — those names are re-derivations onto the doc palette, not imports of
+`web/`'s values. It is predominantly token-compliant. One known deviation:
 
-| Location | Raw value | Closest `--ds-*` token | Note |
-| --- | --- | --- | --- |
-| `--sl-color-text-invert` (light-mode assignment) | `#ffffff` | `--ds-hero-fg` (`#ffffff`) | Used by Starlight's built-in UI for inverted text; same resolved value but a distinct semantic slot |
-| `.site-footer__brand { color }` | `#ffffff` | `--ds-hero-fg` (`#ffffff`) | Bootstrap override for the Starlight footer brand; same resolved value |
+| Location | Raw value | Note |
+| --- | --- | --- |
+| `--sl-color-text-invert`, light-theme assignment (`starlight.css:124`) | `#ffffff` | Used by Starlight's built-in UI for inverted text. The dark-theme assignment of the same slot uses `var(--doc-ground)`, so this is the only raw literal left in the slot mapping |
 
-Both deviations resolve to the same hex value as `--ds-hero-fg`. The `--sl-*` slot system
-already cross-references `--ds-*` tokens elsewhere in `starlight.css` (e.g.
-`--sl-color-accent: var(--ds-accent)`), so these two literals could technically be updated to
-reference `--ds-hero-fg` instead. Doing so is out of scope for this spec — they are documented
-as known current deviations, not necessary architectural exceptions.
+The `.site-footer__brand { color }` literal previously recorded here is resolved: it now reads
+`color: var(--doc-heading)`. Updating the remaining `--sl-color-text-invert` literal to a
+`--doc-*` token is out of scope for this spec — it is documented as a known current
+deviation, not a necessary architectural exception.
 
 The zone-violation lint (`tools/lint_zone_violations.py`) scans `web/src/` only.
 `docs-site/src/styles/starlight.css` is intentionally outside its scope — the two `#ffffff`

--- a/workspace.toml
+++ b/workspace.toml
@@ -652,35 +652,6 @@ open = [
   # Deferred rather than bundled: the fix is to change the publisher's import surface,
   # which is publish-path code this PR deliberately does not touch.
   {slug = "marketplace-publisher-branch-layer-2-only", summary = "The publisher's BRANCH push target is covered by the parity gate's literal layer only, not the resolved-value layer", source = "spec/marketplace-generator-single-source (review concern 4)"},
-  # .github/workflows/build-check.yml carries a comment block describing the
-  # credential-setup skill suite that sits above the WRONG step: the steps
-  # spec/build-check-coverage-gaps inserted displaced it from the
-  # `pytest credential-setup skill` step it documents, and
-  # spec/site-ci-contract-closure's contrast step widened that gap by one more.
-  # A reader takes it as describing whichever step follows it. Fix: move the block
-  # back above its own step. Deliberately deferred rather than tidied in passing:
-  # it pre-dates both changes and neither orphaned it, so it falls outside the
-  # bundled-fixes carve-out. Unblocks when: picked up — comment move only, no
-  # dependency.
-  {slug = "build-check-stranded-credential-setup-comment", source = "spec/site-ci-contract-closure (review concern 16)"},
-  # web/src/design-system.md claims the Starlight CSS imports web/'s tokens.css at
-  # build time (lines ~455-456 and ~492). Already false before
-  # spec/docs-site-build-contract-hardening — starlight.css stopped importing it — and
-  # now unrecoverable, since the copy that made the sentence half-true is gone. Fix:
-  # correct both passages to say the docs palette is self-contained per ADR-0085.
-  # Deferred from that spec: the file is outside every task's Touches and the change
-  # is marketing-side documentation, not the generator contract. Unblocks when: picked
-  # up — prose only, no dependency.
-  {slug = "design-system-md-stale-token-import-claim", source = "spec/docs-site-build-contract-hardening (review blocker 4)"},
-  # tools/lint-build.py's RFC_AUTHORISED_DIRS still credits the `docs-site` entry to
-  # ADR-0055, while the tuple's own header says entries are added only when an
-  # Accepted RFC authorises the directory — and RFC-0089 is now exactly that RFC.
-  # Live-code residue of the starlight-migration-rfc debt, which AC7 of
-  # spec/site-contract-provenance-cleanup otherwise settled. Fix: re-attribute the
-  # `docs-site` comment to RFC-0089 in tools/lint-build.py. Deferred from that spec
-  # because no acceptance criterion covers it and it falls outside every task's
-  # declared Touches. Unblocks when: picked up — one comment line, no dependency.
-  {slug = "lint-build-docs-site-rfc-attribution", source = "spec/site-contract-provenance-cleanup (review concern 7)"},
   # lint-traceability.py classifies any `<dir>/<file>.md` producer pointer as a
   # cross-repository reference, so now that a spec's `Brief:` back-link is the
   # canonical path form it reports a brief that lives in THIS repo as "unknown /
@@ -1660,19 +1631,50 @@ open = [
   # ── Quick wins ───────────────────────────────────────────────────────────────
   # (single focused session; no external environment; small diff)
 
-  # Surfaced 2026-08-16 while closing profiles-agents-normative-pointer. That
-  # entry said it "mirrors" a pointer wave 1 added to packs/AGENTS.md and
-  # packs/README.md. It does not: NEITHER file carries such a pointer. Verified
-  # by grep, and independently recorded at
-  # docs/product/research/catalogue-audience-discovery.md:276 — "packs/AGENTS.md
-  # does NOT say 'the machine source of truth is `contracts/pack.schema.json`'".
-  # So the pattern was established for profiles/ (spec/contracts-readme-
-  # governance-sweep, 2026-08-16) and packs/ is still the odd one out — the exact
-  # inversion of what the original entry assumed.
-  # Fix: add the same one-line pointer to contracts/pack.schema.json in
-  #   packs/AGENTS.md § schema map, and to packs/README.md; keep both under the
-  #   150-line subdirectory AGENTS.md cap.
-  # Unblocks when: picked up — no dependency.
+
+  # BLOCKED, and NOT the one-line edit this entry used to describe. Rewritten
+  # 2026-08-18 by spec/stale-reference-corrections, which tried the edit and
+  # reverted it.
+  #
+  # The gap is real: neither packs/AGENTS.md nor packs/README.md names
+  # contracts/pack.schema.json, while profiles/AGENTS.md:18 names
+  # contracts/profile.schema.json. Independently recorded at
+  # docs/product/research/catalogue-audience-discovery.md:276.
+  #
+  # WHY THE OBVIOUS FIX FAILS. packs/AGENTS.md and packs/README.md are both
+  # projected into the authoring scaffold
+  # (tools/catalogue/sync_authoring_scaffold.py `_SYNC_PAIRS`), and the scaffold is
+  # what `catalogue init` writes into an ADOPTER's catalogue root. That root ships
+  # only guides/ packs/ profiles/ tests/ — there is NO contracts/ directory. So the
+  # pointer is true in this repository and false in every adopter's tree.
+  # test_scaffold_projection.py::test_packs_agents_md_cites_only_paths_it_ships
+  # catches it and fails with "State the rule without the citation, or ship the
+  # file." Measured: the edit reddens `make ci` on arrival. The existing text is
+  # path-free on purpose.
+  #
+  # packs/README.md has NO equivalent assertion, so a pointer added there lands
+  # green — and is just as false for the adopter. Do not take the green as licence.
+  #
+  # SECOND INSTANCE, found the same way: profiles/AGENTS.md already carries the
+  # dangling form, and no test covers profiles/AGENTS.md (test_scaffold_projection
+  # asserts only that it exists and is non-empty). So the file this entry called the
+  # precedent to mirror is a second occurrence of the same defect, not the pattern.
+  #
+  # Fix requires a decision, which is why this is not mechanical:
+  #   (a) ship contracts/pack.schema.json (and profile.schema.json) in the scaffold,
+  #       so the citation is true everywhere. An engine/packaging change — it widens
+  #       what `catalogue init` writes and what the wheel carries.
+  #   (b) state the rule without a path in both trees, i.e. keep today's wording, and
+  #       close this entry as won't-fix — then correct profiles/AGENTS.md to match.
+  #   (c) split the two audiences: a repo-only pointer that the projection strips.
+  #       No such mechanism exists in _SYNC_PAIRS (it is byte-identity), so this is
+  #       the most expensive option.
+  # Recommend (a) if an adopter is ever expected to validate pack.toml offline,
+  # otherwise (b). Either way, extend the cites-only-paths-it-ships assertion to
+  # profiles/AGENTS.md in the same change, or the second instance survives.
+  #
+  # Also still true, and unchanged: packs/AGENTS.md is at exactly 150 lines against
+  # the 150-line subdirectory cap, so any wording change must be net-zero.
   {slug = "packs-agents-normative-pointer", source = "spec/contracts-readme-governance-sweep AC6"},
 
   # docs-site-design-refresh deferral (spec Assumptions). The SCA half
@@ -2392,14 +2394,17 @@ open = [
   {slug = "sast-requirements-hash-locked", summary = "Generate and install a hash-locked tools/requirements-sast-locked.txt with --require-hashes, mirroring the ci-security locked file", source = "spec/build-check-coverage-gaps security review"},
   # pip-audit covers tools/requirements.txt and every packs/*/requirements.txt
   # (Makefile:235) and the PEP 517 build-system requirements (Makefile:238). It
-  # does NOT cover tools/requirements-sast.txt or
-  # tools/requirements-ci-security-locked.txt -- the CI tooling itself has no SCA.
+  # does NOT cover tools/requirements-sast.txt,
+  # tools/requirements-ci-security-locked.txt, or tools/requirements-evals-locked.txt
+  # -- the CI tooling itself has no SCA. The evals file was added here by
+  # spec/stale-reference-corrections: it is equally unaudited and fell outside every
+  # other entry, so nothing named it.
   # Confirmed by reading the audit invocations, not inferred. Adjacent to
   # npm-dependabot-wiring but a different ecosystem and a different file set.
-  # Fix: add the two CI-tooling requirements files to the audit-requirements.py
+  # Fix: add the three CI-tooling requirements files to the audit-requirements.py
   # invocation, or wire Dependabot for pip so the bumps arrive as PRs. Decide
   # which, then do one -- doing both duplicates the noise.
-  {slug = "sast-requirements-not-audited", summary = "Give tools/requirements-sast.txt and requirements-ci-security-locked.txt SCA coverage -- pip-audit skips both today", source = "spec/build-check-coverage-gaps security review"},
+  {slug = "sast-requirements-not-audited", summary = "Give tools/requirements-sast.txt, requirements-ci-security-locked.txt, and requirements-evals-locked.txt SCA coverage -- pip-audit skips all three today", source = "spec/build-check-coverage-gaps security review"},
   # The seven entries below all came out of spec/pip-audit-batching, which was
   # ARCHIVED without shipping (see docs/specs/pip-audit-batching/spec.md for why
   # batching pip-audit trades away per-manifest SCA fidelity). None of them is
@@ -2452,16 +2457,6 @@ open = [
   # is safe (NamedTemporaryFile is O_EXCL, 0600); the directory is the issue.
   # Fix: write each filtered manifest inside a per-run TemporaryDirectory() (0700).
   {slug = "sca-temp-manifest-leaves-its-directory", summary = "The filtered manifest is written to shared /tmp, so a relative include in a requirements file resolves against a world-writable dir", source = "spec/pip-audit-batching security review"},
-  # Makefile:259 cites "docs/backlog.md § semgrep-mcp-cve-allowlist" as the
-  # diagnosis and unblock condition for four live --ignore-vuln suppressions, but
-  # docs/backlog.md is an anchor tombstone and the entry lives in this file. That
-  # stale pointer is the only recorded expiry for those four suppressions.
-  # Also in scope: tools/requirements-evals-locked.txt is unaudited and falls
-  # outside sast-requirements-not-audited above, which names only
-  # requirements-sast.txt and requirements-ci-security-locked.txt.
-  # Fix: repoint the comment at workspace.toml, and widen the slug above to name
-  # the evals file.
-  {slug = "sast-semgrep-cve-allowlist-pointer-stale", summary = "Makefile:259 points the four --ignore-vuln suppressions at docs/backlog.md, which is a tombstone -- their only recorded expiry is dangling", source = "spec/pip-audit-batching security review"},
   # The four entries below all came out of spec/semgrep-selftest-batching, which
   # DID ship (batching the self-test's five semgrep spawns into one). None is
   # caused by that change -- each is a pre-existing property of the control it


### PR DESCRIPTION
## What does this change?

Corrects four `[backlog].open` entries that recorded the same defect class — a comment or a documented claim that was true when written and is false now. The fifth entry in that set is **not** fixed: its prescribed edit was applied, failed a real contract, and was reverted, so the entry is rewritten with what was measured instead.

## Why?

Each of the four had a fully determined `Fix:` line and each was deferred from its parent PR for touched-area reasons rather than difficulty. A reader who trusts any one of them is misled the same way, and a separate PR per one-line comment costs more review attention than the correction is worth.

- Implements: `docs/specs/stale-reference-corrections/spec.md`
- Closes backlog entries: `build-check-stranded-credential-setup-comment`, `design-system-md-stale-token-import-claim`, `lint-build-docs-site-rfc-attribution`, `sast-semgrep-cve-allowlist-pointer-stale`
- Follows from: RFC-0089 (AC3), ADR-0085 (AC2)

### The four corrections

| File | Was | Now |
|---|---|---|
| `.github/workflows/build-check.yml` | The credential-setup comment block sat **four steps above** the step it names, so a reader attributed it to `pytest guides + catalogue navigation` | Moved back above its own step. No step name, `run:` body, `working-directory:`, or ordering changed |
| `web/src/design-system.md` | § 6 and § 8 claimed the docs CSS imports `tokens.css` at build time | Corrected — plus two further errors in the same passage, below |
| `tools/lint-build.py` | `docs-site` credited **ADR-0055**, while the tuple's own header admits entries only on an Accepted **RFC** | Re-attributed to RFC-0089, which is exactly that RFC |
| `Makefile` | The four `--ignore-vuln` suppressions cited `docs/backlog.md § semgrep-mcp-cve-allowlist` as their only recorded expiry — that file is an anchor tombstone with no semgrep section | Repointed at `workspace.toml [backlog].open`. Sibling entry `sast-requirements-not-audited` widened to name `tools/requirements-evals-locked.txt` |

**The suppressions do not lift.** Measured this session: semgrep 1.166.0 still requires `mcp==1.23.3` and `click~=8.1.8`, so the unblock condition the comment states is unmet. All four CVE ids, the manifest, and the invocation are byte-identical in the diff — only the citation moved.

**AC2 was wider than its entry described.** Beyond the `@import` claim, § 6 asserted dark mode applies via `[data-theme='dark']` when the sheet is dark-**first** (`:root` is the dark theme, `:root[data-theme='light']` overrides it), and its resolved-value table cited four `--prim-*`/`--ds-*` hexes that appear nowhere under `docs-site/src/styles/`. § 8's deviation table was also half-resolved — `.site-footer__brand` now reads `var(--doc-heading)`, and the `--ds-hero-fg` comparison column named a token `starlight.css` does not carry. Corrected against the real file, with the measurements recorded in the spec.

## How do I verify it?

```bash
make ci                                              # exit 0, SAST included
python3 tools/test-build-check-workflow.py           # 77 families, 177 mutations
python3 tools/lint-ci-parity.py                      # 76 steps dispositioned
python3 tools/lint-build.py
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .   # spec metadata clean

grep -c '@import' docs-site/src/styles/starlight.css          # 0
grep -c -- '--prim-' docs-site/src/styles/starlight.css       # 0
grep -c "data-theme='dark'" docs-site/src/styles/starlight.css # 0
grep -c 'docs/backlog.md' Makefile                            # 0
```

The only non-comment line in the whole diff is the trailing comment on an otherwise unchanged `RFC_AUTHORISED_DIRS` member:

```
git diff -U0 -- tools/lint-build.py Makefile .github/workflows/build-check.yml \
  | grep -E "^[+-]" | grep -v "^[+-][+-]" | grep -vE "^[+-]\s*#"
```

## What did you not change that you considered?

**`packs-agents-normative-pointer` — attempted, reverted, entry rewritten.** Its prescribed pointer to `contracts/pack.schema.json` was added to `packs/AGENTS.md` and `packs/README.md`, and `make ci` failed on `test_scaffold_projection.py::test_packs_agents_md_cites_only_paths_it_ships`. Both files are byte-projected into the authoring scaffold that `catalogue init` writes into an adopter's root, and that scaffold ships `guides/ packs/ profiles/ tests/` and **no `contracts/` directory** — so the pointer is true here and false in every adopter's tree. The existing path-free wording is deliberate.

The README half was reverted too, rather than shipped on the strength of that file having no equivalent assertion. And the entry's premise inverts: `profiles/AGENTS.md:18`, named as the precedent to mirror, already carries the dangling form with no test covering it — so it is a second instance of the same defect, not the pattern. The rewritten entry carries the constraint, both instances, and three options with a recommendation. AC5 is marked `(deferred: packs-agents-normative-pointer)`.

**Also declined:**

- Re-attributing the `contracts` and `guides` members of `RFC_AUTHORISED_DIRS`. Both carry the same ADR-cited-as-RFC shape, but no RFC authorises either, so the honest edit is unavailable and inventing an attribution is worse than the status quo.
- A lint asserting every `RFC_AUTHORISED_DIRS` comment cites an `RFC-` number. It would fail on those two immediately — a checker that lands red is the trap `npm-allowscripts-enforcement` is already open for.
- § 8's surviving `--sl-color-text-invert` `#ffffff` literal. Narrowing the table to it is in scope; converting it to a token is not.
- Deleting the anchor-only entries whose work is done (`ci-gate-*-branch-protection-widening`, `starlight-migration-rfc`). Each is retained deliberately so a frozen spec's `(deferred: <slug>)` marker resolves; removing one reddens `lint-spec-status` invariant (iv).
- Adding a semgrep section back to `docs/backlog.md`. That would re-establish the split registry the tombstone exists to end.

**Deferred:** `packs-agents-normative-pointer` — blocked on a decision about whether the scaffold should ship `contracts/*.schema.json`; three options recorded in the entry.

---

## Checklist

- [x] Tests pass locally (`make ci`, exit 0 with SAST)
- [x] Lint and typecheck pass (`make lint-ruff`, via `make ci`)
- [ ] Self-review run via the relevant reviewer subagent — **named skip:** subagent dispatch is disabled for this session by operator instruction. The work-loop spec-less self-review checklist was run inline instead: diff matches plan; no functions touched so coverage is unchanged; out-of-plan changes (§ 6/§ 8 breadth, the entry rewrite) are recorded in the spec with measurements; what should have changed and didn't is the Deferred line above.
- [x] Spec and code agree — the spec was updated in this PR to record AC2's true breadth and AC5's reversal
- [x] Living docs match reality — no user-visible behavior change; `web/src/design-system.md` **is** the living doc being corrected
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the projection constraint is recorded in the rewritten backlog entry and in the spec's AC5

🤖 Generated with [Claude Code](https://claude.com/claude-code)