### PR TITLE
eugenelim/rfc88 uid and spike e exception

### DIFF
--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -1548,24 +1548,36 @@ confinement failing when the grant had swallowed it.
 a **group of destinations sharing one profile**, so the disposition is amended to
 per-group. Item 6 remains an accepted risk; only the unit changes.
 
-**Why the destination is the wrong unit.** The requirement's two clauses live at
-different layers. **Block** is a per-context option and does scope per destination —
-by partitioning destinations across separate browser contexts, which is what round
-12's arm D measured, recording `sharedSessionDemonstrated: false` because contexts
-also isolate cookies and storage. **Purge** operates on `Default/Service Worker`, a
-single profile-level directory: destinations register into one shared store, and
-purging for one removes it for all. Contexts partition the block; they do not
-partition an on-disk store. So one policy cannot decide both halves at destination
-granularity.
+**Why the destination is the wrong unit — derived from the block clause alone.**
+Blocking is a per-**context** option, and it does scope: round 12's arm D held
+opposite policies in **one** browser by partitioning destinations across separate
+contexts, and the blocked roles recorded zero worker-script requests and zero
+registrations while the permitted roles completed. But contexts isolate cookies and
+storage, and the same arm records `sharedSessionDemonstrated: false` — it does not
+show per-destination policy inside one shared session. So destinations that must
+share a sign-in must share a context, and destinations sharing a context share one
+worker policy. The unit that can carry the block clause is therefore **the set of
+destinations sharing a session**, not the destination.
+
+**The purge clause is NOT settled, and this amendment does not rest on it.** An
+earlier reading held that purge acts on a single profile-level store and so cannot
+be scoped below the profile. That measurement has been **withdrawn by its author
+pending re-measurement** — its selective-purge figures did not come from a
+post-purge filesystem read. If re-measurement confirms it, the purge clause lands
+on the same group unit and reinforces this amendment; if it refutes it, purge may
+scope more finely than block, and only the block clause forces grouping. Either way
+the amendment stands, because the block clause alone forces it. **Open until
+re-measured.**
 
 **The consequence, stated because it is the decision-relevant part.** Within a
 group, **the weakest member sets the policy**. If any destination in a session group
-requires service workers, the whole group runs with workers permitted, because purge
-cannot exempt one member. A vendor that reuses shared session mechanisms across its
-digital properties therefore yields coarse groups: a mail surface that demonstrably
-does not need a worker still runs with workers permitted if a collaboration surface
-in the same group does. Item 6 then protects very little of that group — not because
-the control fails, but because grouping forces the union of its members' needs.
+requires service workers, the whole group runs with workers permitted, because a
+context cannot both block and permit. A vendor that reuses shared session mechanisms
+across its digital properties therefore yields coarse groups: a mail surface that
+demonstrably does not need a worker still runs with workers permitted if a
+collaboration surface in the same group does. Item 6 then protects very little of
+that group — not because the control fails, but because grouping forces the union of
+its members' needs.
 
 **How groups should be drawn.** By which destinations genuinely must share a
 sign-in, not by product or vendor. Splitting a worker-dependent destination into its

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -1541,6 +1541,37 @@ grants every root, and the partitioning silently does nothing. This was measured
 not anticipated — the first fixture had exactly that layout and reported the
 confinement failing when the grant had swallowed it.
 
+### Provenance carries a numeric uid — examined and retained, 2026-08-19
+
+**Disposition.** An independent reviewer flagged `"uid"` in every artifact's
+provenance block as an account identifier, against the constraint forbidding
+identifiers in evidence. The approver ruled on 2026-08-19 that provenance **keeps
+the field**, and that the reasoning is recorded here so it is an examined
+convention rather than an unexamined default.
+
+**What the field discloses.** `runningAsRoot` is already derivable from `uid == 0`,
+so the numeric value's only marginal information is *which* numbered account — and
+the observed value is the standard first-user id for the platform. It identifies an
+operating-system convention, not a person.
+
+**Why it is not a spike defect.** 44 of the 46 promoted `*-results.json` members
+carry the field; it is the provenance convention of the entire corpus. The
+repository's privacy sweep decodes the archive payloads and scans them, and passes
+on it, so the control that owns this question already adjudicates it. Changing it
+in two files would have left the corpus internally inconsistent for no measured
+gain.
+
+**What "fix it everywhere" would actually cost, and why it is not available.**
+`s1/provenance.mjs` is a manifested member, so editing it changes a promoted digest.
+And existing artifacts cannot be regenerated to match: each carries a per-run nonce,
+which is the property round 10 recorded in R10-4 as making byte-identical
+regeneration impossible. So the real choice was retain-and-record, or change-forward
+and split the corpus. Retain was chosen.
+
+**When to revisit.** If these artifacts are ever published outside the organisation,
+or if a platform is added whose uid encodes something about the account holder, this
+disposition should be re-taken rather than inherited.
+
 ### D / item 6 becomes a per-destination accepted risk — 2026-08-18
 
 **Disposition.** The approver ruled on 2026-08-18 that service-worker suppression

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -1541,6 +1541,67 @@ grants every root, and the partitioning silently does nothing. This was measured
 not anticipated — the first fixture had exactly that layout and reported the
 confinement failing when the grant had swallowed it.
 
+### D / item 6: the accepted risk is per-GROUP, not per-destination — 2026-08-19
+
+**Amendment.** The 2026-08-18 disposition scoped item 6's accepted risk to a
+*destination*. Measurement shows the smallest unit that can carry the requirement is
+a **group of destinations sharing one profile**, so the disposition is amended to
+per-group. Item 6 remains an accepted risk; only the unit changes.
+
+**Why the destination is the wrong unit.** The requirement's two clauses live at
+different layers. **Block** is a per-context option and does scope per destination —
+by partitioning destinations across separate browser contexts, which is what round
+12's arm D measured, recording `sharedSessionDemonstrated: false` because contexts
+also isolate cookies and storage. **Purge** operates on `Default/Service Worker`, a
+single profile-level directory: destinations register into one shared store, and
+purging for one removes it for all. Contexts partition the block; they do not
+partition an on-disk store. So one policy cannot decide both halves at destination
+granularity.
+
+**The consequence, stated because it is the decision-relevant part.** Within a
+group, **the weakest member sets the policy**. If any destination in a session group
+requires service workers, the whole group runs with workers permitted, because purge
+cannot exempt one member. A vendor that reuses shared session mechanisms across its
+digital properties therefore yields coarse groups: a mail surface that demonstrably
+does not need a worker still runs with workers permitted if a collaboration surface
+in the same group does. Item 6 then protects very little of that group — not because
+the control fails, but because grouping forces the union of its members' needs.
+
+**How groups should be drawn.** By which destinations genuinely must share a
+sign-in, not by product or vendor. Splitting a worker-dependent destination into its
+own group restores full item-6 protection for the rest. **Unmeasured:** whether a
+group can be split without costing an additional interactive sign-in. Round 12's
+spike A showed profile-bound re-attach works, and spike E showed a fresh profile does
+require a real sign-in, which suggests each additional group costs one. That figure
+decides whether splitting is cheap or expensive and is not yet measured.
+
+### D / item 6: post-authentication re-attach does NOT require a service worker — 2026-08-19
+
+The residual `rfc0088-post-auth-sso-worker-dependency` is **closed**. It asked
+whether *post*-authentication silent re-attach depends on a service worker; if it
+did, workers would have to be permitted on that destination and item 6 would cover
+almost nothing.
+
+It does not. Measured against a live account under the named exception recorded in
+the round-12 spec: a lived profile carried its session marker identically with
+workers allowed and with workers blocked, and both re-attach runs carried the session
+with **zero** worker registrations present. Two controls held — two independent
+never-signed-in profiles showed zero drift, and the attended phase required an
+observed transition rather than a state, so it could not pass had no sign-in
+occurred.
+
+Taken with the front-door probe (an identity provider's sign-in surface registers no
+worker) and round 11's taxonomy (a mail-class surface renders byte-identically
+without one), **suppression does not break the credential lifecycle**. The concern
+that blocking workers would break re-authentication on a 14-90 day cycle does not
+materialise.
+
+**Bounds.** One destination, one device, one point in time, one tenant. The arm is
+an exploratory spike and is **not promoted evidence**. A first attempt was discarded
+as INVALID rather than reported: it inferred authentication from the absence of a
+password field, which that destination does not show when signed out, so its control
+could not fail and its attended phase never waited for the operator.
+
 ### Provenance carries a numeric uid — examined and retained, 2026-08-19
 
 **Disposition.** An independent reviewer flagged `"uid"` in every artifact's

--- a/docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md
+++ b/docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md
@@ -85,6 +85,35 @@ Five arms, each deciding something:
 - **No credential, real profile, or live account.** Synthetic data and fresh
   synthetic profiles only; never print, log, compare, or archive a credential
   value, even a synthetic one.
+
+  **NAMED EXCEPTION — approver-authorised 2026-08-19, for the post-authentication
+  service-worker arm only.** The one remaining question in the item-6 chain —
+  whether *post*-authentication silent re-attach depends on a service worker —
+  cannot be measured without a real authenticated session. The approver authorised
+  a single attended arm against a live account, under conditions recorded here
+  rather than agreed verbally, because a precondition quietly crossed once stops
+  constraining anything:
+
+  1. **The approver performs the interactive sign-in.** No credential is seen,
+     typed, stored, or handled by the agent at any point.
+  2. **A fresh profile**, created for the run and removed at teardown. Never an
+     existing personal or automation profile.
+  3. **Strictly read-only.** Registration state and re-attach outcome only. No
+     mailbox or message content is read, no API call is issued, and nothing is
+     written, sent, moved, or deleted.
+  4. **Attended and time-boxed.** The approver is present for the whole run.
+  5. **Booleans and counts only** in the artifact. No URI, no content, no account,
+     tenant, or organisation identifier, and no credential value.
+  6. **Credentials rotated afterwards regardless of outcome.**
+  7. **Organisational policy confirmed** by the approver as permitting automated
+     browser access to the tenant. The agent cannot determine this and must not
+     assume it.
+
+  This exception is scoped to that single arm. It does not generalise to any other
+  arm, round, or destination, and it does not alter the standing precondition
+  above, which continues to govern everything else. The round-2 incident — whose
+  broader account-level exposure remains **accepted, not resolved** — is the reason
+  the conditions are enumerated rather than summarised.
 - **Never convert a characterisation fixture, inspection-only result, hard-coded
   literal, or failed security precondition into a Pass.**
 - **Never move RFC-0088 to Accepted, close a blocker item, or revise a recorded

--- a/workspace.toml
+++ b/workspace.toml
@@ -1109,13 +1109,21 @@ open = [
   # worker. Round 12 bounds it further by enumerating which profile stores the
   # item-6 purge removes. Unblocks when: an approver authorises a credentialed arm,
   # or the pilot answers it for its own destination during rollout.
-  {slug = "rfc0088-post-auth-sso-worker-dependency", source = "rfc/0088 open question 4"},
   # Round 11 accepted, and no measured control closes, the exposure that any
   # same-uid process can attach to the browser's unconfined bind endpoint. Round 12
   # measures whether a second OS user closes it (the cheap alternative to
   # containerising, which round 10 showed costs the renderer sandbox without
   # SYS_ADMIN). Unblocks when: round 12 T4 runs, which needs a second local account.
   {slug = "rfc0088-same-uid-attach-exposure", source = "rfc/0088 disposition B"},
+  # Round 12 amended item 6's accepted risk from per-destination to per-GROUP: the
+  # purge clause operates on a profile-level store, so destinations sharing a
+  # profile share worker policy and the weakest member sets it. What is NOT
+  # measured is whether a group can be split without costing an additional
+  # interactive sign-in -- spike A showed profile-bound re-attach works and spike E
+  # showed a fresh profile needs a real sign-in, which suggests one sign-in per
+  # group. That figure decides whether splitting is cheap or expensive.
+  # Unblocks when: a spike measures the per-group sign-in cost.
+  {slug = "rfc0088-destination-group-split-cost", source = "rfc/0088 item 6 per-group amendment"},
   # AGENTS.md § "Commands you'll need" lists only `npm ci --prefix docs-site` as the
   # one-time site setup, but `make site-link-check` runs `npm run build --prefix web`
   # FIRST. Without `npm ci --prefix web` the gate dies with `sh: astro: command not

--- a/workspace.toml
+++ b/workspace.toml
@@ -1115,9 +1115,11 @@ open = [
   # containerising, which round 10 showed costs the renderer sandbox without
   # SYS_ADMIN). Unblocks when: round 12 T4 runs, which needs a second local account.
   {slug = "rfc0088-same-uid-attach-exposure", source = "rfc/0088 disposition B"},
-  # Round 12 amended item 6's accepted risk from per-destination to per-GROUP: the
-  # purge clause operates on a profile-level store, so destinations sharing a
-  # profile share worker policy and the weakest member sets it. What is NOT
+  # Round 12 amended item 6's accepted risk from per-destination to per-GROUP,
+  # derived from the BLOCK clause alone: blocking scopes only per context, contexts
+  # isolate sessions, so destinations sharing a sign-in share one worker policy and
+  # the weakest member sets it. The purge half is WITHDRAWN pending re-measurement
+  # and the amendment does not rest on it. What is NOT
   # measured is whether a group can be split without costing an additional
   # interactive sign-in -- spike A showed profile-bound re-attach works and spike E
   # showed a fresh profile needs a real sign-in, which suggests one sign-in per


### PR DESCRIPTION
- **docs(rfc): retain uid in provenance; record the spike-E named exception**
- **docs(rfc): scope item 6's accepted risk to destination GROUPS, not destinations**
