### PR TITLE
fix(sast): derive the semgrep ratchet's scope from the rule, not a copy of it

### DIFF
--- a/docs/specs/semgrep-ratchet-integrity/plan.md
+++ b/docs/specs/semgrep-ratchet-integrity/plan.md
@@ -1,0 +1,95 @@
+# Plan: semgrep-ratchet-integrity
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `tools/test-semgrep-argv-boundary.py` — the whole change.
+- `workspace.toml` — remove the two closed `[backlog].open` entries.
+- `docs/specs/semgrep-ratchet-integrity/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- Goal-based, with a mutation battery standing in for the disabled adversarial pass.
+- `python3 tools/test-semgrep-argv-boundary.py` → `7/7 passed`, exit 0 read
+  **unpiped** (zsh `PIPESTATUS` is unreliable here).
+- Each of the four mutations in spec AC4 applied, its named failure observed, then
+  reverted; `git diff --stat tools/semgrep/argv-path-boundary.yml` empty afterwards.
+- Skip posture checked both ways (spec AC6).
+- `python3 tools/lint-build.py`, `make lint-ruff`, `make ci` green.
+
+**What I am NOT changing**
+- `tools/semgrep/argv-path-boundary.yml` — the subject under test. Byte-identical.
+- No production script, no `paths.include` membership, no Makefile invocation.
+- Not the three remaining semgrep entries (`sast-semgrep-unparseable-target-reads-clean`,
+  `sast-nosemgrep-has-no-form-lint`, `lint-nosec-form-require-id-registry`) — each
+  needs a decision its own entry names.
+
+## Declined patterns
+
+- **Tempted:** while the file is open, also add the `nosemgrep` assertion from
+  `sast-nosemgrep-has-no-form-lint` — it is three lines and the same file.
+  **Declined:** that entry's fix is an `and/or` between a local assertion and
+  extending the ADR-0084 form-lint; taking half silently leaves the entry open and
+  makes the next author think it is done. It needs its own decision.
+- **Tempted:** add `--strict` while touching `scan_all`, per
+  `sast-semgrep-unparseable-target-reads-clean`. **Declined:** that entry records
+  adopting `--strict` as an ADR-shaped decision, precedent ADR-0084, not a detail.
+- **Tempted:** regex the `paths.include` block instead of importing yaml, to honour
+  AGENTS.md's pure-stdlib line literally. **Declined:** it re-creates the
+  parse-YAML-with-regex antipattern that caused five of six review rounds on
+  `test-build-check-workflow.py`, and the rule is scoped to *new* tools scripts while
+  seven existing ones already import yaml. Recorded as Assumption 2 with the
+  stdlib-audit scope confirmed by reading `lint-build.py`.
+- **Tempted:** drop the `check_id` filter once `ratcheted_scope()` refused multi-rule
+  files, since it is then unreachable. **Declined:** two guards that fail on different
+  mutations, both protecting against a silently-green ratchet. Kept, with the
+  redundancy stated in AC5 rather than hidden.
+- **Tempted:** keep the scope derivation at module level — it reads more cleanly as a
+  constant. **Declined:** it made a malformed rule file exit 1 on a machine with no
+  semgrep, silently changing the documented optional-tool posture. Threaded as a
+  parameter instead (AC6).
+- **Tempted:** add `_loop_guards.py` to `FIXED_SCRIPTS` and stop there — it closes the
+  live drift in one line. **Declined:** it fixes the instance and leaves the
+  mechanism, which is the entry's whole point. The next added path drifts again.
+
+## Tasks
+
+### T1 — Reproduce the fail-open before changing anything
+- **Mode:** goal-based. `Done when:` `FIXED_SCRIPTS = []` is observed passing at
+  exit 0, and the `_loop_guards.py` omission is confirmed against the rule.
+- **Tests:** no stub — this task *is* the test of the old control.
+- **Status:** done. `2/2 passed`, exit 0. `_loop_guards.py` in `paths.include`,
+  absent from `FIXED_SCRIPTS`.
+
+### T2 — Confirm the newly-covered script is clean before covering it
+- **Mode:** goal-based. `Done when:` a direct semgrep run reports
+  `_loop_guards.py` scanned with zero findings.
+- **Tests:** no stub (goal-based).
+- **Status:** done. Ordered before T3 deliberately: if it had findings, the fix
+  would redden the gate on arrival and the task list would need a different shape.
+
+### T3 — Confirm the parser is available where the gate runs
+- **Mode:** goal-based. `Done when:` the invocation context is identified and PyYAML's
+  presence there is established from the manifests, not assumed.
+- **Tests:** no stub (goal-based).
+- **Status:** done. `make sast` is the only invocation; its job installs
+  `requirements-sast.txt`; `bandit` requires `PyYAML>=5.3.1`. Recorded as Assumption 1.
+
+### T4 — Derive the scope; key findings by rule
+- **Mode:** goal-based. `Done when:` `7/7 passed` at exit 0 and no `FIXED_SCRIPTS`
+  reference remains except in explanatory comments.
+- **Tests:** no stub — the file under change is itself the test.
+- **Touches:** `tools/test-semgrep-argv-boundary.py`.
+
+### T5 — Mutate the new control
+- **Mode:** goal-based. `Done when:` all four AC4 mutations produce their named
+  failure and the tree is restored.
+- **Tests:** no stub (goal-based).
+
+### T6 — Close the two backlog entries
+- **Mode:** goal-based. `Done when:` both slugs are gone from `[backlog].open`, the
+  slug-set delta against `HEAD~1` is exactly those two, and `lint-spec-status` is clean.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml`.

--- a/docs/specs/semgrep-ratchet-integrity/spec.md
+++ b/docs/specs/semgrep-ratchet-integrity/spec.md
@@ -1,0 +1,151 @@
+# Spec: semgrep-ratchet-integrity
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — the change is confined to a self-test. No production
+  script, no rule, and no gate invocation moves.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full (work-loop). Risk trigger that fired: compliance/governance/security
+boundary — this file is the sole proof-of-life for the custom SAST rule that guards a
+CWE-22/23 boundary, and a green result here is what licenses trusting the main scan's
+silence (Makefile). Full mode is warranted even though the diff is one file and the
+rule itself is untouched. Adversarial review is a NAMED SKIP (operator disabled
+subagent dispatch); the spec-less self-review checklist and a mutation battery stand in
+its place, and the mutation results are recorded in AC4 rather than asserted. -->
+
+## Objective
+
+`tools/test-semgrep-argv-boundary.py` is the only thing that proves
+`tools/semgrep/argv-path-boundary.yml` still fires. The main `make sast` scan is
+silent both when the rule works and when it has been broken into a no-op, so the
+scan cannot distinguish them — the self-test is the discriminator.
+
+That self-test re-declared the rule's `paths.include` as its own `FIXED_SCRIPTS`
+constant, with nothing reconciling the two. The unchecked direction is the dangerous
+one: a constant **shorter** than the rule's scope leaves a ratcheted script unscanned
+while every assertion still passes.
+
+Success: the rule file is the single definition of what is ratcheted, a shrunken or
+mis-pointed scope is a named failure, and the assertions name the rule they claim to
+prove rather than the file that contains it.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the ratcheted scope is derived from the rule, not restated.**
+  `FIXED_SCRIPTS` is gone. `ratcheted_scope()` parses
+  `tools/semgrep/argv-path-boundary.yml` with `yaml.safe_load` and splits
+  `paths.include` into concrete file entries (the production scripts to scan and
+  assert) and glob entries (the fixtures directory, already covered by
+  `unwired_fixtures`). The concrete list is what `main()` scans.
+
+- [x] **AC2 — the drift that was already present is closed.**
+  `packs/core/.apm/skills/work-loop/scripts/_loop_guards.py` was in the rule's
+  `paths.include` and absent from `FIXED_SCRIPTS`, so it had never been scanned or
+  asserted by this gate. It is now, and it is silent — verified independently by a
+  direct `semgrep --config … -- _loop_guards.py` run reporting it scanned with zero
+  findings, before the derivation was written, so the fix could not turn the gate red
+  on arrival.
+
+  The self-test goes from **5 assertions to 7**: the new coverage assertion plus
+  `_loop_guards.py`.
+
+- [x] **AC3 — an unscanned ratcheted path is a named failure.**
+  `test_ratcheted_scope_is_covered` fails, by name, when any concrete
+  `paths.include` entry is absent from semgrep's `paths.scanned`. Without it, the
+  derivation would be decorative: "no findings" is satisfiable by semgrep never
+  having looked, which is exactly how the shrinking list used to pass.
+
+- [x] **AC4 — the control is proved able to fail.**
+  A green self-test is worth nothing unless breaking what it guards turns it red.
+  Measured, each mutation applied and reverted:
+
+  | Mutation | Before | After |
+  | --- | --- | --- |
+  | `FIXED_SCRIPTS = []` | `2/2 passed`, **exit 0** | n/a — the constant no longer exists |
+  | A `paths.include` entry mis-pointed to a nonexistent file | would pass silently | `5/7 passed`, **exit 1**, `FAIL [every ratcheted path in the rule was scanned]` naming the path |
+  | `paths.include` reduced to globs only | would pass silently | **exit 1**, `paths.include has no concrete file entries … no production script would be asserted` |
+  | A second rule added to the rule file | positive-fixture proof satisfiable by either rule | **exit 1**, `expected exactly 1 rule, found 2` |
+
+  The first row is the defect this spec closes, reproduced before the fix.
+
+- [x] **AC5 — findings are keyed by the rule, not only by path.**
+  `scan_all` filters `payload["results"]` on
+  `check_id.endswith("argv-path-without-boundary-validator")` before grouping.
+  `--config` names a *file*, so previously any rule in that file could satisfy the
+  positive-fixture proof-of-life while the rule under test was neutered.
+
+  The report-consistency guard (a finding on a path semgrep did not list as scanned)
+  stays **before** the filter: an inconsistent report is a defect whichever rule
+  produced it.
+
+  Honest scope: `ratcheted_scope()` now refuses a multi-rule file outright (AC4, row
+  4), so this filter is belt to that brace and is unreachable today. Both are kept —
+  the failure they prevent is a silently green ratchet, and the two guards fail on
+  different mutations.
+
+- [x] **AC6 — the optional-tool skip posture is unchanged.**
+  `ratcheted_scope()` is called inside `main()`, *after* the semgrep-on-PATH check,
+  and the derived list is threaded to the assertions as a parameter rather than a
+  module global.
+
+  This is deliberate and was corrected during implementation: an earlier revision
+  derived the scope at import time, which made a malformed rule file exit 1 on a
+  machine with no semgrep — a behaviour change this fix has no business making.
+  Verified both ways: with `PATH` stripped of semgrep and a deliberately malformed
+  rule, the script prints its `skip:` line and exits 0; with semgrep present, the
+  same malformed rule exits 1.
+
+## Boundaries
+
+**Never do**
+
+- Edit `tools/semgrep/argv-path-boundary.yml`. The rule is the subject under test;
+  changing it to make the test pass inverts the gate. It is byte-identical in this
+  diff (`git diff --stat` on it is empty).
+- Add a path to `paths.include` for a script that has not adopted a boundary
+  validator. The rule's own header states the expansion condition, and a premature
+  entry reddens the gate on unrelated work.
+- Widen the rule's scope to sweep the remaining ~68 argv→path sites. That is
+  `pack-argv-path-boundary-sweep`, explicitly a migration rather than a fix.
+- Reimplement a YAML parser to avoid the `yaml` import. That is the antipattern
+  behind `ci-gate-parallelization-posture-test-yaml-parser`.
+
+## Assumptions
+
+1. **PyYAML is importable wherever this test runs.** Verified rather than assumed.
+   `make sast` (Makefile) is the only invocation — the module docstring says so,
+   because the test needs semgrep on PATH, and `docs.yml` names the file only as a
+   `paths:` trigger. The CI job running `make sast` installs
+   `tools/requirements-sast.txt`, whose `bandit` requires `PyYAML>=5.3.1`; pyyaml is
+   also declared directly in `tools/requirements.txt` for local runs.
+
+   This is a transitive guarantee, which is why the import carries a comment naming
+   both manifests. If `bandit` ever drops PyYAML, this import is the second thing to
+   break and the comment is what makes that diagnosable.
+
+2. **`import yaml` in a `tools/` script is consistent with the repository.**
+   AGENTS.md § *New tool scripts* requires *new additions* to `tools/` to be
+   pure-stdlib; this is an existing file, and seven `tools/` scripts already import
+   yaml, including the closest siblings `lint-ci-parity.py` and
+   `test-ci-security-workflow.py`. `tools/lint-build.py`'s stdlib-import audit is
+   scoped to `LINT_BUILD_DIR` (`packages/agentbundle/agentbundle/build`), not
+   `tools/` — confirmed by reading it, and `lint-build.py` passes.
+
+3. **`_loop_guards.py` scans clean.** Confirmed by direct invocation before the
+   derivation was written (AC2).
+
+## Residual — stated, not closed
+
+Deriving the list guarantees *test scope == rule scope*. It does **not** guarantee
+the rule's scope is complete: shrinking `paths.include` itself still shrinks coverage,
+and the self-test will pass with fewer assertions. What is now impossible is the two
+disagreeing, which is the defect
+`sast-ratchet-scope-duplicated-fails-open` named and the only one this spec claims.
+
+The rule's expansion is tracked separately as `pack-argv-path-boundary-sweep`. A
+guard on the rule's own scope would need a roster of every script that has adopted a
+validator — a different control, and a larger one.

--- a/tools/test-semgrep-argv-boundary.py
+++ b/tools/test-semgrep-argv-boundary.py
@@ -44,6 +44,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+# PyYAML, not stdlib. Deliberate, and safe in the one place this file runs:
+# `make sast` (Makefile), which the module docstring explains is the only
+# invocation because the test needs semgrep on PATH. That target's CI job
+# installs tools/requirements-sast.txt, whose `bandit` requires `PyYAML>=5.3.1`,
+# so the import resolves there; pyyaml is also declared directly in
+# tools/requirements.txt for local runs. The alternative — regex-scraping
+# `paths.include` out of the rule file — is the re-implement-a-YAML-parser
+# antipattern that produced five of six review rounds against
+# tools/test-build-check-workflow.py (see
+# `ci-gate-parallelization-posture-test-yaml-parser` in workspace.toml).
+import yaml
+
 # Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
@@ -52,12 +64,61 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 RULE = REPO_ROOT / "tools" / "semgrep" / "argv-path-boundary.yml"
 FIXTURES = REPO_ROOT / "tools" / "semgrep" / "fixtures" / "argv-path-boundary"
 
-SCRIPTS_DIR = REPO_ROOT / "packs" / "core" / ".apm" / "skills" / "work-loop" / "scripts"
-FIXED_SCRIPTS = [
-    SCRIPTS_DIR / "lint-traceability.py",
-    SCRIPTS_DIR / "lint-spec-status.py",
-    SCRIPTS_DIR / "loop-cohort.py",
-]
+# The rule under test, parsed once. `--config` names a FILE, so a finding's
+# check_id is `<file-stem>.<rule-id>`; RULE_ID is the bare id used to filter.
+RULE_ID = "argv-path-without-boundary-validator"
+
+
+def ratcheted_scope() -> tuple[list[Path], list[str]]:
+    """Split the rule's own `paths.include` into (concrete files, glob patterns).
+
+    THE RULE FILE IS THE ONLY SCOPE DEFINITION. This used to be a FIXED_SCRIPTS
+    constant that restated `paths.include`, with nothing reconciling the two, and
+    the direction that can drift silently is the one that was unchecked: a list
+    SHORTER than the rule's scope leaves a ratcheted script unscanned while every
+    assertion still passes.
+
+    That was not hypothetical. Measured on the commit this function replaced:
+      * `_loop_guards.py` had been added to `paths.include` and never to
+        FIXED_SCRIPTS, so it was never a scan target and never asserted silent.
+      * Setting `FIXED_SCRIPTS = []` printed "2/2 passed" and exited 0 — the
+        entire production half of the ratchet proving nothing, with `make sast`
+        green.
+
+    Deriving the list makes both impossible: a path in the rule is a path this
+    test scans and asserts, and `test_ratcheted_scope_is_covered` fails by name
+    if semgrep did not report one as scanned.
+    """
+    document = yaml.safe_load(RULE.read_text(encoding="utf-8"))
+    rules = document.get("rules") or []
+    if len(rules) != 1:
+        # Not a style objection: the check_id filter below names ONE rule, and
+        # `paths.include` is per-rule. A second rule would need its own scope
+        # read and its own assertions, so fail loudly rather than silently
+        # ratchet against the first one only.
+        raise RuntimeError(
+            f"{RULE.name}: expected exactly 1 rule, found {len(rules)} — "
+            "this self-test's scope derivation and check_id filter both assume one"
+        )
+    include = rules[0].get("paths", {}).get("include") or []
+    if not include:
+        raise RuntimeError(f"{RULE.name}: rule declares no paths.include — nothing is ratcheted")
+    concrete = [REPO_ROOT / entry for entry in include if "*" not in entry]
+    globs = [entry for entry in include if "*" in entry]
+    if not concrete:
+        # Every entry a glob would mean no production script is ratcheted, which
+        # is the fail-open state this function exists to make impossible.
+        raise RuntimeError(
+            f"{RULE.name}: paths.include has no concrete file entries — "
+            f"only globs {globs!r}; no production script would be asserted"
+        )
+    return concrete, globs
+
+
+# NOT called at import time, deliberately. main() returns 0 with a `skip:` line
+# when semgrep is absent, matching `make sast`'s optional-tool posture; a
+# module-level call would turn a malformed rule file into exit 1 on a machine
+# with no semgrep, which is a behaviour change this fix has no business making.
 
 failures: list[str] = []
 ran = 0
@@ -165,7 +226,18 @@ def scan_all(targets: list[Path]) -> dict[str, list[dict]]:
             # A finding on a path semgrep did not list as scanned means the two
             # halves of its own report disagree. Raise rather than create the
             # key, which would hand a caller findings for an unscanned file.
+            # Checked before the rule filter: an inconsistent report is a defect
+            # whichever rule produced the finding.
             raise RuntimeError(f"semgrep reported a finding in unscanned {key}")
+        # Key on the RULE, not just the file. `--config` names a file, so every
+        # rule in argv-path-boundary.yml lands in these results. Grouping by path
+        # alone means a second rule in that file — or a replacement one — could
+        # satisfy the positive-fixture proof-of-life while
+        # argv-path-without-boundary-validator itself is neutered. `ratcheted_scope`
+        # refuses a multi-rule file, so today this filter is belt to that brace;
+        # keep both, because the failure it prevents is a green ratchet.
+        if not hit["check_id"].endswith(RULE_ID):
+            continue
         findings[key].append(hit)
     return findings
 
@@ -230,8 +302,33 @@ def test_negative_fixture_silent(findings: dict[str, list[dict]]) -> None:
         ok(name)
 
 
-def test_fixed_scripts_silent(findings: dict[str, list[dict]]) -> None:
-    for script in FIXED_SCRIPTS:
+def test_ratcheted_scope_is_covered(
+    findings: dict[str, list[dict]], ratcheted: list[Path]
+) -> None:
+    """Every concrete `paths.include` entry was requested AND reported scanned.
+
+    This is the assertion that makes the derived scope load-bearing rather than
+    decorative. `test_ratcheted_scripts_silent` proves each file has no findings;
+    without this one, "no findings" would still be satisfiable by semgrep never
+    having looked — which is precisely how a shrinking target list used to pass.
+    """
+    name = "every ratcheted path in the rule was scanned"
+    missing = [_key(script) for script in ratcheted if _key(script) not in findings]
+    if missing:
+        fail(
+            name,
+            f"in the rule's paths.include but not reported scanned: {missing}. "
+            "Either the path no longer exists, or semgrep declined it — both leave "
+            "that file unratcheted while its silence reads as clean.",
+        )
+    else:
+        ok(name)
+
+
+def test_ratcheted_scripts_silent(
+    findings: dict[str, list[dict]], ratcheted: list[Path]
+) -> None:
+    for script in ratcheted:
         name = f"{script.name} is silent after the fix"
         if not script.is_file():
             fail(name, f"subject not found at {script} — path drifted?")
@@ -262,6 +359,8 @@ def main() -> int:
     # own subjects. Without this a renamed fixture is dropped from the argv and
     # the only diagnosis is hits_for's "check paths.include in the rule", which
     # points at the rule when the file is simply gone.
+    ratcheted, _globs = ratcheted_scope()
+
     missing = [p for p in (FIXTURES / "positive.py", FIXTURES / "negative.py") if not p.is_file()]
     for path in missing:
         fail(f"{path.name} fixture is present", f"fixture not found at {path} — path drifted?")
@@ -270,7 +369,7 @@ def main() -> int:
         print("Failed:", ", ".join(failures), file=sys.stderr)
         return 1
 
-    targets = [FIXTURES / "positive.py", FIXTURES / "negative.py", *FIXED_SCRIPTS]
+    targets = [FIXTURES / "positive.py", FIXTURES / "negative.py", *ratcheted]
     present = [t for t in targets if t.is_file()]
 
     unwired = unwired_fixtures(present)
@@ -281,7 +380,8 @@ def main() -> int:
 
     test_positive_fixture_fires(findings)
     test_negative_fixture_silent(findings)
-    test_fixed_scripts_silent(findings)
+    test_ratcheted_scope_is_covered(findings, ratcheted)
+    test_ratcheted_scripts_silent(findings, ratcheted)
 
     total = ran
     passed = total - len(failures)

--- a/workspace.toml
+++ b/workspace.toml
@@ -2504,28 +2504,6 @@ open = [
   # is safe (NamedTemporaryFile is O_EXCL, 0600); the directory is the issue.
   # Fix: write each filtered manifest inside a per-run TemporaryDirectory() (0700).
   {slug = "sca-temp-manifest-leaves-its-directory", summary = "The filtered manifest is written to shared /tmp, so a relative include in a requirements file resolves against a world-writable dir", source = "spec/pip-audit-batching security review"},
-  # The four entries below all came out of spec/semgrep-selftest-batching, which
-  # DID ship (batching the self-test's five semgrep spawns into one). None is
-  # caused by that change -- each is a pre-existing property of the control it
-  # sped up, found by reviewing it. Read them together: they are four ways the
-  # SAST gate's only proof-of-life for the custom argv-path-boundary rule can
-  # report green while proving less than it appears to. A green ratchet there is
-  # what licenses trusting the main scan's silence (Makefile:282-292).
-  # URGENT first.
-  #
-  # URGENT. tools/test-semgrep-argv-boundary.py re-declares the ratchet's
-  # production-script scope as its FIXED_SCRIPTS constant, duplicating the
-  # authoritative paths.include in tools/semgrep/argv-path-boundary.yml, with
-  # nothing reconciling the two. Verified by mutation: setting FIXED_SCRIPTS = []
-  # prints "2/2 passed" and exits 0 -- the entire production half of the ratchet
-  # proves nothing and make sast is green. The direction that can drift silently
-  # (the list shrinking below the rule's scope) is exactly the unchecked one.
-  # Fix: derive the target list from the rule -- parse paths.include with
-  # yaml.safe_load (pyyaml is already in tools/requirements.txt) and assert every
-  # non-glob entry appears in both the requested targets and paths.scanned, so
-  # the rule file is the single scope definition and a shrunken list is a named
-  # failure.
-  {slug = "sast-ratchet-scope-duplicated-fails-open", summary = "URGENT -- the semgrep ratchet self-test duplicates the rule's paths.include as a constant; emptying it exits 0 with the production half of the ratchet proving nothing", source = "spec/semgrep-selftest-batching security review"},
   # Semgrep's signal for a target it could not parse depends on HOW it failed.
   # A PARTIAL failure (unbalanced bracket, stray token) does surface as a
   # path-attributed PartialParsing entry in `errors`, and --strict escalates it
@@ -2558,16 +2536,6 @@ open = [
   # contains a nosemgrep/nosem comment, and/or extend the ADR-0084 form-lint to
   # nosemgrep with a mandatory rule id and reason.
   {slug = "sast-nosemgrep-has-no-form-lint", summary = "A bare # nosemgrep silently neuters the semgrep ratchet with no signal, and unlike bandit's # nosec it has no form-lint requiring a rule id and reason", source = "spec/semgrep-selftest-batching security review"},
-  # tools/test-semgrep-argv-boundary.py groups findings by path and discards
-  # hit["check_id"], while --config names a FILE. So if argv-path-boundary.yml
-  # ever grows a second rule, or its rule is replaced, a single finding on
-  # positive.py from any rule in that file satisfies the proof-of-life while
-  # argv-path-without-boundary-validator itself is neutered.
-  # Fix: filter payload["results"] on
-  # hit["check_id"].endswith("argv-path-without-boundary-validator") before
-  # grouping, so the assertion names the rule it claims to prove. Cheap now that
-  # findings are already grouped.
-  {slug = "sast-selftest-findings-not-keyed-by-check-id", summary = "The semgrep ratchet self-test keys findings by path only, so a second rule in the same file would satisfy the positive-fixture proof while the rule under test is neutered", source = "spec/semgrep-selftest-batching security review"},
   # lint-nosec-form.py's unknown-id check degrades silently when bandit's
   # registry is unreachable: id_checker() catches Exception and returns None,
   # and main() then appends " (bandit absent: IDs not resolved)" to an EXIT-0


### PR DESCRIPTION
## What does this change?

Makes `tools/semgrep/argv-path-boundary.yml` the single definition of what the SAST ratchet covers, instead of having `tools/test-semgrep-argv-boundary.py` restate it in a `FIXED_SCRIPTS` constant. Also keys findings by rule id rather than by file, so the proof-of-life names the rule it claims to prove.

## Why?

That self-test is the **only** thing proving the rule still fires — `make sast`'s main scan is silent both when the rule works and when it has been broken into a no-op, so the scan cannot tell them apart. The constant restated `paths.include` with nothing reconciling the two, and the unchecked direction was the dangerous one: a list **shorter** than the rule's scope leaves a ratcheted script unscanned while every assertion still passes.

- Implements: `docs/specs/semgrep-ratchet-integrity/spec.md`
- Closes: `sast-ratchet-scope-duplicated-fails-open` (marked **URGENT**), `sast-selftest-findings-not-keyed-by-check-id`

### It had already drifted — this was not hypothetical

The entry described the fail-open as a mutation-proved possibility. Two measurements say it had already happened:

| | |
|---|---|
| `_loop_guards.py` | in the rule's `paths.include`, **absent** from `FIXED_SCRIPTS` — so this gate had never scanned or asserted it |
| `FIXED_SCRIPTS = []` | printed **`2/2 passed`, exit 0** — the entire production half of the ratchet proving nothing, `make sast` green |

Reproduced before changing anything, so the fix is measured against a demonstrated failure. `_loop_guards.py` was confirmed clean by a direct semgrep run **before** the derivation was written, so the fix could not redden the gate on arrival. The suite goes **5 → 7 assertions**.

## How do I verify it?

```bash
python3 tools/test-semgrep-argv-boundary.py     # 7/7 passed, exit 0
make ci                                         # exit 0, SAST/SCA included
git diff --stat -- tools/semgrep/argv-path-boundary.yml   # empty — the rule is untouched
```

Read the exit code **unpiped**; zsh's `PIPESTATUS` is unreliable here.

### The new control is proved able to fail

Each mutation applied and reverted:

| Mutation | Result |
|---|---|
| A `paths.include` entry mis-pointed at a nonexistent file | `5/7`, exit 1, `FAIL [every ratcheted path in the rule was scanned]` naming the path |
| `paths.include` reduced to globs only | exit 1, `paths.include has no concrete file entries … no production script would be asserted` |
| A second rule added to the rule file | exit 1, `expected exactly 1 rule, found 2` |

`test_ratcheted_scope_is_covered` is what makes the derivation load-bearing rather than decorative: "no findings" is otherwise satisfiable by semgrep never having looked, which is exactly how the shrinking list used to pass.

## What did you not change that you considered?

**The rule file itself.** It is the subject under test; editing it to make the test pass would invert the gate. Byte-identical in this diff.

**The scope derivation ran at import time in my first revision.** That silently turned a malformed rule file into exit 1 on a machine with no semgrep, breaking the documented optional-tool skip posture. Moved inside `main()` after the semgrep check, with the list threaded as a parameter. Verified both ways: `PATH` stripped of semgrep + a malformed rule → `skip:` line, exit 0; semgrep present + same rule → exit 1.

**`import yaml` is checked, not assumed.** `make sast` is the only invocation (the module docstring explains why: the test needs semgrep on PATH, and `docs.yml` names the file only as a `paths:` trigger). That job installs `tools/requirements-sast.txt`, whose `bandit` requires `PyYAML>=5.3.1`; pyyaml is also declared in `tools/requirements.txt` for local runs. This is a **transitive** guarantee, so the import carries a comment naming both manifests — if bandit ever drops PyYAML, this is the second thing to break and the comment is what makes it diagnosable. AGENTS.md's pure-stdlib rule scopes to *new* `tools/` scripts; seven existing ones already import yaml, and `lint-build.py`'s stdlib audit covers `packages/agentbundle/agentbundle/build`, not `tools/`.

**Also declined:**

- The `nosemgrep` assertion from `sast-nosemgrep-has-no-form-lint` — three lines in the same file, but that entry's fix is an `and/or` between a local assertion and extending the ADR-0084 form-lint. Taking half silently leaves the entry open while making the next author think it is done.
- `--strict` from `sast-semgrep-unparseable-target-reads-clean` — that entry records adopting it as an ADR-shaped decision, precedent ADR-0084, not a detail.
- Regex-scraping `paths.include` to avoid the yaml import. That is the parse-YAML-with-regex antipattern behind `ci-gate-parallelization-posture-test-yaml-parser`.
- Dropping the `check_id` filter once `ratcheted_scope()` refused multi-rule files, making it unreachable. Two guards, failing on different mutations, both protecting against a silently-green ratchet. Kept, with the redundancy stated in AC5 rather than hidden.
- Just adding `_loop_guards.py` to `FIXED_SCRIPTS`. One line, and it fixes the instance while leaving the mechanism — the next added path drifts again.

**Residual, stated rather than implied:** this guarantees *test scope == rule scope*, not that the rule's scope is complete. Shrinking `paths.include` still shrinks coverage and the self-test will pass with fewer assertions. Guarding the rule's own scope needs a roster of every script that has adopted a validator — a different, larger control. Rule expansion stays tracked as `pack-argv-path-boundary-sweep`.

---

## Checklist

- [x] Tests pass locally (`make ci` exit 0, SAST/SCA included; self-test 7/7)
- [x] Lint and typecheck pass (`make lint-ruff`, `tools/lint-build.py`)
- [ ] Self-review run via the relevant reviewer subagent — **named skip:** subagent dispatch is disabled for this session by operator instruction. In its place: the spec-less self-review checklist inline, plus a three-mutation battery against the new control (recorded in AC4) and a reproduction of the old control's fail-open before any edit.
- [x] Spec and code agree
- [x] Living docs match reality — no user-visible behavior change; the rule's own header already documents the expansion condition
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the transitive-PyYAML reasoning is in the import comment; the residual is in the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)