### PR TITLE
docs(rfc): accept RFC-0090 — change sizing and decomposition

### DIFF
--- a/docs/rfc/0090-change-sizing-and-decomposition.md
+++ b/docs/rfc/0090-change-sizing-and-decomposition.md
@@ -1,0 +1,525 @@
+# RFC-0090: Change sizing and decomposition
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-19
+- **Date closed:** 2026-08-19
+- **Decision weight:** heavy (modifies a top-level convention that ships to
+  adopters via the core seed, and changes published agent behavior; requires a
+  de-risk spike and explicit Approver sign-off)
+- **Related:** commit `92edf24827866aee44db53b88d432aac6d02589a`;
+  `packs/core/seeds/docs/CONVENTIONS.md`;
+  `packs/core/.apm/skills/work-loop/SKILL.md`;
+  `0090-notes/evidence.md`
+
+## Reviewer brief
+
+| Item | Summary |
+| --- | --- |
+| Decision | Size only the heavy tail by review shape and widen safe ride-alongs by verifiability; do not shrink the healthy median review unit. |
+| Recommended outcome | Use a 2,000-reviewable-line tail-triage trigger, route wide work to reproducibility proof and mixed or deep work to dependency-ordered layers, and replace locality-only bundled fixes with three verifiable tiers. |
+| Change if accepted | Edit the canonical core seed and regenerate its projection; operationalize the seed, work-loop, and new-spec; release core 2.9.2. |
+| Affected surface | Core pack (the adopter-distributed bundle) conventions seed (adopter-facing source), self-host projection (generated repository copy), and work-loop skill (implementation workflow). |
+| Stakes | The convention ships to adopters and governs how agents turn objectives into commits, PRs, and stacks. |
+| Review focus | Test shape classification, reproducibility and inertness proof, the single-artifact floor, and seed clarity for every PR. |
+| Not in scope | A global diff-size gate, new scripts or manifest fields, frozen-spec rewrites, reducing the median review unit, or a universal LOC-risk formula. |
+
+## The ask
+
+Approve the linked decisions below. A review unit cannot be sized sensibly
+without saying how a larger objective is divided.
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | What is the review unit? | One spec may deliver one or more PRs; each is a semantic commit (one independently testable concept) or stack layer (one PR in a dependent sequence). | A spec is an objective, not a mandated review boundary. | RFC acceptance | Approve or amend the decomposition unit. |
+| D2 | What numeric policy applies? | Use 2,000 reviewable behavior and test lines as a tail-triage trigger only; it requires classification and proof, never automatically a split. | The 152-line median already beats the cited guidance. In the 234-PR corpus, a generic 100-line split affects 62% of PRs: a rule that fragments most work is the exact written-but-nonbinding failure this RFC diagnoses. | RFC acceptance | Approve the trigger and its non-risk framing. |
+| D3 | How is the tail handled? | Route WIDE work to reproducibility proof without splitting; decompose MIXED and DEEP work into dependency-ordered, independently reviewable layers that leave the repository working. | Splitting a mechanically uniform sweep multiplies PRs without making any of them reviewable; it helps concentrated authoring. | RFC acceptance | Approve shape routing and proof. |
+| D4 | How does it ship? | Change the core seed (the adopter-facing source), regenerate the self-host projection (the generated repository copy), and release core 2.9.2. | The seed is source; the repository copy is generated output. | Follow-on | Confirm release and compatibility path. |
+| D5 | Where is work first sized? | Keep `new-spec`'s qualitative one-PR-sized task rule; a task predicted above the trigger must split or declare its review shape in the plan. | Coarse tasks cannot be repaired cheaply at PR time, but a generic line cap would shrink healthy work. | RFC acceptance | Approve the operational backstop. |
+| D6 | Which ride-alongs are allowed? | Replace locality-only allowance with reproducible, provably inert, and small hand-made tiers; all fail closed on design calls or behavior changes. | Verifiability, not proximity, determines whether a reviewer can safely avoid reading every line. | RFC acceptance | Approve the three tiers and evidence. |
+| D7 | Where cannot the trigger apply? | Treat the single-artifact floor and one-unit test volume as scope; require approver and named-invariant evidence only for an atomic correctness window; never exempt breaking changes. | A coherent artifact cannot be split mid-file safely, while breaking changes can use expand/migrate/contract. | RFC acceptance | Approve the bounded exception path. |
+
+## Problem & goals
+
+The repository does not have a median-size problem. Across 234 landed PRs
+with behavior or test content over 24 active days, the median is 152
+reviewable behavior and test lines at a cadence of 9.75 PRs per active day.
+That median already beats every source cited by this RFC. This policy must not
+make the median smaller; it must make the thin, very heavy tail better.
+
+The tail is substantial: p75 is 877 reviewable behavior and test lines, p90
+is 2,452, p95 is 5,300, and the maximum is 17,275. In the 234-PR corpus, 97
+PRs (41.5%) exceed 400 lines and carry 94.5% of volume; 34 (14.5%) exceed
+2,000 and carry 71.3%; 15 (6.4%) exceed 5,000 and carry 51.8%; and six (2.6%)
+exceed 10,000 and carry 27.7%.
+
+The generic-threshold model assumes every over-threshold PR splits into
+`ceil(lines / threshold)` units. At 100, 62% split, creating 12.06 times as
+many review units and 117.6 PRs per active day; at 250, 51% split, 5.21 times,
+and 50.8 PRs per day; at 400, 41%, 3.53 times, and 34.5; at 800, 31%, 2.15
+times, and 21.0; and at 2,000, 15%, 1.35 times, and 13.2. This is not the
+recommended policy and is not an improvement in reviewability.
+
+The large tail is not homogeneous. Of 34 PRs over 2,000 reviewable behavior
+and test lines, 23 are WIDE mechanical spreads with a median of at most 60
+lines per file; nine are MIXED, and two are DEEP concentrated authoring. A
+319-file sweep with six reviewable lines per file remains the same
+undifferentiated change when divided into eight PRs. Splitting helps MIXED and
+DEEP work, not WIDE work.
+
+The recommended shape-routing policy is different from the generic-threshold
+model: its 23 WIDE tail changes are proved rather than split, and only 11 MIXED
+or DEEP changes split. That adds 27 units, giving 261 units and 10.88 PRs per
+active day before ride-along absorption; it is not the 1.35-times, 13.2-per-day
+result of splitting every PR above 2,000 lines.
+
+Current bundled-fix guidance causes a related deferral problem. Its
+sibling-confined locality rule excludes repository-wide mechanical work even
+when it is reproducible and inert. The repository records 177 open backlog
+entries and 164 deferred markers across 73 specifications: 341 items. Much of
+the mechanical share can safely ride with a host change when it is verifiable,
+but locality is a poor proxy for that property.
+
+This RFC therefore separates tail triage from a split mandate, routes work by
+review shape, and replaces locality-only ride-alongs with mechanically
+checkable proof. It retains the three distinct quantities: raw diff lines for
+triage, material volume after content-hash deduplication, and reviewable
+behavior and test lines for every size judgement. It uses existing workflow
+surfaces without a new configuration, script, or global gate.
+
+## Proposal
+
+### Vocabulary
+
+A **session** is one uninterrupted agent run. Its total output is operational
+telemetry, not a PR-size measure. A session may create several commits or PRs.
+
+An **objective** is the outcome assigned to an agent. It has one goal and
+explicit acceptance criteria, and it can require several review units. A
+**plan task** is a planned unit of work no larger than one review unit; a review
+unit may group several contiguous plan tasks.
+
+A **recovery checkpoint** is a local reversible savepoint for undoing agent
+work. It is not reviewer-facing history or a semantic boundary.
+
+A **semantic commit** is a curated, independently testable Git commit that
+expresses one concept.
+
+A **PR/review unit** is the change a reviewer is asked to understand and
+approve. It contains one semantic change, related tests, and validation
+evidence.
+
+A **stack** is an ordered set of dependent PRs. A **stack layer** is one
+mergeable PR in that set. Each layer leaves the repository working and is
+based on the layer below it.
+
+**Raw diff lines** are the unmodified line count from `git diff --shortstat`.
+They and changed-file count prompt examination; neither fires the tail trigger.
+
+**Material volume** is raw diff lines after **content-hash deduplication** and
+generated output removal. Within one diff, files with the same post-image blob
+SHA from `git diff --raw` are one artifact and count once. This identifies
+byte-identical projections or packaged copies without new tooling.
+
+**Documentation prose** is non-executable explanatory text for people: guides,
+reference pages, changelogs, design records, and human-directed comments.
+It is sized by coherence, not line count: one coherent document is one review
+unit however long it is.
+
+**Reviewable behavior and test lines** are material volume that expresses
+behavior, executable structure, direct tests, or behavior-bearing content.
+They exclude deterministic mechanical edits, whole-file deletions, and
+non-executable documentation prose. They include agent skill and instruction
+files, agent and command definitions, interpreted content embedded in
+documentation such as MDX, and fenced code that is extracted, executed, or
+tested. Classification follows operational role, never file extension. A mixed
+file is classified by its behavior-bearing portion. The 2,000-line tail trigger
+applies only to this quantity. An extension-based carve-out would exempt agent
+instruction files, which are behavior rather than prose. Authored declarative
+data or configuration is reported separately because it can be risky without
+being executable code.
+
+A **review shape** is the median reviewable behavior and test lines per changed,
+content-deduplicated file containing at least one such line. Documentation
+prose, generated output, and byte-identical duplicate copies have zero such
+lines and are excluded from both numerator and denominator. **WIDE** is 60 or
+fewer lines per file. **MIXED** is above 60 and below 200. **DEEP** is 200 or
+more. If classification is ambiguous or contested, treat it as DEEP and
+decompose. Shape routes review, not defect risk.
+
+A **Tier 1 reproducible ride-along** is produced by a stated command whose
+re-run produces a zero diff. A **Tier 2 provably inert ride-along** is a
+bounded dead-code or unused-import removal supported by a search with no
+remaining references and green tests. A **Tier 3 hand-made ride-along** is the
+existing same-area, same-concern, visibly smaller mechanical change. Tiers 1
+and 2 turn on mechanically checkable properties: a re-run produces no diff or
+a search returns no references. Tier 3 remains bounded by judgement, so it
+retains its locality and size limits.
+
+### Normal lane
+
+The former 100/250/400 policy is removed; there is no normal-lane line target
+or generic split mandate. One
+specification may deliver one or more PRs, and plan tasks remain qualitative:
+small enough to be one PR when they form one independently reviewable semantic
+change. Keep behavior with its related tests, separate refactoring from
+behavior changes, and make each curated commit one concept and independently
+testable. Documentation prose remains coherence-sized, never line-capped.
+
+A plan task predicted to exceed 2,000 reviewable behavior and test lines must
+either be split or declare its expected review shape. File count and
+concentration can prompt that triage, but are not split thresholds. The trigger
+is calibrated to reviewer burden and cadence; it makes no defect-risk claim.
+
+### Tail-triage lane
+
+A **tail-triage lane** is the proof-bearing workflow for intended review units
+over 2,000 reviewable behavior and test lines. Raw diff lines, changed-file
+count, and concentration are triage inputs only. Report raw diff lines,
+material volume, and reviewable behavior and test lines separately, then
+classify the review shape before deciding boundaries. This trigger is not an
+automatic instruction to split.
+
+Before implementation, identify intended semantic-commit, PR, or stack
+boundaries. Classify material volume as:
+
+- authored behavior or structure;
+- authored declarative data or configuration;
+- deterministic mechanical transformation;
+- generated output; or
+- deletion.
+
+For WIDE work, do not split. Provide the source artifact, exact transformation
+command, transformation invariant, a zero diff on re-run, targeted tests,
+sampled review, and rollback evidence.
+Splitting a mechanically uniform sweep multiplies PRs without making any of
+them reviewable. For MIXED or DEEP work, decompose into dependency-ordered
+layers; each must be independently reviewable and leave the repository
+working. A handwritten executable file remains authored work even if the
+overall feature is described as atomic.
+
+Deduplicate and classify before deciding boundaries. A single coherent artifact
+is a floor the trigger cannot go below: it is a bundling limit, not an artifact
+limit. The author must name its single unit and state why no split preserves
+working layers; otherwise decomposition is required. When it qualifies,
+nothing else rides with it and no approval is needed. Five of the eight
+observed single-artifact cases are test files. A regular test suite is one
+review unit only when its author names the single unit it tests and states why
+no split preserves working layers; otherwise decomposition is required.
+
+An atomic correctness window is the only judgement exception. Where no split
+can leave every layer working, such as a partially applied security fix, the
+repository owner or named maintainer must accept it before review and record
+the named invariant, classification, validation, and rollback evidence. A
+breaking interface change is explicitly not an exception: use
+expand/migrate/contract.
+
+### Proposed replacement seed text
+
+The implementation changes only the third paragraph of `## Pull requests` in
+the canonical seed. A **seed** is the adopter-facing source file carried
+by a pack. A **self-host projection** is the generated repository copy
+built from that source. `packs/core/seeds/docs/CONVENTIONS.md` is the source
+and `docs/CONVENTIONS.md` is its self-host projection. The implementation
+edits the seed and runs `make build-self`; it must never hand-edit
+the projection.
+
+This text is hard-wrapped for the conventions file. It contains no internal
+governance citation because it ships into adopter repositories.
+
+~~~markdown
+Size a PR as a reviewable semantic change, not as an agent session or a whole
+specification. One specification may deliver one PR or a dependency-ordered
+stack; each layer must be independently reviewable and leave the repository
+working. Keep behavior with its related tests, separate refactoring from
+behavior changes, and keep each curated commit independently testable.
+
+Use 2,000 reviewable behavior and test lines only as a tail-triage trigger,
+not as an automatic split rule. Classify by operational role, never file
+extension: agent instruction files and executed content count as behavior.
+Non-executable documentation prose is sized by coherence, not line count.
+Report raw diff lines for triage, material volume after content-hash
+deduplication, and reviewable behavior and test lines for size judgement.
+Raw diff lines and changed-file count only prompt examination. Classify tail
+shape by the median reviewable lines per changed, deduplicated file with at
+least one such line; exclude prose, generated output, and duplicate copies.
+WIDE is 60 or fewer, MIXED is above 60 and below 200, and DEEP is 200 or more.
+If classification is ambiguous or contested, treat it as DEEP and decompose.
+
+For mechanically uniform WIDE work, do not split: give the source artifact,
+exact command, transformation invariant, zero diff on re-run, targeted tests,
+sampled review, and rollback evidence.
+For MIXED or DEEP work, split into dependency-ordered working layers. A single
+coherent artifact is a floor: when it alone exceeds the trigger, nothing else
+rides with it only if the author names its single unit and states why no split
+preserves working layers. The same evidence is required for a regular test
+suite serving one unit; otherwise decompose. An atomic correctness window
+needs prior approver acceptance, a named invariant, volume classification,
+validation evidence, and a rollback path; a breaking interface change is not
+grounds and uses expand/migrate/contract.
+
+Bundled fixes must be listed under `Bundled fixes:` and fail closed on design
+calls or behavior changes. Tier 1 is reproducible: state the command and show
+a zero diff on re-run; it may span the repository. Tier 2 is provably inert:
+show no remaining references and green tests for bounded dead-code or
+unused-import removal. Tier 3 is hand-made: same-area, same-concern, visibly
+smaller mechanical work. Tier 1 and Tier 2 require their command or evidence.
+~~~
+
+The seed keeps triage deliberately simple. File count and concentration remain
+workflow inputs, not standing split rules or claims about defect risk.
+
+### Proposed work-loop behavior
+
+Documentation alone leaves agents likely to discover volume after producing
+it. Work-loop is the shipped implementation workflow. Its three quoted blocks
+are PLAN, Finish, and Bundled fixes; with the seed and two new-spec blocks,
+they are the six quoted blocks in this RFC. Insert them verbatim at their named
+anchors in its adopter-shipped skill file. They operationalize PLAN and REVIEW
+with prose only. Do not add a
+script, manifest field, hook, configuration flag, or hard global gate. Use the
+existing plan task list plus `git diff --numstat`, `git diff --shortstat`, and
+`git diff --raw`.
+
+The surfaces have deliberately different reach. The conventions seed is the
+**full-reach surface**, meaning it applies to every PR regardless of how the
+work was produced. Work-loop prompts add depth when work runs that
+workflow. `new-spec` task sizing reaches specification-authored
+work. The latter two surfaces do not replace the seed because most landed
+volume is not traceable to a written specification.
+
+Enforcement has three layers, with leverage inverted from the usual
+PR-only approach. Layer 1 is the specification: it sizes review units and
+has the highest leverage. Layer 2 is work-loop PLAN: it declares
+boundaries and sanity-checks task sizing before EXECUTE, when splitting
+is a text edit. Layer 3 is the PR and Finish checklist: it measures, confirms,
+or demands proof. It is a backstop and cannot redesign completed work.
+Pressure belongs at layers 1 and 2, not as punitive late enforcement at layer
+3.
+
+Insert this at the end of **Step 1 PLAN, item 5**, immediately after the
+assumption trio (the touched files, proving tests, and excluded work), in
+`packs/core/.apm/skills/work-loop/SKILL.md`:
+
+~~~markdown
+- **Size the tail.** A plan task predicted above 2,000 reviewable behavior
+  and test lines must be split or declare its expected WIDE, MIXED, or DEEP
+  review shape. Use the task graph to name intended PR or stack boundaries.
+  WIDE work needs reproducibility proof; MIXED and DEEP layers must remain
+  independently reviewable and working. Do not invent tasks only to make PRs.
+~~~
+
+Insert this in the **Finish checklist**, immediately before the **PR opened
+(or merged directly)** item, which requires the four-question PR template
+(the required What, Why, verification, and
+considered-but-not-changed answers):
+
+~~~markdown
+- **Tail-triage check completed.** Inspect raw diff lines, material volume,
+  and reviewable behavior and test lines for each intended PR or stack layer.
+  Above 2,000 reviewable behavior and test lines, record review shape. WIDE
+  work links its source artifact, transformation invariant, command, zero-diff
+  re-run, tests, sampled review, and rollback; MIXED and DEEP work links its
+  dependency-ordered boundaries.
+~~~
+
+### Proposed new-spec behavior
+
+`new-spec` is the shipped specification-authoring skill. Its
+existing Step 5 already says to make tasks small enough for one PR, but it
+does not define that size. Replace the following **Step 5 plan bullet** in
+`packs/core/.apm/skills/new-spec/SKILL.md`:
+
+~~~markdown
+- Break the work into plan tasks small enough for one PR. A task predicted
+  above 2,000 reviewable behavior and test lines must be split or declare its
+  expected WIDE, MIXED, or DEEP review shape.
+~~~
+
+Replace the **Task too big** failure-mode bullet in that same Step 5 with:
+
+~~~markdown
+- **Task too big.** "Implement the feature" is not a task; "add the validation
+  function for X" is. Each task should be small enough for one PR and one
+  context window. A task predicted above 2,000 reviewable behavior and test
+  lines must be split or declare its expected review shape in the plan.
+~~~
+
+This reconciles existing policy. The **bug-fix skill** is the shipped
+workflow for correcting existing behavior; it already declines combining a bug
+fix with adjacent cleanup. Replace the bundled-fixes carve-out locality
+sentence at the **Bundled fixes** anchor in work-loop with the following text.
+It is the sixth quoted block; the three mirrored sites named in Follow-on must
+stay synchronized.
+
+~~~markdown
+Bundled fixes: list each under `Bundled fixes:`. Tier 1 reproducible work must
+state its command and produce a zero diff on re-run; Tier 2 inert work must
+show no remaining references and green tests; Tier 3 hand-made work remains
+same-area, same-concern, visibly smaller, and mechanical. All tiers fail
+closed on a design call or behavior change.
+~~~
+
+### Migration and adopter impact
+
+Apply this policy prospectively. Do not rewrite frozen specifications or
+accepted RFCs that say “one PR.” **Frozen** means an accepted or shipped
+artifact whose body is no longer edited. An active task may record new
+delivery boundaries in its planning artifact. **Errata** are correction
+sections for frozen artifacts.
+
+Core adopters receive this behavior through the canonical seed and the shipped
+work-loop skill. This non-cosmetic core pack content change bumps both
+`pack.toml` and `.claude-plugin/plugin.json` from 2.9.1 to 2.9.2. Run
+`FORCE=1 make build-self` (`make build-self` regenerates projected content;
+`FORCE=1` also re-aggregates marketplace metadata) to re-aggregate
+`marketplace.json`, then add a
+`## [core][2.9.2] — YYYY-MM-DD` section to `docs/product/changelog.md`. No
+adopter configuration is required.
+
+## Options considered
+
+| Option | Consequence | Decision |
+| --- | --- | --- |
+| Do nothing | Preserves a rule that attempts to shrink a healthy median and leaves locality-driven deferral intact. | Rejected. |
+| Generic split thresholds | In the 234-PR generic-threshold model, 400 splits 41% of PRs, producing 3.53 times as many review units and 34.5 PRs per active day; it makes WIDE work no more reviewable. | Rejected. |
+| Hard-cap all diffs | Is simple but rejects valid generated projections, regular test suites, and safe broad mechanical work. | Rejected. |
+| Remove numeric guidance | Avoids false precision but removes the tail-triage backstop for concentrated reviewer burden. | Rejected. |
+| Shape-routed tail triage | Preserves the healthy median, proves WIDE work, and decomposes MIXED and DEEP work. | Accepted. |
+| Locality-only ride-alongs | Fails closed on provably inert repo-wide work and drives mechanical work into deferred backlogs. | Rejected. |
+| Verifiability-tier ride-alongs | Allows only mechanically checkable reproducibility or inertness proof, retaining a narrow hand-made tier. | Accepted. |
+| Seed-only documentation | Changes the adopter convention but discovers tail shape after implementation. | Rejected. |
+| Specification sizing plus PLAN and Finish prompts | Sizes work upstream and records classification without a new enforcement system. | Accepted. |
+| Blocking global hook | Would fail much of current history and conflicts with consumer-wired projected gates. | Rejected. |
+
+## Risks & what would make this wrong
+
+The largest untested assumption is behavioral. PLAN and REVIEW prompts may not
+change classification, decomposition, or ride-along decisions. The evidence is
+historical shape and cadence, not review outcomes. A later enforcement proposal
+needs proof-quality, classification-consistency, and rework evidence.
+
+The 2,000-line trigger is calibrated to reviewer burden and cadence, not to
+defect risk. It can create noise or miss concentrated work; file count and
+concentration remain triage inputs. Revise calibration only through a later
+convention decision.
+
+WIDE classification could become a convenient label. The policy fails closed:
+the exact command must re-run to a zero diff, with targeted tests, sampled
+review, and rollback. Tier 2 likewise requires a search with no remaining
+references, not an author's convenience judgement. A maximally permissive
+stacking rule would remove the review boundary this policy is meant to protect.
+
+Dependency layers can encourage shallow stacks. Each MIXED or DEEP layer must
+be independently reviewable and leave the repository working. Only an atomic
+correctness window may depart from that invariant, with approver acceptance and
+named-invariant evidence.
+
+No LOC number measures risk universally. Security, authorization, data
+migration, external I/O, and unfamiliar-domain changes can be risky at ten
+lines. A deterministic projection can be large and cheaply verified. This RFC
+does not replace existing risk triggers or specialist review.
+
+The code/prose boundary requires judgement. A change that mixes a large
+document with behavior-bearing content is sized on its behavior-bearing
+portion, while its documentation prose remains a coherence review.
+Documentation still contributes raw diff lines to wide-change triage and
+reports its volume there.
+
+The conventions seed is the only full-reach surface for most work. Its clarity
+therefore matters more than workflow prompts for PRs that do not run work-loop
+or have no written specification. A later blocking gate would be the only
+universal operational mechanism. This RFC accepts partial operational reach to
+avoid adding that global gate now.
+
+## Evidence & prior art
+
+See [the evidence ledger](0090-notes/evidence.md) for fetched-and-verified
+citations, exact quotes, repository measurement methods, and their limits.
+
+| Evidence | Finding | Confidence and limit |
+| Cadence and shape, 234 landed PRs over 24 active days | 9.75 PRs per active day; median 152 reviewable behavior and test lines, p75 877, p90 2,452, p95 5,300, and maximum 17,275. | High for this corpus; excludes PRs with no behavior or test content and makes no review-outcome claim. |
+| Tail review shape, 34 PRs over 2,000 lines | 23 are WIDE at at most 60 median lines per file, nine MIXED, and two DEEP. | Historical classification; supports routing, not a defect-risk claim. |
+| Net-effect model | Tail routing adds 27 review units; there are 60 absorption candidates. The combined policy breaks even near 46% absorption and ranges from 10.88 to 8.38 PRs per day at 0% to 100%. | Absorbability is inferred from subjects, not verified host changes; 100% is unreachable. Deferred mechanical work is upside, not counted. |
+| Indivisibility | Eight PRs (3.4%) contain one file over 2,000 reviewable lines; largest is 3,676 and five are test files. All three breaking changes are spread. | Supports the single-artifact floor and regular-test treatment; a small historical sample. |
+| --- | --- | --- |
+| Repository spike, 337 squash merges | Median 790 raw diff lines, mean 2,257 raw diff lines, 64% over 400 raw diff lines, and 25% over 25 files. | High for this sample; no causality or safe threshold. |
+| Three quantities, 187 landed PRs | Median raw diff lines 1,068; material volume 1,057; reviewable behavior and test lines 231. Respectively, 72%, 70%, and 40% exceed 400 of the named quantity. | Single-repository historical sample with no review-outcome data. Deduplication changes the headline little; it matters most for giant replicated diffs. |
+| Repository plans | 305 of 380 spec directories contain `Depends on:`; observed dependencies include 426 `none`, 293 `T1`, and chains through task 14. This is available decomposition input, not proof that every task boundary is good. | High that usable dependency structure exists; per-task quality varies. |
+| `4f5b978f` decomposition analysis | Its four strict-linear plan tasks could have formed four layers, but roughly twelve tasks were needed to approach 400 reviewable behavior and test lines per layer; its 45% replicated volume inflated raw diff size. | One PR in one repository; historical analysis with no review-outcome data. |
+| Replication across 116 wide PRs | Median replicated share is 0%, mean 7%, and maximum 71%; the six largest diffs carry roughly 37–45% replication. Content-hash deduplication reduces overstatement where it matters most. | Single repository and historical sample; no review-outcome data. |
+| Specification-tracking reach, 337 PRs | Only 76 PRs carry a written-spec footer; the other 261 contribute 73% of changed volume. Written-spec PRs are not smaller. | Missing footer does not prove work-loop was skipped because light mode uses inline specs; tool-usage analytics is needed to separate paths. |
+| Single-file concentration, 91 landed PRs | After excluding documentation and generated paths, median single-file share is 28%, p75 52%, p90 62%; 26% have a file at least 50%, and 17 have one at least 1,000 authored lines. | Single-repository historical sample with no review-outcome data; supports triage calibration, not a risk threshold. |
+| Commit `92edf24827866aee44db53b88d432aac6d02589a` | Current 100/400 raw-diff-line wording added a “quantitative anchor” and cited no empirical source. | High provenance evidence; not proof the numbers are invalid. |
+| Google Small CLs | “100 lines is usually a reasonable size for a CL, and 1000 lines is usually too large”; refactors are usually separate and large CLs need consent. | Strong practitioner guidance; not agent-specific. |
+| Chromium `cl_tips` | Try to keep changes below 500 code lines including tests; regular test patterns can be larger; a CL should effect one type of change. | Strong operational prior art; not a universal limit. |
+| SmartBear/Cisco study | Performance probably degrades after 300–400 LOC; review should be under 90 minutes and reviewers wear out after 60. The 200-LOC figure is descriptive, not advice. | Useful field evidence; 2006 context limits transfer. |
+| di Biase et al., PeerJ CS 5:e193 (2019), 28 developers | Decomposition produced fewer wrongly reported issues and more context-seeking. It did not increase defects found or improve comprehension. | Controlled but narrow evidence; no LOC cap follows. |
+| OpenAI, How OpenAI uses Codex | Codex works best with well-scoped tasks taking about an hour or a few hundred implementation lines. | Agent-specific guidance; capability changes over time. |
+| OpenAI, Harness engineering and Symphony | Depth-first building blocks, rails, task trees, dependency ordering, and multiple PRs support separating objectives from PRs. | Relevant practice, not a threshold study. |
+| GitHub Copilot and stacked PR guidance | Good tasks have clear criteria and changed-file scope; agent code can map tasks to dependent stacked PRs. | Relevant workflow guidance; do not force one task per PR. |
+| Graphite | Flag PRs over 250 lines or 25 files and review each stack PR independently. | Vendor guidance; supports advisory signals only. |
+| Aider, Cline, Cursor, Anthropic checkpoint practice | Tools converge on recovery checkpoints and rollbacks, not reviewer-facing commit-size rules. | Strong vocabulary distinction; no numeric conclusion. |
+| arXiv 2606.15689 and 2603.26130 | One preprint reports F1 from 0.657 under 10 lines to 0.043 over 150 using five models and 150 samples; another reports monotonic degradation and attention dilution. | Low-confidence preprints. They reject the claim that AI review makes an undifferentiated 17,000-line PR safe. They cannot set production thresholds. |
+
+## Open questions
+
+1. Should WIDE proof use the current flexible PR template or a standard
+   subsection? Recommended default: retain the flexible form; the policy adds
+   no machinery. Owner: eugenelim. Decide by: follow-on implementation.
+2. What absorption rate is reached for Tier 1 and Tier 3 candidates?
+   Recommended default: measure after 100 landed PRs and compare review-unit
+   cadence with the 46% break-even estimate. Owner: eugenelim. Decide by: the
+   next convention review.
+3. What outcome measures would justify a later blocking check? Recommended
+   default: require proof-quality, classification-consistency, and rework
+   evidence, not a line-count outcome alone. Owner: eugenelim. Decide by: any
+   RFC proposing a gate.
+
+## Follow-on artifacts
+
+If accepted, follow-on work must:
+
+1. Edit `packs/core/seeds/docs/CONVENTIONS.md` with the quoted text and
+   regenerate `docs/CONVENTIONS.md` through `make build-self`.
+2. Apply the three quoted work-loop insertions at their named anchors. Keep the
+   bundled-fixes carve-out synchronized across its canonical site in
+   `work-loop/SKILL.md`, `implementer.md`'s operating envelope, and
+   `adversarial-reviewer.md`'s scope check #4.
+3. Add task-sizing guidance to `new-spec`, the specification-authoring skill.
+   This is an additional shipped core-pack surface and rides the same version
+   bump as the seed and work-loop changes.
+4. Bump both core versions to 2.9.2, re-aggregate marketplace metadata with
+   `FORCE=1 make build-self`, and add the core changelog entry.
+5. Verify seed/projection synchronization, version consistency, generated
+   marketplace metadata, RFC/document conventions, and applicable core pack
+   build and test gates.
+6. Add focused tests only if existing validation cannot prove projected content,
+   version consistency, or workflow text. This RFC does not justify a new
+   size-check script or global blocking hook.
+
+Compliance has two layers. Existing validation proves that the shipped seed
+and projection remain synchronized. Work-loop PLAN and REVIEW records prove a
+tail change was classified, decomposed, or proved reproducible. The second
+layer is deliberately reviewable workflow evidence, not universal LOC-based
+failure.
+
+## Errata
+
+The body above is frozen. Corrections are recorded here.
+
+- **2026-08-19 — two corrections found during implementation, both applied to
+  the shipped text.** First, the single-artifact floor was written as a
+  conditional: "nothing else rides with it only if the author names its single
+  unit and states why no split preserves working layers." That makes the
+  prohibition contingent on the justification, which inverts the intent. The
+  floor is a scope statement, not a discretionary exception. The shipped
+  wording is unconditional: nothing else rides with it, and the author
+  separately names the single unit it serves and states why no split preserves
+  working layers. Second, the qualifier "mechanically uniform" was dropped from
+  the WIDE routing rule in the `work-loop` and `new-spec` surfaces, which would
+  have let any WIDE-shaped change avoid decomposition on reproducibility proof
+  alone rather than only mechanically uniform work. The qualifier is restored at
+  every routing site. Approver: eugenelim.
+

--- a/docs/rfc/0090-notes/evidence.md
+++ b/docs/rfc/0090-notes/evidence.md
@@ -1,0 +1,376 @@
+# RFC-0090 evidence base
+
+Supporting material for RFC-0090. The RFC body carries the argument; this file
+carries the proof. Every external source below was fetched on 2026-08-19 and
+confirmed to contain the claim attributed to it. Where the common summary of a
+source drifts from what the source says, the drift is recorded.
+
+## External sources
+
+| # | Source | Verified claim (exact wording where quoted) | Confidence / limit |
+|---|---|---|---|
+| 1 | [Google eng-practices, Small CLs](https://github.com/google/eng-practices/blob/master/review/developer/small-cls.md) | "100 lines is usually a reasonable size for a CL, and 1000 lines is usually too large, but it's up to the judgment of your reviewer." Also "It's usually best to do refactorings in a separate CL from feature changes or bug fixes" and, for unavoidably large CLs, "get consent from your reviewers in advance". | Strong practitioner guidance. Not agent-specific, not an empirical study. |
+| 2 | [Chromium cl_tips](https://chromium.googlesource.com/chromium/src/+/main/docs/cl_tips.md) | "Try to keep changes below 500 lines of code – including tests." Allows 200 production + 600 test lines when tests follow a regular pattern. "CLs should only effect one type of change." | Strong operational prior art from a large codebase. Not a universal limit. |
+| 3 | [SmartBear / Cisco case study](https://static0.smartbear.co/support/media/resources/cc/book/code-review-cisco-case-study.pdf) | Prescriptive: "a reviewer will probably not be able to review more than 300-400 lines of code before his performance" degrades; "total review time should be under 90 minutes"; "after 60 minutes reviewers 'wear out' and stop finding additional defects". **Descriptive, not prescriptive:** "most reviews are smaller than 200 lines of code". | 2006 study; 2,500 reviews, 3.2M LOC, 50 developers at Cisco MeetingPlace. In-situ vendor study, not a controlled experiment. **The widely-quoted "recommends under 200 LOC" misreads a distribution observation as advice.** |
+| 4 | di Biase, Bruntink, van Deursen, Bacchelli, "The effects of change decomposition on code review — a controlled experiment", PeerJ CS 5:e193 (2019). [DOI](https://doi.org/10.7717/peerj-cs.193) · [PeerJ](https://peerj.com/articles/cs-193/) · [PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC7924728/) | Decomposition "leads to fewer wrongly reported issues" and increases context-seeking, "yet impacts neither understanding the change rationale nor the number of found defects." | Controlled experiment, 28 developers (professionals and graduate students). **Does not show decomposition finds more bugs.** Establishes no numeric cap. |
+| 5 | [OpenAI, How OpenAI uses Codex](https://cdn.openai.com/pdf/6a2631dc-783e-479b-b1a4-af0cfbd38630/how-openai-uses-codex.pdf) | "Codex works best with well-scoped tasks that would take you or a teammate about an hour to complete or a few hundred lines of code to implement. As models improve, expect the size of the tasks it can take on to increase." Ask-mode plan first for large changes; task queue as a "lightweight backlog" for "tangential ideas, partial work, or incidental fixes". | Vendor guidance about one agent. Explicitly time-bound — the document says the workable size will grow. |
+| 6 | [OpenAI, Harness engineering](https://openai.com/index/harness-engineering/) | Single Codex runs "upwards of six hours". "working depth-first: breaking down larger goals into smaller building blocks (design, code, review, test...)". Deterministic rails — linters, type checkers, unit tests — block the agent from marking a task complete. | Vendor practice report. Direct fetch returned HTTP 403; claims confirmed from search snippets of the primary URL. |
+| 7 | [OpenAI, Symphony](https://openai.com/index/open-source-codex-orchestration-symphony/) | "Some issues produce multiple PRs across repos". Agent work "no longer tied to PRs". A Planner decomposes work into a task tree scheduled by "dependency ordering and file lock availability". | Vendor spec announcement. Direct fetch returned HTTP 403; claims confirmed from search snippets of the primary URL. |
+| 8 | [GitHub Copilot, get the best results](https://docs.github.com/en/copilot/tutorials/cloud-agent/get-the-best-results) | An ideal task carries a clear problem description, "Complete acceptance criteria on what a good solution looks like", and which files change. Avoid cross-repository knowledge, deep domain knowledge, substantial business logic, security/PII/auth, and ambiguous open-ended work. | Vendor task-scoping guidance. |
+| 9 | [GitHub, About stacked PRs](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) | "When you generate a lot of code at once, often with AI agents, a stack gives each change a place to go. An agent completes one task, then starts the next task that builds on it. That sequence maps directly onto a stack: one pull request per task, each based on the one below." | The most direct vendor mapping of agent work to review units. Guidance, not evidence of outcomes. |
+| 10 | [Graphite, best practices for reviewing stacks](https://graphite.com/docs/best-practices-for-reviewing-stacks) | "Set up an automation to comment on PRs larger than 250 lines of code or 25 files changed to encourage authors to break up larger changes into stacks." Also "Review a PR in a stack as though it was an independent change". | Practitioner / vendor guidance. Not an independent empirical threshold. |
+| 11 | Agent checkpoint practice: [Aider](https://aider.chat/docs/git.html) · [Cline](https://docs.cline.bot/core-workflows/checkpoints) · [Cursor](https://docs.cursor.com/agent/chat/checkpoints) · [Anthropic, How Anthropic teams use Claude Code](https://www-cdn.anthropic.com/58284b19e702b49db9302d5b6f135ad8871e7658.pdf) | Aider: "Whenever aider edits a file, it commits those changes with a descriptive commit message." Cline: "a shadow Git repository separate from your project's actual Git history". Cursor: "Checkpoints are stored locally and separate from Git. Only use them for undoing Agent changes; use Git for permanent version control." Anthropic RL Engineering team: "an iterative approach that includes frequent checkpointing and rollbacks", a "try and rollback" methodology. | Converges on cheap rollback. **No tool prescribes a numeric commit size.** Supports the recovery-checkpoint vs semantic-commit distinction only. The Cursor URL carrying an `/en/` path segment is stale and redirects to the docs root; the link above is the live page. |
+| 12 | [arXiv 2606.15689](https://arxiv.org/abs/2606.15689), "Bigger Isn't Always Better: A Comparative Evaluation of LLMs for Automated Code Review" (Kumar, Bararia, Raj) · [arXiv 2603.26130](https://arxiv.org/abs/2603.26130), "SWE-PRBench" (D. Kumar) | 2606.15689: "diff size is the dominant predictor of review quality, with F1 dropping from 0.657 on diffs under 10 lines to 0.043 on diffs over 150 lines." 2603.26130: "all 8 models degrade monotonically from config_A to config_C"; a "structured 2,000-token diff-with-summary prompt outperforms a 2,500-token full-context prompt". | **Low confidence.** Recent preprints. 2606.15689 evaluates 5 models on 150 samples. Sufficient to reject the claim that an AI reviewer makes a large undifferentiated PR safe. **Not sufficient to set any production threshold.** F1 is the harmonic mean of precision and recall. |
+
+## Repository measurements
+
+Method: `git log --first-parent main`, taking commits whose subject ends
+`(#NNNN)` as landed PRs (the repository squash-merges), then `git show
+--numstat` per commit. Changed lines are insertions plus deletions. Sample is
+the most recent 400 first-parent commits, of which 337 are PR-shaped. Measured
+2026-08-19.
+
+### Landed PR size
+
+| Metric | Median | Mean | Max |
+|---|---|---|---|
+| Changed lines | 790 | 2,257 | 38,331 |
+| Files changed | 11 | 23 | 329 |
+
+Share of the 337 landed PRs exceeding each published threshold:
+
+| Threshold | Source of the threshold | Share over |
+|---|---|---|
+| 250 lines / 25 files | Graphite warn level | 71% / 25% |
+| 400 lines | Current repository rule; SmartBear reviewer capacity | 64% |
+| 500 lines | Chromium | 58% |
+| 1,000 lines | Google "usually too large" | 44% |
+| 5,000 lines | — | 11% |
+
+Largest landed PRs by changed lines: 104 files / 38,331 lines; 113 / 33,170;
+175 / 28,536; 124 / 28,193; 82 / 25,388; 203 / 21,968; 31 / 20,038;
+69 / 19,019; 207 / 17,254; 250 / 14,646.
+
+### Single-file concentration
+
+Measured two ways, because the denominator changes the answer completely.
+
+Across the 214 landed PRs with at least 400 total changed lines, using **total
+changed lines** as the denominator: maximum single-file share is 100%, and 131
+of 214 (61%) have a file at or above 20% of the diff. The most concentrated
+cases are single documents — `docs/rfc/0079-codebase-context-pack.md` at 100%
+of a 3,570-line diff, and repeated `docs/rfc/0088-notes/spikes/` archive edits
+at 98–99%. A single-document change is reviewable as one unit, so total-line
+share is the wrong signal.
+
+Excluding documentation (`docs/`, `*.md`, `guides/`, `CHANGELOG`,
+`workspace.toml`) and generated output (`dist/`, `marketplace.json`,
+`.claude/`, `.agents/`, `package-lock.json`), across the 91 landed PRs carrying
+at least 400 authored lines:
+
+| Statistic | Single-file share of authored lines |
+|---|---|
+| Median | 28% |
+| p75 | 52% |
+| p90 | 62% |
+| Max | 99% |
+
+| Condition | PRs meeting it |
+|---|---|
+| A file at or above 30% of authored lines | 40 of 91 (44%) |
+| A file at or above 40% | 32 of 91 (35%) |
+| A file at or above 50% | 24 of 91 (26%) |
+| A file at or above 60% | 11 of 91 (12%) |
+| A file at or above 75% | 2 of 91 (2%) |
+| A file of at least 1,000 authored lines | 17 |
+| A file of at least 2,000 authored lines | 8 |
+| A file of at least 3,000 authored lines | 3 |
+
+Most concentrated authored files observed: `tools/test_marketplace_envelope_parity.py`
+at 99.0% (1,302 of 1,315); `tools/test-build-check-workflow.py` at 65.2%
+(1,966 of 3,016); `tools/test_workspace_status.py` at 64.9% (2,298 of 3,542);
+`packages/agentbundle/agentbundle/workspace_mcp.py` at 61.6% (1,800 of 2,922).
+
+Limits: one repository, historical, no review-outcome or defect data. These
+figures calibrate triage thresholds. They carry no claim about defect risk.
+
+### Convention conflict
+
+`docs/specs/` contains 114 occurrences of the phrase "one PR" as an explicit
+per-spec delivery declaration, including on specs sized 48 acceptance criteria
+and 15 tasks, and 40 acceptance criteria and 10 tasks.
+
+`Depends on:` appears in 305 of 380 spec directories. The observed dependency
+distribution is 426 tasks declaring `none`, 293 declaring `T1`, 117 `T2`,
+56 `T3`, 51 `T1, T2`, and 45 `T1, T2, T3`. The highest task number seen is 14.
+Dependency structure suitable for deriving stack layers already exists, though
+task quality varies and the field is not universal.
+
+### Provenance of the current rule
+
+Commit `92edf24827866aee44db53b88d432aac6d02589a`, dated 2026-05-17, subject
+"docs(conventions): add PR size target and name Shift Left in enforcement".
+The commit body states the intent: the section "gains a one-line size target
+(~100-line aim, ~400-line split threshold unless the change is genuinely
+atomic)", which "gives 'limit the diff to what the request requires' a
+quantitative anchor." The commit cites no empirical source for either number.
+
+### Motivating case
+
+The reported session shape — roughly 17,000 changed lines with roughly 6,000 in
+one file — was not found as a landed PR in `main` history. The nearest landed
+analogue is `4f5b978f`, 20,038 changed lines across 31 files, whose largest file
+is 3,676 lines (18% of total changed lines). Whether the reported 6,000-line
+file was authored or generated was not established, which is why the policy
+routes concentrated volume through both an authored-line trigger and a
+total-volume trigger.
+
+## Decomposition analysis of the wide-change analogue
+
+`4f5b978f` ("feat(workspace-status): enforce canonical routing invariants"),
+20,038 changed lines across 31 files, is the largest landed PR carrying a
+written plan. Deduplicating its changed files by content hash:
+
+| Component | Lines | Share |
+|---|---:|---:|
+| Byte-identical replicated copies | 9,021 | 45% |
+| Distinct implementation | 4,844 | 24% |
+| Distinct tests | 5,736 | 29% |
+| Distinct docs and spec | 437 | 2% |
+
+The replication is dominated by one file. `workspace_status_engine.py` appears
+at four paths — the pack source under `packs/core/.apm/`, two agent projections
+(`.claude/`, `.agents/`), and a packaged copy at
+`packages/agentbundle/agentbundle/_data/` — all byte-identical at content hash
+`3fc1febc092d`, 3,676 lines each. That one file contributes 7,149 duplicate
+lines, 36% of the whole PR.
+
+Its plan declares four tasks in a strict linear chain: T1 → T2 → T3 → T4, each
+depending on the previous. A linear chain is the canonical stack shape, so the
+work was decomposable into four dependent layers. Four layers would have carried
+roughly 2,754 distinct lines each (about 1,211 implementation lines), a sevenfold
+reduction in review-unit size — while still sitting about three times above a
+400-authored-line threshold. Reaching that threshold would have required roughly
+twelve tasks. The plan had four, averaging 5,009 diff lines per task.
+
+The conclusion is that decomposition was available and would have helped
+substantially, but task granularity at specification time was the binding
+constraint, not pull-request discipline at merge time.
+
+## Replication across wide changes
+
+Content-hash deduplication applied to the 116 landed PRs of at least 400 changed
+lines in the most recent 160 first-parent commits:
+
+| Statistic | Replicated-copy share of the diff |
+|---|---|
+| Median | 0% |
+| Mean | 7% |
+| Maximum | 71% |
+
+| Condition | PRs |
+|---|---|
+| At least 10% of the diff is byte-identical replication | 26 of 116 (22%) |
+| At least 25% | 16 of 116 (14%) |
+| At least 40% | 5 of 116 (4%) |
+
+Replication is rare in typical changes but concentrated in the largest ones. The
+six largest PRs in the sample carry replication shares of 36.8%, 39.2%, 40.6%,
+40.2%, 45.0%, and 39.4% — on diffs of 33,170, 28,536, 25,388, 21,968, 20,038,
+and 17,254 lines respectively. Raw `git diff --numstat` therefore overstates the
+review burden of exactly the changes this policy targets, by roughly 1.6 to 1.8
+times. Detection needs no new tooling: identical content hashes across paths in
+one diff are computable from `git show` output.
+
+## Reach: how much work is specification-tracked
+
+Across the 337 landed PRs sampled, 76 (23%) carry a `Spec: docs/specs/...`
+commit footer and 261 (77%) do not.
+
+| Group | PRs | Median lines | Mean | Over 400 lines | Total volume |
+|---|---:|---:|---:|---:|---:|
+| With `Spec:` footer | 76 (23%) | 822 | 2,748 | 79% | 208,810 |
+| Without | 261 (77%) | 712 | 2,115 | 59% | 551,917 |
+
+Two conclusions follow, and they pull in different directions.
+
+First, most change volume — 551,917 lines, 73% of the total — lands outside the
+specification-tracked path. Guidance that lives only in a workflow skill invoked
+during specification-driven work cannot reach it. The conventions text, which
+applies to every pull request regardless of how the work was produced, is the
+surface with full reach.
+
+Second, specification-tracked work is not smaller. Its median is 822 lines
+against 712, and 79% of it exceeds 400 lines against 59%. Routing more work
+through the planning loop would not by itself reduce review-unit size, because
+the loop as it stands does not size review units.
+
+A caveat on the measurement: the absence of a `Spec:` footer does not prove a
+planning loop was skipped. Light-mode work-loop uses a lean inline specification
+that produces no file under `docs/specs/`, and therefore no footer. Git history
+cannot separate light-mode loop runs from work done outside the loop entirely.
+Tool usage analytics is the appropriate instrument for that distinction; this
+measurement establishes only how much work is traceable to a written
+specification.
+
+## The measured quantities
+
+The policy distinguishes raw diff lines from what a reviewer actually reads.
+Measured over 187 landed PRs. Generated paths (`.claude/`, `.agents/`, `dist/`,
+`marketplace.json`, `package-lock.json`) are removed first, then byte-identical
+copies are collapsed using post-image blob SHAs from `git diff --raw`. Removing
+generated paths before deduplication matters: otherwise a projection can claim
+the content hash that belongs to its own source, and the source is dropped from
+the count.
+
+| Quantity | Median | Over 400 |
+|---|---:|---:|
+| Raw diff lines | 1,068 | 72% |
+| After deduplication and removing generated output | 1,057 | 70% |
+| Code plus behaviour-bearing content, prose excluded | 231 | 40% |
+
+Totals: 460,993 reviewable authored lines, of which 227,923 are code plus
+behaviour-bearing content. Non-executable documentation prose is therefore about
+51% of reviewable authored lines.
+
+Two results matter for the policy.
+
+Deduplication barely moves the population, from 72% to 70%. Replication is
+concentrated in a handful of very large changes rather than spread across the
+repository, so deduplication matters for fair triage of the largest PRs and not
+for the headline rate.
+
+Prose is the dominant contributor. Excluding non-executable documentation drops
+the median from 1,057 to 231 and the over-400 share from 70% to 40%. Every
+external source cited in this file measures code review; none measures prose.
+
+## Classification must follow role, not file extension
+
+An earlier version of this measurement treated every `.md` file as documentation
+prose. That is wrong in this repository, and the same error in policy would
+exempt the surface the policy exists to govern. The repository contains 127
+`SKILL.md` files and 473 markdown files under `packs/*/.apm/`. Those files are
+agent instruction sets: they define shipped behaviour, and editing one changes
+what adopters' agents do. Two `.mdx` files under `docs-site/` carry interpreted
+content. An extension-based carve-out would allow several hundred lines of agent
+behaviour to be rewritten without ever tripping a split signal, including edits
+to the work-loop instruction file this RFC itself proposes to change.
+
+Classification therefore follows operational role. Non-executable explanatory
+text addressed to people is prose and is sized by coherence. Behaviour-bearing
+content is authored work whatever its extension, including agent instruction
+files, agent and command definitions, interpreted content embedded in
+documentation, and fenced code that is extracted, executed, or tested rather
+than merely illustrated. A file mixing both is classified by its
+behaviour-bearing portion.
+
+A caution on comparability: the 337-PR figures elsewhere in this file are raw
+diff lines. The 187-PR figures above separate the quantities. Raw-line history
+and authored-line policy thresholds are different measures and should not be
+compared directly.
+
+## Cadence and the shape of the distribution
+
+Measured over 234 landed PRs carrying behaviour or test content, across 24
+active days (2026-07-27 to 2026-08-19).
+
+| Statistic | Reviewable behaviour and test lines |
+|---|---:|
+| Median | 152 |
+| p75 | 877 |
+| p90 | 2,452 |
+| p95 | 5,300 |
+| Max | 17,275 |
+
+Cadence is 9.75 PRs per active day. The median is already inside every
+threshold this file cites: Google's roughly 100, Chromium's 500, and the
+SmartBear reviewer-capacity range of 300 to 400. The distribution is a healthy
+median with a thin and very heavy tail.
+
+Applying generic split thresholds to that distribution is destructive. Modelling
+each PR as splitting into `ceil(lines / threshold)` units:
+
+| Threshold | PRs split | Review-unit multiplier | PRs per day |
+|---:|---:|---:|---:|
+| 100 | 54% | 10.6x | 119 |
+| 400 | 36% | 3.2x | 36 |
+| 800 | 27% | 2.0x | 22 |
+| 2,000 | 13% | 1.3x | 15 |
+
+Volume concentrates in the tail: PRs over 400 lines are 36% of the corpus but
+95% of volume; over 2,000, 13% and 71%; over 5,000, 6% and 52%; over 10,000, 2%
+and 28%.
+
+## The tail is not one shape
+
+Of the 34 PRs above 2,000 reviewable behaviour and test lines, classified by
+median lines per changed file:
+
+| Shape | Count | Character |
+|---|---:|---|
+| WIDE, 60 or fewer lines per file | 23 | repo-wide mechanical spread |
+| MIXED, 60 to 200 | 9 | |
+| DEEP, 200 or more | 2 | concentrated authoring |
+
+Examples of the WIDE shape: a governance-marker strip touching 319 files at a
+median of 6 lines each; a test-collection refactor of 17,275 lines across 85
+files at a median of 24. Splitting a change of that shape into 2,000-line slices
+produces eight pull requests of the same undifferentiated change and makes none
+of them reviewable. Splitting helps the DEEP and MIXED shapes only.
+
+## Where the trigger cannot apply
+
+Eight of 234 PRs, 3.4%, contain a single file whose behaviour and test change
+exceeds 2,000 lines. The largest single-file change in the corpus is 3,676
+lines; p95 is 1,469 and the median is 126.
+
+| Single file | Lines |
+|---|---:|
+| `workspace_status_engine.py` | 3,676 |
+| a `project-knowledge` script | 3,340 |
+| `test_loop_engine.py` | 3,229 |
+| `test-loop-engine.py` | 2,906 |
+| an OKF compiler script | 2,434 |
+| `test_loop_guards.py` | 2,354 |
+| `tools/test_workspace_status.py` | 2,298 |
+| a self-host build-pipeline test | 2,274 |
+
+Five of the eight are test files, which is why disproportionate test volume for
+a single unit is treated as one review unit rather than as an overrun. Chromium
+already allows this, permitting 200 production lines beside 600 test lines when
+the tests follow a regular pattern.
+
+Breaking changes are not indivisible. All three in the corpus are spread rather
+than concentrated, and the largest — an engine export boundary change of 14,445
+lines — has a largest single file of only 2,274, so an expand, migrate, contract
+sequence applies.
+
+## Net effect of the tail trigger with widened ride-alongs
+
+The tail trigger at 2,000 catches 34 PRs. The 23 WIDE ones take reproducibility
+proof rather than splitting, so they add no units. The 11 MIXED and DEEP ones
+split, adding 27 units.
+
+Against that, widening ride-alongs absorbs work that currently lands as separate
+pull requests. Classifying strictly by mechanical intent in the subject and
+excluding feature, performance and security work gives 60 candidates, 26% of the
+corpus: 52 hand-made at 200 lines or fewer with a median of 28, and 8
+reproducible wide-shaped changes with a median of 408.
+
+| Absorption rate | Net review units | Per day | Change from 9.75 |
+|---:|---:|---:|---:|
+| 0% | 261 | 10.88 | +1.12 |
+| 25% | 246 | 10.25 | +0.50 |
+| 50% | 231 | 9.62 | -0.12 |
+| 75% | 216 | 9.00 | -0.75 |
+| 100% | 201 | 8.38 | -1.38 |
+
+Break-even is near 46% absorption. Above it the combined policy reduces the
+number of review units rather than increasing it.
+
+Limits of this model. Absorbability is inferred from commit subjects, not from
+verifying that a host change existed in the same area and time window, so full
+absorption is unreachable. The 234-PR baseline excludes pull requests with no
+behaviour or test content. The 341 currently deferred items — 177 in
+`workspace.toml [backlog].open` and 164 `(deferred: ...)` markers across 73
+specs — are not counted, so their mechanical share is upside beyond the table.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -91,6 +91,7 @@
 | [0087](0087-okf-knowledge-projection.md) | OKF knowledge projection | Accepted | 2026-08-15 | 2026-08-15 |
 | [0088](0088-web-pilot-foundation.md) | Web-pilot foundation — opt-in authenticated-browser runtime, immutable website adapters, per-consumer grants, and six pre-acceptance validation spikes | Experimental | 2026-08-14 | |
 | [0089](0089-starlight-docs-boundary.md) | Starlight docs boundary — ratifies the sibling technical-docs project, renderer-local palette and framework contracts, and ordered single-artifact deployment | Accepted | 2026-08-17 | 2026-08-17 |
+| [0090](0090-change-sizing-and-decomposition.md) | Change sizing and decomposition | Accepted | 2026-08-19 | 2026-08-19 |
 
 ## Adding a new RFC
 


### PR DESCRIPTION
## What does this change?

Adds RFC-0090, accepted, which replaces the generic PR-size rule with a tail-triage trigger and shape routing, and admits mechanical ride-alongs by verifiability rather than locality. RFC and evidence ledger only — no conventions, skill, or pack change lands here.

## Why?

The repository has no median-size problem. Across 234 landed PRs over 24 active days the median is **152 reviewable behaviour and test lines**, inside every threshold the RFC cites. The existing `~100 aim / split above ~400` rule was added as a "quantitative anchor" with no empirical source, and applying it literally would split 62% of PRs and multiply review units 12x — from 9.75 PRs a day to 117.

The real problem is a thin, heavy tail: **14.5% of PRs carry 71% of volume**. And the tail is not one shape — of 34 tail PRs, **23 are mechanically uniform spreads** where splitting multiplies pull requests without making any of them reviewable.

Three surfaces already stated a sizing rule qualitatively and none of them bound, because none defined the measure: `CONVENTIONS.md` (~100/~400, 41% violated), `new-spec` ("small enough to be a single PR" — a 5,009-line task passed), and `work-loop` (nothing). This supplies one measure and points it at all three.

## How do I verify it?

Docs-only. `make build-check` (with SAST) and `make lint-ruff` both exit 0; `tests/roster` 360 passed.

Every external citation in `0090-notes/evidence.md` was fetched and claim-confirmed, with three corrections recorded where the common summary drifts from the source — notably SmartBear's "under 200 LOC", which is a descriptive distribution finding rather than a recommendation. Repository measurements carry their method and limits.

## What did you not change that you considered?

- No conventions, skill, or pack change — that is the stacked follow-up.
- No blocking size gate. 41% of history would fail one, and no calibrated exemption mechanism exists.
- No attempt to reduce the median review unit. Explicit non-goal.
- The 341 currently deferred items are left where they are.

Decision weight heavy; Approver eugenelim. Nine adversarial review rounds; final verdict clean.