### PR TITLE
fix(sast): close six silent-pass paths in the pip-audit SCA gate

### DIFF
--- a/docs/specs/sca-gate-hardening/plan.md
+++ b/docs/specs/sca-gate-hardening/plan.md
@@ -1,0 +1,96 @@
+# Plan: sca-gate-hardening
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `tools/audit-requirements.py` — all six behaviour fixes.
+- `tools/test-audit-requirements.py` — cases 10-12 (predicate, env scrub, floor).
+- `workspace.toml` — remove the six closed `[backlog].open` entries.
+- `docs/specs/sca-gate-hardening/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- `python3 tools/test-audit-requirements.py` exits 0 with the new cases passing.
+- The REAL leg runs green: `python3 tools/audit-requirements.py tools/requirements.txt
+  $(find packs -name requirements.txt | sort)` at exit 0 over all nine manifests.
+- Each of the five mutations in spec AC6 produces its named failure, then reverts.
+- A warm-cache before/after timing pair for AC1's "measured free" claim.
+- `make lint-ruff`, `python3 tools/lint-build.py`, `make ci` green.
+
+**What I am NOT changing**
+- Not the Makefile's `--ignore-vuln` suppressions or its manifest list.
+- Not the three unaudited `tools/` manifests' coverage (AC7 pins, does not widen).
+- Not `partition()`'s first-party skipping, which is the file's original subject.
+- Not batching anything — the archived spec explains why.
+
+## Declined patterns
+
+- **Tempted:** add the three unaudited `tools/` manifests to the invocation while the
+  file is open; it is one argument each and closes a sibling entry.
+  **Declined:** `sast-requirements-not-audited` records an explicit
+  audit-vs-Dependabot decision ("Decide which, then do one — doing both duplicates the
+  noise"). Taking the audit half unilaterally pre-empts it. AC7 pins the roster so a
+  new manifest is deliberate, which is the part that needs no decision.
+- **Tempted:** make `sca-requirements-include-lines-unaudited` exit 2 on an
+  include-only manifest, the entry's stated alternative. **Declined:** the entry offers
+  "count them as content that must be audited, **or** exit 2". Counting them audits
+  the manifest, which is what the gate is for; exiting 2 refuses a shape self-test
+  case 4 already blesses.
+- **Tempted:** assert AC2 by calling `audit()` and checking the printed output — it
+  exercises the real path. **Declined, after doing it:** it spawned pip-audit against a
+  nonexistent include, adding network I/O and a usage error to a self-test. Asserted on
+  the predicate instead (AC8). The first version also *passed*, which is why this was
+  caught by timing the suite rather than by it failing.
+- **Tempted:** pin the manifest roster by content hash rather than count, so a *changed*
+  manifest also fails. **Declined:** that is the noisy-re-sign trade recorded under
+  `ci-parity-hidden-gate-in-dispositioned-step`; a manifest's contents changing is
+  normal and the audit already reads them.
+- **Tempted:** raise `--strict` to the `--build-system` and `--optional-group`
+  invocations too. **Declined:** the entry explicitly scopes that as a separate
+  decision ("Decide separately whether the requirements-sast.txt and /dev/stdin
+  invocations get it too"). They flow through the same `audit_lines`, so they DO
+  inherit it — noted here because that is a consequence worth being explicit about
+  rather than silent, and it is the desirable direction.
+
+## Tasks
+
+### T1 — Read the six entries against the code; confirm each is live
+- **Mode:** goal-based. `Done when:` each defect is located in `audit_requirements.py`
+  or the Makefile and confirmed present.
+- **Tests:** no stub (goal-based).
+- **Status:** done. All six live; AC2's is latent-but-sanctioned.
+
+### T2 — Implement AC1-AC5
+- **Mode:** goal-based. `Done when:` `lint-ruff` clean and the real leg exits 0.
+- **Tests:** no stub for the behaviour; T4 adds the assertions.
+- **Touches:** `tools/audit-requirements.py`.
+
+### T3 — Verify the flags by invocation, not by reading
+- **Mode:** goal-based. `Done when:` the real leg runs green over all nine manifests.
+- **Tests:** no stub (goal-based).
+- **Status:** done, and it earned its place — `--service` was wrong (`-s` /
+  `--vulnerability-service` is the real flag) and the failure did not name the flag.
+  Reading the diff would not have caught it.
+
+### T4 — AC7 + AC8: the floor and the predicate cases
+- **Mode:** goal-based. `Done when:` self-test exits 0 with cases 10-12 present.
+- **Tests:** the file under change is the test.
+- **Touches:** `tools/test-audit-requirements.py`.
+
+### T5 — AC6: mutate every new control
+- **Mode:** goal-based. `Done when:` all five mutations produce their named failure
+  and `git diff --stat Makefile` is empty afterwards.
+- **Tests:** no stub (goal-based).
+
+### T6 — AC1's timing claim
+- **Mode:** goal-based. `Done when:` a warm-cache before/after pair exists, taken
+  back to back after a discarded warm-up, with the frame recorded beside the numbers.
+- **Tests:** no stub (goal-based).
+
+### T7 — Close the six backlog entries
+- **Mode:** goal-based. `Done when:` the slug-set delta against `HEAD~1` is exactly
+  those six and `lint-spec-status` is clean.
+- **Tests:** no stub (goal-based).
+- **Touches:** `workspace.toml`.

--- a/docs/specs/sca-gate-hardening/spec.md
+++ b/docs/specs/sca-gate-hardening/spec.md
@@ -1,0 +1,172 @@
+# Spec: sca-gate-hardening
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — no public interface. The gate's *behaviour* changes: it now
+  fails on conditions it previously passed, which § Blast radius bounds.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: full (work-loop). Risk trigger that fired: security boundary — this is the
+repository's SCA gate, one of five required merge contexts, and every criterion here
+turns a silent pass into a failure. Adversarial review is a NAMED SKIP (operator
+disabled subagent dispatch); a mutation battery per criterion stands in for it and the
+results are recorded in AC6 rather than asserted. -->
+
+## Objective
+
+`make sast`'s pip-audit leg has six ways to report success while auditing less than it
+appears to. All six came out of the security review on `spec/pip-audit-batching`, which
+was **archived without shipping** — none is caused by batching, and every one is live in
+`make sast` today. Each was left as its own entry because each is its own decision; they
+are taken together because all six land in one 210-line file plus its self-test, and the
+triage of "did this gate actually run" happens once.
+
+One of the six, AC2, was initially triaged OUT of this batch as an either/or needing a
+decision. On reading it against the code the choice collapsed: its two options are
+"count include lines as content" and "exit 2 on one", and exiting 2 would refuse a shape
+the self-test already blesses. The reasoning is recorded in `plan.md` § Declined
+patterns rather than left as a silent scope change.
+
+Success: every silent-skip path either audits or fails, the data sources are pinned in
+code rather than inherited from the environment, and the audited input set has a floor
+that fails by name when it shrinks.
+
+## Acceptance Criteria
+
+- [x] **AC1 — `--strict`, so an unresolvable dependency is not silently skipped.**
+  `-S/--strict` is passed. Without it a dependency the advisory service cannot serve
+  (a PyPI 404 for that name+version) is skipped while pip-audit still exits 0 — the
+  same "a silent no-op is not a pass" class ADR-0084 already gated for bandit.
+
+  Measured free, warm cache, same nine manifests, both green:
+  `HEAD 1.12s / 2.20s` vs `this change 1.23s / 1.26s`. (Frame matters: a *cold*-cache
+  first run of the same leg took 77s on this machine. All four figures above are
+  warm-cache, back to back, after a discarded warm-up run — a cold-vs-warm comparison
+  would have manufactured a 7× regression that is not there.)
+
+- [x] **AC2 — dependency-bearing option lines count as content.**
+  `partition()` sends every `-`-prefixed line into the audited half, and the emptiness
+  test then excluded exactly those lines. So a manifest whose only content was
+  `-r nested.txt`, `-c constraints.txt` or `-e .` printed
+  `no third-party requirements to audit` and was audited **zero** times, at exit 0.
+
+  `_is_dependency_bearing()` now recognises `-r/--requirement`, `-c/--constraint`,
+  `-e/--editable`, `-f/--find-links` as content, matching on the option token so
+  `--requirement=x.txt` counts too. `--index-url`, `--extra-index-url` and
+  `--no-binary` deliberately do **not**: they configure resolution, they do not add a
+  requirement.
+
+  Latent rather than live — no such manifest exists today — but self-test case 4
+  already blesses `-r other.txt` as a supported shape, so the shape is sanctioned.
+
+- [x] **AC3 — the advisory feed and index cannot be re-aimed by the environment.**
+  `-s pypi` and `--format columns` are passed explicitly, and `PIP_AUDIT_*`,
+  `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL` are stripped from the child environment.
+  pip-audit defaults its service, OSV URL, format and output from `PIP_AUDIT_*`, and
+  the resolution venv's pip honours the index variables; either can produce
+  `No known vulnerabilities found` at exit 0 without touching a tracked file. The
+  realistic trigger is a stale shell profile, not an attacker.
+
+  **`-s`, not `--service`.** The long form is `--vulnerability-service`
+  (pip-audit 2.10.1); `--service` is not accepted, and the first revision of this
+  change used it. It did not fail loudly — the run surfaced as
+  `argument project_path: not allowed with argument -r/--requirement`, which does not
+  name the offending flag. Caught by invoking the real leg rather than by reading the
+  diff, and the corrected form is verified against a live manifest at exit 0.
+
+- [x] **AC4 — an indefinite hang becomes a failure.**
+  Every pip-audit invocation carries `timeout=300`, and `TimeoutExpired` is caught and
+  returned as a failure with a named message rather than surfacing as a traceback.
+  Each invocation measures 7–17s cold, so 300s is well clear of normal; the failure
+  being bounded is a pathological resolver backtrack hanging CI, not a slow audit.
+
+- [x] **AC5 — the filtered manifest no longer lands in a shared directory.**
+  Each filtered manifest is written inside a per-run `TemporaryDirectory()` (0700)
+  instead of `NamedTemporaryFile` in the shared system temp dir. The file *mode* was
+  already safe (`O_EXCL`, 0600); the **directory** was the issue, because a relative
+  `-r` / `-c` / `--find-links` / local-path reference inside a manifest re-resolves
+  against the file's own directory — which was world-writable.
+
+- [x] **AC6 — every new control is proved able to fail.**
+  A green gate is worth nothing unless breaking what it guards turns it red. Each
+  mutation applied and reverted, `Makefile` confirmed byte-identical afterwards:
+
+  | Mutation | Result |
+  | --- | --- |
+  | Drop `$(find packs …)` from the Makefile invocation | exit 1, `FAIL the Makefile still enumerates packs manifests by find` |
+  | A `packs/**/requirements.txt` disappears (rename) | exit 1, `FAIL packs manifest count is 8 … found 7` naming the survivors |
+  | A new `tools/requirements*.txt` appears | exit 1, `FAIL the tools/ manifest roster is unchanged` |
+  | Revert AC2's predicate | exit 1, `FAIL an include-only manifest counts as having content to audit` |
+  | Revert AC3's env scrub | exit 1, two failures (`PIP_AUDIT_*`, `PIP_INDEX_URL`) |
+
+  The self-test's own first revision also failed for the right reason and was
+  corrected: its Makefile-line predicate matched the `SAST_CONFIG :=` assignment,
+  which also names `tools/audit-requirements.py`. It now matches on the recipe
+  invocation prefix, and a `the … invocation was located in the Makefile` case fails
+  if no recipe line is found at all — so an empty match cannot pass the two
+  assertions that read it.
+
+- [x] **AC7 — the audited input set has a floor.**
+  `Makefile`'s `$(find packs -name requirements.txt | sort)` has its exit status
+  swallowed by the pipeline, so a renamed, moved or deleted manifest shrank the
+  audited set silently at exit 0 and nothing asserted the expected count. The
+  self-test now pins:
+  - the invocation still enumerates packs manifests by `find` and still names
+    `tools/requirements.txt` explicitly;
+  - `_EXPECTED_PACK_MANIFESTS = 8`, so a vanished manifest fails by name;
+  - `_EXPECTED_TOOLS_MANIFESTS`, the four-file roster, so a **new**
+    `tools/requirements*.txt` cannot silently join the unaudited set.
+
+  The three unaudited `tools/` manifests stay unaudited — that is
+  `sast-requirements-not-audited`, a separate open entry with its own
+  audit-vs-Dependabot decision. This criterion pins the roster so a fourth is
+  deliberate; it does not widen coverage.
+
+- [x] **AC8 — the self-test does not reach the network.**
+  AC2's case asserts the content predicate directly instead of calling `audit()`,
+  which would spawn pip-audit against a nonexistent include — network I/O and a usage
+  error inside a self-test. Runtime went 5.6s → 3.5s, and the predicate is the thing
+  under test.
+
+## Blast radius
+
+This change makes a required merge context **stricter**. Conditions that previously
+passed and now fail:
+
+- a dependency the advisory service cannot resolve (AC1);
+- a manifest whose only content is an include (AC2) — no such manifest exists today;
+- a pip-audit run exceeding 300s (AC4);
+- a shrunken or grown manifest roster (AC7).
+
+Verified before proposing: the real leg over all nine current manifests exits **0**
+under the new flags. So nothing in the tree trips the new failures — they are
+guards, not a backlog of work this PR creates.
+
+## Boundaries
+
+**Never do**
+
+- Add the three unaudited `tools/` manifests to the audit invocation. That is
+  `sast-requirements-not-audited` and needs its audit-vs-Dependabot decision first;
+  AC7 pins the roster instead.
+- Batch the per-manifest invocations. `spec/pip-audit-batching` was archived
+  precisely because batching trades away per-manifest SCA fidelity.
+- Relax `--strict` if a future manifest trips it. A dependency the service cannot
+  serve is the finding, not the noise.
+- Touch the four `--ignore-vuln` semgrep-transitive suppressions. Unrelated leg,
+  and their unblock condition is still unmet (semgrep 1.166.0 pins `mcp==1.23.3`).
+
+## Assumptions
+
+1. **`-s pypi` is the correct flag and `pypi` a valid choice.** Verified against
+   `pip-audit --help` (2.10.1: `choices: osv, pypi, esms`, default `pypi`) and by a
+   live invocation at exit 0. Passing it explicitly pins today's default against a
+   future upstream change as well as against the environment.
+2. **300s is comfortably above normal.** Each invocation measures 7–17s cold. The
+   number is a hang bound, not a performance budget.
+3. **No manifest currently relies on a relative include resolving against the shared
+   temp dir.** None contains `-r`, `-c` or `--find-links` at all, which is also why
+   AC2 is latent.

--- a/tools/audit-requirements.py
+++ b/tools/audit-requirements.py
@@ -23,6 +23,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -34,6 +35,28 @@ sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Generous against a measured 7-17s per invocation. The failure this bounds is an
+# indefinite CI hang, not a slow audit, so the number only has to be well clear of
+# normal.
+_PIP_AUDIT_TIMEOUT_S = 300
+
+# Environment variables that can re-point pip-audit's advisory feed, or the pip
+# index the resolution venv uses. A stale local export is the realistic trigger,
+# not an attacker: either one can produce "No known vulnerabilities found" at
+# exit 0 without touching a tracked file.
+_SCRUBBED_ENV_PREFIXES = ("PIP_AUDIT_",)
+_SCRUBBED_ENV_NAMES = ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL")
+
+
+def _scrubbed_env() -> dict[str, str]:
+    """os.environ minus the variables that can silently re-aim this gate."""
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(_SCRUBBED_ENV_PREFIXES) and key not in _SCRUBBED_ENV_NAMES
+    }
+
 
 # A requirement line's distribution name: everything before the first extras
 # bracket, version specifier, marker, or whitespace.
@@ -55,6 +78,24 @@ def first_party_names(root: Path) -> set[str]:
                 names.add(_canonical(match.group(1)))
                 break
     return names
+
+
+# Option lines that pull in dependencies pip-audit would have to resolve. A
+# manifest containing only these is NOT "no third-party requirements" — it is a
+# manifest whose content lives elsewhere. `--index-url` and friends are excluded
+# deliberately: they configure resolution, they do not add a requirement.
+_DEPENDENCY_BEARING_OPTIONS = ("-r", "--requirement", "-c", "--constraint",
+                               "-e", "--editable", "-f", "--find-links")
+
+
+def _is_dependency_bearing(stripped: str) -> bool:
+    """True when a `-`-prefixed requirements line contributes dependencies.
+
+    Matches on the option token only, so `-r nested.txt`, `--requirement=x.txt`
+    and `-e .` all count while `--index-url https://…` does not.
+    """
+    token = stripped.split("=", 1)[0].split()[0]
+    return token in _DEPENDENCY_BEARING_OPTIONS
 
 
 def partition(lines: list[str], first_party: set[str]) -> tuple[list[str], list[str]]:
@@ -84,22 +125,65 @@ def audit_lines(label: str, lines: list[str], first_party: set[str]) -> int:
     print(f"pip-audit -r {label}")
     for pin in skipped:
         print(f"  skipped (built in this repo, declares no dependencies): {pin}")
+    # A line is content when it is a real pin OR a dependency-bearing option. The
+    # old test excluded every `-` line, so a manifest whose only content was
+    # `-r nested.txt` / `-c constraints.txt` / `-e .` printed
+    # "no third-party requirements to audit" and was audited ZERO times, at
+    # exit 0. Latent — no such manifest exists today — but self-test case 4
+    # already blesses `-r other.txt` as a supported shape.
     if not any(
-        line.strip() and not line.strip().startswith(("#", "-")) for line in audited
+        stripped
+        and (not stripped.startswith("#"))
+        and (not stripped.startswith("-") or _is_dependency_bearing(stripped))
+        for stripped in (line.strip() for line in audited)
     ):
         print("  no third-party requirements to audit")
         return 0
-    with tempfile.NamedTemporaryFile(
-        "w", suffix=".txt", delete=False, encoding="utf-8"
-    ) as handle:
-        handle.write("\n".join(audited) + "\n")
-        temp = Path(handle.name)
-    try:
-        return subprocess.run(  # noqa: S603
-            [sys.executable, "-m", "pip_audit", "-r", str(temp)], check=False
-        ).returncode
-    finally:
-        temp.unlink(missing_ok=True)
+    # Write the filtered manifest inside a per-run 0700 directory, not the shared
+    # system temp dir. NamedTemporaryFile's own mode was already safe (O_EXCL,
+    # 0600); the DIRECTORY was the issue, because a relative `-r` / `-c` /
+    # `--find-links` / local-path reference inside a manifest re-resolves against
+    # the file's own directory — which was world-writable.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp = Path(tmpdir) / "filtered-requirements.txt"
+        temp.write_text("\n".join(audited) + "\n", encoding="utf-8")
+        try:
+            return subprocess.run(  # noqa: S603
+                [
+                    sys.executable, "-m", "pip_audit",
+                    "-r", str(temp),
+                    # A dependency the advisory service cannot serve (a PyPI 404
+                    # for that name+version) is otherwise SKIPPED while pip-audit
+                    # still exits 0 — the "a silent no-op is not a pass" class
+                    # ADR-0084 already gated for bandit. Measured free to adopt:
+                    # the nine-manifest audit ran 11.3s with --strict vs 11.1s
+                    # without, same input, both green.
+                    "--strict",
+                    # Pin the advisory source and output shape in code. Without
+                    # these, PIP_AUDIT_* environment variables select them, so a
+                    # stale shell export could re-point the feed and yield
+                    # "No known vulnerabilities found" at exit 0. `-s`, not
+                    # `--service`: the long form is `--vulnerability-service`
+                    # (pip-audit 2.10.1), and `--service` is not accepted —
+                    # verified by invocation, and it is what the first revision of
+                    # this change got wrong.
+                    "-s", "pypi",
+                    "--format", "columns",
+                ],
+                check=False,
+                env=_scrubbed_env(),
+                # No timeout meant a pathological pip resolver backtrack hung the
+                # gate instead of failing it. Each invocation measures 7-17s.
+                timeout=_PIP_AUDIT_TIMEOUT_S,
+            ).returncode
+        except subprocess.TimeoutExpired:
+            print(
+                f"audit-requirements: pip-audit exceeded "
+                f"{_PIP_AUDIT_TIMEOUT_S}s on {label} — failing the gate rather "
+                f"than hanging it",
+                file=sys.stderr,
+            )
+            return 1
 
 
 def audit(path: Path, first_party: set[str]) -> int:

--- a/tools/test-audit-requirements.py
+++ b/tools/test-audit-requirements.py
@@ -28,6 +28,16 @@ _SPEC.loader.exec_module(_MOD)
 
 FAILURES: list[str] = []
 
+# Pinned so a shrinking SCA input set is a named failure rather than a quieter
+# gate. Raise these in the same commit that adds a manifest.
+_EXPECTED_PACK_MANIFESTS = 8
+_EXPECTED_TOOLS_MANIFESTS = [
+    "requirements-ci-security-locked.txt",
+    "requirements-evals-locked.txt",
+    "requirements-sast.txt",
+    "requirements.txt",
+]
+
 
 def check(label: str, condition: bool, detail: str = "") -> None:
     if condition:
@@ -145,6 +155,117 @@ def main() -> int:
         else:
             missing_extra_refused = False
         check("missing optional dependency group fails closed", missing_extra_refused)
+
+    # 10. Dependency-bearing option lines count as content, so a manifest whose
+    #     only content is an include is audited rather than reported empty.
+    for line in ("-r nested.txt", "--requirement=nested.txt", "-c constraints.txt",
+                 "-e .", "--editable .", "-f ./wheels", "--find-links ./wheels"):
+        check(
+            f"dependency-bearing option is content: {line!r}",
+            _MOD._is_dependency_bearing(line),
+        )
+    for line in ("--index-url https://example.invalid/simple",
+                 "--extra-index-url https://example.invalid/simple",
+                 "--no-binary :all:"):
+        check(
+            f"resolution-only option is not content: {line!r}",
+            not _MOD._is_dependency_bearing(line),
+        )
+    # Asserted on the CONTENT PREDICATE rather than by calling audit(), which
+    # would spawn pip-audit against a nonexistent include — network I/O and a
+    # usage error inside a self-test. The predicate is the thing under test; the
+    # old bug was that `-r nested.txt` did not count as content.
+    include_only = ["# only an include", "", "-r nested.txt"]
+    audited_only, _ = _MOD.partition(include_only, first_party)
+    has_content = any(
+        stripped
+        and not stripped.startswith("#")
+        and (not stripped.startswith("-") or _MOD._is_dependency_bearing(stripped))
+        for stripped in (line.strip() for line in audited_only)
+    )
+    check(
+        "an include-only manifest counts as having content to audit",
+        has_content,
+        str(audited_only),
+    )
+
+    # 11. The environment scrub really removes the variables that can re-aim the
+    #     advisory feed or the index, and leaves everything else alone.
+    import os as _os
+    _os.environ["PIP_AUDIT_VULNERABILITY_SERVICE"] = "osv"
+    _os.environ["PIP_INDEX_URL"] = "https://example.invalid/simple"
+    _os.environ["AUDIT_SELFTEST_KEEP_ME"] = "kept"
+    try:
+        scrubbed = _MOD._scrubbed_env()
+        check("PIP_AUDIT_* is scrubbed",
+              "PIP_AUDIT_VULNERABILITY_SERVICE" not in scrubbed)
+        check("PIP_INDEX_URL is scrubbed", "PIP_INDEX_URL" not in scrubbed)
+        check("unrelated variables survive",
+              scrubbed.get("AUDIT_SELFTEST_KEEP_ME") == "kept")
+    finally:
+        for key in ("PIP_AUDIT_VULNERABILITY_SERVICE", "PIP_INDEX_URL",
+                    "AUDIT_SELFTEST_KEEP_ME"):
+            _os.environ.pop(key, None)
+
+    # 12. THE AUDITED SET HAS A FLOOR.
+    #     Makefile's `$(find packs -name requirements.txt | sort)` has its exit
+    #     status swallowed by the pipeline, so a renamed, moved or deleted manifest
+    #     shrinks the audited input silently at exit 0 and nothing notices the gate
+    #     covers less than it did. Pin the shape AND the count.
+    repo_root = _HERE.parent
+    makefile = (repo_root / "Makefile").read_text(encoding="utf-8")
+    # A recipe line, not the SAST_CONFIG assignment that also names the script:
+    # match on the invocation prefix so `SAST_CONFIG := … tools/audit-requirements.py …`
+    # cannot satisfy this case (it did, on the first attempt).
+    audit_invocation = next(
+        (
+            line for line in makefile.splitlines()
+            if line.lstrip("\t ").startswith("python3 tools/audit-requirements.py")
+            and "--build-system" not in line
+            and "--optional-group" not in line
+        ),
+        "",
+    )
+    check(
+        "the packs+tools audit invocation was located in the Makefile",
+        bool(audit_invocation),
+        "no `python3 tools/audit-requirements.py <manifests>` recipe line found",
+    )
+    check(
+        "the Makefile still enumerates packs manifests by find",
+        "find packs -name requirements.txt" in audit_invocation,
+        audit_invocation.strip(),
+    )
+    check(
+        "the Makefile still audits tools/requirements.txt explicitly",
+        "tools/requirements.txt" in audit_invocation,
+        audit_invocation.strip(),
+    )
+    pack_manifests = sorted(
+        path.relative_to(repo_root).as_posix()
+        for path in (repo_root / "packs").rglob("requirements.txt")
+    )
+    check(
+        f"packs manifest count is {_EXPECTED_PACK_MANIFESTS}",
+        len(pack_manifests) == _EXPECTED_PACK_MANIFESTS,
+        f"found {len(pack_manifests)}: {pack_manifests}. If a manifest was added, "
+        f"raise _EXPECTED_PACK_MANIFESTS in the same commit; if one vanished, the "
+        f"SCA input just shrank and that is the failure this case exists for.",
+    )
+    #     A NEW tools/requirements*.txt must not silently join the unaudited set.
+    #     The three below are unaudited today and tracked as
+    #     `sast-requirements-not-audited` in workspace.toml [backlog].open; this
+    #     case pins the roster so a fourth is a deliberate decision.
+    tools_manifests = sorted(
+        path.name for path in (repo_root / "tools").glob("requirements*.txt")
+    )
+    check(
+        "the tools/ manifest roster is unchanged",
+        tools_manifests == _EXPECTED_TOOLS_MANIFESTS,
+        f"found {tools_manifests}, expected {_EXPECTED_TOOLS_MANIFESTS}. A new "
+        f"tools/requirements*.txt is unaudited until it is added to the Makefile "
+        f"invocation or dispositioned under sast-requirements-not-audited.",
+    )
 
     if FAILURES:
         print(f"\naudit-requirements self-test: {len(FAILURES)} failure(s)")

--- a/workspace.toml
+++ b/workspace.toml
@@ -2474,58 +2474,6 @@ open = [
   # invocation, or wire Dependabot for pip so the bumps arrive as PRs. Decide
   # which, then do one -- doing both duplicates the noise.
   {slug = "sast-requirements-not-audited", summary = "Give tools/requirements-sast.txt, requirements-ci-security-locked.txt, and requirements-evals-locked.txt SCA coverage -- pip-audit skips all three today", source = "spec/build-check-coverage-gaps security review"},
-  # The seven entries below all came out of spec/pip-audit-batching, which was
-  # ARCHIVED without shipping (see docs/specs/pip-audit-batching/spec.md for why
-  # batching pip-audit trades away per-manifest SCA fidelity). None of them is
-  # caused by batching -- every one is live in `make sast` today, and each was
-  # left here rather than bundled into that PR because each is its own decision.
-  # Cheapest first: sca-no-strict-flag is a one-flag change measured free.
-  #
-  # Without -S, a resolved dependency the advisory service cannot serve (a PyPI
-  # 404 for that name+version) is skipped while pip-audit still exits 0 -- the
-  # same "silent no-op is not a pass" class ADR-0084 already gated for bandit.
-  # Measured free: the nine-manifest audit ran 11.3s with --strict vs 11.1s
-  # without, same input, both green.
-  # Fix: add -S to the audit-requirements.py invocations. Decide separately
-  # whether the requirements-sast.txt and /dev/stdin invocations get it too.
-  {slug = "sca-no-strict-flag", summary = "pip-audit runs without -S/--strict, so a dependency the advisory service cannot serve is skipped at exit 0 -- measured free to adopt", source = "spec/pip-audit-batching security review"},
-  # partition() sends every line starting with `-` into the audited half, and the
-  # emptiness test at audit_lines() then excludes exactly those lines. So a
-  # manifest whose only content is `-r nested.txt`, `-c constraints.txt` or `-e .`
-  # prints "no third-party requirements to audit" and is audited ZERO times, at
-  # exit 0. Latent -- no such manifest exists today -- but self-test case 4
-  # already treats `-r other.txt` as a supported shape, so the shape is blessed.
-  # Fix: count dependency-bearing option lines (-r, -c, -e, --find-links, bare
-  # URL/path) as content that must be audited, or exit 2 on one.
-  {slug = "sca-requirements-include-lines-unaudited", summary = "A manifest containing only -r/-c/-e lines reports no-third-party and is audited zero times at exit 0", source = "spec/pip-audit-batching security review"},
-  # pip-audit defaults its vulnerability service, OSV URL, format and output from
-  # PIP_AUDIT_* env vars, and the resolution venv's pip honours PIP_INDEX_URL /
-  # PIP_EXTRA_INDEX_URL. A stale local export re-points the advisory feed or the
-  # index and yields "No known vulnerabilities found" at exit 0 without touching
-  # a tracked file. Realistic trigger is a stale shell profile, not an attacker.
-  # Fix: pass -s pypi and --format columns explicitly, and run each pip-audit
-  # with PIP_AUDIT_* / PIP_INDEX_URL / PIP_EXTRA_INDEX_URL scrubbed from the
-  # child environment, so the gate's data sources are code-pinned.
-  {slug = "sca-ambient-env-can-green-the-gate", summary = "PIP_AUDIT_* and PIP_INDEX_URL can re-point the SCA gate's advisory feed or index and green it at exit 0", source = "spec/pip-audit-batching security review"},
-  # Makefile:247 builds argv from $(find packs -name requirements.txt | sort),
-  # whose exit status is swallowed by the pipeline. A renamed, moved or missing
-  # manifest shrinks the audited set silently at exit 0; nothing asserts the
-  # expected count, so the gate cannot tell "all nine clean" from "six clean".
-  # Fix: assert in tools/test-audit-requirements.py that the audited set covers
-  # every requirements*.txt on disk under packs/ and tools/, and its count.
-  {slug = "sca-audited-set-has-no-floor", summary = "A renamed or missing per-skill requirements.txt shrinks the pip-audit input set silently at exit 0", source = "spec/pip-audit-batching security review"},
-  # No pip-audit invocation carries a timeout=, so a pathological pip resolver
-  # backtrack hangs the gate instead of failing it. Low severity today (each
-  # invocation measured 7-17s) but the failure mode is an indefinite CI hang.
-  # Fix: pass an explicit timeout= and aggregate TimeoutExpired as a failure
-  # rather than letting it surface as a traceback.
-  {slug = "sca-no-timeout-on-pip-audit", summary = "pip-audit invocations have no timeout, so a resolver backtrack hangs the gate instead of failing it", source = "spec/pip-audit-batching security review"},
-  # audit_lines() writes the filtered manifest to the shared system temp dir, so
-  # any relative -r / -c / --find-links / local-path reference inside a manifest
-  # re-resolves against a world-writable directory instead of its own. File mode
-  # is safe (NamedTemporaryFile is O_EXCL, 0600); the directory is the issue.
-  # Fix: write each filtered manifest inside a per-run TemporaryDirectory() (0700).
-  {slug = "sca-temp-manifest-leaves-its-directory", summary = "The filtered manifest is written to shared /tmp, so a relative include in a requirements file resolves against a world-writable dir", source = "spec/pip-audit-batching security review"},
   # Semgrep's signal for a target it could not parse depends on HOW it failed.
   # A PARTIAL failure (unbalanced bracket, stray token) does surface as a
   # path-attributed PartialParsing entry in `errors`, and --strict escalates it


### PR DESCRIPTION
## What does this change?

Closes six ways `make sast`'s pip-audit leg could report success while auditing less than it appears to, and gives the audited input set a floor that fails by name when it shrinks.

## Why?

All six came out of the security review on `spec/pip-audit-batching`, which was **archived without shipping**. None is caused by batching — every one is live in `make sast` today. Each was left as its own entry because each is its own decision; they are taken together because all six land in one 210-line file plus its self-test, so the "did this gate actually run" triage happens once.

- Implements: `docs/specs/sca-gate-hardening/spec.md`
- Closes: `sca-no-strict-flag`, `sca-requirements-include-lines-unaudited`, `sca-ambient-env-can-green-the-gate`, `sca-no-timeout-on-pip-audit`, `sca-temp-manifest-leaves-its-directory`, `sca-audited-set-has-no-floor`

| Fix | What was wrong |
|---|---|
| `--strict` | A dependency the advisory service cannot serve (a PyPI 404 for that name+version) was **skipped** while pip-audit still exited 0 — the "a silent no-op is not a pass" class ADR-0084 already gated for bandit |
| Include lines count as content | `partition()` sent every `-` line into the audited half and the emptiness test then excluded exactly those, so a manifest whose only content was `-r nested.txt` printed `no third-party requirements to audit` and was audited **zero** times at exit 0 |
| `-s pypi` + `--format columns`, scrubbed env | `PIP_AUDIT_*` / `PIP_INDEX_URL` / `PIP_EXTRA_INDEX_URL` could re-point the advisory feed or the index and yield `No known vulnerabilities found` at exit 0 without touching a tracked file |
| `timeout=300` | A pathological resolver backtrack **hung** the gate instead of failing it |
| Per-run 0700 `TemporaryDirectory` | The file mode was already safe (`O_EXCL`, 0600); the **directory** was the issue — a relative `-r`/`-c`/`--find-links` inside a manifest re-resolved against a world-writable dir |
| Manifest floor | `$(find packs -name requirements.txt)` has its exit status swallowed by the pipeline, so a renamed or deleted manifest shrank the audited set silently |

### `-s`, not `--service` — and it did not fail loudly

The long form is `--vulnerability-service` (pip-audit 2.10.1). My first revision used `--service`, and the run surfaced as:

```
pip-audit: error: argument project_path: not allowed with argument -r/--requirement
```

which never names the offending flag. Caught by invoking the real leg over all nine manifests, not by reading the diff. That is this change's own subject turned on itself: the gate could report success while doing nothing, and the first fix made it report a *confusing failure* while doing nothing.

## How do I verify it?

```bash
python3 tools/test-audit-requirements.py                                    # exit 0
python3 tools/audit-requirements.py tools/requirements.txt \
  $(find packs -name requirements.txt | sort)                               # exit 0, all nine
make ci                                                                     # exit 0, SAST/SCA included
```

**`--strict` is free.** Warm cache, same nine manifests, back to back after a discarded warm-up, both green: `1.12s / 2.20s` before vs `1.23s / 1.26s` after. Frame matters — a *cold*-cache first run of the same leg took 77s here, so comparing that against a warm baseline would have manufactured a 7× regression that does not exist.

### Every new control is proved able to fail

Each mutation applied and reverted, `Makefile` byte-identical afterwards:

| Mutation | Result |
|---|---|
| Drop `$(find packs …)` from the invocation | exit 1, `FAIL the Makefile still enumerates packs manifests by find` |
| A `packs/**/requirements.txt` disappears | exit 1, `FAIL packs manifest count is 8 … found 7`, naming the survivors |
| A new `tools/requirements*.txt` appears | exit 1, `FAIL the tools/ manifest roster is unchanged` |
| Revert the content predicate | exit 1, `FAIL an include-only manifest counts as having content to audit` |
| Revert the env scrub | exit 1, two failures (`PIP_AUDIT_*`, `PIP_INDEX_URL`) |

## What did you not change that you considered?

**Two defects in my own self-test, found and fixed in passing:**

- Its Makefile-line predicate matched the `SAST_CONFIG :=` assignment, which also names `tools/audit-requirements.py`. It now matches the recipe invocation prefix, with a separate case that fails if no recipe line is found at all — so an empty match cannot satisfy the assertions that read it.
- Its include-line case asserted through `audit()`, which spawned pip-audit against a nonexistent include: network I/O and a usage error inside a self-test. It **passed**, so it was found by timing the suite (5.6s → 3.5s), not by a failure. It now asserts the content predicate directly.

**Declined:**

- Adding the three unaudited `tools/` manifests to the invocation. `sast-requirements-not-audited` carries an explicit audit-vs-Dependabot decision ("Decide which, then do one — doing both duplicates the noise"); taking the audit half unilaterally pre-empts it. The floor **pins** the roster so a fourth manifest is deliberate — it does not widen coverage.
- Exiting 2 on an include-only manifest (that entry's stated alternative). Counting them as content audits the manifest, which is what the gate is for; exiting 2 refuses a shape self-test case 4 already blesses.
- Pinning the roster by content hash rather than count. That is the noisy-re-sign trade recorded under `ci-parity-hidden-gate-in-dispositioned-step`; a manifest's contents changing is normal and the audit already reads them.
- Batching. `spec/pip-audit-batching` was archived precisely because batching trades away per-manifest SCA fidelity.
- Touching the four `--ignore-vuln` semgrep-transitive suppressions — unrelated leg, and their unblock condition is still unmet (semgrep 1.166.0 pins `mcp==1.23.3`).

**Scope note:** this was triaged as five items; it is six. `sca-requirements-include-lines-unaudited` was initially set aside as an either/or needing a decision, but reading it against the code collapsed the choice. The reasoning is recorded in `plan.md` § Declined patterns rather than left as a silent scope change.

**Blast radius:** this makes a required merge context **stricter** — an unresolvable dependency, an include-only manifest, a >300s run, or a changed manifest roster now fail. Verified before proposing that the real leg over all nine current manifests exits 0 under the new flags, so nothing in the tree trips them. They are guards, not a backlog this PR creates.

---

## Checklist

- [x] Tests pass locally (`make ci` exit 0, SAST/SCA included)
- [x] Lint and typecheck pass (`make lint-ruff`, `tools/lint-build.py`)
- [ ] Self-review run via the relevant reviewer subagent — **named skip:** subagent dispatch is disabled for this session by operator instruction. In its place: the spec-less self-review checklist inline, a five-mutation battery (recorded in AC6), and end-to-end invocation of the real gate leg — which is what caught the `--service` defect.
- [x] Spec and code agree
- [x] Living docs match reality — no user-visible behavior change
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the flag-verification lesson is in AC3 and the commit body

🤖 Generated with [Claude Code](https://claude.com/claude-code)