### PR TITLE
chore(workspace): reconcile four Shipped specs out of their queues

### DIFF
--- a/docs/specs/workspace-queue-reconciliation/plan.md
+++ b/docs/specs/workspace-queue-reconciliation/plan.md
@@ -1,0 +1,87 @@
+# Plan: workspace-queue-reconciliation
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `workspace.toml` — three `[work]` moves by tool, one by hand, one appended comment.
+- `docs/specs/workspace-queue-reconciliation/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- Goal-based throughout. No code changes, so no test earns its place; the engine's
+  own reconciliation output is the assertion.
+- `repair-apply` reports `operations_applied: 3`, all three `applied: true` (AC1).
+- `repair-plan` lists the fourth under `manual_findings` with
+  `reason: "type2-queue-canonical-blocked"` (AC2).
+- `reconcile` reports `type2=0`, `type3=0`, `complete: true` (AC3).
+- `tomllib` parses `workspace.toml` and confirms each moved path's new collection.
+- `python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .` clean.
+- `make ci` green before the PR opens.
+
+**What I am NOT changing**
+- No code, no lint, no CI, no dependency.
+- Not the Type 1 finding — dispositioned in AC4, deliberately not registered.
+- Not `tracker-refresh-writeback`'s spec, plan, or `needs`. It becomes ready as a
+  consequence; reanchoring it is separate tracked work.
+- Not the reanchor entries, `[backlog].open` membership, or any `needs` edge.
+
+## Declined patterns
+
+- **Tempted:** hand-edit all four entries in one pass — it is the same edit and the
+  script was already written. **Declined:** `repair-apply` re-reads each spec's
+  `Status` at apply time and revalidates canonical eligibility immediately before an
+  atomic, comment-preserving write. A hand move skips all three protections to save
+  nothing. The tool is used where it applies and bypassed only where it refuses.
+- **Tempted:** register `rfc0088-round10-measurement` to drive Type 1 to zero, since a
+  clean report is satisfying and I had approval to do it. **Declined:** the evidence
+  says registration is selective (121 of 372) and RFC-0088 tracks its own rounds, so
+  the entry would be invented rather than restored. A zero I manufactured is worse
+  than a finding I explained. Recorded as AC4 and re-confirmed with the owner.
+- **Tempted:** add a `needs` edge or a marker on `tracker-refresh-writeback` so the
+  reanchor is enforced rather than merely documented. **Declined:** that is the
+  `ini-008-anchor-staleness-check` design, which needs a real mechanism (`needs`
+  carries no timestamp) and an engine change. Faking it with a dependency edge would
+  encode a false claim about what depends on what.
+- **Tempted:** leave the fourth entry alone, since the tool refused it and refusals
+  are usually right to respect. **Declined:** the refusal is about needing *review*,
+  not about the move being wrong. Respecting it means measuring the consequence and
+  deciding, which is what § Consequence records — not declining to act.
+- **Tempted:** while reconciliation is open, also clear the five `missing_plan` and
+  three `missing_artifact` canonical findings. **Declined:** each needs a plan
+  authored or a spec directory created. That is real work, not reconciliation.
+
+## Tasks
+
+### T1 — Read the findings; confirm no duplicate-membership trap (no writes)
+- **Mode:** goal-based. `Done when:` every one of the four target paths is confirmed
+  present in exactly one collection before any move.
+- **Tests:** no stub (goal-based).
+- **Status:** done. All four were queue-only; a `tomllib` parse ruled out the
+  duplicate-membership hazard a queue→shipped move would otherwise create.
+
+### T2 — AC1: apply the three auto-eligible moves
+- **Mode:** goal-based. `Done when:` `repair-apply` reports three applied.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml` (via tool).
+
+### T3 — Measure the consequence of AC2 before making it
+- **Mode:** goal-based. `Done when:` the `canonical.ready` delta from the fourth move
+  is known and recorded in the spec.
+- **Tests:** no stub (goal-based).
+- **Status:** done. Simulated on a scratch copy; `tracker-refresh-writeback` is the
+  single addition. Surfaced to the owner with the alternative before proceeding.
+
+### T4 — AC2: move the fourth entry by hand
+- **Mode:** goal-based. `Done when:` `tomllib` finds it in `ini-008.work.shipped` and
+  in no queue, with its Group 5 comment lines intact.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml`.
+
+### T5 — AC3 + AC4: verify and disposition
+- **Mode:** goal-based. `Done when:` `reconcile` reports `type2=0`/`type3=0`, the
+  Type 1 disposition is written into the spec, and the live instance is appended to
+  `ini-008-anchor-staleness-check`.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml` (comment only), `spec.md`.

--- a/docs/specs/workspace-queue-reconciliation/spec.md
+++ b/docs/specs/workspace-queue-reconciliation/spec.md
@@ -1,0 +1,153 @@
+# Spec: workspace-queue-reconciliation
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — this spec corrects `workspace.toml` lifecycle membership. It
+  adds no artifact and changes no code, but it does change dispatchability, which
+  § Consequence records explicitly.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (work-loop). No risk trigger fired. The governance-boundary trigger
+was checked and did NOT fire: `[work]` membership is read by the dispatch classifiers,
+but this change moves entries to the collection their own artifact Status already
+mandates rather than defining new routing. The one substantive consequence (a spec
+becoming dispatchable) was MEASURED before the edit and is recorded in § Consequence
+rather than discovered afterwards. Lean fill: Objective + Acceptance Criteria +
+Consequence + Boundaries + Assumptions. -->
+
+## Objective
+
+`workspace-status reconcile` reported four Type 2 findings: four specs whose `Status`
+is `Shipped` while their `workspace.toml` entry still sits in a `[work].queue`. A
+Shipped spec in a queue is not a stale label — it is a contradiction the canonical
+classifiers refuse (`impossible_transition` + `unapproved_spec`), so each one is
+permanently non-dispatchable and permanently reported.
+
+Success: Type 2 and Type 3 findings reach zero, every moved entry keeps its complete
+structured record, and the one dispatchability change the correction causes is stated
+in advance rather than found later.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the three auto-eligible entries move queue → shipped via the tool.**
+  `docs/specs/work-loop-in-process-guards/spec.md`,
+  `docs/specs/ci-gate-parallelization/spec.md` and
+  `docs/specs/ci-gate-credbroker/spec.md` (all `ini-002`) move through
+  `repair-plan` → `repair-apply --yes`, which is the only sanctioned
+  `workspace.toml` writer for this class.
+
+  `workspace.toml` is **not** hand-edited for these three. `repair-apply` preserves
+  the complete structured entry, re-reads each spec's `Status` at apply time, and
+  revalidates canonical eligibility immediately before the atomic write — none of
+  which a manual move guarantees.
+
+  Verification: `repair-apply` reports `applied: true`,
+  `operations_applied: 3`, and `applied: true` for each of the three in
+  `per_operation`.
+
+- [x] **AC2 — the fourth entry moves by hand, because the tool correctly refused it.**
+  `docs/specs/tracker-intake-adapters/spec.md` (`ini-008`) is moved queue → shipped
+  manually, carrying its two Group 5 comment lines with it.
+
+  Why the tool refused, precisely — this is not a tool defect:
+  `_repair_entry_eligibility` admits an entry only when its blocking codes are a
+  subset of `{impossible_transition, unapproved_spec}`
+  (`workspace_status_engine.py`). This entry's set is larger, because
+  `unsatisfied_dependency` findings raised by its two **dependents**
+  (`tracker-refresh-writeback`, `work-intake-migration-docs`, both of which declare a
+  typed `needs` on it) carry *its* path as their `path`. So the refusal is the engine
+  declining to make a routing change with consequences for other entries without
+  review — exactly the right call, and the reason AC2 is a separate criterion with
+  § Consequence attached.
+
+  Verification: `repair-plan` lists it under `manual_findings` with
+  `reason: "type2-queue-canonical-blocked"`, and after the move
+  `tomllib` finds it in `ini-008.work.shipped` and not in any queue.
+
+- [x] **AC3 — Type 2 and Type 3 findings reach zero.**
+  `workspace-status reconcile --root .` reports `type2=0` and `type3=0` with
+  `complete: true`.
+
+- [x] **AC4 — the surviving Type 1 finding is dispositioned, not registered.**
+  `spec/rfc0088-round10-measurement` (`Status: Implementing`, in no initiative list)
+  is deliberately left unregistered, and this criterion is the durable record of why,
+  so the next reader does not "fix" it.
+
+  Measured against this PR's base (`e999b396`):
+  - Registration is **selective**, not universal: 122 work entries against 373
+    `docs/specs/*/spec.md` on disk. Being absent from `workspace.toml` is the norm.
+  - RFC-0088 is its own tracker. `docs/rfc/0088-web-pilot-foundation.md` records at
+    length what each round measured, closed, and commissioned next.
+  - The round-10 spec names no initiative.
+  - **Registration of RFC-0088 rounds is prospective, not retroactive.** All three
+    rounds on disk:
+
+    | Spec | Status | Registered |
+    | --- | --- | --- |
+    | `rfc0088-round10-measurement` | Implementing | no |
+    | `rfc0088-round11-binding-requirements` | Shipped | no |
+    | `rfc0088-round12-consumer-shaped-residuals` | Draft | `ini-002.work.queue` |
+
+    Round 12 was registered by #1027 while it was still `Draft` — i.e. when it became
+    *planned* work. Rounds 10 and 11 were executed outside the queue and were never
+    added after the fact.
+
+  So registering round-10 now would be a retroactive entry of exactly the kind the
+  repository has declined to make for its Shipped sibling, and would imply ini-002
+  ("Platform Core · P5 Adopt") owns a web-pilot measurement round it never claimed.
+  The finding is a true observation about a deliberately out-of-queue spec, and Type 1
+  is advisory — it blocks nothing.
+
+  Note this criterion was revised mid-PR: an earlier reading claimed *no* RFC-0088
+  spec was registered, which #1027 falsified between this PR's first gate run and its
+  rebase. The conclusion is unchanged and now rests on the prospective/retroactive
+  distinction rather than on absence.
+
+## Consequence
+
+**`docs/specs/tracker-refresh-writeback/spec.md` becomes canonically ready.** This
+was measured before the edit, by simulating AC2's move against a scratch copy and
+diffing the `canonical.ready` set:
+
+```
+before: guide-metadata-completion, journey-page-completion, site-shared-chrome,
+        catalogue-wave4-semantic-contracts-index
+after:  … + docs/specs/tracker-refresh-writeback/spec.md   (ini-008)
+```
+
+It should **not** be built as it stands: `[backlog].open` carries
+`tracker-refresh-writeback-reanchor`, recording that its spec/plan predates the
+Group 2/3 contracts it builds on and needs a refresh loop first. Nothing in the repo
+detects that — which is the open `ini-008-anchor-staleness-check` item, and this PR
+appends the live instance to that entry, including the observation that the guard must
+fire on a **membership** change and not only on a dependency shipping, since that is
+what triggered this one.
+
+The alternative was to leave a Shipped spec sitting in a queue. That keeps a false
+record, keeps a permanent Type 2 finding, and keeps reconciliation non-clean forever —
+a worse trade than a measured, documented dispatchability change.
+
+## Boundaries
+
+**Never do**
+
+- Hand-edit `workspace.toml` for a Type 2 finding the tool accepts. `repair-apply` is
+  the only sanctioned writer for that class (AC1).
+- Convert a structured entry to a bare `spec/<slug>` string while moving it. `ini-008`
+  documents that a legacy path there yields `invalid_artifact_path` and refuses dispatch.
+- Register `spec/rfc0088-round10-measurement`, or move it to `[backlog]`. See AC4.
+- Change any `needs` edge, `source` block, `summary`, or initiative `status`.
+- Touch `[shaping_queue]`, `[brief_queue]`, or `[backlog].open` membership. The only
+  `[backlog]` change is comment text appended to one existing entry.
+
+## Assumptions
+
+1. `tomlkit` is installed, which `repair-apply` requires and exits 2 without.
+   Confirmed: 0.15.1.
+2. The four spec `Status` fields do not change between plan and apply.
+   `repair-apply` revalidates and would skip any that did; all three reported applied.
+3. Type 1 remaining non-zero is acceptable and blocks no gate. Confirmed —
+   `reconcile` exits 0 with the finding present, and `lint-spec-status` does not read it.

--- a/workspace.toml
+++ b/workspace.toml
@@ -223,6 +223,9 @@ shipped = [
   {path = "docs/specs/site-contract-provenance-cleanup/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Reconcile frozen site decisions, living guidance, and legacy provenance", needs = []},
   {path = "docs/specs/site-now-surface/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Publish released changelog highlights at Now without exposing in-progress work", needs = []},
   {path = "docs/specs/site-browser-quality-gate/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Gate emitted-site responsiveness, accessibility, and navigation behavior", needs = []},
+  {path = "docs/specs/work-loop-in-process-guards/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run every work-loop transition guard in the engine's own process", needs = []},
+  {path = "docs/specs/ci-gate-parallelization/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the SAST and export-boundary legs from build-check.yml into their own jobs behind a name-preserving aggregator, and split Gate A; targets in AC11", needs = []},
+  {path = "docs/specs/ci-gate-credbroker/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the credbroker suite from gate-main into its own gate-credbroker job", needs = []},
 ]
 queue   = [
   # RFC-0088 round 12 — measures open questions 4, 5 and 6 plus two residuals that
@@ -242,7 +245,6 @@ queue   = [
   # that the engine and the existing CLIs both call, so the two surfaces cannot
   # drift. Read-only guard surface only: no FSM, state-schema, or mutation-verb
   # change, and no MCP, daemon, or new dependency.
-  {path = "docs/specs/work-loop-in-process-guards/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run every work-loop transition guard in the engine's own process", needs = []},
 
   # Project knowledge lifecycle roadmap — RFC-0077 / ADR-0081 / ADR-0082.
   # This sequence is adaptive: at each completed slice, compare measured behavior and
@@ -290,13 +292,11 @@ queue   = [
   # only .github/workflows/, the Makefile's gate_verdict banner, and docs/adr/.
   # The critical path is set by one serial job, so the fix is job layout, not
   # making any gate faster; the export-boundary gate's own cost is deferred.
-  {path = "docs/specs/ci-gate-parallelization/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the SAST and export-boundary legs from build-check.yml into their own jobs behind a name-preserving aggregator, and split Gate A; targets in AC11", needs = []},
   # Follow-on to the spec above, under the same ADR-0086 decision: move the 27s
   # credbroker suite out of gate-main into its own job. Deliberately the CHEAPEST
   # extraction that reaches the current ceiling (gate-sast, mean 160s) — extracting
   # more buys nothing until that job shrinks. The RFC-0082 carve-out step is an
   # explicit non-goal; its coupling graph defeated four revisions of the spec above.
-  {path = "docs/specs/ci-gate-credbroker/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the credbroker suite from gate-main into its own gate-credbroker job", needs = []},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2775,6 +2775,21 @@ open = [
   # Needs a design pass first: `needs` carries no timestamp, so the comparison
   # has to come from git history or a new recorded field.
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Detect queued specs whose shipped dependencies moved after the spec was last revised"},
+  # LIVE INSTANCE, 2026-08-18 (spec/workspace-queue-reconciliation). This stopped
+  # being hypothetical. That PR moved the Shipped docs/specs/tracker-intake-adapters
+  # entry out of ini-008's queue into its shipped list — the truthful record — and the
+  # immediate effect was that docs/specs/tracker-refresh-writeback/spec.md became
+  # canonically READY, dispatchable by an argless work-loop. It should not be built as
+  # it stands: tracker-refresh-writeback-reanchor (above) says its spec/plan predates
+  # the Group 2/3 contracts it builds on and needs a refresh loop first. Nothing
+  # detected the transition; the ready-set delta was measured by hand before the move,
+  # and the move was made anyway because leaving a Shipped spec in a queue is a false
+  # record that blocks all reconciliation.
+  # So the failure mode is now demonstrated end to end: a routine, correct
+  # reconciliation edit silently promoted a stale spec to dispatchable. The reanchor
+  # entries are the one-off correction; this is the control. Raise the priority
+  # accordingly, and note the guard has to fire on a MEMBERSHIP change, not only on a
+  # dependency shipping — this instance was triggered by the former.
 
   # Surfaced 2026-08-15 while auditing every [backlog].open entry against the
   # engine's own classifier. The five reanchor entries above carry `type = "spec"`,
@@ -3208,12 +3223,12 @@ shipped = [
   {path = "docs/specs/workspace-routing-invariants/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Make lifecycle, reconciliation, and dispatch routing deterministic", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}]},
   # Group 4 — standalone work-intake front door and compatibility alias.
   {path = "docs/specs/work-intake-surface/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Provide one core entry point for work intake and routing", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/workspace-routing-invariants/spec.md"}]},
-]
-active = []
-queue = [
   # Group 5 — Jira, Jira Align, Linear and GitHub adapters converge on the shared
   # contract. Acquisition and normalization stay adapter-specific.
   {path = "docs/specs/tracker-intake-adapters/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Normalize tracker work through shared intake contracts", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/work-intake-surface/spec.md"}]},
+]
+active = []
+queue = [
   # Group 6 — origin-aware refresh, conflict resolution, execution locks and
   # limited post-execution write-back across supported trackers.
   {path = "docs/specs/tracker-refresh-writeback/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Review tracker deltas and constrain lifecycle-aware write-back", needs = [{type = "local", kind = "spec", path = "docs/specs/normalized-intake-workspace-contracts/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/workspace-routing-invariants/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/work-intake-surface/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/tracker-intake-adapters/spec.md"}]},


### PR DESCRIPTION
## What does this change?

Moves four specs whose `Status` is `Shipped` out of the `[work].queue` they were still sitting in, taking `workspace-status reconcile` from **5 findings to 1**. The one that remains is a Type 1 that is deliberately dispositioned rather than fixed.

## Why?

A Shipped spec in a queue is not a stale label — it is a contradiction the canonical classifiers refuse (`impossible_transition` + `unapproved_spec`), so each entry was permanently non-dispatchable *and* permanently reported. Type 2 and Type 3 are now zero.

- Implements: `docs/specs/workspace-queue-reconciliation/spec.md`

| Entry | Initiative | How |
|---|---|---|
| `work-loop-in-process-guards` | `ini-002` | `repair-apply` |
| `ci-gate-parallelization` | `ini-002` | `repair-apply` |
| `ci-gate-credbroker` | `ini-002` | `repair-apply` |
| `tracker-intake-adapters` | `ini-008` | by hand — the tool refused it, correctly |

The three went through `repair-plan` → `repair-apply --yes`, the only sanctioned writer for this class: it preserves the complete structured entry, re-reads each spec's `Status` at apply time, and revalidates canonical eligibility immediately before the atomic, comment-preserving write. None of that is guaranteed by a hand edit, so `workspace.toml` was not hand-edited for them.

**Why the fourth was refused, precisely.** `_repair_entry_eligibility` admits an entry only when its blocking codes are a subset of `{impossible_transition, unapproved_spec}`. This entry's set is larger, because `unsatisfied_dependency` findings raised by its **two dependents** (`tracker-refresh-writeback`, `work-intake-migration-docs`, both declaring a typed `needs` on it) carry *its* path as their `path`. The refusal is the engine declining to change routing for other entries without review — the right call, not a defect.

## ⚠️ Consequence — measured before the edit, not discovered after

**`docs/specs/tracker-refresh-writeback/spec.md` becomes canonically ready.** Established by simulating the move on a scratch copy and diffing the `canonical.ready` set:

```
before: guide-metadata-completion, journey-page-completion, site-shared-chrome,
        catalogue-wave4-semantic-contracts-index
after:  … + docs/specs/tracker-refresh-writeback/spec.md   (ini-008)
```

**It should not be built as it stands.** `[backlog].open` carries `tracker-refresh-writeback-reanchor`, recording that its spec/plan predates the Group 2/3 contracts it builds on and needs a refresh loop first. Nothing in the repo detects that — which is the open `ini-008-anchor-staleness-check` item. This PR appends the live instance to that entry, including the observation that the guard must fire on a **membership** change and not only on a dependency shipping, since a membership change is what triggered this one.

The alternative was leaving a Shipped spec in a queue: a false record, a permanent Type 2 finding, and reconciliation never clean. That is the worse trade, so the move was made and the consequence documented rather than avoided.

## How do I verify it?

```bash
python3 .claude/skills/workspace-status/scripts/workspace_status.py reconcile --root .
#   -> type1=1  type2=0  type3=0  complete=true

python3 -c "
import tomllib; d=tomllib.load(open('workspace.toml','rb'))
for t in ['work-loop-in-process-guards','ci-gate-parallelization','ci-gate-credbroker','tracker-intake-adapters']:
    print(t, [f'{i}.{l}' for i,s in d.items() if i.startswith('ini-')
              for l in ('queue','active','shipped')
              for e in s['work'].get(l,[]) if t in str(e.get('path', e))])
"
#   -> each in exactly one *.shipped

make ci   # exit 0
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .   # spec metadata clean
```

Verify membership by **parsing**, not by reading the diff: git's function-context heuristic renders the `ini-008` move as if it were inverted (`@@ … shipped = [` on the removal, `@@ … queue = [` on the insertion). It is not.

## What did you not change that you considered?

**The Type 1 finding — `spec/rfc0088-round10-measurement` is deliberately not registered.** AC4 is the durable record so the next reader does not "fix" it. Measured against this PR's base:

- Registration is **selective**: 122 work entries against 373 `docs/specs/*/spec.md` on disk. Absence is the norm.
- RFC-0088 tracks its own rounds at length in `docs/rfc/0088-web-pilot-foundation.md`; the round-10 spec names no initiative.
- Round registration is **prospective, not retroactive**:

  | Spec | Status | Registered |
  |---|---|---|
  | `rfc0088-round10-measurement` | Implementing | no |
  | `rfc0088-round11-binding-requirements` | Shipped | no |
  | `rfc0088-round12-consumer-shaped-residuals` | Draft | `ini-002.work.queue` |

  #1027 registered round 12 while it was still `Draft` — when it became *planned* work. Rounds 10 and 11 ran outside the queue and were never added afterwards.

Registering round-10 now would be exactly the retroactive entry the repo declined to make for its Shipped sibling. Type 1 is advisory and blocks nothing. **AC4 was revised mid-PR:** an earlier reading claimed *no* RFC-0088 spec was registered, which #1027 falsified between the first gate run and the rebase. The conclusion is unchanged; its basis is now the prospective/retroactive distinction rather than absence.

**Also declined:**

- Hand-editing all four in one pass. It is the same edit, but `repair-apply`'s three protections are worth more than the convenience.
- Adding a `needs` edge or marker to enforce the `tracker-refresh-writeback` reanchor. That is the `ini-008-anchor-staleness-check` design and needs a real mechanism (`needs` carries no timestamp); faking it with a dependency edge would encode a false claim about what depends on what.
- Clearing the five `missing_plan` and three `missing_artifact` canonical findings while reconciliation was open. Each needs a plan authored or a spec directory created — real work, not reconciliation.
- Converting any structured entry to a bare `spec/<slug>` string. `ini-008` documents that a legacy path there yields `invalid_artifact_path` and refuses dispatch.

---

## Checklist

- [x] Tests pass locally (`make ci`, exit 0)
- [x] Lint and typecheck pass (via `make ci`)
- [ ] Self-review run via the relevant reviewer subagent — **named skip:** subagent dispatch is disabled for this session by operator instruction. The work-loop spec-less self-review checklist was run inline: diff matches plan; no code touched so coverage is unchanged; the one out-of-plan change (AC4's revision) is recorded in the spec with its trigger; what should have changed and didn't is above.
- [x] Spec and code agree — the spec was updated in this PR when #1027 moved the evidence under AC4
- [x] Living docs match reality — `workspace.toml` **is** the living record being corrected; no user-visible behavior change
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the selective-registration fact and the `repair-apply` refusal semantics are recorded in the spec and in agent memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)