### PR TITLE
fix(agentbundle): verify knowledge bundles on Windows, not just Linux and macOS

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -58,7 +58,7 @@ jobs:
   agentbundle-windows:
     name: AgentBundle compatibility (windows)
     runs-on: windows-latest
-    # Dependency setup plus the remaining 15 sequential portability stages can
+    # Dependency setup plus the remaining 16 sequential portability stages can
     # exceed the old 10-minute ceiling on a cold runner. CredBroker's package
     # suite is split below, so 15 minutes remains a bounded compatibility budget.
     timeout-minutes: 15
@@ -96,7 +96,8 @@ jobs:
       - name: Windows compat build-check
         # Drives agentbundle/catalogue_tooling/self_host_windows.py:
         # catalogue build → self-host drift check → path-sensitive pytest suite
-        # → experience lint → pre-pr aggregator. Stops on first failure.
+        # → experience lint → pre-pr aggregator → okf compiler checks. Stops on
+        # first failure.
         run: agentbundle catalogue self-host --check --windows --root .
 
   credbroker-tests-windows:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -374,7 +374,8 @@ jobs:
             tools/test_check_release_impact.py \
             tools/test_scaffold_projection.py \
             tools/test_conformance_portability.py \
-            tools/test_lint_guides_no_repo_only_refs.py -q
+            tools/test_lint_guides_no_repo_only_refs.py \
+            tools/test_okf_pre_pr.py -q
 
       # credbroker-user-scope T3: the build pipeline vendors credbroker to the
       # per-scope lib floor (.agentbundle/lib/) + the catalogue pack copy,

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ docs/knowledge/**/*.lock
 docs/knowledge/*.lock
 docs/knowledge/**/*.lock.stale-*
 docs/knowledge/*.lock.stale-*
+
+# Coverage artifacts from local --cov runs (binary; never committed).
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,8 @@ test:
 		tools/test_check_release_impact.py \
 		tools/test_scaffold_projection.py \
 		tools/test_conformance_portability.py \
-		tools/test_lint_guides_no_repo_only_refs.py -q
+		tools/test_lint_guides_no_repo_only_refs.py \
+		tools/test_okf_pre_pr.py -q
 
 # Local CI gate. Exactly one workflow is watched: build-check.yml.
 # tools/lint-ci-parity.py — chained into build-check — holds a disposition per

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -59,6 +59,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   address returns a 404 rather than implying the surface moved. `Work` in the
   site navigation is now `Now`.
 
+### [agentbundle][0.38.1] — 2026-08-18
+
+#### Fixed
+
+- **Windows runners now verify knowledge-bundle output instead of being assumed
+  to.** The Windows compat suite ran the adopter-facing pre-PR hook, which
+  carries no OKF gate, so no Windows runner touched the compiler at all. The
+  suite gains an `okf compiler checks` stage: it re-renders every declared
+  bundle and compares the result against the committed tree, so a Windows-only
+  encoding, path, or ordering difference now fails there instead of reaching
+  main unnoticed.
+
 ### [agentbundle][0.38.0] — 2026-08-17
 
 #### Added

--- a/docs/rfc/0087-notes/pilot-results.md
+++ b/docs/rfc/0087-notes/pilot-results.md
@@ -40,6 +40,8 @@ them with inferred measurements.
 | Cost compiler check | `python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack _okf-pilot-cost-engineering --check` | `OKF000 check clean packs/_okf-pilot-cost-engineering` |
 | Real-pilot JSON discovery and release-surface tests | `env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/agentbundle python3 -m pytest -p no:cacheprovider tests/roster/test_okf_catalogue_discovery.py -q` | `3 passed` |
 | Focused discovery and version suite | `env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/agentbundle python3 -m pytest -p no:cacheprovider packages/agentbundle/tests/unit/test_okf_discovery.py packages/agentbundle/tests/integration/test_show_cmd.py packages/agentbundle/tests/unit/test_local_scope_t12_show.py packages/agentbundle/tests/unit/test_version.py -q` | Passed after the release-surface boundary repair |
+| macOS write-mode determinism (AC22 partial) | Compile each managed pack twice in write mode (`python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack <pack>`), then compare the managed tree between the two runs — `git status` stays clean, so the second compile reproduces the first byte for byte | macOS 25.5.0 arm64 / CPython 3.13.13. `_okf-pilot-cost-engineering`: both compiles succeed and leave an identical tree. `core`: write mode refuses both times with `OKF010 packs/core/.apm/skills/security-checklists ownership conflict`, because that managed directory also holds 11 hand-authored `references/*.md` this pilot deliberately retains. Check mode is clean for both packs. |
+| Windows knowledge-bundle verification | `agentbundle catalogue self-host --check --windows --root .` gained an `okf compiler checks` stage invoking `tools/check-okf-managed-packs.py` | Wired in required CI. Before it, no Windows runner invoked the compiler: the Windows suite runs the adopter-facing `tools/hooks/pre-pr.py`, while the OKF gate lives in the maintainer aggregator `tools/catalogue/pre_pr_catalogue.py`. Write mode remains unavailable on Windows by design — `_apply_outputs_transactionally` refuses with `OKF010` because `os.supports_dir_fd` is empty there. |
 | Adapter preservation spike | `env PYTHONPATH=packages/agentbundle python3 docs/rfc/0087-notes/verify_adapter_spike.py` | All seven adapters passed; nested OKF tree digest `sha256:4c502a8833a955799b8aaa2f52769306fedcaa79c0233dcc086c321ea8366900` |
 | Fast repository build check | `SKIP_SAST=1 make build-check` | Passed in supervisor-recorded T8 evidence |
 | Full AgentBundle package suite | Isolated-venv `make ci` invocation supplied by the operator on 2026-08-17 | Passed to 100%; the same run also passed the CredBroker package suite |
@@ -64,14 +66,14 @@ them with inferred measurements.
 | D4 authority boundary | Compiler checks and generated Skills preserve no-tools and inert knowledge boundaries. | Evidence present from compiler and focused tests; model behavior still pending |
 | D5 pilot experiment | Cost pilot remains underscore-prefixed and unpublished; security-checklists remains the in-place core pilot. | Partial: experiment assets exist, model E2E and Approver decision pending |
 | D6 catalogue discovery | `show --format json` exposes OKF data only as pre-release single-pack discovery and excludes cross-pack publication surfaces. | Evidence present from discovery tests |
-| D7 deterministic verification | `compile-okf --check` is wired and clean for both pilots; fast build-check, the full AgentBundle package suite, and full SAST/SCA passed. | Partial: Windows byte-identical evidence remains unavailable |
+| D7 deterministic verification | `compile-okf --check` is wired and clean for both pilots on Linux, Windows, and macOS; fast build-check, the full AgentBundle package suite, and full SAST/SCA passed. | Check-mode evidence present on all three platforms; write-mode evidence is macOS-only and cannot be produced on Windows or for `core` (see AC22) |
 | D8 single-version support | Active profile remains `agentbundle-okf/v1` mapping to OKF 0.2. | Evidence present |
 
 ## Acceptance criterion accounting
 
 | Criterion | Status |
 | --- | --- |
-| AC22 | Local compiler checks are clean for both pilots. Linux/Windows CI byte-identical evidence is not locally produced in this session. |
+| AC22 | Deferred as unsatisfiable as written (`okf-ac22-write-mode-unsatisfiable-as-written`). Check mode is clean for both pilots on Linux CI, Windows CI, and macOS. Write mode is byte-identical across two compiles for `_okf-pilot-cost-engineering` on macOS, refuses on Windows (`os.supports_dir_fd` empty), and refuses for `core` on every platform (unmanaged siblings in the managed directory). |
 | AC23 | The adapter spike preserves nested OKF regular-file bytes across Claude Code, Kiro IDE, Kiro CLI, Copilot, Cursor, Codex, and Gemini. |
 | AC24 | The compile-okf Skill and authoring prerequisite are shipped in catalogue-curation. Fast build-check and the operator-supplied isolated-venv full SAST/SCA run passed. |
 | AC25 | Both pilots compile through the generic compiler path. No caller-name branch evidence is recorded in the focused compiler tests. |
@@ -79,7 +81,7 @@ them with inferred measurements.
 | AC26 | Cost-engineering satisfies the frozen case and hand-authored baseline prerequisite. Security-checklists has matching frozen case counts and enough security-critical cases, but its model E2E baseline remains pending, so the overall AC remains pending. |
 | AC27 | Pending. No local model E2E harness was available, so no generated-router success rate, security-critical attempt result, or fabricated-path measurement is claimed. |
 | AC28 | Pending. No maintainer update/timing exercise was completed in this local run. |
-| AC29 | Fast repository build-check, direct compiler checks, the full AgentBundle package suite, full SAST/SCA, focused post-repair package and roster suites, and the exact real-sdist gate passed. Combined operator evidence covers every local `make ci` leg after the repair; site-link and Windows evidence remain external. |
+| AC29 | Fast repository build-check, direct compiler checks, the full AgentBundle package suite, full SAST/SCA, focused post-repair package and roster suites, and the exact real-sdist gate passed. Combined operator evidence covers every local `make ci` leg after the repair. Windows now runs the compiler check in required CI; site-link evidence remains external. |
 
 ## Pending human and external gates
 

--- a/docs/specs/okf-authoring-projection/plan.md
+++ b/docs/specs/okf-authoring-projection/plan.md
@@ -407,7 +407,7 @@ and the baseline/case freeze predates generated runs.
 
 **Depends on:** T6, T7
 
-**Touches:** `tools/catalogue/pre_pr_catalogue.py`, `tools/test_*.py`, `packages/agentbundle/tests/build_pipeline/**`, `Makefile`
+**Touches:** `tools/catalogue/pre_pr_catalogue.py`, `tools/test_*.py`, `packages/agentbundle/tests/build_pipeline/**`, `Makefile`, `tools/check-okf-managed-packs.py`, `packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py`, `.github/workflows/build-check-windows.yml`
 
 **Verification mode:** Goal-based integration checks.
 

--- a/docs/specs/okf-authoring-projection/spec.md
+++ b/docs/specs/okf-authoring-projection/spec.md
@@ -218,9 +218,15 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   their trees differ, otherwise fails as `OKF011` for any committed drift, and
   leaves source, generated output, stdout-visible candidate review values, and
   the working tree unchanged.
-- [ ] **AC22:** Two write-mode compiles from identical canonical bytes and
-  profile/compiler versions produce byte-identical complete managed trees on
-  Linux and Windows CI runners and in a recorded local macOS verification.
+- [ ] **AC22:** (deferred: okf-ac22-write-mode-unsatisfiable-as-written)
+  <!-- The marker leads deliberately. lint-spec-status invariant (ii)
+       matches per physical line, so moving it onto a continuation line
+       passes today and fails when this spec goes Shipped. -->
+  Two write-mode compiles from identical canonical bytes and profile/compiler
+  versions produce byte-identical complete managed trees on Linux and Windows
+  CI runners and in a recorded local macOS verification. Measurements and the
+  proposed rewording live in `workspace.toml [backlog].open` under that slug;
+  measured evidence is in [`pilot-results.md`](../../rfc/0087-notes/pilot-results.md).
 - [ ] **AC23:** Claude Code, Kiro IDE, Kiro CLI, Copilot, Cursor, Codex, and
   Gemini projections preserve the generated router's nested OKF regular-file
   bytes and pass existing Agent Skills/catalogue lint rules.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.38.1] — 2026-08-18
+
+### Fixed
+
+- **The Windows compatibility suite now verifies declared knowledge bundles.**
+  It ran the adopter-facing pre-PR hook, which carries no knowledge-bundle gate,
+  so no Windows runner invoked the compiler. The suite now re-renders every
+  declared bundle and compares the result against the committed tree, so a
+  Windows-only encoding, path, or ordering difference fails there rather than
+  reaching main. Managed *writes* remain unavailable on Windows by design — they
+  require directory-descriptor-confined operations the platform does not offer —
+  so the Windows stage verifies committed output rather than producing it.
+
 ## [0.38.0] — 2026-08-17
 
 ### Added

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -14,6 +14,13 @@ python -m pip install agentbundle
 
 Requires Python 3.11+. Runs on macOS, Linux, and Windows.
 
+## What's new in 0.38.1
+
+`agentbundle catalogue self-host --check --windows` gained a stage that verifies
+a source catalogue's declared knowledge bundles against their committed output.
+The verification itself is performed by the catalogue's own tooling, so this
+changes nothing for installing or using a pack.
+
 ## What's new in 0.38.0
 
 `agentbundle show <pack> --format json` now emits the additive pre-release rich

--- a/packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/self_host_windows.py
@@ -127,6 +127,17 @@ def run_windows_compat(root: Path) -> int:
             [py, str(root / "tools" / "hooks" / "pre-pr.py")],
             root,
         ),
+        # Re-renders every declared knowledge bundle and compares the result
+        # against the committed tree, so a Windows-only encoding, path, or
+        # ordering difference fails here rather than reaching main. The
+        # adopter-facing hook above does not carry this gate — it is a
+        # catalogue-maintainer concern — so without this stage no Windows runner
+        # touches the compiler at all.
+        (
+            "okf compiler checks",
+            [py, str(root / "tools" / "check-okf-managed-packs.py"), "--root", str(root)],
+            root,
+        ),
     ]
 
     for label, cmd, cwd in steps:

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.38.0"
+CLI_VERSION = "0.38.1"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.38.0"
+version = "0.38.1"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/tests/roster/test_okf_catalogue_discovery.py
+++ b/tests/roster/test_okf_catalogue_discovery.py
@@ -37,7 +37,7 @@ def _assert_show_schema(response: dict[str, object]) -> None:
 
 def test_release_metadata_moves_together_for_okf_catalogue_discovery() -> None:
     """Public show JSON changes must move repository release surfaces together."""
-    expected = "0.38.0"
+    expected = "0.38.1"
     pyproject = tomllib.loads(
         (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     )

--- a/tools/catalogue/pre_pr_catalogue.py
+++ b/tools/catalogue/pre_pr_catalogue.py
@@ -22,7 +22,6 @@ import argparse
 import os
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
@@ -89,65 +88,15 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _okf_pack_dirs(repo_root: Path) -> list[Path]:
-    """Return every pack directory declaring managed OKF metadata.
+def _okf_check_script(repo_root: Path) -> Path:
+    """The shared OKF check entry point.
 
-    This is repo-level experiment plumbing, not public catalogue discovery:
-    underscore-prefixed pilot packs are intentionally included here while normal
-    list/install/publish surfaces still skip them.
+    Pack discovery and the per-pack compiler invocation live in that script so
+    this aggregator and the Windows compat suite cannot drift into scanning
+    different pack sets — the platform that scanned fewer would report a pass it
+    had not earned.
     """
-    packs_root = repo_root / "packs"
-    if not packs_root.is_dir():
-        return []
-    managed: list[Path] = []
-    for pack_dir in sorted(packs_root.iterdir(), key=lambda path: path.name):
-        pack_toml = pack_dir / "pack.toml"
-        if not pack_toml.is_file():
-            continue
-        try:
-            data = tomllib.loads(pack_toml.read_text(encoding="utf-8"))
-        except (OSError, tomllib.TOMLDecodeError):
-            continue
-        pack = data.get("pack")
-        metadata = pack.get("metadata") if isinstance(pack, dict) else None
-        okf = metadata.get("okf") if isinstance(metadata, dict) else None
-        if isinstance(okf, dict):
-            managed.append(pack_dir)
-    return managed
-
-
-def _okf_compiler_script(repo_root: Path) -> Path:
-    return (
-        repo_root
-        / "packs"
-        / "catalogue-curation"
-        / ".apm"
-        / "skills"
-        / "compile-okf"
-        / "scripts"
-        / "compile_okf.py"
-    )
-
-
-def _run_okf_checks(repo_root: Path, py: str) -> None:
-    compiler = _okf_compiler_script(repo_root)
-    packs = _okf_pack_dirs(repo_root)
-    if not packs:
-        print("pre-pr: ✓ okf compiler checks (no managed packs)")
-        return
-    for pack_dir in packs:
-        _run(
-            f"okf compiler check {pack_dir.name}",
-            [
-                py,
-                str(compiler),
-                "--root",
-                str(repo_root),
-                "--pack",
-                pack_dir.name,
-                "--check",
-            ],
-        )
+    return repo_root / "tools" / "check-okf-managed-packs.py"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -196,7 +145,10 @@ def main(argv: list[str] | None = None) -> int:
     _run("journey-contract lint", [py, "tools/lint-journey-contract.py"])
     _run("journey-contract lint self-test",
          [py, "tools/test-lint-journey-contract.py"])
-    _run_okf_checks(repo_root, py)
+    _run(
+        "okf compiler checks",
+        [py, str(_okf_check_script(repo_root)), "--root", str(repo_root)],
+    )
 
     # Delegate to the shipped adopter-facing hook for the work-loop caps gate.
     result = subprocess.run(

--- a/tools/check-okf-managed-packs.py
+++ b/tools/check-okf-managed-packs.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Run the OKF compiler's check mode over every pack declaring managed OKF metadata.
+
+Check mode re-renders each declared bundle and compares the result against the
+committed tree, so "this command passed on this platform" is the evidence that
+the committed output is what this platform produces. That is why the gate runs
+on Linux and Windows rather than only where the output was authored.
+
+It lives in its own script rather than inline in one aggregator because two
+callers need it: the Linux path reaches it through
+`tools/catalogue/pre_pr_catalogue.py`, the Windows path through the compat
+suite's stage list. Two copies of the pack-discovery rule would eventually
+disagree about which packs are managed, and the platform that scanned fewer
+packs would report a pass it had not earned.
+
+Every way of scanning fewer packs than exist is therefore an error here, not a
+`continue`: a missing `packs/` tree, an unreadable `pack.toml`, and a
+wrong-shaped `metadata.okf` all fail loudly. A gate that silently narrows its
+own scope is worse than no gate, because it reports success.
+
+Usage:
+    python tools/check-okf-managed-packs.py [--root DIR]
+
+Exits 0 when every managed pack checks clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_COMPILER_RELATIVE = Path(
+    "packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py"
+)
+
+# A hung compiler would otherwise block until the CI job's own ceiling, which is
+# reported as a job timeout and names neither this gate nor the pack.
+_COMPILE_TIMEOUT_SECONDS = 600
+
+
+def compiler_script(repo_root: Path) -> Path:
+    """Path to the authoring compiler the catalogue ships as a Skill script."""
+    return repo_root / _COMPILER_RELATIVE
+
+
+def managed_pack_dirs(repo_root: Path) -> list[Path]:
+    """Every pack directory declaring managed OKF metadata, in sorted order.
+
+    This is repo-level experiment plumbing, not public catalogue discovery:
+    underscore-prefixed pilot packs are intentionally included here while normal
+    list/install/publish surfaces still skip them.
+
+    Raises ``ValueError`` when a pack cannot be classified, so a typo in an OKF
+    block removes the pack from the gate loudly rather than silently.
+    """
+    packs_root = repo_root / "packs"
+    if not packs_root.is_dir():
+        raise ValueError(f"no packs/ directory under {repo_root}")
+    managed: list[Path] = []
+    for pack_dir in sorted(packs_root.iterdir(), key=lambda path: path.name):
+        # `packs/` also holds a few authoring `.md` files; only directories are
+        # candidates. A directory without a manifest IS an error — that is the
+        # shape a half-deleted or half-created pack takes, and skipping it is
+        # how a pack leaves the gate unnoticed.
+        if not pack_dir.is_dir():
+            continue
+        pack_toml = pack_dir / "pack.toml"
+        if not pack_toml.is_file():
+            raise ValueError(f"{pack_dir.name}/ has no pack.toml")
+        try:
+            data = tomllib.loads(pack_toml.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise ValueError(f"{pack_dir.name}/pack.toml is unreadable: {exc}") from exc
+        pack = data.get("pack")
+        if not isinstance(pack, dict):
+            raise ValueError(
+                f"{pack_dir.name}/pack.toml has no [pack] table"
+                if pack is None
+                else f"{pack_dir.name}/pack.toml declares pack as "
+                f"{type(pack).__name__}, not a table"
+            )
+        metadata = pack.get("metadata")
+        # A pack with no metadata, or metadata carrying no okf block, is simply
+        # not an OKF pack — the only sanctioned skip in this loop.
+        if metadata is None:
+            continue
+        if not isinstance(metadata, dict):
+            raise ValueError(
+                f"{pack_dir.name}/pack.toml declares pack.metadata as "
+                f"{type(metadata).__name__}, not a table"
+            )
+        if "okf" not in metadata:
+            continue
+        okf = metadata["okf"]
+        if not isinstance(okf, dict):
+            raise ValueError(
+                f"{pack_dir.name}/pack.toml declares metadata.okf as "
+                f"{type(okf).__name__}, not a table"
+            )
+        managed.append(pack_dir)
+    return managed
+
+
+def _check_pack(compiler: Path, repo_root: Path, pack_dir: Path) -> bool:
+    """Check one pack; return True when clean, forwarding the compiler's output."""
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(compiler),
+                "--root",
+                str(repo_root),
+                "--pack",
+                pack_dir.name,
+                "--check",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            # The compiler's diagnostics are the only way to tell an OKF011 drift
+            # from an OKF012 non-determinism. Losing them to a decode error would
+            # leave a Windows-only failure with nothing to act on.
+            errors="replace",
+            check=False,
+            timeout=_COMPILE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"okf-check: ✖ {pack_dir.name} timed out after "
+            f"{_COMPILE_TIMEOUT_SECONDS}s",
+            file=sys.stderr,
+        )
+        return False
+
+    if result.returncode != 0:
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+        print(f"okf-check: ✖ {pack_dir.name} failed", file=sys.stderr)
+        return False
+
+    print(f"okf-check: ✓ {pack_dir.name}")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Windows cp1252 guard. Inside main() so importing this module for its
+    # helpers does not reconfigure stdout for an entire pytest process, and
+    # guarded because a redirected stream is not always a real text file.
+    for stream, errors in ((sys.stdout, "strict"), (sys.stderr, "backslashreplace")):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors=errors)
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        default=str(_REPO_ROOT),
+        help="catalogue repository root (default: this checkout)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.root).resolve()
+    try:
+        packs = managed_pack_dirs(repo_root)
+    except ValueError as exc:
+        print(f"okf-check: ✖ {exc}", file=sys.stderr)
+        return 1
+
+    if not packs:
+        print("okf-check: ✓ no packs declare managed OKF metadata")
+        return 0
+
+    compiler = compiler_script(repo_root)
+    # Managed packs with no compiler is a broken checkout, not a reason to report
+    # clean — the packs declare output that nothing can verify.
+    if not compiler.is_file():
+        print(
+            f"okf-check: ✖ {len(packs)} managed pack(s) but no compiler at "
+            f"{_COMPILER_RELATIVE}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Every pack runs even after one fails. A platform-specific defect usually
+    # affects more than one pack, and each check costs about a second; stopping
+    # at the first would cost another full Windows job to learn the rest.
+    failed: list[str] = []
+    for pack_dir in packs:
+        if not _check_pack(compiler, repo_root, pack_dir):
+            failed.append(pack_dir.name)
+    if failed:
+        print(
+            f"okf-check: ✖ {len(failed)} of {len(packs)} pack(s) failed: "
+            f"{', '.join(failed)}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -585,34 +585,16 @@ EXPECTED_PRE_PR_REPO_STEPS = [
         "journey-contract lint self-test",
         [sys.executable, "tools/test-lint-journey-contract.py"],
     ),
+    # One gate, not one per pack: pack discovery moved into the shared script so
+    # the Linux aggregator and the Windows compat suite cannot drift into
+    # scanning different pack sets.
     (
-        "okf compiler check _okf-pilot-cost-engineering",
+        "okf compiler checks",
         [
             sys.executable,
-            str(
-                gc.REPO_ROOT
-                / "packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py"
-            ),
+            str(gc.REPO_ROOT / "tools" / "check-okf-managed-packs.py"),
             "--root",
             str(gc.REPO_ROOT),
-            "--pack",
-            "_okf-pilot-cost-engineering",
-            "--check",
-        ],
-    ),
-    (
-        "okf compiler check core",
-        [
-            sys.executable,
-            str(
-                gc.REPO_ROOT
-                / "packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py"
-            ),
-            "--root",
-            str(gc.REPO_ROOT),
-            "--pack",
-            "core",
-            "--check",
         ],
     ),
 ]

--- a/tools/test_okf_pre_pr.py
+++ b/tools/test_okf_pre_pr.py
@@ -1,11 +1,19 @@
-"""Tests for the repo-only OKF compiler pre-PR gate."""
+"""Tests for the repo-only OKF compiler check gate and both platforms' wiring.
+
+The gate itself lives in `tools/check-okf-managed-packs.py`. Two callers reach
+it — the Linux aggregator (`tools/catalogue/pre_pr_catalogue.py`) and the Windows
+compat suite's stage list — and the last two tests here pin those call sites,
+because a gate nothing invokes is indistinguishable from a gate that passes.
+"""
 
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import io
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -14,6 +22,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parent / "catalogue"))
 import pre_pr_catalogue as pre_pr  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, path: Path):
+    """Import a hyphenated script by path (not importable by name)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+okf_check = _load("check_okf_managed_packs", REPO_ROOT / "tools" / "check-okf-managed-packs.py")
 
 
 def _write_pack(root: Path, name: str, *, okf_path: str = "okf/demo") -> Path:
@@ -58,130 +77,424 @@ def _write_pack(root: Path, name: str, *, okf_path: str = "okf/demo") -> Path:
     return pack
 
 
-class OkfPrePrGateTests(unittest.TestCase):
+class OkfCheckGateTests(unittest.TestCase):
     def test_discovery_includes_underscore_pilots_and_excludes_plain_packs(self) -> None:
-        with self.subTest("discovery"):
-            import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "_okf-pilot")
+            _write_pack(root, "managed")
+            plain = root / "packs" / "plain"
+            plain.mkdir(parents=True)
+            (plain / "pack.toml").write_text('[pack]\nname = "plain"\n', encoding="utf-8")
 
-            with tempfile.TemporaryDirectory() as tmp:
-                root = Path(tmp)
-                _write_pack(root, "_okf-pilot")
-                _write_pack(root, "managed")
-                plain = root / "packs" / "plain"
-                plain.mkdir(parents=True)
-                (plain / "pack.toml").write_text(
-                    '[pack]\nname = "plain"\n', encoding="utf-8"
-                )
-
-                discovered = [path.name for path in pre_pr._okf_pack_dirs(root)]
+            discovered = [path.name for path in okf_check.managed_pack_dirs(root)]
 
         self.assertEqual(discovered, ["_okf-pilot", "managed"])
 
-    def test_run_okf_checks_invokes_compiler_for_each_managed_pack(self) -> None:
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            _write_pack(root, "_pilot")
-            _write_pack(root, "core")
-            seen: list[tuple[str, list[str]]] = []
-
-            def fake_run(label: str, argv: list[str], env: dict | None = None) -> None:
-                del env
-                seen.append((label, argv))
-
-            with mock.patch.object(pre_pr, "_run", fake_run):
-                pre_pr._run_okf_checks(root, sys.executable)
-
-        self.assertEqual([label for label, _ in seen], [
-            "okf compiler check _pilot",
-            "okf compiler check core",
-        ])
-        for _, argv in seen:
-            self.assertIn("--check", argv)
-            self.assertIn("--pack", argv)
-
-    def test_clean_drift_and_unsafe_inputs_use_shipped_compiler_check(self) -> None:
-        import tempfile
-
+    def test_a_clean_tree_passes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_pack(root, "managed")
-            compiler = pre_pr._okf_compiler_script(REPO_ROOT)
+            compiler = okf_check.compiler_script(REPO_ROOT)
             write = subprocess.run(
-                [
-                    sys.executable,
-                    str(compiler),
-                    "--root",
-                    str(root),
-                    "--pack",
-                    "managed",
-                ],
+                [sys.executable, str(compiler), "--root", str(root), "--pack", "managed"],
                 check=False,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
             )
             self.assertEqual(write.returncode, 0, write.stderr)
 
-            with mock.patch.object(pre_pr, "_okf_compiler_script", return_value=compiler):
-                pre_pr._run_okf_checks(root, sys.executable)
-
-            router = (
-                root
-                / "packs"
-                / "managed"
-                / ".apm"
-                / "skills"
-                / "demo-router"
-                / "SKILL.md"
-            )
-            router.write_text(
-                router.read_text(encoding="utf-8") + "\nmanual drift\n",
-                encoding="utf-8",
-            )
             with (
-                mock.patch.object(pre_pr, "_okf_compiler_script", return_value=compiler),
-                self.assertRaises(SystemExit),
+                mock.patch.object(okf_check, "compiler_script", return_value=compiler),
+                contextlib.redirect_stdout(io.StringIO()),
             ):
-                pre_pr._run_okf_checks(root, sys.executable)
+                self.assertEqual(okf_check.main(["--root", str(root)]), 0)
 
+    def test_an_unsafe_bundle_path_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             _write_pack(root, "unsafe", okf_path="okf/../escape")
             stderr = io.StringIO()
             with (
-                mock.patch.object(pre_pr, "_okf_compiler_script", return_value=compiler),
+                mock.patch.object(
+                    okf_check, "compiler_script", return_value=okf_check.compiler_script(REPO_ROOT)
+                ),
+                contextlib.redirect_stdout(io.StringIO()),
                 contextlib.redirect_stderr(stderr),
-                self.assertRaises(SystemExit),
             ):
-                pre_pr._run_okf_checks(root, sys.executable)
-            self.assertIn("okf compiler check unsafe", stderr.getvalue())
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("unsafe failed", stderr.getvalue())
 
-    def test_plain_catalogue_has_no_okf_check_and_gate_imports_no_pyyaml(self) -> None:
-        import tempfile
+    def test_the_gate_runs_the_compiler_in_check_mode(self) -> None:
+        """`--check` is the whole gate: without it this is a silent rewriter.
 
+        Every other assertion in this file survives dropping `--check` — a
+        drifted tree still exits non-zero (as an ownership conflict rather than
+        output drift), so the failure text still matches. Only the argv
+        distinguishes verifying from overwriting.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "managed")
+            seen: list[list[str]] = []
+
+            class _Ok:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            def record(argv, **kwargs):
+                seen.append(list(argv))
+                return _Ok()
+
+            with (
+                mock.patch.object(
+                    okf_check, "compiler_script", return_value=okf_check.compiler_script(REPO_ROOT)
+                ),
+                mock.patch.object(okf_check.subprocess, "run", record),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 0)
+
+        self.assertEqual(len(seen), 1)
+        argv = seen[0]
+        self.assertIn("--check", argv)
+        self.assertIn("--pack", argv)
+        self.assertEqual(argv[argv.index("--pack") + 1], "managed")
+
+    def test_a_drifted_tree_is_reported_without_being_rewritten(self) -> None:
+        """Reporting drift must not repair it.
+
+        A gate that rewrites the tree it is checking passes on its second run
+        and gates nothing.
+        """
+        compiler = okf_check.compiler_script(REPO_ROOT)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "managed")
+            subprocess.run(
+                [sys.executable, str(compiler), "--root", str(root), "--pack", "managed"],
+                check=True,
+                capture_output=True,
+            )
+            router = root / "packs" / "managed" / ".apm" / "skills" / "demo-router" / "SKILL.md"
+            drifted = router.read_text(encoding="utf-8") + "\nmanual drift\n"
+            router.write_text(drifted, encoding="utf-8")
+
+            with (
+                mock.patch.object(okf_check, "compiler_script", return_value=compiler),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+
+            self.assertEqual(router.read_text(encoding="utf-8"), drifted)
+
+    def test_a_catalogue_with_no_managed_packs_passes_cleanly(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             plain = root / "packs" / "plain"
             plain.mkdir(parents=True)
             (plain / "pack.toml").write_text('[pack]\nname = "plain"\n', encoding="utf-8")
 
-            with mock.patch.object(pre_pr, "_run") as run:
-                stdout = io.StringIO()
-                with contextlib.redirect_stdout(stdout):
-                    pre_pr._run_okf_checks(root, sys.executable)
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 0)
 
-        run.assert_not_called()
-        self.assertIn("no managed packs", stdout.getvalue())
-        source = (REPO_ROOT / "tools" / "catalogue" / "pre_pr_catalogue.py").read_text(
-            encoding="utf-8"
+        self.assertIn("no packs declare managed OKF metadata", stdout.getvalue())
+
+    def test_a_hung_compiler_fails_the_gate_rather_than_the_job(self) -> None:
+        """A timeout that returns True turns a hung compiler into a passing gate.
+
+        Without this, the natural mutation of the handler is green, and a hang
+        surfaces only as a CI job timeout that names neither the gate nor the
+        pack.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "slow")
+
+            def hang(argv, **kwargs):
+                raise subprocess.TimeoutExpired(argv, okf_check._COMPILE_TIMEOUT_SECONDS)
+
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(
+                    okf_check, "compiler_script", return_value=okf_check.compiler_script(REPO_ROOT)
+                ),
+                mock.patch.object(okf_check.subprocess, "run", hang),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("timed out after", stderr.getvalue())
+
+    def test_the_gate_survives_a_cp1252_console(self) -> None:
+        """The Windows encoding guard is load-bearing and no other test reaches it.
+
+        Every other test redirects stdout to a StringIO, which has no
+        `reconfigure`, so the guard no-ops throughout the suite. Deleting it
+        makes the gate's own success line raise UnicodeEncodeError on a cp1252
+        console — a failure that looks like a broken gate, not a broken locale.
+        """
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "packs").mkdir()
+            result = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "tools" / "check-okf-managed-packs.py"),
+                 "--root", tmp],
+                capture_output=True,
+                text=True,
+                # Decode as UTF-8 rather than the parent's locale. Without this
+                # the one test whose subject IS encoding determinism is the only
+                # locale-sensitive test in the file: under an ASCII parent it
+                # dies in `communicate` on the child's correct UTF-8 bytes,
+                # before any assertion runs.
+                encoding="utf-8",
+                env={**os.environ, "PYTHONIOENCODING": "cp1252"},
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("✓", result.stdout)
+
+    def test_the_gate_does_not_pull_in_pyyaml(self) -> None:
+        """pyyaml is an authoring-time prerequisite; the gate must not need it.
+
+        Asserted by loading the script in a fresh interpreter and inspecting
+        `sys.modules`, not by grepping for `import yaml` — that grep passes for
+        `from yaml import safe_load`, `import yaml as y`, and importlib.
+        """
+        probe = (
+            "import importlib.util, sys;"
+            "spec = importlib.util.spec_from_file_location('g', sys.argv[1]);"
+            "m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m);"
+            "print('yaml' in sys.modules)"
         )
-        self.assertNotIn("import yaml", source)
+        result = subprocess.run(
+            [sys.executable, "-c", probe, str(REPO_ROOT / "tools" / "check-okf-managed-packs.py")],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(result.stdout.strip(), "False", result.stderr)
+
+    def test_every_managed_pack_is_checked_not_just_the_first(self) -> None:
+        """The gate's whole purpose is that no platform scans a smaller set.
+
+        Every other test here stages one pack, so `for pack_dir in packs[:1]`
+        left the suite green while `core` — which sorts after the underscore
+        pilot — silently stopped being verified on both platforms.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "_pilot")
+            _write_pack(root, "core")
+            _write_pack(root, "extra")
+            seen: list[str] = []
+
+            class _Ok:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            def record(argv, **kwargs):
+                seen.append(argv[argv.index("--pack") + 1])
+                return _Ok()
+
+            with (
+                mock.patch.object(
+                    okf_check, "compiler_script", return_value=okf_check.compiler_script(REPO_ROOT)
+                ),
+                mock.patch.object(okf_check.subprocess, "run", record),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 0)
+
+        self.assertEqual(seen, ["_pilot", "core", "extra"])
+
+    def test_a_failing_pack_does_not_stop_the_remaining_packs(self) -> None:
+        """One Windows job should report every affected pack, not just the first."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "alpha")
+            _write_pack(root, "beta")
+            seen: list[str] = []
+
+            class _Fail:
+                returncode = 1
+                stdout = ""
+                stderr = ""
+
+            def record(argv, **kwargs):
+                seen.append(argv[argv.index("--pack") + 1])
+                return _Fail()
+
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(
+                    okf_check, "compiler_script", return_value=okf_check.compiler_script(REPO_ROOT)
+                ),
+                mock.patch.object(okf_check.subprocess, "run", record),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+
+        self.assertEqual(seen, ["alpha", "beta"])
+        self.assertIn("2 of 2 pack(s) failed", stderr.getvalue())
+        self.assertIn("alpha, beta", stderr.getvalue())
+
+    def test_a_root_without_a_packs_tree_is_an_error_not_a_clean_pass(self) -> None:
+        """A mis-rooted invocation must not read as verified."""
+        with tempfile.TemporaryDirectory() as tmp:
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(okf_check.main(["--root", tmp]), 1)
+            self.assertIn("no packs/ directory", stderr.getvalue())
+
+    def test_an_unclassifiable_pack_fails_instead_of_leaving_the_gate(self) -> None:
+        """A typo in an OKF block must not quietly remove a pack from the scan."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            broken = root / "packs" / "broken"
+            broken.mkdir(parents=True)
+            (broken / "pack.toml").write_text("[pack]\nname = ", encoding="utf-8")
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("unreadable", stderr.getvalue())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            wrong = root / "packs" / "wrong"
+            wrong.mkdir(parents=True)
+            (wrong / "pack.toml").write_text(
+                '[pack]\nname = "wrong"\n\n[pack.metadata]\nokf = "yes"\n', encoding="utf-8"
+            )
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("not a table", stderr.getvalue())
+
+        for body, expected in (
+            ('name = "x"\n', "no [pack] table"),
+            ('[pack]\nname = "x"\n\n[other]\nk = 1\n', None),
+            ('pack = "scalar"\n', "not a table"),
+            ('[pack]\nname = "x"\nmetadata = "scalar"\n', "pack.metadata as str"),
+        ):
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                d = root / "packs" / "odd"
+                d.mkdir(parents=True)
+                (d / "pack.toml").write_text(body, encoding="utf-8")
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+                    rc = okf_check.main(["--root", str(root)])
+                if expected is None:
+                    # A valid pack that simply declares no OKF block is the one
+                    # sanctioned skip; it must stay a clean pass.
+                    self.assertEqual(rc, 0)
+                else:
+                    self.assertEqual(rc, 1)
+                    self.assertIn(expected, stderr.getvalue())
+
+    def test_a_pack_directory_without_a_manifest_is_an_error(self) -> None:
+        """A half-created or half-deleted pack must not drop out of the scan."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "packs" / "orphan").mkdir(parents=True)
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("has no pack.toml", stderr.getvalue())
+
+    def test_managed_packs_without_a_compiler_fail_rather_than_report_clean(self) -> None:
+        """A broken checkout must not read as "nothing to verify"."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_pack(root, "managed")
+            missing = root / "no" / "such" / "compile_okf.py"
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(okf_check, "compiler_script", return_value=missing),
+                contextlib.redirect_stderr(stderr),
+            ):
+                self.assertEqual(okf_check.main(["--root", str(root)]), 1)
+            self.assertIn("no compiler", stderr.getvalue())
+
+    def test_linux_aggregator_invokes_the_shared_check(self) -> None:
+        """Asserted by running the aggregator, not by grepping it.
+
+        A source grep for the script name survives deleting the call, because
+        the helper that builds the path still names the file — the gate would
+        read as wired while nothing invoked it.
+        """
+        self.assertEqual(
+            pre_pr._okf_check_script(REPO_ROOT),
+            REPO_ROOT / "tools" / "check-okf-managed-packs.py",
+        )
+
+        calls: list[tuple[str, list[str]]] = []
+        cwd = Path.cwd()
+        try:
+            with (
+                mock.patch.object(pre_pr, "_repo_root", return_value=REPO_ROOT),
+                mock.patch.object(pre_pr, "_run", lambda label, argv, env=None: calls.append(
+                    (label, argv)
+                )),
+                # `_run` covers the gate list, but main() also shells out
+                # directly to the shipped hook; unmocked, this test would fail
+                # on unrelated live-tree state (knowledge lint, caps gate).
+                mock.patch.object(
+                    pre_pr.subprocess, "run", lambda *a, **k: mock.Mock(returncode=0)
+                ),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                pre_pr.main(["--skip-verify"])
+        finally:
+            import os
+
+            os.chdir(cwd)
+
+        labels = [label for label, _ in calls]
+        self.assertIn("okf compiler checks", labels)
+        argv = next(argv for label, argv in calls if label == "okf compiler checks")
+        self.assertIn(str(REPO_ROOT / "tools" / "check-okf-managed-packs.py"), argv)
+
+    def test_windows_compat_suite_invokes_the_shared_check(self) -> None:
+        """Asserted by running the suite with its step runner captured.
+
+        Kept beside its Linux twin rather than in the engine's own test tree:
+        the two call sites are one contract, and splitting them is how one half
+        gets deleted without the other noticing.
+
+        Grepping the stage list for the script name passes for any arrangement
+        where the tuple exists but is never reached — moved behind a branch, or
+        the list rebuilt below it. The adopter-facing hook the suite already
+        runs carries no OKF gate, so a silently unreachable stage would leave
+        the Windows determinism claim resting on a suite that never compiles.
+        """
+        from agentbundle.catalogue_tooling import self_host_windows
+
+        executed: list[tuple[str, list[str]]] = []
+
+        def record(label, cmd, cwd):
+            executed.append((label, list(cmd)))
+            return 0
+
+        with mock.patch.object(self_host_windows, "_step", record):
+            self.assertEqual(self_host_windows.run_windows_compat(REPO_ROOT), 0)
+
+        labels = [label for label, _ in executed]
+        self.assertIn("okf compiler checks", labels)
+        argv = next(cmd for label, cmd in executed if label == "okf compiler checks")
+        self.assertIn(str(REPO_ROOT / "tools" / "check-okf-managed-packs.py"), argv)
+        self.assertIn("--root", argv)
 
     def test_dependency_audit_and_scanners_cover_okf_compiler_paths(self) -> None:
-        requirements = (REPO_ROOT / "tools" / "requirements.txt").read_text(
-            encoding="utf-8"
-        )
+        requirements = (REPO_ROOT / "tools" / "requirements.txt").read_text(encoding="utf-8")
         self.assertIn("pyyaml>=6.0", requirements.lower())
 
         makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")

--- a/workspace.toml
+++ b/workspace.toml
@@ -2249,6 +2249,28 @@ open = [
   # Unblocks when: a Tier-B grading RFC or cassette harness spec is accepted.
   {slug = "behavior-check-for-backend-skills"},
 
+  # spec/okf-authoring-projection AC22. The AC asks for two WRITE-mode compiles
+  # producing byte-identical managed trees on Linux and Windows CI plus a local
+  # macOS run. Two measured facts make that unsatisfiable as written:
+  #   1. Windows cannot write at all. _apply_outputs_transactionally refuses with
+  #      OKF010 "safe managed output writes are unavailable on this platform"
+  #      because os.supports_dir_fd is empty there; the dir-fd confinement is a
+  #      deliberate security control, not a portability bug.
+  #   2. `core` cannot write on ANY platform. Its managed directory
+  #      packs/core/.apm/skills/security-checklists/ also holds 11 hand-authored
+  #      references/*.md that RFC-0087 deliberately retains for current
+  #      orchestrator loading, and the ownership guard refuses to take over a
+  #      directory holding files it does not manage (OKF010 ownership conflict).
+  # Measured 2026-08-18 on macOS 25.5.0 arm64 / CPython 3.13.13: two write-mode
+  # compiles of _okf-pilot-cost-engineering are byte-identical; `core` write mode
+  # refuses both times; check mode is clean for both packs.
+  # Fix: amend AC22 to state that check mode (re-render + committed-byte
+  #   comparison) is the evidence wherever write mode is unavailable, and say
+  #   which packs and platforms that covers — alongside the AC26/AC27 amendment,
+  #   since all three are the same Approver decision.
+  # Unblocks when: the RFC-0087 erratum covering AC22/AC26/AC27 is signed off.
+  {slug = "okf-ac22-write-mode-unsatisfiable-as-written"},
+
   # spec/m6-role-journey-guides Agent section follow-on. The Agent section of
   # guides/core/explanation/role-journeys.md covers headless AI execution
   # (agent-executes-spec journey). The swarm/coordinated-agent-pipeline extension


### PR DESCRIPTION
## What does this change?

No Windows runner ever invoked the OKF compiler, so a Windows-only encoding, path, or ordering difference in generated output could reach `main` unnoticed.

The Windows compat suite ends by running `tools/hooks/pre-pr.py` — the shipped, **adopter-facing** hook. The OKF gate lives in `tools/catalogue/pre_pr_catalogue.py`, the **catalogue-maintainer** aggregator, which no Windows job runs. Grepping `build-check-windows.yml` for the aggregator's name finds nothing and looks like the answer; the real mechanism is that the two aggregators are different files and only one carries the gate.

Pack discovery and the per-pack invocation move into a shared `tools/check-okf-managed-packs.py`, called by both the Linux aggregator and a new Windows compat stage.

## Why?

- Partially implements: `docs/specs/okf-authoring-projection/spec.md` AC22 — **the Windows arm only. This PR does not close AC22.**
- Follows from: RFC-0087 § Experiment / validation

One shared script rather than two copies of the discovery rule: two copies would eventually disagree about which packs are managed, and the platform that scanned fewer packs would report a pass it had not earned.

## AC22 is unsatisfiable as written — recorded, not papered over

AC22 asks for two **write-mode** compiles producing byte-identical managed trees on Linux and Windows CI plus a local macOS run. Measured on macOS 25.5.0 arm64 / CPython 3.13.13:

| Target | Write mode | Cause |
|---|---|---|
| Any pack on Windows | refuses | `os.supports_dir_fd` is empty, so `_apply_outputs_transactionally` returns `OKF010`. The dir-fd confinement is a deliberate security control, not a portability defect. |
| `core`, every platform | refuses | Its managed directory also holds 11 hand-authored `references/*.md` that RFC-0087 deliberately retains for orchestrator loading; the ownership guard refuses a directory containing files it does not manage. |
| `_okf-pilot-cost-engineering` | works | Two write-mode compiles are byte-identical. |

Check mode is clean for both packs on all three platforms.

So AC22 needs an **amendment, not a tick**, and this PR leaves it unticked. Recorded as `okf-ac22-write-mode-unsatisfiable-as-written` in `workspace.toml [backlog].open` with the measurements and proposed wording. It belongs with the AC26/AC27 amendment — all three are one Approver decision.

## How do I verify it?

```
python3 tools/check-okf-managed-packs.py
# okf-check: ✓ _okf-pilot-cost-engineering
# okf-check: ✓ core

PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/packages/agentbundle:$PWD/packages/credbroker \
  python3 -m pytest tools/test_okf_pre_pr.py tools/test_build_gate_chain.py -q   # 35 passed
```

Adversarial review found **three controls that could not fail**. All are now mutation-verified:

| Mutation | Before | After |
|---|---|---|
| Delete the Linux `_run(...)` call | passed (grep found the name in the path helper) | fails |
| Make the Windows stage unreachable but leave the text in the file | passed (source grep) | fails |
| Drop `--check` from the gate | passed (a drifted tree exits non-zero either way) | fails |

The third was the dangerous one: without `--check` the gate silently *rewrites* the tree it is supposed to verify. There is now an argv assertion plus a test that a drifted tree is reported without being repaired.

Review also found the suite ran in **no CI job at all** — absent from every `Makefile` pytest line and every workflow, so all of the above was dead. Wired into both.

Full gates: `make build-check SAST_DELEGATED=1` exit 0 · `lint-ruff` pass · `lint-mypy` 120 files clean · `lint-spec-status` clean.

## Anything else?

`tools/test_build_gate_chain.py` pins the ordered pre-PR gate sequence and was updated: two per-pack labels collapse into one `okf compiler checks` entry with an explicit `--root`. That is the extraction's intended shape, not a loosened assertion.

Version bump without a PyPI release: no CLI verb, flag, output layout, or schema changed. `README-pypi.md` describes the change at the level the **wheel** delivers — the compiler itself ships in the `catalogue-curation` pack, not in this package.

Carries `Engine-Change-RFC: RFC-0087` for the curation guard's protected-tree path gate.

**Note for reviewers running tests locally:** a bare interpreter in this repo may resolve `agentbundle` to a *different worktree* if another checkout was `pip install -e`'d more recently. Set `PYTHONPATH` explicitly, as above.