### PR TITLE
docs(rfc): shape RFC-0088's remaining work into dispatchable items

### DIFF
--- a/docs/rfc/0088-notes/spikes/2026-08-18-front-door-worker-landscape-probe.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-18-front-door-worker-landscape-probe.md
@@ -1,0 +1,87 @@
+# RFC-0088 — front-door service-worker landscape probe
+
+**Status: EXPLORATORY. Not a promoted arm, not a manifest member, and not part of
+any round's evidence.** It is recorded because it materially narrows a residual
+round 11 left open, and because a reader who finds that residual should find this
+alongside it rather than re-running the work.
+
+## Why it exists
+
+Round 11's amended D/item 6 requires the profile's persisted service-worker
+storage to be purged and registration blocked for the session. Round 11 measured
+the *cost shape* of that requirement as a taxonomy — a flow with no worker and a
+flow that merely registers one both survive suppression; only a sign-in path that
+genuinely **depends** on a worker breaks — and recorded plainly that it could not
+say which class real destinations fall into. That was named a landscape question,
+not a fixture question.
+
+This probe answers part of it.
+
+## What was measured
+
+Three public enterprise front doors, addressed by **role** rather than by product,
+because the finding generalises by role:
+
+| Role | Registers a worker | Renders with workers allowed | Renders with workers blocked | Reading |
+| --- | --- | --- | --- | --- |
+| **Sign-in surface** — an enterprise identity provider's sign-in page | no | yes | yes, unchanged | **Authentication does not need a service worker** |
+| **Webmail surface** — a high-volume enterprise mail front door | attempts one | yes | yes, **byte-identical** | Present, **not load-bearing** |
+| **Collaboration surface** — a real-time collaboration front door | yes | yes | **no — collapses to a stub** | **LOAD-BEARING** |
+
+The suppression mechanism demonstrably works against real properties: registrations
+drop to zero and each blocked arm logs a refusal.
+
+## The three readings, in order of how much they matter
+
+**1. Authentication itself does not depend on a service worker.** The sign-in
+surface registers none and renders identically with workers blocked. This is the
+scenario that could have invalidated D/item 6 outright — the fear that suppressing
+workers breaks the very sign-in the pilot exists to protect. It does not.
+
+**2. A mail surface is the "present but idle" class**, which round 11's taxonomy
+predicted and this confirms against a real product: it attempts a registration and
+renders byte-identically without it, same interactive element counts. The
+requirement costs this class nothing.
+
+**3. A real-time collaboration surface is load-bearing** and does not survive
+suppression. This is the class round 11 identified as expensive, and it exists in
+the wild.
+
+## The design consequence
+
+**A global worker block is the wrong shape.** Suppression should be
+**destination-scoped**, which is the axis decision C already chose for egress. A
+destination policy that already decides *where* a session may talk is the natural
+place to decide *whether a worker may run there*, rather than a separate global
+switch that must be all-or-nothing across surfaces with opposite needs.
+
+That is a proposed amendment, not a decision. It is recorded in the RFC's open
+questions.
+
+## Limits — and one instrument that is not trustworthy
+
+- **Unauthenticated front doors only.** Whether the *post-authentication*
+  silent-SSO path — a device-bound refresh credential persisted in the browser
+  profile — needs a worker is **not measured**, because it requires credentials the
+  security preconditions forbid. The sign-in surface carrying no worker is strong
+  evidence the authentication step does not, but it is evidence, not proof. This
+  probe **bounds** the residual; it does not close it.
+- **The registration count is timing-sensitive and must not be quoted.** The
+  webmail surface reported one registration in one run and zero in another, purely
+  on observation timing. The readings that were stable across runs are the *refusal
+  signal* under block and the *render equality*, and those are what the table above
+  rests on. A round that promoted the count as a fact would be publishing an
+  artifact of its own wait loop.
+- A single point in time; these front doors ship continuously.
+- Run with the signed, MDM-provisioned system browser — the runtime a real adopter
+  pack requires, because only it reaches the OS keychain for the device-compliance
+  certificate — against a fresh synthetic profile, with nothing submitted.
+
+## Privacy
+
+No URI is persisted anywhere in the probe artifact: no landing URL, redirect,
+worker scope, domain, page text, or title. Target endpoints and the browser binary
+are supplied through the environment by the caller and are not written to the
+fixture or the artifact. What survives is a role label chosen by the fixture,
+booleans, and counts. Verified by scanning the artifact for any URI and for vendor
+or product names: none present.

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -920,6 +920,9 @@ history assumptions.
 1. **Which operating systems and browser channels enter the first supported release?** Recommended candidate: macOS with bundled Chromium; S1 must also test one system channel so the Experimental exit can either admit it or record an explicit deferral. Keep path and IPC contracts portable. Owner: RFC approver. Decide by: Experimental exit.
 2. **Does adapter packaging require build-only bundler tooling?** Recommended default: accept plain self-contained ESM if S2 proves dependency isolation; add exact-pinned, scanned, non-shipped build tooling only when the spike demonstrates it is necessary and record the deviation in this RFC before acceptance. Owner: RFC owner with approver. Decide by: S2 / Experimental exit.
 3. **Does the pack clear the charter's “used often enough” bar?** Recommended default: require S5 to prove two independent software-delivery provider consumers before acceptance. Owner: RFC approver. Decide by: Experimental exit.
+4. **Should service-worker suppression be destination-scoped rather than global?** D/item 6 currently reads as a session-wide control. Measurement shows real destinations have opposite needs: a sign-in surface needs no worker, a mail surface has one but does not depend on it, and a real-time collaboration surface breaks without one. A global switch therefore forces a choice between losing a surface and losing the control. Recommended candidate: fold worker policy into the **destination** constraint decision C already established, so one policy decides both where a session may talk and whether a worker may run there. Owner: RFC approver. Decide by: Experimental exit.
+5. **How is a consumer that captures and replays a scoped API token accommodated?** The RFC's credential posture assumes the session stays in the browser, and decision C keeps the broker outside the credential boundary so that no component holds the user's session in cleartext. A realistic consumer instead intercepts a scoped bearer token from the page's own requests and replays it, because that is how an agent acts as a frontend user at volume. No blocker item covers this pattern. Recommended candidate: require the token to remain **page-resident** — captured and used inside the document by the same init-script mechanism the egress shim already uses — so the broker still never holds it. Owner: RFC approver. Decide by: Experimental exit.
+6. **Is the browser-provenance anchor a file digest or a signing identity?** Item 2 assumes a digest pinned from an independently verified channel. That is unachievable for an MDM-provisioned, auto-updating system browser, which is the runtime a real adopter requires because only it reaches the OS keychain for the device-compliance certificate. Such a binary does, however, carry a **stable vendor team identifier, notarization, and library-validation** — an anchor that survives updates and blocks a code-injection class a digest pin never addressed. Recommended candidate: accept signing identity as the anchor for system channels and keep digest pinning for bundled ones. Owner: RFC approver. Decide by: Experimental exit.
 
 ## Follow-on artifacts
 
@@ -1500,9 +1503,20 @@ restored browser, while a control arm that purges the cookie store instead answe
 
 *What the requirement costs.* Measured as a taxonomy, suppression breaks only
 flows whose login path genuinely depends on a worker. A flow with no worker and a
-flow that merely registers one both complete. **How common the load-bearing class
-is among real identity providers is not measured** and remains a residual — the
-pilot can answer it for its own destination.
+flow that merely registers one both complete.
+
+*How common the load-bearing class is — narrowed, not closed.* An exploratory
+probe against three public enterprise front doors, addressed by role, found:
+an identity provider's **sign-in surface registers no worker and renders
+identically with workers blocked**, so authentication itself does not depend on
+one; a **webmail surface is the present-but-idle class**, rendering byte-identically
+without its worker; and a **real-time collaboration surface is load-bearing** and
+does not survive suppression. So the expensive class exists in the wild, and the
+sign-in step — the part the pilot most needed to protect — is not in it. The
+post-authentication silent-SSO path remains unmeasured, because it requires
+credentials. Details, limits, and one instrument that proved untrustworthy are in
+the [front-door worker landscape probe](0088-notes/spikes/2026-08-18-front-door-worker-landscape-probe.md).
+**That probe is exploratory and is not a promoted arm.**
 
 **D / item 3 — was "one consumer per connection". Now reads:**
 

--- a/docs/specs/rfc0088-round12-consumer-shaped-residuals/plan.md
+++ b/docs/specs/rfc0088-round12-consumer-shaped-residuals/plan.md
@@ -1,0 +1,188 @@
+# Plan: rfc0088-round12-consumer-shaped-residuals
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Drafting
+
+## Approach
+
+Five independent arms in the existing RFC-0088 evidence tree, promoted through the
+tree's existing cycle (`r9-promote.sh`). Ordered by **information value**: the two
+that decide open questions with a recommended candidate the RFC would otherwise
+adopt on reasoning alone go first.
+
+Every arm follows the shape this evidence base converged on over eleven rounds: an
+enforcing arm plus a control that removes exactly the control under test in the
+same run; ground truth from an independent observer; read-back rather than
+assertion; per-row `ok` fields and a `provenance` block.
+
+**Naming and privacy.** New drivers write to `s3/r12-*`, `s2/r12-*`, `s1/r12-*`.
+Destinations are addressed by **role**; endpoints and binary paths come from the
+environment via the runner's explicit allowlist and are never hard-coded or
+persisted. No arm records a URI, vendor, product, tenant, or account identifier.
+
+## Constraints
+
+- macOS only; Linux and Windows remain deferred by disposition B.
+- No new dependency, toolchain, or compile step — that is an *Ask first* boundary
+  and is why the native-addon residual is not in this round.
+- No credential, account, or live authenticated session in any arm.
+- Playwright's browsers live under the real home cache; a synthetic HOME needs
+  `PLAYWRIGHT_BROWSERS_PATH` set explicitly.
+- Short `TMPDIR` — macOS caps Unix socket paths near 104 bytes.
+- Node's permission model realpaths an absolute entry script's ancestors; pass the
+  entry relative with cwd inside the granted scope.
+- A bootstrap read grant must not be an ancestor of the paths under test.
+
+## Construction tests
+
+Per-task `Tests:` below; every task is **visual / manual QA**, so no red stubs
+(`no stub (manual QA)`). The construction test for each arm is its **control arm**.
+
+Two cross-cutting checks after all arms: extend `r11-fact-negative-tests.py` with
+one mutation per new fact, and scan every artifact and note for URIs and vendor or
+product names.
+
+## Design (LLD)
+
+### Design decisions
+
+- **A1 models a destination as a browser context**, because `serviceWorkers` is a
+  per-context option. If per-destination scoping requires something stronger, that
+  is the finding.
+- **A2 keeps the token in a closure inside the page**, installed by the same
+  `addInitScript` mechanism the egress shim already uses, so the design is
+  consistent with what the RFC already requires rather than a parallel mechanism.
+- **A3 reads the signature from the binary**, never from a vendor claim.
+- **A4 uses a second OS user**, not a container — round 10 measured that a
+  container cannot start a sandboxed renderer without `SYS_ADMIN`, so containerising
+  trades the renderer sandbox for isolation, while a second uid does not.
+
+### Failure, edge cases & resilience
+
+- Any driver that cannot complete sets `fatal`; `build-archive.py` refuses such an
+  artifact unless declared via `expectedFatal`.
+- A control arm that passes when it should have failed **invalidates its own arm**
+  and is recorded as such.
+
+### Dependencies & integration
+
+None new. Existing Playwright, Node, `/usr/bin/codesign`, `/usr/sbin/spctl`, macOS
+`sandbox-exec`.
+
+## Tasks
+
+### T1: Destination-scoped worker policy
+
+**Depends on:** none
+**Touches:** `s3/r12-destination-scoped-worker-policy.mjs` + results
+
+**Tests:** manual QA. Control: a **global** block must break the worker-dependent
+destination's flow in the same run — otherwise "scoping helped" is unfalsifiable.
+Second control: the worker-independent destination must complete in every arm.
+
+**Approach:** Two synthetic destinations — one whose flow depends on a service
+worker, one that registers a worker but does not need it (both shapes are already
+built in round 11's arm 2). Three arms: workers global-allow, workers global-block,
+and per-destination policy (block for the independent destination, allow for the
+dependent one). Record per destination whether the flow completed and whether a
+registration existed. Satisfies AC1.
+
+### T2: Page-resident token boundary
+
+**Depends on:** none
+**Touches:** `s3/r12-page-resident-token.mjs` + results
+
+**Tests:** manual QA. Control: the identical calls without the shim must fail
+(the synthetic API refuses unauthenticated requests). Second control: the driver's
+own token-visibility check must be shown capable of failing, by a deliberately
+leaky arm that does pass the token through the driver.
+
+**Approach:** A synthetic API that issues a scoped bearer token to page JS and
+requires it on every call. An init script hooks `fetch`, captures the token into a
+**closure**, and exposes only `__call({url, method, body})`. The driver issues
+request shapes and never receives the token. Assert from the driver side that the
+token value appears in none of: the job file, the child environment, argv, stdout,
+or the results artifact. Satisfies AC2, AC3.
+
+### T3: Browser signing-identity anchor
+
+**Depends on:** none
+**Touches:** `s1/r12-signing-identity-anchor.mjs` + results
+
+**Tests:** manual QA. Control: a binary **without** a vendor team identifier (the
+bundled browser, which round 10 recorded as carrying none) must be distinguishable
+from one with it — otherwise the anchor cannot discriminate.
+
+**Approach:** Read team identifier, notarization/Gatekeeper verdict, and hardened
+runtime plus library-validation flags from a system browser and from a bundled one,
+via the OS tools. Record whether the identity is present, and whether it is stable
+in form across the two. Satisfies AC4. **The identifier value is recorded as a
+presence boolean and a stable-form check, not as a vendor identifier string.**
+
+### T4: Separate-uid attachment isolation
+
+**Depends on:** none
+**Touches:** `s1/r12-separate-uid-attach.mjs` + results
+
+**Tests:** manual QA. Control: a **same-uid** process must reach the bind endpoint
+in the same run — that is disposition B's accepted exposure, and if it does not
+reproduce, the isolation arm proves nothing.
+
+**Approach:** Launch a browser with a bind endpoint. Arm 1: a same-uid process
+attaches (expected to succeed). Arm 2: a process running as a different OS user
+attempts the same attach (expected to be refused). Record the refusal shape.
+**Requires a second local account; if none is available the arm is recorded as
+not-run rather than inferred.** Satisfies AC5.
+
+### T5: What the worker purge touches
+
+**Depends on:** none
+**Touches:** `s3/r12-purge-blast-radius.mjs` + results
+
+**Tests:** manual QA. Control: a store the purge is **not** expected to touch must
+be shown present both before and after — otherwise "it only removed one thing"
+could be satisfied by a purge that removed nothing.
+
+**Approach:** Seed a profile with a worker plus several profile-resident stores.
+Enumerate the store inventory before and after the item-6 purge, recording store
+names only (never contents). Report which stores the purge removes and which it
+leaves. Satisfies AC6.
+
+### T6: Promotion, note, RFC evidence layer, negative tests
+
+**Depends on:** T1, T2, T3, T4, T5
+**Touches:** a round-12 note, the RFC's evidence layer and open questions,
+`r11-fact-negative-tests.py`, `corpus_docs.py`, `build-archive.py`, `workspace.toml`
+
+**Tests:** goal-based. `build-archive.py` exits 0; figure verifier reports zero
+wrong and zero claimed-nowhere with the round-12 note added **via `corpus_docs.py`,
+the single definition**; negative tests catch every new fact; `r9-gates.sh` all OK;
+RFC status still `Experimental`; the privacy scan finds no URI or vendor name.
+
+**Approach:** Write the round-12 note; add its layer to the RFC without touching a
+disposition; answer open questions 4, 5 and 6 with measurements or record why an
+arm could not. Satisfies AC7, AC8, AC9.
+
+## Rollout
+
+- **Delivery:** one PR per arm, then a promotion PR — the increment shape the
+  round-11 retrospective settled on.
+- **Infrastructure / external systems:** none. All arms are synthetic or local; no
+  live destination is contacted.
+- **Deployment sequencing:** T1–T5 independent; T6 depends on all five.
+
+## Risks
+
+- **Per-destination scoping may not be expressible** with a per-context option
+  alone. That is a finding against open question 4's candidate, not a failure.
+- **The leaky-arm control in T2 must genuinely leak**, or the token-visibility
+  check is a control that cannot fail — the defect this base has produced most.
+- **T4 may be unrunnable** without a second local account; recorded as not-run
+  rather than inferred either way.
+- **Scope pressure** to fold in the native-addon residual or a credentialed SSO
+  arm. Both are *Ask first*; neither is in this round.
+
+## Changelog
+
+- 2026-08-18 — Initial plan. Arms ordered by information value; the two residuals
+  needing a toolchain or a credential are deliberately excluded and named.

--- a/docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md
+++ b/docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md
@@ -1,0 +1,159 @@
+# Spec: rfc0088-round12-consumer-shaped-residuals
+
+- **Status:** Draft
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0088](../../rfc/0088-web-pilot-foundation.md) — Experimental; this spec measures open questions 4, 5 and 6 and two residuals, and changes no disposition
+- **Contract:** none — this spec produces evidence, not interfaces.
+- **Shape:** service
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full (work-loop). Risk triggers: security boundary (browser launch,
+credential handling, OS isolation, filesystem) and multi-feature/dependent tasks.
+Full-mode scripts live at .claude/skills/work-loop/scripts/ — skill-relative. -->
+
+## Objective
+
+Round 11 measured the binding requirements the 2026-08-18 dispositions attach, and
+two of them were amended as a result. Reading those amendments against a **real
+consumer pack** — an adopter's productivity pack in a separate catalogue, which
+this repository does not modify — surfaced three design questions the RFC could not
+answer from its own fixtures, now recorded as open questions 4, 5 and 6.
+
+This round measures them. Its user is the approver, who needs each open question to
+rest on an observation rather than on a structural argument before an acceptance
+carries it. Success is that every arm produces an artifact containing a row that
+**could have failed**, and that any arm contradicting a recommended candidate is
+reported as a finding.
+
+The round measures the **architecture** and does **not** re-measure the apparatus.
+No coverage percentage, claim-accounting total, or mutation-corpus figure is a
+deliverable.
+
+Five arms, each deciding something:
+
+1. **Destination-scoped worker policy** (open question 4). A global suppression
+   switch forces a choice between losing a surface and losing the control, because
+   real destinations have opposite needs.
+2. **Page-resident token boundary** (open question 5). Whether a consumer that
+   must replay a scoped API token can do so without the broker ever holding it.
+3. **Browser signing-identity anchor** (open question 6). Whether a stable vendor
+   team identifier plus notarization and library-validation is a usable provenance
+   anchor for an auto-updating system browser.
+4. **Separate-uid attachment isolation.** Whether running the browser under a
+   different OS user closes the same-uid endpoint-attachment exposure that
+   disposition B accepted — the cheap alternative to containerising.
+5. **What the worker purge actually touches.** Enumerating which profile stores the
+   item-6 purge removes, which bounds whether a device-bound refresh credential
+   survives it.
+
+## Boundaries
+
+### Always do
+
+- Run every subprocess under an explicit environment allowlist, never the ambient
+  environment, and prove it by having the child print its own environment.
+- Give every arm a control that fails when the control under test is removed, and
+  admit the arm only if that control actually failed in the same run.
+- Read a mode, platform, identity or state back from the artifact rather than
+  asserting what was requested.
+- Mutation-test each new fact individually and record the one-line result.
+- Compare every touched member against `manifest-r7.sha256` before promoting.
+
+### Ask first
+
+- **Adding any dependency, toolchain, or compile step** — this is the recorded
+  unblock condition for the native-addon residual, which is deliberately NOT in
+  this round.
+- Any arm that would require a credential, an account, or a live authenticated
+  session.
+- Extending the round beyond these five arms.
+- Any change to an RFC decision, disposition, blocker item, or status field.
+
+### Never do
+
+- **No implementation.** No production packs, runtime code, dependencies,
+  contracts, catalogue entries, adapters, or new top-level directories.
+- **No modification of any other catalogue or pack.** A real consumer pack informed
+  these questions; it is read-only context and this round writes nothing to it.
+- **No vendor, product, employer, tenant or account identifier** in any artifact,
+  note, fixture, or commit — and **no URI**. Address destinations by role. Supply
+  endpoints and binary paths through the environment, never hard-coded.
+- **No credential, real profile, or live account.** Synthetic data and fresh
+  synthetic profiles only; never print, log, compare, or archive a credential
+  value, even a synthetic one.
+- **Never convert a characterisation fixture, inspection-only result, hard-coded
+  literal, or failed security precondition into a Pass.**
+- **Never move RFC-0088 to Accepted, close a blocker item, or revise a recorded
+  disposition.**
+
+## Testing Strategy
+
+Verification mode for every task is **visual / manual QA against the real
+artifact**: these are measurement fixtures, and the deliverable is the observed
+behaviour of a real browser, a real OS boundary, or a real signed binary. A passing
+unit gate would prove nothing, because what is under test is whether the platform
+behaves as an open question assumes.
+
+Each task runs the real driver end-to-end, writes a results artifact with per-row
+`ok` fields and a `provenance` block, and is admitted only if it records a row that
+**could have failed**. Figures are derived by `verify-note-figures-r7.py` and each
+new fact is mutation-tested by the `r11-fact-negative-tests.py` mechanism.
+
+Gate order: `build-archive.py` → `verify-note-figures-r7.py` → `r9-gates.sh`.
+
+## Acceptance Criteria
+
+- [ ] **AC1 — Worker policy can be applied per destination.** One session suppresses
+      service workers for one destination while permitting them for another, with a
+      control arm showing a global block breaking the permitted destination's flow.
+      If per-destination scoping proves impossible, that is recorded as a finding
+      against open question 4's recommended candidate.
+- [ ] **AC2 — A scoped API token can be replayed without the broker holding it.**
+      A page-resident capture-and-use shim performs authenticated calls against a
+      synthetic API while the driver process never receives the token, asserted from
+      the driver side. A control arm without the shim fails the same calls.
+- [ ] **AC3 — The token never reaches a durable surface.** The artifact records that
+      no token value appears in the job file, the driver environment, process argv,
+      stdout, or the results artifact — each checked explicitly, not asserted.
+- [ ] **AC4 — Signing identity is a usable provenance anchor.** The artifact records
+      a system browser's team identifier, notarization status, and hardened-runtime
+      and library-validation flags, read from the binary, with a control showing a
+      binary lacking that identity is distinguishable.
+- [ ] **AC5 — Separate-uid isolation measured.** Whether a process running as a
+      different OS user can reach the browser's bind endpoint, with a same-uid
+      control arm that **can** reach it — otherwise the isolation row proves nothing.
+- [ ] **AC6 — The worker purge's blast radius is enumerated.** The artifact lists
+      which profile stores the item-6 purge removes and which it leaves, so whether
+      a profile-resident credential survives is bounded by observation.
+- [ ] **AC7 — Every new fact is mutation-tested individually**, with the one-line
+      result recorded per fact.
+- [ ] **AC8 — No apparatus figure is a deliverable**, and no vendor, product,
+      tenant, account identifier, or URI appears in any artifact or note — verified
+      by an explicit scan.
+- [ ] **AC9 — Gates clean**: archive builds, figure verifier reports zero wrong and
+      zero claimed-nowhere, `r9-gates.sh` passes, RFC status still `Experimental`.
+
+## Assumptions
+
+- Technical: the evidence tree and its helpers are reconstructible from the archive
+  note; round 11 left the promote cycle converging and the manifest matching its
+  tree at rest (source: round-11 note, R11-2 and R11-6)
+- Technical: `serviceWorkers: 'allow' | 'block'` is a per-**context** option, so
+  per-destination scoping plausibly means one context per destination — to be
+  measured, not assumed (source: round-11 arm 2)
+- Technical: an MDM-provisioned system browser carries a stable vendor team
+  identifier, notarization, and hardened-runtime plus library-validation flags
+  (source: local signature read, 2026-08-18)
+- Product: the token-replay pattern comes from a real adopter pack read as
+  read-only context; this round writes nothing to it (source: user direction
+  2026-08-18)
+- Process: the native-addon confinement bypass stays OUT of this round because it
+  needs a toolchain, which is an *Ask first* boundary (source: backlog entry
+  `rfc0088-native-addon-confinement-bypass`)
+- Process: the post-authentication silent-SSO worker dependency is not measurable
+  under the security preconditions and is not scheduled (source: front-door probe
+  note, Limits)

--- a/workspace.toml
+++ b/workspace.toml
@@ -42,6 +42,21 @@ parent    = "INI-001"
 ["ini-002".shaping_queue]
 active  = []
 backlog = [
+  # RFC-0088 · consumer-shaped design questions raised by reading round 11's
+  # amended requirements against a real adopter pack in a separate catalogue
+  # (read-only context; this repo writes nothing to it).
+  # Shape: how should a broker accommodate a consumer that must replay a scoped API
+  # token? The RFC's credential posture assumes the session stays in the browser;
+  # a realistic consumer intercepts a scoped token and replays it. RFC open
+  # question 5 carries the recommended candidate (keep the token page-resident);
+  # round 12 measures whether that candidate works. This item shapes what the
+  # broker CONTRACT should say once it does.
+  {slug = "rfc0088-token-replay-consumer-contract", type = "shape"},
+  # Shape: destination-scoped constraint as a single axis. Decision C constrains
+  # egress by destination; measurement shows worker policy needs the same scoping
+  # because real surfaces have opposite needs. Should destination become the one
+  # place a session's per-destination policy lives (egress + worker + more)?
+  {slug = "rfc0088-destination-scoped-policy-axis", type = "shape"},
   # Signal items — hand-authored by strategist; ongoing, non-graduating
   {slug = "ai-native-regulatory-watch", type = "signal"},
   # Research items — any user with the desk-research pack can pick these up
@@ -210,6 +225,15 @@ shipped = [
   {path = "docs/specs/site-browser-quality-gate/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Gate emitted-site responsiveness, accessibility, and navigation behavior", needs = []},
 ]
 queue   = [
+  # RFC-0088 round 12 — measures open questions 4, 5 and 6 plus two residuals that
+  # surfaced when round 11's amended requirements were read against a real adopter
+  # consumer. Five arms, all synthetic or local: destination-scoped worker policy,
+  # page-resident token boundary, browser signing-identity anchor, separate-uid
+  # attachment isolation, and the worker purge's blast radius. Deliberately EXCLUDES
+  # the native-addon bypass (needs a toolchain — Ask first) and the
+  # post-authentication SSO worker dependency (needs a credential — not measurable
+  # under the security preconditions). Spec is Draft: approve it to make it ready.
+  {path = "docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Measure RFC-0088 open questions 4-6 and two consumer-shaped residuals", needs = []},
   # Work-loop runtime: one transition, one Python process. `loop-engine.py
   # transition` shelled out to `loop-cohort.py` and `check-spec-status.py` for
   # its read-only guards, so a single transition started up to three extra
@@ -1084,6 +1108,22 @@ open = [
   # Unblocks when: an approver accepts a toolchain in the evidence tree, or the
   # pilot commits to denying addons unconditionally so the bypass is moot.
   {slug = "rfc0088-native-addon-confinement-bypass", source = "spec/rfc0088-round11-binding-requirements AC7"},
+  # NOT measurable under the security preconditions: it needs a real authenticated
+  # session. Round 11 measured the taxonomy and a follow-up probe measured the
+  # UNAUTHENTICATED front doors -- establishing that an identity provider's sign-in
+  # surface registers no service worker, so authentication itself does not depend on
+  # one. What stays open is whether the POST-authentication silent-SSO path (a
+  # device-bound refresh credential persisted in the browser profile) needs a
+  # worker. Round 12 bounds it further by enumerating which profile stores the
+  # item-6 purge removes. Unblocks when: an approver authorises a credentialed arm,
+  # or the pilot answers it for its own destination during rollout.
+  {slug = "rfc0088-post-auth-sso-worker-dependency", source = "rfc/0088 open question 4"},
+  # Round 11 accepted, and no measured control closes, the exposure that any
+  # same-uid process can attach to the browser's unconfined bind endpoint. Round 12
+  # measures whether a second OS user closes it (the cheap alternative to
+  # containerising, which round 10 showed costs the renderer sandbox without
+  # SYS_ADMIN). Unblocks when: round 12 T4 runs, which needs a second local account.
+  {slug = "rfc0088-same-uid-attach-exposure", source = "rfc/0088 disposition B"},
   # AGENTS.md § "Commands you'll need" lists only `npm ci --prefix docs-site` as the
   # one-time site setup, but `make site-link-check` runs `npm run build --prefix web`
   # FIRST. Without `npm ci --prefix web` the gate dies with `sh: astro: command not


### PR DESCRIPTION
## What does this change?

Turns RFC-0088's remaining work into items `workspace-status` can surface: a Draft
round-12 spec in the work queue, two design questions in the shaping queue, and two
residuals in the open backlog — plus the RFC open questions and the probe note that
justify them.

## Why?

Reading round 11's amended requirements against a **real adopter consumer** (a pack
in a separate catalogue, read as read-only context — this PR writes nothing to it)
surfaced three design questions the RFC could not answer from its own fixtures.

- Follows from: [RFC-0088](docs/rfc/0088-web-pilot-foundation.md) § *Open questions* 4–6
- Spec: `docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md` (Draft)

**The probe note narrows the item-6 landscape residual** without closing it. Three
public front doors, addressed by role:

| Role | Registers a worker | Renders under block | Reading |
|---|---|---|---|
| Sign-in surface | no | yes, unchanged | **Authentication does not need a worker** |
| Webmail surface | attempts one | yes, byte-identical | Present, not load-bearing |
| Collaboration surface | yes | **no — collapses** | **LOAD-BEARING** |

The scenario that could have invalidated item 6 outright — suppression breaking the
sign-in the pilot exists to protect — does not occur. The expensive class does
exist in the wild.

**Three open questions added:** destination-scoped worker policy (real surfaces
have opposite needs, so a global switch forces losing a surface or losing the
control); the token-replay consumer pattern (no blocker item covers it, and the
RFC's credential posture assumes the session stays in the browser); and whether the
provenance anchor is a digest or a signing identity (a digest is unachievable for
an auto-updating MDM-provisioned system browser, which does carry a stable team
identifier, notarization, and library-validation).

## How do I verify it?

```bash
python3 .claude/skills/work-loop/scripts/lint-spec-status.py     # clean
PYTHONDONTWRITEBYTECODE=1 ./r9-gates.sh                          # ALL GATES OK
python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb'))"   # parses
```

Then `workspace-status` surfaces the round-12 spec as a queued item needing
approval, the two shaping items, and the residuals as context.

## What did you not change that you considered?

- **The native-addon confinement bypass.** Needs a toolchain, which is an *Ask
  first* boundary. Left as a backlog residual with its unblock condition rather
  than smuggled into a round.
- **The post-authentication SSO worker dependency.** Needs a real authenticated
  session, which the security preconditions forbid. Registered as a residual; round
  12 bounds it further by enumerating what the purge removes.
- **Any disposition, blocker item, or the status field.** RFC-0088 stays
  `Experimental`.
- **The other catalogue.** It informed these questions and is read-only context;
  nothing here modifies it.
- **Promoting the probe.** It is exploratory and marked as such — its registration
  count proved timing-sensitive across runs, so the note records that the count
  must not be quoted and rests its findings on the stable readings instead.

**Bundled fixes:** none. **Deferred:** two residuals, both registered with unblock
conditions.

**Privacy:** no vendor, product, employer, tenant or account identifier, and no
URI, appears in any added line — verified by scanning the diff, not the files.
Probe endpoints and the browser binary are supplied through the environment.

---

## Checklist

- [x] Tests pass locally (`r9-gates.sh` ALL GATES OK; privacy sweep clean)
- [x] Lint passes (`lint-spec-status` clean; `workspace.toml` parses)
- [ ] Self-review via reviewer subagent — **named skip**: standing instruction not to dispatch subagents
- [x] Spec and code agree (spec is Draft by design; approval is the trigger)
- [x] Living docs match reality
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured
