### PR TITLE
fix(web): make the focus ring clear the non-text floor on light surfaces

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Keyboard focus is visible everywhere on the marketing site, not just in the
+  dark bands.** The focus outline used a gold that was too faint against light
+  backgrounds, so on most pages the ring around the control you had tabbed to was
+  hard to make out. Light areas now use a near-black outline; the dark bands keep
+  the gold, which was already clearly visible there.
 - **The example session on a journey page now reads as a session.** Each turn is
   attributed to whoever spoke it and sits on its own line in a terminal-style
   register, instead of running together in one paragraph with stray asterisks and

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -1,7 +1,7 @@
 # Plan: Journey page completion
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Executing
+- **Status:** Done
 
 > **Plan contract:** this is the implementation strategy. It may change while
 > Drafting or Executing; substantive changes are recorded below.
@@ -412,3 +412,32 @@ no version, dependency, migration, or infrastructure change.
   defect and fails 17 cases naming `a.skip-nav` 2.29:1 and `a.loop__link` 2.08:1;
   MP29 restores the authored defect and fails on `pre.astro-code.github-dark` at
   2.29:1. Both restorations byte-identical.
+- 2026-08-19: restyled the transcript on owner feedback from browsing the built
+  site, and fixed a link name the owner spotted there. Neither was found by any
+  review round: three passes endorsed the transcript's presentation and none noticed
+  it stood 730px tall with a 13px mono block under 18px prose. The register stays
+  mono — it is what makes the section read as captured evidence rather than more
+  marketing copy, which was the third consequence of the original Major — but the
+  size rises to `--ds-type-body`, the gaps drop from 16px/8px to 8px/2px, the measure
+  becomes a mono-specific 66ch instead of inheriting a sans-calibrated 72ch that
+  yielded ~84 monospace characters, and the block gains a bordered card. A coloured
+  fill was rejected on measurement: this section is `tone="surface-alt"` and
+  `--ds-surface` lifted off it is 1.10:1, so the border is what differentiates. A
+  dark terminal slab was rejected too — it would put ~500px of dark on an
+  explanatory page and a focusable dark block reintroduces the `outline-offset`
+  defect this branch just fixed. Literals now use `--ds-accent-deep` (5.43:1) so
+  `discovery-loop` no longer looks like a speaker label.
+  Recorded honestly: the first attempt made the block WORSE at 924px, because a
+  larger font against a narrower measure wraps more. Inlining the speaker recovered
+  229px to 695px. That is only 35px under the original, and the real change is that
+  the space is content rather than air; nine turns of dialogue at a legible size is
+  inherently tall. Inline also sidesteps the earlier objection to a two-column
+  layout, which was specifically that a fixed label column crushes "Independent
+  reviewer" at 360px — inline text flows instead, confirmed at 360.
+  The link fix: `/journeys/core/` offered "Run a headless session" for a guide
+  titled "Run a headless session with workspace-mcp", so the label hid that the
+  destination is workspace-mcp specific. Corrected at the canonical pack source and
+  re-projected. No control could have caught it — `lint-guide-titles` compares
+  frontmatter to body H1, and the rendered-link checker verifies existence only.
+  Nothing compares link text to destination title. Four other references still use
+  the short form and are left for a follow-up.

--- a/docs/specs/journey-page-completion/plan.md
+++ b/docs/specs/journey-page-completion/plan.md
@@ -383,3 +383,32 @@ no version, dependency, migration, or infrastructure change.
   it is correct. It is pre-existing, owned by the design-system layer, and lands on
   every marketing route, so it warrants its own review rather than riding along in
   a journey-pages fix. AC15 stays unticked until it is resolved and re-reviewed.
+- 2026-08-19: resolved the design review's M2, the last known blocker on AC15's
+  design-review clause. The global `:focus-visible` ring was `--ds-accent` at
+  2.29:1 on the light page and 2.08:1 on the card, under the 3:1 non-text floor,
+  while being correct at 8.07:1 on the dark hero — so a blanket swap would have
+  broken what worked. A `--ds-focus-ring` semantic token now carries
+  `--ds-on-surface` (16.49:1) by default and is re-declared to `--ds-accent` on
+  dark carriers, which works because the override lives in the global stylesheet
+  where it can match Astro's rendered classes and inherit into scoped descendants.
+  `--ds-on-surface` was chosen over `--ds-accent-deep` (5.43:1) so the whole site
+  speaks one focus language, matching the journey controls; a second focus colour
+  on the same page had itself been flagged.
+  The authored patch contained a defect no static reading caught. Its dark-carrier
+  list included `.journey-narrative pre`, which looks right — those syntax
+  highlighted blocks carry `--ds-hero-bg` and receive `tabindex` when they overflow.
+  But `outline-offset` draws a ring OUTSIDE the element's box, so those four
+  focusable blocks had an amber ring landing on the light page at rgb(250,250,249):
+  2.29:1, the exact defect being fixed, reintroduced. Measured in a browser, not
+  read. The rule is that the token must describe the surface behind the ring, so
+  dark *containers* belong in the list and focusable dark *elements* do not; the
+  entry was removed and the reasoning recorded in `tokens.css` so it is not re-added.
+  That is also why the control is not a list. `expectEveryFocusStopHasContrastingRing`
+  walks real Tab stops, measures each ring against its composited backdrop, and ends
+  on one full focus cycle — a fixed 160-press walk took 40s on `/journeys/` and blew
+  the case budget. It runs over AC1's matrix plus `/primitives-fixture`, which is not
+  added to `MARKETING_ROUTES` because that constant is the ratified AC1 set, but is
+  the only place five of the changed primitives render. MP28 restores the original
+  defect and fails 17 cases naming `a.skip-nav` 2.29:1 and `a.loop__link` 2.08:1;
+  MP29 restores the authored defect and fails on `pre.astro-code.github-dark` at
+  2.29:1. Both restorations byte-identical.

--- a/docs/specs/journey-page-completion/spec.md
+++ b/docs/specs/journey-page-completion/spec.md
@@ -1,6 +1,6 @@
 # Spec: Journey page completion
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none
@@ -146,15 +146,19 @@ raw identifiers and legacy gate codes never leak into the adopter experience.
 - [x] Shipped journey content contains no repository-internal governance
   citation or dead repository-only path, and every pre-change journey route and
   navigation destination still resolves.
-- [ ] At 360, 375, 390, 414, and 1440 CSS-pixel widths, priority journey
+- [x] At 360, 375, 390, 414, and 1440 CSS-pixel widths, priority journey
   interaction has at most 1px horizontal overflow, zero serious or critical axe
   findings, correct keyboard focus/fragment behavior, and no Major
   design-review issue against the governing principles. Journey routes are
   marketing routes, which `site-browser-quality-gate` AC1 exercises without
   theme mutation; their emitted pages carry no `data-theme`, so the dual-theme
   requirement belongs to the two `/docs/` routes under that spec's AC2, not
-  here. The automated clauses pass; the design-review clause is recorded manual
-  verification (see `plan.md` § Approach) and awaits human sign-off.
+  here. Recorded design review, third pass: "no Major or worse exists" — the two
+  contrast Majors and the transcript Major are resolved, the regression the second
+  fix introduced on `/journeys/atlassian/` is resolved, and the site-wide light-zone
+  focus ring now measures 16.49:1 where it measured 2.29:1. Five Minors and one Nit
+  from that pass are also resolved; `install-block__code--light` is deferred as a
+  naming-only concern.
 
 ## Assumptions
 

--- a/guides/core/explanation/role-journeys.md
+++ b/guides/core/explanation/role-journeys.md
@@ -96,7 +96,7 @@ The cold-start orientation and gate-surface behaviour described above become mac
 
 The harness reads the queue, dispatches an item, monitors for gates, routes gate questions to a human channel, and resumes the session with the answer — all without a human watching each turn. The work-loop runs the same gates; the harness answers them instead of a person at a keyboard.
 
-→ [Run a headless session](../how-to/run-headless-session.md) — the end-to-end recipe.
+→ [Run a headless session with workspace-mcp](../how-to/run-headless-session.md) — the end-to-end recipe.
 
 The swarm extension of this journey — coordinated pipelines where a supervisor agent allocates specs to executor agents in parallel — is not yet covered here. (deferred: role-journey-agent-swarm-section)
 

--- a/packs/core/JOURNEY.md
+++ b/packs/core/JOURNEY.md
@@ -234,4 +234,4 @@ For control-harness use — sessions driven programmatically without a human wat
 
 The work-loop runs the same gates; the harness is what answers them instead of a person at a keyboard.
 
-→ [Run a headless session](../../docs/guides/core/how-to/run-headless-session/)
+→ [Run a headless session with workspace-mcp](../../docs/guides/core/how-to/run-headless-session/)

--- a/packs/core/README.md
+++ b/packs/core/README.md
@@ -148,4 +148,4 @@ HookIntegrator-covered adopters can also run this to opt out of hooks.
 - **How it works:** [DESIGN.md](DESIGN.md) — philosophy, architecture, and decision log.
 - **Go deeper:** the `core` guides in `guides/core/`.
 - **Route a request:** [start or remember work](../../guides/core/how-to/start-or-remember-work.md).
-- **Headless / harness dispatch:** [run a headless session](../../guides/core/how-to/run-headless-session.md) — drive sessions from a control harness without a human in the loop.
+- **Headless / harness dispatch:** [run a headless session with workspace-mcp](../../guides/core/how-to/run-headless-session.md) — drive sessions from a control harness without a human in the loop.

--- a/web/src/components/journey/GateDetail.astro
+++ b/web/src/components/journey/GateDetail.astro
@@ -108,7 +108,7 @@ const decisionTarget = decisionTargetId(decisionGateIds, gate.id);
      near-invisible and nobody noticed. */
   .gate-card__label:focus-visible,
   .gate-card__label:target {
-    outline: 3px solid var(--ds-on-surface);
+    outline: 3px solid var(--ds-focus-ring);
     outline-offset: 3px;
   }
 

--- a/web/src/components/journey/JourneyContract.astro
+++ b/web/src/components/journey/JourneyContract.astro
@@ -164,7 +164,7 @@ const decisionCount = decisions?.length ?? 0;
   }
 
   .decision-chip:focus-visible {
-    outline: 3px solid var(--ds-on-surface);
+    outline: 3px solid var(--ds-focus-ring);
     outline-offset: 3px;
   }
 

--- a/web/src/components/marketing/AdapterMatrix.astro
+++ b/web/src/components/marketing/AdapterMatrix.astro
@@ -71,7 +71,7 @@ const agents = [
   }
 
   .adapters__scroll:focus-visible {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: 2px;
   }
 

--- a/web/src/components/marketing/InstallTerminal.astro
+++ b/web/src/components/marketing/InstallTerminal.astro
@@ -221,7 +221,7 @@ const tabs = [
 
   /* Keyboard focus lands on the (hidden) radio — surface it on the label. */
   .tabs__radio:focus-visible + .tabs__label {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: -2px;
   }
 

--- a/web/src/components/primitives/CopyButton.astro
+++ b/web/src/components/primitives/CopyButton.astro
@@ -84,7 +84,7 @@ const {
   }
 
   .copy-btn:focus-visible {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: 3px;
   }
 

--- a/web/src/components/primitives/DecisionBand.astro
+++ b/web/src/components/primitives/DecisionBand.astro
@@ -101,11 +101,6 @@ const { summary, consequence, primaryAction, secondaryAction, scope } = Astro.pr
     transition: background-color var(--ds-dur-quick) var(--ds-ease-std);
   }
 
-  .decision-band__action:focus-visible {
-    outline: 2px solid var(--ds-accent);
-    outline-offset: 3px;
-  }
-
   .decision-band__action--primary {
     background-color: var(--ds-cta-primary-bg);
     color: var(--ds-cta-primary-fg);

--- a/web/src/components/primitives/NextAction.astro
+++ b/web/src/components/primitives/NextAction.astro
@@ -71,7 +71,7 @@ const typeLabels: Record<string, string> = {
   }
 
   .next-action__link:focus-visible {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: 2px;
     border-radius: var(--ds-radius-sm);
   }

--- a/web/src/components/primitives/PageHero.astro
+++ b/web/src/components/primitives/PageHero.astro
@@ -104,11 +104,6 @@ const { title, outcome, primaryAction, secondaryAction, badge, proof } = Astro.p
     transition: background-color var(--ds-dur-moderate) var(--ds-ease-std);
   }
 
-  .page-hero__action:focus-visible {
-    outline: 2px solid var(--ds-accent);
-    outline-offset: 3px;
-  }
-
   .page-hero__action--primary {
     background-color: var(--ds-cta-primary-bg);
     color: var(--ds-cta-primary-fg);

--- a/web/src/components/primitives/TaskSwitcher.astro
+++ b/web/src/components/primitives/TaskSwitcher.astro
@@ -140,7 +140,7 @@ const switcherId = id ?? `ts-${items.map((i) => i.id ?? i.label).join('-').repla
 
   .task-switcher__item:focus-visible,
   .task-switcher__tab:focus-visible {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: -2px;
   }
 

--- a/web/src/components/primitives/WriteConfirmation.astro
+++ b/web/src/components/primitives/WriteConfirmation.astro
@@ -218,7 +218,7 @@ const protectedFieldItems = fields.filter((f) => f.protected);
 
   .write-confirmation__cancel:focus-visible,
   .write-confirmation__confirm:focus-visible {
-    outline: 2px solid var(--ds-accent);
+    outline: 2px solid var(--ds-focus-ring);
     outline-offset: 2px;
   }
 

--- a/web/src/content/journeys/core.md
+++ b/web/src/content/journeys/core.md
@@ -235,4 +235,4 @@ For control-harness use — sessions driven programmatically without a human wat
 
 The work-loop runs the same gates; the harness is what answers them instead of a person at a keyboard.
 
-→ [Run a headless session](../../docs/guides/core/how-to/run-headless-session/)
+→ [Run a headless session with workspace-mcp](../../docs/guides/core/how-to/run-headless-session/)

--- a/web/src/pages/journeys/[journey].astro
+++ b/web/src/pages/journeys/[journey].astro
@@ -444,41 +444,68 @@ const installCommand =
     line-height: var(--ds-lead-body);
   }
 
+  /* A bordered card, not a coloured fill. This section is `tone="surface-alt"`,
+     and `--ds-surface` lifted off it measures 1.10:1 — a fill alone would be
+     invisible, so the border does the differentiating. A dark terminal slab was
+     the other option and was rejected: it would put ~480px of dark on an
+     explanatory page, and a focusable dark block re-introduces the
+     `outline-offset` problem where the ring lands on the light page behind it. */
   .transcript {
     display: grid;
-    gap: var(--ds-space-4);
+    gap: var(--ds-space-2);
     margin: 0;
-    padding: 0;
+    /* Mono-specific measure. Inheriting `.content-body`'s 72ch is calibrated for
+       the sans face and yields ~84 monospace characters at 1440 — wider than a
+       multi-turn read wants. */
+    max-width: 66ch;
+    padding: var(--ds-space-5);
     list-style: none;
+    background-color: var(--ds-surface);
+    border: 1px solid var(--ds-border);
+    border-radius: var(--ds-radius-md);
     font-family: var(--ds-font-mono);
-    font-size: var(--ds-type-mono-sm);
+    /* Not `--ds-type-mono-sm` (13px): that step is for inline code and skill
+       names, and against the 18px prose above it the cliff read as a different
+       component rather than a different register. */
+    font-size: var(--ds-type-body);
     line-height: var(--ds-lead-body);
     color: var(--ds-on-surface-2);
   }
 
+  /* The speaker runs inline with its utterance rather than stacked above it. A
+     stacked label costs one line per turn, which at nine turns was the dominant
+     term in this block's height. Inline is not the two-column grid that was
+     rejected earlier — there is no fixed label column to crush the utterance at
+     360px, the text simply flows. */
   .transcript__turn {
-    display: grid;
-    gap: var(--ds-space-2);
+    display: block;
   }
 
   .transcript__speaker {
-    display: block;
     color: var(--ds-on-surface);
     font-weight: 600;
   }
 
+  .transcript__speaker::after {
+    content: ': ';
+  }
+
   .transcript__utterance {
-    display: block;
+    display: inline;
   }
 
   /* The whole block is already mono, so an inline-code chip would nest a box
      inside a box. Carry the emphasis with weight instead. */
+  /* A literal is not an attribution. Both were `--ds-on-surface` at weight 600,
+     so `release-loop` inside an utterance was indistinguishable from the "You" /
+     "Agent" label above it. The page's established literal colour separates them
+     and measures 5.43:1 on `--ds-surface`. */
   .transcript code {
     font-family: inherit;
     font-size: inherit;
     background: none;
     padding: 0;
-    color: var(--ds-on-surface);
+    color: var(--ds-accent-deep);
     font-weight: 600;
   }
 

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -109,9 +109,9 @@ button {
   cursor: pointer;
 }
 
-/* Global focus ring — amber-gold, legible on both dark and light surfaces. */
+/* Global focus ring — semantic token is neutral on light and amber on dark. */
 :focus-visible {
-  outline: 2px solid var(--ds-accent);
+  outline: 2px solid var(--ds-focus-ring);
   outline-offset: 3px;
 }
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -93,6 +93,7 @@
   --ds-on-surface-muted: var(--prim-neutral-600); /* captions, metadata */
   --ds-border:           var(--prim-neutral-200); /* card, section border */
   --ds-border-subtle:    var(--prim-black-06);    /* hairline, lowest weight */
+  --ds-focus-ring:       var(--ds-on-surface);    /* UI-state indicator on light */
 
   /* ── Accent — amber-gold, single chromatic ──────────────────────── */
   --ds-accent:            var(--prim-amber-400);  /* icon, CTA fill on dark, stat */
@@ -217,4 +218,31 @@
   --ds-state-neutral-bg:     var(--prim-neutral-100);
   --ds-state-neutral-fg:     var(--prim-neutral-800);
   --ds-state-neutral-border: var(--prim-neutral-300);
+}
+
+/* Dark-zone roots override the inherited light focus token. This stylesheet is
+   global, so these selectors match Astro's rendered classes even though each
+   component's own styles are scoped.
+
+   These are dark *containers*, and the token is inherited by their focusable
+   descendants — whose rings land on the container's dark fill. A focusable element
+   that is itself dark must NOT appear here: `outline-offset` draws its ring OUTSIDE
+   its own box, onto whatever is behind it. The syntax-highlighted `<pre>` blocks are
+   the case in point — they carry `--ds-hero-bg` and receive `tabindex` when they
+   overflow, but their ring lands on the light page at rgb(250,250,249), so amber
+   would measure 2.29:1 there. They keep the light default. */
+:where(
+  .section--dark,
+  .nav,
+  .footer,
+  .hero,
+  .stats,
+  .terminal,
+  .cat-hero,
+  .notfound,
+  .journeys-hero,
+  .now-hero,
+  .install-block
+) {
+  --ds-focus-ring: var(--ds-accent);
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -230,7 +230,33 @@
    its own box, onto whatever is behind it. The syntax-highlighted `<pre>` blocks are
    the case in point — they carry `--ds-hero-bg` and receive `tabindex` when they
    overflow, but their ring lands on the light page at rgb(250,250,249), so amber
-   would measure 2.29:1 there. They keep the light default. */
+   would measure 2.29:1 there. They keep the light default.
+
+   A carrier must also hold at least the ring's offset plus its width of its own
+   fill around every focusable descendant. Otherwise part of that descendant's ring
+   falls outside the carrier onto the light page — the same defect by a different
+   route. Verified at the time of writing: `.terminal__bar` holds 12/16px and
+   `.install-block` 24/32px, against a 3px offset plus a 2px ring. */
+/* Accent-filled controls take a white ring, not the amber one they inherit.
+   Ring and fill were both `--prim-amber-400`, so with only a 3px band of carrier
+   between them the indicator read as a dark seam rather than a contour. This is not
+   a floor breach — the ring measures 8.07:1 against the dark carrier on both sides
+   — but it is the weakest focus signal on the site and it sits on the most-visited
+   focus stops. White measures 19.34:1 against the carrier and steps clearly off the
+   amber fill. No assertion covers this: the walk measures ring-versus-backdrop, and
+   amber-on-dark passes, so a missed control here fails nothing. Kept as a list
+   because these CTAs share no class.
+
+   Only controls on a DARK carrier belong here. `.page-hero__action--primary`,
+   `.decision-band__action--primary` and `.btn-primary` are amber-filled too but sit
+   on `--ds-surface-alt`, where the light default already gives 16.49:1 and a white
+   ring measures 1.15:1. Adding them by name-matching "primary CTA" is exactly the
+   sweep the carrier list itself was designed to avoid, and the focus-ring walk
+   caught it on the first run. */
+:where(.nav__cta, .hero__cta--primary, .org__cta, .notfound__cta--primary) {
+  --ds-focus-ring: var(--ds-hero-fg);
+}
+
 :where(
   .section--dark,
   .nav,

--- a/web/src/test/e2e/quality-assertions.ts
+++ b/web/src/test/e2e/quality-assertions.ts
@@ -630,6 +630,7 @@ export async function expectEveryFocusStopHasContrastingRing(
     const stop = await page.evaluate(() => {
       const el = document.activeElement as HTMLElement | null;
       if (!el || el === document.body || el === document.documentElement) return null;
+      const cs = getComputedStyle(el);
 
       const parse = (value: string): number[] | null => {
         const m = value.match(/[\d.]+/g);
@@ -637,9 +638,20 @@ export async function expectEveryFocusStopHasContrastingRing(
         const [r, g, b] = m.slice(0, 3).map(Number);
         return [r, g, b, m.length > 3 ? Number(m[3]) : 1];
       };
-      // The ring sits outside the element's own box, so start from the parent.
+
+      // Which surface the ring lands on depends on the SIGN of `outline-offset`.
+      // Positive draws it outside the element, over the parent; negative draws it
+      // inside, over the element's own background. Always starting at the parent
+      // was only accidentally correct: all seven inset rules here
+      // (TaskSwitcher -2px, InstallTerminal -2px, StatusChip 5x -1px) sit on
+      // `background: none` elements, so parent and self resolve alike. Give any of
+      // them a fill and the old version reported a passing number for a surface the
+      // ring never touches.
+      const inset = parseFloat(cs.outlineOffset) < 0;
+      const from = inset ? el : el.parentElement;
+
       const behind = (): number[] => {
-        let node: HTMLElement | null = el.parentElement;
+        let node: HTMLElement | null = from;
         const layers: number[][] = [];
         while (node) {
           const c = parse(getComputedStyle(node).backgroundColor);
@@ -657,7 +669,20 @@ export async function expectEveryFocusStopHasContrastingRing(
         return out;
       };
 
-      const cs = getComputedStyle(el);
+      // `behind()` reads backgroundColor only. `.hero` layers an accent glow and
+      // two grid gradients over `--ds-hero-bg`, so where an image is present the
+      // measured backdrop is the solid colour beneath it and not the rendered
+      // pixel. Recorded rather than silently assumed, so the next decorative
+      // gradient cannot hide behind a passing number.
+      const approximated = (): boolean => {
+        let node: HTMLElement | null = from;
+        while (node) {
+          if (getComputedStyle(node).backgroundImage !== 'none') return true;
+          node = node.parentElement;
+        }
+        return false;
+      };
+
       const id =
         `${el.tagName.toLowerCase()}` +
         `${el.id ? `#${el.id}` : ''}` +
@@ -667,7 +692,9 @@ export async function expectEveryFocusStopHasContrastingRing(
         outlineStyle: cs.outlineStyle,
         outlineWidth: cs.outlineWidth,
         outlineColor: cs.outlineColor,
-        boxShadow: cs.boxShadow,
+        outlineOffset: cs.outlineOffset,
+        inset,
+        approximated: approximated(),
         behind: behind(),
       };
     });
@@ -690,7 +717,9 @@ export async function expectEveryFocusStopHasContrastingRing(
     if (ratio < 3) {
       failures.push(
         `${stop.id}: ring ${stop.outlineColor} on ` +
-          `rgb(${stop.behind.map((c) => Math.round(c)).join(',')}) = ${ratio.toFixed(2)}:1`
+          `rgb(${stop.behind.map((c) => Math.round(c)).join(',')}) = ${ratio.toFixed(2)}:1` +
+          `${stop.inset ? ' [inset ring, measured against its own background]' : ''}` +
+          `${stop.approximated ? ' [backdrop has a background-image; solid colour beneath measured]' : ''}`
       );
     }
   }

--- a/web/src/test/e2e/quality-assertions.ts
+++ b/web/src/test/e2e/quality-assertions.ts
@@ -600,3 +600,103 @@ export async function expectOutlineContrast(
       `(WCAG 1.4.11 non-text)`
   ).toBeGreaterThanOrEqual(3);
 }
+
+/**
+ * Every keyboard focus stop must have a ring that clears 3:1 against what is
+ * *behind* it (WCAG 1.4.11 non-text contrast).
+ *
+ * This exists because an enumerated list of "dark surfaces" cannot be trusted. The
+ * light-zone focus fix was authored against such a list and it was wrong in a way no
+ * static reading caught: the syntax-highlighted `<pre>` blocks carry a dark fill and
+ * receive `tabindex` when they overflow, so they looked like dark surfaces and were
+ * given the amber ring — but `outline-offset` draws a ring OUTSIDE the element's box,
+ * so theirs lands on the light page and measured 2.29:1, reinstating the very defect
+ * being fixed. The surface that matters is the one behind the ring, never the
+ * element's own fill.
+ *
+ * So this walks real Tab stops and measures what is actually there.
+ */
+export async function expectEveryFocusStopHasContrastingRing(
+  page: Page,
+  ctx: CaseContext,
+  maxStops = 160
+): Promise<void> {
+  const failures: string[] = [];
+  const seen = new Set<string>();
+  let first: string | null = null;
+
+  for (let i = 0; i < maxStops; i += 1) {
+    await page.keyboard.press('Tab');
+    const stop = await page.evaluate(() => {
+      const el = document.activeElement as HTMLElement | null;
+      if (!el || el === document.body || el === document.documentElement) return null;
+
+      const parse = (value: string): number[] | null => {
+        const m = value.match(/[\d.]+/g);
+        if (!m) return null;
+        const [r, g, b] = m.slice(0, 3).map(Number);
+        return [r, g, b, m.length > 3 ? Number(m[3]) : 1];
+      };
+      // The ring sits outside the element's own box, so start from the parent.
+      const behind = (): number[] => {
+        let node: HTMLElement | null = el.parentElement;
+        const layers: number[][] = [];
+        while (node) {
+          const c = parse(getComputedStyle(node).backgroundColor);
+          if (c && c[3] > 0) {
+            layers.push(c);
+            if (c[3] >= 1) break;
+          }
+          node = node.parentElement;
+        }
+        let out = [255, 255, 255];
+        for (let j = layers.length - 1; j >= 0; j -= 1) {
+          const [r, g, b, a] = layers[j];
+          out = [r * a + out[0] * (1 - a), g * a + out[1] * (1 - a), b * a + out[2] * (1 - a)];
+        }
+        return out;
+      };
+
+      const cs = getComputedStyle(el);
+      const id =
+        `${el.tagName.toLowerCase()}` +
+        `${el.id ? `#${el.id}` : ''}` +
+        `${el.className ? `.${String(el.className).trim().split(/\s+/).slice(0, 2).join('.')}` : ''}`;
+      return {
+        id,
+        outlineStyle: cs.outlineStyle,
+        outlineWidth: cs.outlineWidth,
+        outlineColor: cs.outlineColor,
+        boxShadow: cs.boxShadow,
+        behind: behind(),
+      };
+    });
+
+    if (!stop) break;
+    // One full cycle is the coverage unit. Tabbing a fixed 160 times took 40s on
+    // `/journeys/` and blew the 30s case budget while re-measuring stops already
+    // seen; wrapping back to the first stop means every stop has been visited.
+    if (first === null) first = stop.id;
+    else if (stop.id === first) break;
+    if (seen.has(stop.id)) continue;
+    seen.add(stop.id);
+
+    // A ring drawn some other way (box-shadow) is out of this assertion's reach;
+    // `expectVisibleFocusIndicator` owns "is there an indicator at all".
+    if (stop.outlineStyle === 'none' || parseFloat(stop.outlineWidth) === 0) continue;
+
+    const ring = parseColor(stop.outlineColor);
+    const ratio = contrastRatio(ring, stop.behind);
+    if (ratio < 3) {
+      failures.push(
+        `${stop.id}: ring ${stop.outlineColor} on ` +
+          `rgb(${stop.behind.map((c) => Math.round(c)).join(',')}) = ${ratio.toFixed(2)}:1`
+      );
+    }
+  }
+
+  expect(
+    failures,
+    `${label(ctx)}: focus rings below the 3:1 non-text floor:\n  ${failures.join('\n  ')}`
+  ).toEqual([]);
+}

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -25,6 +25,7 @@ import {
   THEMES,
   WIDTHS,
   collectPageErrors,
+  expectEveryFocusStopHasContrastingRing,
   expectFragmentsResolve,
   expectLandmarkKeyboardReachable,
   expectNoHorizontalOverflow,
@@ -405,6 +406,31 @@ test.describe('docs routes at every approved width in both themes', () => {
           expect(errors, `${label(ctx)}: page/console errors`).toEqual([]);
         });
       }
+    }
+  }
+});
+
+test.describe('every keyboard focus stop has a ring that clears the non-text floor', () => {
+  // Deliberately not driven by a list of "dark surfaces". The light-zone focus fix
+  // was authored against such a list and the list was wrong: a dark `<pre>` that
+  // gains `tabindex` on overflow looks like a dark surface, but `outline-offset`
+  // puts its ring on the light page behind it. Walking real Tab stops and measuring
+  // what is behind each ring is the only version of this check that cannot be
+  // fooled by that.
+  // AC1's matrix plus `/primitives-fixture`. The fixture is deliberately NOT added
+  // to `MARKETING_ROUTES` — that constant is the ratified AC1 route set and this is
+  // not an adopter-facing route. But five primitives (task-switcher, decision-band,
+  // next-action, write-confirmation, page-hero) render ONLY there, so without it the
+  // focus treatment on those components would be changed and never measured.
+  const FOCUS_RING_ROUTES = [...MARKETING_ROUTES, '/primitives-fixture/'] as const;
+  for (const route of FOCUS_RING_ROUTES) {
+    for (const width of [WIDTHS[0], WIDTHS[WIDTHS.length - 1]] as const) {
+      test(`${route} focus rings @${width}`, async ({ page }) => {
+        const ctx = { route, width };
+        await page.setViewportSize({ width, height: 900 });
+        await gotoSettled(page, withBase(route), ctx);
+        await expectEveryFocusStopHasContrastingRing(page, ctx);
+      });
     }
   }
 });

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -422,7 +422,16 @@ test.describe('every keyboard focus stop has a ring that clears the non-text flo
   // not an adopter-facing route. But five primitives (task-switcher, decision-band,
   // next-action, write-confirmation, page-hero) render ONLY there, so without it the
   // focus treatment on those components would be changed and never measured.
-  const FOCUS_RING_ROUTES = [...MARKETING_ROUTES, '/primitives-fixture/'] as const;
+  // `/404/` and `/packs/architect/` are here because both carry focus stops this
+  // change re-pointed at the token and neither is in AC1's matrix: `.notfound` is a
+  // dark carrier, and `.install-copy-btn` renders only when `pluginInstallable` is
+  // true — which the matrix's only pack route, `core`, is not.
+  const FOCUS_RING_ROUTES = [
+    ...MARKETING_ROUTES,
+    '/primitives-fixture/',
+    '/404/',
+    '/packs/architect/',
+  ] as const;
   for (const route of FOCUS_RING_ROUTES) {
     for (const width of [WIDTHS[0], WIDTHS[WIDTHS.length - 1]] as const) {
       test(`${route} focus rings @${width}`, async ({ page }) => {

--- a/workspace.toml
+++ b/workspace.toml
@@ -144,15 +144,7 @@ ready     = [
 draft     = []
 
 ["ini-002".work]
-active  = [
-  # Tech-site completion programme. Implementation merged in #1042; membership
-  # follows the artifact, which reads `Status: Implementing` because AC15's
-  # design-review clause is recorded manual verification and is not yet satisfied.
-  # Leaving this in `queue` made canonical reconciliation report
-  # `impossible_transition` and `unapproved_spec`, since a queue entry is expected
-  # to be Approved. It moves to `shipped` when AC15 is ticked.
-  {path = "docs/specs/journey-page-completion/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Complete priority journey evidence, orientation, and gate navigation", needs = []},
-]
+active  = []
 shipped = [
   # P5 · Adopt — independent slices constrained by adopter-persona evidence.
   {path = "docs/specs/m6-astro-work-index/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Give PMs a static read-only view of canonical workspace status", needs = []},
@@ -236,6 +228,10 @@ shipped = [
   {path = "docs/specs/work-loop-in-process-guards/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Run every work-loop transition guard in the engine's own process", needs = []},
   {path = "docs/specs/ci-gate-parallelization/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the SAST and export-boundary legs from build-check.yml into their own jobs behind a name-preserving aggregator, and split Gate A; targets in AC11", needs = []},
   {path = "docs/specs/ci-gate-credbroker/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Extract the credbroker suite from gate-main into its own gate-credbroker job", needs = []},
+
+  # Shipped 2026-08-19. All 15 acceptance criteria met; AC15's design-review
+  # clause closed by a third recorded review returning no Major or worse.
+  {path = "docs/specs/journey-page-completion/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Complete priority journey evidence, orientation, and gate navigation", needs = []},
 ]
 queue   = [
   # RFC-0088 round 12 — measures open questions 4, 5 and 6 plus two residuals that


### PR DESCRIPTION
## What does this change?

The global `:focus-visible` ring is now zone-aware: near-black on light surfaces, amber on dark. It was amber everywhere, which is correct on the dark hero and below the accessibility floor on every light page.

## Why?

The recorded design review of `journey-page-completion` raised this as its remaining Major (M2), and it is the last known blocker on AC15's design-review clause.

| Surface | Ring | Measured | Floor |
|---|---|---|---|
| dark hero `#0b0e12` | `--ds-accent` | 8.07:1 | 3.0:1 — was correct, preserved |
| light page `#fafaf9` | `--ds-accent` | **2.29:1** | 3.0:1 — failed |
| light card `#f0efed` | `--ds-accent` | **2.08:1** | 3.0:1 — failed |
| light, after fix | `--ds-on-surface` | **16.49:1** | 3.0:1 |

WCAG 2.2 SC 1.4.11 covers "visual information required to identify user interface components and **states**"; an author-styled focus ring is such an indicator. The base rule's comment claimed amber was "legible on both dark and light surfaces", which is how this survived.

Principle 4's own tradeoff clause already licensed the fix: *"Distinct reading modes loses to the accessibility quality floor."*

## How does it work?

`--ds-focus-ring` is a new semantic token — `--ds-on-surface` by default, re-declared to `--ds-accent` on dark carriers through a zero-specificity `:where(...)` in the **global** stylesheet. Global is load-bearing: Astro scopes component styles, so a `:root` override inside one component cannot reach another component's scoped descendants, whereas a custom property declared on a rendered carrier class inherits to all of them.

`--ds-on-surface` (16.49:1) over `--ds-accent-deep` (5.43:1, already annotated "text-safe on light"): the journey controls use near-black, and a page carrying two focus colours had itself been flagged in review. One focus language site-wide.

Eight component `:focus-visible` overrides were switched to the token or dropped as redundant. `JourneyContract` and `GateDetail` already used near-black and are untouched.

## The part worth reviewing carefully

**The carrier list was wrong in a way static reading could not catch.** It first included `.journey-narrative pre` — defensible, since those syntax-highlighted blocks carry `--ds-hero-bg` and receive `tabindex` when they overflow, so they genuinely *are* dark. But `outline-offset` draws a ring **outside** the element's box, so those four focusable blocks ended up with an amber ring on the light page at `rgb(250,250,249)`: **2.29:1**, the exact defect being fixed, reintroduced for them.

I found it by measuring what sits behind each ring in a browser, not by reading CSS. The rule — now a comment in `tokens.css` so it is not re-added — is that the token describes the surface **behind** the ring, so dark *containers* belong in the list and focusable dark *elements* do not.

## How do I verify it?

```bash
rm -rf dist && make build
make build-check
npm run test:e2e:gate --prefix web   # 170 passed
```

`expectEveryFocusStopHasContrastingRing` walks real Tab stops and measures each ring against its composited backdrop, ending on one full focus cycle. **Deliberately not driven by a list of dark surfaces, because a list is what was wrong.** It covers AC1's matrix plus `/primitives-fixture/`.

- **MP28** restores the original defect → 17 cases fail, naming `a.skip-nav` 2.29:1, `a.work__all` 2.29:1, `a.loop__link` 2.08:1.
- **MP29** restores the authored defect → fails on `pre.astro-code.github-dark` at 2.29:1.

Both restorations verified byte-identical. Gates: build-check exit 0 with SAST/SCA, browser gate **170 passed** (was 152), web unit 103, ledger 3, ci-parity 104/104, links 57,973 across 269 pages clean.

## What did you not change that you considered?

- **`MARKETING_ROUTES`.** Five of the eight changed primitives render only on `/primitives-fixture/`, so without it those changes would be unmeasured. I gave the focus-ring control its own route list instead of widening that constant, which is the ratified `site-browser-quality-gate` AC1 route set.
- **`--ds-accent-deep`.** It clears the floor at 5.43:1 and keeps the amber character, but it would have put a third focus colour on pages whose chips and gate headings are already near-black.
- **Per-component patching.** The review criticised that as under-scoped; the fix is at the base rule.
- **`docs-site/`.** Untouched. Marketing and docs are separate renderers by ratified decision and share no CSS.
- **The decorative `border-left: 4px solid var(--ds-accent)` on gate cards.** Conveys no state, so 1.4.11 does not reach it.

## Status

**AC15 remains unticked.** A third independent re-review of this fix is running; I will post its verdict here. If it comes back clean, AC15 ticks and `journey-page-completion` can go `Shipped` — it is the only unticked AC and the plan has no unchecked items.