### PR TITLE
feat(journeys): complete priority journey decisions, evidence, and gate navigation

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -250,6 +250,9 @@ jobs:
       - name: pytest make-free gate chains (windows-build-gate-chain)
         run: python -m pytest tools/test_build_gate_chain.py
 
+      - name: pytest journey editorial decisions
+        run: python -m pytest tools/test_journey_editorial_decisions.py
+
       # The generated guides sidebar: sidebar-config.json is gitignored, so
       # these set-equality, label-parity and determinism guards are the only
       # thing standing between a generator regression and a broken published

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ test:
 	$(PYTHON) -m pytest packs/desk-research/tests/skills/desk-research-project-status/ -q
 	$(PYTHON) -m pytest packs/desk-research/tests/skills/desk-research-project-synthesize/ -q
 	$(PYTHON) -m pytest packs/desk-research/tests/skills/devils-advocate/ -q
-	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
+	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_journey_editorial_decisions.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q
 	$(PYTHON) -m pytest \

--- a/contracts/catalogue-index.schema.json
+++ b/contracts/catalogue-index.schema.json
@@ -115,7 +115,8 @@
                     "useItWhen": {"type": "string"},
                     "youProvide": {"type": "string"},
                     "youReceive": {"type": "string"},
-                    "yourDecisions": {"type": "array", "items": {"type": "string"}}
+                    "yourDecisions": {"type": "array", "items": {"type": "string"}},
+                    "decisionGateIds": {"type": "array", "items": {"type": "string"}}
                   }
                 }
               }

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -37,6 +37,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Every decision point on a journey page is now a link you can share.** Each
+  place the agent pauses for you has a stable address, so you can send someone
+  straight to the decision itself rather than to the top of the page. The links
+  survive rewording and reordering: if a decision is renamed or moved, an address
+  you shared earlier still lands on the same decision. They also work from the
+  keyboard — tab to a decision, press Enter, and the page moves focus to it.
+- **Decision labels read as plain language.** They describe what you are being
+  asked to do — "Approve the plan", "Confirm the backlog scope" — instead of
+  exposing internal codes. No page shows an internal identifier as visible text.
+- **The core, product engineering, and release engineering journeys open with a
+  one-line summary and a worked example.** Each shows an abbreviated session so
+  you can see the shape of the exchange, and where your decisions fall in it,
+  before committing to the journey.
+
 ### [core][2.9.1] — 2026-08-19
 
 #### Added

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Journey authors can record which decisions a reader meets, and in what
+  order.** A pack's `JOURNEY.md` may now carry an optional
+  `contract.decisionGateIds` — an ordered list of `humanGates[].id` values. It
+  holds identifiers only; the wording readers see still comes from each gate's
+  label. The field is optional and `yourDecisions` remains required, so every
+  pack authored before this stays valid with no edit.
+
 ### Changed
 
 - **Every decision point on a journey page is now a link you can share.** Each

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -316,3 +316,23 @@ no version, dependency, migration, or infrastructure change.
   normalised rather than compared. Proved by MP16 (hard break 2 -> 1 space now
   fails, previously passed) and MP17 (2 -> 3 spaces still passes, since three
   spaces is still a hard break).
+- 2026-08-19: extended the published catalogue contract additively, under
+  explicit authorization, after CI surfaced a conflict local gates could not see.
+  `tests/roster/test_catalogue_wave4_live_contracts.py` arrived in #1025 — one of
+  the eleven commits this branch rebased onto — and is wired only in
+  `build-check.yml`, never the Makefile, so `make build-check` passed locally
+  while `gate-main` failed. Its validator treats `contract.*` as a closed set and
+  also requires `yourDecisions`, so the ratified `contract.decisionGateIds` was
+  rejected on all 12 canonical packs. Because the approved ledger fixes the field
+  inside `contract`, relocating it was not available, even though unknown
+  top-level keys are accepted today. AC13 routes a discovered installed-output
+  change to a spec amendment rather than a silent version bump, so the work
+  stopped and asked. The authorized resolution is additive: `decisionGateIds`
+  optional in `journey_validator`, both byte-identical schema copies, and both
+  authoring-standard copies; `yourDecisions` remains required and was restored
+  byte-for-byte from the merge-base into all 12 packs. Adopter impact is nil.
+  MP18-MP20 prove the change did not open the gate: removing `yourDecisions`
+  still fails, a non-array `decisionGateIds` fails, and an unknown contract field
+  still fails. The scaffold copy is a projection, so `manifest.json` was
+  regenerated with `tools/catalogue/sync_authoring_scaffold.py --write` rather
+  than hand-edited.

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -1,7 +1,7 @@
 # Plan: Journey page completion
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Approved
+- **Status:** Executing
 
 > **Plan contract:** this is the implementation strategy. It may change while
 > Drafting or Executing; substantive changes are recorded below.
@@ -236,3 +236,83 @@ no version, dependency, migration, or infrastructure change.
 - 2026-08-17: fixed the 34-ID mapping, label ownership, invisible-ID behavior,
   exact priority copy, invocation convention, unchanged-version consequence,
   deterministic migration order, and exhaustive evidence contract.
+- 2026-08-18: applied the approved 34 semantic IDs and labels. Reconciled the
+  three affected gate bodies minimally: `decide-rfc` now uses the RFC outcomes
+  accepted or rejected (the RFC vocabulary in `docs/CONVENTIONS.md` contains no
+  Deferred status); `approve-journey` now matches the derived-screen review;
+  and `approve-okr-cascade` now matches its gap-ranking and routing work.
+- 2026-08-18: rewrote canonical rendered legacy-code prose by mechanical
+  substitution. The six hand-authored journeys remain deferred as
+  `legacy-hand-authored-journey-gate-mappings` because the approved ledger has
+  no semantic ID or label mappings for them.
+- 2026-08-18: made decision fragments conditional on `decisionGateIds`.
+  Canonical journeys emit stable semantic fragments and keyboard/focus behavior;
+  hand-authored `yourDecisions` journeys remain display-only, preventing new
+  durable links from legacy codes.
+- 2026-08-18: discharged `browser-gate-journey-chip-cases-inert`. The six
+  decision-chip cases in `web/src/test/e2e/site-quality-gate.spec.ts`, which
+  `spec/site-browser-quality-gate` registered because semantic chips were absent
+  and the cases skipped, now run and pass: 112 passed, 0 skipped, for core,
+  product-engineering, and release-engineering at 360 and 1440. This spec
+  withdrew the entry from `[backlog].open`.
+- 2026-08-18: expanded priority decision-chip interaction coverage to all five
+  approved marketing widths. Themes are deliberately not mutated for journey
+  routes: `docs/specs/site-browser-quality-gate/spec.md:78` requires marketing
+  routes to run without theme mutation; the marketing matrix already supplies
+  their all-width overflow, axe, and fragment coverage.
+- 2026-08-18: reconciled three shortened labels with their gate bodies only:
+  `decide-rfc` removes the stale Deferred vocabulary (RFC statuses are defined
+  in `docs/CONVENTIONS.md`), `approve-journey` narrows the screen-list check to
+  its derivation from the journey, and `approve-okr-cascade` names the cascade
+  rather than its downstream gap routing.
+- 2026-08-18: decision fragments, chip hrefs, and focus behavior are conditional
+  on `decisionGateIds`; this avoids minting public fragments from legacy codes on
+  hand-authored journeys. Their unresolved display-copy migration is deferred as
+  `legacy-hand-authored-journey-gate-mappings` pending approved ledger mappings.
+- 2026-08-19: closed two evidence gaps found after the gates were green. The
+  independent reviewer showed the priority eyebrow and transcript copy had no
+  automated control, though the evidence contract requires the three priority
+  pages to emit it exactly; `tools/test_journey_editorial_decisions.py` now
+  compares the ledger against canonical frontmatter byte-for-byte and confines
+  eyebrows to the priority set. A sweep of the evidence contract against the
+  suite then showed direct fragment loading was equally unverified, so the
+  browser gate gained six cold-load cases. Both are mutation-proved: a one-word
+  eyebrow or transcript drift fails, an eyebrow added to a non-priority journey
+  fails, and removing the gate heading's `tabindex="-1"` fails every cold-load
+  case. Transcript absence is deliberately not asserted for non-priority
+  journeys — `atlassian` carried a `goodOutputDescription` before this spec.
+- 2026-08-19: recorded that cold-load focus is provided by the HTML
+  fragment-navigation algorithm focusing a focusable target, not by the inline
+  script, which serves the same-document `hashchange` path. The two mechanisms
+  are complementary, and the new cases pin both.
+- 2026-08-19: amended AC15 to drop "in both approved themes". Journey routes are
+  marketing routes, which `site-browser-quality-gate` AC1 exercises without
+  theme mutation, and their emitted pages carry no `data-theme`; that spec's AC2
+  owns dual-theme coverage for the two `/docs/` routes. No approved theme,
+  width, overflow tolerance, or axe threshold changed — the clause named a
+  condition these routes cannot express.
+- 2026-08-19: hardened the editorial control after independent review showed the
+  first version could not support AC8's word "verbatim": both sides trimmed
+  whitespace and dropped blank lines, so an inserted blank paragraph or a
+  re-indented line compared equal. Each side now strips only the presentation its
+  own format forces — the ledger's blockquote marker and hard-break spaces — and
+  the canonical side is compared byte-for-byte with no trailing-space
+  normalisation, so stray whitespace in a pack fails. Both sides mirror YAML
+  `|-` chomping so a layout-only blank line before the closing fence is not a
+  false failure. AC8 now names the three tolerated presentation differences
+  instead of claiming an unqualified "verbatim". Transcript confinement uses
+  subset rather than set equality: the ledger's claim is that no journey *gains*
+  a transcript, and equality would have pinned `atlassian`'s pre-existing copy in
+  place forever. Proved by MP11–MP15 — mid-transcript blank line, extra
+  indentation, a stray trailing space, and a transcript added to a non-priority
+  journey all fail; a trailing blank line before the fence correctly does not.
+- 2026-08-19: narrowed the ledger-side normalisation after review showed it was
+  broader than AC8 claimed. `rstrip(" ")` removed any number of trailing spaces,
+  but a Markdown hard break is two or more; a one-space edit therefore changed
+  the ledger's rendering while still comparing equal. The parser now strips
+  trailing spaces only when there are at least two, and preserves a lone
+  trailing space so it fails. AC8 also dropped the phrase "byte-for-byte", which
+  overclaimed: both sources are decoded and split, so line endings are
+  normalised rather than compared. Proved by MP16 (hard break 2 -> 1 space now
+  fails, previously passed) and MP17 (2 -> 3 spaces still passes, since three
+  spaces is still a hard break).

--- a/docs/specs/journey-page-completion/spec.md
+++ b/docs/specs/journey-page-completion/spec.md
@@ -33,6 +33,17 @@ raw identifiers and legacy gate codes never leak into the adopter experience.
   derived output.
 - Keep pack versions and Claude-plugin descriptions unchanged because this
   migration does not change installed functional behavior.
+- **Amendment, 2026-08-19, authorized.** Accept `contract.decisionGateIds` in
+  the published catalogue contract, additively. `#1025` landed a live contract
+  test after this spec was approved; its validator treats `contract.*` as a
+  closed set and so rejected the ratified field on all 12 canonical packs. The
+  extension is additive only: `decisionGateIds` is optional, `yourDecisions`
+  stays required and is restored to every canonical journey, and no pack
+  authored against the previous contract needs an edit. `yourDecisions` and
+  `decisionGateIds` therefore coexist — the IDs drive fragments and ordering,
+  the strings remain adopter-facing prose, and the renderer prefers the IDs so
+  nothing is shown twice. No version was bumped: `docs/product/changelog.md` is
+  itself a Gate G release indicator.
 
 ### Ask first
 

--- a/docs/specs/journey-page-completion/spec.md
+++ b/docs/specs/journey-page-completion/spec.md
@@ -1,6 +1,6 @@
 # Spec: Journey page completion
 
-- **Status:** Approved
+- **Status:** Implementing
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none
@@ -66,52 +66,64 @@ raw identifiers and legacy gate codes never leak into the adopter experience.
 
 ## Acceptance Criteria
 
-- [ ] Every canonical journey source represents contract decisions as ordered
+- [x] Every canonical journey source represents contract decisions as ordered
   `decisionGateIds`, and every referenced ID resolves to exactly one human gate
   in that journey.
-- [ ] All 34 human gates use the exact internal IDs and adopter-facing labels in
+- [x] All 34 human gates use the exact internal IDs and adopter-facing labels in
   `editorial-decisions.md`; IDs satisfy the lowercase semantic-key contract and
   are unique within their journey.
-- [ ] Identity is exactly `(journey_id, humanGate.id)`, independent of the gate
+- [x] Identity is exactly `(journey_id, humanGate.id)`, independent of the gate
   label and position; mutation tests prove that copy changes and reordering do
   not change fragments.
-- [ ] Decision chips display only `humanGates[].label`, follow
+- [x] Decision chips display only `humanGates[].label`, follow
   `decisionGateIds` order, and derive human ordinals from that order without
   storing them as identity.
-- [ ] The decision section uses the approved “Where you decide” heading and
+- [x] The decision section uses the approved “Where you decide” heading and
   intro; no visible content exposes a raw semantic ID, `globalGate`, or legacy
-  `G…` code.
-- [ ] Every chip is a real link to exactly one
+  `G…` code. (deferred: legacy-hand-authored-journey-gate-mappings)
+- [x] Every chip is a real link to exactly one
   `#decision-<semantic-id>` heading; click and keyboard activation update the
   URL, bring the heading into view, move focus to it, and show a clear
   renderer-native focused/targeted state.
-- [ ] Duplicate, malformed, missing, and unresolved ID fixtures fail before
+- [x] Duplicate, malformed, missing, and unresolved ID fixtures fail before
   rendering; a direct fragment load resolves without consulting label text.
-- [ ] The exact priority set is `core`, `product-engineering`, and
+- [x] The exact priority set is `core`, `product-engineering`, and
   `release-engineering`; each emits its approved eyebrow and transcript
   verbatim, and no non-priority journey is required to gain either field.
-- [ ] Priority transcript invocations follow the approved harness-neutral
+  "Verbatim" is enforced line for line against canonical source, interior blank
+  lines and indentation included, after decoding and line-ending normalisation.
+  Exactly three differences are tolerated, each a presentation artefact one
+  format cannot express: the ledger's Markdown blockquote markers, its
+  hard-break trailing spaces (two or more -- a single trailing space is not a
+  hard break and does not pass), and trailing blank lines that YAML `|-` chomps.
+  Trailing whitespace inside canonical transcript lines is not tolerated.
+- [x] Priority transcript invocations follow the approved harness-neutral
   convention: ordinary language demonstrates routing, while `discovery-loop`
   and `release-loop` are explicitly named where their complete supervisor is
   required; canonical content contains no slash-prefixed invocation.
-- [ ] The living journey-priority template identifies
+- [x] The living journey-priority template identifies
   `product-engineering` and `release-engineering` by their canonical IDs rather
   than the stale `discovery` and `release` IDs.
-- [ ] Generated journey content matches canonical pack sources exactly after
+- [x] Generated journey content matches canonical pack sources exactly after
   the normal generation command; no generated copy is maintained by hand.
-- [ ] All 12 emitted journey pages contain the exact approved labels, one link
+- [x] All 12 emitted journey pages contain the exact approved labels, one link
   and one matching target per gate, and no adopter-visible internal or legacy
   identifier; the combined rendered-link checker reports no broken fragment.
-- [ ] Pack and plugin versions and plugin descriptions remain unchanged; if an
+- [x] Pack and plugin versions and plugin descriptions remain unchanged; if an
   installed functional behavior change is discovered, implementation stops for
   a spec amendment rather than silently versioning it.
-- [ ] Shipped journey content contains no repository-internal governance
+- [x] Shipped journey content contains no repository-internal governance
   citation or dead repository-only path, and every pre-change journey route and
   navigation destination still resolves.
-- [ ] At 360, 375, 390, 414, and 1440 CSS-pixel widths in both approved themes,
-  priority journey interaction has at most 1px horizontal overflow, zero
-  serious or critical axe findings, correct keyboard focus/fragment behavior,
-  and no Major design-review issue against the governing principles.
+- [ ] At 360, 375, 390, 414, and 1440 CSS-pixel widths, priority journey
+  interaction has at most 1px horizontal overflow, zero serious or critical axe
+  findings, correct keyboard focus/fragment behavior, and no Major
+  design-review issue against the governing principles. Journey routes are
+  marketing routes, which `site-browser-quality-gate` AC1 exercises without
+  theme mutation; their emitted pages carry no `data-theme`, so the dual-theme
+  requirement belongs to the two `/docs/` routes under that spec's AC2, not
+  here. The automated clauses pass; the design-review clause is recorded manual
+  verification (see `plan.md` § Approach) and awaits human sign-off.
 
 ## Assumptions
 

--- a/docs/specs/platform-site/journey-page-template.md
+++ b/docs/specs/platform-site/journey-page-template.md
@@ -141,8 +141,8 @@ Journey content is authored in this priority order:
 | Journey | Priority | Rationale |
 |---|---|---|
 | `core` | 1 | Every adopter installs this; it's the entry point |
-| `discovery` | 1 | The discovery loop is the product's conceptual differentiator |
-| `release` | 1 | Completes the full SDLC story |
+| `product-engineering` | 1 | The discovery loop is the product's conceptual differentiator |
+| `release-engineering` | 1 | Completes the full SDLC story |
 | `desk-research` | 2 | High independent utility |
 | `architect` | 2 | Common in engineering-lead audiences |
 | `experience-design` | 2 | Differentiates for product-engineering teams |

--- a/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/guides/_shared/reference/catalogue-authoring-standards.md
@@ -488,8 +488,12 @@ Use these fields:
   `confirmed-write`.
 - `scope`: `repo` or `user`.
 - `tagline`: a plain-language summary of at most 120 characters.
-- `contract`: a closed object. `useItWhen`, `youProvide`, and `youReceive` are
-  strings; `yourDecisions` is an array of strings.
+- `contract`: a closed object with one optional member. `useItWhen`,
+  `youProvide`, and `youReceive` are strings; `yourDecisions` is an array of
+  strings. `decisionGateIds` is optional and, when present, is an array of
+  `humanGates[].id` strings in the order a reader meets those decisions; it
+  carries identifiers only, never adopter-facing wording. Packs authored before
+  it existed stay valid, because `yourDecisions` remains required.
 
 Malformed YAML, a missing required field, or a field with the wrong type stops index
 generation before any output is replaced.

--- a/packages/agentbundle/agentbundle/_data/catalogue-index.schema.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-index.schema.json
@@ -115,7 +115,8 @@
                     "useItWhen": {"type": "string"},
                     "youProvide": {"type": "string"},
                     "youReceive": {"type": "string"},
-                    "yourDecisions": {"type": "array", "items": {"type": "string"}}
+                    "yourDecisions": {"type": "array", "items": {"type": "string"}},
+                    "decisionGateIds": {"type": "array", "items": {"type": "string"}}
                   }
                 }
               }

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/guides/_shared/reference/catalogue-authoring-standards.md
@@ -488,8 +488,12 @@ Use these fields:
   `confirmed-write`.
 - `scope`: `repo` or `user`.
 - `tagline`: a plain-language summary of at most 120 characters.
-- `contract`: a closed object. `useItWhen`, `youProvide`, and `youReceive` are
-  strings; `yourDecisions` is an array of strings.
+- `contract`: a closed object with one optional member. `useItWhen`,
+  `youProvide`, and `youReceive` are strings; `yourDecisions` is an array of
+  strings. `decisionGateIds` is optional and, when present, is an array of
+  `humanGates[].id` strings in the order a reader meets those decisions; it
+  carries identifiers only, never adopter-facing wording. Packs authored before
+  it existed stay valid, because `yourDecisions` remains required.
 
 Malformed YAML, a missing required field, or a field with the wrong type stops index
 generation before any output is replaced.

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "guides/_shared/reference/catalogue-authoring-standards.md": "d7eb37f3c97179cd30959089e6a26ac76a6c33f9b9b64133a11d967915a4c511",
+    "guides/_shared/reference/catalogue-authoring-standards.md": "2dc73a24b1cd2e196e2292bb53fe8344c2d031ae687c3bc538ad30afc51bd76e",
     "guides/_shared/reference/catalogue-ci-contract.md": "fae793ab47989b6dd3c731afcb0b4cda21c7d08bbe7fa40fca6d3abb3d158141",
     "packs/AGENTS.md": "9bfeda4069826e518a4f4fdae45bd40f4393c1c5aaf146149d3eb4aece30be83",
     "packs/README.md": "d2de5f9556f4c8e521103474bde74636e02cc805f9bf5312a3a61a1f3eb45d8f",

--- a/packages/agentbundle/agentbundle/catalogue_tooling/journey_validator.py
+++ b/packages/agentbundle/agentbundle/catalogue_tooling/journey_validator.py
@@ -19,7 +19,11 @@ REQUIRED_KEYS = (
     "tagline",
     "contract",
 )
-CONTRACT_KEYS = ("useItWhen", "youProvide", "youReceive", "yourDecisions")
+REQUIRED_CONTRACT_KEYS = ("useItWhen", "youProvide", "youReceive", "yourDecisions")
+# Additive: a journey may also carry an ordered list of internal gate IDs. It is
+# optional, so every pack authored against the previous contract stays valid.
+OPTIONAL_CONTRACT_KEYS = ("decisionGateIds",)
+CONTRACT_KEYS = REQUIRED_CONTRACT_KEYS
 STATE_VALUES = {"read-only", "proposed-write", "confirmed-write"}
 SCOPE_VALUES = {"repo", "user"}
 EFFECT_KINDS = {
@@ -62,10 +66,11 @@ def _validate_required(data: dict[str, Any], location: str) -> list[str]:
     contract = data["contract"]
     if not isinstance(contract, dict):
         return [f"{location}: contract must be an object"]
-    unknown = sorted(set(contract) - set(CONTRACT_KEYS))
+    known = set(REQUIRED_CONTRACT_KEYS) | set(OPTIONAL_CONTRACT_KEYS)
+    unknown = sorted(set(contract) - known)
     if unknown:
         return [f"{location}: unknown contract field: {unknown[0]}"]
-    for key in CONTRACT_KEYS:
+    for key in REQUIRED_CONTRACT_KEYS:
         if key not in contract:
             return [f"{location}: missing required contract key: {key}"]
     for key in ("useItWhen", "youProvide", "youReceive"):
@@ -76,6 +81,12 @@ def _validate_required(data: dict[str, Any], location: str) -> list[str]:
         isinstance(item, str) for item in decisions
     ):
         return [f"{location}: contract.yourDecisions must be an array of strings"]
+    gate_ids = contract.get("decisionGateIds")
+    if gate_ids is not None and (
+        not isinstance(gate_ids, list)
+        or not all(isinstance(item, str) for item in gate_ids)
+    ):
+        return [f"{location}: contract.decisionGateIds must be an array of strings"]
 
     effects = data.get("effects", [])
     if not isinstance(effects, list):

--- a/packs/architect/JOURNEY.md
+++ b/packs/architect/JOURNEY.md
@@ -10,6 +10,9 @@ contract:
   useItWhen: "You need a technical design doc, architecture diagram, or design critique for your codebase."
   youProvide: "The design problem, real constraints, and the repo's reference architecture."
   youReceive: "An approved Stage 1 design document with alternatives and an independent severity-tagged critique."
+  yourDecisions:
+    - "Approve the Stage 0 concept"
+    - "Review the design and independent critique"
   decisionGateIds:
     - approve-architecture-concept
     - review-architecture-design

--- a/packs/architect/JOURNEY.md
+++ b/packs/architect/JOURNEY.md
@@ -10,9 +10,9 @@ contract:
   useItWhen: "You need a technical design doc, architecture diagram, or design critique for your codebase."
   youProvide: "The design problem, real constraints, and the repo's reference architecture."
   youReceive: "An approved Stage 1 design document with alternatives and an independent severity-tagged critique."
-  yourDecisions:
-    - "Approve the Stage 0 concept"
-    - "Review the design and independent critique"
+  decisionGateIds:
+    - approve-architecture-concept
+    - review-architecture-design
 whatChanges: "After installing architect, every design decision gets a method: `architect-design` shapes a Stage 0 concept before any full write-up begins, writes the complete Google-style doc, and converges it against review; `architect-diagram` draws any system in Mermaid (C4, sequence, state, ER, or flowchart); `architect-review` critiques any design artifact with severity-tagged findings and may consult one bounded untrusted project-knowledge envelope after fixing its scope and rubric. The `design-reviewer` subagent reads finished artifacts cold — no authoring context — so the review cannot mark its own homework. Retrieved knowledge remains candidate evidence, and you decide at two gates: the Stage 0 concept before the full doc is written, and the independently grounded review findings before the doc is shared or acted on."
 skills:
   - name: architect-design
@@ -25,9 +25,9 @@ skills:
     description: "Critiques an existing design doc, diagram, RFC, or ADR with a rubric-routed severity-tagged review; an optional CQ-REVIEW enquiry supplies untrusted candidate checks without changing independent judgment."
     humanTouches: 1
 humanGates:
-  - id: G-concept
+  - id: approve-architecture-concept
     globalGate: null
-    label: "Approve the Stage 0 concept"
+    label: "Approve the architecture concept"
     trigger: "After architect-design emits the initial Stage 0 concept framing"
     duration: "5–10 minutes"
     whatToCheck:
@@ -38,9 +38,9 @@ humanGates:
     whatGoodLooksLike: "A half-page concept that names the problem, real constraints, and a candidate approach — specific enough to commit to a full design doc or redirect before one is written."
     whatBadLooksLike: "A concept that describes an approach without stating what problem it solves, or one that lists constraints the team would actually trade away if asked."
     consequence: "The concept approval gates the full write-up. A wrong concept means the agent writes a polished doc for the wrong problem — the cost is a full write-up cycle, not a concept cycle."
-  - id: G-review
+  - id: review-architecture-design
     globalGate: null
-    label: "Review the design and independent critique"
+    label: "Review the architecture design"
     trigger: "After architect-review or the design-reviewer subagent returns its findings"
     duration: "15–25 minutes"
     whatToCheck:

--- a/packs/atlassian/JOURNEY.md
+++ b/packs/atlassian/JOURNEY.md
@@ -10,6 +10,11 @@ contract:
   useItWhen: "You want to see what the team can work on, improve stories that are not actionable, apply approved Jira updates, or share a team summary — without writing JQL or selecting skills manually."
   youProvide: "Your team name, project keys, or a description of the scope you want reviewed. For writes: explicit confirmation of the exact fields to change."
   youReceive: "A grouped, annotated backlog — ready to pull, needs story work, blocked, in progress — with scope and completeness disclosed. Draft story improvements where requested. Exact write previews before any Jira change. A stand-up summary and optional Confluence draft on request."
+  yourDecisions:
+    - "Confirm or correct the resolved team scope before reading backlog results"
+    - "Select which story drafts to approve for writing"
+    - "Confirm the exact issue keys and fields before any Jira write"
+    - "Approve the Confluence draft before publishing"
   decisionGateIds:
     - confirm-backlog-scope
     - review-story-drafts

--- a/packs/atlassian/JOURNEY.md
+++ b/packs/atlassian/JOURNEY.md
@@ -10,11 +10,11 @@ contract:
   useItWhen: "You want to see what the team can work on, improve stories that are not actionable, apply approved Jira updates, or share a team summary — without writing JQL or selecting skills manually."
   youProvide: "Your team name, project keys, or a description of the scope you want reviewed. For writes: explicit confirmation of the exact fields to change."
   youReceive: "A grouped, annotated backlog — ready to pull, needs story work, blocked, in progress — with scope and completeness disclosed. Draft story improvements where requested. Exact write previews before any Jira change. A stand-up summary and optional Confluence draft on request."
-  yourDecisions:
-    - "Confirm or correct the resolved team scope before reading backlog results"
-    - "Select which story drafts to approve for writing"
-    - "Confirm the exact issue keys and fields before any Jira write"
-    - "Approve the Confluence draft before publishing"
+  decisionGateIds:
+    - confirm-backlog-scope
+    - review-story-drafts
+    - confirm-jira-writes
+    - approve-confluence-publish
 whatChanges: "After installing the Atlassian pack, you can ask for your team's full backlog in plain language and receive a structured, annotated result — grouped by readiness, with scope and completeness disclosed — without opening a browser or writing JQL. The pack selects the right workflow for each request: orient first (read-only), improve unclear work when needed (draft), and write only after the requested change is explicit and confirmed. You do not need to know which skill handles each stage."
 skills:
   - name: jira-team-status
@@ -51,9 +51,9 @@ skills:
     description: "Compare two flow-metrics outputs and produce a Markdown adoption report. Read-only; does not call Jira or Confluence."
     humanTouches: 1
 humanGates:
-  - id: G-scope
+  - id: confirm-backlog-scope
     globalGate: null
-    label: "Confirm team scope"
+    label: "Confirm the backlog scope"
     trigger: "When the agent resolves more than one plausible team scope — before returning any backlog results"
     duration: "1–2 minutes"
     whatToCheck:
@@ -63,9 +63,9 @@ humanGates:
     whatGoodLooksLike: "A scope that names the correct board, project set, or Team field — confirmed in one sentence."
     whatBadLooksLike: "A scope that includes the wrong projects, misses a key sprint, or uses the Team field when the board is the right source of truth."
     consequence: "Wrong scope means wrong backlog. Catching it here is a 30-second correction; catching it after reading 184 issues means starting over."
-  - id: G-draft-review
+  - id: review-story-drafts
     globalGate: null
-    label: "Review story drafts"
+    label: "Review the story drafts"
     trigger: "After jira-story-triage produces proposed rewrites — before any write is requested"
     duration: "5–15 minutes"
     whatToCheck:
@@ -76,9 +76,9 @@ humanGates:
     whatGoodLooksLike: "A draft you could hand to an engineer and have them begin work without asking a follow-up question."
     whatBadLooksLike: "A draft that rewrites prose but leaves the ambiguous scope or missing acceptance criteria untouched."
     consequence: "Approving a weak draft locks in the ambiguity. Story triage is the last cheap moment to catch a missing acceptance criterion before it reaches engineering."
-  - id: G-write-confirm
+  - id: confirm-jira-writes
     globalGate: "G4"
-    label: "Confirm exact Jira writes"
+    label: "Confirm the Jira changes"
     trigger: "After the agent shows the write preview — before any Jira data is changed"
     duration: "2–5 minutes"
     whatToCheck:
@@ -89,9 +89,9 @@ humanGates:
     whatGoodLooksLike: "A write payload that exactly matches the approved draft — no extra fields, no unexpected issues, protected fields not listed."
     whatBadLooksLike: "A payload that includes issues you did not select, or fields beyond description and acceptance criteria."
     consequence: "Jira writes are immediate and visible to the team. Confirming the wrong payload means a manual rollback."
-  - id: G-publish
+  - id: approve-confluence-publish
     globalGate: null
-    label: "Approve Confluence publish"
+    label: "Approve publishing to Confluence"
     trigger: "After the agent produces a Confluence-ready draft — before publishing to the space"
     duration: "2–5 minutes"
     whatToCheck:

--- a/packs/core/JOURNEY.md
+++ b/packs/core/JOURNEY.md
@@ -10,9 +10,9 @@ contract:
   useItWhen: "You're implementing a feature, fixing a bug, or changing an existing repo."
   youProvide: "The task and its important constraints."
   youReceive: "An agreed plan, a checked implementation, review findings, and a merge decision."
-  yourDecisions:
-    - "Approve the plan"
-    - "Merge the PR"
+  decisionGateIds:
+    - approve-plan
+    - merge-reviewed-change
 whatChanges: "After installing core, work-intake becomes the front door for starting, remembering, inspecting, or refreshing work. It writes a canonical artifact and lifecycle entry before any processor runs. Approved specs then move through work-loop: plan → execute → verify → independently grounded review. Stable brief/spec/plan authoring gates may capture reusable supporting practice through project-knowledge; review planning may separately enquire once for untrusted candidate checks, while Draft work, reviewer scratch, findings, and normative artifact content remain untouched. The loop cannot self-certify: it surfaces to you for plan approval and merge."
 skills:
   - name: work-intake
@@ -61,7 +61,7 @@ skills:
     description: "Provides a read-only reference view of the security checklist library. Normal security reviews use security-checklists."
     humanTouches: 0
 humanGates:
-  - id: G-plan
+  - id: approve-plan
     globalGate: null
     label: "Approve the plan"
     trigger: "Before work-loop begins execution — after the agent writes the trio and risk-trigger assessment"
@@ -74,9 +74,9 @@ humanGates:
     whatGoodLooksLike: "A bounded plan with a clear trio, no scope creep, correct risk-trigger assessment, and plausible assumptions."
     whatBadLooksLike: "A plan that extends the scope of the request, missing risk triggers that should have fired, or a trio that doesn't name a specific user."
     consequence: "If you approve a bad plan, the agent executes it faithfully. The cost of a bad plan is the cost of a full loop iteration — plan approval is the cheapest gate."
-  - id: G-pr
+  - id: merge-reviewed-change
     globalGate: "G4"
-    label: "Merge the PR"
+    label: "Merge the reviewed change"
     trigger: "After all mechanical gates pass and adversarial review is clean"
     duration: "10–20 minutes"
     whatToCheck:
@@ -86,7 +86,7 @@ humanGates:
       - "Is there anything in the diff that wasn't in the plan?"
     whatGoodLooksLike: "Green gates, clean adversarial review, spec and implementation aligned, no unexplained diff."
     whatBadLooksLike: "Adversarial reviewer flagged a Blocker and you merged anyway. Or the spec drifted from the implementation without an update."
-    consequence: "G4 is the last line of defense before the build loop output goes to release. A bad merge is harder to undo than a bad plan."
+    consequence: "This is the last line of defense before the build loop output goes to release. A bad merge is harder to undo than a bad plan."
 typicalSession:
   agentTurns: "8–12"
   humanTouches: 2
@@ -95,6 +95,18 @@ docsUrl: /docs/guides/core/
 packUrl: /packs/core/
 relatedJourneys:
   - release-engineering
+eyebrow: "From scoped work to a reviewed merge"
+goodOutputDescription: |-
+  **You:** Start work on adding export filters without changing the existing
+  API route.
+  **Agent:** I routed this to the approved spec. The plan changes the query
+  contract, handler, and emitted API tests. It adds no dependency or
+  migration.
+  **You:** Approve the plan.
+  **Agent:** Implemented. Focused tests, type checking, lint, and the full suite
+  pass. The emitted contract exposes filters and preserves existing defaults.
+  **Independent reviewer:** Clean — ready to commit.
+  **Agent:** The reviewed change is ready for your merge decision.
 ---
 
 | Say this | What happens |

--- a/packs/core/JOURNEY.md
+++ b/packs/core/JOURNEY.md
@@ -10,6 +10,9 @@ contract:
   useItWhen: "You're implementing a feature, fixing a bug, or changing an existing repo."
   youProvide: "The task and its important constraints."
   youReceive: "An agreed plan, a checked implementation, review findings, and a merge decision."
+  yourDecisions:
+    - "Approve the plan"
+    - "Merge the PR"
   decisionGateIds:
     - approve-plan
     - merge-reviewed-change

--- a/packs/desk-research/JOURNEY.md
+++ b/packs/desk-research/JOURNEY.md
@@ -10,9 +10,9 @@ contract:
   useItWhen: "You have a question that needs evidence grounded in primary sources — single-session query or a sustained multi-week investigation."
   youProvide: "A research question, a chosen depth mode, and any known sources or prior corpus."
   youReceive: "A confidence-graded synthesis brief citing primary sources, with an explicit gap map."
-  yourDecisions:
-    - "Set scope and depth"
-    - "Review the synthesized brief"
+  decisionGateIds:
+    - set-research-scope-and-depth
+    - review-research-synthesis
 whatChanges: "After installing desk-research, every question your agent takes on is evidence-grounded before it answers. `desk-research` runs scoping, source curation, and synthesis in one session across four depth modes. For sustained investigations, the four `desk-research-project-*` skills run a lifecycle that accumulates a corpus and ends in a confidence-graded brief. Gaps are named explicitly — honest gaps are better than false confidence."
 skills:
   - name: desk-research
@@ -52,9 +52,9 @@ skills:
     description: "Synthesizes the corpus digest into a brief graded by confidence, ready to hand to a decision."
     humanTouches: 1
 humanGates:
-  - id: G-scope
+  - id: set-research-scope-and-depth
     globalGate: null
-    label: "Set scope and depth"
+    label: "Set the research scope and depth"
     trigger: "Before /research or desk-research-project-start runs"
     duration: "3–5 minutes"
     whatToCheck:
@@ -65,9 +65,9 @@ humanGates:
     whatGoodLooksLike: "A specific, answerable question with a chosen depth mode and a clear success criterion — something a colleague could pick up and continue."
     whatBadLooksLike: "A question that can't be falsified or finished — 'what is the best approach to X?' with no scope boundary or success criterion."
     consequence: "The scope gate sets the direction for everything that follows. A bad scope means the agent searches the wrong space and returns a synthesis that looks complete but answers the wrong question."
-  - id: G-synthesis
+  - id: review-research-synthesis
     globalGate: null
-    label: "Review the synthesized brief"
+    label: "Review the research synthesis"
     trigger: "After the synthesis step completes"
     duration: "10–20 minutes"
     whatToCheck:

--- a/packs/desk-research/JOURNEY.md
+++ b/packs/desk-research/JOURNEY.md
@@ -10,6 +10,9 @@ contract:
   useItWhen: "You have a question that needs evidence grounded in primary sources — single-session query or a sustained multi-week investigation."
   youProvide: "A research question, a chosen depth mode, and any known sources or prior corpus."
   youReceive: "A confidence-graded synthesis brief citing primary sources, with an explicit gap map."
+  yourDecisions:
+    - "Set scope and depth"
+    - "Review the synthesized brief"
   decisionGateIds:
     - set-research-scope-and-depth
     - review-research-synthesis

--- a/packs/experience-design/JOURNEY.md
+++ b/packs/experience-design/JOURNEY.md
@@ -10,10 +10,10 @@ contract:
   useItWhen: "A product team needs a full design thread — from outcome to independently-reviewed screens — before build begins."
   youProvide: "The feature, user, and intended outcome, plus any existing brand or design-system constraints."
   youReceive: "A complete, independently-reviewed design set — journey map, screen inventory, interaction specs, and accessibility-clean designs."
-  yourDecisions:
-    - "Approve the customer journey and derived screen list"
-    - "Approve the aesthetic direction and token set"
-    - "Review the designs after the independent experience-reviewer pass"
+  decisionGateIds:
+    - approve-journey
+    - approve-aesthetic-direction
+    - review-experience-designs
 whatChanges: "After installing experience-design, every design task runs a fixed thread: journey-mapping to anchor user outcomes, user-flow to derive the screen inventory, a craft sequence (creative-direction → design-system → information-architecture → interaction-design) to design each screen, and an independent experience-reviewer pass that reads design artifacts cold. The quality floor — handle-all-states, WCAG 2.2 AA, reduced-motion — is non-negotiable at every step. You decide at three gates: the journey and screen list, the aesthetic direction, and the post-review pass before design feeds the build loop. experience-status orients to the thread at the start of any session."
 skills:
   - name: journey-mapping
@@ -77,22 +77,22 @@ skills:
     description: "Orients to the current design thread at a glance — reads design artifacts from the configured output directory and surfaces what exists, what's missing, and which skill to run next."
     humanTouches: 0
 humanGates:
-  - id: G-journey
+  - id: approve-journey
     globalGate: null
-    label: "Approve the customer journey and derived screen list"
+    label: "Approve the journey"
     trigger: "After journey-mapping and user-flow complete"
     duration: "10–15 minutes"
     whatToCheck:
       - "Does the journey capture the outcome the user is trying to achieve — not just the tasks they perform in the current product?"
-      - "Is the screen list derived from the journey, not from the existing implementation or a wish list?"
+      - "Does the journey provide a clear basis for the derived screen list, rather than the existing implementation or a wish list?"
       - "Are the key failure modes named — the moments the current journey breaks down, and why?"
       - "Is every screen in the list implied by the journey? (Remove screens that aren't.)"
     whatGoodLooksLike: "A journey map that names the outcome, the failure modes, and a screen list with a clear derivation — each screen traceable to a moment in the journey."
     whatBadLooksLike: "A screen list that maps to the current implementation screen-by-screen. This means the agent documented the status quo instead of designing for the outcome."
     consequence: "The screen list is the contract for all design work that follows. A screen list derived from the wrong model means the design thread designs the wrong product — faithfully."
-  - id: G-aesthetic
+  - id: approve-aesthetic-direction
     globalGate: null
-    label: "Approve the aesthetic direction and token set"
+    label: "Approve the aesthetic direction"
     trigger: "After creative-direction and optionally design-system complete"
     duration: "5–10 minutes"
     whatToCheck:
@@ -103,9 +103,9 @@ humanGates:
     whatGoodLooksLike: "A named aesthetic reference with a token set that derives directly from it, passes the contrast floor, and could be handed to a developer without ambiguity."
     whatBadLooksLike: "An aesthetic direction that could apply to any product, or a token set that introduces hardcoded values outside the semantic token system."
     consequence: "The aesthetic direction is the constraint every subsequent screen must satisfy. Approving a vague direction means screens drift with no shared reference to hold them together — and the experience-reviewer will flag every screen for the same missing constraint."
-  - id: G-experience-review
+  - id: review-experience-designs
     globalGate: null
-    label: "Review the designs after the independent experience-reviewer pass"
+    label: "Review the experience designs"
     trigger: "After the experience-reviewer subagent returns findings on the completed screen designs"
     duration: "15–25 minutes"
     whatToCheck:

--- a/packs/experience-design/JOURNEY.md
+++ b/packs/experience-design/JOURNEY.md
@@ -10,6 +10,10 @@ contract:
   useItWhen: "A product team needs a full design thread — from outcome to independently-reviewed screens — before build begins."
   youProvide: "The feature, user, and intended outcome, plus any existing brand or design-system constraints."
   youReceive: "A complete, independently-reviewed design set — journey map, screen inventory, interaction specs, and accessibility-clean designs."
+  yourDecisions:
+    - "Approve the customer journey and derived screen list"
+    - "Approve the aesthetic direction and token set"
+    - "Review the designs after the independent experience-reviewer pass"
   decisionGateIds:
     - approve-journey
     - approve-aesthetic-direction

--- a/packs/frontend-engineering/JOURNEY.md
+++ b/packs/frontend-engineering/JOURNEY.md
@@ -10,10 +10,11 @@ contract:
   useItWhen: "You need to create, retrofit, audit, or verify an HTML/CSS/JS surface with a page/screen contract, accessible states, Core Web Vitals targets, and completion evidence."
   youProvide: "A surface brief, existing page, or completed implementation, plus any product constraints, routes, viewports, design references, and available performance data."
   youReceive: "A proportional page/screen contract, implementation or audit path, gate results, evidence manifest, and independent frontend review focused on regressions that ordinary tests miss."
-  yourDecisions:
-    - "Choose create, retrofit, audit, or verify"
-    - "Approve the page/screen contract before significant UI code"
-    - "Accept or fix known exceptions before completion"
+  decisionGateIds:
+    - choose-frontend-operating-mode
+    - approve-frontend-surface-contract
+    - accept-frontend-evidence
+    - review-frontend-implementation
 whatChanges: "After installing frontend-engineering, the main skill gives one operating path for web surfaces: create starts from a contract, retrofit starts from brownfield inspection, audit reports findings without code changes, and verify runs gates against a completed surface. Supporting skills cover tokens, accessibility, performance, rendering, component contracts, responsive layout, CSS architecture, and status. The frontend-reviewer agent provides an independent diff read for token drift, ARIA mutation completeness, state coverage, WCAG 2.2 manual checks, and Core Web Vitals regression signals."
 skills:
   - name: frontend-engineering
@@ -44,9 +45,9 @@ skills:
     description: "Reads the evidence manifest and reports current frontend quality state."
     humanTouches: 0
 humanGates:
-  - id: G-mode
+  - id: choose-frontend-operating-mode
     globalGate: null
-    label: "Choose the operating mode"
+    label: "Choose the frontend operating mode"
     trigger: "Before planning starts, after you describe the surface or review target"
     duration: "2-5 minutes"
     whatToCheck:
@@ -57,9 +58,9 @@ humanGates:
     whatGoodLooksLike: "The mode matches the job and the expected output is named before work begins."
     whatBadLooksLike: "A small component tweak gets treated like a full new route, or a review-only request silently turns into code edits."
     consequence: "The wrong mode either overburdens a small change or skips evidence a larger surface needs."
-  - id: G-contract
+  - id: approve-frontend-surface-contract
     globalGate: null
-    label: "Approve the page/screen contract"
+    label: "Approve the frontend surface contract"
     trigger: "Before significant UI code in create mode, or before a retrofit becomes a substantial rebuild"
     duration: "10-15 minutes"
     whatToCheck:
@@ -69,9 +70,9 @@ humanGates:
     whatGoodLooksLike: "A reader can tell what the first screen must accomplish and what evidence will prove it."
     whatBadLooksLike: "The contract repeats vague product goals or omits error, empty, keyboard-only, high-zoom, or reduced-motion states that apply."
     consequence: "A weak contract lets the implementation drift into a polished happy path with missing states."
-  - id: G-evidence
+  - id: accept-frontend-evidence
     globalGate: null
-    label: "Accept the evidence manifest"
+    label: "Accept the frontend implementation evidence"
     trigger: "After implementation, audit, or verify mode produces gate results"
     duration: "10-20 minutes"
     whatToCheck:
@@ -81,9 +82,9 @@ humanGates:
     whatGoodLooksLike: "The manifest names what was tested, what passed, what could not be tested, and what remains accepted risk."
     whatBadLooksLike: "Completion is claimed from source inspection alone, or field performance, manual WCAG 2.2 checks, and screenshots are left implicit."
     consequence: "Without evidence, the surface may look complete while still failing in browser, accessibility, or performance review."
-  - id: G-review
+  - id: review-frontend-implementation
     globalGate: null
-    label: "Run independent frontend review"
+    label: "Review the frontend implementation"
     trigger: "After gates and manifest are ready, before merge or handoff"
     duration: "10-20 minutes"
     whatToCheck:

--- a/packs/frontend-engineering/JOURNEY.md
+++ b/packs/frontend-engineering/JOURNEY.md
@@ -10,6 +10,10 @@ contract:
   useItWhen: "You need to create, retrofit, audit, or verify an HTML/CSS/JS surface with a page/screen contract, accessible states, Core Web Vitals targets, and completion evidence."
   youProvide: "A surface brief, existing page, or completed implementation, plus any product constraints, routes, viewports, design references, and available performance data."
   youReceive: "A proportional page/screen contract, implementation or audit path, gate results, evidence manifest, and independent frontend review focused on regressions that ordinary tests miss."
+  yourDecisions:
+    - "Choose create, retrofit, audit, or verify"
+    - "Approve the page/screen contract before significant UI code"
+    - "Accept or fix known exceptions before completion"
   decisionGateIds:
     - choose-frontend-operating-mode
     - approve-frontend-surface-contract

--- a/packs/governance-extras/JOURNEY.md
+++ b/packs/governance-extras/JOURNEY.md
@@ -11,6 +11,10 @@ contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."
   youReceive: "A completed RFC, a merged ADR, or an updated CONVENTIONS.md — with structured rationale the next person can follow."
+  yourDecisions:
+    - "Review the RFC draft before circulation"
+    - "Accept, reject, or defer the RFC"
+    - "Merge the ADR"
   decisionGateIds:
     - review-rfc-draft
     - decide-rfc

--- a/packs/governance-extras/JOURNEY.md
+++ b/packs/governance-extras/JOURNEY.md
@@ -11,10 +11,10 @@ contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."
   youReceive: "A completed RFC, a merged ADR, or an updated CONVENTIONS.md — with structured rationale the next person can follow."
-  yourDecisions:
-    - "Review the RFC draft before circulation"
-    - "Accept, reject, or defer the RFC"
-    - "Merge the ADR"
+  decisionGateIds:
+    - review-rfc-draft
+    - decide-rfc
+    - merge-accepted-adr
 whatChanges: "After installing governance-extras, cross-cutting changes go through a structured RFC before anyone builds anything. Architectural decisions are recorded in ADRs with honest critique tracks. When core project knowledge is present, reusable supporting practice can be captured only at the written-and-clean RFC handoff or the decision-maker's ADR acceptance; normative content stays in its owning artifact. CONVENTIONS.md evolves through tracked updates, not drift. Every significant 'why did we choose this?' has an answer that survives personnel changes."
 skills:
   - name: new-rfc
@@ -30,9 +30,9 @@ skills:
     description: "Surfaces the current RFC landscape at a glance — how many RFCs are in each lifecycle state, which are active, and how many findings are waiting in the candidate register."
     humanTouches: 0
 humanGates:
-  - id: G-draft
+  - id: review-rfc-draft
     globalGate: null
-    label: "Review the RFC draft before circulation"
+    label: "Review the RFC draft"
     trigger: "After new-rfc produces a draft — before it is shared with stakeholders"
     duration: "10–20 minutes"
     whatToCheck:
@@ -43,22 +43,21 @@ humanGates:
     whatGoodLooksLike: "An RFC whose problem statement you could send to someone who doesn't know the project and they'd understand what's being debated. Objections that a thoughtful opponent would actually raise."
     whatBadLooksLike: "An RFC that proposes the solution in the problem statement — 'we should adopt X' instead of 'we need to solve Y.' Or objections that are obviously weaker than the proposer's case and weren't genuinely steelmanned."
     consequence: "A bad RFC draft circulates and the feedback it gets is on the framing, not the substance — wasting reviewers' time and forcing a rewrite. The draft gate is cheap; the rewrite gate is not."
-  - id: G-accept
+  - id: decide-rfc
     globalGate: null
-    label: "Accept, reject, or defer the RFC"
+    label: "Accept or decline the RFC"
     trigger: "After the comment period closes and the RFC is ready for a decision"
     duration: "15–30 minutes"
     whatToCheck:
       - "Have all objections been addressed — or explicitly acknowledged and set aside with a reason?"
-      - "Is the decision clearly stated: Accepted, Rejected, or Deferred — with a rationale?"
+      - "Is the decision clearly stated: Accepted or Rejected — with a rationale?"
       - "If Accepted: is there a follow-on ADR planned to record the architectural decision?"
-      - "If Deferred: is there a trigger condition that would bring it back — or is Deferred a polite way of saying Rejected?"
     whatGoodLooksLike: "A clear disposition with a rationale a future reader could follow. Accepted means someone is building it. Rejected means no one is building it and the document explains why."
-    whatBadLooksLike: "An RFC that accumulates comments and then sits in limbo — no decision, no follow-on. Or a Deferred with no trigger condition, which means it will never be reconsidered."
+    whatBadLooksLike: "An RFC that accumulates comments and then sits in limbo — no decision, no follow-on."
     consequence: "An undecided RFC becomes technical debt in the governance register. People build around it, reference it as precedent, or ignore it entirely — none of those outcomes is what the RFC process is for."
-  - id: G-merge
+  - id: merge-accepted-adr
     globalGate: "G4"
-    label: "Merge the ADR"
+    label: "Merge the accepted ADR"
     trigger: "After new-adr produces a draft ADR ready for review"
     duration: "10–15 minutes"
     whatToCheck:
@@ -106,7 +105,7 @@ new-rfc [adopt trunk-based development]
 Approve? ›
 ```
 
-- **You decide:** review the RFC draft at G-draft before circulating — the most common error is naming the solution in the problem statement; redirect to reframe around the underlying need.
+- **You decide:** review the RFC draft before circulating — the most common error is naming the solution in the problem statement; redirect to reframe around the underlying need.
 - **Output:** `docs/rfc/0043-trunk-based-development.md` — a circulated RFC draft with a clear problem statement and genuine adversarial perspectives. After every mandatory check is clean and the RFC and index entry are written, `rfc-handoff-ready` may capture reusable supporting practice through core's public seam; incomplete or abandoned work produces no capture.
 - **State:** proposed-write
 
@@ -158,6 +157,6 @@ new-adr [branching strategy: trunk-based development]
 Approve? ›
 ```
 
-- **You decide:** accept, reject, or defer the RFC at G-accept; then merge the ADR at G-merge.
+- **You decide:** accept or decline the RFC; then merge the accepted ADR.
 - **Output:** a decided RFC and, if accepted, a merged ADR with honest rationale — linked from the RFC that produced it. Only the decision-maker's Proposed-to-Accepted transition reaches `adr-accepted`; previewed, rejected, or abandoned ADRs never capture, and normative decisions remain solely in the ADR.
 - **State:** confirmed-write

--- a/packs/iac-terraform/JOURNEY.md
+++ b/packs/iac-terraform/JOURNEY.md
@@ -12,23 +12,23 @@ contract:
   useItWhen: "You're authoring or reconciling governed Terraform infrastructure — from intent to a digest-pinned, policy-clean plan."
   youProvide: "A plain-language infrastructure intent with target cloud, engine, environments, isolation model, and CI system."
   youReceive: "A digest-pinned Terraform plan with policy-pass evidence, security review, reversibility hints, and a release readiness record."
-  yourDecisions:
-    - "Approve the governance gate"
-    - "Approve the inner-loop plan"
-    - "Approve the G4 handoff — merge the PR"
-    - "Approve the prod ship"
-whatChanges: "After installing iac-terraform, a plain-language infrastructure intent moves through a governed authoring loop: a mandatory Stage-0 ADR gate → a vocabulary-firewalled spec → schema-grounded Terraform generation → policy-as-code and security preflight → G4 handoff to release-loop. The pack ships two skills: generate-iac authors the Terraform and stops at a digest-pinnable plan; reconcile-iac audits plan-visible drift and proposes a per-resource disposition without applying autonomously. The agent never runs terraform apply — it produces and pins the plan; release-loop (or the generated human-gated pipeline) routes it to the real account."
+  decisionGateIds:
+    - approve-infrastructure-governance
+    - approve-infrastructure-plan
+    - merge-infrastructure-change
+    - approve-production-infrastructure-release
+whatChanges: "After installing iac-terraform, a plain-language infrastructure intent moves through a governed authoring loop: a mandatory Stage-0 ADR gate → a vocabulary-firewalled spec → schema-grounded Terraform generation → policy-as-code and security preflight → a reviewed handoff to release-loop. The pack ships two skills: generate-iac authors the Terraform and stops at a digest-pinnable plan; reconcile-iac audits plan-visible drift and proposes a per-resource disposition without applying autonomously. The agent never runs terraform apply — it produces and pins the plan; release-loop (or the generated human-gated pipeline) routes it to the real account."
 skills:
   - name: generate-iac
-    description: "Turns a plain-language intent into governed, schema-grounded Terraform — ADR-gated, vocabulary-firewalled, and stopping at a digest-pinnable plan for G4 handoff."
+    description: "Turns a plain-language intent into governed, schema-grounded Terraform — ADR-gated, vocabulary-firewalled, and stopping at a digest-pinnable plan for a reviewed handoff."
     humanTouches: 3
   - name: reconcile-iac
     description: "Audits plan-visible drift between Terraform state and the live control plane, proposes a disposition per drifted resource, and routes remediation for human approval — never autonomously applies."
     humanTouches: 1
 humanGates:
-  - id: G-governance
+  - id: approve-infrastructure-governance
     globalGate: null
-    label: "Approve the governance gate"
+    label: "Approve the infrastructure governance"
     trigger: "Before any Terraform is authored — after the agent loads the governance index and identifies which ADRs bind the intent"
     duration: "5–15 minutes"
     whatToCheck:
@@ -39,9 +39,9 @@ humanGates:
     whatGoodLooksLike: "A governance index loaded, the right ADRs cited, no uncovered decision domain, and a vocabulary-firewalled spec."
     whatBadLooksLike: "The agent cited an ADR that doesn't cover the decision domain, skipped the governance index load, or wrote RDS/S3/GCS into the spec before PLAN."
     consequence: "If you skip or rubber-stamp the governance gate, the generated Terraform will be ungoverned — no decision records binding the choices, no constraint on which cloud services are used, and no way to review the decision retrospectively."
-  - id: G-plan
+  - id: approve-infrastructure-plan
     globalGate: null
-    label: "Approve the inner-loop plan"
+    label: "Approve the infrastructure plan"
     trigger: "After ADR gate passes and inputs are confirmed — before Terraform authoring begins"
     duration: "5–10 minutes"
     whatToCheck:
@@ -52,9 +52,9 @@ humanGates:
     whatGoodLooksLike: "A tier-ordered task list with ADR citations, explicit isolation model, and parallel annotations only where safe."
     whatBadLooksLike: "Tasks in arbitrary order, missing ADR citations, or the account isolation model left undocumented."
     consequence: "A mis-ordered task plan produces apply-time dependency conflicts — the most expensive class of apply-time failure, invisible to plan."
-  - id: G4
+  - id: merge-infrastructure-change
     globalGate: "G4"
-    label: "Approve the G4 handoff — merge the PR"
+    label: "Merge the infrastructure change"
     trigger: "After plan is digest-pinned: fmt clean, validate clean, plan clean, policy-as-code clean, security reviewer clean"
     duration: "15–30 minutes"
     whatToCheck:
@@ -62,13 +62,13 @@ humanGates:
       - "Did policy-as-code (OPA/Conftest) pass against the plan JSON — no unapproved resource types, required tags present?"
       - "Did the security reviewer find no new misconfigurations (Trivy/Checkov clean)?"
       - "Are reversibility hints correct? (Stateful data stores must be one-way-door, not reversible.)"
-      - "If Infracost produced a cost delta, is the projected spend acceptable — or does it require a spend gate at G5?"
+      - "If Infracost produced a cost delta, is the projected spend acceptable — or does it require a production spend gate?"
     whatGoodLooksLike: "A digest-pinned plan with policy-pass evidence, security review clean, correct reversibility hints, and an acceptable cost delta."
     whatBadLooksLike: "A plan without a pinned digest — the deploy step could apply a later, unreviewed plan. Or a reversibility hint of reversible on a DynamoDB table or RDS instance."
-    consequence: "G4 is the last gate before deploy. An unpinned plan or missing policy-pass lets an unreviewed change reach a real account. A wrong reversibility hint silences the G5 spend or data gate."
-  - id: G5
+    consequence: "This is the last gate before deploy. An unpinned plan or missing policy-pass lets an unreviewed change reach a real account. A wrong reversibility hint silences the production spend or data gate."
+  - id: approve-production-infrastructure-release
     globalGate: "G5"
-    label: "Approve the prod ship"
+    label: "Approve the production infrastructure release"
     trigger: "After the deployed whole converges on the ephemeral environment — e2e clean, telemetry stable, security review done"
     duration: "15–30 minutes"
     whatToCheck:
@@ -78,7 +78,7 @@ humanGates:
       - "Is the rollback path tested on the ephemeral environment — and do you trust it for prod?"
     whatGoodLooksLike: "A complete release readiness record, no open borderline gates, and a rollback path that was actually run on the ephemeral environment."
     whatBadLooksLike: "A record with missing sections, borderline gates waved through, or a rollback path that was described but never exercised."
-    consequence: "G5 gates the prod ship. After this gate the change reaches real infrastructure — partially applied states require targeted destroy/re-apply paths, not clean undo."
+    consequence: "This gates the production infrastructure release. After this gate the change reaches real infrastructure — partially applied states require targeted destroy/re-apply paths, not clean undo."
 typicalSession:
   agentTurns: "12–20"
   humanTouches: 3
@@ -121,13 +121,13 @@ relatedJourneys:
 
 ---
 
-### 3. Run static preflight and hand off to G4
+### 3. Run static preflight and prepare the reviewed handoff
 
-- **Agent does:** runs policy-as-code (OPA/Conftest against the plan JSON — approved resource types, required tags, encryption at rest, no hard-coded credentials); runs Infracost for an optional cost delta; pins the plan digest; assembles the G4 handoff artifact with all evidence.
+- **Agent does:** runs policy-as-code (OPA/Conftest against the plan JSON — approved resource types, required tags, encryption at rest, no hard-coded credentials); runs Infracost for an optional cost delta; pins the plan digest; assembles the reviewed handoff artifact with all evidence.
 - **Reviewer does:** security-reviewer scans the generated configurations (Trivy/Checkov); adversarial-reviewer reads the spec, plan, and diff cold with no context from the authoring session.
-- **You do:** read the policy-pass evidence and security review summary; check reversibility hints on stateful resources — a wrong hint silences the G5 spend or data gate; decide whether the cost delta requires a spend gate at G5.
-- **You decide:** approve the G4 handoff — merge the PR.
-- **Output:** a digest-pinned G4 handoff — deploy-ready Terraform, policy-pass evidence, security review summary, reversibility hints on stateful resources, and cost delta if present.
+- **You do:** read the policy-pass evidence and security review summary; check reversibility hints on stateful resources — a wrong hint silences the production spend or data gate; decide whether the cost delta requires a production spend gate.
+- **You decide:** merge the infrastructure change.
+- **Output:** a digest-pinned reviewed handoff — deploy-ready Terraform, policy-pass evidence, security review summary, reversibility hints on stateful resources, and cost delta if present.
 - **State:** confirmed-write
 
 ---

--- a/packs/iac-terraform/JOURNEY.md
+++ b/packs/iac-terraform/JOURNEY.md
@@ -12,6 +12,11 @@ contract:
   useItWhen: "You're authoring or reconciling governed Terraform infrastructure — from intent to a digest-pinned, policy-clean plan."
   youProvide: "A plain-language infrastructure intent with target cloud, engine, environments, isolation model, and CI system."
   youReceive: "A digest-pinned Terraform plan with policy-pass evidence, security review, reversibility hints, and a release readiness record."
+  yourDecisions:
+    - "Approve the governance gate"
+    - "Approve the inner-loop plan"
+    - "Approve the G4 handoff — merge the PR"
+    - "Approve the prod ship"
   decisionGateIds:
     - approve-infrastructure-governance
     - approve-infrastructure-plan

--- a/packs/product-documentation/JOURNEY.md
+++ b/packs/product-documentation/JOURNEY.md
@@ -10,18 +10,18 @@ contract:
   useItWhen: "You need to write, improve, or audit any catalogue-facing guide, pack README, or journey — whether you're starting from scratch, reworking legacy docs, or checking that existing pages hold up to their Diátaxis page contract."
   youProvide: "A description of what you want to document, improve, or check, and optionally the mode (create / revise / retrofit / audit / verify)."
   youReceive: "A draft, revision, retrofit plan, audit report, or verification result — whichever fits the request — with the Diátaxis page kind confirmed and the write destination resolved."
-  yourDecisions:
-    - "Confirm the Diátaxis page kind (tutorial / how-to / reference / explanation)"
-    - "Review the drafted or revised output before it is merged"
+  decisionGateIds:
+    - confirm-documentation-page-kind
+    - review-product-documentation
 whatChanges: "After installing product-documentation, your project has the `author-product-docs` skill — one entry point for five documentation modes. The skill infers the mode from your request, resolves the correct destination (`guides/` for catalogue-facing content, `docs/guides/` for maintainer docs), and follows Diátaxis as a page contract rather than a mandatory directory structure. Pack READMEs are treated as first-class artifacts alongside guide pages."
 skills:
   - name: author-product-docs
     description: "Creates, revises, retrofits, audits, or verifies documentation using Diátaxis as a page contract — one skill, five modes, no forced directory skeleton."
     humanTouches: 2
 humanGates:
-  - id: G-kind
+  - id: confirm-documentation-page-kind
     globalGate: null
-    label: "Confirm the Diátaxis page kind"
+    label: "Confirm the documentation page kind"
     trigger: "Before author-product-docs begins drafting — to confirm the page kind inferred from your request"
     duration: "2–4 minutes"
     whatToCheck:
@@ -31,9 +31,9 @@ humanGates:
     whatGoodLooksLike: "A confirmed page kind that you could justify in one sentence — 'This is a how-to because the reader already knows they want to install X and just needs the steps.'"
     whatBadLooksLike: "An explanation that buries the reader in background before revealing what they can do, or a how-to that opens with three paragraphs about why the tool exists."
     consequence: "A doc written against the wrong page contract misleads the reader from the first sentence. The classification gate catches this before the first paragraph is drafted — cheap here, expensive after it's live."
-  - id: G-review
+  - id: review-product-documentation
     globalGate: "G4"
-    label: "Review the drafted or revised output"
+    label: "Review the product documentation"
     trigger: "After author-product-docs produces an output — before it is committed or merged"
     duration: "10–20 minutes"
     whatToCheck:

--- a/packs/product-documentation/JOURNEY.md
+++ b/packs/product-documentation/JOURNEY.md
@@ -10,6 +10,9 @@ contract:
   useItWhen: "You need to write, improve, or audit any catalogue-facing guide, pack README, or journey — whether you're starting from scratch, reworking legacy docs, or checking that existing pages hold up to their Diátaxis page contract."
   youProvide: "A description of what you want to document, improve, or check, and optionally the mode (create / revise / retrofit / audit / verify)."
   youReceive: "A draft, revision, retrofit plan, audit report, or verification result — whichever fits the request — with the Diátaxis page kind confirmed and the write destination resolved."
+  yourDecisions:
+    - "Confirm the Diátaxis page kind (tutorial / how-to / reference / explanation)"
+    - "Review the drafted or revised output before it is merged"
   decisionGateIds:
     - confirm-documentation-page-kind
     - review-product-documentation

--- a/packs/product-engineering/JOURNEY.md
+++ b/packs/product-engineering/JOURNEY.md
@@ -10,11 +10,11 @@ contract:
   useItWhen: "You have a raw product idea or problem and need to converge on a build-ready decision brief before anyone writes code."
   youProvide: "A product idea or problem description, with any scope constraints or prior discovery context."
   youReceive: "A build-ready decision brief — intent, validated candidate, assumption-test, and decomposition into delivery briefs."
-  yourDecisions:
-    - "Shape intent"
-    - "Mid-discovery check"
-    - "Reconcile"
-    - "Commit to build"
+  decisionGateIds:
+    - approve-intent
+    - select-candidate
+    - approve-decision-brief
+    - commit-to-build
 whatChanges: "After installing product-engineering, upstream intent work runs through discovery-loop: frame → explore → converge → commit. The discovery-lead agent diverges across candidate product shapes, drives the lens roster to convergence, and emits a connected hypothesis with validation hooks — no engine. You review at four human gates; the agent runs everything between them."
 skills:
   - name: discovery-loop
@@ -63,9 +63,9 @@ skills:
     description: "Coordinates a multi-component product intent across a business-unit value stream."
     humanTouches: 1
 humanGates:
-  - id: G0
+  - id: approve-intent
     globalGate: "G0"
-    label: "Shape intent"
+    label: "Approve the intent"
     trigger: "After frame-intent emits the initial framing"
     duration: "10–15 minutes"
     whatToCheck:
@@ -74,10 +74,10 @@ humanGates:
       - "Is the outcome measurable — what would change in the world if this succeeded?"
     whatGoodLooksLike: "A framing that names a specific user, a falsifiable problem, and a measurable outcome."
     whatBadLooksLike: "A framing that could apply to any product — 'improve developer productivity' is not a problem statement."
-    consequence: "G0 is the framing gate. A bad framing means the entire discovery loop explores the wrong space."
-  - id: "G1.5"
+    consequence: "This is the framing gate. A bad framing means the entire discovery loop explores the wrong space."
+  - id: select-candidate
     globalGate: null
-    label: "Mid-discovery check"
+    label: "Choose a candidate"
     trigger: "After explore-options and the first lens-roster pass"
     duration: "15–20 minutes"
     whatToCheck:
@@ -87,9 +87,9 @@ humanGates:
     whatGoodLooksLike: "A clear field of two or three differentiated candidates, each with a distinct tradeoff profile."
     whatBadLooksLike: "All candidates converged to the same shape before the lens roster ran — the diverge step didn't diverge."
     consequence: "The mid-discovery check prevents the loop from converging on a bad candidate without the human noticing."
-  - id: G2
+  - id: approve-decision-brief
     globalGate: null
-    label: "Reconcile"
+    label: "Approve the decision brief"
     trigger: "After the full lens-roster pass on the surviving candidates"
     duration: "20–30 minutes"
     whatToCheck:
@@ -98,8 +98,8 @@ humanGates:
       - "Is the decomposition granular enough to fit in one build-loop iteration?"
     whatGoodLooksLike: "A build-ready decision brief — reviewers clean, falsifiable hypothesis, decomposition that fits the delivery loop."
     whatBadLooksLike: "A brief that passes the gate but skips the riskiest assumption. Or a decomposition too large for one loop."
-    consequence: "G2 produces the build commitment artifact. A bad brief means the delivery loop builds the wrong thing faithfully."
-  - id: G3
+    consequence: "This produces the build commitment artifact. A bad brief means the delivery loop builds the wrong thing faithfully."
+  - id: commit-to-build
     globalGate: "G3"
     label: "Commit to build"
     trigger: "After the reconciliation record is ratified"
@@ -109,7 +109,7 @@ humanGates:
       - "Is there anything in the brief you are not prepared to ship?"
     whatGoodLooksLike: "You ratify the brief and hand it to the delivery loop."
     whatBadLooksLike: "You ratify with reservations and don't surface them. The delivery loop builds faithfully to a brief you had doubts about."
-    consequence: "G3 is the discovery-to-delivery handoff. After this gate, the delivery loop builds."
+    consequence: "This is the discovery-to-delivery handoff. After this gate, the delivery loop builds."
 typicalSession:
   agentTurns: "12–20"
   humanTouches: 4
@@ -118,6 +118,27 @@ docsUrl: /docs/guides/product-engineering/
 packUrl: /packs/product-engineering/
 relatedJourneys:
   - core
+eyebrow: "From an uncertain idea to a build-ready decision"
+goodOutputDescription: |-
+  **You:** Use `discovery-loop` to take this feature idea to a build-ready
+  decision brief. Release owners can see which automated check failed, but not
+  what action will unblock it. Diverge before converging.
+  **Agent:** Initial framing: the affected user is the release owner; the
+  failure names the rule but not the corrective action; success means choosing
+  the next step without inspecting source code.
+  **You:** Approve the intent.
+  **Agent:** I compared three candidates: richer inline guidance, a linked
+  runbook, and interactive remediation. I recommend concise inline guidance
+  with a stable documentation link: it shortens recovery without creating a
+  new runtime path.
+  **You:** Choose that candidate.
+  **Agent:** The decision brief now records the evidence, boundaries, risks,
+  rejected alternatives, and success measures.
+  **You:** Approve the decision brief.
+  **Agent:** The capability map separates failure diagnosis, corrective
+  guidance, and verification. The first build slice is specified and
+  independently reviewable.
+  **You:** Commit to build.
 ---
 
 | Say this | What happens |
@@ -198,7 +219,7 @@ frame-intent
 Ratify framing? ›
 ```
 
-- **You decide:** G0 — ratify the framing before the loop diverges. A vague problem means the loop explores the wrong space.
+- **You decide:** approve the intent — ratify the framing before the loop diverges. A vague problem means the loop explores the wrong space.
 - **Output:** an intent document with a specific problem, named user, and measurable outcome, stamped with the confirmed `Level`.
 - **State:** draft
 
@@ -248,7 +269,7 @@ discovery-reliability-reviewer
 The agent surfaces the surviving candidates for your mid-course review.
 
 ```text
-discovery-loop [G1.5]
+discovery-loop
 
   Candidate   Status       Note
   Shape A     surviving    concern addressed — trust framing added
@@ -259,7 +280,7 @@ discovery-loop [G1.5]
 Mid-discovery check — confirm candidates? ›
 ```
 
-- **You decide:** G1.5 — confirm the surviving candidates or direct a re-exploration. This is the last cheap moment to expand the option space.
+- **You decide:** choose a candidate — confirm the surviving candidates or direct a re-exploration. This is the last cheap moment to expand the option space.
 - **Output:** a confirmed candidate field ready for convergence.
 - **State:** draft
 
@@ -295,7 +316,7 @@ A child whose riskiest assumption is killed bubbles back up — the parent must 
 The agent presents the full discovery sidecar — intent, assumption-test, validated candidate, and decomposition — for your final review.
 
 ```text
-discovery-loop [G2]
+discovery-loop
 
   Section          Status     Notes
   intent           ratified   feature level, onboarding-activation
@@ -306,6 +327,6 @@ discovery-loop [G2]
 Reconcile? ›
 ```
 
-- **You decide:** G2 — is the brief complete? Then G3 — am I ready to build this? These are two distinct decisions; read the brief in full before ratifying either.
+- **You decide:** approve the decision brief — is the brief complete? Then commit to build — am I ready to build this? These are two distinct decisions; read the brief in full before ratifying either.
 - **Output:** a ratified decision brief with a connected hypothesis and validation hooks. At `feature` level this hands off to the delivery loop via `receive-brief`. At `capability` or above it produces ratified child intents — each re-enters the loop independently at its own level.
 - **State:** confirmed-write

--- a/packs/product-engineering/JOURNEY.md
+++ b/packs/product-engineering/JOURNEY.md
@@ -10,6 +10,11 @@ contract:
   useItWhen: "You have a raw product idea or problem and need to converge on a build-ready decision brief before anyone writes code."
   youProvide: "A product idea or problem description, with any scope constraints or prior discovery context."
   youReceive: "A build-ready decision brief — intent, validated candidate, assumption-test, and decomposition into delivery briefs."
+  yourDecisions:
+    - "Shape intent"
+    - "Mid-discovery check"
+    - "Reconcile"
+    - "Commit to build"
   decisionGateIds:
     - approve-intent
     - select-candidate

--- a/packs/product-strategy/JOURNEY.md
+++ b/packs/product-strategy/JOURNEY.md
@@ -10,6 +10,10 @@ contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."
   youReceive: "Committed SWOT, PRFAQ, OKR-derived gap entries in workspace.toml, ux-strategy.md, and content-strategy.md."
+  yourDecisions:
+    - "Approve the market situation picture"
+    - "Approve the PRFAQ"
+    - "Approve the OKR cascade and gap routing"
   decisionGateIds:
     - approve-strategy-situation
     - approve-prfaq

--- a/packs/product-strategy/JOURNEY.md
+++ b/packs/product-strategy/JOURNEY.md
@@ -10,10 +10,10 @@ contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."
   youReceive: "Committed SWOT, PRFAQ, OKR-derived gap entries in workspace.toml, ux-strategy.md, and content-strategy.md."
-  yourDecisions:
-    - "Approve the market situation picture"
-    - "Approve the PRFAQ"
-    - "Approve the OKR cascade and gap routing"
+  decisionGateIds:
+    - approve-strategy-situation
+    - approve-prfaq
+    - approve-okr-cascade
 whatChanges: "After installing product-strategy, every initiative starts with a committed artifact set instead of planning-meeting notes. Nine skills span the full strategy layer: market situation (PESTLE, Porter's, BCG, SWOT), altitude-0 direction (PRFAQ), OKR routing to the PE shaping queue, and the UX and content strategy anchors the experience-design pack reads from. Every artifact commits to `docs/product/shaping/` — the shared path downstream packs reference by name. The OKR cascade writes directly to `workspace.toml`, where product engineers pick up strategy-driven shaping items via `workspace-status`."
 skills:
   - name: synthesize-stakeholder-research
@@ -44,9 +44,9 @@ skills:
     description: "Produces a committed content-strategy.md using the Halvorson quad (Purpose + Process + Structure + Governance) — the organizational governance layer that the experience-design pack's content-design skill consumes."
     humanTouches: 0
 humanGates:
-  - id: G-situation
+  - id: approve-strategy-situation
     globalGate: null
-    label: "Approve the market situation picture"
+    label: "Approve the situation framing"
     trigger: "After run-swot synthesizes the macro environment, competitive landscape, and portfolio inputs"
     duration: "10–15 minutes"
     whatToCheck:
@@ -57,9 +57,9 @@ humanGates:
     whatGoodLooksLike: "A SWOT that reads as a compressed situation summary — each quadrant traceable to a specific finding from PESTLE, Porter's, or the portfolio analysis, with the most critical items named explicitly."
     whatBadLooksLike: "A SWOT that could apply to any company in any market — generic strengths like 'talented team' and generic threats like 'competition'. This means the market analysis didn't surface specific signal."
     consequence: "The SWOT is the situation anchor for the PRFAQ and OKR cascade that follow. A vague SWOT means the altitude-0 artifacts build on an ungrounded situation picture — and the OKR cascade will identify the wrong gaps."
-  - id: G-prfaq
+  - id: approve-prfaq
     globalGate: null
-    label: "Approve the PRFAQ"
+    label: "Approve the PR/FAQ"
     trigger: "After write-prfaq produces the press release and FAQ draft"
     duration: "10–20 minutes"
     whatToCheck:
@@ -70,13 +70,13 @@ humanGates:
     whatGoodLooksLike: "A press release that names a specific person, delivers a measurable benefit, and a FAQ that addresses real objections — readable without the prior market context and still fully specific."
     whatBadLooksLike: "A press release in corporate voice that names no specific person and delivers no measurable benefit. Or a FAQ that only addresses questions the team already knows the answers to."
     consequence: "The PRFAQ is the altitude-0 forcing function — the artifact that initiative briefs trace back to. An unspecific PRFAQ means teams shape initiatives without a shared vision of success. Every product engineer and designer will form their own theory of what 'done' means."
-  - id: G-cascade
+  - id: approve-okr-cascade
     globalGate: null
-    label: "Approve the OKR cascade and gap routing"
+    label: "Approve the OKR cascade"
     trigger: "After run-okr-cascade identifies gaps and before writing strategy-type entries to workspace.toml"
     duration: "10–15 minutes"
     whatToCheck:
-      - "Does each gap entry reflect an actual gap between current state and an OKR target — not a feature the team wants to build regardless?"
+      - "Does the OKR cascade identify actual gaps between current state and each target — not features the team wants to build regardless?"
       - "Are the gaps ranked — does the highest-weight OKR produce the highest-priority gap entries?"
       - "Is each gap specific enough for frame-situation to scope into a shaping brief, or is it too vague to act on?"
       - "Are there OKR targets vague enough that the cascade missed important gaps — should any OKRs be tightened before the cascade completes?"

--- a/packs/release-engineering/JOURNEY.md
+++ b/packs/release-engineering/JOURNEY.md
@@ -11,6 +11,8 @@ contract:
   useItWhen: "A build-loop PR is adversarial-review-clean and ready to go to production."
   youProvide: "A merged, adversarial-review-clean inner build-loop output."
   youReceive: "A release readiness record — e2e results, telemetry snapshot, security review — and a convergence-verified prod ship."
+  yourDecisions:
+    - "Approve the prod ship"
   decisionGateIds:
     - approve-production-release
 whatChanges: "After installing release-engineering, completed build-loop output goes through release-loop before reaching production. The release-lead agent deploys to an ephemeral environment, runs e2e tests, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. You review at one gate: the prod ship."

--- a/packs/release-engineering/JOURNEY.md
+++ b/packs/release-engineering/JOURNEY.md
@@ -11,8 +11,8 @@ contract:
   useItWhen: "A build-loop PR is adversarial-review-clean and ready to go to production."
   youProvide: "A merged, adversarial-review-clean inner build-loop output."
   youReceive: "A release readiness record — e2e results, telemetry snapshot, security review — and a convergence-verified prod ship."
-  yourDecisions:
-    - "Approve the prod ship"
+  decisionGateIds:
+    - approve-production-release
 whatChanges: "After installing release-engineering, completed build-loop output goes through release-loop before reaching production. The release-lead agent deploys to an ephemeral environment, runs e2e tests, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. You review at one gate: the prod ship."
 skills:
   - name: release-loop
@@ -22,9 +22,9 @@ skills:
     description: "Authors an OpenSLO v1 YAML document for a service. Produces the SLO artifact the release-loop PRR gate reads to populate the error-budget status field."
     humanTouches: 0
 humanGates:
-  - id: G5
+  - id: approve-production-release
     globalGate: "G5"
-    label: "Approve the prod ship"
+    label: "Approve the production release"
     trigger: "After the deployed whole converges — e2e clean, telemetry stable, security review done"
     duration: "15–30 minutes"
     whatToCheck:
@@ -34,7 +34,7 @@ humanGates:
       - "Is the rollback path documented and tested?"
     whatGoodLooksLike: "A release readiness record showing convergence — e2e clean, telemetry stable, security reviewer clean, no borderline gates."
     whatBadLooksLike: "A record that notes borderline gates you wave through. Or a record that omits the security diff review."
-    consequence: "G5 gates the prod ship. The agent cannot ship to production without your ratification. After this gate, the change reaches real users or real data — irreversible."
+    consequence: "This gates the production release. The agent cannot ship to production without your ratification. After this gate, the change reaches real users or real data — irreversible."
 typicalSession:
   agentTurns: "varies"
   humanTouches: 1
@@ -43,6 +43,24 @@ docsUrl: /docs/guides/release-engineering/
 packUrl: /packs/release-engineering/
 relatedJourneys:
   - core
+eyebrow: "From a clean build to a verified production release"
+goodOutputDescription: |-
+  **You:** Use `release-loop` for the merged export-filter change. Deploy it to
+  an isolated ephemeral environment, converge on end-to-end results and
+  telemetry, then prepare the release-readiness record. Do not deploy to
+  production without my approval.
+  **Agent:** The target is the merged, independently reviewed change. The
+  environment is isolated from production data and traffic, and teardown is
+  available. Starting the ephemeral deployment.
+  **Agent:** First iteration: the empty-result export flow failed end to end.
+  Other checks and telemetry remained stable. I returned the defect to the
+  inner loop, verified the reviewed fix, and redeployed.
+  **Agent:** Second iteration: all release end-to-end checks pass; latency and
+  errors remain within the recorded service objectives; the deployed-diff
+  security review is clean; and the rollback rehearsal passes. The
+  release-readiness record links the evidence. Borderline gates: none.
+  Production remains unchanged.
+  **You:** Approve the production release.
 ---
 
 ### 1. Trigger and confirm the deploy

--- a/tools/lint-ci-parity.py
+++ b/tools/lint-ci-parity.py
@@ -362,8 +362,10 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
         LOCAL("test"),
     "pytest make-free gate chains (windows-build-gate-chain)":
         LOCAL("test"),
-    "pytest guides sidebar generation":
-        LOCAL("test"),
+        "pytest guides sidebar generation":
+            LOCAL("test"),
+        "pytest journey editorial decisions":
+            LOCAL("test"),
     # Both wired by docs/specs/build-check-coverage-gaps. The seven files these
     # two steps run were on `make test`'s Makefile line and in no workflow's
     # run: steps — locally gated, remotely not.

--- a/tools/lint-journey-contract.py
+++ b/tools/lint-journey-contract.py
@@ -103,8 +103,12 @@ def _check_contract(fm: str) -> list[str]:
         block.append(line)
 
     is_generated = any(re.match(r"generated:\s*true\s*$", line) for line in lines)
-    decision_key = GENERATED_DECISION_KEY if is_generated else HAND_AUTHORED_DECISION_KEY
-    required_keys = (*COMMON_CONTRACT_KEYS, decision_key)
+    # A generated journey carries both: `decisionGateIds` drives fragments and
+    # ordering, and `yourDecisions` is still required by the published catalogue
+    # contract. Hand-authored journeys carry only the display strings.
+    required_keys = (*COMMON_CONTRACT_KEYS, HAND_AUTHORED_DECISION_KEY)
+    if is_generated:
+        required_keys = (*required_keys, GENERATED_DECISION_KEY)
     missing = [
         key for key in required_keys
         if not any(re.match(rf"\s+{key}:", b) for b in block)

--- a/tools/lint-journey-contract.py
+++ b/tools/lint-journey-contract.py
@@ -3,8 +3,9 @@
 
 Each file in web/src/content/journeys/ must carry:
 
-  1. a `contract:` frontmatter object with all four keys — useItWhen,
-     youProvide, youReceive, yourDecisions;
+  1. a `contract:` frontmatter object with useItWhen, youProvide, and
+     youReceive, plus decisionGateIds for generated journey copies or
+     yourDecisions for hand-authored journeys;
   2. a staged narrative whose stages use ONLY the fixed label set, in the
      fixed order, with `Output` always present:
        You provide  <  <Actor> does  <  You do  <  You decide  <  Output
@@ -30,7 +31,11 @@ import re
 import subprocess
 import sys
 
-CONTRACT_KEYS = ("useItWhen", "youProvide", "youReceive", "yourDecisions")
+COMMON_CONTRACT_KEYS = ("useItWhen", "youProvide", "youReceive")
+# Generated copies carry approved semantic identities; hand-authored pages retain
+# display-only decisions until their mappings are editorially approved.
+GENERATED_DECISION_KEY = "decisionGateIds"
+HAND_AUTHORED_DECISION_KEY = "yourDecisions"
 
 ACTORS = ("Agent", "Reviewer", "Loop")
 
@@ -80,7 +85,7 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
 
 
 def _check_contract(fm: str) -> list[str]:
-    """The frontmatter must carry a contract: block with all four keys."""
+    """Validate shared keys plus the generated or hand-authored decision key."""
     lines = fm.splitlines()
     start = None
     for i, line in enumerate(lines):
@@ -97,8 +102,11 @@ def _check_contract(fm: str) -> list[str]:
             break
         block.append(line)
 
+    is_generated = any(re.match(r"generated:\s*true\s*$", line) for line in lines)
+    decision_key = GENERATED_DECISION_KEY if is_generated else HAND_AUTHORED_DECISION_KEY
+    required_keys = (*COMMON_CONTRACT_KEYS, decision_key)
     missing = [
-        key for key in CONTRACT_KEYS
+        key for key in required_keys
         if not any(re.match(rf"\s+{key}:", b) for b in block)
     ]
     return [f"contract missing key `{k}`" for k in missing]

--- a/tools/test-lint-journey-contract.py
+++ b/tools/test-lint-journey-contract.py
@@ -45,6 +45,14 @@ contract:
 - **Output:** a green implementation.
 """
 
+_GENERATED_VALID = _VALID.replace(
+    "pack: alpha\n",
+    "pack: alpha\ngenerated: true\n",
+).replace(
+    '  yourDecisions:\n    - "Approve the plan"\n',
+    "  decisionGateIds:\n    - approve-plan\n",
+)
+
 
 def _run(journey_dir: pathlib.Path) -> subprocess.CompletedProcess[str]:
     env = {**os.environ, "LJC_JOURNEY_DIR": str(journey_dir)}
@@ -85,6 +93,51 @@ def test_missing_contract_key() -> None:
             f"expected exit 1 when a contract key is missing; got {r.returncode}",
         )
         _assert("youReceive" in r.stderr, f"expected missing-key message; got:\n{r.stderr}")
+
+
+def test_generated_contract_with_decision_gate_ids_passes() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp)
+        _write(j, "alpha.md", _GENERATED_VALID)
+        r = _run(j)
+        _assert(
+            r.returncode == 0,
+            f"expected exit 0 for valid generated journey; got {r.returncode}\n{r.stderr}",
+        )
+
+
+def test_generated_requires_decision_gate_ids() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp)
+        _write(
+            j,
+            "alpha.md",
+            _GENERATED_VALID.replace("  decisionGateIds:\n    - approve-plan\n", ""),
+        )
+        r = _run(j)
+        _assert(
+            r.returncode == 1,
+            f"expected exit 1 without decisionGateIds; got {r.returncode}",
+        )
+        _assert(
+            "contract missing key `decisionGateIds`" in r.stderr,
+            f"expected missing decisionGateIds message; got:\n{r.stderr}",
+        )
+
+
+def test_hand_authored_requires_display_decisions() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp)
+        _write(j, "alpha.md", _VALID.replace('  yourDecisions:\n    - "Approve the plan"\n', ""))
+        r = _run(j)
+        _assert(
+            r.returncode == 1,
+            f"expected exit 1 without yourDecisions; got {r.returncode}",
+        )
+        _assert(
+            "contract missing key `yourDecisions`" in r.stderr,
+            f"expected missing yourDecisions message; got:\n{r.stderr}",
+        )
 
 
 def test_stage_missing_output() -> None:
@@ -136,6 +189,9 @@ def main() -> None:
     tests = [
         test_valid_passes,
         test_missing_contract_key,
+        test_generated_contract_with_decision_gate_ids_passes,
+        test_generated_requires_decision_gate_ids,
+        test_hand_authored_requires_display_decisions,
         test_stage_missing_output,
         test_unknown_actor,
         test_surviving_old_heading,

--- a/tools/test-lint-journey-contract.py
+++ b/tools/test-lint-journey-contract.py
@@ -45,11 +45,15 @@ contract:
 - **Output:** a green implementation.
 """
 
+# A generated journey carries BOTH decision keys. `decisionGateIds` drives
+# fragments and ordering; `yourDecisions` is still required by the published
+# catalogue contract, so it is added alongside rather than substituted.
 _GENERATED_VALID = _VALID.replace(
     "pack: alpha\n",
     "pack: alpha\ngenerated: true\n",
 ).replace(
     '  yourDecisions:\n    - "Approve the plan"\n',
+    '  yourDecisions:\n    - "Approve the plan"\n'
     "  decisionGateIds:\n    - approve-plan\n",
 )
 
@@ -125,6 +129,33 @@ def test_generated_requires_decision_gate_ids() -> None:
         )
 
 
+def test_generated_requires_display_decisions_too() -> None:
+    """A generated journey still needs `yourDecisions`.
+
+    The published catalogue contract requires it, so dropping it must fail even
+    when `decisionGateIds` is present. Without this case the additive contract
+    change would have no control at all on the repo side.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        j = pathlib.Path(tmp)
+        _write(
+            j,
+            "alpha.md",
+            _GENERATED_VALID.replace(
+                '  yourDecisions:\n    - "Approve the plan"\n', ""
+            ),
+        )
+        r = _run(j)
+        _assert(
+            r.returncode == 1,
+            f"expected exit 1 without yourDecisions on a generated journey; got {r.returncode}",
+        )
+        _assert(
+            "contract missing key `yourDecisions`" in r.stderr,
+            f"expected missing yourDecisions message; got:\n{r.stderr}",
+        )
+
+
 def test_hand_authored_requires_display_decisions() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         j = pathlib.Path(tmp)
@@ -191,6 +222,7 @@ def main() -> None:
         test_missing_contract_key,
         test_generated_contract_with_decision_gate_ids_passes,
         test_generated_requires_decision_gate_ids,
+        test_generated_requires_display_decisions_too,
         test_hand_authored_requires_display_decisions,
         test_stage_missing_output,
         test_unknown_actor,

--- a/tools/test_journey_editorial_decisions.py
+++ b/tools/test_journey_editorial_decisions.py
@@ -1,0 +1,200 @@
+"""Enforce the approved journey decision mapping against canonical sources."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "docs/specs/journey-page-completion/editorial-decisions.md"
+PACKS = ROOT / "packs"
+ROW = re.compile(
+    r"^\| `(?P<journey>[^`]+)` \| `[^`]+` \| `(?P<identifier>[^`]+)` \| "
+    r"(?P<label>[^|]+?) \|$"
+)
+
+
+def _frontmatter(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "---", f"{path}: missing frontmatter fence"
+    return lines[1 : lines.index("---", 1)]
+
+
+def _scalar(value: str) -> str:
+    return value.strip().strip('"').strip("'")
+
+
+def _ledger_mapping() -> dict[str, list[tuple[str, str]]]:
+    mapping: dict[str, list[tuple[str, str]]] = {}
+    in_table = False
+    for line in LEDGER.read_text(encoding="utf-8").splitlines():
+        if line == "## Approved migration mapping":
+            in_table = True
+            continue
+        if in_table and line.startswith("## "):
+            break
+        if not in_table:
+            continue
+        match = ROW.match(line)
+        if match:
+            mapping.setdefault(match["journey"], []).append(
+                (match["identifier"], match["label"].strip())
+            )
+    return mapping
+
+
+def _pack_mapping(journey: str) -> list[tuple[str, str]]:
+    lines = _frontmatter(PACKS / journey / "JOURNEY.md")
+    gates: list[tuple[str, str]] = []
+    in_gates = False
+    current_id: str | None = None
+    for line in lines:
+        if line == "humanGates:":
+            in_gates = True
+            continue
+        if in_gates and line and not line[0].isspace():
+            break
+        if not in_gates:
+            continue
+        id_match = re.match(r"  - id:\s*(.+)$", line)
+        if id_match:
+            current_id = _scalar(id_match[1])
+            continue
+        label_match = re.match(r"    label:\s*(.+)$", line)
+        if label_match:
+            assert current_id is not None, f"{journey}: label without gate ID"
+            gates.append((current_id, _scalar(label_match[1])))
+            current_id = None
+    return gates
+
+
+def test_editorial_mapping_matches_every_canonical_human_gate() -> None:
+    """The approved ledger is the single source for canonical IDs and labels."""
+    expected = _ledger_mapping()
+
+    assert sum(len(gates) for gates in expected.values()) == 34
+    assert set(expected) == {path.parent.name for path in PACKS.glob("*/JOURNEY.md")}
+
+    actual = {journey: _pack_mapping(journey) for journey in expected}
+    assert actual == expected
+
+
+PRIORITY = ("core", "product-engineering", "release-engineering")
+# `atlassian` carried a `goodOutputDescription` before this spec. It is named here
+# so the absence check stays exact: grandfathered copy is tolerated, a transcript
+# newly added to any other non-priority journey is not.
+GRANDFATHERED_TRANSCRIPTS = frozenset({"atlassian"})
+EYEBROW_ROW = re.compile(r"^Eyebrow: \*\*(?P<eyebrow>.+)\*\*$")
+BLOCK_INDENT = "  "
+
+
+def _ledger_editorial() -> dict[str, tuple[str, list[str]]]:
+    """Parse each priority journey's approved eyebrow and transcript."""
+    editorial: dict[str, tuple[str, list[str]]] = {}
+    journey: str | None = None
+    eyebrow: str | None = None
+    transcript: list[str] = []
+    in_section = False
+
+    def flush() -> None:
+        if journey is None:
+            return
+        assert eyebrow is not None, f"{journey}: ledger section states no eyebrow"
+        assert transcript, f"{journey}: ledger section states no transcript"
+        editorial[journey] = (eyebrow, _chomp(list(transcript)))
+
+    for line in LEDGER.read_text(encoding="utf-8").splitlines():
+        if line == "## Priority journeys":
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if not in_section:
+            continue
+        if line.startswith("### "):
+            flush()
+            journey = line[4:].strip().lower().replace(" ", "-")
+            eyebrow, transcript = None, []
+            continue
+        match = EYEBROW_ROW.match(line)
+        if match:
+            eyebrow = match["eyebrow"]
+            continue
+        # Strip exactly the blockquote marker, then only a Markdown HARD BREAK,
+        # which is two or more trailing spaces. A single trailing space is not a
+        # hard break -- it renders as ordinary spacing the block scalar could have
+        # carried -- so it is preserved and will fail the comparison. Leading
+        # indentation and interior blank lines are preserved on both sides.
+        if line.startswith(">"):
+            quoted = line[2:] if line.startswith("> ") else line[1:]
+            without_trailing = quoted.rstrip(" ")
+            trailing = len(quoted) - len(without_trailing)
+            transcript.append(without_trailing if trailing >= 2 else quoted)
+    flush()
+    return editorial
+
+
+def _chomp(lines: list[str]) -> list[str]:
+    """Drop trailing blank lines, mirroring YAML's `|-` strip chomping."""
+    end = len(lines)
+    while end and not lines[end - 1]:
+        end -= 1
+    return lines[:end]
+
+
+def _pack_editorial(journey: str) -> tuple[str, list[str]]:
+    lines = _frontmatter(PACKS / journey / "JOURNEY.md")
+    eyebrow: str | None = None
+    transcript: list[str] = []
+    in_block = False
+    for line in lines:
+        if in_block:
+            if line and not line.startswith(BLOCK_INDENT):
+                in_block = False
+            else:
+                # Only the base indent belongs to YAML; anything deeper is content.
+                # No rstrip here. Trailing spaces are YAML content, and the ledger
+                # cannot express them, so a stray one in canonical source must fail
+                # rather than be normalised away.
+                transcript.append(line[len(BLOCK_INDENT):] if line else "")
+                continue
+        eyebrow_match = re.match(r"eyebrow:\s*(.+)$", line)
+        if eyebrow_match:
+            eyebrow = _scalar(eyebrow_match[1])
+            continue
+        if re.match(r"goodOutputDescription:\s*\|-?\s*$", line):
+            in_block = True
+    assert eyebrow is not None, f"{journey}: canonical frontmatter states no eyebrow"
+    assert transcript, f"{journey}: canonical frontmatter states no transcript"
+    return eyebrow, _chomp(transcript)
+
+
+def test_priority_pages_emit_the_approved_eyebrow_and_transcript() -> None:
+    """The ledger is the single source for priority eyebrow and transcript copy."""
+    expected = _ledger_editorial()
+
+    assert set(expected) == set(PRIORITY)
+
+    actual = {journey: _pack_editorial(journey) for journey in expected}
+    assert actual == expected
+
+
+def test_editorial_copy_is_confined_to_the_priority_journeys() -> None:
+    """No other journey gains an eyebrow or transcript through this spec."""
+    with_eyebrow: set[str] = set()
+    with_transcript: set[str] = set()
+    for path in sorted(PACKS.glob("*/JOURNEY.md")):
+        lines = _frontmatter(path)
+        if any(re.match(r"eyebrow:", line) for line in lines):
+            with_eyebrow.add(path.parent.name)
+        if any(re.match(r"goodOutputDescription:", line) for line in lines):
+            with_transcript.add(path.parent.name)
+
+    # Eyebrows are exact: this spec created all three and no others exist.
+    assert with_eyebrow == set(PRIORITY)
+    # Transcripts are a subset check, not equality. The ledger's claim is that no
+    # journey *gains* one through this spec, so a new transcript anywhere outside
+    # the allowed set must fail — but deleting the grandfathered `atlassian` copy
+    # is not this spec's business, and equality would wrongly pin it in place.
+    # The priority three are proved present by the comparison test above.
+    assert with_transcript <= set(PRIORITY) | GRANDFATHERED_TRANSCRIPTS

--- a/web/src/components/journey/GateDetail.astro
+++ b/web/src/components/journey/GateDetail.astro
@@ -3,9 +3,10 @@
 // border (task instruction: "amber-bordered gate cards on #fafaf9 background").
 // Uses <details>/<summary> for expandable what-to-check content — zero JS.
 
+import { decisionTargetId } from '../../lib/journey-decisions';
+
 interface Gate {
   id: string;
-  globalGate: string | null;
   label: string;
   trigger: string;
   duration: string;
@@ -17,18 +18,20 @@ interface Gate {
 
 interface Props {
   gate: Gate;
+  decisionGateIds?: string[];
 }
 
-const { gate } = Astro.props;
+const { gate, decisionGateIds } = Astro.props;
+const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
 ---
 
 <div class="gate-card">
   <div class="gate-card__header">
-    <div class="gate-card__id-row">
-      <span class="gate-id">{gate.id}</span>
-      {gate.globalGate && <span class="global-gate">{gate.globalGate}</span>}
-    </div>
-    <h3 class="gate-card__label">{gate.label}</h3>
+    <h3
+      id={decisionTarget}
+      class="gate-card__label"
+      tabindex={decisionTarget ? '-1' : undefined}
+    >{gate.label}</h3>
     <dl class="gate-card__meta">
       <dt>Trigger</dt>
       <dd>{gate.trigger}</dd>
@@ -79,40 +82,26 @@ const { gate } = Astro.props;
     border-radius: var(--ds-radius-md);
   }
 
+  .gate-card:has(.gate-card__label:target),
+  .gate-card:has(.gate-card__label:focus-visible) {
+    outline: 3px solid var(--ds-accent);
+    outline-offset: 3px;
+  }
+
   .gate-card__header {
     padding: var(--ds-space-6);
     padding-bottom: var(--ds-space-4);
-  }
-
-  .gate-card__id-row {
-    display: flex;
-    align-items: center;
-    gap: var(--ds-space-3);
-    margin-bottom: var(--ds-space-3);
-  }
-
-  .gate-id {
-    font-family: var(--ds-font-mono);
-    font-weight: var(--ds-weight-heavy);
-    font-size: var(--ds-type-body-lg);
-    color: var(--ds-accent-deep);
-  }
-
-  .global-gate {
-    font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-xs);
-    text-transform: uppercase;
-    letter-spacing: var(--ds-track-label);
-    background-color: var(--ds-accent-subtle);
-    color: var(--ds-accent-deep);
-    padding: 0.1rem 0.5rem;
-    border-radius: var(--ds-radius-sm);
   }
 
   .gate-card__label {
     font-size: var(--ds-type-h3);
     margin-bottom: var(--ds-space-4);
     color: var(--ds-on-surface);
+  }
+
+  .gate-card__label:focus-visible {
+    outline: 3px solid var(--ds-accent);
+    outline-offset: 3px;
   }
 
   .gate-card__meta {

--- a/web/src/components/journey/JourneyContract.astro
+++ b/web/src/components/journey/JourneyContract.astro
@@ -8,14 +8,24 @@ interface Contract {
   useItWhen: string;
   youProvide: string;
   youReceive: string;
-  yourDecisions: string[];
+  decisionGateIds?: string[];
+  yourDecisions?: string[];
+}
+
+interface Gate {
+  id: string;
+  label: string;
 }
 
 interface Props {
   contract: Contract;
+  humanGates: Gate[];
 }
 
-const { contract } = Astro.props;
+const { contract, humanGates } = Astro.props;
+const gatesById = new Map(humanGates.map((gate) => [gate.id, gate]));
+const decisions = contract.decisionGateIds?.map((id) => gatesById.get(id));
+const decisionCount = decisions?.length ?? 0;
 ---
 
 <div class="contract-card">
@@ -32,16 +42,40 @@ const { contract } = Astro.props;
       <dt>You receive</dt>
       <dd>{contract.youReceive}</dd>
     </div>
-    <div class="contract-row">
-      <dt>Your decisions</dt>
-      <dd class="contract-decisions">
-        {contract.yourDecisions.map((decision) => (
-          <span class="decision-chip">{decision}</span>
-        ))}
-      </dd>
-    </div>
   </dl>
+
+  <section class="contract-decisions" aria-labelledby="where-you-decide">
+    <h3 id="where-you-decide">Where you decide</h3>
+    <p>The agent pauses at these points. You choose whether to continue, redirect, or stop.</p>
+    <div class="decision-chip-list">
+      {decisions?.map((gate, index) => gate && (
+        <a class="decision-chip" href={`#decision-${gate.id}`}>
+          <span>{gate.label}</span>
+          <span class="decision-chip__ordinal">Decision {index + 1} of {decisionCount}</span>
+        </a>
+      ))}
+      {!decisions && contract.yourDecisions?.map((decision) => (
+        <span class="decision-chip">{decision}</span>
+      ))}
+    </div>
+  </section>
 </div>
+
+{decisions && (
+  <script is:inline>
+    const focusDecisionTarget = () => {
+      if (!window.location.hash.startsWith('#decision-')) return;
+      const target = document.getElementById(decodeURIComponent(window.location.hash.slice(1)));
+      if (target instanceof HTMLElement) {
+        target.focus({ preventScroll: true });
+        target.scrollIntoView({ block: 'start' });
+      }
+    };
+
+    window.addEventListener('hashchange', focusDecisionTarget);
+    focusDecisionTarget();
+  </script>
+)}
 
 <style>
   .contract-card {
@@ -81,18 +115,53 @@ const { contract } = Astro.props;
   }
 
   .contract-decisions {
+    margin-top: var(--ds-space-5);
+    padding-top: var(--ds-space-5);
+    border-top: 1px solid var(--ds-border);
+  }
+
+  .contract-decisions h3 {
+    color: var(--ds-on-surface);
+    font-size: var(--ds-type-h3);
+    margin-bottom: var(--ds-space-2);
+  }
+
+  .contract-decisions p {
+    color: var(--ds-on-surface-2);
+    margin-bottom: var(--ds-space-4);
+  }
+
+  .decision-chip-list {
     display: flex;
     flex-wrap: wrap;
     gap: var(--ds-space-3);
   }
 
   .decision-chip {
+    display: grid;
+    gap: var(--ds-space-1);
     font-family: var(--ds-font-mono);
     font-size: var(--ds-type-mono-sm);
     background-color: var(--ds-accent-subtle);
     color: var(--ds-accent-deep);
     padding: 0.25rem 0.6rem;
     border-radius: var(--ds-radius-sm);
+    text-decoration: none;
+  }
+
+  .decision-chip:hover,
+  .decision-chip:focus-visible {
+    background-color: var(--ds-accent);
+    color: var(--ds-hero-fg);
+  }
+
+  .decision-chip:focus-visible {
+    outline: 3px solid var(--ds-on-surface);
+    outline-offset: 3px;
+  }
+
+  .decision-chip__ordinal {
+    font-size: var(--ds-type-xs);
   }
 
   /* Stack labels above values on narrow viewports. */

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from 'astro:content';
 import { z } from 'astro/zod';
 import { glob } from 'astro/loaders';
+import { journeySchema } from './lib/journey-schema';
 
 const packs = defineCollection({
   loader: glob({ pattern: '*.md', base: './src/content/packs' }),
@@ -24,55 +25,7 @@ const packs = defineCollection({
 
 const journeys = defineCollection({
   loader: glob({ pattern: '*.md', base: './src/content/journeys' }),
-  schema: z.object({
-    pack: z.string(),
-    scope: z.enum(['user', 'repo']),
-    tagline: z.string(),
-    prerequisitePacks: z.array(z.string()).default([]),
-    whatChanges: z.string().optional(),
-    // Compact above-the-fold contract (journey-template-revamp). Required —
-    // every journey carries one, enforced here and by lint-journey-contract.py.
-    contract: z.object({
-      useItWhen: z.string(),
-      youProvide: z.string(),
-      youReceive: z.string(),
-      yourDecisions: z.array(z.string()),
-    }),
-    skills: z.array(
-      z.object({
-        name: z.string(),
-        description: z.string(),
-        humanTouches: z.number().int().min(0),
-      })
-    ),
-    humanGates: z.array(
-      z.object({
-        id: z.string(),
-        globalGate: z.string().nullable(),
-        label: z.string(),
-        trigger: z.string(),
-        duration: z.string(),
-        whatToCheck: z.array(z.string()),
-        whatGoodLooksLike: z.string(),
-        whatBadLooksLike: z.string(),
-        consequence: z.string(),
-      })
-    ),
-    typicalSession: z.object({
-      agentTurns: z.string(),
-      humanTouches: z.number().int(),
-      wallClockMinutes: z.string(),
-    }),
-    docsUrl: z.string(),
-    packUrl: z.string(),
-    relatedJourneys: z.array(z.string()).default([]),
-    goodOutputDescription: z.string().optional(),
-    // Phase 2B: pack-local JOURNEY.md additions (optional for legacy compatibility)
-    journey_id: z.string().optional(),
-    start_state: z.string().optional(),
-    end_state: z.string().optional(),
-    generated: z.boolean().optional(),
-  }),
+  schema: journeySchema,
 });
 
 export const collections = { packs, journeys };

--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -11,6 +11,9 @@ contract:
   useItWhen: "You need a technical design doc, architecture diagram, or design critique for your codebase."
   youProvide: "The design problem, real constraints, and the repo's reference architecture."
   youReceive: "An approved Stage 1 design document with alternatives and an independent severity-tagged critique."
+  yourDecisions:
+    - "Approve the Stage 0 concept"
+    - "Review the design and independent critique"
   decisionGateIds:
     - approve-architecture-concept
     - review-architecture-design

--- a/web/src/content/journeys/architect.md
+++ b/web/src/content/journeys/architect.md
@@ -11,9 +11,9 @@ contract:
   useItWhen: "You need a technical design doc, architecture diagram, or design critique for your codebase."
   youProvide: "The design problem, real constraints, and the repo's reference architecture."
   youReceive: "An approved Stage 1 design document with alternatives and an independent severity-tagged critique."
-  yourDecisions:
-    - "Approve the Stage 0 concept"
-    - "Review the design and independent critique"
+  decisionGateIds:
+    - approve-architecture-concept
+    - review-architecture-design
 whatChanges: "After installing architect, every design decision gets a method: `architect-design` shapes a Stage 0 concept before any full write-up begins, writes the complete Google-style doc, and converges it against review; `architect-diagram` draws any system in Mermaid (C4, sequence, state, ER, or flowchart); `architect-review` critiques any design artifact with severity-tagged findings and may consult one bounded untrusted project-knowledge envelope after fixing its scope and rubric. The `design-reviewer` subagent reads finished artifacts cold — no authoring context — so the review cannot mark its own homework. Retrieved knowledge remains candidate evidence, and you decide at two gates: the Stage 0 concept before the full doc is written, and the independently grounded review findings before the doc is shared or acted on."
 skills:
   - name: architect-design
@@ -26,9 +26,9 @@ skills:
     description: "Critiques an existing design doc, diagram, RFC, or ADR with a rubric-routed severity-tagged review; an optional CQ-REVIEW enquiry supplies untrusted candidate checks without changing independent judgment."
     humanTouches: 1
 humanGates:
-  - id: G-concept
+  - id: approve-architecture-concept
     globalGate: null
-    label: "Approve the Stage 0 concept"
+    label: "Approve the architecture concept"
     trigger: "After architect-design emits the initial Stage 0 concept framing"
     duration: "5–10 minutes"
     whatToCheck:
@@ -39,9 +39,9 @@ humanGates:
     whatGoodLooksLike: "A half-page concept that names the problem, real constraints, and a candidate approach — specific enough to commit to a full design doc or redirect before one is written."
     whatBadLooksLike: "A concept that describes an approach without stating what problem it solves, or one that lists constraints the team would actually trade away if asked."
     consequence: "The concept approval gates the full write-up. A wrong concept means the agent writes a polished doc for the wrong problem — the cost is a full write-up cycle, not a concept cycle."
-  - id: G-review
+  - id: review-architecture-design
     globalGate: null
-    label: "Review the design and independent critique"
+    label: "Review the architecture design"
     trigger: "After architect-review or the design-reviewer subagent returns its findings"
     duration: "15–25 minutes"
     whatToCheck:

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -11,11 +11,11 @@ contract:
   useItWhen: "You want to see what the team can work on, improve stories that are not actionable, apply approved Jira updates, or share a team summary — without writing JQL or selecting skills manually."
   youProvide: "Your team name, project keys, or a description of the scope you want reviewed. For writes: explicit confirmation of the exact fields to change."
   youReceive: "A grouped, annotated backlog — ready to pull, needs story work, blocked, in progress — with scope and completeness disclosed. Draft story improvements where requested. Exact write previews before any Jira change. A stand-up summary and optional Confluence draft on request."
-  yourDecisions:
-    - "Confirm or correct the resolved team scope before reading backlog results"
-    - "Select which story drafts to approve for writing"
-    - "Confirm the exact issue keys and fields before any Jira write"
-    - "Approve the Confluence draft before publishing"
+  decisionGateIds:
+    - confirm-backlog-scope
+    - review-story-drafts
+    - confirm-jira-writes
+    - approve-confluence-publish
 whatChanges: "After installing the Atlassian pack, you can ask for your team's full backlog in plain language and receive a structured, annotated result — grouped by readiness, with scope and completeness disclosed — without opening a browser or writing JQL. The pack selects the right workflow for each request: orient first (read-only), improve unclear work when needed (draft), and write only after the requested change is explicit and confirmed. You do not need to know which skill handles each stage."
 skills:
   - name: jira-team-status
@@ -52,9 +52,9 @@ skills:
     description: "Compare two flow-metrics outputs and produce a Markdown adoption report. Read-only; does not call Jira or Confluence."
     humanTouches: 1
 humanGates:
-  - id: G-scope
+  - id: confirm-backlog-scope
     globalGate: null
-    label: "Confirm team scope"
+    label: "Confirm the backlog scope"
     trigger: "When the agent resolves more than one plausible team scope — before returning any backlog results"
     duration: "1–2 minutes"
     whatToCheck:
@@ -64,9 +64,9 @@ humanGates:
     whatGoodLooksLike: "A scope that names the correct board, project set, or Team field — confirmed in one sentence."
     whatBadLooksLike: "A scope that includes the wrong projects, misses a key sprint, or uses the Team field when the board is the right source of truth."
     consequence: "Wrong scope means wrong backlog. Catching it here is a 30-second correction; catching it after reading 184 issues means starting over."
-  - id: G-draft-review
+  - id: review-story-drafts
     globalGate: null
-    label: "Review story drafts"
+    label: "Review the story drafts"
     trigger: "After jira-story-triage produces proposed rewrites — before any write is requested"
     duration: "5–15 minutes"
     whatToCheck:
@@ -77,9 +77,9 @@ humanGates:
     whatGoodLooksLike: "A draft you could hand to an engineer and have them begin work without asking a follow-up question."
     whatBadLooksLike: "A draft that rewrites prose but leaves the ambiguous scope or missing acceptance criteria untouched."
     consequence: "Approving a weak draft locks in the ambiguity. Story triage is the last cheap moment to catch a missing acceptance criterion before it reaches engineering."
-  - id: G-write-confirm
+  - id: confirm-jira-writes
     globalGate: "G4"
-    label: "Confirm exact Jira writes"
+    label: "Confirm the Jira changes"
     trigger: "After the agent shows the write preview — before any Jira data is changed"
     duration: "2–5 minutes"
     whatToCheck:
@@ -90,9 +90,9 @@ humanGates:
     whatGoodLooksLike: "A write payload that exactly matches the approved draft — no extra fields, no unexpected issues, protected fields not listed."
     whatBadLooksLike: "A payload that includes issues you did not select, or fields beyond description and acceptance criteria."
     consequence: "Jira writes are immediate and visible to the team. Confirming the wrong payload means a manual rollback."
-  - id: G-publish
+  - id: approve-confluence-publish
     globalGate: null
-    label: "Approve Confluence publish"
+    label: "Approve publishing to Confluence"
     trigger: "After the agent produces a Confluence-ready draft — before publishing to the space"
     duration: "2–5 minutes"
     whatToCheck:

--- a/web/src/content/journeys/atlassian.md
+++ b/web/src/content/journeys/atlassian.md
@@ -11,6 +11,11 @@ contract:
   useItWhen: "You want to see what the team can work on, improve stories that are not actionable, apply approved Jira updates, or share a team summary — without writing JQL or selecting skills manually."
   youProvide: "Your team name, project keys, or a description of the scope you want reviewed. For writes: explicit confirmation of the exact fields to change."
   youReceive: "A grouped, annotated backlog — ready to pull, needs story work, blocked, in progress — with scope and completeness disclosed. Draft story improvements where requested. Exact write previews before any Jira change. A stand-up summary and optional Confluence draft on request."
+  yourDecisions:
+    - "Confirm or correct the resolved team scope before reading backlog results"
+    - "Select which story drafts to approve for writing"
+    - "Confirm the exact issue keys and fields before any Jira write"
+    - "Approve the Confluence draft before publishing"
   decisionGateIds:
     - confirm-backlog-scope
     - review-story-drafts

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -11,9 +11,9 @@ contract:
   useItWhen: "You're implementing a feature, fixing a bug, or changing an existing repo."
   youProvide: "The task and its important constraints."
   youReceive: "An agreed plan, a checked implementation, review findings, and a merge decision."
-  yourDecisions:
-    - "Approve the plan"
-    - "Merge the PR"
+  decisionGateIds:
+    - approve-plan
+    - merge-reviewed-change
 whatChanges: "After installing core, work-intake becomes the front door for starting, remembering, inspecting, or refreshing work. It writes a canonical artifact and lifecycle entry before any processor runs. Approved specs then move through work-loop: plan → execute → verify → independently grounded review. Stable brief/spec/plan authoring gates may capture reusable supporting practice through project-knowledge; review planning may separately enquire once for untrusted candidate checks, while Draft work, reviewer scratch, findings, and normative artifact content remain untouched. The loop cannot self-certify: it surfaces to you for plan approval and merge."
 skills:
   - name: work-intake
@@ -62,7 +62,7 @@ skills:
     description: "Provides a read-only reference view of the security checklist library. Normal security reviews use security-checklists."
     humanTouches: 0
 humanGates:
-  - id: G-plan
+  - id: approve-plan
     globalGate: null
     label: "Approve the plan"
     trigger: "Before work-loop begins execution — after the agent writes the trio and risk-trigger assessment"
@@ -75,9 +75,9 @@ humanGates:
     whatGoodLooksLike: "A bounded plan with a clear trio, no scope creep, correct risk-trigger assessment, and plausible assumptions."
     whatBadLooksLike: "A plan that extends the scope of the request, missing risk triggers that should have fired, or a trio that doesn't name a specific user."
     consequence: "If you approve a bad plan, the agent executes it faithfully. The cost of a bad plan is the cost of a full loop iteration — plan approval is the cheapest gate."
-  - id: G-pr
+  - id: merge-reviewed-change
     globalGate: "G4"
-    label: "Merge the PR"
+    label: "Merge the reviewed change"
     trigger: "After all mechanical gates pass and adversarial review is clean"
     duration: "10–20 minutes"
     whatToCheck:
@@ -87,7 +87,7 @@ humanGates:
       - "Is there anything in the diff that wasn't in the plan?"
     whatGoodLooksLike: "Green gates, clean adversarial review, spec and implementation aligned, no unexplained diff."
     whatBadLooksLike: "Adversarial reviewer flagged a Blocker and you merged anyway. Or the spec drifted from the implementation without an update."
-    consequence: "G4 is the last line of defense before the build loop output goes to release. A bad merge is harder to undo than a bad plan."
+    consequence: "This is the last line of defense before the build loop output goes to release. A bad merge is harder to undo than a bad plan."
 typicalSession:
   agentTurns: "8–12"
   humanTouches: 2
@@ -96,6 +96,18 @@ docsUrl: /docs/guides/core/
 packUrl: /packs/core/
 relatedJourneys:
   - release-engineering
+eyebrow: "From scoped work to a reviewed merge"
+goodOutputDescription: |-
+  **You:** Start work on adding export filters without changing the existing
+  API route.
+  **Agent:** I routed this to the approved spec. The plan changes the query
+  contract, handler, and emitted API tests. It adds no dependency or
+  migration.
+  **You:** Approve the plan.
+  **Agent:** Implemented. Focused tests, type checking, lint, and the full suite
+  pass. The emitted contract exposes filters and preserves existing defaults.
+  **Independent reviewer:** Clean — ready to commit.
+  **Agent:** The reviewed change is ready for your merge decision.
 ---
 
 | Say this | What happens |

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -11,6 +11,9 @@ contract:
   useItWhen: "You're implementing a feature, fixing a bug, or changing an existing repo."
   youProvide: "The task and its important constraints."
   youReceive: "An agreed plan, a checked implementation, review findings, and a merge decision."
+  yourDecisions:
+    - "Approve the plan"
+    - "Merge the PR"
   decisionGateIds:
     - approve-plan
     - merge-reviewed-change

--- a/web/src/content/journeys/desk-research.md
+++ b/web/src/content/journeys/desk-research.md
@@ -11,9 +11,9 @@ contract:
   useItWhen: "You have a question that needs evidence grounded in primary sources — single-session query or a sustained multi-week investigation."
   youProvide: "A research question, a chosen depth mode, and any known sources or prior corpus."
   youReceive: "A confidence-graded synthesis brief citing primary sources, with an explicit gap map."
-  yourDecisions:
-    - "Set scope and depth"
-    - "Review the synthesized brief"
+  decisionGateIds:
+    - set-research-scope-and-depth
+    - review-research-synthesis
 whatChanges: "After installing desk-research, every question your agent takes on is evidence-grounded before it answers. `desk-research` runs scoping, source curation, and synthesis in one session across four depth modes. For sustained investigations, the four `desk-research-project-*` skills run a lifecycle that accumulates a corpus and ends in a confidence-graded brief. Gaps are named explicitly — honest gaps are better than false confidence."
 skills:
   - name: desk-research
@@ -53,9 +53,9 @@ skills:
     description: "Synthesizes the corpus digest into a brief graded by confidence, ready to hand to a decision."
     humanTouches: 1
 humanGates:
-  - id: G-scope
+  - id: set-research-scope-and-depth
     globalGate: null
-    label: "Set scope and depth"
+    label: "Set the research scope and depth"
     trigger: "Before /research or desk-research-project-start runs"
     duration: "3–5 minutes"
     whatToCheck:
@@ -66,9 +66,9 @@ humanGates:
     whatGoodLooksLike: "A specific, answerable question with a chosen depth mode and a clear success criterion — something a colleague could pick up and continue."
     whatBadLooksLike: "A question that can't be falsified or finished — 'what is the best approach to X?' with no scope boundary or success criterion."
     consequence: "The scope gate sets the direction for everything that follows. A bad scope means the agent searches the wrong space and returns a synthesis that looks complete but answers the wrong question."
-  - id: G-synthesis
+  - id: review-research-synthesis
     globalGate: null
-    label: "Review the synthesized brief"
+    label: "Review the research synthesis"
     trigger: "After the synthesis step completes"
     duration: "10–20 minutes"
     whatToCheck:

--- a/web/src/content/journeys/desk-research.md
+++ b/web/src/content/journeys/desk-research.md
@@ -11,6 +11,9 @@ contract:
   useItWhen: "You have a question that needs evidence grounded in primary sources — single-session query or a sustained multi-week investigation."
   youProvide: "A research question, a chosen depth mode, and any known sources or prior corpus."
   youReceive: "A confidence-graded synthesis brief citing primary sources, with an explicit gap map."
+  yourDecisions:
+    - "Set scope and depth"
+    - "Review the synthesized brief"
   decisionGateIds:
     - set-research-scope-and-depth
     - review-research-synthesis

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -11,6 +11,10 @@ contract:
   useItWhen: "A product team needs a full design thread — from outcome to independently-reviewed screens — before build begins."
   youProvide: "The feature, user, and intended outcome, plus any existing brand or design-system constraints."
   youReceive: "A complete, independently-reviewed design set — journey map, screen inventory, interaction specs, and accessibility-clean designs."
+  yourDecisions:
+    - "Approve the customer journey and derived screen list"
+    - "Approve the aesthetic direction and token set"
+    - "Review the designs after the independent experience-reviewer pass"
   decisionGateIds:
     - approve-journey
     - approve-aesthetic-direction

--- a/web/src/content/journeys/experience-design.md
+++ b/web/src/content/journeys/experience-design.md
@@ -11,10 +11,10 @@ contract:
   useItWhen: "A product team needs a full design thread — from outcome to independently-reviewed screens — before build begins."
   youProvide: "The feature, user, and intended outcome, plus any existing brand or design-system constraints."
   youReceive: "A complete, independently-reviewed design set — journey map, screen inventory, interaction specs, and accessibility-clean designs."
-  yourDecisions:
-    - "Approve the customer journey and derived screen list"
-    - "Approve the aesthetic direction and token set"
-    - "Review the designs after the independent experience-reviewer pass"
+  decisionGateIds:
+    - approve-journey
+    - approve-aesthetic-direction
+    - review-experience-designs
 whatChanges: "After installing experience-design, every design task runs a fixed thread: journey-mapping to anchor user outcomes, user-flow to derive the screen inventory, a craft sequence (creative-direction → design-system → information-architecture → interaction-design) to design each screen, and an independent experience-reviewer pass that reads design artifacts cold. The quality floor — handle-all-states, WCAG 2.2 AA, reduced-motion — is non-negotiable at every step. You decide at three gates: the journey and screen list, the aesthetic direction, and the post-review pass before design feeds the build loop. experience-status orients to the thread at the start of any session."
 skills:
   - name: journey-mapping
@@ -78,22 +78,22 @@ skills:
     description: "Orients to the current design thread at a glance — reads design artifacts from the configured output directory and surfaces what exists, what's missing, and which skill to run next."
     humanTouches: 0
 humanGates:
-  - id: G-journey
+  - id: approve-journey
     globalGate: null
-    label: "Approve the customer journey and derived screen list"
+    label: "Approve the journey"
     trigger: "After journey-mapping and user-flow complete"
     duration: "10–15 minutes"
     whatToCheck:
       - "Does the journey capture the outcome the user is trying to achieve — not just the tasks they perform in the current product?"
-      - "Is the screen list derived from the journey, not from the existing implementation or a wish list?"
+      - "Does the journey provide a clear basis for the derived screen list, rather than the existing implementation or a wish list?"
       - "Are the key failure modes named — the moments the current journey breaks down, and why?"
       - "Is every screen in the list implied by the journey? (Remove screens that aren't.)"
     whatGoodLooksLike: "A journey map that names the outcome, the failure modes, and a screen list with a clear derivation — each screen traceable to a moment in the journey."
     whatBadLooksLike: "A screen list that maps to the current implementation screen-by-screen. This means the agent documented the status quo instead of designing for the outcome."
     consequence: "The screen list is the contract for all design work that follows. A screen list derived from the wrong model means the design thread designs the wrong product — faithfully."
-  - id: G-aesthetic
+  - id: approve-aesthetic-direction
     globalGate: null
-    label: "Approve the aesthetic direction and token set"
+    label: "Approve the aesthetic direction"
     trigger: "After creative-direction and optionally design-system complete"
     duration: "5–10 minutes"
     whatToCheck:
@@ -104,9 +104,9 @@ humanGates:
     whatGoodLooksLike: "A named aesthetic reference with a token set that derives directly from it, passes the contrast floor, and could be handed to a developer without ambiguity."
     whatBadLooksLike: "An aesthetic direction that could apply to any product, or a token set that introduces hardcoded values outside the semantic token system."
     consequence: "The aesthetic direction is the constraint every subsequent screen must satisfy. Approving a vague direction means screens drift with no shared reference to hold them together — and the experience-reviewer will flag every screen for the same missing constraint."
-  - id: G-experience-review
+  - id: review-experience-designs
     globalGate: null
-    label: "Review the designs after the independent experience-reviewer pass"
+    label: "Review the experience designs"
     trigger: "After the experience-reviewer subagent returns findings on the completed screen designs"
     duration: "15–25 minutes"
     whatToCheck:

--- a/web/src/content/journeys/frontend-engineering.md
+++ b/web/src/content/journeys/frontend-engineering.md
@@ -11,6 +11,10 @@ contract:
   useItWhen: "You need to create, retrofit, audit, or verify an HTML/CSS/JS surface with a page/screen contract, accessible states, Core Web Vitals targets, and completion evidence."
   youProvide: "A surface brief, existing page, or completed implementation, plus any product constraints, routes, viewports, design references, and available performance data."
   youReceive: "A proportional page/screen contract, implementation or audit path, gate results, evidence manifest, and independent frontend review focused on regressions that ordinary tests miss."
+  yourDecisions:
+    - "Choose create, retrofit, audit, or verify"
+    - "Approve the page/screen contract before significant UI code"
+    - "Accept or fix known exceptions before completion"
   decisionGateIds:
     - choose-frontend-operating-mode
     - approve-frontend-surface-contract

--- a/web/src/content/journeys/frontend-engineering.md
+++ b/web/src/content/journeys/frontend-engineering.md
@@ -11,10 +11,11 @@ contract:
   useItWhen: "You need to create, retrofit, audit, or verify an HTML/CSS/JS surface with a page/screen contract, accessible states, Core Web Vitals targets, and completion evidence."
   youProvide: "A surface brief, existing page, or completed implementation, plus any product constraints, routes, viewports, design references, and available performance data."
   youReceive: "A proportional page/screen contract, implementation or audit path, gate results, evidence manifest, and independent frontend review focused on regressions that ordinary tests miss."
-  yourDecisions:
-    - "Choose create, retrofit, audit, or verify"
-    - "Approve the page/screen contract before significant UI code"
-    - "Accept or fix known exceptions before completion"
+  decisionGateIds:
+    - choose-frontend-operating-mode
+    - approve-frontend-surface-contract
+    - accept-frontend-evidence
+    - review-frontend-implementation
 whatChanges: "After installing frontend-engineering, the main skill gives one operating path for web surfaces: create starts from a contract, retrofit starts from brownfield inspection, audit reports findings without code changes, and verify runs gates against a completed surface. Supporting skills cover tokens, accessibility, performance, rendering, component contracts, responsive layout, CSS architecture, and status. The frontend-reviewer agent provides an independent diff read for token drift, ARIA mutation completeness, state coverage, WCAG 2.2 manual checks, and Core Web Vitals regression signals."
 skills:
   - name: frontend-engineering
@@ -45,9 +46,9 @@ skills:
     description: "Reads the evidence manifest and reports current frontend quality state."
     humanTouches: 0
 humanGates:
-  - id: G-mode
+  - id: choose-frontend-operating-mode
     globalGate: null
-    label: "Choose the operating mode"
+    label: "Choose the frontend operating mode"
     trigger: "Before planning starts, after you describe the surface or review target"
     duration: "2-5 minutes"
     whatToCheck:
@@ -58,9 +59,9 @@ humanGates:
     whatGoodLooksLike: "The mode matches the job and the expected output is named before work begins."
     whatBadLooksLike: "A small component tweak gets treated like a full new route, or a review-only request silently turns into code edits."
     consequence: "The wrong mode either overburdens a small change or skips evidence a larger surface needs."
-  - id: G-contract
+  - id: approve-frontend-surface-contract
     globalGate: null
-    label: "Approve the page/screen contract"
+    label: "Approve the frontend surface contract"
     trigger: "Before significant UI code in create mode, or before a retrofit becomes a substantial rebuild"
     duration: "10-15 minutes"
     whatToCheck:
@@ -70,9 +71,9 @@ humanGates:
     whatGoodLooksLike: "A reader can tell what the first screen must accomplish and what evidence will prove it."
     whatBadLooksLike: "The contract repeats vague product goals or omits error, empty, keyboard-only, high-zoom, or reduced-motion states that apply."
     consequence: "A weak contract lets the implementation drift into a polished happy path with missing states."
-  - id: G-evidence
+  - id: accept-frontend-evidence
     globalGate: null
-    label: "Accept the evidence manifest"
+    label: "Accept the frontend implementation evidence"
     trigger: "After implementation, audit, or verify mode produces gate results"
     duration: "10-20 minutes"
     whatToCheck:
@@ -82,9 +83,9 @@ humanGates:
     whatGoodLooksLike: "The manifest names what was tested, what passed, what could not be tested, and what remains accepted risk."
     whatBadLooksLike: "Completion is claimed from source inspection alone, or field performance, manual WCAG 2.2 checks, and screenshots are left implicit."
     consequence: "Without evidence, the surface may look complete while still failing in browser, accessibility, or performance review."
-  - id: G-review
+  - id: review-frontend-implementation
     globalGate: null
-    label: "Run independent frontend review"
+    label: "Review the frontend implementation"
     trigger: "After gates and manifest are ready, before merge or handoff"
     duration: "10-20 minutes"
     whatToCheck:

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -12,6 +12,10 @@ contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."
   youReceive: "A completed RFC, a merged ADR, or an updated CONVENTIONS.md — with structured rationale the next person can follow."
+  yourDecisions:
+    - "Review the RFC draft before circulation"
+    - "Accept, reject, or defer the RFC"
+    - "Merge the ADR"
   decisionGateIds:
     - review-rfc-draft
     - decide-rfc

--- a/web/src/content/journeys/governance-extras.md
+++ b/web/src/content/journeys/governance-extras.md
@@ -12,10 +12,10 @@ contract:
   useItWhen: "A cross-cutting change, architectural decision, or working-convention update needs a structured paper trail that survives personnel changes."
   youProvide: "The change or decision to document, plus any objections or alternatives already under consideration."
   youReceive: "A completed RFC, a merged ADR, or an updated CONVENTIONS.md — with structured rationale the next person can follow."
-  yourDecisions:
-    - "Review the RFC draft before circulation"
-    - "Accept, reject, or defer the RFC"
-    - "Merge the ADR"
+  decisionGateIds:
+    - review-rfc-draft
+    - decide-rfc
+    - merge-accepted-adr
 whatChanges: "After installing governance-extras, cross-cutting changes go through a structured RFC before anyone builds anything. Architectural decisions are recorded in ADRs with honest critique tracks. When core project knowledge is present, reusable supporting practice can be captured only at the written-and-clean RFC handoff or the decision-maker's ADR acceptance; normative content stays in its owning artifact. CONVENTIONS.md evolves through tracked updates, not drift. Every significant 'why did we choose this?' has an answer that survives personnel changes."
 skills:
   - name: new-rfc
@@ -31,9 +31,9 @@ skills:
     description: "Surfaces the current RFC landscape at a glance — how many RFCs are in each lifecycle state, which are active, and how many findings are waiting in the candidate register."
     humanTouches: 0
 humanGates:
-  - id: G-draft
+  - id: review-rfc-draft
     globalGate: null
-    label: "Review the RFC draft before circulation"
+    label: "Review the RFC draft"
     trigger: "After new-rfc produces a draft — before it is shared with stakeholders"
     duration: "10–20 minutes"
     whatToCheck:
@@ -44,22 +44,21 @@ humanGates:
     whatGoodLooksLike: "An RFC whose problem statement you could send to someone who doesn't know the project and they'd understand what's being debated. Objections that a thoughtful opponent would actually raise."
     whatBadLooksLike: "An RFC that proposes the solution in the problem statement — 'we should adopt X' instead of 'we need to solve Y.' Or objections that are obviously weaker than the proposer's case and weren't genuinely steelmanned."
     consequence: "A bad RFC draft circulates and the feedback it gets is on the framing, not the substance — wasting reviewers' time and forcing a rewrite. The draft gate is cheap; the rewrite gate is not."
-  - id: G-accept
+  - id: decide-rfc
     globalGate: null
-    label: "Accept, reject, or defer the RFC"
+    label: "Accept or decline the RFC"
     trigger: "After the comment period closes and the RFC is ready for a decision"
     duration: "15–30 minutes"
     whatToCheck:
       - "Have all objections been addressed — or explicitly acknowledged and set aside with a reason?"
-      - "Is the decision clearly stated: Accepted, Rejected, or Deferred — with a rationale?"
+      - "Is the decision clearly stated: Accepted or Rejected — with a rationale?"
       - "If Accepted: is there a follow-on ADR planned to record the architectural decision?"
-      - "If Deferred: is there a trigger condition that would bring it back — or is Deferred a polite way of saying Rejected?"
     whatGoodLooksLike: "A clear disposition with a rationale a future reader could follow. Accepted means someone is building it. Rejected means no one is building it and the document explains why."
-    whatBadLooksLike: "An RFC that accumulates comments and then sits in limbo — no decision, no follow-on. Or a Deferred with no trigger condition, which means it will never be reconsidered."
+    whatBadLooksLike: "An RFC that accumulates comments and then sits in limbo — no decision, no follow-on."
     consequence: "An undecided RFC becomes technical debt in the governance register. People build around it, reference it as precedent, or ignore it entirely — none of those outcomes is what the RFC process is for."
-  - id: G-merge
+  - id: merge-accepted-adr
     globalGate: "G4"
-    label: "Merge the ADR"
+    label: "Merge the accepted ADR"
     trigger: "After new-adr produces a draft ADR ready for review"
     duration: "10–15 minutes"
     whatToCheck:
@@ -107,7 +106,7 @@ new-rfc [adopt trunk-based development]
 Approve? ›
 ```
 
-- **You decide:** review the RFC draft at G-draft before circulating — the most common error is naming the solution in the problem statement; redirect to reframe around the underlying need.
+- **You decide:** review the RFC draft before circulating — the most common error is naming the solution in the problem statement; redirect to reframe around the underlying need.
 - **Output:** `docs/rfc/0043-trunk-based-development.md` — a circulated RFC draft with a clear problem statement and genuine adversarial perspectives. After every mandatory check is clean and the RFC and index entry are written, `rfc-handoff-ready` may capture reusable supporting practice through core's public seam; incomplete or abandoned work produces no capture.
 - **State:** proposed-write
 
@@ -159,6 +158,6 @@ new-adr [branching strategy: trunk-based development]
 Approve? ›
 ```
 
-- **You decide:** accept, reject, or defer the RFC at G-accept; then merge the ADR at G-merge.
+- **You decide:** accept or decline the RFC; then merge the accepted ADR.
 - **Output:** a decided RFC and, if accepted, a merged ADR with honest rationale — linked from the RFC that produced it. Only the decision-maker's Proposed-to-Accepted transition reaches `adr-accepted`; previewed, rejected, or abandoned ADRs never capture, and normative decisions remain solely in the ADR.
 - **State:** confirmed-write

--- a/web/src/content/journeys/iac-terraform.md
+++ b/web/src/content/journeys/iac-terraform.md
@@ -13,6 +13,11 @@ contract:
   useItWhen: "You're authoring or reconciling governed Terraform infrastructure — from intent to a digest-pinned, policy-clean plan."
   youProvide: "A plain-language infrastructure intent with target cloud, engine, environments, isolation model, and CI system."
   youReceive: "A digest-pinned Terraform plan with policy-pass evidence, security review, reversibility hints, and a release readiness record."
+  yourDecisions:
+    - "Approve the governance gate"
+    - "Approve the inner-loop plan"
+    - "Approve the G4 handoff — merge the PR"
+    - "Approve the prod ship"
   decisionGateIds:
     - approve-infrastructure-governance
     - approve-infrastructure-plan

--- a/web/src/content/journeys/iac-terraform.md
+++ b/web/src/content/journeys/iac-terraform.md
@@ -13,23 +13,23 @@ contract:
   useItWhen: "You're authoring or reconciling governed Terraform infrastructure — from intent to a digest-pinned, policy-clean plan."
   youProvide: "A plain-language infrastructure intent with target cloud, engine, environments, isolation model, and CI system."
   youReceive: "A digest-pinned Terraform plan with policy-pass evidence, security review, reversibility hints, and a release readiness record."
-  yourDecisions:
-    - "Approve the governance gate"
-    - "Approve the inner-loop plan"
-    - "Approve the G4 handoff — merge the PR"
-    - "Approve the prod ship"
-whatChanges: "After installing iac-terraform, a plain-language infrastructure intent moves through a governed authoring loop: a mandatory Stage-0 ADR gate → a vocabulary-firewalled spec → schema-grounded Terraform generation → policy-as-code and security preflight → G4 handoff to release-loop. The pack ships two skills: generate-iac authors the Terraform and stops at a digest-pinnable plan; reconcile-iac audits plan-visible drift and proposes a per-resource disposition without applying autonomously. The agent never runs terraform apply — it produces and pins the plan; release-loop (or the generated human-gated pipeline) routes it to the real account."
+  decisionGateIds:
+    - approve-infrastructure-governance
+    - approve-infrastructure-plan
+    - merge-infrastructure-change
+    - approve-production-infrastructure-release
+whatChanges: "After installing iac-terraform, a plain-language infrastructure intent moves through a governed authoring loop: a mandatory Stage-0 ADR gate → a vocabulary-firewalled spec → schema-grounded Terraform generation → policy-as-code and security preflight → a reviewed handoff to release-loop. The pack ships two skills: generate-iac authors the Terraform and stops at a digest-pinnable plan; reconcile-iac audits plan-visible drift and proposes a per-resource disposition without applying autonomously. The agent never runs terraform apply — it produces and pins the plan; release-loop (or the generated human-gated pipeline) routes it to the real account."
 skills:
   - name: generate-iac
-    description: "Turns a plain-language intent into governed, schema-grounded Terraform — ADR-gated, vocabulary-firewalled, and stopping at a digest-pinnable plan for G4 handoff."
+    description: "Turns a plain-language intent into governed, schema-grounded Terraform — ADR-gated, vocabulary-firewalled, and stopping at a digest-pinnable plan for a reviewed handoff."
     humanTouches: 3
   - name: reconcile-iac
     description: "Audits plan-visible drift between Terraform state and the live control plane, proposes a disposition per drifted resource, and routes remediation for human approval — never autonomously applies."
     humanTouches: 1
 humanGates:
-  - id: G-governance
+  - id: approve-infrastructure-governance
     globalGate: null
-    label: "Approve the governance gate"
+    label: "Approve the infrastructure governance"
     trigger: "Before any Terraform is authored — after the agent loads the governance index and identifies which ADRs bind the intent"
     duration: "5–15 minutes"
     whatToCheck:
@@ -40,9 +40,9 @@ humanGates:
     whatGoodLooksLike: "A governance index loaded, the right ADRs cited, no uncovered decision domain, and a vocabulary-firewalled spec."
     whatBadLooksLike: "The agent cited an ADR that doesn't cover the decision domain, skipped the governance index load, or wrote RDS/S3/GCS into the spec before PLAN."
     consequence: "If you skip or rubber-stamp the governance gate, the generated Terraform will be ungoverned — no decision records binding the choices, no constraint on which cloud services are used, and no way to review the decision retrospectively."
-  - id: G-plan
+  - id: approve-infrastructure-plan
     globalGate: null
-    label: "Approve the inner-loop plan"
+    label: "Approve the infrastructure plan"
     trigger: "After ADR gate passes and inputs are confirmed — before Terraform authoring begins"
     duration: "5–10 minutes"
     whatToCheck:
@@ -53,9 +53,9 @@ humanGates:
     whatGoodLooksLike: "A tier-ordered task list with ADR citations, explicit isolation model, and parallel annotations only where safe."
     whatBadLooksLike: "Tasks in arbitrary order, missing ADR citations, or the account isolation model left undocumented."
     consequence: "A mis-ordered task plan produces apply-time dependency conflicts — the most expensive class of apply-time failure, invisible to plan."
-  - id: G4
+  - id: merge-infrastructure-change
     globalGate: "G4"
-    label: "Approve the G4 handoff — merge the PR"
+    label: "Merge the infrastructure change"
     trigger: "After plan is digest-pinned: fmt clean, validate clean, plan clean, policy-as-code clean, security reviewer clean"
     duration: "15–30 minutes"
     whatToCheck:
@@ -63,13 +63,13 @@ humanGates:
       - "Did policy-as-code (OPA/Conftest) pass against the plan JSON — no unapproved resource types, required tags present?"
       - "Did the security reviewer find no new misconfigurations (Trivy/Checkov clean)?"
       - "Are reversibility hints correct? (Stateful data stores must be one-way-door, not reversible.)"
-      - "If Infracost produced a cost delta, is the projected spend acceptable — or does it require a spend gate at G5?"
+      - "If Infracost produced a cost delta, is the projected spend acceptable — or does it require a production spend gate?"
     whatGoodLooksLike: "A digest-pinned plan with policy-pass evidence, security review clean, correct reversibility hints, and an acceptable cost delta."
     whatBadLooksLike: "A plan without a pinned digest — the deploy step could apply a later, unreviewed plan. Or a reversibility hint of reversible on a DynamoDB table or RDS instance."
-    consequence: "G4 is the last gate before deploy. An unpinned plan or missing policy-pass lets an unreviewed change reach a real account. A wrong reversibility hint silences the G5 spend or data gate."
-  - id: G5
+    consequence: "This is the last gate before deploy. An unpinned plan or missing policy-pass lets an unreviewed change reach a real account. A wrong reversibility hint silences the production spend or data gate."
+  - id: approve-production-infrastructure-release
     globalGate: "G5"
-    label: "Approve the prod ship"
+    label: "Approve the production infrastructure release"
     trigger: "After the deployed whole converges on the ephemeral environment — e2e clean, telemetry stable, security review done"
     duration: "15–30 minutes"
     whatToCheck:
@@ -79,7 +79,7 @@ humanGates:
       - "Is the rollback path tested on the ephemeral environment — and do you trust it for prod?"
     whatGoodLooksLike: "A complete release readiness record, no open borderline gates, and a rollback path that was actually run on the ephemeral environment."
     whatBadLooksLike: "A record with missing sections, borderline gates waved through, or a rollback path that was described but never exercised."
-    consequence: "G5 gates the prod ship. After this gate the change reaches real infrastructure — partially applied states require targeted destroy/re-apply paths, not clean undo."
+    consequence: "This gates the production infrastructure release. After this gate the change reaches real infrastructure — partially applied states require targeted destroy/re-apply paths, not clean undo."
 typicalSession:
   agentTurns: "12–20"
   humanTouches: 3
@@ -122,13 +122,13 @@ relatedJourneys:
 
 ---
 
-### 3. Run static preflight and hand off to G4
+### 3. Run static preflight and prepare the reviewed handoff
 
-- **Agent does:** runs policy-as-code (OPA/Conftest against the plan JSON — approved resource types, required tags, encryption at rest, no hard-coded credentials); runs Infracost for an optional cost delta; pins the plan digest; assembles the G4 handoff artifact with all evidence.
+- **Agent does:** runs policy-as-code (OPA/Conftest against the plan JSON — approved resource types, required tags, encryption at rest, no hard-coded credentials); runs Infracost for an optional cost delta; pins the plan digest; assembles the reviewed handoff artifact with all evidence.
 - **Reviewer does:** security-reviewer scans the generated configurations (Trivy/Checkov); adversarial-reviewer reads the spec, plan, and diff cold with no context from the authoring session.
-- **You do:** read the policy-pass evidence and security review summary; check reversibility hints on stateful resources — a wrong hint silences the G5 spend or data gate; decide whether the cost delta requires a spend gate at G5.
-- **You decide:** approve the G4 handoff — merge the PR.
-- **Output:** a digest-pinned G4 handoff — deploy-ready Terraform, policy-pass evidence, security review summary, reversibility hints on stateful resources, and cost delta if present.
+- **You do:** read the policy-pass evidence and security review summary; check reversibility hints on stateful resources — a wrong hint silences the production spend or data gate; decide whether the cost delta requires a production spend gate.
+- **You decide:** merge the infrastructure change.
+- **Output:** a digest-pinned reviewed handoff — deploy-ready Terraform, policy-pass evidence, security review summary, reversibility hints on stateful resources, and cost delta if present.
 - **State:** confirmed-write
 
 ---

--- a/web/src/content/journeys/product-engineering.md
+++ b/web/src/content/journeys/product-engineering.md
@@ -11,6 +11,11 @@ contract:
   useItWhen: "You have a raw product idea or problem and need to converge on a build-ready decision brief before anyone writes code."
   youProvide: "A product idea or problem description, with any scope constraints or prior discovery context."
   youReceive: "A build-ready decision brief — intent, validated candidate, assumption-test, and decomposition into delivery briefs."
+  yourDecisions:
+    - "Shape intent"
+    - "Mid-discovery check"
+    - "Reconcile"
+    - "Commit to build"
   decisionGateIds:
     - approve-intent
     - select-candidate

--- a/web/src/content/journeys/product-engineering.md
+++ b/web/src/content/journeys/product-engineering.md
@@ -11,11 +11,11 @@ contract:
   useItWhen: "You have a raw product idea or problem and need to converge on a build-ready decision brief before anyone writes code."
   youProvide: "A product idea or problem description, with any scope constraints or prior discovery context."
   youReceive: "A build-ready decision brief — intent, validated candidate, assumption-test, and decomposition into delivery briefs."
-  yourDecisions:
-    - "Shape intent"
-    - "Mid-discovery check"
-    - "Reconcile"
-    - "Commit to build"
+  decisionGateIds:
+    - approve-intent
+    - select-candidate
+    - approve-decision-brief
+    - commit-to-build
 whatChanges: "After installing product-engineering, upstream intent work runs through discovery-loop: frame → explore → converge → commit. The discovery-lead agent diverges across candidate product shapes, drives the lens roster to convergence, and emits a connected hypothesis with validation hooks — no engine. You review at four human gates; the agent runs everything between them."
 skills:
   - name: discovery-loop
@@ -64,9 +64,9 @@ skills:
     description: "Coordinates a multi-component product intent across a business-unit value stream."
     humanTouches: 1
 humanGates:
-  - id: G0
+  - id: approve-intent
     globalGate: "G0"
-    label: "Shape intent"
+    label: "Approve the intent"
     trigger: "After frame-intent emits the initial framing"
     duration: "10–15 minutes"
     whatToCheck:
@@ -75,10 +75,10 @@ humanGates:
       - "Is the outcome measurable — what would change in the world if this succeeded?"
     whatGoodLooksLike: "A framing that names a specific user, a falsifiable problem, and a measurable outcome."
     whatBadLooksLike: "A framing that could apply to any product — 'improve developer productivity' is not a problem statement."
-    consequence: "G0 is the framing gate. A bad framing means the entire discovery loop explores the wrong space."
-  - id: "G1.5"
+    consequence: "This is the framing gate. A bad framing means the entire discovery loop explores the wrong space."
+  - id: select-candidate
     globalGate: null
-    label: "Mid-discovery check"
+    label: "Choose a candidate"
     trigger: "After explore-options and the first lens-roster pass"
     duration: "15–20 minutes"
     whatToCheck:
@@ -88,9 +88,9 @@ humanGates:
     whatGoodLooksLike: "A clear field of two or three differentiated candidates, each with a distinct tradeoff profile."
     whatBadLooksLike: "All candidates converged to the same shape before the lens roster ran — the diverge step didn't diverge."
     consequence: "The mid-discovery check prevents the loop from converging on a bad candidate without the human noticing."
-  - id: G2
+  - id: approve-decision-brief
     globalGate: null
-    label: "Reconcile"
+    label: "Approve the decision brief"
     trigger: "After the full lens-roster pass on the surviving candidates"
     duration: "20–30 minutes"
     whatToCheck:
@@ -99,8 +99,8 @@ humanGates:
       - "Is the decomposition granular enough to fit in one build-loop iteration?"
     whatGoodLooksLike: "A build-ready decision brief — reviewers clean, falsifiable hypothesis, decomposition that fits the delivery loop."
     whatBadLooksLike: "A brief that passes the gate but skips the riskiest assumption. Or a decomposition too large for one loop."
-    consequence: "G2 produces the build commitment artifact. A bad brief means the delivery loop builds the wrong thing faithfully."
-  - id: G3
+    consequence: "This produces the build commitment artifact. A bad brief means the delivery loop builds the wrong thing faithfully."
+  - id: commit-to-build
     globalGate: "G3"
     label: "Commit to build"
     trigger: "After the reconciliation record is ratified"
@@ -110,7 +110,7 @@ humanGates:
       - "Is there anything in the brief you are not prepared to ship?"
     whatGoodLooksLike: "You ratify the brief and hand it to the delivery loop."
     whatBadLooksLike: "You ratify with reservations and don't surface them. The delivery loop builds faithfully to a brief you had doubts about."
-    consequence: "G3 is the discovery-to-delivery handoff. After this gate, the delivery loop builds."
+    consequence: "This is the discovery-to-delivery handoff. After this gate, the delivery loop builds."
 typicalSession:
   agentTurns: "12–20"
   humanTouches: 4
@@ -119,6 +119,27 @@ docsUrl: /docs/guides/product-engineering/
 packUrl: /packs/product-engineering/
 relatedJourneys:
   - core
+eyebrow: "From an uncertain idea to a build-ready decision"
+goodOutputDescription: |-
+  **You:** Use `discovery-loop` to take this feature idea to a build-ready
+  decision brief. Release owners can see which automated check failed, but not
+  what action will unblock it. Diverge before converging.
+  **Agent:** Initial framing: the affected user is the release owner; the
+  failure names the rule but not the corrective action; success means choosing
+  the next step without inspecting source code.
+  **You:** Approve the intent.
+  **Agent:** I compared three candidates: richer inline guidance, a linked
+  runbook, and interactive remediation. I recommend concise inline guidance
+  with a stable documentation link: it shortens recovery without creating a
+  new runtime path.
+  **You:** Choose that candidate.
+  **Agent:** The decision brief now records the evidence, boundaries, risks,
+  rejected alternatives, and success measures.
+  **You:** Approve the decision brief.
+  **Agent:** The capability map separates failure diagnosis, corrective
+  guidance, and verification. The first build slice is specified and
+  independently reviewable.
+  **You:** Commit to build.
 ---
 
 | Say this | What happens |
@@ -199,7 +220,7 @@ frame-intent
 Ratify framing? ›
 ```
 
-- **You decide:** G0 — ratify the framing before the loop diverges. A vague problem means the loop explores the wrong space.
+- **You decide:** approve the intent — ratify the framing before the loop diverges. A vague problem means the loop explores the wrong space.
 - **Output:** an intent document with a specific problem, named user, and measurable outcome, stamped with the confirmed `Level`.
 - **State:** draft
 
@@ -249,7 +270,7 @@ discovery-reliability-reviewer
 The agent surfaces the surviving candidates for your mid-course review.
 
 ```text
-discovery-loop [G1.5]
+discovery-loop
 
   Candidate   Status       Note
   Shape A     surviving    concern addressed — trust framing added
@@ -260,7 +281,7 @@ discovery-loop [G1.5]
 Mid-discovery check — confirm candidates? ›
 ```
 
-- **You decide:** G1.5 — confirm the surviving candidates or direct a re-exploration. This is the last cheap moment to expand the option space.
+- **You decide:** choose a candidate — confirm the surviving candidates or direct a re-exploration. This is the last cheap moment to expand the option space.
 - **Output:** a confirmed candidate field ready for convergence.
 - **State:** draft
 
@@ -296,7 +317,7 @@ A child whose riskiest assumption is killed bubbles back up — the parent must 
 The agent presents the full discovery sidecar — intent, assumption-test, validated candidate, and decomposition — for your final review.
 
 ```text
-discovery-loop [G2]
+discovery-loop
 
   Section          Status     Notes
   intent           ratified   feature level, onboarding-activation
@@ -307,6 +328,6 @@ discovery-loop [G2]
 Reconcile? ›
 ```
 
-- **You decide:** G2 — is the brief complete? Then G3 — am I ready to build this? These are two distinct decisions; read the brief in full before ratifying either.
+- **You decide:** approve the decision brief — is the brief complete? Then commit to build — am I ready to build this? These are two distinct decisions; read the brief in full before ratifying either.
 - **Output:** a ratified decision brief with a connected hypothesis and validation hooks. At `feature` level this hands off to the delivery loop via `receive-brief`. At `capability` or above it produces ratified child intents — each re-enters the loop independently at its own level.
 - **State:** confirmed-write

--- a/web/src/content/journeys/product-strategy.md
+++ b/web/src/content/journeys/product-strategy.md
@@ -11,10 +11,10 @@ contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."
   youReceive: "Committed SWOT, PRFAQ, OKR-derived gap entries in workspace.toml, ux-strategy.md, and content-strategy.md."
-  yourDecisions:
-    - "Approve the market situation picture"
-    - "Approve the PRFAQ"
-    - "Approve the OKR cascade and gap routing"
+  decisionGateIds:
+    - approve-strategy-situation
+    - approve-prfaq
+    - approve-okr-cascade
 whatChanges: "After installing product-strategy, every initiative starts with a committed artifact set instead of planning-meeting notes. Nine skills span the full strategy layer: market situation (PESTLE, Porter's, BCG, SWOT), altitude-0 direction (PRFAQ), OKR routing to the PE shaping queue, and the UX and content strategy anchors the experience-design pack reads from. Every artifact commits to `docs/product/shaping/` — the shared path downstream packs reference by name. The OKR cascade writes directly to `workspace.toml`, where product engineers pick up strategy-driven shaping items via `workspace-status`."
 skills:
   - name: synthesize-stakeholder-research
@@ -45,9 +45,9 @@ skills:
     description: "Produces a committed content-strategy.md using the Halvorson quad (Purpose + Process + Structure + Governance) — the organizational governance layer that the experience-design pack's content-design skill consumes."
     humanTouches: 0
 humanGates:
-  - id: G-situation
+  - id: approve-strategy-situation
     globalGate: null
-    label: "Approve the market situation picture"
+    label: "Approve the situation framing"
     trigger: "After run-swot synthesizes the macro environment, competitive landscape, and portfolio inputs"
     duration: "10–15 minutes"
     whatToCheck:
@@ -58,9 +58,9 @@ humanGates:
     whatGoodLooksLike: "A SWOT that reads as a compressed situation summary — each quadrant traceable to a specific finding from PESTLE, Porter's, or the portfolio analysis, with the most critical items named explicitly."
     whatBadLooksLike: "A SWOT that could apply to any company in any market — generic strengths like 'talented team' and generic threats like 'competition'. This means the market analysis didn't surface specific signal."
     consequence: "The SWOT is the situation anchor for the PRFAQ and OKR cascade that follow. A vague SWOT means the altitude-0 artifacts build on an ungrounded situation picture — and the OKR cascade will identify the wrong gaps."
-  - id: G-prfaq
+  - id: approve-prfaq
     globalGate: null
-    label: "Approve the PRFAQ"
+    label: "Approve the PR/FAQ"
     trigger: "After write-prfaq produces the press release and FAQ draft"
     duration: "10–20 minutes"
     whatToCheck:
@@ -71,13 +71,13 @@ humanGates:
     whatGoodLooksLike: "A press release that names a specific person, delivers a measurable benefit, and a FAQ that addresses real objections — readable without the prior market context and still fully specific."
     whatBadLooksLike: "A press release in corporate voice that names no specific person and delivers no measurable benefit. Or a FAQ that only addresses questions the team already knows the answers to."
     consequence: "The PRFAQ is the altitude-0 forcing function — the artifact that initiative briefs trace back to. An unspecific PRFAQ means teams shape initiatives without a shared vision of success. Every product engineer and designer will form their own theory of what 'done' means."
-  - id: G-cascade
+  - id: approve-okr-cascade
     globalGate: null
-    label: "Approve the OKR cascade and gap routing"
+    label: "Approve the OKR cascade"
     trigger: "After run-okr-cascade identifies gaps and before writing strategy-type entries to workspace.toml"
     duration: "10–15 minutes"
     whatToCheck:
-      - "Does each gap entry reflect an actual gap between current state and an OKR target — not a feature the team wants to build regardless?"
+      - "Does the OKR cascade identify actual gaps between current state and each target — not features the team wants to build regardless?"
       - "Are the gaps ranked — does the highest-weight OKR produce the highest-priority gap entries?"
       - "Is each gap specific enough for frame-situation to scope into a shaping brief, or is it too vague to act on?"
       - "Are there OKR targets vague enough that the cascade missed important gaps — should any OKRs be tightened before the cascade completes?"

--- a/web/src/content/journeys/product-strategy.md
+++ b/web/src/content/journeys/product-strategy.md
@@ -11,6 +11,10 @@ contract:
   useItWhen: "You're building the committed strategy layer — market analysis, altitude-0 direction, and OKR-derived gap routing — upstream of any product initiative."
   youProvide: "Company OKRs, any prior desk-research outputs, and the scope of the initiative or strategic question to address."
   youReceive: "Committed SWOT, PRFAQ, OKR-derived gap entries in workspace.toml, ux-strategy.md, and content-strategy.md."
+  yourDecisions:
+    - "Approve the market situation picture"
+    - "Approve the PRFAQ"
+    - "Approve the OKR cascade and gap routing"
   decisionGateIds:
     - approve-strategy-situation
     - approve-prfaq

--- a/web/src/content/journeys/release-engineering.md
+++ b/web/src/content/journeys/release-engineering.md
@@ -12,8 +12,8 @@ contract:
   useItWhen: "A build-loop PR is adversarial-review-clean and ready to go to production."
   youProvide: "A merged, adversarial-review-clean inner build-loop output."
   youReceive: "A release readiness record — e2e results, telemetry snapshot, security review — and a convergence-verified prod ship."
-  yourDecisions:
-    - "Approve the prod ship"
+  decisionGateIds:
+    - approve-production-release
 whatChanges: "After installing release-engineering, completed build-loop output goes through release-loop before reaching production. The release-lead agent deploys to an ephemeral environment, runs e2e tests, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. You review at one gate: the prod ship."
 skills:
   - name: release-loop
@@ -23,9 +23,9 @@ skills:
     description: "Authors an OpenSLO v1 YAML document for a service. Produces the SLO artifact the release-loop PRR gate reads to populate the error-budget status field."
     humanTouches: 0
 humanGates:
-  - id: G5
+  - id: approve-production-release
     globalGate: "G5"
-    label: "Approve the prod ship"
+    label: "Approve the production release"
     trigger: "After the deployed whole converges — e2e clean, telemetry stable, security review done"
     duration: "15–30 minutes"
     whatToCheck:
@@ -35,7 +35,7 @@ humanGates:
       - "Is the rollback path documented and tested?"
     whatGoodLooksLike: "A release readiness record showing convergence — e2e clean, telemetry stable, security reviewer clean, no borderline gates."
     whatBadLooksLike: "A record that notes borderline gates you wave through. Or a record that omits the security diff review."
-    consequence: "G5 gates the prod ship. The agent cannot ship to production without your ratification. After this gate, the change reaches real users or real data — irreversible."
+    consequence: "This gates the production release. The agent cannot ship to production without your ratification. After this gate, the change reaches real users or real data — irreversible."
 typicalSession:
   agentTurns: "varies"
   humanTouches: 1
@@ -44,6 +44,24 @@ docsUrl: /docs/guides/release-engineering/
 packUrl: /packs/release-engineering/
 relatedJourneys:
   - core
+eyebrow: "From a clean build to a verified production release"
+goodOutputDescription: |-
+  **You:** Use `release-loop` for the merged export-filter change. Deploy it to
+  an isolated ephemeral environment, converge on end-to-end results and
+  telemetry, then prepare the release-readiness record. Do not deploy to
+  production without my approval.
+  **Agent:** The target is the merged, independently reviewed change. The
+  environment is isolated from production data and traffic, and teardown is
+  available. Starting the ephemeral deployment.
+  **Agent:** First iteration: the empty-result export flow failed end to end.
+  Other checks and telemetry remained stable. I returned the defect to the
+  inner loop, verified the reviewed fix, and redeployed.
+  **Agent:** Second iteration: all release end-to-end checks pass; latency and
+  errors remain within the recorded service objectives; the deployed-diff
+  security review is clean; and the rollback rehearsal passes. The
+  release-readiness record links the evidence. Borderline gates: none.
+  Production remains unchanged.
+  **You:** Approve the production release.
 ---
 
 ### 1. Trigger and confirm the deploy

--- a/web/src/content/journeys/release-engineering.md
+++ b/web/src/content/journeys/release-engineering.md
@@ -12,6 +12,8 @@ contract:
   useItWhen: "A build-loop PR is adversarial-review-clean and ready to go to production."
   youProvide: "A merged, adversarial-review-clean inner build-loop output."
   youReceive: "A release readiness record — e2e results, telemetry snapshot, security review — and a convergence-verified prod ship."
+  yourDecisions:
+    - "Approve the prod ship"
   decisionGateIds:
     - approve-production-release
 whatChanges: "After installing release-engineering, completed build-loop output goes through release-loop before reaching production. The release-lead agent deploys to an ephemeral environment, runs e2e tests, observes telemetry, and feeds deployed findings back to the inner loop — no human relay. You review at one gate: the prod ship."

--- a/web/src/lib/journey-decisions.ts
+++ b/web/src/lib/journey-decisions.ts
@@ -1,0 +1,7 @@
+/** Return the public fragment target only for semantic-ID journeys. */
+export function decisionTargetId(
+  decisionGateIds: readonly string[] | undefined,
+  gateId: string,
+): string | undefined {
+  return decisionGateIds?.includes(gateId) ? `decision-${gateId}` : undefined;
+}

--- a/web/src/lib/journey-schema.ts
+++ b/web/src/lib/journey-schema.ts
@@ -67,13 +67,10 @@ export const journeySchema = z.object({
     });
     return;
   }
-  if (journey.generated && journey.contract.yourDecisions) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['contract', 'yourDecisions'],
-      message: 'generated journeys use decision gate IDs, not display decision strings',
-    });
-  }
+  // `yourDecisions` deliberately coexists with `decisionGateIds`. The published
+  // catalogue contract still requires it, so a generated journey carries both:
+  // the IDs drive fragments and ordering, the strings stay the adopter-facing
+  // prose. The renderer prefers the IDs, so nothing is displayed twice.
   if (!decisionGateIds) return;
 
   const gateIds = new Set(journey.humanGates.map((gate) => gate.id));

--- a/web/src/lib/journey-schema.ts
+++ b/web/src/lib/journey-schema.ts
@@ -1,0 +1,116 @@
+import { z } from 'astro/zod';
+
+const semanticGateId = z.string().regex(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/);
+
+export const journeySchema = z.object({
+  pack: z.string(),
+  scope: z.enum(['user', 'repo']),
+  tagline: z.string(),
+  prerequisitePacks: z.array(z.string()).default([]),
+  whatChanges: z.string().optional(),
+  contract: z.object({
+    useItWhen: z.string(),
+    youProvide: z.string(),
+    youReceive: z.string(),
+    decisionGateIds: z.array(semanticGateId).optional(),
+    yourDecisions: z.array(z.string()).optional(),
+  }),
+  skills: z.array(z.object({
+    name: z.string(),
+    description: z.string(),
+    humanTouches: z.number().int().min(0),
+  })),
+  humanGates: z.array(z.object({
+    id: z.string(),
+    globalGate: z.string().nullable(),
+    label: z.string(),
+    trigger: z.string(),
+    duration: z.string(),
+    whatToCheck: z.array(z.string()),
+    whatGoodLooksLike: z.string(),
+    whatBadLooksLike: z.string(),
+    consequence: z.string(),
+  })).superRefine((gates, context) => {
+    const ids = new Set<string>();
+    for (const [index, gate] of gates.entries()) {
+      if (ids.has(gate.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'id'],
+          message: `duplicate human gate ID: ${gate.id}`,
+        });
+      }
+      ids.add(gate.id);
+    }
+  }),
+  typicalSession: z.object({
+    agentTurns: z.string(),
+    humanTouches: z.number().int(),
+    wallClockMinutes: z.string(),
+  }),
+  docsUrl: z.string(),
+  packUrl: z.string(),
+  relatedJourneys: z.array(z.string()).default([]),
+  eyebrow: z.string().optional(),
+  goodOutputDescription: z.string().optional(),
+  journey_id: z.string().optional(),
+  start_state: z.string().optional(),
+  end_state: z.string().optional(),
+  generated: z.boolean().optional(),
+}).superRefine((journey, context) => {
+  const decisionGateIds = journey.contract.decisionGateIds;
+  if (journey.generated && !decisionGateIds) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['contract', 'decisionGateIds'],
+      message: 'generated journeys require decision gate IDs',
+    });
+    return;
+  }
+  if (journey.generated && journey.contract.yourDecisions) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['contract', 'yourDecisions'],
+      message: 'generated journeys use decision gate IDs, not display decision strings',
+    });
+  }
+  if (!decisionGateIds) return;
+
+  const gateIds = new Set(journey.humanGates.map((gate) => gate.id));
+  const referenced = new Set<string>();
+  for (const [index, gate] of journey.humanGates.entries()) {
+    if (!semanticGateId.safeParse(gate.id).success) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['humanGates', index, 'id'],
+        message: `invalid human gate ID: ${gate.id}`,
+      });
+    }
+  }
+  for (const [index, id] of decisionGateIds.entries()) {
+    if (referenced.has(id)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contract', 'decisionGateIds', index],
+        message: `duplicate decision gate ID: ${id}`,
+      });
+    }
+    if (!gateIds.has(id)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contract', 'decisionGateIds', index],
+        message: `unresolved decision gate ID: ${id}`,
+      });
+    }
+    referenced.add(id);
+  }
+  for (const gate of journey.humanGates) {
+    if (!referenced.has(gate.id)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contract', 'decisionGateIds'],
+        message: `human gate is not a contract decision: ${gate.id}`,
+      });
+    }
+  }
+});

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -46,12 +46,20 @@ const installCommand =
     docsUrl={data.docsUrl}
   />
 
+  {data.eyebrow && (
+    <Section tone="surface-alt">
+      <div class="content-body">
+        <p class="journey-eyebrow">{data.eyebrow}</p>
+      </div>
+    </Section>
+  )}
+
   <!-- 2. The contract — compact above-the-fold summary (journey-template-revamp) -->
   {data.contract && (
     <Section tone="surface">
       <div class="content-body">
         <h2 class="section-h2">The contract</h2>
-        <JourneyContract contract={data.contract} />
+        <JourneyContract contract={data.contract} humanGates={data.humanGates} />
       </div>
     </Section>
   )}
@@ -111,7 +119,7 @@ const installCommand =
       <ul class="gates-list" role="list">
         {data.humanGates.map((gate) => (
           <li>
-            <GateDetail gate={gate} />
+            <GateDetail gate={gate} decisionGateIds={data.contract.decisionGateIds} />
           </li>
         ))}
       </ul>
@@ -210,6 +218,13 @@ const installCommand =
     letter-spacing: var(--ds-track-heading);
     margin-bottom: var(--ds-space-5);
     color: var(--ds-on-surface);
+  }
+
+  .journey-eyebrow {
+    color: var(--ds-accent-deep);
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-body-lg);
+    font-weight: var(--ds-weight-semibold);
   }
 
   /* What changes (section 3) */

--- a/web/src/test/JourneyDecisions.test.ts
+++ b/web/src/test/JourneyDecisions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { decisionTargetId } from '../lib/journey-decisions';
+
+describe('journey decision fragments', () => {
+  it('does not emit a decision fragment for display-only legacy decisions', () => {
+    expect(decisionTargetId(undefined, 'G-classify')).toBeUndefined();
+  });
+
+  it('emits a semantic decision fragment only for an ordered decision ID', () => {
+    expect(decisionTargetId(['approve-plan'], 'approve-plan')).toBe('decision-approve-plan');
+    expect(decisionTargetId(['approve-plan'], 'merge-reviewed-change')).toBeUndefined();
+  });
+
+  it('keeps fragments stable when a gate label changes', () => {
+    const decisionGateIds = ['approve-plan', 'merge-reviewed-change'];
+    const gates = [
+      { id: 'approve-plan', label: 'Approve the plan' },
+      { id: 'merge-reviewed-change', label: 'Merge the reviewed change' },
+    ];
+    const changedCopy = gates.map((gate) => ({ ...gate, label: `${gate.label} now` }));
+
+    expect(changedCopy.map((gate) => decisionTargetId(decisionGateIds, gate.id)))
+      .toEqual(gates.map((gate) => decisionTargetId(decisionGateIds, gate.id)));
+  });
+
+  it('keeps fragments stable when decision display order changes', () => {
+    const gateIds = ['approve-plan', 'merge-reviewed-change'];
+    const originalOrder = ['approve-plan', 'merge-reviewed-change'];
+    const reordered = [...originalOrder].reverse();
+
+    expect(gateIds.map((id) => decisionTargetId(reordered, id)))
+      .toEqual(gateIds.map((id) => decisionTargetId(originalOrder, id)));
+  });
+});

--- a/web/src/test/JourneySchema.test.ts
+++ b/web/src/test/JourneySchema.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { journeySchema } from '../lib/journey-schema';
+
+const gate = {
+  id: 'approve-plan',
+  globalGate: null,
+  label: 'Approve the plan',
+  trigger: 'After planning',
+  duration: '5 minutes',
+  whatToCheck: ['The plan is complete.'],
+  whatGoodLooksLike: 'A complete plan.',
+  whatBadLooksLike: 'An incomplete plan.',
+  consequence: 'The work does not proceed.',
+};
+
+const generatedJourney = {
+  pack: 'example-pack',
+  scope: 'repo' as const,
+  tagline: 'Example journey.',
+  prerequisitePacks: [],
+  contract: {
+    useItWhen: 'You need an example.',
+    youProvide: 'An example.',
+    youReceive: 'An example result.',
+    decisionGateIds: ['approve-plan'],
+  },
+  skills: [],
+  humanGates: [gate],
+  typicalSession: {
+    agentTurns: '1',
+    humanTouches: 1,
+    wallClockMinutes: '5',
+  },
+  docsUrl: '/docs/guides/example/',
+  packUrl: '/packs/example-pack/',
+  generated: true,
+};
+
+describe('generated journey identity contracts', () => {
+  it('rejects a pack-sourced journey that omits decision gate IDs', () => {
+    const { decisionGateIds: _omitted, ...legacyContract } = generatedJourney.contract;
+
+    const result = journeySchema.safeParse({
+      ...generatedJourney,
+      contract: legacyContract,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('generated journey without IDs unexpectedly validated');
+    expect(result.error.issues).toContainEqual(expect.objectContaining({
+      path: ['contract', 'decisionGateIds'],
+      message: 'generated journeys require decision gate IDs',
+    }));
+  });
+
+  it('permits a hand-authored display-only legacy journey', () => {
+    const { decisionGateIds: _semanticIds, ...legacyContract } = generatedJourney.contract;
+
+    const result = journeySchema.safeParse({
+      ...generatedJourney,
+      generated: undefined,
+      contract: { ...legacyContract, yourDecisions: ['Approve the plan'] },
+      humanGates: [{ ...gate, id: 'G-plan' }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -116,9 +116,7 @@ test.describe('journey decision chips reach their gate by keyboard', () => {
     '/journeys/release-engineering/',
   ] as const;
   for (const route of PRIORITY) {
-    // Narrowest and widest of the approved set rather than literals, so a change to
-    // WIDTHS carries here too.
-    for (const width of [WIDTHS[0], WIDTHS[WIDTHS.length - 1]] as const) {
+    for (const width of WIDTHS) {
       test(`${route} @${width}`, async ({ page }) => {
         const ctx = { route, width };
         await page.setViewportSize({ width, height: 900 });
@@ -126,12 +124,7 @@ test.describe('journey decision chips reach their gate by keyboard', () => {
 
         const chips = page.locator('a[href^="#decision-"]');
         const count = await chips.count();
-        if (count === 0) {
-          // Semantic gate IDs are `journey-page-completion`'s contract and may
-          // not have landed yet. Skip loudly rather than assert a shape this
-          // spec does not own.
-          test.skip(true, `${label(ctx)}: no #decision- chips emitted yet`);
-        }
+        expect(count, `${label(ctx)}: decision chips must be emitted`).toBeGreaterThan(0);
         for (let i = 0; i < count; i += 1) {
           const chip = chips.nth(i);
           const href = await chip.getAttribute('href');
@@ -144,10 +137,63 @@ test.describe('journey decision chips reach their gate by keyboard', () => {
           await tabToAndAssertFocus(page, `a[href="${href}"]`, ctx, 120);
           await page.keyboard.press('Enter');
           await expect(
-            page.locator(`#${CSS.escape(id)}`),
+            page.locator(`#${id}`),
             `${label(ctx)}: #${id} did not become visible`
           ).toBeVisible();
           expect(new URL(page.url()).hash, `${label(ctx)}: URL fragment`).toBe(`#${id}`);
+          await expect(page.locator(`#${id}`), `${label(ctx)}: gate focus`)
+            .toBeFocused();
+        }
+      });
+    }
+  }
+});
+
+test.describe('journey decision gates resolve on a direct fragment load', () => {
+  // `journey-page-completion` AC7 and its evidence contract require that a direct
+  // fragment load target the same gate, without consulting label text. Keyboard
+  // activation above fires `hashchange`; a cold load takes the other branch, so it
+  // was the one path the gate never exercised. Narrowest and widest only — focus
+  // transfer is not width-sensitive, matching the docs search/theme case below.
+  const PRIORITY = [
+    '/journeys/core/',
+    '/journeys/product-engineering/',
+    '/journeys/release-engineering/',
+  ] as const;
+  for (const route of PRIORITY) {
+    for (const width of [WIDTHS[0], WIDTHS[WIDTHS.length - 1]] as const) {
+      test(`${route} direct fragment @${width}`, async ({ page }) => {
+        const ctx = { route, width };
+        await page.setViewportSize({ width, height: 900 });
+        await gotoSettled(page, withBase(route), ctx);
+
+        const hrefs = await page.locator('a[href^="#decision-"]').evaluateAll(
+          (nodes) => nodes.map((node) => node.getAttribute('href') ?? '')
+        );
+        expect(hrefs.length, `${label(ctx)}: decision chips must be emitted`)
+          .toBeGreaterThan(0);
+
+        for (const href of hrefs) {
+          const id = decodeURIComponent(href.slice(1));
+          // A fresh page, because the fragment must be present on the FIRST
+          // navigation. Re-using `page` makes it a same-document hash change:
+          // `goto` issues no request, returns null, and `gotoSettled` fails on
+          // its own precondition without ever testing the cold-load path.
+          const cold = await page.context().newPage();
+          try {
+            await cold.setViewportSize({ width, height: 900 });
+            await gotoSettled(cold, `${withBase(route)}${href}`, ctx);
+            await expect(
+              cold.locator(`#${id}`),
+              `${label(ctx)}: #${id} not visible on direct load`
+            ).toBeVisible();
+            await expect(
+              cold.locator(`#${id}`),
+              `${label(ctx)}: #${id} did not receive focus on direct load`
+            ).toBeFocused();
+          } finally {
+            await cold.close();
+          }
         }
       });
     }

--- a/workspace.toml
+++ b/workspace.toml
@@ -505,6 +505,10 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # The six hand-authored journey pages retain legacy display copy but have no
+  # approved semantic-ID/label mappings. Their fragments are intentionally not
+  # emitted; closing this requires an approved editorial ledger extension.
+  {slug = "legacy-hand-authored-journey-gate-mappings", source = "spec/journey-page-completion AC5", summary = "Approve semantic ID and label mappings for the six hand-authored journey pages before migrating their visible legacy gate-code prose"},
   # === spec/guide-typed-asides-test-gate deferrals ===
   # tools/test_guide_typed_asides.py pins a frozen 165-row blockquote ledger across
   # 193 guides/** files (docs/specs/guide-typed-asides-conversion/notes/*.jsonl).
@@ -2515,15 +2519,6 @@ open = [
   # asserted by test_the_archival_conversion_record_stays_unwired.
   # Closing this file as a sanctioned case reduces the leak count again; the numeral
   # in the summary drifts with every instance closed, so trust the enumeration, not it.
-  # spec/site-browser-quality-gate shipped its decision-to-gate keyboard cases in a
-  # state where they SKIP: semantic `#decision-<id>` chips are
-  # spec/journey-page-completion's contract and are not emitted yet, so six cases in
-  # web/src/test/e2e/site-quality-gate.spec.ts assert nothing today. They begin
-  # gating the moment that slice lands, and nobody is presently prompted to confirm
-  # they did. Fix: after journey-page-completion merges, run the gate and confirm the
-  # six cases RUN rather than skip; if they still skip, the chip contract and the
-  # gate's selector disagree.
-  {slug = "browser-gate-journey-chip-cases-inert", source = "spec/site-browser-quality-gate AC6", summary = "Confirm the six decision-chip browser cases stop skipping once journey-page-completion emits semantic gate IDs"},
   # The tap-target audit's docs-footer rows measure a footer that
   # spec/site-shared-chrome replaces with the approved three-group taxonomy, and its
   # product-orientation band does not exist yet so has no rows at all. The audit says


### PR DESCRIPTION
## What does this change?

Every decision point on the 12 canonical journey pages becomes a shareable, keyboard-reachable link whose address is stable across rewording and reordering. The three priority journeys gain their approved eyebrow and worked transcript, and five new controls hold the state this establishes.

## Why?

Implements `docs/specs/journey-page-completion/spec.md`. 14 of 15 ACs met.

**AC15 is deliberately left unticked.** Its automated clauses pass, but it also requires "no Major design-review issue against the governing principles", which `plan.md` § Approach designates *recorded manual verification*. That is a human sign-off and is not mine to give.

AC15 also dropped "in both approved themes". Journey routes are marketing routes, which `site-browser-quality-gate` AC1 exercises **without theme mutation**, and their emitted pages carry no `data-theme`; that spec's AC2 owns dual-theme coverage for the two `/docs/` routes. No approved width, theme, overflow tolerance, or axe threshold changed — the clause named a condition these routes cannot express. Recorded in the plan changelog.

## How do I verify it?

```bash
rm -rf dist && make build          # dist/ is untracked and goes stale on pull
make build-check                   # includes SAST/SCA
PYTHONPATH=packages/agentbundle:packages/credbroker PYTHONDONTWRITEBYTECODE=1 \
  python3 -m pytest tools/test_journey_editorial_decisions.py -q
npm run test --prefix web
npm run test:e2e:gate --prefix web
```

Measured on this branch: `build-check` exit 0 with SAST/SCA, e2e **127 passed / 0 failed / 0 skipped**, web unit 91, ledger control 3, ci-parity 104/104, rendered links 57,919 across 269 pages clean, journey-contract and web parity 18/18, projection re-sync changes no file.

**Every control is mutation-proved, not assumed.** Reverting either drifted label, deriving fragments from ordinals, disabling the generated-requires-IDs schema rule, forcing the linter's hand-authored key, dropping `decisionGateIds` from a generated journey, altering an eyebrow or one transcript word, inserting a blank line or extra indentation, reducing a Markdown hard break from two spaces to one, adding editorial copy to a non-priority journey, or removing the gate heading's `tabindex="-1"` each fails exactly the control that claims to cover it. Every restoration was verified byte-identical with `cmp`.

Two controls existed only because review kept finding the state unheld:

- The 34 `(journey, id, label)` triples had no automated check. Adding one immediately found **two labels that had never been applied** — `atlassian/review-story-drafts` and `product-strategy/approve-prfaq` — while all 15 browser cases were green. AC2 was false and no gate could see it.
- The priority eyebrow and transcript were verified only by a one-time hand read, though the evidence contract requires exact emission. They are now compared to the ledger line for line. Three review rounds were needed to make that comparison actually support the word "verbatim": `.strip()` hid blank-line and indentation drift, then `rstrip(" ")` tolerated any trailing spaces when a Markdown hard break requires two or more.

## What did you not change that you considered?

- **No pack or plugin version bump.** Verified against the rebuilt 1644-file `dist/`: no `JOURNEY.md` ships and zero installed files carry a semantic gate id, so the migration changes no installed output. AC13's consequence rule did not fire.
- **The six hand-authored journeys.** They keep display-only `yourDecisions` and emit no fragments. The approved ledger has no mappings for them, so inventing IDs would have created a public link contract nobody approved. Deferred as `legacy-hand-authored-journey-gate-mappings`, registered and cross-referenced from the spec.
- **`atlassian`'s pre-existing transcript.** Transcript confinement is a subset check rather than set equality: the ledger's claim is that no journey *gains* one, and equality would have pinned that grandfathered copy in place forever. Narrowing pre-existing copy is outside this spec.
- **The stale `discovery`/`release` IDs in frozen historical specs** (`platform-site`, `phase4-product-docs-rollout`, `ux-writing-rename`, `pack-journeys-phase2b`). Only the *living* template was corrected; frozen artifacts keep their provenance.
- **The inline `hashchange` script's placement.** I predicted a cold-load focus bug from its byte offset preceding its target, and the browser disproved it: focus comes from the HTML fragment-navigation algorithm focusing a `tabindex="-1"` target. Six cold-load cases now pin both mechanisms; no source change was warranted.

### Diff size

1183 insertions across 43 files exceeds the ~400-line guidance. It is genuinely atomic: 11 of those files are generated journey copies that must move with their pack sources or `lint-web-journey-parity` fails, and the ledger test is unusable until registered in all four of its required places.

### Flagged for a maintainer

The spec's `workspace.toml` entry sits in `[work].queue` while `spec.md` reads `Status: Implementing`, so canonical reconciliation reports `impossible_transition` + `unapproved_spec`. It needs `queue` → `active`. I did not hand-edit it: membership changes route through a canonical work-intake transaction, and `work-intake` exposes no such transition. This does not affect any required check.

Spec: docs/specs/journey-page-completion/spec.md