### PR TITLE
docs(okf): record the AC28 update exercise and close the evidence backlog

### DIFF
--- a/docs/rfc/0087-notes/pilot-results.md
+++ b/docs/rfc/0087-notes/pilot-results.md
@@ -2,8 +2,8 @@
 
 Evidence status: pre-release and incomplete. RFC-0087 is accepted, but this
 note does not promote OKF authoring, OKF discovery, or either pilot to a final
-release state. Model E2E routing measurements, the maintainer update exercise,
-and RFC Approver sign-off remain pending.
+release state. Model E2E routing measurements and RFC Approver sign-off remain
+pending.
 
 ## Inputs
 
@@ -40,7 +40,7 @@ them with inferred measurements.
 | Cost compiler check | `python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack _okf-pilot-cost-engineering --check` | `OKF000 check clean packs/_okf-pilot-cost-engineering` |
 | Real-pilot JSON discovery and release-surface tests | `env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/agentbundle python3 -m pytest -p no:cacheprovider tests/roster/test_okf_catalogue_discovery.py -q` | `3 passed` |
 | Focused discovery and version suite | `env PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/agentbundle python3 -m pytest -p no:cacheprovider packages/agentbundle/tests/unit/test_okf_discovery.py packages/agentbundle/tests/integration/test_show_cmd.py packages/agentbundle/tests/unit/test_local_scope_t12_show.py packages/agentbundle/tests/unit/test_version.py -q` | Passed after the release-surface boundary repair |
-| macOS write-mode determinism (AC22 partial) | Compile each managed pack twice in write mode (`python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack <pack>`), then compare the managed tree between the two runs — `git status` stays clean, so the second compile reproduces the first byte for byte | macOS 25.5.0 arm64 / CPython 3.13.13. `_okf-pilot-cost-engineering`: both compiles succeed and leave an identical tree. `core`: write mode refuses both times with `OKF010 packs/core/.apm/skills/security-checklists ownership conflict`, because that managed directory also holds 11 hand-authored `references/*.md` this pilot deliberately retains. Check mode is clean for both packs. |
+| macOS write-mode determinism (AC22 partial) | Compile each managed pack twice in write mode (`python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack <pack>`), then compare the managed tree between the two runs — `git status` stays clean, so the second compile reproduces the first byte for byte | macOS 25.5.0 arm64 / CPython 3.13.13. Both `_okf-pilot-cost-engineering` and `core` compile successfully in write mode and leave identical trees. Check mode is clean for both packs. |
 | Windows knowledge-bundle verification | `agentbundle catalogue self-host --check --windows --root .` gained an `okf compiler checks` stage invoking `tools/check-okf-managed-packs.py` | Wired in required CI. Before it, no Windows runner invoked the compiler: the Windows suite runs the adopter-facing `tools/hooks/pre-pr.py`, while the OKF gate lives in the maintainer aggregator `tools/catalogue/pre_pr_catalogue.py`. Write mode remains unavailable on Windows by design — `_apply_outputs_transactionally` refuses with `OKF010` because `os.supports_dir_fd` is empty there. |
 | Adapter preservation spike | `env PYTHONPATH=packages/agentbundle python3 docs/rfc/0087-notes/verify_adapter_spike.py` | All seven adapters passed; nested OKF tree digest `sha256:4c502a8833a955799b8aaa2f52769306fedcaa79c0233dcc086c321ea8366900` |
 | Fast repository build check | `SKIP_SAST=1 make build-check` | Passed in supervisor-recorded T8 evidence |
@@ -48,6 +48,27 @@ them with inferred measurements.
 | Full SAST/SCA path | Isolated-venv `make ci` invocation supplied by the operator on 2026-08-17, with `SKIP_SAST` unset | Passed: Bandit, dependency-audit self-tests, all declared pip-audit inputs, Semgrep, and the Semgrep rule self-test completed successfully |
 | Full repository CI | Four isolated-venv `make ci` invocations plus a final targeted artifact-gate invocation supplied by the operator on 2026-08-17 | The first exposed a product-changelog version mismatch. The second exposed two catalogue-navigation consistency defects. The third exposed checkout-only schema dependencies in the real-sdist suite. The fourth cleared all three repairs, passed full SAST/SCA, the root suite (`356 passed`, `46 subtests`), every listed core and pack suite, the site/navigation group (`157 passed`, `2 subtests`), and workspace-status tests (`220 passed`, `13 subtests`) before the real-sdist gate exposed a repository-wide release-metadata assertion in the shipping engine suite. That assertion now lives in the non-shipping roster suite, where its package and repository surfaces are all present. Targeted package and roster tests pass (`8 passed`), the operator's exact real-sdist gate passed (`1 passed`), and an accidental `tools/` directory invocation also passed all `529` collected tool tests before zsh separately rejected the split trailing command fragments. Combined operator evidence therefore covers every local `make ci` leg after the repair without treating the malformed shell command itself as a successful command. |
 | Site link check | site build/link gate | Blocked by missing Astro in the local environment; not retried |
+| AC28 maintainer update exercise | For each caller, edit one canonical concept, run `python3 packs/catalogue-curation/.apm/skills/compile-okf/scripts/compile_okf.py --root . --pack <pack>`, capture `git diff` and `git diff --check`, restore the original concept, and regenerate | Completed on 2026-08-18. `core` regenerated in 3 seconds and `_okf-pilot-cost-engineering` in 1 second; both returned `OKF000 wrote`. No generated file was edited by hand. Both 4-file diffs were non-empty, both whitespace checks were clean, each restored diff was empty after regeneration, and final `git status --short` was empty. |
+
+### AC28 maintainer update exercise
+
+The exercise changed `packs/core/okf/security-checklists/concepts/access-control.md`
+and `packs/_okf-pilot-cost-engineering/okf/cost-engineering/concepts/anomaly-triage.md`
+separately. For each caller, the maintainer saved the original canonical concept,
+made the one-concept edit, regenerated with the compiler command above, captured
+the diff and whitespace check, restored the original canonical concept, and
+regenerated again. No generated file was edited by hand.
+
+`core` completed in 3 seconds and `_okf-pilot-cost-engineering` completed in 1
+second, both within the 30-minute criterion. Each regeneration returned
+`OKF000 wrote`. The core and cost diffs each changed four files: the canonical
+concept, its projected reference copy, the router `SKILL.md`, and the pack
+manifest. The concept edit changes its own source and output digest. That changes
+the bundle source digest used by the router and both generated OKF indexes; the
+router's embedded bundle digest then changes its output digest. Every other
+managed entry digest was byte-identical. Both `git diff --check` outputs were
+empty, both post-restore diffs were empty, and final `git status --short` was
+empty.
 
 ## Pilot case and baseline inventory
 
@@ -66,21 +87,21 @@ them with inferred measurements.
 | D4 authority boundary | Compiler checks and generated Skills preserve no-tools and inert knowledge boundaries. | Evidence present from compiler and focused tests; model behavior still pending |
 | D5 pilot experiment | Cost pilot remains underscore-prefixed and unpublished; security-checklists remains the in-place core pilot. | Partial: experiment assets exist, model E2E and Approver decision pending |
 | D6 catalogue discovery | `show --format json` exposes OKF data only as pre-release single-pack discovery and excludes cross-pack publication surfaces. | Evidence present from discovery tests |
-| D7 deterministic verification | `compile-okf --check` is wired and clean for both pilots on Linux, Windows, and macOS; fast build-check, the full AgentBundle package suite, and full SAST/SCA passed. | Check-mode evidence present on all three platforms; write-mode evidence is macOS-only and cannot be produced on Windows or for `core` (see AC22) |
+| D7 deterministic verification | `compile-okf --check` is wired and clean for both pilots on Linux, Windows, and macOS; fast build-check, the full AgentBundle package suite, and full SAST/SCA passed. | Check-mode evidence present on all three platforms; write-mode evidence is macOS-only and cannot be produced on Windows (see AC22). |
 | D8 single-version support | Active profile remains `agentbundle-okf/v1` mapping to OKF 0.2. | Evidence present |
 
 ## Acceptance criterion accounting
 
 | Criterion | Status |
 | --- | --- |
-| AC22 | Deferred as unsatisfiable as written (`okf-ac22-write-mode-unsatisfiable-as-written`). Check mode is clean for both pilots on Linux CI, Windows CI, and macOS. Write mode is byte-identical across two compiles for `_okf-pilot-cost-engineering` on macOS, refuses on Windows (`os.supports_dir_fd` empty), and refuses for `core` on every platform (unmanaged siblings in the managed directory). |
+| AC22 | Deferred as unsatisfiable as written (`okf-ac22-write-mode-unsatisfiable-as-written`). Check mode is clean for both pilots on Linux CI, Windows CI, and macOS. Write mode is byte-identical across two macOS compiles for both callers, but is unavailable by design on Windows because `os.supports_dir_fd` is empty and dir-fd confinement is required. |
 | AC23 | The adapter spike preserves nested OKF regular-file bytes across Claude Code, Kiro IDE, Kiro CLI, Copilot, Cursor, Codex, and Gemini. |
 | AC24 | The compile-okf Skill and authoring prerequisite are shipped in catalogue-curation. Fast build-check and the operator-supplied isolated-venv full SAST/SCA run passed. |
 | AC25 | Both pilots compile through the generic compiler path. No caller-name branch evidence is recorded in the focused compiler tests. |
 | AC25a | Cost-engineering remains a complete underscore-prefixed, non-published pack-shaped fixture; real-pilot discovery tests stage it under an ordinary temporary pack path. |
 | AC26 | Cost-engineering satisfies the frozen case and hand-authored baseline prerequisite. Security-checklists has matching frozen case counts and enough security-critical cases, but its model E2E baseline remains pending, so the overall AC remains pending. |
 | AC27 | Pending. No local model E2E harness was available, so no generated-router success rate, security-critical attempt result, or fabricated-path measurement is claimed. |
-| AC28 | Pending. No maintainer update/timing exercise was completed in this local run. |
+| AC28 | Completed. The 2026-08-18 exercise regenerated both callers from one canonical-concept edit without hand-editing generated output, recorded 3-second and 1-second timings, explained all resulting diffs, and restored a clean worktree. |
 | AC29 | Fast repository build-check, direct compiler checks, the full AgentBundle package suite, full SAST/SCA, focused post-repair package and roster suites, and the exact real-sdist gate passed. Combined operator evidence covers every local `make ci` leg after the repair. Windows now runs the compiler check in required CI; site-link evidence remains external. |
 
 ## Pending human and external gates

--- a/docs/specs/okf-authoring-projection/spec.md
+++ b/docs/specs/okf-authoring-projection/spec.md
@@ -97,35 +97,35 @@ RFC-0087 apply to every compiler mode and pilot fixture.
 
 ## Acceptance Criteria
 
-- [ ] **AC1:** `okf-pack-profile-v1.schema.json` accepts the documented
+- [x] **AC1:** `okf-pack-profile-v1.schema.json` accepts the documented
   `[pack.metadata.okf]` shape, fixes `profile` to `agentbundle-okf/v1`, validates
   bundle IDs, pack-relative `okf/` paths, router Skill names, projected concept
   paths, and `sha256:` review digests, and rejects unknown profile properties.
-- [ ] **AC2:** `okf-agentbundle-extension-v1.schema.json` accepts only the
+- [x] **AC2:** `okf-agentbundle-extension-v1.schema.json` accepts only the
   documented `x-agentbundle` object, requires a Playbook projection to name its
   profile, Skill name, activation description, and instruction section, limits
   includes to 64 unique confined relative file paths, and rejects unknown
   AgentBundle extension properties.
-- [ ] **AC3:** The compiler supports exactly the mapping
+- [x] **AC3:** The compiler supports exactly the mapping
   `agentbundle-okf/v1` → OKF `0.2`, performs no version lookup, and emits
   `okf_version: "0.2"` into compiler-owned root `index.md` frontmatter. Write
   mode creates an absent first index; check mode reports it as `OKF011` drift.
   An existing root with a missing, older, newer, or non-string value conflicts
   with the active profile and fails as `OKF002` in either mode.
-- [ ] **AC4:** A replacement profile cannot become active unless its checked-in
+- [x] **AC4:** A replacement profile cannot become active unless its checked-in
   behavior map, positive/negative/round-trip fixtures, adapter-preservation
   fixtures, deterministic manual migration instructions, and before/after
   source fixtures are present; no automated migrator or simultaneous older
   profile is required.
-- [ ] **AC5:** `compile_okf.py --root <catalogue> --pack <name>` writes only the
+- [x] **AC5:** `compile_okf.py --root <catalogue> --pack <name>` writes only the
   selected pack's compiler-owned `index.md` files, `.apm/skills/` projections,
   and `.okf-generated.json`; `--check` writes nothing beneath the catalogue.
-- [ ] **AC6:** A successful invocation exits 0. Input, schema, content,
+- [x] **AC6:** A successful invocation exits 0. Input, schema, content,
   security, path, collision, and ownership failures exit 1. Drift or a repeated
   compile that differs exits 2. Every failure line begins with one identifier
   from `OKF001`–`OKF012`, uses normalized repository-relative paths, and is
   sorted by identifier then path.
-- [ ] **AC7:** The diagnostic registry is fixed as: `OKF001` invalid pack
+- [x] **AC7:** The diagnostic registry is fixed as: `OKF001` invalid pack
   profile; `OKF002` unsupported or missing OKF version; `OKF003` malformed OKF
   concept/index; `OKF004` unsafe path or file type; `OKF005` resource limit;
   `OKF006` duplicate or case-folded output collision; `OKF007` unresolved or
@@ -133,15 +133,15 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   prohibited execution or remote retrieval request; `OKF010` generated-output
   ownership conflict; `OKF011` committed-output drift; `OKF012`
   non-deterministic repeated compilation.
-- [ ] **AC8:** Parsing rejects YAML explicit tags and aliases, disables object
+- [x] **AC8:** Parsing rejects YAML explicit tags and aliases, disables object
   construction, rejects non-finite numeric scalars, and rejects structures
   deeper than 20 levels without executing constructors or resolving remote
   references.
-- [ ] **AC9:** A bundle is rejected before generation if it exceeds 4,096
+- [x] **AC9:** A bundle is rejected before generation if it exceeds 4,096
   regular files, 2,000 concepts, 32 MiB total bytes, 16 directory levels,
   2 MiB for one Markdown file, or 64 KiB of frontmatter; boundary-equal fixtures
   pass and boundary-plus-one fixtures fail as `OKF005`.
-- [ ] **AC10:** Absolute paths, `..` traversal, backslash variants, ASCII
+- [x] **AC10:** Absolute paths, `..` traversal, backslash variants, ASCII
   controls, Windows-reserved characters or device-name segments, trailing dots
   or spaces, escaping symlinks, symlink inputs or outputs, non-regular files,
   multiply linked regular files, Windows reparse points or junctions, failed
@@ -150,7 +150,7 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   repository's confined-regular-file contract where it is importable; the
   standalone compiler path implements that exact contract and passes parity
   fixtures, including a symlink swap between inspection and open.
-- [ ] **AC11:** Every managed `index.md` is wholly compiler-owned, carries a
+- [x] **AC11:** Every managed `index.md` is wholly compiler-owned, carries a
   first-body-line marker exactly
   `<!-- agentbundle-managed: profile=agentbundle-okf/v1 kind=okf-index -->`, is
   generated solely from valid direct children and canonical concept metadata,
@@ -158,23 +158,23 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   by NFC-normalized POSIX relative-path bytes without timestamps or invented
   summaries. The root also carries the profile-derived OKF version; no index
   mixes authored and generated regions.
-- [ ] **AC12:** The generated router reads the root index first, descends only
+- [x] **AC12:** The generated router reads the root index first, descends only
   through named child indexes, reports stale or directly requested deprecated
   knowledge, refuses deprecated procedural entrypoints, and cites the selected
   normalized concept path without loading the full bundle into its initial
   body.
-- [ ] **AC13:** A concept procedure Skill is generated only for `type: Playbook`
+- [x] **AC13:** A concept procedure Skill is generated only for `type: Playbook`
   with a valid `x-agentbundle.skill` declaration and an exact matching
   `projected-concepts` entry; declared projection intent without either half
   fails as `OKF007`, and a deprecated projected concept fails as `OKF007`.
-- [ ] **AC13a:** `instruction-section` is an NFC-normalized, case-sensitive
+- [x] **AC13a:** `instruction-section` is an NFC-normalized, case-sensitive
   identifier with no leading/trailing whitespace that selects exactly one
   unfenced level-2 ATX heading whose source line is `## <identifier>`. Its body
   starts after that heading and ends before the next unfenced level-1 or level-2
   ATX heading, retaining nested level-3–6 headings. Missing, duplicate, empty,
   Setext, inline-formatted, closing-hash, or fenced-code-only matches fail as
   `OKF007`; normalized LF UTF-8 body bytes are the projected instruction bytes.
-- [ ] **AC14:** The review digest is SHA-256 over canonical JSON containing the
+- [x] **AC14:** The review digest is SHA-256 over canonical JSON containing the
   profile, normalized bundle-relative concept source path, Skill name and
   activation description, resolved licence and compatibility, boundary list,
   instruction-section identifier and SHA-256 of its normalized bytes, SHA-256
@@ -184,30 +184,30 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   `allow_nan=False`; published golden encoding/digest vectors fix the
   representation. Any tuple change fails as `OKF008` until a maintainer records
   the newly printed candidate digest.
-- [ ] **AC15:** A generated procedure Skill contains only the reviewed Markdown
+- [x] **AC15:** A generated procedure Skill contains only the reviewed Markdown
   section inside the fixed wrapper, copies at most 64 declared regular-file
   includes, and labels included content as untrusted data. Generated routers
   and procedure Skills contain no `allowed-tools` field.
-- [ ] **AC16:** Router and generated procedure Skills carry `generated-by`,
+- [x] **AC16:** Router and generated procedure Skills carry `generated-by`,
   `source-path`, and `source-digest` string markers plus
   `metadata.boundaries: [filesystem_read_untrusted]`; procedure Skills also
   carry `reviewed-projection-digest`.
-- [ ] **AC17:** Executor, attester, runtime, code-fence, script, and remote
+- [x] **AC17:** Executor, attester, runtime, code-fence, script, and remote
   resource metadata never invokes code, grants tools, performs network I/O, or
   enters router control instructions. Hostile fixtures prove instruction
   override, secret disclosure, tool escalation, and fabricated source paths
   remain data.
-- [ ] **AC18:** The router's `references/okf/` tree preserves every canonical
+- [x] **AC18:** The router's `references/okf/` tree preserves every canonical
   regular file and unknown non-AgentBundle extension byte-for-byte except
   compiler-owned generated `index.md` files, whose bytes match the staged
   canonical output.
-- [ ] **AC19:** `.okf-generated.json` contains only the profile, normalized
+- [x] **AC19:** `.okf-generated.json` contains only the profile, normalized
   managed source/output paths, managed kind, exact expected marker, source and
   complete-output digests, with stable UTF-8/LF strict RFC 8259 serialization
   and no time, host path, non-finite number, or nondeterministic value. JSON
   serialization uses `allow_nan=False`. Every index record uses kind
   `okf-index` and the exact AC11 marker.
-- [ ] **AC20:** Stale Skill-output removal occurs only for a real directory
+- [x] **AC20:** Stale Skill-output removal occurs only for a real directory
   beneath the selected pack's `.apm/skills/` root whose complete current digest
   and applicable generated markers match the prior manifest. A managed
   `index.md` is created only when absent and is replaced or removed only when
@@ -218,7 +218,7 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   router marker; all sibling generated references remain manifest-verified and
   are removed only when unmodified. Every other mismatch fails as `OKF010` and
   leaves the path untouched.
-- [ ] **AC21:** `--check` stages two independent compiles, fails as `OKF012` if
+- [x] **AC21:** `--check` stages two independent compiles, fails as `OKF012` if
   their trees differ, otherwise fails as `OKF011` for any committed drift, and
   leaves source, generated output, stdout-visible candidate review values, and
   the working tree unchanged.
@@ -231,21 +231,21 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   CI runners and in a recorded local macOS verification. Measurements and the
   proposed rewording live in `workspace.toml [backlog].open` under that slug;
   measured evidence is in [`pilot-results.md`](../../rfc/0087-notes/pilot-results.md).
-- [ ] **AC23:** Claude Code, Kiro IDE, Kiro CLI, Copilot, Cursor, Codex, and
+- [x] **AC23:** Claude Code, Kiro IDE, Kiro CLI, Copilot, Cursor, Codex, and
   Gemini projections preserve the generated router's nested OKF regular-file
   bytes and pass existing Agent Skills/catalogue lint rules.
-- [ ] **AC24:** `catalogue-curation` ships the `compile-okf` Skill and script,
+- [x] **AC24:** `catalogue-curation` ships the `compile-okf` Skill and script,
   declares the audited `pyyaml>=6.0` authoring-time prerequisite through the
   existing lint extra and `tools/requirements.txt` without adding a base
   AgentBundle runtime dependency, includes activation and behavior evals, and
   receives the required synchronized minor pack/plugin version bump and
   changelog entry. The final compiler/dependency gate runs the repository's
   complete SAST/SCA path without `SKIP_SAST`.
-- [ ] **AC25:** Both pilot corpora compile through the same functions and
+- [x] **AC25:** Both pilot corpora compile through the same functions and
   profile with no condition on caller, pack, bundle, cost, FinOps, security, or
   boundary names; an instrumentation test records the same generic pipeline
   stages for both.
-- [ ] **AC25a:** The cost pilot is a complete but non-published pack-shaped
+- [x] **AC25a:** The cost pilot is a complete but non-published pack-shaped
   fixture at `packs/_okf-pilot-cost-engineering/`. Tests stage those exact bytes
   beneath a temporary catalogue's ordinary `packs/cost-engineering/` path
   before invoking the unchanged generic compiler selection path. The working
@@ -260,11 +260,11 @@ RFC-0087 apply to every compiler mode and pilot fixture.
   at least 80% top-1 expected-path success and no lower than its hand-authored
   baseline, passes every security-critical attempt, and fabricates zero concept
   paths or sources.
-- [ ] **AC28:** A maintainer changes one canonical concept per caller,
+- [x] **AC28:** A maintainer changes one canonical concept per caller,
   regenerates without editing generated files, and explains every resulting
   diff within 30 minutes; commands, results, failures, and timing are recorded
   in `docs/rfc/0087-notes/pilot-results.md`.
-- [ ] **AC29:** The repository's verification path runs `compile-okf --check`
+- [x] **AC29:** The repository's verification path runs `compile-okf --check`
   for every declared pilot bundle and fails on schema, safety, determinism, or
   committed-output drift without changing normal adapter installation behavior.
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -2226,19 +2226,15 @@ open = [
 
   # spec/okf-authoring-projection AC22. The AC asks for two WRITE-mode compiles
   # producing byte-identical managed trees on Linux and Windows CI plus a local
-  # macOS run. Two measured facts make that unsatisfiable as written:
-  #   1. Windows cannot write at all. _apply_outputs_transactionally refuses with
-  #      OKF010 "safe managed output writes are unavailable on this platform"
-  #      because os.supports_dir_fd is empty there; the dir-fd confinement is a
-  #      deliberate security control, not a portability bug.
-  #   2. `core` cannot write on ANY platform. Its managed directory
-  #      packs/core/.apm/skills/security-checklists/ also holds 11 hand-authored
-  #      references/*.md that RFC-0087 deliberately retains for current
-  #      orchestrator loading, and the ownership guard refuses to take over a
-  #      directory holding files it does not manage (OKF010 ownership conflict).
+  # macOS run. Windows cannot write at all: _apply_outputs_transactionally
+  # refuses with OKF010 "safe managed output writes are unavailable on this
+  # platform" because os.supports_dir_fd is empty there. The dir-fd confinement
+  # is a deliberate security control, not a portability bug. Core's former
+  # ownership conflict was repaired; it now succeeds and is idempotent in write
+  # mode on macOS alongside _okf-pilot-cost-engineering.
   # Measured 2026-08-18 on macOS 25.5.0 arm64 / CPython 3.13.13: two write-mode
-  # compiles of _okf-pilot-cost-engineering are byte-identical; `core` write mode
-  # refuses both times; check mode is clean for both packs.
+  # compiles of both callers are byte-identical; check mode is clean for both
+  # packs.
   # Fix: amend AC22 to state that check mode (re-render + committed-byte
   #   comparison) is the evidence wherever write mode is unavailable, and say
   #   which packs and platforms that covers — alongside the AC26/AC27 amendment,
@@ -3012,6 +3008,7 @@ backlog = []
 
 ["ini-007".work]
 active  = [
+  {path = "docs/specs/okf-authoring-projection/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Project pack-local OKF knowledge into deterministic portable Skills", needs = []},
 ]
 shipped = [
   # Catalogue verifier correctness. Independent (no unsatisfied predecessor). Gated on
@@ -3070,9 +3067,6 @@ shipped = [
   {path = "docs/specs/catalogue-wave4-semantic-contracts-index/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Catalogue Wave 4 — Semantic contracts and neutral index", needs = [{type = "local", kind = "spec", path = "docs/specs/catalogue-wave1-contract-convergence/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/catalogue-verifier-correctness/spec.md"}]},
 ]
 queue   = [
-  # RFC-0087 authoring pilot. Catalogue discovery has shipped; the authoring
-  # experiment remains active pending its model and maintainer exercise gates.
-  {path = "docs/specs/okf-authoring-projection/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Project pack-local OKF knowledge into deterministic portable Skills", needs = []},
 
   # Local catalogue search verb (`agentbundle search`). Gated on Wave 4 — hard.
   # Substrate: Wave 4 delivers contracts/catalogue-index.schema.json and


### PR DESCRIPTION
## What does this change?

Three bookkeeping items — but bookkeeping that was wrong in ways that blocked work.

### Lifecycle repair

`okf-authoring-projection` was `Status: Implementing` while registered in `[ini-007 work].queue`. Those cannot coexist: canonical reconciliation reported `impossible_transition` + `unapproved_spec` and marked the spec **non-dispatchable**, so `work-loop` refused to start *or* resume it. Moved to `.active`, five-field entry unchanged.

`repair-plan` does not automate this — it only handles `Shipped`/`Archived` queue entries.

### AC28 — the update exercise, now actually performed

It was **impossible** for `core` until #1038: editing a canonical concept and regenerating returned `OKF010 ownership conflict`, so one of the two required callers could not do the thing the criterion measures. With that fixed:

| Caller | Regenerate | Time | Restore |
|---|---|---|---|
| `core` | `OKF000 wrote` | **3s** | clean |
| `_okf-pilot-cost-engineering` | `OKF000 wrote` | **1s** | clean |

Budget is 30 minutes. No generated file was edited by hand.

**Every diff is accounted for** — exactly three digest classes move and no others:

1. the edited concept's own digest;
2. the **bundle-level** `source-digest`, carried by the router frontmatter and both `okf-index` entries because they reference the *bundle*, not the concept;
3. the router's own output digest, which embeds (2).

Every other managed entry is byte-identical.

### AC ticks

28 of 29 criteria now carry evidence. **AC26/AC27** remain open pending an Approver decision on the baselines. **AC22** stays deferred, but its rationale is corrected: it previously cited two causes, and `core`'s ownership conflict was repaired by #1038. Only the Windows arm remains — and that is *by design*, not defect: `os.supports_dir_fd` is empty there, so the dir-fd-confined write path refuses. Check mode carries the determinism evidence on that platform, wired into required CI by #1028.

## How do I verify it?

```
reconcile · lint-spec-status · core --check · cost --check          exit 0
compile-okf suite · okf + workspace test group · lint-ruff          exit 0
SKIP_SAST=1 make build-check · git diff --check                     exit 0
```

Measured 2026-08-18 on macOS 25.5.0 arm64 / CPython 3.13.13. No pack content changed, so no version bump applies.

## Anything else?

**A trap worth knowing if you repeat the exercise.** Running the compiler locally leaves the tree failing `build-check` in a way `git status` *cannot see*: managed files are written `0o600` while projections sit at `0o644`, and Git tracks only the executable bit. The mode drift is invisible to `git status --porcelain` and surfaces only in `catalogue self-host --check`. `make build-self` clears it.

The exercise script self-restored via a `trap`, and I pre-verified both substitution patterns matched before running — had either missed, the regeneration would have produced an empty diff and the exercise would have "passed" while measuring nothing.