### PR TITLE
fix(ci): key the Pages concurrency group so runs stop cancelling across branches

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,10 +56,14 @@ on:
 permissions:
   contents: read
 
-# Allow only one concurrent deployment; cancel in-flight runs on new push.
+# AC12's ratified shape: PR runs key on server-assigned github.ref
+# (refs/pull/<n>/merge), so only the same PR supersedes itself and forks cannot
+# influence the key. Non-PR runs key on github.run_id and cannot be cancelled.
+# The former unkeyed "pages" group let every Pages run cancel another (18 of 40,
+# including a PR cancelling a main deploy); see deploy below for the production lane.
 concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  group: pages-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -214,6 +218,15 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: build
+    # Production writers must not be terminated mid-write; environments do not
+    # serialize deployments. GitHub permits one running and one pending entry, so
+    # a third queued deployment can displace the pending entry. This group must be
+    # bare "pages" for rollout ordering; the workflow group must retain its keyed
+    # "pages-" prefix and never become bare "pages", or matching job/workflow
+    # groups deadlock and GitHub skips this job.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/specs/pages-concurrency-isolation/plan.md
+++ b/docs/specs/pages-concurrency-isolation/plan.md
@@ -1,0 +1,26 @@
+# Plan: pages-concurrency-isolation
+
+- **Spec:** [spec.md](spec.md)
+- **Status:** Done
+
+> **Plan contract:** This plan records the smallest implementation and verification sequence required to satisfy the linked specification.
+
+<!-- Lean fill: only the workflow edit and its goal-based verification are recorded. Dependency, rollout, migration, and test-stub sections are omitted because this is a reversible CI configuration change with no new code path. -->
+
+## Approach
+
+Separate build isolation from deployment serialization: apply the ratified AC12 workflow-level expression, then add the non-cancelling bare `pages` job-level lane to the sole Pages writer so it preserves rollout ordering with in-flight old-workflow runs holding the workflow-level `pages` group.
+
+## Tasks
+
+1. Replace the workflow-level Pages concurrency block with the AC12 PR/non-PR expression.
+   Tests: no stub (goal-based).
+   Done when: PR runs group by `github.ref`, while every non-PR run uses `github.run_id` and is not cancelled.
+
+2. Add the bare `pages` non-cancelling concurrency lane to the `deploy` job, preserving rollout ordering with in-flight old-workflow runs holding the workflow-level `pages` group.
+   Tests: no stub (goal-based).
+   Done when: main deploys share the bare `pages` job-level lane without cancelling an in-flight deployment.
+
+3. Run the workflow posture, specification-status, YAML, lint, and build-check gates.
+   Tests: no stub (goal-based).
+   Done when: all requested verification commands complete successfully.

--- a/docs/specs/pages-concurrency-isolation/spec.md
+++ b/docs/specs/pages-concurrency-isolation/spec.md
@@ -1,0 +1,55 @@
+# Spec: pages-concurrency-isolation
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [plan.md](plan.md)
+
+> **Spec contract:** This document defines the accepted behavior and boundaries for this change. Implementation and verification must satisfy every acceptance criterion.
+
+<!-- Mode: light (work-loop). No risk trigger fired: the change adds no dependency, crosses no security boundary, is not structural or a public-interface change, and is reversible rather than destructive. -->
+
+## Objective
+
+Prevent Pages validation runs from cancelling unrelated sessions while preserving a single, non-cancelling production deployment lane.
+
+## Acceptance Criteria
+
+- [x] AC1 — The workflow-level concurrency group is keyed so a `pull_request` run groups by `github.ref` and every non-PR event receives a unique `github.run_id` group; no two distinct refs share a group, while repeated runs of the same PR ref intentionally do so a superseded run is cancelled, and `github.head_ref` is not used.
+- [x] AC2 — `cancel-in-progress` is true only for `pull_request` events.
+- [x] AC3 — The `deploy` job carries its own repo-wide bare `pages` lane with `cancel-in-progress: false`, preserving rollout ordering with in-flight old-workflow runs that hold the workflow-level `pages` group while serializing main deployments without cancelling an in-flight deployment.
+- [x] AC4 — `python3 tools/test-pages-workflow.py` exits 0; the deploy-blocking posture contract for path filters, gate presence, gate ordering, and `deploy-needs-build` is unchanged.
+- [x] AC5 — Only the two concurrency blocks and their directly associated explanatory comments change; `paths:` filters, steps, gate ordering, `permissions:`, and action pins remain byte-identical.
+
+## Boundaries
+
+Always do:
+
+- Keep build concurrency isolated per PR and non-cancelling for non-PR events.
+- Serialize production Pages writers in the deploy job.
+
+Never do:
+
+- Use `github.head_ref` for the concurrency key.
+- Change path filters, steps, gate ordering, permissions, action pins, or other workflows.
+
+## Testing Strategy
+
+Goal-based verification:
+
+```bash
+python3 tools/test-pages-workflow.py
+python3 .claude/skills/work-loop/scripts/lint-spec-status.py
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pages.yml'))"
+make lint-ruff
+SKIP_SAST=1 make build-check
+```
+
+## Assumptions
+
+- About 45% of recent Pages runs were cancelled; allowing qualifying runs to complete will increase Pages CI consumption.
+- GitHub concurrency allows one running and one pending run per group, so a third queued deployment can still displace the pending deployment.
+- The deploy lane gives mutual exclusion, NOT ordering. Because builds now run in distinct workflow groups, two Pages-relevant merges to `main` build concurrently and their deploy jobs enter the shared `pages` lane in build-completion order, which need not match merge order — so the older commit's content can be published last. This is a TRADE, not a pure win: under the previous unkeyed group the newer run cancelled the older one outright, so inversion was impossible. The window needs two Pages-relevant merges inside one build duration AND inverted build completion; it self-heals on the next Pages-relevant merge, and it does not lose data. A "deploy only if still the tip of `main`" guard is deliberately NOT added here — no acceptance criterion requires it and it introduces its own skip path. Tracked as `pages-deploy-ordering-not-guaranteed`.
+
+## Deferred
+
+No required-CI assertion covers `pages.yml` concurrency; `tools/test-pages-workflow.py` deliberately does not cover it. The gap is tracked as `pages-concurrency-has-no-regression-gate` in `workspace.toml`.

--- a/workspace.toml
+++ b/workspace.toml
@@ -2886,6 +2886,26 @@ open = [
   # marketing catalogue and pack cards, so aligning it is a naming decision
   # across surfaces that spec does not own.
   { slug = "iac-terraform-group-label-alignment", source = "spec/guide-title-clarity", summary = "Align the iac-terraform sidebar GROUP label with its retitled index page" },
+  # tools/test-pages-workflow.py deliberately does not assert concurrency: its
+  # charter is deploy-blocking gates, their ordering, and paths: filters, and
+  # every assertion family requires mutation coverage. Required CI therefore
+  # would not catch restoration of unkeyed group: "pages" with cancellation,
+  # which cancelled 18 of 40 runs, including a PR run cancelling a main deploy.
+  # Closing this needs a dedicated mutation-tested concurrency check and a
+  # tools/lint-ci-parity.py registration, not a patch; avoid the unwired
+  # tools/test-ci-security-workflow.py anti-precedent. Unblocks when: ready now.
+  { slug = "pages-concurrency-has-no-regression-gate", source = "spec/pages-concurrency-isolation (review concern)", summary = "pages.yml concurrency has no required-CI assertion, so restoring unkeyed group: \"pages\" would silently reintroduce cross-branch run cancellation" },
+  # Surfaced by a peer session while coordinating the pages-concurrency-isolation
+  # merge. The deploy lane serializes Pages deployments but does NOT order them:
+  # builds now run in distinct workflow groups, so two Pages-relevant merges to main
+  # build concurrently and their deploy jobs enter the shared "pages" lane in
+  # build-completion order, which need not match merge order. The older commit can
+  # therefore publish last. Self-heals on the next Pages-relevant merge and loses no
+  # data, but it is a real trade: the previous unkeyed group made inversion impossible
+  # by cancelling the older run outright. A "deploy only if still the tip of main"
+  # guard would close it and was declined as unrequested hardening with its own skip
+  # path. Decide whether the burst rate on main justifies it. Unblocks when: ready now.
+  { slug = "pages-deploy-ordering-not-guaranteed", source = "spec/pages-concurrency-isolation (peer coordination)", summary = "Pages deploy lane serializes but does not order deployments, so an older commit can publish last after two close merges to main" },
 ]
 
 # Resolved repo-durable items. Kept rather than deleted so a reader who arrives

--- a/workspace.toml
+++ b/workspace.toml
@@ -2904,7 +2904,14 @@ open = [
   # data, but it is a real trade: the previous unkeyed group made inversion impossible
   # by cancelling the older run outright. A "deploy only if still the tip of main"
   # guard would close it and was declined as unrequested hardening with its own skip
-  # path. Decide whether the burst rate on main justifies it. Unblocks when: ready now.
+  # path. Decide whether the burst rate on main justifies it — and note the two
+  # arguments point OPPOSITE ways: a high burst rate makes inversion more likely but
+  # the stale window shorter, while a quiet period makes inversion rarer and the
+  # window unbounded. "Self-heals on the next Pages-relevant merge" is load-bearing on
+  # there BEING a next merge: an inverted pair that is the last Pages-relevant activity
+  # before a weekend or freeze leaves the site on the older commit for the whole gap,
+  # with nothing signalling it. Weigh both cases, not just the burst one.
+  # Unblocks when: ready now.
   { slug = "pages-deploy-ordering-not-guaranteed", source = "spec/pages-concurrency-isolation (peer coordination)", summary = "Pages deploy lane serializes but does not order deployments, so an older commit can publish last after two close merges to main" },
 ]
 


### PR DESCRIPTION
## What does this change?

`pages.yml`'s workflow-level concurrency group is now keyed per-ref for pull requests and per-`run_id` for every other event, instead of the unkeyed literal `group: "pages"`. The `deploy` job takes its own bare `pages` lane at `cancel-in-progress: false` so production deployments still serialize and are never killed mid-write.

## Why?

Spec: [`docs/specs/pages-concurrency-isolation/spec.md`](docs/specs/pages-concurrency-isolation/spec.md). Shape is the ratified one from [`docs/specs/ci-gate-parallelization/spec.md`](docs/specs/ci-gate-parallelization/spec.md) AC12.

The old group was repo-wide rather than per-ref, so **any** Pages run from **any** branch cancelled any other in flight. 18 of the last 40 runs were cancelled (45%) — including two dependabot branches 8 seconds apart, and a PR run cancelling a main deploy.

The cost was not mainly wasted minutes. Because `build` and `deploy` share the workflow they died together, and a `cancelled` Pages run is visually indistinguishable from a real failure. Three sessions independently spent time last night deciding whether a cancellation was their own defect; one had to warn two others not to misread it. And because `pages.yml` is not a required merge context, every one of those cancellations was a deploy that shipped **without** its 60-case browser matrix and emitted-site assertions having completed.

`github.head_ref` is deliberately not used — it is fork-supplied, and AC12 forbids it for that reason.

## How do I verify it?

```bash
python3 tools/test-pages-workflow.py          # posture contract intact
python3 tools/lint-ci-parity.py
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pages.yml'))"
make lint-ruff
SKIP_SAST=1 make build-check                  # run after: rm -rf dist && make build
```

`tools/test-pages-workflow.py` asserts **nothing** about concurrency (by design — its charter is deploy-blocking gates and path filters), so its green is not evidence this fix works. Verification was a harness that parses the real workflow, evaluates the real group expressions under simulated event contexts (two different PRs, the same PR twice, two pushes to main, `workflow_dispatch`), asserts the criteria, then re-runs them against the **old** config and requires failure:

```
CURRENT config → ALL ACs PASS
OLD config     → 7 failures, incl. AC1:two-different-PRs-share-a-group
```

AC5 was verified structurally rather than by eyeball: path filters (17 entries, both triggers), `permissions`, the whole `build` job, deploy `environment`/`permissions`, and all 7 pinned action SHAs are byte-identical.

Also green: 407 + 110 + 689 + 220 tests, `lint-spec-status` clean.

## What did you not change that you considered?

- **The `paths:` filters.** The first half of the original request was "only trigger on pages changes" — it already does, since #776. Narrowing further would reopen a documented fail-open: entries like `tools/check-site-plugin-offers.py` and `.github/workflows/pages.yml` exist so that an edit *disabling* a check still triggers the run that would catch it. Six of them are pinned by `tools/test-pages-workflow.py`.
- **A concurrency assertion in `tools/test-pages-workflow.py`.** That file pins deploy-blocking gates; concurrency is not one. Every assertion family there needs mutation coverage, and a half-wired test would recreate this repo's own named anti-precedent (`tools/test-ci-security-workflow.py`, "invoked nowhere despite a shipped AC claiming it gates `ci-security.yml`"). Deferred instead.
- **`ci-security.yml` / `codeql.yml`**, which `ci-gate-parallelization` records as carrying the same refuted `cancel-in-progress` belief. Separate workflows, and that spec already holds a backlog entry.
- **Naming the deploy lane `pages-deploy`.** Reverted to the bare name during review: at merge time an in-flight *old-workflow* run still holds `pages`, and a differently-named lane would not contend with it, so the older run could publish behind the newer one.
- **A "deploy only if still the tip of `main`" guard.** Would close the ordering residual below, but no acceptance criterion requires it and it adds its own skip path.
- **`timeout-minutes` / `persist-credentials: false`** to match `build-check.yml`'s hardening. Unrequested, separate concern.

## Deferred

- `pages-concurrency-has-no-regression-gate` — no required-CI assertion covers the concurrency shape, so restoring the unkeyed group would be silent.
- `pages-deploy-ordering-not-guaranteed` — the deploy lane gives mutual exclusion, **not** ordering. Builds now run in distinct groups, so two Pages-relevant merges can enter the lane in build-completion order rather than merge order, and the older commit can publish last. Self-heals on the next Pages-relevant merge; surfaced by a peer session during merge coordination.

Both recorded in `workspace.toml [backlog].open`.

## Expected consequence

Pages CI will consume more minutes: runs that used to die at 45% now run to completion.