### PR TITLE
fix(journeys): repair the three Major design-review findings on journey pages

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The example session on a journey page now reads as a session.** Each turn is
+  attributed to whoever spoke it and sits on its own line in a terminal-style
+  register, instead of running together in one paragraph with stray asterisks and
+  backticks showing. The wording is unchanged.
+- **Keyboard focus on a journey decision is easier to see.** Focusing a decision
+  no longer makes its label harder to read than the ones beside it, and the
+  heading you land on after activating one now takes the same clearly visible
+  outline the decision itself uses.
 - **Every decision point on a journey page is now a link you can share.** Each
   place the agent pauses for you has a stable address, so you can send someone
   straight to the decision itself rather than to the top of the page. The links

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -356,3 +356,30 @@ no version, dependency, migration, or infrastructure change.
   Also moved the spec's workspace entry from `queue` to the initiative's existing
   empty `active` list, clearing the `impossible_transition` and `unapproved_spec`
   findings that a merged-but-Implementing artifact produced in a queue.
+- 2026-08-19: re-review of the three Major fixes confirmed all three resolved and
+  found two more. One was a regression this branch introduced: the transcript fix
+  changed a shared template, and `atlassian` ships a `goodOutputDescription` that
+  is prose rather than a session — the grandfathered field whose allowlist entry
+  this spec already carries. It was rendering as a single unattributed turn: an
+  empty `<dt>` around 127 words of author prose in the 13px mono session register,
+  asserting session evidence for a paraphrase. The template now branches on the
+  parse result and prose renders in the prose register. The control could not see
+  it because it looped only the three priority routes, so it is now enumerated
+  from the built site and covers all 18 journey routes; MP27 forces every route
+  into the session register and fails exactly one of eighteen. A guard case
+  asserts the enumeration is non-empty, because an empty route list would make
+  every case vacuous.
+  The second was a Minor this branch made conspicuous rather than caused: the gate
+  heading and its card both painted an identical 3px near-black ring at the same
+  offset, verified from computed styles on both elements. Invisible while both sat
+  at 2.08:1; obvious at 15:1. The heading now owns the indicator for both
+  `:focus-visible` and `:target`, so the cold-load path that needs its own
+  selector survives — programmatic focus on a `tabindex="-1"` heading matches
+  `:focus-visible` only by Chromium heuristic — and the card computes
+  `outline-style: none`.
+  Deferred to its own PR by owner decision: the review's M2, the global
+  `:focus-visible` amber ring in `web/src/styles/base.css`, which measures 2.29:1
+  on light surfaces against a 3:1 non-text floor and 8.07:1 on the dark hero where
+  it is correct. It is pre-existing, owned by the design-system layer, and lands on
+  every marketing route, so it warrants its own review rather than riding along in
+  a journey-pages fix. AC15 stays unticked until it is resolved and re-reviewed.

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -336,3 +336,23 @@ no version, dependency, migration, or infrastructure change.
   still fails. The scaffold copy is a projection, so `manifest.json` was
   regenerated with `tools/catalogue/sync_authoring_scaffold.py --write` rather
   than hand-edited.
+- 2026-08-19: fixed the recorded design review's three Major findings. Two were
+  contrast failures invisible to the browser gate by construction: axe scans the
+  resting DOM, so a `:hover`/`:focus-visible` declaration never applies during the
+  scan, which is how a chip whose focus style measured 2.40:1 passed a green
+  accessibility gate. The chip's focused text is now the system's own
+  dark-on-amber CTA pairing (8.07:1) and the gate heading's ring is the same
+  near-black the chip already used (16.74:1), so one interaction stops speaking
+  two focus languages. The third was a presentation defect the ledger control
+  could not see: it compares source to source and was green throughout while the
+  rendered page showed markup characters. `parseTranscript` now returns speaker
+  turns and the template renders real elements in the page's mono register — no
+  Markdown dependency, no `set:html`, so no injection surface. Three new controls
+  close the gaps: `expectTextContrast` and `expectOutlineContrast` measure the
+  state the element is actually in and composite alpha rather than treating a
+  translucent token as an opaque fill, and a transcript case asserts multiple
+  attributed turns with no `*` or backtick reaching the reader. MP24-MP26 prove
+  each fails without its fix, reproducing 2.40:1, 2.08:1 and a missing transcript.
+  Also moved the spec's workspace entry from `queue` to the initiative's existing
+  empty `active` list, clearing the `impossible_transition` and `unapproved_spec`
+  findings that a merged-but-Implementing artifact produced in a queue.

--- a/docs/specs/journey-page-completion/spec.md
+++ b/docs/specs/journey-page-completion/spec.md
@@ -33,6 +33,15 @@ raw identifiers and legacy gate codes never leak into the adopter experience.
   derived output.
 - Keep pack versions and Claude-plugin descriptions unchanged because this
   migration does not change installed functional behavior.
+- **Amendment, 2026-08-19, authorized (third).** Fix the regression the second
+  amendment introduced on `/journeys/atlassian/`, whose `goodOutputDescription` is
+  spec-permitted prose rather than a session, and remove the duplicate focus ring
+  the contrast fix made conspicuous. The `goodOutputDescription` register is now
+  chosen by content shape: attributed turns render as a session, an unlabelled
+  single turn renders as prose. AC15's design-review clause remains unsatisfied —
+  the review's M2, the site-wide `:focus-visible` amber ring at 2.29:1 on light
+  surfaces, is deferred to its own PR by owner decision because it is pre-existing,
+  owned by the design-system layer, and affects every marketing route.
 - **Amendment, 2026-08-19, authorized (second).** Fix the three Major findings
   from the recorded design review, and add the controls that would have caught
   them. The decision chip's `:hover`/`:focus-visible` fill paired white

--- a/docs/specs/journey-page-completion/spec.md
+++ b/docs/specs/journey-page-completion/spec.md
@@ -33,6 +33,17 @@ raw identifiers and legacy gate codes never leak into the adopter experience.
   derived output.
 - Keep pack versions and Claude-plugin descriptions unchanged because this
   migration does not change installed functional behavior.
+- **Amendment, 2026-08-19, authorized (second).** Fix the three Major findings
+  from the recorded design review, and add the controls that would have caught
+  them. The decision chip's `:hover`/`:focus-visible` fill paired white
+  `--ds-hero-fg` with `--ds-accent` on a light surface at 2.40:1; both tokens are
+  documented "on dark". The gate heading's target/focus ring was amber at
+  2.29:1 on the page and 2.08:1 on the card, under the 3:1 non-text floor. And
+  `goodOutputDescription` was interpolated into a `<p>`, so Astro escaped it and
+  the approved transcript shipped with literal `**` and backticks while HTML
+  whitespace collapsing flattened every turn into one paragraph. The approved
+  transcript *text* is unchanged; only its presentation is. AC15 stays unticked
+  until the design review is re-run against the fixes.
 - **Amendment, 2026-08-19, authorized.** Accept `contract.decisionGateIds` in
   the published catalogue contract, additively. `#1025` landed a live contract
   test after this spec was approved; its validator treats `contract.*` as a

--- a/web/src/components/journey/GateDetail.astro
+++ b/web/src/components/journey/GateDetail.astro
@@ -83,8 +83,15 @@ const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
   }
 
   .gate-card:has(.gate-card__label:target),
+  /* Near-black, matching `.decision-chip:focus-visible`. Amber on the light
+     card measured 2.29:1 on the page and 2.08:1 on the card, under the 3:1
+     non-text floor for a state indicator (WCAG 1.4.11) — and this is the
+     indicator a keyboard user relies on AFTER activating a chip, once focus has
+     left the chip and its own ring is gone. The chip already overrode the
+     global amber ring; carrying the same treatment here means one interaction
+     speaks one focus language. `--ds-on-surface` measures 16.74:1. */
   .gate-card:has(.gate-card__label:focus-visible) {
-    outline: 3px solid var(--ds-accent);
+    outline: 3px solid var(--ds-on-surface);
     outline-offset: 3px;
   }
 
@@ -100,7 +107,7 @@ const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
   }
 
   .gate-card__label:focus-visible {
-    outline: 3px solid var(--ds-accent);
+    outline: 3px solid var(--ds-on-surface);
     outline-offset: 3px;
   }
 

--- a/web/src/components/journey/GateDetail.astro
+++ b/web/src/components/journey/GateDetail.astro
@@ -82,19 +82,6 @@ const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
     border-radius: var(--ds-radius-md);
   }
 
-  .gate-card:has(.gate-card__label:target),
-  /* Near-black, matching `.decision-chip:focus-visible`. Amber on the light
-     card measured 2.29:1 on the page and 2.08:1 on the card, under the 3:1
-     non-text floor for a state indicator (WCAG 1.4.11) — and this is the
-     indicator a keyboard user relies on AFTER activating a chip, once focus has
-     left the chip and its own ring is gone. The chip already overrode the
-     global amber ring; carrying the same treatment here means one interaction
-     speaks one focus language. `--ds-on-surface` measures 16.74:1. */
-  .gate-card:has(.gate-card__label:focus-visible) {
-    outline: 3px solid var(--ds-on-surface);
-    outline-offset: 3px;
-  }
-
   .gate-card__header {
     padding: var(--ds-space-6);
     padding-bottom: var(--ds-space-4);
@@ -106,7 +93,21 @@ const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
     color: var(--ds-on-surface);
   }
 
-  .gate-card__label:focus-visible {
+  /* One interaction, one indicator, on the element that actually holds the state.
+     Amber measured 2.29:1 on the page and 2.08:1 on the card, under the 3:1
+     non-text floor (WCAG 1.4.11), and this is the indicator a keyboard user
+     relies on AFTER activating a chip, once focus has left the chip and its own
+     ring is gone. `--ds-on-surface` measures 16.49:1, matching
+     `.decision-chip:focus-visible` so one interaction speaks one focus language.
+
+     `:target` is here, not on an ancestor `:has()`: programmatic focus on a
+     `tabindex="-1"` heading matches `:focus-visible` only by Chromium heuristic,
+     so a cold fragment load needs its own selector. Declaring both on the heading
+     rather than one here and one on the card avoids painting two concentric,
+     visually identical rings at once — which is what happened while both were
+     near-invisible and nobody noticed. */
+  .gate-card__label:focus-visible,
+  .gate-card__label:target {
     outline: 3px solid var(--ds-on-surface);
     outline-offset: 3px;
   }

--- a/web/src/components/journey/JourneyContract.astro
+++ b/web/src/components/journey/JourneyContract.astro
@@ -152,7 +152,15 @@ const decisionCount = decisions?.length ?? 0;
   .decision-chip:hover,
   .decision-chip:focus-visible {
     background-color: var(--ds-accent);
-    color: var(--ds-hero-fg);
+    /* Dark on amber, not white. `--ds-hero-fg` is white "primary text on dark"
+       and `--ds-accent` is the "CTA fill on dark" — pairing them on a LIGHT
+       surface gave 2.40:1 against a 4.5:1 requirement for this 13px/12px
+       weight-400 text, so acquiring focus made the chip less legible than its
+       resting neighbours. `--ds-cta-primary-fg` is the system's own
+       dark-on-amber CTA pairing and measures 8.07:1. axe cannot see this: it
+       scans the resting DOM, so a :hover/:focus-visible rule never applies
+       during the scan. `assertStateContrast` in the browser gate covers it. */
+    color: var(--ds-cta-primary-fg);
   }
 
   .decision-chip:focus-visible {

--- a/web/src/lib/journey-transcript.ts
+++ b/web/src/lib/journey-transcript.ts
@@ -1,0 +1,76 @@
+/**
+ * Parse an approved journey transcript into speaker turns.
+ *
+ * `goodOutputDescription` is a YAML block scalar written in light Markdown: each
+ * turn opens with a `**Speaker:**` label and may soft-wrap onto following lines,
+ * and a turn may contain inline `` `code` ``. It used to be interpolated straight
+ * into a `<p>`, which Astro escapes — so the asterisks and backticks shipped as
+ * visible characters and HTML whitespace collapsing flattened every turn into one
+ * run-on paragraph, destroying the who-said-what-in-what-order structure that is
+ * the whole point of a transcript.
+ *
+ * This returns structure instead of a string so the template can render real
+ * elements. Nothing here emits markup, so there is no `set:html` and no injection
+ * surface, and no Markdown dependency is added.
+ */
+
+/** One span of a turn: literal text, or a fragment that was backtick-quoted. */
+export interface TranscriptPart {
+  kind: 'text' | 'code';
+  value: string;
+}
+
+/** One labelled turn. `speaker` is empty for text preceding any label. */
+export interface TranscriptTurn {
+  speaker: string;
+  parts: TranscriptPart[];
+}
+
+/** `**Speaker:**` at the start of a line, capturing the speaker and the rest. */
+const SPEAKER_LINE = /^\*\*(.+?):\*\*\s*(.*)$/;
+
+/** Split a turn's text on backtick pairs. An unpaired backtick stays literal. */
+function splitInlineCode(text: string): TranscriptPart[] {
+  const parts: TranscriptPart[] = [];
+  let rest = text;
+  while (rest.length > 0) {
+    const open = rest.indexOf('`');
+    if (open === -1) break;
+    const close = rest.indexOf('`', open + 1);
+    if (close === -1) break;
+    if (open > 0) parts.push({ kind: 'text', value: rest.slice(0, open) });
+    parts.push({ kind: 'code', value: rest.slice(open + 1, close) });
+    rest = rest.slice(close + 1);
+  }
+  if (rest.length > 0) parts.push({ kind: 'text', value: rest });
+  return parts;
+}
+
+export function parseTranscript(raw: string): TranscriptTurn[] {
+  const turns: TranscriptTurn[] = [];
+  let speaker: string | null = null;
+  let buffer: string[] = [];
+
+  const flush = (): void => {
+    if (speaker === null && buffer.length === 0) return;
+    // Lines within a turn are soft wraps of one utterance, so they rejoin with a
+    // single space rather than a line break.
+    const text = buffer.join(' ').replace(/\s+/g, ' ').trim();
+    if (speaker === null && text === '') return;
+    turns.push({ speaker: speaker ?? '', parts: splitInlineCode(text) });
+  };
+
+  for (const line of raw.split('\n')) {
+    const match = SPEAKER_LINE.exec(line.trim());
+    if (match) {
+      flush();
+      speaker = match[1];
+      buffer = match[2] ? [match[2]] : [];
+      continue;
+    }
+    if (line.trim() === '') continue;
+    buffer.push(line.trim());
+  }
+  flush();
+  return turns;
+}

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -6,6 +6,7 @@ import JourneyHero from '../../components/journey/JourneyHero.astro';
 import JourneyContract from '../../components/journey/JourneyContract.astro';
 import GateDetail from '../../components/journey/GateDetail.astro';
 import { withBase } from '../../lib/paths';
+import { parseTranscript } from '../../lib/journey-transcript';
 
 export async function getStaticPaths() {
   const journeys = await getCollection('journeys');
@@ -104,7 +105,18 @@ const installCommand =
     <Section tone="surface-alt">
       <div class="content-body">
         <h2 class="section-h2">What good output looks like</h2>
-        <p class="good-output">{data.goodOutputDescription}</p>
+        <dl class="transcript">
+          {parseTranscript(data.goodOutputDescription).map((turn) => (
+            <div class="transcript__turn">
+              <dt class="transcript__speaker">{turn.speaker}</dt>
+              <dd class="transcript__utterance">
+                {turn.parts.map((part) =>
+                  part.kind === 'code' ? <code>{part.value}</code> : part.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
       </div>
     </Section>
   )}
@@ -400,10 +412,47 @@ const installCommand =
   }
 
   /* What good output looks like (section 5) */
-  .good-output {
-    font-size: var(--ds-type-body-lg);
-    color: var(--ds-on-surface-2);
+  /* A captured session, not prose. The approved copy is a light-Markdown block
+     scalar; it used to be interpolated into a <p>, so Astro escaped it and the
+     asterisks and backticks shipped as visible characters while HTML whitespace
+     collapsing flattened every turn into one paragraph. `parseTranscript` returns
+     structure so these are real elements, and the mono register matches how the
+     rest of the page presents machine output. Turns stack rather than using a
+     two-column grid: this page carries no media query, and a speaker as long as
+     "Independent reviewer" squeezes the utterance at 360px. */
+  .transcript {
+    display: grid;
+    gap: var(--ds-space-4);
+    margin: 0;
+    font-family: var(--ds-font-mono);
+    font-size: var(--ds-type-mono-sm);
     line-height: var(--ds-lead-body);
+    color: var(--ds-on-surface-2);
+  }
+
+  .transcript__turn {
+    display: grid;
+    gap: var(--ds-space-2);
+  }
+
+  .transcript__speaker {
+    color: var(--ds-on-surface);
+    font-weight: 600;
+  }
+
+  .transcript__utterance {
+    margin: 0;
+  }
+
+  /* The whole block is already mono, so an inline-code chip would nest a box
+     inside a box. Carry the emphasis with weight instead. */
+  .transcript code {
+    font-family: inherit;
+    font-size: inherit;
+    background: none;
+    padding: 0;
+    color: var(--ds-on-surface);
+    font-weight: 600;
   }
 
   /* Section 7 */

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -105,18 +105,34 @@ const installCommand =
     <Section tone="surface-alt">
       <div class="content-body">
         <h2 class="section-h2">What good output looks like</h2>
-        <dl class="transcript">
-          {parseTranscript(data.goodOutputDescription).map((turn) => (
-            <div class="transcript__turn">
-              <dt class="transcript__speaker">{turn.speaker}</dt>
-              <dd class="transcript__utterance">
-                {turn.parts.map((part) =>
-                  part.kind === 'code' ? <code>{part.value}</code> : part.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
+        {(() => {
+          const turns = parseTranscript(data.goodOutputDescription);
+          // A `goodOutputDescription` need not be a transcript. The spec permits a
+          // prose summary — `atlassian` ships one — and dressing narrative prose in
+          // the mono session register would assert session evidence for a
+          // paraphrase, the inverse of principle 2's "name the evidence boundary".
+          // An unlabelled single turn is that case.
+          const isSession = turns.length > 1 || (turns[0] && turns[0].speaker !== '');
+          const parts = (turn: (typeof turns)[number]) =>
+            turn.parts.map((part) =>
+              part.kind === 'code' ? <code>{part.value}</code> : part.value
+            );
+          return isSession ? (
+            // An ordered list, not a `dl`: the HTML standard calls `dl`
+            // inappropriate for dialogue, so a screen reader would announce a
+            // term/definition list for a sequence of speaker turns.
+            <ol class="transcript">
+              {turns.map((turn) => (
+                <li class="transcript__turn">
+                  <span class="transcript__speaker">{turn.speaker}</span>
+                  <span class="transcript__utterance">{parts(turn)}</span>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p class="good-output">{turns.map((turn) => parts(turn))}</p>
+          );
+        })()}
       </div>
     </Section>
   )}
@@ -420,10 +436,20 @@ const installCommand =
      rest of the page presents machine output. Turns stack rather than using a
      two-column grid: this page carries no media query, and a speaker as long as
      "Independent reviewer" squeezes the utterance at 360px. */
+  /* The prose register, for a `goodOutputDescription` that is a summary rather
+     than a captured session. */
+  .good-output {
+    font-size: var(--ds-type-body-lg);
+    color: var(--ds-on-surface-2);
+    line-height: var(--ds-lead-body);
+  }
+
   .transcript {
     display: grid;
     gap: var(--ds-space-4);
     margin: 0;
+    padding: 0;
+    list-style: none;
     font-family: var(--ds-font-mono);
     font-size: var(--ds-type-mono-sm);
     line-height: var(--ds-lead-body);
@@ -436,12 +462,13 @@ const installCommand =
   }
 
   .transcript__speaker {
+    display: block;
     color: var(--ds-on-surface);
     font-weight: 600;
   }
 
   .transcript__utterance {
-    margin: 0;
+    display: block;
   }
 
   /* The whole block is already mono, so an inline-code chip would nest a box

--- a/web/src/test/JourneyTranscript.test.ts
+++ b/web/src/test/JourneyTranscript.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseTranscript } from '../lib/journey-transcript';
+
+const PRIORITY = ['core', 'product-engineering', 'release-engineering'] as const;
+
+/** The approved block scalar, read from the canonical pack source.
+ *
+ * Built with `node:path` rather than `new URL(..., import.meta.url)`: Vite
+ * statically analyses the latter as an asset import and denies it for paths
+ * outside its root. Vitest runs with `web/` as cwd. */
+function canonicalTranscript(journey: string): string {
+  const path = resolve(process.cwd(), '..', 'packs', journey, 'JOURNEY.md');
+  const text = readFileSync(path, 'utf8');
+  const match = /^goodOutputDescription: \|-\n((?:  .*\n|\n)+)/m.exec(text);
+  if (!match) throw new Error(`${journey}: no goodOutputDescription block scalar`);
+  return match[1]
+    .split('\n')
+    .map((line) => (line.startsWith('  ') ? line.slice(2) : line))
+    .join('\n');
+}
+
+describe('parseTranscript', () => {
+  it('splits labelled turns and keeps their order', () => {
+    const turns = parseTranscript('**You:** Do the thing.\n**Agent:** Done.');
+    expect(turns.map((t) => t.speaker)).toEqual(['You', 'Agent']);
+    expect(turns[0].parts).toEqual([{ kind: 'text', value: 'Do the thing.' }]);
+  });
+
+  it('rejoins a soft-wrapped turn into one utterance', () => {
+    // The wrap is a YAML artefact, not a line break the reader should see.
+    const turns = parseTranscript('**You:** Start work on adding\nexport filters.');
+    expect(turns).toHaveLength(1);
+    expect(turns[0].parts).toEqual([
+      { kind: 'text', value: 'Start work on adding export filters.' },
+    ]);
+  });
+
+  it('extracts inline code as its own part', () => {
+    const turns = parseTranscript('**You:** Use `release-loop` now.');
+    expect(turns[0].parts).toEqual([
+      { kind: 'text', value: 'Use ' },
+      { kind: 'code', value: 'release-loop' },
+      { kind: 'text', value: ' now.' },
+    ]);
+  });
+
+  it('leaves an unpaired backtick as literal text rather than dropping copy', () => {
+    const turns = parseTranscript('**You:** A stray ` mark.');
+    expect(turns[0].parts).toEqual([{ kind: 'text', value: 'A stray ` mark.' }]);
+  });
+
+  it('keeps text that precedes any speaker label', () => {
+    const turns = parseTranscript('Preamble line.\n**You:** Then this.');
+    expect(turns.map((t) => t.speaker)).toEqual(['', 'You']);
+    expect(turns[0].parts).toEqual([{ kind: 'text', value: 'Preamble line.' }]);
+  });
+
+  it('returns nothing for empty input', () => {
+    expect(parseTranscript('')).toEqual([]);
+    expect(parseTranscript('\n\n')).toEqual([]);
+  });
+
+  describe.each(PRIORITY)('the approved %s transcript', (journey) => {
+    const turns = parseTranscript(canonicalTranscript(journey));
+
+    it('parses into labelled turns', () => {
+      expect(turns.length).toBeGreaterThan(0);
+      // Every turn is attributed; an unlabelled turn would mean the parser lost
+      // a speaker and the transcript would stop being verifiable.
+      expect(turns.every((t) => t.speaker !== '')).toBe(true);
+      expect(new Set(turns.map((t) => t.speaker)).size).toBeGreaterThan(1);
+    });
+
+    it('leaves no Markdown character in any rendered part', () => {
+      // This is the defect that shipped: `**` and backticks reached the page as
+      // visible characters. The parser must consume both.
+      for (const turn of turns) {
+        expect(turn.speaker).not.toMatch(/[*`]/);
+        for (const part of turn.parts) {
+          expect(part.value).not.toMatch(/[*`]/);
+        }
+      }
+    });
+  });
+});

--- a/web/src/test/e2e/quality-assertions.ts
+++ b/web/src/test/e2e/quality-assertions.ts
@@ -466,3 +466,137 @@ export async function expectLandmarkKeyboardReachable(
       'were reachable by Tab'
   ).toBe(expected);
 }
+
+/**
+ * WCAG contrast ratio between two opaque colours.
+ *
+ * Callers must pass an already-composited background. Compositing is not
+ * optional bookkeeping: `--ds-accent-subtle` is `#e8952b1a`, an 8-digit hex whose
+ * trailing `1a` is a 10% alpha channel. Treating that as an opaque fill reports
+ * 2.37:1 for the resting decision chip, which renders at 4.59:1 — a fabricated
+ * failure. `compositedBackground` below does the layering.
+ */
+function contrastRatio(fg: readonly number[], bg: readonly number[]): number {
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const lum = (c: readonly number[]): number =>
+    0.2126 * channel(c[0]) + 0.7152 * channel(c[1]) + 0.0722 * channel(c[2]);
+  const a = lum(fg);
+  const b = lum(bg);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+/** `rgb()` / `rgba()` to `[r, g, b, a]`. */
+function parseColor(value: string): number[] {
+  const parts = value.match(/[\d.]+/g);
+  if (!parts) throw new Error(`unparseable colour: ${value}`);
+  const [r, g, b] = parts.slice(0, 3).map(Number);
+  return [r, g, b, parts.length > 3 ? Number(parts[3]) : 1];
+}
+
+/** Flatten an element's background stack, alpha included, over white. */
+function compositedBackground(layers: readonly number[][]): number[] {
+  let out = [255, 255, 255];
+  for (let i = layers.length - 1; i >= 0; i -= 1) {
+    const [r, g, b, a] = layers[i];
+    out = [r * a + out[0] * (1 - a), g * a + out[1] * (1 - a), b * a + out[2] * (1 - a)];
+  }
+  return out;
+}
+
+/** Collect the background layers behind an element, optionally skipping itself. */
+async function backgroundLayers(
+  page: Page,
+  selector: string,
+  fromParent: boolean
+): Promise<number[][]> {
+  const raw = await page.evaluate(
+    ({ sel, skipSelf }) => {
+      let node: HTMLElement | null = document.querySelector(sel);
+      if (!node) throw new Error(`no element matches ${sel}`);
+      if (skipSelf) node = node.parentElement;
+      const out: string[] = [];
+      while (node) {
+        out.push(getComputedStyle(node).backgroundColor);
+        node = node.parentElement;
+      }
+      return out;
+    },
+    { sel: selector, skipSelf: fromParent }
+  );
+  const layers: number[][] = [];
+  for (const value of raw) {
+    const parsed = parseColor(value);
+    if (parsed[3] <= 0) continue;
+    layers.push(parsed);
+    if (parsed[3] >= 1) break;
+  }
+  return layers;
+}
+
+/**
+ * Assert an element's *current* text contrast, whatever state it is in.
+ *
+ * This exists because axe cannot reach it. axe scans the resting DOM, so a
+ * `:hover` or `:focus-visible` declaration never applies during the scan — which
+ * is how a chip whose focus style put white on amber at 2.40:1 passed a green
+ * accessibility gate. Tab to the element first, then call this.
+ */
+export async function expectTextContrast(
+  page: Page,
+  selector: string,
+  ctx: CaseContext,
+  what: string
+): Promise<void> {
+  const style = await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) throw new Error(`no element matches ${sel}`);
+    const cs = getComputedStyle(el);
+    return { color: cs.color, fontSize: cs.fontSize, fontWeight: cs.fontWeight };
+  }, selector);
+  const fg = parseColor(style.color);
+  const bg = compositedBackground(await backgroundLayers(page, selector, false));
+  const ratio = contrastRatio(fg, bg);
+  const px = parseFloat(style.fontSize);
+  const bold = Number.parseInt(style.fontWeight, 10) >= 700;
+  const large = px >= 24 || (px >= 18.66 && bold);
+  const floor = large ? 3 : 4.5;
+  expect(
+    ratio,
+    `${label(ctx)}: ${what} text contrast ${ratio.toFixed(2)}:1 at ${px}px ` +
+      `weight ${style.fontWeight} needs ${floor}:1`
+  ).toBeGreaterThanOrEqual(floor);
+}
+
+/**
+ * Assert a state indicator's contrast against what it sits on (WCAG 1.4.11, 3:1).
+ *
+ * The outline is measured against the *parent* background because
+ * `outline-offset` places the ring outside the element's own box.
+ */
+export async function expectOutlineContrast(
+  page: Page,
+  selector: string,
+  ctx: CaseContext,
+  what: string
+): Promise<void> {
+  const outline = await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) throw new Error(`no element matches ${sel}`);
+    const cs = getComputedStyle(el);
+    return { color: cs.outlineColor, width: cs.outlineWidth, style: cs.outlineStyle };
+  }, selector);
+  expect(
+    outline.style,
+    `${label(ctx)}: ${what} has no outline to measure`
+  ).not.toBe('none');
+  const bg = compositedBackground(await backgroundLayers(page, selector, true));
+  const ratio = contrastRatio(parseColor(outline.color), bg);
+  expect(
+    ratio,
+    `${label(ctx)}: ${what} indicator contrast ${ratio.toFixed(2)}:1 needs 3:1 ` +
+      `(WCAG 1.4.11 non-text)`
+  ).toBeGreaterThanOrEqual(3);
+}

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -18,6 +18,8 @@
  * outside the required subset (AC11).
  */
 import { test, expect } from '@playwright/test';
+import { existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import {
   THEMES,
@@ -240,41 +242,62 @@ test.describe('decision chip and gate focus states meet contrast in the state th
   }
 });
 
-test.describe('journey transcripts render as a session, not escaped markdown', () => {
-  // `goodOutputDescription` is a light-Markdown block scalar. Interpolating it into
-  // a <p> shipped `**You:**` and backticks as visible characters and collapsed every
-  // turn into one paragraph. Source fidelity could not see this: the ledger control
-  // compares source to source and was green throughout.
-  const PRIORITY = [
-    '/journeys/core/',
-    '/journeys/product-engineering/',
-    '/journeys/release-engineering/',
-  ] as const;
-  for (const route of PRIORITY) {
-    test(`${route} transcript`, async ({ page }) => {
+test.describe('journey good-output renders in the register its content earns', () => {
+  // Enumerated from the BUILT site, not from a hand-written list. The first version
+  // of this suite looped only the three priority routes, so it could not see that
+  // the transcript fix had regressed `/journeys/atlassian/` — whose
+  // `goodOutputDescription` is spec-sanctioned prose, not a session, and which the
+  // shared template was wrapping in an empty speaker term and the mono register.
+  const BUILD_JOURNEYS = fileURLToPath(new URL('../../../../build/journeys', import.meta.url));
+  const ROUTES = existsSync(BUILD_JOURNEYS)
+    ? readdirSync(BUILD_JOURNEYS, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => `/journeys/${e.name}/`)
+        .sort()
+    : [];
+
+  test('the built site was enumerated', () => {
+    // Guards the guard: an empty list would make every case below vacuous.
+    expect(ROUTES.length, 'no journey routes found in build/').toBeGreaterThan(10);
+  });
+
+  for (const route of ROUTES) {
+    test(`${route} good output`, async ({ page }) => {
       const ctx = { route, width: WIDTHS[WIDTHS.length - 1] };
       await page.setViewportSize({ width: ctx.width, height: 900 });
       await gotoSettled(page, withBase(route), ctx);
 
-      const transcript = page.locator('dl.transcript');
-      await expect(transcript, `${label(ctx)}: no transcript rendered`).toHaveCount(1);
+      const session = page.locator('ol.transcript');
+      const prose = page.locator('p.good-output');
+      const sessions = await session.count();
+      const proses = await prose.count();
 
-      const speakers = transcript.locator('dt.transcript__speaker');
-      const turns = await speakers.count();
-      expect(turns, `${label(ctx)}: transcript must have multiple labelled turns`)
-        .toBeGreaterThan(1);
+      if (sessions === 0 && proses === 0) return; // route carries no good-output
+      expect(
+        sessions + proses,
+        `${label(ctx)}: good output must render in exactly one register`
+      ).toBe(1);
 
-      // Every turn is attributed and every attribution is real text.
-      for (let i = 0; i < turns; i += 1) {
-        const who = (await speakers.nth(i).innerText()).trim();
-        expect(who, `${label(ctx)}: turn ${i} has no speaker`).not.toBe('');
+      const block = sessions === 1 ? session : prose;
+      const rendered = await block.innerText();
+
+      // The defect that shipped: no Markdown character may reach the reader, in
+      // either register.
+      expect(rendered, `${label(ctx)}: asterisk visible in good output`).not.toContain('*');
+      expect(rendered, `${label(ctx)}: backtick visible in good output`).not.toContain('`');
+      expect(rendered.length, `${label(ctx)}: good output is empty`).toBeGreaterThan(80);
+
+      if (sessions === 1) {
+        const speakers = session.locator('.transcript__speaker');
+        const turns = await speakers.count();
+        expect(turns, `${label(ctx)}: a session needs multiple turns`).toBeGreaterThan(1);
+        for (let i = 0; i < turns; i += 1) {
+          const who = (await speakers.nth(i).innerText()).trim();
+          // An empty term is the atlassian regression: prose forced into the
+          // session register produces exactly one unattributed turn.
+          expect(who, `${label(ctx)}: turn ${i} has no speaker`).not.toBe('');
+        }
       }
-
-      // The defect that shipped: no Markdown character may reach the reader.
-      const rendered = await transcript.innerText();
-      expect(rendered, `${label(ctx)}: asterisk visible in transcript`).not.toContain('*');
-      expect(rendered, `${label(ctx)}: backtick visible in transcript`).not.toContain('`');
-      expect(rendered.length, `${label(ctx)}: transcript is empty`).toBeGreaterThan(80);
     });
   }
 });

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -27,7 +27,9 @@ import {
   expectLandmarkKeyboardReachable,
   expectNoHorizontalOverflow,
   expectNoSeriousAxeViolations,
+  expectOutlineContrast,
   expectSkipLinkFirst,
+  expectTextContrast,
   gotoSettled,
   label,
   tabToAndAssertFocus,
@@ -197,6 +199,83 @@ test.describe('journey decision gates resolve on a direct fragment load', () => 
         }
       });
     }
+  }
+});
+
+test.describe('decision chip and gate focus states meet contrast in the state they are in', () => {
+  // axe scans the resting DOM, so a `:hover`/`:focus-visible` declaration never
+  // applies during the scan. A chip whose focus style put white on amber measured
+  // 2.40:1 against a 4.5:1 requirement and passed a green accessibility gate for
+  // exactly that reason. These cases enter the state first, then measure.
+  const PRIORITY = [
+    '/journeys/core/',
+    '/journeys/product-engineering/',
+    '/journeys/release-engineering/',
+  ] as const;
+  for (const route of PRIORITY) {
+    for (const width of [WIDTHS[0], WIDTHS[WIDTHS.length - 1]] as const) {
+      test(`${route} focus-state contrast @${width}`, async ({ page }) => {
+        const ctx = { route, width };
+        await page.setViewportSize({ width, height: 900 });
+        await gotoSettled(page, withBase(route), ctx);
+
+        const first = page.locator('a[href^="#decision-"]').first();
+        const href = await first.getAttribute('href');
+        expect(href, `${label(ctx)}: no decision chip to measure`).toBeTruthy();
+        const selector = `a[href="${href}"]`;
+
+        // Reached by keyboard so `:focus-visible` genuinely applies.
+        await tabToAndAssertFocus(page, selector, ctx, 120);
+        await expectTextContrast(page, `${selector} span`, ctx, 'focused decision chip label');
+        await expectOutlineContrast(page, selector, ctx, 'focused decision chip ring');
+
+        // Activating moves focus off the chip and onto the gate heading, so the
+        // destination indicator is what a keyboard user now relies on.
+        await page.keyboard.press('Enter');
+        const id = decodeURIComponent((href ?? '').slice(1));
+        await expect(page.locator(`#${id}`), `${label(ctx)}: gate focus`).toBeFocused();
+        await expectOutlineContrast(page, `#${id}`, ctx, 'activated gate heading ring');
+      });
+    }
+  }
+});
+
+test.describe('journey transcripts render as a session, not escaped markdown', () => {
+  // `goodOutputDescription` is a light-Markdown block scalar. Interpolating it into
+  // a <p> shipped `**You:**` and backticks as visible characters and collapsed every
+  // turn into one paragraph. Source fidelity could not see this: the ledger control
+  // compares source to source and was green throughout.
+  const PRIORITY = [
+    '/journeys/core/',
+    '/journeys/product-engineering/',
+    '/journeys/release-engineering/',
+  ] as const;
+  for (const route of PRIORITY) {
+    test(`${route} transcript`, async ({ page }) => {
+      const ctx = { route, width: WIDTHS[WIDTHS.length - 1] };
+      await page.setViewportSize({ width: ctx.width, height: 900 });
+      await gotoSettled(page, withBase(route), ctx);
+
+      const transcript = page.locator('dl.transcript');
+      await expect(transcript, `${label(ctx)}: no transcript rendered`).toHaveCount(1);
+
+      const speakers = transcript.locator('dt.transcript__speaker');
+      const turns = await speakers.count();
+      expect(turns, `${label(ctx)}: transcript must have multiple labelled turns`)
+        .toBeGreaterThan(1);
+
+      // Every turn is attributed and every attribution is real text.
+      for (let i = 0; i < turns; i += 1) {
+        const who = (await speakers.nth(i).innerText()).trim();
+        expect(who, `${label(ctx)}: turn ${i} has no speaker`).not.toBe('');
+      }
+
+      // The defect that shipped: no Markdown character may reach the reader.
+      const rendered = await transcript.innerText();
+      expect(rendered, `${label(ctx)}: asterisk visible in transcript`).not.toContain('*');
+      expect(rendered, `${label(ctx)}: backtick visible in transcript`).not.toContain('`');
+      expect(rendered.length, `${label(ctx)}: transcript is empty`).toBeGreaterThan(80);
+    });
   }
 });
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -144,7 +144,15 @@ ready     = [
 draft     = []
 
 ["ini-002".work]
-active  = []
+active  = [
+  # Tech-site completion programme. Implementation merged in #1042; membership
+  # follows the artifact, which reads `Status: Implementing` because AC15's
+  # design-review clause is recorded manual verification and is not yet satisfied.
+  # Leaving this in `queue` made canonical reconciliation report
+  # `impossible_transition` and `unapproved_spec`, since a queue entry is expected
+  # to be Approved. It moves to `shipped` when AC15 is ticked.
+  {path = "docs/specs/journey-page-completion/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Complete priority journey evidence, orientation, and gate navigation", needs = []},
+]
 shipped = [
   # P5 · Adopt — independent slices constrained by adopter-persona evidence.
   {path = "docs/specs/m6-astro-work-index/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Give PMs a static read-only view of canonical workspace status", needs = []},
@@ -279,7 +287,6 @@ queue   = [
   # Tech-site completion programme — approved 2026-08-17 from the canonical brief.
   # These entries are independently shippable. `needs` records only hard delivery
   # ordering; the brief retains the broader wave and evidence sequence.
-  {path = "docs/specs/journey-page-completion/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Complete priority journey evidence, orientation, and gate navigation", needs = []},
   {path = "docs/specs/site-shared-chrome/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Share destination architecture while retaining renderer-local chrome", needs = [{type = "local", kind = "spec", path = "docs/specs/site-now-surface/spec.md"}, {type = "local", kind = "spec", path = "docs/specs/site-browser-quality-gate/spec.md"}]},
   # CI throughput. Independent of the project-knowledge chain above — it touches
   # only .github/workflows/, the Makefile's gate_verdict banner, and docs/adr/.


### PR DESCRIPTION
## What does this change?

Fixes the three Major findings from the recorded design review of the three priority journey pages — two contrast failures and a transcript that shipped as escaped Markdown — and adds the controls that would have caught each. All three were live because of #1042.

## Why?

`docs/specs/journey-page-completion/spec.md` AC15 requires "no Major design-review issue against the governing principles". The recorded review (on #1042) returned **SHIP WITH CHANGES** with three Majors, so the clause could not be ticked.

| # | Defect | Was | Now | Floor |
|---|---|---|---|---|
| 1 | Chip `:hover`/`:focus-visible` text | **2.40:1** (white on amber) | **8.07:1** | 4.5:1 |
| 2 | Gate heading `:target`/`:focus-visible` ring | **2.29:1** page / **2.08:1** card | **16.74:1** | 3.0:1 (WCAG 1.4.11) |
| 3 | Transcript | literal `**` and backticks, turns collapsed into one paragraph | 6/9/5 attributed turns, zero markup characters | — |

On **1**, both token comments read "on dark" — `--ds-hero-fg` is "primary text on dark", `--ds-accent` is "CTA fill on dark" — and they were paired on a light surface. `--prim-amber-900` is annotated for exactly this job, but components reference zero `--prim-*` tokens directly, so `--ds-cta-primary-fg` is the pairing that fits the convention.

On **2**, this is the indicator a keyboard user relies on *after* activating a chip, once focus has left the chip and its own ring is gone. `.decision-chip:focus-visible` had already overridden the global amber ring; the same fix simply had not been carried fifteen lines away. One interaction now speaks one focus language.

On **3**, `parseTranscript` returns `{speaker, parts}` and the template renders real elements in the page's mono register. No Markdown dependency was added and there is no `set:html`, so no injection surface. Soft-wrapped source lines rejoin into one utterance. **The approved wording is untouched — only its presentation changed.**

## How do I verify it?

```bash
rm -rf dist && make build
make build-check
npm run test --prefix web            # 103 passed, incl. 12 parser tests
npm run test:e2e:gate --prefix web   # 136 passed
```

Measured on this branch: build-check exit 0 with SAST/SCA, browser gate **136 passed / 0 failed** (was 127: +6 focus-state contrast, +3 transcript), web unit **103** (was 91), ledger control 3, journey-contract lint 18 conform with a 9-case self-test, ci-parity 104/104, links 57,973 across 269 pages clean, CI-only roster test 3 passed, 4-stage build all exit 0.

**Why the existing gates missed these.** Axe scans the resting DOM, so a `:hover`/`:focus-visible` declaration never applies during the scan — that is how a 2.40:1 chip passed a green accessibility gate. And the ledger control compares source to source; it was green throughout while the rendered page showed asterisks. `expectTextContrast` / `expectOutlineContrast` now enter the state first, then measure, and they composite alpha layers rather than treating a translucent token as opaque — `--ds-accent-subtle` is `#e8952b1a`, whose trailing `1a` is 10% alpha, and treating that as an opaque fill reports 2.37:1 for a chip that renders at 4.59:1.

**MP24–MP26** revert each fix and reproduce 2.40:1, 2.08:1 and a missing transcript; all restorations verified byte-identical with `cmp`.

## What did you not change that you considered?

- **A Markdown renderer for finding 3.** "Add no dependency" is ratified, so the parser handles the two constructs the approved transcripts actually contain — a leading `**Speaker:**` label and inline `` `code` `` — verified by enumerating them. An unpaired backtick stays literal rather than swallowing copy.
- **`set:html`.** It would have been shorter and would have introduced an injection surface for no benefit.
- **A two-column speaker/utterance grid.** This page carries no media query, and a speaker as long as "Independent reviewer" squeezes the utterance at 360px. Turns stack instead.
- **The decorative `border-left: 4px solid var(--ds-accent)` on the gate card.** It conveys no state, so WCAG 1.4.11 does not reach it, and changing it would be scope creep.
- **The review's Minors and Advisories** — deferred by owner decision to keep this to the three Majors: suppressing `Decision 1 of 1`, the two labels on one `docsUrl` destination, a persistent affordance distinguishing navigational chips from label chips, and a latent `"Approve the G4 handoff"` string in `iac-terraform.md`'s adopter-facing `yourDecisions` (invisible today only because the renderer prefers `decisionGateIds`).

## Lifecycle

Moves the spec's `workspace.toml` entry from `queue` into `["ini-002".work]`'s existing empty `active` list. A merged artifact reading `Status: Implementing` inside a queue made canonical reconciliation report `impossible_transition` and `unapproved_spec`; it now reports `classification: active` with no blocking needs. It moves to `shipped` when AC15 is ticked. `site-shared-chrome` stays queued and untouched.

**AC15 remains unticked pending re-review of these fixes.** I will post the re-review verdict on this PR.

Spec: docs/specs/journey-page-completion/spec.md