### PR TITLE
build(ci): open npm bump PRs with Dependabot, at the lowest useful volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot — npm bump PRs for the two Node projects in this repository.
+#
+# WHY THIS EXISTS, and what it is NOT. ADR-0083 chose `npm audit` as the SCA GATE
+# and recorded Dependabot as complementary rather than a substitute: they answer
+# different questions — "may this merge?" versus "should we bump?". `tools/audit-npm.py`
+# still blocks a merge on a known advisory; nothing here weakens or replaces it.
+# Without this file, remediation was hand-driven (`npm audit fix --package-lock-only`)
+# and only ever happened when someone went looking.
+#
+# ADR-0083 lists this as deferred "to the repo owner because it changes how much review
+# the team absorbs per week". That is a volume decision, not a technical one, and the
+# settings below are chosen to keep the volume low:
+#
+#   * weekly, not daily;
+#   * minor and patch updates GROUPED into one PR per project, so a quiet week is one
+#     PR rather than nine;
+#   * majors ungrouped and individual, because they are the ones that need reading;
+#   * a hard cap per project, so a burst cannot flood the queue.
+#
+# Both projects ship committed lockfiles, which is what makes a lockfile-only bump PR
+# meaningful here.
+#
+# NOT WIRED, deliberately:
+#   * `pip` — `sast-requirements-not-audited` in workspace.toml [backlog].open carries
+#     an explicit audit-vs-Dependabot decision for the Python side ("Decide which, then
+#     do one -- doing both duplicates the noise"). Adding a pip ecosystem here would
+#     pre-empt it.
+#   * `github-actions` — every action in this repo is already SHA-pinned, and turning
+#     this on is its own volume decision nobody has taken.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docs-site-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      web-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/docs/specs/npm-dependabot-wiring/plan.md
+++ b/docs/specs/npm-dependabot-wiring/plan.md
@@ -1,0 +1,70 @@
+# Plan: npm-dependabot-wiring
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+**Files I'll touch**
+- `.github/dependabot.yml` — new.
+- `workspace.toml` — remove `npm-dependabot-wiring`; append an instance note to
+  `adr-errata-convention`.
+- `docs/specs/npm-dependabot-wiring/{spec.md,plan.md}` — this contract.
+
+**What demonstrates done**
+- Goal-based. The artifact is a service config; there is nothing to unit-test that
+  would not just restate the file.
+- `yaml.safe_load` parses it, `version == 2`, and each `directory` contains a
+  `package.json` — asserted, not eyeballed.
+- `lint-spec-status` clean after the slug is removed.
+- `make ci` green.
+
+**What I am NOT changing**
+- No code, no gate, no workflow, no permission, no token.
+- Not `tools/audit-npm.py` or the `make sast` chain.
+- Not ADR-0083 or `docs/specs/npm-sca-gate/spec.md` — both frozen.
+
+## Declined patterns
+
+- **Tempted:** add `pip` and `github-actions` ecosystems while the file is open —
+  it is four more lines and the file is new, so there is no precedent to break.
+  **Declined:** `sast-requirements-not-audited` owns an explicit audit-vs-Dependabot
+  decision for Python, and github-actions is its own volume call. The owner approved
+  *npm* wiring; silently widening the blast radius of a volume decision is the one
+  thing this item must not do.
+- **Tempted:** leave the slug in `[backlog].open` as an anchor, the way
+  `starlight-migration-rfc` and the branch-protection entries are retained.
+  **Declined:** those are retained because a frozen spec's `(deferred: <slug>)` marker
+  makes `lint-spec-status` invariant (iv) require them. Nothing requires this one —
+  verified by removing it and running the lint. Retaining it would make the backlog
+  claim open work that is done, which is the complaint those entries' own comments
+  make about themselves.
+- **Tempted:** correct ADR-0083's two references while closing the slug, so nothing
+  dangles. **Declined:** the ADR body is frozen and no errata mechanism exists — that
+  is `adr-errata-convention`, still open. Recorded there as a concrete instance
+  instead of inventing a shape in a config PR.
+- **Tempted:** daily interval and no grouping, which surfaces advisories fastest.
+  **Declined:** the only stated objection to this item was weekly review volume.
+  Optimising against the objection the owner raised is the point.
+
+## Tasks
+
+### T1 — Read ADR-0083's disposition before writing anything
+- **Mode:** goal-based. `Done when:` the ADR's recorded reason for deferring is known
+  and the settings answer it.
+- **Tests:** no stub (goal-based).
+- **Status:** done. Deferred on review volume, not technique; AC2 is the response.
+
+### T2 — Write and validate the config
+- **Mode:** goal-based. `Done when:` it parses, `version == 2`, and both directories
+  contain a `package.json`.
+- **Tests:** no stub — nothing in CI validates dependabot.yml; the check is the
+  parse assertion recorded in AC4.
+- **Touches:** `.github/dependabot.yml`.
+
+### T3 — Close the slug; establish what depends on it
+- **Mode:** goal-based. `Done when:` the slug is gone, `lint-spec-status` is clean,
+  and every surviving reference to it is enumerated.
+- **Tests:** no stub (goal-based).
+- **Status:** done. Four prose references in two frozen documents; no lint invariant
+  depends on the slug. Recorded as AC5 and appended to `adr-errata-convention`.

--- a/docs/specs/npm-dependabot-wiring/spec.md
+++ b/docs/specs/npm-dependabot-wiring/spec.md
@@ -1,0 +1,98 @@
+# Spec: npm-dependabot-wiring
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none — one new `.github/dependabot.yml`. No code, no gate, no
+  interface. It changes what GitHub *opens*, not what merges.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (work-loop). No risk trigger fired. Two were checked. (1) New
+dependency: none — Dependabot is a GitHub service, nothing is added to a manifest or a
+lockfile. (2) Security boundary: the file grants no permission and touches no token;
+the SCA gate that blocks merges is unchanged. Lean fill: Objective + Acceptance
+Criteria + Boundaries + Assumptions. -->
+
+## Objective
+
+`tools/audit-npm.py` blocks a merge on a known npm advisory, but nothing opened the
+bump PRs — remediation was hand-driven (`npm audit fix --package-lock-only`) and only
+happened when someone went looking. ADR-0083 chose the gate first and recorded
+Dependabot as **complementary, not a substitute**: the two answer different questions,
+"may this merge?" versus "should we bump?".
+
+It was deferred to the repo owner, explicitly on volume grounds rather than technical
+ones — "it changes how much review the team absorbs per week". The owner has now asked
+for it, so the work is to wire it at the lowest volume that still delivers the bumps.
+
+## Acceptance Criteria
+
+- [x] **AC1 — both npm projects are covered.** `.github/dependabot.yml` is schema
+  version 2 and declares one `npm` ecosystem entry per project directory:
+  `/docs-site` and `/web`. Both ship committed lockfiles, which is what makes a
+  lockfile-only bump PR meaningful.
+
+- [x] **AC2 — the volume the owner was asked about is bounded.** The settings are
+  chosen against the one stated objection, not left at defaults:
+
+  | Setting | Value | Why |
+  | --- | --- | --- |
+  | `schedule.interval` | `weekly` | not daily |
+  | `groups.*.update-types` | `minor`, `patch` | a quiet week is **one** PR per project, not nine |
+  | majors | ungrouped | they are the ones that need reading individually |
+  | `open-pull-requests-limit` | `5` | a burst cannot flood the queue |
+
+- [x] **AC3 — nothing about the merge gate changes.** `tools/audit-npm.py` still runs
+  as a leg of `make sast` and still blocks on a known advisory. This file adds no
+  permission, no token, and no workflow. ADR-0083's choice of `npm audit` as the gate
+  stands; this is the complement it named.
+
+- [x] **AC4 — the config is valid, and verified as such.** It parses as YAML, declares
+  `version: 2`, and each entry resolves to a directory that actually contains a
+  `package.json`. Verified by parsing, since nothing in CI validates
+  `.github/dependabot.yml` — `actionlint` and `zizmor` lint *workflows*, and this is
+  not one.
+
+- [x] **AC5 — the deferral's dangling references are recorded, not silently created.**
+  Closing this slug leaves four prose references pointing at it from **frozen**
+  documents: `docs/adr/0083-…md:72` and `:201`, and
+  `docs/specs/npm-sca-gate/spec.md:203` and `:263`.
+
+  They are deliberately **not** corrected here. CONVENTIONS freezes an ADR body, the
+  shipped `new-adr` template moves only the Status line, and the `## Errata` convention
+  is RFC-scoped — there is no licensed shape for "this accepted deferral has since been
+  discharged". Inventing one in this PR would be a governance change smuggled into a
+  config file.
+
+  `lint-spec-status` is clean: these are prose mentions, not `(deferred: <slug>)`
+  anchors, so no invariant depends on the slug surviving. The instance is appended to
+  the open `adr-errata-convention` entry instead, with the observation that its shape
+  differs from ADR-0071's — that one names a **deleted file** (wrong on its face),
+  these name a **resolved deferral** (true when written, still true as history). Which
+  of those actually needs annotating is the decision that entry owes.
+
+## Boundaries
+
+**Never do**
+
+- Add a `pip` ecosystem entry. `sast-requirements-not-audited` carries an explicit
+  audit-vs-Dependabot decision for the Python side ("Decide which, then do one —
+  doing both duplicates the noise"). Adding pip here pre-empts it.
+- Add a `github-actions` ecosystem entry. Every action in this repo is already
+  SHA-pinned, and enabling it is its own volume decision nobody has taken.
+- Weaken, replace, or reroute `tools/audit-npm.py`. Dependabot does not gate.
+- Edit ADR-0083 or `docs/specs/npm-sca-gate/spec.md`. Both are frozen (AC5).
+
+## Assumptions
+
+1. **Dependabot is enabled for the repository.** The config is inert until it is; if
+   the service is off, this file is a no-op rather than an error, so nothing here
+   fails closed on the owner's account settings.
+2. **Grouped minor/patch bumps are the right default.** If a grouped PR ever proves
+   hard to review, splitting a group is a one-line change to this file — the cheap
+   direction to be wrong in, which is why it is the starting point.
+3. **Both lockfiles stay committed.** `docs-site/package-lock.json` and
+   `web/package-lock.json` are already in `SAST_CONFIG`, so their removal would
+   surface elsewhere first.

--- a/workspace.toml
+++ b/workspace.toml
@@ -1563,6 +1563,23 @@ open = [
   # governance-extras, then file the ADR-0071 erratum. A governance change, so it
   # wants its own PR. Unblocks when: picked up.
   {slug = "adr-errata-convention", source = "spec/pack-test-boundary-remaining-packs review"},
+  # SECOND CONCRETE INSTANCE, 2026-08-18 (spec/npm-dependabot-wiring). ADR-0083's
+  # comparison table (:72) and its deferred-items list (:201) both name
+  # `npm-dependabot-wiring` as deferred to the repo owner. That item has now SHIPPED and
+  # its [backlog].open entry is deleted, so both references resolve to nothing — the
+  # dangling-pointer class this repository has already fixed twice elsewhere
+  # (sast-semgrep-cve-allowlist-pointer-stale cited a tombstone; the phase4b docsUrl AC
+  # asserted a superseded direction).
+  # It was NOT corrected in that PR, and the reason is exactly this entry: CONVENTIONS
+  # freezes an ADR body, the shipped new-adr template moves only the Status line, and
+  # the `## Errata` convention is RFC-scoped. There is no licensed shape for "this
+  # accepted deferral has since been discharged". docs/specs/npm-sca-gate/spec.md (:203,
+  # :263) carries the same two references and is equally frozen.
+  # Note the shape differs from ADR-0071's: that one names a DELETED FILE, which is
+  # wrong-on-its-face. These name a RESOLVED DEFERRAL, which was true when written and
+  # is still true as history — so whatever mechanism this entry lands should decide
+  # whether a discharged deferral needs annotating at all, or only a false claim does.
+  # Cheap either way: both are pointer updates once a licensed shape exists.
 
   # The repo has no CI for JavaScript that lives in a pack. `web/` and
   # `docs-site/` are covered — pages.yml and pack-evals.yml run npm, and both
@@ -1706,16 +1723,6 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
-  # npm-sca-gate deferrals (spec Assumptions).
-  #
-  # Dependabot: the npm SCA gate blocks merges on known CVEs, but nothing opens
-  #   the bump PRs — remediation is hand-driven (`npm audit fix
-  #   --package-lock-only`). Dependabot is the complementary automation. Left to
-  #   the repo owner because it changes weekly PR volume and review workload,
-  #   not because it is technically hard: it is one `.github/dependabot.yml`
-  #   with an `npm` ecosystem entry per project directory.
-  # Unblocks when: the repo owner decides the PR volume is wanted.
-  {slug = "npm-dependabot-wiring", summary = "Add .github/dependabot.yml with npm ecosystem entries for docs-site/ and web/ so transitive advisory bumps arrive as PRs instead of waiting for someone to run npm audit fix", source = "spec/npm-sca-gate"},
 
   # allowScripts enforcement: both docs-site/AGENTS.md and web/AGENTS.md document
   #   an invariant — the lockfile's `"hasInstallScript": true` entries must stay


### PR DESCRIPTION
## What does this change?

Adds `.github/dependabot.yml` with an `npm` ecosystem entry for each of the two Node projects (`/docs-site`, `/web`), tuned to keep weekly PR volume low.

## Why?

`tools/audit-npm.py` blocks a merge on a known npm advisory, but nothing opened the bump PRs — remediation was hand-driven (`npm audit fix --package-lock-only`) and only happened when someone went looking.

ADR-0083 chose `npm audit` as the **gate** and recorded Dependabot as complementary rather than a substitute: they answer different questions, *"may this merge?"* versus *"should we bump?"*. It deferred adoption to the repo owner explicitly on volume grounds, not technical ones — "it changes how much review the team absorbs per week."

- Implements: `docs/specs/npm-dependabot-wiring/spec.md`
- Closes: `npm-dependabot-wiring`
- Follows from: ADR-0083

### The settings answer the objection that was actually raised

| Setting | Value | Why |
|---|---|---|
| `schedule.interval` | `weekly` | not daily |
| `groups.*.update-types` | `minor`, `patch` | a quiet week is **one** PR per project, not nine |
| majors | ungrouped | they are the ones that need reading individually |
| `open-pull-requests-limit` | `5` | a burst cannot flood the queue |

Both projects ship committed lockfiles, which is what makes a lockfile-only bump PR meaningful here.

**Nothing about the merge gate changes.** No permission, no token, no workflow. `tools/audit-npm.py` still runs as a leg of `make sast` and still blocks on a known advisory.

## How do I verify it?

```bash
python3 -c "
import yaml, json, pathlib
d = yaml.safe_load(open('.github/dependabot.yml'))
assert d['version'] == 2
for u in d['updates']:
    pj = pathlib.Path(u['directory'].lstrip('/')) / 'package.json'
    assert pj.is_file(); json.load(open(pj))
    print(u['directory'], '->', pj, 'ok')
"
make build-check   # exit 0, SAST/SCA included
```

Validated by **parsing**, not by eye: nothing in CI checks `.github/dependabot.yml` — `actionlint` and `zizmor` lint *workflows*, and this is not one. So the check is that it loads as YAML at version 2 and that each `directory` resolves to a real `package.json`.

## What did you not change that you considered?

**`pip` and `github-actions` ecosystems.** `sast-requirements-not-audited` carries an explicit audit-vs-Dependabot decision for the Python side ("Decide which, then do one — doing both duplicates the noise"), so a pip entry here pre-empts it. Every action in this repo is already SHA-pinned, and enabling that ecosystem is its own volume decision nobody has taken. The approval was for *npm* wiring; quietly widening the blast radius of a volume decision is the one thing this item must not do.

**Dangling references — recorded, not silently created.** Closing this slug leaves four prose references to it in **frozen** documents: `docs/adr/0083-…md:72` and `:201`, and `docs/specs/npm-sca-gate/spec.md:203` and `:263`.

They are deliberately not corrected here. CONVENTIONS freezes an ADR body, the shipped `new-adr` template moves only the Status line, and the `## Errata` convention is RFC-scoped — there is no licensed shape for *"this accepted deferral has since been discharged"*. Inventing one would be a governance change smuggled into a config PR.

`lint-spec-status` is clean — verified by removing the slug and running it. These are prose mentions, not `(deferred: <slug>)` anchors, so no invariant depends on the slug surviving. The instance is appended to the open `adr-errata-convention` entry instead, noting its shape differs from ADR-0071's: that one names a **deleted file** (wrong on its face), these name a **resolved deferral** (true when written, still true as history). Deciding which of those needs annotating is what that entry owes.

**Also declined:**

- Retaining the slug in `[backlog].open` as an anchor, the way `starlight-migration-rfc` and the branch-protection entries are. Those are retained because a frozen spec's `(deferred: <slug>)` marker makes `lint-spec-status` invariant (iv) require them; nothing requires this one. Keeping it would make the backlog claim open work that is done — the complaint those entries' own comments make about themselves.
- Daily interval and no grouping, which surfaces advisories fastest. The only stated objection to this item was weekly review volume; optimising against the objection the owner raised is the point.

---

## Checklist

- [x] Tests pass locally (`make build-check` exit 0, SAST/SCA included)
- [x] Lint and typecheck pass (`lint-spec-status` clean)
- [ ] Self-review run via the relevant reviewer subagent — **named skip:** subagent dispatch is disabled for this session by operator instruction. In its place: the spec-less self-review checklist inline, plus a parse-level validation of the config and an enumeration of every surviving reference to the closed slug.
- [x] Spec and code agree
- [x] Living docs match reality — ADR-0083 already documents this as the complementary automation; its body is frozen and is not edited (see above)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the frozen-deferral gap is recorded against `adr-errata-convention`

🤖 Generated with [Claude Code](https://claude.com/claude-code)