### PR TITLE
feat(core): adopt RFC-0090 change-sizing policy across seed, work-loop, new-spec

### DIFF
--- a/.agents/skills/new-spec/SKILL.md
+++ b/.agents/skills/new-spec/SKILL.md
@@ -288,14 +288,23 @@ look like?" before any code.
 
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
-   - Break the work into tasks small enough to be a single PR each.
+   - Break the work into plan tasks small enough for one PR. Above 2,000
+     reviewable behavior and test lines, declare the task's review shape and
+     act on it: mechanically uniform WIDE work is not split but carries
+     reproducibility proof;
+     MIXED and DEEP work decomposes into dependency-ordered layers, each
+     independently reviewable and leaving the repository working. Ambiguous
+     shape is DEEP.
    - Carry **construction tests** per task — `Tests:` before `Approach:`
      in each task, designed up front. "We'll test it" is not a strategy.
 
    Push back hard on these plan-stage failure modes (mirror of step 4):
    - **Task too big.** "Implement the feature" is not a task; "add the
-     validation function for X" is. Each task should fit a single PR
-     and a single context window. Split coarse tasks until they do.
+     validation function for X" is. Each task should be small enough for one
+     PR and one context window. Above 2,000 reviewable behavior and test
+     lines, the plan states the task's review shape and its consequence:
+     mechanically uniform WIDE carries reproducibility proof, MIXED and DEEP decompose into working
+     layers, ambiguous is DEEP.
    - **`Depends on:` omitted.** Every task must state `Depends on:`
      explicitly — prior task IDs or `none`. Don't let authors lean on
      task order to imply dependency; that hides serial-by-default

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -128,6 +128,14 @@ After orientation:
 3. Use the existing plan's task list; don't invent one.
 4. Use extended thinking for architecturally significant work.
 5. Write the **assumption trio** — which files you'll touch, what tests demonstrate "done", what you are *not* changing. Below the trio, **name what you were tempted to add and declined** (one line each: temptation + reason). Non-trivial tasks always have something to name; common patterns: new abstractions, structural choices, new dependencies, defensive scaffolding, hypothetical configurability.
+
+   - **Size the tail.** For a plan task predicted above 2,000 reviewable
+     behavior and test lines, declare its expected review shape and act on it:
+     mechanically uniform WIDE work is not split and must carry
+     reproducibility proof; MIXED and
+     DEEP work is decomposed into dependency-ordered layers, each independently
+     reviewable and leaving the repository working. Ambiguous shape is DEEP.
+     Use the task graph to name the boundaries; do not invent tasks to make PRs.
 6. **Run self-coverage net-new checks**: conditional domain-grounding (when the build rests on an ungrounded domain claim) and open the resolve-vs-surface disposition record (see [Work-loop contract](#work-loop-contract)).
 7. **Pick the verification mode for each task** before writing code:
    - **TDD** — compressible invariant (pure functions, state machines, protocols). ACs + Testing Strategy in spec; red stub in `plan.md` under `Tests:` before `Approach:`. Default for testable logic.
@@ -348,7 +356,16 @@ Match discipline to verification mode:
 <!-- Bundled-fixes carve-out — canonical site. Mirrored by
      implementer.md (operating envelope) and adversarial-reviewer.md
      (scope check #4). Keep all three in sync. -->
-**Bundled-fixes carve-out.** Same-area, same-concern, mechanical ride-alongs land in the change — dead import, stale comment contradicting new code, unused local orphaned by the change, typo in a sibling file. *Same area* = a file in a directory already containing a file the change edits (siblings only; not parent walk-up, not sideways to unedited directories). "The change" = the current plan task for the executor; the merged PR diff for the reviewer. List ride-alongs in the PR description under a standalone `Bundled fixes:` section (append below standard template content; do not modify the template). Fails closed on: file outside touched directory, design call, behavior change. **Volume guard:** each fix is a line or two; the bundle must be visibly smaller than the primary change. In supervisor mode, the dispatch brief must explicitly authorize the carve-out.
+**Bundled-fixes carve-out.** Ride-alongs are admitted by verifiability, not
+locality. "The change" = the current plan task for the executor; the merged PR
+diff for the reviewer. List each under a standalone `Bundled fixes:` section (append below standard
+template content; do not modify the template). Tier 1 reproducible work must
+state its command and produce a zero diff on re-run; it may span the
+repository. Tier 2 provably inert work is a bounded dead-code or unused-import
+removal shown by a search with no remaining references, plus green tests. Tier 3 hand-made work remains same-area, same-concern,
+visibly smaller, and mechanical. All tiers fail closed on a design call or
+behavior change. In supervisor mode, the dispatch brief must explicitly
+authorize the carve-out.
 
 **Simplify pass.** After this task's GATES are green, shrink the diff: inline a single-use helper, delete orphaned code, collapse needless indirection, drop parameters no caller varies. Scope to new code only; leave tests DAMP. In Claude Code, `/simplify` performs this (optional accelerant, never a dependency).
 
@@ -601,6 +618,12 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.
 - [ ] Learnings captured per [Capture learnings](#capture-learnings).
+- [ ] **Tail-triage check completed.** Inspect raw diff lines, material volume,
+  and reviewable behavior and test lines for each intended PR or stack layer.
+  Above 2,000 reviewable behavior and test lines, record review shape. WIDE
+  work links its source artifact, transformation invariant, command, zero-diff
+  re-run, tests, sampled review, and rollback; MIXED and DEEP work links its
+  dependency-ordered boundaries.
 - [ ] PR opened (or merged directly) with the four-question template filled in.
 
 ## FIX

--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -180,20 +180,15 @@ checklists; verification-mode awareness applies to every review.
 4. **Scope.** Does the diff contain changes outside the plan? Each
    out-of-scope change is a Blocker until justified, extracted, or
    listed in the PR description's `Bundled fixes:` section. Authorized
-   bundled fixes are same-area, same-concern, mechanical ride-alongs
-   (dead import the change orphaned, stale comment that now
-   contradicts the new code, unused local the change orphaned,
-   sibling-file typo). The causal qualifier matters — a pre-existing
-   dead import or unused local that *this change didn't orphan* is
-   not a ride-along; it's an out-of-scope cleanup attempt.
-   *Same area* = a file in a directory that already contains a file
-   the change is editing — at review time the merged PR diff defines
-   the change. If a `Bundled fixes:` line claims something outside a
-   touched directory, requires a design call, or changes user-visible
-   behavior, that's still a Blocker — the carve-out fails closed.
-   Flag the bundle as Blocker-grade sprawl if it isn't visibly
-   smaller than the primary change — i.e. if a reader couldn't
-   immediately tell which part is primary and which are ride-alongs.
+   ride-alongs are admitted by verifiability, not locality. Tier 1
+   reproducible work states its command and has a zero diff on re-run; it may
+   span the repository. Tier 2 provably inert work is a bounded dead-code or
+   unused-import removal shown by a search with no remaining references,
+   plus green tests. Tier 3 hand-made work keeps same-area,
+   same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+   design call or behavior change. Treat any claimed ride-along lacking its
+   required Tier 1 or Tier 2 evidence, or exceeding Tier 3's limits, as a
+   Blocker.
 5. **Spec drift.** If the implementation differs from the spec, the spec
    must be updated in the same PR. Otherwise it's drift, not done. *Semantic*
    drift (does the behavior match the contract?) is your judgment call — but

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -56,21 +56,14 @@ If the supervisor's brief omits the spec/plan paths, ask — don't guess.
 - **One task:** implement only the task you were assigned. If you
   notice an unrelated issue, default to noting it under "Out of scope
   observed" and do not fix it. **Exception — bundled-fixes carve-out.**
-  If the supervisor's brief explicitly authorizes bundled fixes, you
-  may land same-area, same-concern, mechanical ride-alongs (dead
-  import, stale comment that now contradicts the new code, unused
-  local the change orphaned, typo in a sibling file). *Same area*
-  means a file in a directory that already contains a file this task
-  is editing — siblings in the touched directory, not a walk-up to
-  the parent and not a sideways jump to a directory this task isn't
-  editing. Report ride-alongs under `Bundled fixes:`. The carve-out
-  fails closed on any of: a file outside a touched directory, a
-  design call, a behavior change — those stay under "Out of scope
-  observed". Keep ride-alongs individually small (a line or two
-  each). The bundle should be visibly smaller than the primary
-  change — if a reader couldn't immediately tell which part is
-  primary and which are ride-alongs, you've sprawled; drop the
-  surplus to "Out of scope observed" for the supervisor to triage.
+  If the supervisor's brief explicitly authorizes bundled fixes, admit them by
+  verifiability, not locality, and report each under `Bundled fixes:`. Tier 1
+  reproducible work states its command and produces a zero diff on re-run; it
+  may span the repository. Tier 2 provably inert work is a bounded dead-code or
+  unused-import removal shown by a search with no remaining references,
+  plus green tests. Tier 3 hand-made work keeps the same-area,
+  same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+  design call or behavior change; leave those under "Out of scope observed".
 - **Gates:** run the project's lint, typecheck, and test commands as
   documented in `AGENTS.md` and the project's root README. Capture
   pass/fail and any failing output. Your gate results are **advisory**

--- a/.claude/skills/new-spec/SKILL.md
+++ b/.claude/skills/new-spec/SKILL.md
@@ -288,14 +288,23 @@ look like?" before any code.
 
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
-   - Break the work into tasks small enough to be a single PR each.
+   - Break the work into plan tasks small enough for one PR. Above 2,000
+     reviewable behavior and test lines, declare the task's review shape and
+     act on it: mechanically uniform WIDE work is not split but carries
+     reproducibility proof;
+     MIXED and DEEP work decomposes into dependency-ordered layers, each
+     independently reviewable and leaving the repository working. Ambiguous
+     shape is DEEP.
    - Carry **construction tests** per task — `Tests:` before `Approach:`
      in each task, designed up front. "We'll test it" is not a strategy.
 
    Push back hard on these plan-stage failure modes (mirror of step 4):
    - **Task too big.** "Implement the feature" is not a task; "add the
-     validation function for X" is. Each task should fit a single PR
-     and a single context window. Split coarse tasks until they do.
+     validation function for X" is. Each task should be small enough for one
+     PR and one context window. Above 2,000 reviewable behavior and test
+     lines, the plan states the task's review shape and its consequence:
+     mechanically uniform WIDE carries reproducibility proof, MIXED and DEEP decompose into working
+     layers, ambiguous is DEEP.
    - **`Depends on:` omitted.** Every task must state `Depends on:`
      explicitly — prior task IDs or `none`. Don't let authors lean on
      task order to imply dependency; that hides serial-by-default

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -128,6 +128,14 @@ After orientation:
 3. Use the existing plan's task list; don't invent one.
 4. Use extended thinking for architecturally significant work.
 5. Write the **assumption trio** — which files you'll touch, what tests demonstrate "done", what you are *not* changing. Below the trio, **name what you were tempted to add and declined** (one line each: temptation + reason). Non-trivial tasks always have something to name; common patterns: new abstractions, structural choices, new dependencies, defensive scaffolding, hypothetical configurability.
+
+   - **Size the tail.** For a plan task predicted above 2,000 reviewable
+     behavior and test lines, declare its expected review shape and act on it:
+     mechanically uniform WIDE work is not split and must carry
+     reproducibility proof; MIXED and
+     DEEP work is decomposed into dependency-ordered layers, each independently
+     reviewable and leaving the repository working. Ambiguous shape is DEEP.
+     Use the task graph to name the boundaries; do not invent tasks to make PRs.
 6. **Run self-coverage net-new checks**: conditional domain-grounding (when the build rests on an ungrounded domain claim) and open the resolve-vs-surface disposition record (see [Work-loop contract](#work-loop-contract)).
 7. **Pick the verification mode for each task** before writing code:
    - **TDD** — compressible invariant (pure functions, state machines, protocols). ACs + Testing Strategy in spec; red stub in `plan.md` under `Tests:` before `Approach:`. Default for testable logic.
@@ -348,7 +356,16 @@ Match discipline to verification mode:
 <!-- Bundled-fixes carve-out — canonical site. Mirrored by
      implementer.md (operating envelope) and adversarial-reviewer.md
      (scope check #4). Keep all three in sync. -->
-**Bundled-fixes carve-out.** Same-area, same-concern, mechanical ride-alongs land in the change — dead import, stale comment contradicting new code, unused local orphaned by the change, typo in a sibling file. *Same area* = a file in a directory already containing a file the change edits (siblings only; not parent walk-up, not sideways to unedited directories). "The change" = the current plan task for the executor; the merged PR diff for the reviewer. List ride-alongs in the PR description under a standalone `Bundled fixes:` section (append below standard template content; do not modify the template). Fails closed on: file outside touched directory, design call, behavior change. **Volume guard:** each fix is a line or two; the bundle must be visibly smaller than the primary change. In supervisor mode, the dispatch brief must explicitly authorize the carve-out.
+**Bundled-fixes carve-out.** Ride-alongs are admitted by verifiability, not
+locality. "The change" = the current plan task for the executor; the merged PR
+diff for the reviewer. List each under a standalone `Bundled fixes:` section (append below standard
+template content; do not modify the template). Tier 1 reproducible work must
+state its command and produce a zero diff on re-run; it may span the
+repository. Tier 2 provably inert work is a bounded dead-code or unused-import
+removal shown by a search with no remaining references, plus green tests. Tier 3 hand-made work remains same-area, same-concern,
+visibly smaller, and mechanical. All tiers fail closed on a design call or
+behavior change. In supervisor mode, the dispatch brief must explicitly
+authorize the carve-out.
 
 **Simplify pass.** After this task's GATES are green, shrink the diff: inline a single-use helper, delete orphaned code, collapse needless indirection, drop parameters no caller varies. Scope to new code only; leave tests DAMP. In Claude Code, `/simplify` performs this (optional accelerant, never a dependency).
 
@@ -601,6 +618,12 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.
 - [ ] Learnings captured per [Capture learnings](#capture-learnings).
+- [ ] **Tail-triage check completed.** Inspect raw diff lines, material volume,
+  and reviewable behavior and test lines for each intended PR or stack layer.
+  Above 2,000 reviewable behavior and test lines, record review shape. WIDE
+  work links its source artifact, transformation invariant, command, zero-diff
+  re-run, tests, sampled review, and rollback; MIXED and DEEP work links its
+  dependency-ordered boundaries.
 - [ ] PR opened (or merged directly) with the four-question template filled in.
 
 ## FIX

--- a/.codex/agents/adversarial-reviewer.toml
+++ b/.codex/agents/adversarial-reviewer.toml
@@ -181,20 +181,15 @@ checklists; verification-mode awareness applies to every review.
 4. **Scope.** Does the diff contain changes outside the plan? Each
    out-of-scope change is a Blocker until justified, extracted, or
    listed in the PR description's `Bundled fixes:` section. Authorized
-   bundled fixes are same-area, same-concern, mechanical ride-alongs
-   (dead import the change orphaned, stale comment that now
-   contradicts the new code, unused local the change orphaned,
-   sibling-file typo). The causal qualifier matters — a pre-existing
-   dead import or unused local that *this change didn't orphan* is
-   not a ride-along; it's an out-of-scope cleanup attempt.
-   *Same area* = a file in a directory that already contains a file
-   the change is editing — at review time the merged PR diff defines
-   the change. If a `Bundled fixes:` line claims something outside a
-   touched directory, requires a design call, or changes user-visible
-   behavior, that's still a Blocker — the carve-out fails closed.
-   Flag the bundle as Blocker-grade sprawl if it isn't visibly
-   smaller than the primary change — i.e. if a reader couldn't
-   immediately tell which part is primary and which are ride-alongs.
+   ride-alongs are admitted by verifiability, not locality. Tier 1
+   reproducible work states its command and has a zero diff on re-run; it may
+   span the repository. Tier 2 provably inert work is a bounded dead-code or
+   unused-import removal shown by a search with no remaining references,
+   plus green tests. Tier 3 hand-made work keeps same-area,
+   same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+   design call or behavior change. Treat any claimed ride-along lacking its
+   required Tier 1 or Tier 2 evidence, or exceeding Tier 3's limits, as a
+   Blocker.
 5. **Spec drift.** If the implementation differs from the spec, the spec
    must be updated in the same PR. Otherwise it's drift, not done. *Semantic*
    drift (does the behavior match the contract?) is your judgment call — but

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -57,21 +57,14 @@ If the supervisor's brief omits the spec/plan paths, ask — don't guess.
 - **One task:** implement only the task you were assigned. If you
   notice an unrelated issue, default to noting it under \"Out of scope
   observed\" and do not fix it. **Exception — bundled-fixes carve-out.**
-  If the supervisor's brief explicitly authorizes bundled fixes, you
-  may land same-area, same-concern, mechanical ride-alongs (dead
-  import, stale comment that now contradicts the new code, unused
-  local the change orphaned, typo in a sibling file). *Same area*
-  means a file in a directory that already contains a file this task
-  is editing — siblings in the touched directory, not a walk-up to
-  the parent and not a sideways jump to a directory this task isn't
-  editing. Report ride-alongs under `Bundled fixes:`. The carve-out
-  fails closed on any of: a file outside a touched directory, a
-  design call, a behavior change — those stay under \"Out of scope
-  observed\". Keep ride-alongs individually small (a line or two
-  each). The bundle should be visibly smaller than the primary
-  change — if a reader couldn't immediately tell which part is
-  primary and which are ride-alongs, you've sprawled; drop the
-  surplus to \"Out of scope observed\" for the supervisor to triage.
+  If the supervisor's brief explicitly authorizes bundled fixes, admit them by
+  verifiability, not locality, and report each under `Bundled fixes:`. Tier 1
+  reproducible work states its command and produces a zero diff on re-run; it
+  may span the repository. Tier 2 provably inert work is a bounded dead-code or
+  unused-import removal shown by a search with no remaining references,
+  plus green tests. Tier 3 hand-made work keeps the same-area,
+  same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+  design call or behavior change; leave those under \"Out of scope observed\".
 - **Gates:** run the project's lint, typecheck, and test commands as
   documented in `AGENTS.md` and the project's root README. Capture
   pass/fail and any failing output. Your gate results are **advisory**

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -819,9 +819,42 @@ A PR description should answer four questions in this order:
 4. **What did you not change that you considered?** (The dog that didn't bark.
    This catches more bugs than any other section.)
 
-Aim for under ~100 lines of diff. PRs that grow beyond ~400 lines should be
-split unless the change is genuinely atomic (e.g. a generated file, a single
-rename across many call-sites).
+Size a PR as a reviewable semantic change, not as an agent session or a whole
+specification. One specification may deliver one PR or a dependency-ordered
+stack; each layer must be independently reviewable and leave the repository
+working. Keep behavior with its related tests, separate refactoring from
+behavior changes, and keep each curated commit independently testable.
+
+Use 2,000 reviewable behavior and test lines only as a tail-triage trigger,
+not as an automatic split rule. Classify by operational role, never file
+extension: agent instruction files and executed content count as behavior.
+Non-executable documentation prose is sized by coherence, not line count.
+Report raw diff lines for triage, material volume after content-hash
+deduplication, and reviewable behavior and test lines for size judgement.
+Raw diff lines and changed-file count only prompt examination. Classify tail
+shape by the median reviewable lines per changed, deduplicated file with at
+least one such line; exclude prose, generated output, and duplicate copies.
+WIDE is 60 or fewer, MIXED is above 60 and below 200, and DEEP is 200 or more.
+If classification is ambiguous or contested, treat it as DEEP and decompose.
+
+For mechanically uniform WIDE work, do not split: give the source artifact,
+exact command, transformation invariant, zero diff on re-run, targeted tests,
+sampled review, and rollback evidence.
+For MIXED or DEEP work, split into dependency-ordered working layers. A single
+coherent artifact is a floor: when it alone exceeds the trigger, nothing else
+rides with it. The author names the single unit it serves and states why no
+split preserves working layers. The same evidence is required for a regular
+test suite serving one unit; otherwise decompose. An atomic correctness window
+needs prior approver acceptance, a named invariant, volume classification,
+validation evidence, and a rollback path; a breaking interface change is not
+grounds and uses expand/migrate/contract.
+
+Bundled fixes must be listed under `Bundled fixes:` and fail closed on design
+calls or behavior changes. Tier 1 is reproducible: state the command and show
+a zero diff on re-run; it may span the repository. Tier 2 is provably inert:
+show no remaining references and green tests for bounded dead-code or
+unused-import removal. Tier 3 is hand-made: same-area, same-concern, visibly
+smaller mechanical work. Tier 1 and Tier 2 require their command or evidence.
 
 CI must be green. Specs must match implementation. Public-interface changes
 must be noted in `CHANGELOG.md`.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -75,6 +75,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you can see the shape of the exchange, and where your decisions fall in it,
   before committing to the journey.
 
+### [core][2.9.5] — 2026-08-19
+
+#### Changed
+
+- **PR size guidance no longer asks you to split ordinary changes.** The old
+  target of roughly 100 changed lines, with a split above roughly 400, is
+  replaced by a single tail trigger: a change is examined once it exceeds 2,000
+  reviewable behavior and test lines. Below that, size the change by whether it
+  is one reviewable idea, not by a line count. Documentation prose is sized by
+  coherence and is never split on length.
+- **A large change is now routed by its shape rather than sliced by length.** A
+  broad mechanical sweep is proved with the command that produced it and a
+  zero-diff re-run, not broken into arbitrary parts. Concentrated authored work
+  is decomposed into dependency-ordered layers that each leave the repository
+  working.
+- **Mechanical ride-alongs are admitted by verifiability, not by locality.**
+  Work reproducible from a stated command, or provably inert, may now land with
+  the change that occasions it even when it spans the repository, so routine
+  cleanup stops accumulating as deferred backlog. Hand-made ride-alongs keep
+  their existing same-area and size limits, and every tier still fails closed on
+  a design call or a behavior change.
+
 ### [core][2.9.4] — 2026-08-19
 
 #### Changed
@@ -84,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   direct root guidance to the canonical privacy policy.
 - **Risk-trigger documentation is explicitly single-sourced.** ADR-0088 records
   the `work-loop` skill as the sole block home without changing mode selection.
+
 
 ### [core][2.9.2] — 2026-08-19
 
@@ -116,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `profiles/AGENTS.md` are shorter and restructured, so `agentbundle catalogue
   init` starts catalogues with leaner instructions. No CLI verb, flag, or output
   format changed.
+
 
 ### [core][2.9.1] — 2026-08-19
 

--- a/packs/core/.apm/agents/adversarial-reviewer.md
+++ b/packs/core/.apm/agents/adversarial-reviewer.md
@@ -180,20 +180,15 @@ checklists; verification-mode awareness applies to every review.
 4. **Scope.** Does the diff contain changes outside the plan? Each
    out-of-scope change is a Blocker until justified, extracted, or
    listed in the PR description's `Bundled fixes:` section. Authorized
-   bundled fixes are same-area, same-concern, mechanical ride-alongs
-   (dead import the change orphaned, stale comment that now
-   contradicts the new code, unused local the change orphaned,
-   sibling-file typo). The causal qualifier matters — a pre-existing
-   dead import or unused local that *this change didn't orphan* is
-   not a ride-along; it's an out-of-scope cleanup attempt.
-   *Same area* = a file in a directory that already contains a file
-   the change is editing — at review time the merged PR diff defines
-   the change. If a `Bundled fixes:` line claims something outside a
-   touched directory, requires a design call, or changes user-visible
-   behavior, that's still a Blocker — the carve-out fails closed.
-   Flag the bundle as Blocker-grade sprawl if it isn't visibly
-   smaller than the primary change — i.e. if a reader couldn't
-   immediately tell which part is primary and which are ride-alongs.
+   ride-alongs are admitted by verifiability, not locality. Tier 1
+   reproducible work states its command and has a zero diff on re-run; it may
+   span the repository. Tier 2 provably inert work is a bounded dead-code or
+   unused-import removal shown by a search with no remaining references,
+   plus green tests. Tier 3 hand-made work keeps same-area,
+   same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+   design call or behavior change. Treat any claimed ride-along lacking its
+   required Tier 1 or Tier 2 evidence, or exceeding Tier 3's limits, as a
+   Blocker.
 5. **Spec drift.** If the implementation differs from the spec, the spec
    must be updated in the same PR. Otherwise it's drift, not done. *Semantic*
    drift (does the behavior match the contract?) is your judgment call — but

--- a/packs/core/.apm/agents/implementer.md
+++ b/packs/core/.apm/agents/implementer.md
@@ -56,21 +56,14 @@ If the supervisor's brief omits the spec/plan paths, ask — don't guess.
 - **One task:** implement only the task you were assigned. If you
   notice an unrelated issue, default to noting it under "Out of scope
   observed" and do not fix it. **Exception — bundled-fixes carve-out.**
-  If the supervisor's brief explicitly authorizes bundled fixes, you
-  may land same-area, same-concern, mechanical ride-alongs (dead
-  import, stale comment that now contradicts the new code, unused
-  local the change orphaned, typo in a sibling file). *Same area*
-  means a file in a directory that already contains a file this task
-  is editing — siblings in the touched directory, not a walk-up to
-  the parent and not a sideways jump to a directory this task isn't
-  editing. Report ride-alongs under `Bundled fixes:`. The carve-out
-  fails closed on any of: a file outside a touched directory, a
-  design call, a behavior change — those stay under "Out of scope
-  observed". Keep ride-alongs individually small (a line or two
-  each). The bundle should be visibly smaller than the primary
-  change — if a reader couldn't immediately tell which part is
-  primary and which are ride-alongs, you've sprawled; drop the
-  surplus to "Out of scope observed" for the supervisor to triage.
+  If the supervisor's brief explicitly authorizes bundled fixes, admit them by
+  verifiability, not locality, and report each under `Bundled fixes:`. Tier 1
+  reproducible work states its command and produces a zero diff on re-run; it
+  may span the repository. Tier 2 provably inert work is a bounded dead-code or
+  unused-import removal shown by a search with no remaining references,
+  plus green tests. Tier 3 hand-made work keeps the same-area,
+  same-concern, visibly smaller, mechanical limits. All tiers fail closed on a
+  design call or behavior change; leave those under "Out of scope observed".
 - **Gates:** run the project's lint, typecheck, and test commands as
   documented in `AGENTS.md` and the project's root README. Capture
   pass/fail and any failing output. Your gate results are **advisory**

--- a/packs/core/.apm/skills/new-spec/SKILL.md
+++ b/packs/core/.apm/skills/new-spec/SKILL.md
@@ -288,14 +288,23 @@ look like?" before any code.
 
 5. Fill in the plan second. The plan should:
    - Cite any ADRs or RFCs it follows from.
-   - Break the work into tasks small enough to be a single PR each.
+   - Break the work into plan tasks small enough for one PR. Above 2,000
+     reviewable behavior and test lines, declare the task's review shape and
+     act on it: mechanically uniform WIDE work is not split but carries
+     reproducibility proof;
+     MIXED and DEEP work decomposes into dependency-ordered layers, each
+     independently reviewable and leaving the repository working. Ambiguous
+     shape is DEEP.
    - Carry **construction tests** per task — `Tests:` before `Approach:`
      in each task, designed up front. "We'll test it" is not a strategy.
 
    Push back hard on these plan-stage failure modes (mirror of step 4):
    - **Task too big.** "Implement the feature" is not a task; "add the
-     validation function for X" is. Each task should fit a single PR
-     and a single context window. Split coarse tasks until they do.
+     validation function for X" is. Each task should be small enough for one
+     PR and one context window. Above 2,000 reviewable behavior and test
+     lines, the plan states the task's review shape and its consequence:
+     mechanically uniform WIDE carries reproducibility proof, MIXED and DEEP decompose into working
+     layers, ambiguous is DEEP.
    - **`Depends on:` omitted.** Every task must state `Depends on:`
      explicitly — prior task IDs or `none`. Don't let authors lean on
      task order to imply dependency; that hides serial-by-default

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -128,6 +128,14 @@ After orientation:
 3. Use the existing plan's task list; don't invent one.
 4. Use extended thinking for architecturally significant work.
 5. Write the **assumption trio** — which files you'll touch, what tests demonstrate "done", what you are *not* changing. Below the trio, **name what you were tempted to add and declined** (one line each: temptation + reason). Non-trivial tasks always have something to name; common patterns: new abstractions, structural choices, new dependencies, defensive scaffolding, hypothetical configurability.
+
+   - **Size the tail.** For a plan task predicted above 2,000 reviewable
+     behavior and test lines, declare its expected review shape and act on it:
+     mechanically uniform WIDE work is not split and must carry
+     reproducibility proof; MIXED and
+     DEEP work is decomposed into dependency-ordered layers, each independently
+     reviewable and leaving the repository working. Ambiguous shape is DEEP.
+     Use the task graph to name the boundaries; do not invent tasks to make PRs.
 6. **Run self-coverage net-new checks**: conditional domain-grounding (when the build rests on an ungrounded domain claim) and open the resolve-vs-surface disposition record (see [Work-loop contract](#work-loop-contract)).
 7. **Pick the verification mode for each task** before writing code:
    - **TDD** — compressible invariant (pure functions, state machines, protocols). ACs + Testing Strategy in spec; red stub in `plan.md` under `Tests:` before `Approach:`. Default for testable logic.
@@ -348,7 +356,16 @@ Match discipline to verification mode:
 <!-- Bundled-fixes carve-out — canonical site. Mirrored by
      implementer.md (operating envelope) and adversarial-reviewer.md
      (scope check #4). Keep all three in sync. -->
-**Bundled-fixes carve-out.** Same-area, same-concern, mechanical ride-alongs land in the change — dead import, stale comment contradicting new code, unused local orphaned by the change, typo in a sibling file. *Same area* = a file in a directory already containing a file the change edits (siblings only; not parent walk-up, not sideways to unedited directories). "The change" = the current plan task for the executor; the merged PR diff for the reviewer. List ride-alongs in the PR description under a standalone `Bundled fixes:` section (append below standard template content; do not modify the template). Fails closed on: file outside touched directory, design call, behavior change. **Volume guard:** each fix is a line or two; the bundle must be visibly smaller than the primary change. In supervisor mode, the dispatch brief must explicitly authorize the carve-out.
+**Bundled-fixes carve-out.** Ride-alongs are admitted by verifiability, not
+locality. "The change" = the current plan task for the executor; the merged PR
+diff for the reviewer. List each under a standalone `Bundled fixes:` section (append below standard
+template content; do not modify the template). Tier 1 reproducible work must
+state its command and produce a zero diff on re-run; it may span the
+repository. Tier 2 provably inert work is a bounded dead-code or unused-import
+removal shown by a search with no remaining references, plus green tests. Tier 3 hand-made work remains same-area, same-concern,
+visibly smaller, and mechanical. All tiers fail closed on a design call or
+behavior change. In supervisor mode, the dispatch brief must explicitly
+authorize the carve-out.
 
 **Simplify pass.** After this task's GATES are green, shrink the diff: inline a single-use helper, delete orphaned code, collapse needless indirection, drop parameters no caller varies. Scope to new code only; leave tests DAMP. In Claude Code, `/simplify` performs this (optional accelerant, never a dependency).
 
@@ -601,6 +618,12 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.
 - [ ] Learnings captured per [Capture learnings](#capture-learnings).
+- [ ] **Tail-triage check completed.** Inspect raw diff lines, material volume,
+  and reviewable behavior and test lines for each intended PR or stack layer.
+  Above 2,000 reviewable behavior and test lines, record review shape. WIDE
+  work links its source artifact, transformation invariant, command, zero-diff
+  re-run, tests, sampled review, and rollback; MIXED and DEEP work links its
+  dependency-ordered boundaries.
 - [ ] PR opened (or merged directly) with the four-question template filled in.
 
 ## FIX

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.9.4"
+version = "2.9.5"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -819,9 +819,42 @@ A PR description should answer four questions in this order:
 4. **What did you not change that you considered?** (The dog that didn't bark.
    This catches more bugs than any other section.)
 
-Aim for under ~100 lines of diff. PRs that grow beyond ~400 lines should be
-split unless the change is genuinely atomic (e.g. a generated file, a single
-rename across many call-sites).
+Size a PR as a reviewable semantic change, not as an agent session or a whole
+specification. One specification may deliver one PR or a dependency-ordered
+stack; each layer must be independently reviewable and leave the repository
+working. Keep behavior with its related tests, separate refactoring from
+behavior changes, and keep each curated commit independently testable.
+
+Use 2,000 reviewable behavior and test lines only as a tail-triage trigger,
+not as an automatic split rule. Classify by operational role, never file
+extension: agent instruction files and executed content count as behavior.
+Non-executable documentation prose is sized by coherence, not line count.
+Report raw diff lines for triage, material volume after content-hash
+deduplication, and reviewable behavior and test lines for size judgement.
+Raw diff lines and changed-file count only prompt examination. Classify tail
+shape by the median reviewable lines per changed, deduplicated file with at
+least one such line; exclude prose, generated output, and duplicate copies.
+WIDE is 60 or fewer, MIXED is above 60 and below 200, and DEEP is 200 or more.
+If classification is ambiguous or contested, treat it as DEEP and decompose.
+
+For mechanically uniform WIDE work, do not split: give the source artifact,
+exact command, transformation invariant, zero diff on re-run, targeted tests,
+sampled review, and rollback evidence.
+For MIXED or DEEP work, split into dependency-ordered working layers. A single
+coherent artifact is a floor: when it alone exceeds the trigger, nothing else
+rides with it. The author names the single unit it serves and states why no
+split preserves working layers. The same evidence is required for a regular
+test suite serving one unit; otherwise decompose. An atomic correctness window
+needs prior approver acceptance, a named invariant, volume classification,
+validation evidence, and a rollback path; a breaking interface change is not
+grounds and uses expand/migrate/contract.
+
+Bundled fixes must be listed under `Bundled fixes:` and fail closed on design
+calls or behavior changes. Tier 1 is reproducible: state the command and show
+a zero diff on re-run; it may span the repository. Tier 2 is provably inert:
+show no remaining references and green tests for bounded dead-code or
+unused-import removal. Tier 3 is hand-made: same-area, same-concern, visibly
+smaller mechanical work. Tier 1 and Tier 2 require their command or evidence.
 
 CI must be green. Specs must match implementation. Public-interface changes
 must be noted in `CHANGELOG.md`.

--- a/tests/roster/test_security_checklists_okf_projection.py
+++ b/tests/roster/test_security_checklists_okf_projection.py
@@ -103,8 +103,8 @@ def test_core_version_and_okf_declaration_are_synchronized() -> None:
         (PACK_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
 
-    assert pack["pack"]["version"] == "2.9.4"
-    assert plugin["version"] == "2.9.4"
+    assert pack["pack"]["version"] == "2.9.5"
+    assert plugin["version"] == "2.9.5"
     assert pack["pack"]["metadata"]["okf"]["profile"] == "agentbundle-okf/v1"
     bundle = pack["pack"]["metadata"]["okf"]["bundles"][0]
     assert bundle["id"] == "security-checklists"


### PR DESCRIPTION
## What does this change?

Implements accepted RFC-0090 across the three surfaces it names. The seed conventions gain the new policy and project into `docs/CONVENTIONS.md`; `work-loop` and `new-spec` gain the workflow prompts; the bundled-fixes carve-out moves from a locality test to a verifiability test at all three mirrored sites. core `2.9.1 → 2.9.5`.

**Stacked on #1050** — review that first; this targets its branch.

## Why?

Per RFC-0090. The operative changes:

- **2,000 reviewable behaviour and test lines is a tail-triage trigger, not a split mandate.** Once it fires, shape routes the remedy: mechanically uniform WIDE work carries reproducibility proof and is *not* split; MIXED and DEEP decompose into dependency-ordered working layers; ambiguous shape is DEEP.
- **Shape is measured as median reviewable lines per changed, deduplicated file carrying at least one such line**, so prose and generated output cannot dilute the denominator to claim WIDE.
- **Ride-alongs are admitted by verifiability.** Tier 1 reproducible from a stated command with a zero diff on re-run may span the repository; Tier 2 is a bounded dead-code or unused-import removal shown by a search with no remaining references plus green tests; Tier 3 hand-made keeps the existing same-area and size limits. All fail closed on a design call or behaviour change.
- **A single coherent artifact is a floor the trigger cannot go below** — a bundling limit, not an artifact limit. A breaking interface change is explicitly not grounds for an exception.

## How do I verify it?

```
make build-check          # with SAST — exit 0
make lint-ruff            # exit 0
```

Suites, run with `PYTHONPATH=packages/agentbundle:packages/credbroker`:

```
skills/work-loop      689 passed, 5 skipped
tests/roster          360 passed, 46 subtests
pack 15 · hooks 21 · adapt-to-project 22 · author-brief 1 · bug-fix 5
capture-work 4 · new-spec 1 · receive-brief 22 · work-intake 25
```

Note the pack suites sit in `make test`, not `make build-check`; they are run explicitly here because this touches `packs/core/**`.

Every generated projection is byte-identical to its source (sha1 compared). Only the seed was edited; `docs/CONVENTIONS.md`, `.claude/**`, `.agents/**` and `.codex/**` were regenerated via `FORCE=1 make build-self`.

## What did you not change that you considered?

- No new script, hook, config flag, manifest field, or gate. Content-hash deduplication is `git diff --raw`, stock tooling.
- No hand-edited projection.
- `packs/governance-extras/seeds/docs/{adr,rfc}/README.md` carry six `.claude/...` occurrences in the seed-path backlog constant. Exempted, and not this lane.

**Follow-up worth someone's time:** `docs/product/changelog.md` carries two heading eras, and appending near the recent entries lands in the older `##` block. Two sessions hit that independently today. A lint asserting the newest heading per pack uses `###` would catch it cheaply.

RFC-0090 carries an Errata entry recording two corrections found during implementation.