### PR TITLE
fix(ci): install the full dev dependency set in the release Gate H

### DIFF
--- a/.github/workflows/release-agentbundle.yml
+++ b/.github/workflows/release-agentbundle.yml
@@ -143,7 +143,15 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install agentbundle (editable) + optional extras + pytest
-        run: python -m pip install -e 'packages/agentbundle[lint]' -e packages/credbroker pytest
+        # `tools/requirements.txt` is the canonical dev-dependency list and is
+        # what build-check.yml installs. Gate H previously installed only the
+        # `[lint]` extra (pyyaml), so `jsonschema` was absent and three modules
+        # that import it at module scope failed collection — `agentbundle
+        # 0.38.1` could not publish. Gate H is `if: ref_type == 'tag'`, so it
+        # never runs on a PR and nothing could observe the gap until a real
+        # release was attempted. Install from the shared file rather than
+        # re-listing deps here, so this cannot drift out of sync again.
+        run: python -m pip install -r tools/requirements.txt -e 'packages/agentbundle[lint]' -e packages/credbroker pytest
 
       - name: Full agentbundle test suite (Gate H pre-publish)
         working-directory: packages/agentbundle


### PR DESCRIPTION
## What

One line: Gate H in `release-agentbundle.yml` now installs
`-r tools/requirements.txt` alongside the editable packages.

## Why

Tagging `agentbundle-v0.38.1` failed. `Gate H — pre-release gates` installed only:

```
python -m pip install -e 'packages/agentbundle[lint]' -e packages/credbroker pytest
```

The `[lint]` extra is `pyyaml>=6.0` and nothing else, so `jsonschema` was absent.
Three modules import it at module scope:

- `tests/contracts/test_agentbundle_show_schema.py`
- `tests/contracts/test_skill_schema.py`
- `tests/integration/test_show_cmd.py`

```
from jsonschema import Draft202012Validator
E   ModuleNotFoundError: No module named 'jsonschema'
Interrupted: 3 errors during collection
```

Exit 2 → `pre-release-gates` failed → `publish-pypi` skipped → no release.
(`publish-artifactory` reported success having published nothing: its
secret-presence check exits 0 with a notice when secrets are unset.)

## Why it survived until now

Gate H is `if: github.ref_type == 'tag'`. It never runs on a pull request — it
reports `skipping` there. So the job guarding publication was the one job whose
environment nothing could exercise until a real release was attempted. A green
PR could never have caught this.

## Why `tools/requirements.txt` rather than adding `jsonschema` inline

`build-check.yml` already installs from that file (lines 81, 794), and the file
carries `jsonschema>=4.0` with a comment explaining why it is needed. Re-listing
dependencies in a second workflow is how the two drifted apart in the first
place; sourcing both from one file removes the drift rather than patching this
instance of it. `build-check.yml` line 815 already names the complete set as
`_DEPENDENCY_IMPORTS = ("pytest", "yaml", "jsonschema", "credbroker")`.

## Verification

Gate H cannot be exercised by this PR — that is the defect. Verified by
establishing that `jsonschema` is the only missing dependency (the three modules'
sole unguarded third-party import beyond `pytest` and `agentbundle` itself) and
running them with it present:

```
python3 -m pytest tests/contracts/test_agentbundle_show_schema.py \
  tests/contracts/test_skill_schema.py tests/integration/test_show_cmd.py -q
135 passed
```

Also verified: workflow YAML parses, and `tools/lint-ci-parity.py` reports
`ok — 77 step(s) across 1 in-scope workflow(s), all dispositioned`.

The real proof is the next tag run reaching `publish-pypi`.

## Follow-up not taken here

`publish-artifactory` reporting `success` while publishing nothing is a separate
latent problem — a job named "publish" whose exit code does not distinguish
"published" from "skipped because unconfigured". Out of scope for unblocking the
release; worth its own change.