### PR TITLE
feat(tools): worktree hygiene — scan/clean doctor, leased preview ports, selective bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,12 @@ build/
 # build/** override so it applies inside the exception too).
 __pycache__/
 .pytest_cache/
+# Type- and lint-checker caches. Unignored, these are staged by `git add -A`
+# (~62MB of .mypy_cache across worktrees), and tools/repo/worktree_hygiene.py
+# only ever deletes ignored paths, so its --test-artifacts category is inert
+# without them.
+.mypy_cache/
+.ruff_cache/
 
 # Build pipeline output.
 dist/

--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,8 @@ test:
 	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_journey_editorial_decisions.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
+	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q
+	$(PYTHON) -m pytest tools/test_bootstrap.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q
 	$(PYTHON) -m pytest \
 		tools/test_lint_agents_md_diataxis_block.py \
@@ -457,3 +459,20 @@ site-link-check: site-build  ## Build both sites, then audit emitted internal li
 
 site-serve: site-sync  ## Start Starlight dev server at http://localhost:4321
 	npm run dev --prefix docs-site
+
+.PHONY: worktree-doctor bootstrap-web bootstrap-docs-site bootstrap-sites web-browser-gate
+
+worktree-doctor:  ## Inspect worktree-local generated and runtime artifacts
+	$(PYTHON) tools/repo/worktree_hygiene.py scan
+
+bootstrap-web:  ## Install only web npm dependencies
+	$(PYTHON) tools/repo/bootstrap.py web
+
+bootstrap-docs-site:  ## Install only docs-site npm dependencies
+	$(PYTHON) tools/repo/bootstrap.py docs-site
+
+bootstrap-sites:  ## Install web and docs-site npm dependencies
+	$(PYTHON) tools/repo/bootstrap.py sites
+
+web-browser-gate:  ## Run the browser gate on a leased preview port
+	$(PYTHON) tools/repo/frontend_runtime.py gate

--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ test:
 	$(PYTHON) -m pytest packs/desk-research/tests/skills/devils-advocate/ -q
 	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_journey_editorial_decisions.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
+	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q
 	$(PYTHON) -m pytest \
 		tools/test_lint_agents_md_diataxis_block.py \

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -1,0 +1,26 @@
+# Plan: worktree-runtime-hygiene
+
+- **Status:** Executing
+- **Spec:** [`spec.md`](spec.md)
+
+## Task 1 — scan and safe clean (this implementation)
+
+1. Add the pure-stdlib repository-local CLI with porcelain-only discovery, one-pass
+   classification, measurement labelling, cache/editable-install diagnosis, and stable
+   JSON/human rendering.
+2. Add receipt-only clean plus opt-in category deletion guarded by registered-root,
+   link, Git-administration, tracked, ignored, protection, lock, and editable-install
+   checks.
+3. Add tempfile falsification tests and bounded-process/traversal proofs.
+4. Append a dedicated pytest invocation for the new tool test; do not merge it into
+   the existing basename-collision-prone invocation.
+
+## Task 2 — concurrency runtime controls (not started by this task)
+
+1. Add a preview-port override and gate wrapper with a port lease.
+2. Add browser-cache path resolution and selective bootstrap profiles.
+3. Add a cooperative worktree lease shared by cleanup and mutating build/test entry
+   points to close the remaining check-to-delete concurrency window.
+
+Task 2 implements AC6–AC7. It has no code change in this task and must be scheduled
+as its own implementation work rather than smuggled into scan/clean.

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -1,0 +1,114 @@
+# Spec: worktree-runtime-hygiene
+
+- **Status:** Implementing
+- **Owner:** repository maintainers
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none <!-- no REST/event/RPC surface; the `scan --json` shape is a command-output contract held in code and tests, not a published interface -->
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Make parallel worktrees deterministic and safe to inspect and selectively clean.
+Byte counts are diagnostic, never a disk-reclamation promise. The disk emergency is
+over; its pressure previously caused browser-cache evictions, broken environment
+state, and silently skipped tests unrelated to the actual space problem.
+
+## Acceptance Criteria
+
+- [ ] **AC1 — scan has one authoritative worktree model.** `scan` discovers only
+  `git worktree list --porcelain -z` records, including bare, detached, and prunable
+  records, and emits deterministic human and JSON (`schema_version`, repository,
+  git_common_dir, measurement, worktrees, shared_caches, warnings, totals) output.
+  Paths with spaces and non-ASCII text are preserved. It performs one bounded,
+  non-link-following traversal per present worktree, classifying candidates as it
+  walks rather than rewalking per category.
+
+- [ ] **AC2 — byte output is honest.** Candidate byte counts use allocated blocks
+  when `st_blocks` exists and logical size otherwise; the selected measurement is
+  labelled. Sparse files and clones therefore do not become an unqualified
+  "reclaimable" claim. Human output is a compact per-worktree category table,
+  followed by shared storage and only the largest candidates.
+
+- [ ] **AC3 — scan diagnoses, but does not mutate, shared state.** It reports
+  Playwright browser-path mode, local `.local-browsers`, duplicate browser revisions,
+  npm cache placement, and worktree-local shared-cache resolution. It reports
+  registered prunable records; it never removes worktrees, branches, browser caches,
+  or arbitrary temporary-looking roots.
+
+- [ ] **AC4 — clean defaults to a receipt-only dry run.** `clean` deletes nothing
+  unless both `--apply` and one or more category switches are supplied. Expensive
+  dependency cleanup additionally requires `--include-dependencies`. There is no
+  all/force option. Unlike repository-wide `scan`, `clean` defaults to the current
+  worktree and accepts at most one explicit `--worktree`. Its kebab-case category
+  switches and safety options are described by `clean --help`. The receipt names
+  selected and skipped candidates, reasons, measurable bytes, failures, and remaining
+  largest candidates.
+
+- [ ] **AC5 — every deletion has a bounded safety proof.** Before deletion the tool
+  proves a known-model candidate is inside a selected registered worktree without a
+  resolving link escape; rejects common-dir and `.git` administration paths, tracked
+  files, non-ignored paths, `.loop-run`, `.context`, locks/leases, caller-protected
+  worktrees, and paths that an installed distribution currently resolves into; then
+  prints the exact target and bytes. Ignore and tracked checks are batched once per
+  worktree. Common-directory discovery and path-taking Git-control failures fail
+  closed, Git pathspecs are literal, and mount points are rejected. The current
+  worktree is protected from expensive cleanup; callers may repeat
+  `--protect-worktree` and supply protection roots through the environment.
+  Attachment is never labelled liveness or activity: liveness is unobservable without
+  that explicit handshake. The complete local safety predicate is re-run immediately
+  before each deletion, narrowing but not eliminating the concurrent-mutation window.
+  Git query failures reject the whole worktree rather than becoming negative answers.
+  `__pycache__` is a correctness cleanup because stale bytecode can violate CAT-V-014
+  during a run.
+
+- [ ] **AC6 — round 2: concurrent operations are explicitly leased.** The second
+  implementation task adds a caller-selected preview-port override and a gate wrapper
+  that leases it without binding the shared default port. It also adds the cooperative
+  worktree lease shared by cleanup and mutating build/test entry points; only that
+  shared lease can close the remaining check-to-delete concurrency window completely.
+
+- [ ] **AC7 — round 2: bootstrap and browser cache choices remain explicit.** The
+  second implementation task adds a browser-cache resolver and selective bootstrap
+  profiles without shared mutable dependencies, symlinked virtualenvs, or automatic
+  background work.
+
+## Limitations
+
+Linux same-filesystem bind-mount detection uses one `/proc/self/mountinfo` snapshot for
+selection and a fresh snapshot for each candidate immediately before deletion. Unit
+tests cover mount-table parsing, mount-predicate propagation, and cross-device
+boundaries, but no privileged fixture creates a genuine bind mount. A mount
+created after that final re-assertion and before recursive deletion completes remains
+unobservable without the cooperative lease deferred to round 2.
+
+## Boundaries
+
+**Never do**
+
+- Infer a worktree from its directory name, infer activity from a pty, or follow
+  symlinks/junctions while walking or deleting.
+- Hash file content, invoke Git once per file, run `git check-ignore` once per
+  candidate, or emit one confident clone-inflated reclaimable total.
+- Remove a worktree, branch, Playwright cache, arbitrary path, `/private/tmp` root,
+  or state outside a registered selected worktree.
+- Change installation configuration, bind port 4321, add a dependency, or start
+  round 2 in this implementation task.
+
+## Testing Strategy
+
+Real `tempfile` fixtures exercise scan and clean guards. A fake subprocess runner
+supplies Git porcelain and batched responses and proves Git calls are bounded by
+worktree count; a traversal counter proves one walk per worktree. Mutations remove
+each guard and must make its named falsification case fail. Python formatting, type,
+and focused pytest gates are run by the supervisor only.
+
+## Assumptions
+
+1. Git is available when the command is invoked; scan reports a command failure
+   rather than inventing a directory-based fallback.
+2. Registered worktree paths are the only deletion roots; missing prunable paths are
+   report-only records.
+3. The environment protection variable is path-separator-delimited and is additive
+   to repeated command-line protection roots.

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -112,3 +112,11 @@ and focused pytest gates are run by the supervisor only.
    report-only records.
 3. The environment protection variable is path-separator-delimited and is additive
    to repeated command-line protection roots.
+
+## Known residual: preview-port probe TOCTOU
+
+Alongside task 1's deferred cleanup TOCTOU, port selection retains one bounded race.
+Participating gate wrappers are coordinated by the shared lease, but the availability
+probe closes before Astro binds. An unrelated machine-local listener can therefore
+take the selected port during that interval. The wrapper does not claim an absolute
+reservation guarantee, and handing a bound socket to Astro is outside this scope.

--- a/tools/repo/bootstrap.py
+++ b/tools/repo/bootstrap.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Bootstrap only the requested frontend dependency profile."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PROFILES = ("web", "docs-site", "sites")
+
+
+class BootstrapError(RuntimeError):
+    """An actionable bootstrap configuration or execution error."""
+
+
+def profile_commands(profile: str) -> tuple[tuple[str, ...], ...]:
+    """Return the exact npm commands belonging to one bootstrap profile."""
+    if profile == "web":
+        return (("npm", "ci", "--prefix", "web"),)
+    if profile == "docs-site":
+        return (("npm", "ci", "--prefix", "docs-site"),)
+    if profile == "sites":
+        return (
+            ("npm", "ci", "--prefix", "web"),
+            ("npm", "ci", "--prefix", "docs-site"),
+        )
+    choices = ", ".join(PROFILES)
+    raise BootstrapError(f"unknown profile {profile!r}; choose one of: {choices}")
+
+
+def bootstrap(
+    profile: str,
+    *,
+    repo_root: Path = REPO_ROOT,
+    install_gate_browser: bool = False,
+    browsers_path: str | None = None,
+) -> int:
+    """Install only the npm dependency trees selected by ``profile``."""
+    if install_gate_browser and profile == "docs-site":
+        raise BootstrapError("--install-gate-browser requires the web or sites profile")
+    commands = profile_commands(profile)
+    if shutil.which("npm") is None:
+        raise BootstrapError("npm was not found; install Node.js/npm before bootstrapping")
+    for profile_command in commands:
+        try:
+            result = subprocess.run(profile_command, cwd=repo_root, check=False)
+        except FileNotFoundError as error:
+            raise BootstrapError(
+                "npm could not be started; install Node.js/npm before bootstrapping"
+            ) from error
+        if result.returncode != 0:
+            return result.returncode
+    if install_gate_browser:
+        command: list[str] = [
+            sys.executable,
+            str(repo_root / "tools" / "repo" / "frontend_runtime.py"),
+            "install-browsers",
+        ]
+        if browsers_path is not None:
+            command.extend(("--browsers-path", browsers_path))
+        result = subprocess.run(command, cwd=repo_root, check=False)
+        return result.returncode
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", nargs="?", choices=PROFILES)
+    parser.add_argument(
+        "--install-gate-browser",
+        action="store_true",
+        help="also install the Chromium browser used by the web gate",
+    )
+    parser.add_argument("--browsers-path", help="shared Playwright browser cache")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the selective-bootstrap command-line interface."""
+    args = _parser().parse_args(argv)
+    if args.profile is None:
+        profiles = ", ".join(PROFILES)
+        print(f"error: select a bootstrap profile: {profiles}", file=sys.stderr)
+        return 2
+    try:
+        return bootstrap(
+            args.profile,
+            install_gate_browser=args.install_gate_browser,
+            browsers_path=args.browsers_path,
+        )
+    except BootstrapError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Run the frontend browser gate with shared browser and port coordination.
+
+Lease ownership uses a PID plus a unique token. PID identity is approximate because
+operating systems can reuse process IDs, so leases older than 24 hours are reclaimable
+even when that PID is live. This bounds a PID-reuse wedge without another dependency.
+
+Participating wrappers cannot select the same leased port. The availability probe is
+necessarily closed before Astro binds, however, so an unrelated machine-local process
+can still take the port in that interval. This known TOCTOU residual is not presented
+as an absolute reservation guarantee.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from types import FrameType
+from typing import Any, Callable, Iterator, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GATE_COMMAND = ("npm", "run", "test:e2e:gate", "--prefix", "web")
+DEFAULT_PREVIEW_PORT = 4321
+LEASE_DIRECTORY = "agent-ready-repo-port-leases"
+LEASE_MAX_AGE_SECONDS = 24 * 60 * 60
+LEASE_RETRY_LIMIT = 20
+LEASE_RETRY_DELAY_SECONDS = 0.05
+PROCESS_TREE_EXIT_TIMEOUT_SECONDS = 5.0
+SignalHandler = Callable[[int, FrameType | None], Any] | int | None
+
+
+class FrontendRuntimeError(RuntimeError):
+    """An actionable frontend-runtime configuration or execution error."""
+
+
+@dataclass(frozen=True)
+class BrowserCache:
+    """A resolved Playwright browser cache and the rule that selected it."""
+
+    path: Path
+    source: str
+    warning: str | None = None
+
+
+def _platform_browser_cache(environ: Mapping[str, str]) -> Path:
+    """Return Playwright's documented cache directory for this platform."""
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "ms-playwright"
+    if os.name == "nt":
+        profile = environ.get("USERPROFILE")
+        home = Path(profile).expanduser() if profile else Path.home()
+        return home / "AppData" / "Local" / "ms-playwright"
+    return Path.home() / ".cache" / "ms-playwright"
+
+
+def _external_cache_path(raw: str, repo_root: Path) -> Path:
+    """Resolve a cache path and reject browser binaries inside the repository."""
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    path = path.resolve()
+    root = repo_root.resolve()
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return path
+    raise FrontendRuntimeError(
+        f"browser cache {path} is inside the repository; choose a shared external path"
+    )
+
+
+def resolve_browser_cache(
+    explicit: str | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> BrowserCache:
+    """Resolve the browser cache using the documented precedence rules."""
+    values = os.environ if environ is None else environ
+    warning = None
+    if values.get("PLAYWRIGHT_BROWSERS_PATH") == "0":
+        warning = (
+            "PLAYWRIGHT_BROWSERS_PATH=0 enables hermetic browser installs under "
+            "each worktree's node_modules; using the shared platform default instead"
+        )
+
+    if explicit is not None:
+        if not explicit:
+            raise FrontendRuntimeError("--browsers-path must not be empty")
+        return BrowserCache(
+            _external_cache_path(explicit, repo_root), "explicit --browsers-path", warning
+        )
+
+    arr_path = values.get("ARR_PLAYWRIGHT_BROWSERS_PATH")
+    if arr_path:
+        return BrowserCache(
+            _external_cache_path(arr_path, repo_root),
+            "ARR_PLAYWRIGHT_BROWSERS_PATH",
+            warning,
+        )
+
+    playwright_path = values.get("PLAYWRIGHT_BROWSERS_PATH")
+    if playwright_path and playwright_path != "0":
+        return BrowserCache(
+            _external_cache_path(playwright_path, repo_root),
+            "PLAYWRIGHT_BROWSERS_PATH",
+        )
+
+    default = _external_cache_path(str(_platform_browser_cache(values)), repo_root)
+    return BrowserCache(default, "platform default", warning)
+
+
+def announce_browser_cache(cache: BrowserCache) -> None:
+    """Print the selected browser cache and any hermetic-mode warning."""
+    print(f"Playwright browser cache: {cache.path} (source: {cache.source})", flush=True)
+    if cache.warning:
+        print(f"WARNING: {cache.warning}", file=sys.stderr, flush=True)
+
+
+def parse_port(raw: str, source: str) -> int:
+    """Parse a user-supplied TCP port without silently changing invalid input."""
+    if not raw.isascii() or not raw.isdecimal():
+        raise FrontendRuntimeError(
+            f"{source} has invalid value {raw!r}; expected an integer from 1 to 65535"
+        )
+    port = int(raw)
+    if port <= 0 or port > 65535:
+        raise FrontendRuntimeError(
+            f"{source} has invalid value {raw!r}; expected an integer from 1 to 65535"
+        )
+    return port
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return whether a process id still identifies a live process."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+@contextlib.contextmanager
+def _port_coordination_lock(lease_dir: Path, port: int) -> Iterator[None]:
+    """Serialize stale inspection and reclamation for one port across processes."""
+    path = lease_dir / f"preview-{port}.lock"
+    with path.open("a+b") as handle:
+        if os.name == "nt":
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            windows_locking: Any = importlib.import_module("msvcrt")
+
+            def windows_acquire() -> None:
+                windows_locking.locking(
+                    handle.fileno(), windows_locking.LK_NBLCK, 1
+                )
+
+            def windows_release() -> None:
+                windows_locking.locking(handle.fileno(), windows_locking.LK_UNLCK, 1)
+
+            acquire = windows_acquire
+            release = windows_release
+        else:
+            posix_locking: Any = importlib.import_module("fcntl")
+
+            def posix_acquire() -> None:
+                posix_locking.flock(
+                    handle.fileno(), posix_locking.LOCK_EX | posix_locking.LOCK_NB
+                )
+
+            def posix_release() -> None:
+                posix_locking.flock(handle.fileno(), posix_locking.LOCK_UN)
+
+            acquire = posix_acquire
+            release = posix_release
+
+        for attempt in range(LEASE_RETRY_LIMIT):
+            try:
+                acquire()
+                break
+            except OSError:
+                if attempt + 1 < LEASE_RETRY_LIMIT:
+                    time.sleep(LEASE_RETRY_DELAY_SECONDS)
+        else:
+            raise FrontendRuntimeError(
+                f"could not acquire coordination lock for preview port {port}"
+            )
+        try:
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                handle.seek(0)
+                release()
+
+
+def _lease_age_seconds(path: Path, existing: Mapping[str, object] | None) -> float:
+    """Return lease age from its payload, falling back to filesystem modification time."""
+    created_at = existing.get("created_at") if existing is not None else None
+    try:
+        if isinstance(created_at, (int, float, str)):
+            created = float(created_at)
+        else:
+            created = path.stat().st_mtime
+    except (OSError, TypeError, ValueError):
+        return 0.0
+    return max(0.0, time.time() - created)
+
+
+def _lease_reclaimable(path: Path) -> bool | None:
+    """Return stale status, or ``None`` while an unreadable lease is still young."""
+    try:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        owner = int(existing["pid"])
+    except (KeyError, OSError, UnicodeError, ValueError, TypeError):
+        age = _lease_age_seconds(path, None)
+        return True if age > LEASE_MAX_AGE_SECONDS else None
+    age = _lease_age_seconds(path, existing)
+    return not _pid_is_alive(owner) or age > LEASE_MAX_AGE_SECONDS
+
+
+def _publish_lease_candidate(lease_dir: Path, path: Path, payload: str) -> None:
+    """Publish a complete lease without exposing a partially written destination."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".preview-{path.stem}-", dir=lease_dir
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as candidate:
+            candidate.write(payload)
+        os.link(temporary, path)
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+
+
+@dataclass
+class PortLease:
+    """An atomically claimed preview-port coordination file."""
+
+    port: int
+    path: Path
+    token: str
+
+    @classmethod
+    def try_acquire(cls, common_dir: Path, port: int) -> PortLease | None:
+        """Claim a port lease, reclaiming a lease whose owner is dead."""
+        lease_dir = common_dir / LEASE_DIRECTORY
+        lease_dir.mkdir(parents=True, exist_ok=True)
+        path = lease_dir / f"preview-{port}.json"
+
+        for attempt in range(LEASE_RETRY_LIMIT):
+            token = uuid.uuid4().hex
+            payload = json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "token": token,
+                    "port": port,
+                    "created_at": time.time(),
+                }
+            )
+            try:
+                _publish_lease_candidate(lease_dir, path, payload)
+            except FileExistsError:
+                with _port_coordination_lock(lease_dir, port):
+                    reclaimable = _lease_reclaimable(path)
+                    if reclaimable is False:
+                        return None
+                    if reclaimable is True:
+                        with contextlib.suppress(OSError):
+                            path.unlink()
+                if attempt + 1 < LEASE_RETRY_LIMIT:
+                    time.sleep(LEASE_RETRY_DELAY_SECONDS)
+                continue
+            return cls(port=port, path=path, token=token)
+        raise FrontendRuntimeError(
+            f"could not acquire preview port {port}: lease remained unreadable"
+        )
+
+    def release(self) -> None:
+        """Remove this lease without deleting a replacement owner's lease."""
+        with _port_coordination_lock(self.path.parent, self.port):
+            try:
+                existing = json.loads(self.path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return
+            if existing.get("token") != self.token:
+                return
+            with contextlib.suppress(OSError):
+                self.path.unlink()
+
+
+def _port_is_available(port: int) -> bool:
+    """Bind-test a localhost port to detect unrelated listeners."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind(("127.0.0.1", port))
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
+
+
+def lease_preview_port(common_dir: Path, requested: int | None) -> PortLease:
+    """Lease an explicit port or the first free coordinated port from 4321."""
+    if requested is not None:
+        lease = PortLease.try_acquire(common_dir, requested)
+        if lease is None:
+            raise FrontendRuntimeError(
+                f"preview port {requested} is already leased by another gate"
+            )
+        if not _port_is_available(requested):
+            lease.release()
+            raise FrontendRuntimeError(
+                f"preview port {requested} is already occupied by another process"
+            )
+        return lease
+
+    candidates = range(DEFAULT_PREVIEW_PORT, 65536)
+    for port in candidates:
+        lease = PortLease.try_acquire(common_dir, port)
+        if lease is None:
+            continue
+        if _port_is_available(port):
+            return lease
+        lease.release()
+    raise FrontendRuntimeError("no available preview port could be leased")
+
+
+def git_common_dir(repo_root: Path = REPO_ROOT) -> Path:
+    """Ask Git for the local directory shared by all linked worktrees."""
+    try:
+        result = subprocess.run(
+            ("git", "rev-parse", "--git-common-dir"),
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise FrontendRuntimeError(
+            "git is required to locate the shared worktree lease directory"
+        ) from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "not inside a Git worktree"
+        raise FrontendRuntimeError(f"could not resolve Git common directory: {detail}")
+    raw = Path(result.stdout.strip())
+    return raw.resolve() if raw.is_absolute() else (repo_root / raw).resolve()
+
+
+def _require_npm() -> None:
+    """Fail before spawning when npm is unavailable."""
+    if shutil.which("npm") is None:
+        raise FrontendRuntimeError(
+            "npm was not found; install Node.js/npm and bootstrap the web profile"
+        )
+
+
+def _spawn_child(
+    command: Sequence[str], env: Mapping[str, str], cwd: Path
+) -> subprocess.Popen[Any]:
+    """Spawn the gate in a process group dedicated to its complete descendant tree."""
+    if os.name == "nt":
+        creation_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        return subprocess.Popen(
+            tuple(command),
+            cwd=cwd,
+            env=dict(env),
+            creationflags=creation_flags,
+        )
+    return subprocess.Popen(
+        tuple(command),
+        cwd=cwd,
+        env=dict(env),
+        start_new_session=True,
+    )
+
+
+@dataclass(frozen=True)
+class _ProcessTreeSignal:
+    """Information the main flow needs after a handler signals the process tree."""
+
+    process_group: int | None = None
+    taskkill: subprocess.Popen[Any] | None = None
+
+
+def _signal_process_tree(
+    child: subprocess.Popen[Any], signum: int
+) -> _ProcessTreeSignal:
+    """Signal the gate tree without waiting, polling, or sleeping."""
+    if os.name == "nt":
+        try:
+            taskkill = subprocess.Popen(
+                ("taskkill", "/T", "/F", "/PID", str(child.pid)),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return _ProcessTreeSignal(taskkill=taskkill)
+        except OSError:
+            pass
+    else:
+        try:
+            process_group = os.getpgid(child.pid)
+            os.killpg(process_group, signum)
+            return _ProcessTreeSignal(process_group=process_group)
+        except ProcessLookupError:
+            return _ProcessTreeSignal()
+        except OSError:
+            pass
+    with contextlib.suppress(OSError):
+        child.send_signal(signum)
+    return _ProcessTreeSignal()
+
+
+def _reap_process_tree(
+    child: subprocess.Popen[Any], tree_signal: _ProcessTreeSignal
+) -> None:
+    """Wait for a signalled tree and escalate from the main flow only."""
+    if tree_signal.taskkill is not None:
+        try:
+            tree_signal.taskkill.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            tree_signal.taskkill.kill()
+            tree_signal.taskkill.wait()
+    try:
+        child.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        if tree_signal.process_group is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(tree_signal.process_group, signal.SIGKILL)
+        else:
+            with contextlib.suppress(OSError):
+                child.kill()
+        child.wait()
+
+    if tree_signal.process_group is None:
+        return
+    try:
+        os.killpg(tree_signal.process_group, 0)
+    except ProcessLookupError:
+        return
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(tree_signal.process_group, signal.SIGKILL)
+
+
+def _run_child(command: Sequence[str], env: Mapping[str, str], cwd: Path) -> int:
+    """Run a gate child, forwarding supported termination signals."""
+    interrupted: list[int] = []
+    tree_signals: list[_ProcessTreeSignal] = []
+    previous_handlers: dict[int, SignalHandler] = {}
+    child: subprocess.Popen[Any] | None = None
+
+    def forward(signum: int, _frame: FrameType | None) -> None:
+        interrupted.append(signum)
+        if child is not None:
+            tree_signals.append(_signal_process_tree(child, signum))
+
+    if threading.current_thread() is threading.main_thread():
+        for name in ("SIGINT", "SIGTERM"):
+            signum = getattr(signal, name, None)
+            if signum is not None:
+                previous_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, forward)
+
+    try:
+        if interrupted:
+            return 128 + interrupted[0]
+        try:
+            child = _spawn_child(command, env, cwd)
+        except FileNotFoundError as error:
+            raise FrontendRuntimeError(
+                f"gate executable {command[0]!r} was not found"
+            ) from error
+        if interrupted:
+            if not tree_signals:
+                tree_signals.append(_signal_process_tree(child, interrupted[0]))
+            _reap_process_tree(child, tree_signals[-1])
+            return 128 + interrupted[0]
+        try:
+            returncode = child.wait()
+        except KeyboardInterrupt:
+            tree_signal = _signal_process_tree(child, signal.SIGINT)
+            _reap_process_tree(child, tree_signal)
+            return 130
+        if interrupted:
+            _reap_process_tree(child, tree_signals[-1])
+            return 128 + interrupted[0]
+        return returncode
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+@contextlib.contextmanager
+def _release_lease_on_signals(lease: PortLease) -> Iterator[None]:
+    """Cover the short setup/teardown windows around the signal-aware child."""
+    previous_handlers: dict[int, SignalHandler] = {}
+
+    def release(signum: int, _frame: FrameType | None) -> None:
+        lease.release()
+        raise SystemExit(128 + signum)
+
+    if threading.current_thread() is threading.main_thread():
+        for name in ("SIGINT", "SIGTERM"):
+            signum = getattr(signal, name, None)
+            if signum is not None:
+                previous_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, release)
+    try:
+        yield
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+
+
+def run_gate(
+    *,
+    port: str | None = None,
+    browsers_path: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path = REPO_ROOT,
+    common_dir: Path | None = None,
+    gate_command: Sequence[str] | None = None,
+) -> int:
+    """Lease a port, configure the browser cache, and run the pinned gate."""
+    values = dict(os.environ if environ is None else environ)
+    raw_port = port if port is not None else values.get("ARR_PREVIEW_PORT")
+    source = "--port" if port is not None else "ARR_PREVIEW_PORT"
+    requested = parse_port(raw_port, source) if raw_port is not None else None
+    cache = resolve_browser_cache(browsers_path, environ=values, repo_root=repo_root)
+    command = GATE_COMMAND if gate_command is None else tuple(gate_command)
+    if gate_command is None:
+        _require_npm()
+
+    lease = lease_preview_port(
+        git_common_dir(repo_root) if common_dir is None else common_dir,
+        requested,
+    )
+    try:
+        with _release_lease_on_signals(lease):
+            values["ARR_PREVIEW_PORT"] = str(lease.port)
+            values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
+            announce_browser_cache(cache)
+            print(f"Preview port lease: {lease.port}", flush=True)
+            return _run_child(command, values, repo_root)
+    finally:
+        lease.release()
+
+
+def install_browsers(
+    *,
+    browsers_path: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> int:
+    """Install only the Chromium browser required by the quality gate."""
+    values = dict(os.environ if environ is None else environ)
+    cache = resolve_browser_cache(browsers_path, environ=values, repo_root=repo_root)
+    executable_name = "playwright.cmd" if os.name == "nt" else "playwright"
+    executable = repo_root / "web" / "node_modules" / ".bin" / executable_name
+    if not executable.is_file():
+        raise FrontendRuntimeError(
+            "Playwright is not installed under web/node_modules; run "
+            "python tools/repo/bootstrap.py web first"
+        )
+    values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
+    announce_browser_cache(cache)
+    try:
+        result = subprocess.run(
+            (str(executable), "install", "chromium"),
+            cwd=repo_root,
+            env=values,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise FrontendRuntimeError(
+            "the local Playwright executable could not be started; verify Node.js is installed"
+        ) from error
+    return result.returncode
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    gate = subparsers.add_parser("gate", help="run the browser quality gate")
+    gate.add_argument("--port", help="explicit preview port")
+    gate.add_argument("--browsers-path", help="shared Playwright browser cache")
+
+    browsers = subparsers.add_parser("browsers", help="show browser cache resolution")
+    browsers.add_argument("--browsers-path", help="shared Playwright browser cache")
+
+    install = subparsers.add_parser(
+        "install-browsers", help="install the gate's Chromium browser"
+    )
+    install.add_argument("--browsers-path", help="shared Playwright browser cache")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the frontend-runtime command-line interface."""
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "gate":
+            return run_gate(port=args.port, browsers_path=args.browsers_path)
+        if args.command == "install-browsers":
+            return install_browsers(browsers_path=args.browsers_path)
+        cache = resolve_browser_cache(args.browsers_path)
+        announce_browser_cache(cache)
+        return 0
+    except FrontendRuntimeError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -1,0 +1,1227 @@
+#!/usr/bin/env python3
+"""Inspect registered Git worktrees and perform explicitly selected safe cleanup.
+
+This repository-local command deliberately makes the useful operation the dry run.
+It never guesses worktree roots from names and never follows links while traversing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+def _configure_stream(stream: object, errors: str) -> None:
+    """Configure a standard stream when the host stream supports reconfiguration."""
+    reconfigure = getattr(stream, "reconfigure", None)
+    if callable(reconfigure):
+        reconfigure(encoding="utf-8", errors=errors)
+
+
+_configure_stream(sys.stdout, "strict")
+_configure_stream(sys.stderr, "backslashreplace")
+
+SCHEMA_VERSION = 1
+CATEGORIES = ("dependencies", "generated", "test_artifacts")
+CLEANABLE_CATEGORIES = frozenset(CATEGORIES)
+EXPENSIVE = {"dependencies"}
+PROTECTED_ROOTS = {".loop-run", ".context"}
+NAMES = {
+    "node_modules": "dependencies",
+    ".venv": "dependencies",
+    "venv": "dependencies",
+    "env": "dependencies",
+    "build": "generated",
+    "dist": "generated",
+    ".astro": "generated",
+    "test-results": "test_artifacts",
+    "playwright-report": "test_artifacts",
+    ".pytest_cache": "test_artifacts",
+    ".coverage": "test_artifacts",
+    ".ruff_cache": "test_artifacts",
+    ".mypy_cache": "test_artifacts",
+    "__pycache__": "test_artifacts",
+    ".local-browsers": "shared_caches",
+}
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+MountCheck = Callable[[Path], bool]
+
+
+@dataclass(frozen=True)
+class Worktree:
+    path: Path
+    head: str = ""
+    branch: str = ""
+    bare: bool = False
+    detached: bool = False
+    prunable: str = ""
+
+    def __post_init__(self) -> None:
+        """Keep every root comparison in one canonical path namespace."""
+        object.__setattr__(self, "path", self.path.resolve())
+
+
+@dataclass
+class Candidate:
+    path: Path
+    category: str
+    bytes: int
+    is_dir: bool
+    ignored: bool = False
+    protected: bool = False
+    git_admin: bool = False
+    canonical_path: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Retain the lexical path for link checks and a canonical comparison path."""
+        self.canonical_path = self.path.resolve()
+
+
+@dataclass
+class ScanResult:
+    worktree: Worktree
+    candidates: list[Candidate] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    traversals: int = 0
+
+
+@dataclass(frozen=True)
+class GitPathsResult:
+    paths: set[Path]
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class GitStatus:
+    ignored: set[Path]
+    tracked: set[Path]
+    error: str = ""
+
+
+def _run(
+    argv: list[str],
+    *,
+    input: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        input=input,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
+def _call(
+    runner: Runner,
+    argv: list[str],
+    *,
+    input: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return runner(argv, input=input, env=env)
+
+
+def _parse_porcelain(text: str) -> list[Worktree]:
+    records: list[dict[str, str]] = []
+    record: dict[str, str] = {}
+    for entry in text.split("\0"):
+        if not entry:
+            if record:
+                records.append(record)
+                record = {}
+            continue
+        key, _, value = entry.partition(" ")
+        record[key] = value
+    if record:
+        records.append(record)
+    return [
+        Worktree(
+            Path(item["worktree"]),
+            item.get("HEAD", ""),
+            item.get("branch", ""),
+            "bare" in item,
+            "detached" in item,
+            item.get("prunable", ""),
+        )
+        for item in records
+        if "worktree" in item
+    ]
+
+
+def discover_worktrees(
+    repository: Path,
+    runner: Runner = _run,
+) -> tuple[Path, Path | None, list[Worktree], list[str]]:
+    """Return repository identity, common dir, porcelain records, and warnings."""
+    warnings: list[str] = []
+    listed = _call(
+        runner,
+        [
+            "git",
+            "-C",
+            str(repository),
+            "worktree",
+            "list",
+            "--porcelain",
+            "-z",
+        ],
+    )
+    if listed.returncode:
+        return (
+            repository.resolve(),
+            repository.resolve() / ".git",
+            [],
+            [listed.stderr.strip() or "git worktree list failed"],
+        )
+    common = _call(
+        runner,
+        ["git", "-C", str(repository), "rev-parse", "--git-common-dir"],
+    )
+    if common.returncode:
+        detail = common.stderr.strip() or f"exit {common.returncode}"
+        warnings.append(f"git common directory unavailable: {detail}")
+        return repository.resolve(), None, _parse_porcelain(listed.stdout), warnings
+    common_dir = Path(common.stdout.strip())
+    if not common_dir.is_absolute():
+        common_dir = repository / common_dir
+    return (
+        repository.resolve(),
+        common_dir.resolve(),
+        _parse_porcelain(listed.stdout),
+        warnings,
+    )
+
+
+def _measurement_name() -> str:
+    return "allocated" if hasattr(os.stat_result, "st_blocks") else "logical"
+
+
+def _size(path: Path, warnings: list[str]) -> tuple[int, str]:
+    """Measure a path without following a link; tolerate concurrent removal."""
+    try:
+        stat = path.stat(follow_symlinks=False)
+    except (FileNotFoundError, PermissionError) as exc:
+        warnings.append(f"cannot stat {path}: {exc.__class__.__name__}")
+        return 0, _measurement_name()
+    blocks = getattr(stat, "st_blocks", None)
+    if blocks is not None:
+        return int(blocks) * 512, "allocated"
+    return int(stat.st_size), "logical"
+
+
+def _tree_size(
+    path: Path,
+    warnings: list[str],
+    protected_entries: list[Path] | None = None,
+    git_entries: list[Path] | None = None,
+) -> tuple[int, str]:
+    total, measurement = _size(path, warnings)
+    if not path.is_dir() or path.is_symlink():
+        return total, measurement
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(os.scandir(current), key=lambda entry: entry.name)
+        except (FileNotFoundError, PermissionError) as exc:
+            warnings.append(f"cannot read {current}: {exc.__class__.__name__}")
+            continue
+        for entry in entries:
+            child = Path(entry.path)
+            if entry.name == ".git":
+                if git_entries is not None:
+                    git_entries.append(child)
+                continue
+            if protected_entries is not None and (
+                entry.name in PROTECTED_ROOTS
+                or entry.name.endswith((".lock", ".lease"))
+            ):
+                protected_entries.append(child)
+            try:
+                if entry.is_symlink():
+                    size, measurement = _size(child, warnings)
+                    total += size
+                elif entry.is_dir(follow_symlinks=False):
+                    stack.append(child)
+                else:
+                    size, measurement = _size(child, warnings)
+                    total += size
+            except (FileNotFoundError, PermissionError) as exc:
+                warnings.append(f"cannot inspect {child}: {exc.__class__.__name__}")
+    return total, measurement
+
+
+def scan_worktree(worktree: Worktree) -> ScanResult:
+    """Classify candidates in one walk, stopping at each candidate root."""
+    result = ScanResult(worktree=worktree, traversals=1)
+    if worktree.prunable or not worktree.path.exists() or worktree.bare:
+        if not worktree.path.exists() and not worktree.bare:
+            result.warnings.append(
+                f"registered worktree is missing: {worktree.path}"
+            )
+        return result
+    stack = [worktree.path]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(os.scandir(current), key=lambda entry: entry.name)
+        except (FileNotFoundError, PermissionError) as exc:
+            result.warnings.append(
+                f"cannot read {current}: {exc.__class__.__name__}"
+            )
+            continue
+        for entry in entries:
+            child = Path(entry.path)
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+                is_symlink = entry.is_symlink()
+            except (FileNotFoundError, PermissionError) as exc:
+                result.warnings.append(
+                    f"cannot inspect {child}: {exc.__class__.__name__}"
+                )
+                continue
+            if entry.name == ".git":
+                continue
+            if entry.name in PROTECTED_ROOTS:
+                size, _ = _tree_size(child, result.warnings)
+                result.candidates.append(
+                    Candidate(
+                        child,
+                        "protected",
+                        size,
+                        is_dir,
+                        protected=True,
+                    )
+                )
+                continue
+            category = NAMES.get(entry.name)
+            if category:
+                protected_entries: list[Path] = []
+                git_entries: list[Path] = []
+                size, _ = _tree_size(
+                    child,
+                    result.warnings,
+                    protected_entries,
+                    git_entries,
+                )
+                result.candidates.append(
+                    Candidate(
+                        child,
+                        category,
+                        size,
+                        is_dir,
+                        protected=bool(protected_entries),
+                        git_admin=bool(git_entries),
+                    )
+                )
+                continue
+            if is_dir and not is_symlink:
+                stack.append(child)
+    result.candidates.sort(key=lambda item: (str(item.path), item.category))
+    return result
+
+
+def _under(path: Path, root: Path) -> bool:
+    """Return whether *path* resolves beneath *root* without raising."""
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _protected_paths(values: Iterable[str]) -> set[Path]:
+    paths = {Path(value).resolve() for value in values if value}
+    environment_values = os.environ.get(
+        "WORKTREE_HYGIENE_PROTECT_WORKTREES",
+        "",
+    ).split(os.pathsep)
+    paths.update(Path(value).resolve() for value in environment_values if value)
+    return paths
+
+
+def _parse_mountinfo(text: str) -> set[Path]:
+    """Return decoded mount points from Linux procfs mount information."""
+    replacements = {
+        "\\040": " ",
+        "\\011": "\t",
+        "\\012": "\n",
+        "\\134": "\\",
+    }
+    mount_points: set[Path] = set()
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) < 5:
+            continue
+        value = fields[4]
+        for escaped, decoded in replacements.items():
+            value = value.replace(escaped, decoded)
+        mount_points.add(Path(value).resolve())
+    return mount_points
+
+
+def _linux_mount_points() -> set[Path] | None:
+    """Read the current Linux mount table once, when procfs is available."""
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        text = Path("/proc/self/mountinfo").read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    return _parse_mountinfo(text)
+
+
+def _default_mount_check() -> MountCheck:
+    """Compose portable mount detection with one Linux mount-table snapshot."""
+    mount_points = _linux_mount_points()
+
+    def is_mount(path: Path) -> bool:
+        return os.path.ismount(path) or (
+            mount_points is not None and path.resolve() in mount_points
+        )
+
+    return is_mount
+
+
+def _git_paths(
+    runner: Runner,
+    argv: list[str],
+    paths: list[Path],
+) -> GitPathsResult:
+    """Run check-ignore, where exits zero and one are both successful."""
+    if not paths:
+        return GitPathsResult(set())
+    payload = "\0".join(str(path) for path in paths) + "\0"
+    result = _call(runner, argv, input=payload)
+    if result.returncode not in {0, 1}:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        return GitPathsResult(set(), detail)
+    parsed = {Path(value) for value in result.stdout.split("\0") if value}
+    return GitPathsResult(parsed)
+
+
+def _mark_git_status(
+    root: Path,
+    candidates: list[Candidate],
+    runner: Runner,
+) -> GitStatus:
+    if not candidates:
+        return GitStatus(set(), set())
+    paths: list[Path] = []
+    for candidate in candidates:
+        if _under(candidate.canonical_path, root):
+            paths.append(candidate.canonical_path.relative_to(root))
+    if not paths:
+        return GitStatus(set(), set())
+    ignored_result = _git_paths(
+        runner,
+        [
+            "git",
+            "-C",
+            str(root),
+            "check-ignore",
+            "-z",
+            "--stdin",
+        ],
+        paths,
+    )
+    if ignored_result.error:
+        return GitStatus(
+            set(),
+            set(),
+            f"git check-ignore failed: {ignored_result.error}",
+        )
+    result = _call(
+        runner,
+        [
+            "git",
+            "--literal-pathspecs",
+            "-C",
+            str(root),
+            "ls-files",
+            "-z",
+            "--",
+            *map(str, paths),
+        ],
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        return GitStatus(set(), set(), f"git ls-files failed: {detail}")
+    tracked = {Path(value) for value in result.stdout.split("\0") if value}
+    return GitStatus(ignored_result.paths, tracked)
+
+
+def _mark_scan_ignored(result: ScanResult, runner: Runner) -> None:
+    """Attach ignored status with one batched query for a scanned worktree."""
+    relative_candidates: list[tuple[Candidate, Path]] = []
+    for candidate in result.candidates:
+        try:
+            relative = candidate.path.relative_to(result.worktree.path)
+        except ValueError:
+            continue
+        relative_candidates.append((candidate, relative))
+    ignored_result = _git_paths(
+        runner,
+        [
+            "git",
+            "-C",
+            str(result.worktree.path),
+            "check-ignore",
+            "-z",
+            "--stdin",
+        ],
+        [relative for _, relative in relative_candidates],
+    )
+    if ignored_result.error:
+        result.warnings.append(
+            f"git check-ignore failed: {ignored_result.error}"
+        )
+        return
+    for candidate, relative in relative_candidates:
+        candidate.ignored = relative in ignored_result.paths
+
+
+def _installed_distribution_locations() -> list[Path]:
+    """Return resolved locations used by distributions in this interpreter."""
+    locations: set[Path] = set()
+    for distribution in importlib.metadata.distributions():
+        try:
+            locations.add(Path(str(distribution.locate_file(""))).resolve())
+        except (FileNotFoundError, OSError):
+            continue
+    return sorted(locations, key=str)
+
+
+def _default_playwright_path() -> Path:
+    """Return Playwright's documented default without importing Playwright."""
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "ms-playwright"
+    if os.name == "nt":
+        default = Path.home() / "AppData" / "Local"
+        base = os.environ.get("LOCALAPPDATA", str(default))
+        return Path(base) / "ms-playwright"
+    return Path.home() / ".cache" / "ms-playwright"
+
+
+def _cache_diagnostics(
+    worktrees: list[Worktree],
+    runner: Runner,
+    warnings: list[str],
+) -> list[dict[str, object]]:
+    roots = [worktree.path for worktree in worktrees]
+    configured = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    browser_path = Path(configured).expanduser() if configured else _default_playwright_path()
+    mode = "documented_platform_default"
+    if configured:
+        mode = "hermetic" if configured == "0" else "explicitly_shared"
+    result: list[dict[str, object]] = []
+    if configured != "0":
+        resolved = browser_path.resolve()
+        result.append(
+            {
+                "kind": "playwright",
+                "path": str(resolved),
+                "mode": mode,
+                "revisions": _browser_revisions(resolved, warnings),
+                "beneath_worktree": any(
+                    _under(resolved, root) for root in roots
+                ),
+            }
+        )
+    npm = _call(runner, ["npm", "config", "get", "cache"])
+    if npm.returncode == 0 and npm.stdout.strip():
+        cache = Path(npm.stdout.strip()).expanduser().resolve()
+        result.append(
+            {
+                "kind": "npm",
+                "path": str(cache),
+                "mode": "effective",
+                "beneath_worktree": any(
+                    _under(cache, root) for root in roots
+                ),
+            }
+        )
+    return result
+
+
+def _browser_revisions(path: Path, warnings: list[str]) -> list[str]:
+    """List browser revision directories without following links."""
+    if not path.is_dir() or path.is_symlink():
+        return []
+    try:
+        entries = sorted(os.scandir(path), key=lambda entry: entry.name)
+    except (FileNotFoundError, PermissionError) as exc:
+        warnings.append(f"cannot read browser cache {path}: {exc.__class__.__name__}")
+        return []
+    revisions: list[str] = []
+    for entry in entries:
+        try:
+            if entry.is_dir(follow_symlinks=False) and not entry.is_symlink():
+                revisions.append(entry.name)
+        except (FileNotFoundError, PermissionError) as exc:
+            child = Path(entry.path)
+            warnings.append(
+                f"cannot inspect browser revision {child}: {exc.__class__.__name__}"
+            )
+    return revisions
+
+
+def _duplicate_browser_revisions(
+    caches: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    locations: defaultdict[str, set[str]] = defaultdict(set)
+    for cache in caches:
+        if cache.get("kind") not in {"playwright", "playwright-local"}:
+            continue
+        path = str(cache["path"])
+        revisions = cache.get("revisions")
+        if not isinstance(revisions, list):
+            continue
+        for revision in revisions:
+            locations[str(revision)].add(path)
+    duplicates: list[dict[str, object]] = []
+    for revision, paths in sorted(locations.items()):
+        if len(paths) > 1:
+            ordered = sorted(paths)
+            duplicates.append(
+                {
+                    "kind": "playwright-duplicate-revision",
+                    "path": ", ".join(ordered),
+                    "mode": "duplicate",
+                    "revision": revision,
+                    "paths": ordered,
+                }
+            )
+    return duplicates
+
+
+def _candidate_data(candidate: Candidate) -> dict[str, object]:
+    return {
+        "path": str(candidate.path),
+        "category": candidate.category,
+        "bytes": candidate.bytes,
+        "ignored": candidate.ignored,
+        "protected": candidate.protected,
+        "git_admin": candidate.git_admin,
+    }
+
+
+def scan(
+    repository: Path,
+    selected: list[Path] | None = None,
+    runner: Runner = _run,
+    *,
+    include_ignore_status: bool = True,
+) -> dict[str, Any]:
+    repo, common, worktrees, warnings = discover_worktrees(repository, runner)
+    selected_roots = {path.resolve() for path in selected or []}
+    if selected_roots:
+        registered = {worktree.path for worktree in worktrees}
+        for path in sorted(selected_roots - registered, key=str):
+            warnings.append(f"selected worktree is not registered: {path}")
+        worktrees = [
+            worktree
+            for worktree in worktrees
+            if worktree.path in selected_roots
+        ]
+    results = [
+        scan_worktree(worktree)
+        for worktree in sorted(worktrees, key=lambda item: str(item.path))
+    ]
+    if include_ignore_status:
+        for result in results:
+            _mark_scan_ignored(result, runner)
+    worktree_data: list[dict[str, Any]] = []
+    for result in results:
+        category_totals: defaultdict[str, int] = defaultdict(int)
+        for candidate in result.candidates:
+            if candidate.category != "shared_caches":
+                category_totals[candidate.category] += candidate.bytes
+        worktree_data.append(
+            {
+                "path": str(result.worktree.path),
+                "head": result.worktree.head,
+                "branch": result.worktree.branch,
+                "bare": result.worktree.bare,
+                "detached": result.worktree.detached,
+                "prunable": result.worktree.prunable,
+                "categories": dict(sorted(category_totals.items())),
+                "total_local": sum(category_totals.values()),
+                "candidates": [
+                    _candidate_data(candidate)
+                    for candidate in result.candidates
+                ],
+            }
+        )
+        warnings.extend(result.warnings)
+    shared: list[dict[str, object]] = []
+    local_browsers = [
+        candidate
+        for result in results
+        for candidate in result.candidates
+        if candidate.path.name == ".local-browsers"
+    ]
+    for candidate in local_browsers:
+        shared.append(
+            {
+                "kind": "playwright-local",
+                "path": str(candidate.path),
+                "mode": "hermetic",
+                "revisions": _browser_revisions(candidate.path, warnings),
+                "beneath_worktree": True,
+            }
+        )
+    shared.extend(_cache_diagnostics(worktrees, runner, warnings))
+    shared.extend(_duplicate_browser_revisions(shared))
+    totals: defaultdict[str, int] = defaultdict(int)
+    for data in worktree_data:
+        for category, count in data["categories"].items():
+            totals[category] += count
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repository": str(repo),
+        "git_common_dir": str(common) if common is not None else None,
+        "measurement": _measurement_name(),
+        "worktrees": worktree_data,
+        "shared_caches": shared,
+        "warnings": sorted(set(warnings)),
+        "totals": dict(sorted(totals.items())),
+    }
+
+
+def _human(report: dict[str, Any]) -> str:
+    lines = [
+        f"measurement: {report['measurement']} bytes",
+        "worktree  dependencies  generated  tests  protected  total local",
+    ]
+    for worktree_data in report["worktrees"]:
+        categories = worktree_data["categories"]
+        values = (
+            worktree_data["path"],
+            categories.get("dependencies", 0),
+            categories.get("generated", 0),
+            categories.get("test_artifacts", 0),
+            categories.get("protected", 0),
+            worktree_data["total_local"],
+        )
+        lines.append("{}  {}  {}  {}  {}  {}".format(*values))
+    lines.append("shared storage:")
+    lines.extend(
+        f"  {cache['kind']}: {cache['path']} ({cache['mode']})"
+        for cache in report["shared_caches"]
+    )
+    lines.append("largest cleanup candidates:")
+    display_candidates: list[dict[str, Any]] = sorted(
+        (
+            candidate_data
+            for worktree_data in report["worktrees"]
+            for candidate_data in worktree_data["candidates"]
+        ),
+        key=lambda data: (-data["bytes"], data["path"]),
+    )[:10]
+    for data in display_candidates:
+        recovery = (
+            "expensive" if data["category"] in EXPENSIVE else "cheap"
+        )
+        ignored = "yes" if data["ignored"] else "no"
+        protected = "yes" if data["protected"] else "no"
+        category_flag = str(data["category"]).replace("_", "-")
+        description = (
+            "  {path} [{category}] {bytes} ignored? {ignored} "
+            "protected? {protected} recover: {recovery}".format(
+                path=data["path"],
+                category=data["category"],
+                bytes=data["bytes"],
+                ignored=ignored,
+                protected=protected,
+                recovery=recovery,
+            )
+        )
+        if data["category"] in CATEGORIES:
+            description += f"; dry-run: clean --{category_flag}"
+        else:
+            description += "; cleanup: report only"
+        lines.append(description)
+    lines.extend(f"warning: {warning}" for warning in report["warnings"])
+    return "\n".join(lines)
+
+
+def _is_tracked(relative: Path, tracked: set[Path]) -> bool:
+    return any(
+        path == relative or relative in path.parents
+        for path in tracked
+    )
+
+
+def _is_in_use(candidate: Candidate, locations: list[Path]) -> bool:
+    return any(
+        _under(location, candidate.canonical_path)
+        for location in locations
+    )
+
+
+def _candidate_from_data(data: dict[str, Any]) -> Candidate:
+    path = Path(data["path"])
+    return Candidate(
+        path,
+        str(data["category"]),
+        int(data["bytes"]),
+        path.is_dir(),
+        ignored=bool(data.get("ignored", False)),
+        protected=bool(data.get("protected", False)),
+        git_admin=bool(data.get("git_admin", False)),
+    )
+
+
+def _path_component_reason(
+    candidate: Candidate,
+    root: Path,
+    mount_check: MountCheck,
+) -> str:
+    """Re-stat the candidate path from its registered root without following links."""
+    try:
+        relative = candidate.path.relative_to(root)
+    except ValueError:
+        return "link or root escape"
+    current = root
+    for part in relative.parts:
+        current /= part
+        try:
+            mode = current.lstat().st_mode
+        except OSError:
+            return "path changed or cannot be verified"
+        if stat.S_ISLNK(mode):
+            return "link or root escape"
+        if mount_check(current):
+            return "mount point"
+        junction_check = getattr(current, "is_junction", None)
+        if callable(junction_check) and junction_check():
+            return "junction or root escape"
+    try:
+        resolved = candidate.path.resolve()
+    except OSError:
+        return "path changed or cannot be verified"
+    if resolved != candidate.canonical_path:
+        return "path changed or cannot be verified"
+    if not _under(candidate.canonical_path, root):
+        return "link or root escape"
+    return ""
+
+
+def _subtree_safety_reason(path: Path, mount_check: MountCheck) -> str:
+    """Find protected state or Git administration without following links."""
+    if mount_check(path):
+        return "mount point"
+    try:
+        root_stat = path.lstat()
+    except OSError:
+        return "candidate changed or cannot be verified"
+    if stat.S_ISLNK(root_stat.st_mode):
+        return "link inside candidate"
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return ""
+    root_device = root_stat.st_dev
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(os.scandir(current), key=lambda entry: entry.name)
+        except OSError:
+            return "candidate changed or cannot be verified"
+        for entry in entries:
+            if entry.name == ".git":
+                return "git administration"
+            if entry.name in PROTECTED_ROOTS or entry.name.endswith(
+                (".lock", ".lease")
+            ):
+                return "protected state or lock"
+            child = Path(entry.path)
+            try:
+                child_stat = child.lstat()
+                if child_stat.st_dev != root_device:
+                    return "filesystem boundary"
+                if stat.S_ISLNK(child_stat.st_mode):
+                    return "link inside candidate"
+                if mount_check(child):
+                    return "mount point"
+                junction_check = getattr(child, "is_junction", None)
+                if callable(junction_check) and junction_check():
+                    return "junction inside candidate"
+                if stat.S_ISDIR(child_stat.st_mode):
+                    stack.append(child)
+            except OSError:
+                return "candidate changed or cannot be verified"
+    return ""
+
+
+def _candidate_safety_reason(
+    candidate: Candidate,
+    root: Path,
+    common: Path,
+    protected: set[Path],
+    mount_check: MountCheck,
+) -> str:
+    """Return the complete local safety rejection reason for one candidate."""
+    effective_protection = protected | _protected_paths([])
+    if root in effective_protection:
+        return "protected worktree"
+    if candidate.protected or candidate.path.name in PROTECTED_ROOTS:
+        return "protected state or lock"
+    if candidate.git_admin:
+        return "git administration"
+    path_reason = _path_component_reason(candidate, root, mount_check)
+    if path_reason:
+        return path_reason
+    if (
+        _under(candidate.canonical_path, common)
+        or _under(common, candidate.canonical_path)
+        or ".git" in candidate.path.parts
+    ):
+        return "git administration"
+    subtree_reason = _subtree_safety_reason(candidate.path, mount_check)
+    if subtree_reason:
+        return subtree_reason
+    return _path_component_reason(candidate, root, mount_check)
+
+
+def _current_worktree(repository: Path, runner: Runner) -> Path:
+    """Resolve the registered worktree containing the invocation directory."""
+    current = repository.resolve()
+    _, _, worktrees, _ = discover_worktrees(repository, runner)
+    matches = [
+        worktree.path
+        for worktree in worktrees
+        if _under(current, worktree.path)
+    ]
+    return max(matches, key=lambda path: len(path.parts), default=current)
+
+
+def _append_receipt_summary(
+    lines: list[str],
+    *,
+    selected: int,
+    skipped: int,
+    reclaimed: int,
+    failures: int,
+    remaining: list[tuple[int, Path, str]],
+) -> None:
+    lines.append(
+        f"summary: selected={selected} skipped={skipped} "
+        f"reclaimed={reclaimed} failures={failures}"
+    )
+    lines.append("remaining largest candidates:")
+    ordered = sorted(remaining, key=lambda item: (-item[0], str(item[1])))[:10]
+    if not ordered:
+        lines.append("  none")
+    for size, path, reason in ordered:
+        lines.append(f"  {path}: {size} bytes ({reason})")
+
+
+def clean(
+    repository: Path,
+    categories: set[str],
+    *,
+    apply: bool,
+    include_dependencies: bool,
+    protected: set[Path],
+    selected: list[Path] | None = None,
+    runner: Runner = _run,
+    mount_check: MountCheck | None = None,
+) -> tuple[int, list[str]]:
+    """Print a receipt; delete only candidates passing every safety guard."""
+    lines = ["clean receipt: apply" if apply else "clean receipt: dry run"]
+    selected_count = 0
+    skipped_count = 0
+    reclaimed = 0
+    failure_count = 0
+    remaining: list[tuple[int, Path, str]] = []
+    unsupported = categories - CLEANABLE_CATEGORIES
+    if unsupported:
+        names = ", ".join(sorted(unsupported))
+        lines.append(f"refusing cleanup: unsupported categories: {names}")
+        _append_receipt_summary(
+            lines,
+            selected=0,
+            skipped=0,
+            reclaimed=0,
+            failures=0,
+            remaining=[],
+        )
+        return 2, lines
+    if selected is not None and len(selected) > 1:
+        lines.append("refusing deletion: select exactly one worktree")
+        _append_receipt_summary(
+            lines,
+            selected=0,
+            skipped=0,
+            reclaimed=0,
+            failures=0,
+            remaining=[],
+        )
+        return 2, lines
+    effective_mount_check = mount_check or _default_mount_check()
+    # Scan is safely repository-wide by default. Clean deliberately is not: an
+    # unqualified mutation may inspect only the worktree containing the invocation.
+    invocation_root = _current_worktree(repository, runner)
+    clean_selection = selected or [invocation_root]
+    report = scan(
+        repository,
+        clean_selection,
+        runner,
+        include_ignore_status=False,
+    )
+    lines.extend(f"warning: {warning}" for warning in report["warnings"])
+    common_value = report["git_common_dir"]
+    if not isinstance(common_value, str) or not common_value:
+        lines.append("refusing cleanup: git common directory unavailable")
+        _append_receipt_summary(
+            lines,
+            selected=0,
+            skipped=0,
+            reclaimed=0,
+            failures=0,
+            remaining=[],
+        )
+        return 2, lines
+    if apply and not categories:
+        lines.append("refusing deletion: select at least one category")
+        _append_receipt_summary(
+            lines,
+            selected=0,
+            skipped=0,
+            reclaimed=0,
+            failures=0,
+            remaining=[],
+        )
+        return 2, lines
+    if "dependencies" in categories and not include_dependencies:
+        lines.append("refusing dependency cleanup without --include-dependencies")
+        _append_receipt_summary(
+            lines,
+            selected=0,
+            skipped=0,
+            reclaimed=0,
+            failures=0,
+            remaining=[],
+        )
+        return 2, lines
+    if "dependencies" in categories:
+        protected.add(invocation_root)
+    common = Path(common_value).resolve()
+    in_use_locations = _installed_distribution_locations()
+    for worktree_data in report["worktrees"]:
+        root = Path(worktree_data["path"]).resolve()
+        candidates = [
+            _candidate_from_data(data)
+            for data in worktree_data["candidates"]
+            if data["category"] in categories
+        ]
+        if root in protected:
+            lines.append(f"skipped protected worktree: {root}")
+            lines.extend(
+                f"warning: skipped {candidate.path}: protected worktree"
+                for candidate in candidates
+            )
+            skipped_count += len(candidates)
+            remaining.extend(
+                (candidate.bytes, candidate.path, "protected worktree")
+                for candidate in candidates
+            )
+            continue
+        decisions: list[tuple[Candidate, Path | None, str]] = []
+        git_candidates: list[Candidate] = []
+        for candidate in candidates:
+            reason = _candidate_safety_reason(
+                candidate,
+                root,
+                common,
+                protected,
+                effective_mount_check,
+            )
+            if reason:
+                decisions.append((candidate, None, reason))
+                continue
+            relative = candidate.canonical_path.relative_to(root)
+            git_candidates.append(candidate)
+            decisions.append((candidate, relative, ""))
+        git_status = _mark_git_status(root, git_candidates, runner)
+        if git_status.error:
+            lines.append(f"warning: skipped worktree {root}: {git_status.error}")
+            lines.extend(
+                f"warning: skipped {candidate.path}: {git_status.error}"
+                for candidate in candidates
+            )
+            skipped_count += len(candidates)
+            remaining.extend(
+                (candidate.bytes, candidate.path, git_status.error)
+                for candidate in candidates
+            )
+            continue
+        for candidate, relative, reason in decisions:
+            if not reason and relative is not None:
+                if _is_tracked(relative, git_status.tracked):
+                    reason = "tracked"
+                elif relative not in git_status.ignored:
+                    reason = "not ignored"
+                elif _is_in_use(candidate, in_use_locations):
+                    reason = "installed distribution resolves into target"
+            if reason:
+                lines.append(f"warning: skipped {candidate.path}: {reason}")
+                skipped_count += 1
+                remaining.append((candidate.bytes, candidate.path, reason))
+                continue
+            lines.append(f"selected {candidate.path}: {candidate.bytes} bytes")
+            selected_count += 1
+            if not apply:
+                remaining.append((candidate.bytes, candidate.path, "dry run"))
+                continue
+            predelete_mount_check = mount_check or _default_mount_check()
+            recheck_reason = _candidate_safety_reason(
+                candidate,
+                root,
+                common,
+                protected,
+                predelete_mount_check,
+            )
+            if recheck_reason:
+                lines.append(
+                    f"aborted {candidate.path}: safety changed: {recheck_reason}"
+                )
+                skipped_count += 1
+                remaining.append(
+                    (candidate.bytes, candidate.path, recheck_reason)
+                )
+                continue
+            try:
+                if candidate.is_dir:
+                    shutil.rmtree(candidate.path)
+                else:
+                    candidate.path.unlink()
+            except OSError as exc:
+                lines.append(f"failure {candidate.path}: {exc}")
+                failure_count += 1
+                remaining.append((candidate.bytes, candidate.path, str(exc)))
+            else:
+                reclaimed += candidate.bytes
+    _append_receipt_summary(
+        lines,
+        selected=selected_count,
+        skipped=skipped_count,
+        reclaimed=reclaimed,
+        failures=failure_count,
+        remaining=remaining,
+    )
+    return 0, lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    scan_parser = subparsers.add_parser(
+        "scan",
+        help="Inspect all registered worktrees without changing them.",
+    )
+    scan_parser.add_argument(
+        "--worktree",
+        type=Path,
+        help="Inspect only this registered worktree.",
+    )
+    scan_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit deterministic JSON instead of the human report.",
+    )
+    clean_parser = subparsers.add_parser(
+        "clean",
+        help="Preview or apply cleanup in exactly one worktree.",
+    )
+    clean_parser.add_argument(
+        "--worktree",
+        type=Path,
+        help="Clean this registered worktree instead of the current one.",
+    )
+    clean_parser.add_argument(
+        "--protect-worktree",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Protect a worktree; repeatable and supplemented by "
+            "WORKTREE_HYGIENE_PROTECT_WORKTREES."
+        ),
+    )
+    clean_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete selected safe candidates; otherwise print a dry run.",
+    )
+    clean_parser.add_argument(
+        "--include-dependencies",
+        action="store_true",
+        help="Acknowledge expensive dependency cleanup.",
+    )
+    clean_parser.add_argument(
+        "--dependencies",
+        action="store_true",
+        help="Select local dependency directories.",
+    )
+    clean_parser.add_argument(
+        "--generated",
+        action="store_true",
+        help="Select reproducible generated output.",
+    )
+    clean_parser.add_argument(
+        "--test-artifacts",
+        action="store_true",
+        help="Select test, coverage, lint, and bytecode artifacts.",
+    )
+    args = parser.parse_args(argv)
+    if args.command == "scan":
+        selected = [args.worktree] if args.worktree else None
+        report = scan(Path.cwd(), selected)
+        if args.json:
+            print(
+                json.dumps(
+                    report,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        else:
+            print(_human(report))
+        return 0
+    categories = {
+        category for category in CATEGORIES if getattr(args, category)
+    }
+    protected = _protected_paths(
+        str(path) for path in args.protect_worktree
+    )
+    current = Path.cwd().resolve()
+    code, lines = clean(
+        current,
+        categories,
+        apply=args.apply,
+        include_dependencies=args.include_dependencies,
+        protected=protected,
+        selected=[args.worktree] if args.worktree else None,
+    )
+    print("\n".join(lines))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_bootstrap.py
+++ b/tools/test_bootstrap.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.repo import bootstrap
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        ("web", [("npm", "ci", "--prefix", "web")]),
+        ("docs-site", [("npm", "ci", "--prefix", "docs-site")]),
+        (
+            "sites",
+            [
+                ("npm", "ci", "--prefix", "web"),
+                ("npm", "ci", "--prefix", "docs-site"),
+            ],
+        ),
+    ],
+)
+def test_profile_has_only_its_declared_npm_commands(
+    profile: str, expected: list[tuple[str, ...]]
+) -> None:
+    assert list(bootstrap.profile_commands(profile)) == expected
+
+
+def _fake_npm(bin_dir: Path) -> Path:
+    if os.name == "nt":
+        executable = bin_dir / "npm.cmd"
+        executable.write_text(
+            "@echo off\r\n"
+            'echo ["%1","%2","%3"]>>"%NPM_TEST_LOG%"\r\n'
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+        return executable
+
+    executable = bin_dir / "npm"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "with open(os.environ['NPM_TEST_LOG'], 'a', encoding='utf-8') as output:\n"
+        "    output.write(json.dumps(sys.argv[1:]) + '\\n')\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return executable
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        ("web", [["ci", "--prefix", "web"]]),
+        ("docs-site", [["ci", "--prefix", "docs-site"]]),
+        (
+            "sites",
+            [
+                ["ci", "--prefix", "web"],
+                ["ci", "--prefix", "docs-site"],
+            ],
+        ),
+    ],
+)
+def test_bootstrap_executes_only_selected_profile_and_creates_no_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+    expected: list[list[str]],
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _fake_npm(bin_dir)
+    log = tmp_path / "npm-commands.jsonl"
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("NPM_TEST_LOG", str(log))
+
+    result = bootstrap.bootstrap(profile, repo_root=tmp_path)
+
+    assert result == 0
+    commands = [json.loads(line) for line in log.read_text().splitlines()]
+    assert commands == expected
+    assert not (tmp_path / ".venv").exists()
+    assert not (tmp_path / "venv").exists()
+
+
+def test_no_profile_errors_with_available_profiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert bootstrap.main([]) == 2
+
+    error = capsys.readouterr().err
+    assert "web, docs-site, sites" in error
+    assert not (tmp_path / ".venv").exists()
+    assert not (tmp_path / "venv").exists()
+
+
+def test_missing_npm_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PATH", "")
+
+    with pytest.raises(bootstrap.BootstrapError, match="npm was not found"):
+        bootstrap.bootstrap("web", repo_root=tmp_path)
+
+    assert not (tmp_path / "web" / "node_modules").exists()
+
+
+def test_unknown_profile_is_actionable() -> None:
+    with pytest.raises(bootstrap.BootstrapError, match="web, docs-site, sites"):
+        bootstrap.profile_commands("all")
+
+
+def test_docs_site_cannot_request_gate_browser(tmp_path: Path) -> None:
+    with pytest.raises(bootstrap.BootstrapError, match="requires the web or sites"):
+        bootstrap.bootstrap(
+            "docs-site", repo_root=tmp_path, install_gate_browser=True
+        )
+
+    assert not (tmp_path / "docs-site" / "node_modules").exists()

--- a/tools/test_frontend_runtime.py
+++ b/tools/test_frontend_runtime.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.repo import frontend_runtime as runtime
+
+
+def _python_gate(output: Path, delay: float = 0.0) -> tuple[str, ...]:
+    code = (
+        "import os,sys,time;"
+        "from pathlib import Path;"
+        "Path(sys.argv[1]).write_text(os.environ['ARR_PREVIEW_PORT']);"
+        "time.sleep(float(sys.argv[2]))"
+    )
+    return (sys.executable, "-c", code, str(output), str(delay))
+
+
+def test_concurrent_gates_lease_different_ports(tmp_path: Path) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    outputs = (tmp_path / "first-port", tmp_path / "second-port")
+
+    def invoke(output: Path) -> int:
+        return runtime.run_gate(
+            environ={},
+            repo_root=tmp_path,
+            common_dir=common_dir,
+            gate_command=_python_gate(output, 0.4),
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(invoke, outputs))
+
+    assert results == [0, 0]
+    assert outputs[0].read_text() != outputs[1].read_text()
+    assert not list((common_dir / runtime.LEASE_DIRECTORY).glob("*.json"))
+
+
+def test_concurrent_acquirers_publish_one_complete_lease_per_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    lease_dir = common_dir / runtime.LEASE_DIRECTORY
+    lease_dir.mkdir()
+    stale_path = lease_dir / "preview-4321.json"
+    stale_path.write_text(
+        json.dumps(
+            {
+                "pid": 999_999_999,
+                "token": "stale-owner",
+                "port": runtime.DEFAULT_PREVIEW_PORT,
+                "created_at": time.time() - runtime.LEASE_MAX_AGE_SECONDS - 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    barrier = threading.Barrier(2)
+    counter_lock = threading.Lock()
+    link_calls = 0
+    real_link = runtime.os.link
+
+    def coordinated_link(source: Path, destination: Path) -> None:
+        nonlocal link_calls
+        if Path(destination).name == "preview-4321.json":
+            payload = json.loads(Path(source).read_text(encoding="utf-8"))
+            assert payload["token"]
+            assert payload["created_at"]
+            with counter_lock:
+                link_calls += 1
+            barrier.wait(timeout=2)
+        real_link(source, destination)
+
+    monkeypatch.setattr(runtime.os, "link", coordinated_link)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(runtime.lease_preview_port, common_dir, None)
+            for _ in range(2)
+        ]
+        leases = [future.result() for future in futures]
+
+    try:
+        assert len({lease.port for lease in leases}) == 2
+        assert link_calls >= 2
+        lease_files = list(lease_dir.glob("*.json"))
+        assert {path.name for path in lease_files} == {
+            f"preview-{lease.port}.json" for lease in leases
+        }
+        for lease in leases:
+            payload = json.loads(lease.path.read_text(encoding="utf-8"))
+            assert payload["token"] == lease.token
+    finally:
+        for lease in leases:
+            lease.release()
+
+
+def test_young_empty_lease_is_not_stolen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lease_dir = tmp_path / runtime.LEASE_DIRECTORY
+    lease_dir.mkdir()
+    path = lease_dir / f"preview-{runtime.DEFAULT_PREVIEW_PORT}.json"
+    path.touch()
+    monkeypatch.setattr(runtime, "LEASE_RETRY_LIMIT", 2)
+    monkeypatch.setattr(runtime, "LEASE_RETRY_DELAY_SECONDS", 0)
+
+    with pytest.raises(runtime.FrontendRuntimeError, match="remained unreadable"):
+        runtime.PortLease.try_acquire(tmp_path, runtime.DEFAULT_PREVIEW_PORT)
+
+    assert path.exists()
+    assert path.read_bytes() == b""
+
+
+def test_old_empty_lease_is_reclaimable(tmp_path: Path) -> None:
+    lease_dir = tmp_path / runtime.LEASE_DIRECTORY
+    lease_dir.mkdir()
+    path = lease_dir / f"preview-{runtime.DEFAULT_PREVIEW_PORT}.json"
+    path.touch()
+    old = time.time() - runtime.LEASE_MAX_AGE_SECONDS - 1
+    os.utime(path, (old, old))
+
+    lease = runtime.PortLease.try_acquire(tmp_path, runtime.DEFAULT_PREVIEW_PORT)
+
+    assert lease is not None
+    try:
+        assert json.loads(path.read_text(encoding="utf-8"))["token"] == lease.token
+    finally:
+        lease.release()
+
+
+def test_live_pid_lease_is_reclaimed_after_age_threshold(tmp_path: Path) -> None:
+    lease = runtime.PortLease.try_acquire(tmp_path, runtime.DEFAULT_PREVIEW_PORT)
+    assert lease is not None
+    payload = json.loads(lease.path.read_text(encoding="utf-8"))
+    payload["pid"] = os.getpid()
+    payload["created_at"] = time.time() - runtime.LEASE_MAX_AGE_SECONDS - 1
+    lease.path.write_text(json.dumps(payload), encoding="utf-8")
+
+    replacement = runtime.PortLease.try_acquire(
+        tmp_path, runtime.DEFAULT_PREVIEW_PORT
+    )
+
+    assert replacement is not None
+    try:
+        assert replacement.token != lease.token
+        assert json.loads(replacement.path.read_text(encoding="utf-8"))[
+            "created_at"
+        ]
+    finally:
+        replacement.release()
+
+
+def test_occupied_default_port_is_not_leased(tmp_path: Path) -> None:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        try:
+            listener.bind(("127.0.0.1", runtime.DEFAULT_PREVIEW_PORT))
+            listener.listen()
+        except OSError:
+            pass
+
+        lease = runtime.lease_preview_port(tmp_path, requested=None)
+        try:
+            assert lease.port != runtime.DEFAULT_PREVIEW_PORT
+        finally:
+            lease.release()
+    finally:
+        listener.close()
+
+
+@pytest.mark.parametrize("value", ["bad", "1.5", "0", "-1", "65536", ""])
+def test_invalid_arr_preview_port_has_no_fallback_or_lease(
+    tmp_path: Path, value: str
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+
+    with pytest.raises(runtime.FrontendRuntimeError, match="ARR_PREVIEW_PORT"):
+        runtime.run_gate(
+            environ={"ARR_PREVIEW_PORT": value},
+            repo_root=tmp_path,
+            common_dir=common_dir,
+            gate_command=(sys.executable, "-c", "raise SystemExit(0)"),
+        )
+
+    assert not (common_dir / runtime.LEASE_DIRECTORY).exists()
+
+
+def test_valid_arr_preview_port_is_honoured(tmp_path: Path) -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    probe.close()
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    output = tmp_path / "selected-port"
+
+    result = runtime.run_gate(
+        environ={"ARR_PREVIEW_PORT": str(port)},
+        repo_root=tmp_path,
+        common_dir=common_dir,
+        gate_command=_python_gate(output),
+    )
+
+    assert result == 0
+    assert output.read_text() == str(port)
+
+
+def test_gate_failure_exit_code_is_propagated_and_lease_released(
+    tmp_path: Path,
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+
+    result = runtime.run_gate(
+        environ={},
+        repo_root=tmp_path,
+        common_dir=common_dir,
+        gate_command=(sys.executable, "-c", "raise SystemExit(23)"),
+    )
+
+    assert result == 23
+    assert not list((common_dir / runtime.LEASE_DIRECTORY).glob("*.json"))
+
+
+def test_signal_handlers_are_installed_before_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signum = getattr(signal, "SIGTERM", None)
+    if signum is None:
+        pytest.skip("SIGTERM is unavailable on this platform")
+    previous = signal.getsignal(signum)
+    observed: dict[str, object] = {}
+
+    class FakeChild:
+        pid = 12345
+
+        def wait(self) -> int:
+            return 0
+
+    def fake_popen(*_args: object, **kwargs: object) -> FakeChild:
+        assert signal.getsignal(signum) is not previous
+        observed.update(kwargs)
+        return FakeChild()
+
+    monkeypatch.setattr(runtime.subprocess, "Popen", fake_popen)
+
+    assert runtime._run_child(("gate",), {}, tmp_path) == 0
+    assert signal.getsignal(signum) is previous
+    if os.name == "nt":
+        assert observed["creationflags"]
+    else:
+        assert observed["start_new_session"] is True
+
+
+def test_spawn_failure_restores_signal_handlers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signum = getattr(signal, "SIGTERM", None)
+    if signum is None:
+        pytest.skip("SIGTERM is unavailable on this platform")
+    previous = signal.getsignal(signum)
+
+    def fail_spawn(*_args: object, **_kwargs: object) -> None:
+        assert signal.getsignal(signum) is not previous
+        raise FileNotFoundError
+
+    monkeypatch.setattr(runtime.subprocess, "Popen", fail_spawn)
+
+    with pytest.raises(runtime.FrontendRuntimeError, match="was not found"):
+        runtime._run_child(("missing-gate",), {}, tmp_path)
+    assert signal.getsignal(signum) is previous
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows SIGTERM forcibly ends subprocesses")
+def test_gate_sigterm_terminates_descendants_and_releases_lease(
+    tmp_path: Path,
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    repo_root = Path(__file__).resolve().parent.parent
+    grandchild_pid_path = tmp_path / "grandchild-pid"
+    child_code = (
+        "import subprocess,sys,time;"
+        "from pathlib import Path;"
+        "child=subprocess.Popen((sys.executable,'-c','import time; time.sleep(30)'));"
+        "Path(sys.argv[1]).write_text(str(child.pid));"
+        "time.sleep(30)"
+    )
+    wrapper_code = (
+        "import sys;"
+        "from pathlib import Path;"
+        "from tools.repo.frontend_runtime import run_gate;"
+        "raise SystemExit(run_gate("
+        f"environ={{}},repo_root=Path({str(repo_root)!r}),"
+        f"common_dir=Path({str(common_dir)!r}),"
+        f"gate_command=(sys.executable,'-c',{child_code!r},"
+        f"{str(grandchild_pid_path)!r})))"
+    )
+    wrapper = subprocess.Popen(
+        (sys.executable, "-c", wrapper_code),
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    lease_dir = common_dir / runtime.LEASE_DIRECTORY
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and (
+        not list(lease_dir.glob("*.json")) or not grandchild_pid_path.exists()
+    ):
+        time.sleep(0.02)
+    assert list(lease_dir.glob("*.json")), "wrapper did not acquire a lease"
+    assert grandchild_pid_path.exists(), "gate parent did not spawn its child"
+    grandchild_pid = int(grandchild_pid_path.read_text())
+
+    wrapper.send_signal(signal.SIGTERM)
+    wrapper.communicate(timeout=5)
+
+    assert wrapper.returncode == 128 + signal.SIGTERM
+    assert not list(lease_dir.glob("*.json"))
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and runtime._pid_is_alive(grandchild_pid):
+        time.sleep(0.02)
+    assert not runtime._pid_is_alive(grandchild_pid)
+
+
+def test_stale_dead_owner_lease_is_reclaimed(tmp_path: Path) -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    probe.close()
+    lease_dir = tmp_path / runtime.LEASE_DIRECTORY
+    lease_dir.mkdir()
+    path = lease_dir / f"preview-{port}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "pid": 999_999_999,
+                "token": "stale-owner",
+                "port": port,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    lease = runtime.lease_preview_port(tmp_path, requested=port)
+    try:
+        assert json.loads(path.read_text(encoding="utf-8"))["token"] == lease.token
+    finally:
+        lease.release()
+    assert not path.exists()
+
+
+def test_release_preserves_replacement_owner_lease(tmp_path: Path) -> None:
+    lease = runtime.PortLease.try_acquire(tmp_path, runtime.DEFAULT_PREVIEW_PORT)
+    assert lease is not None
+    replacement_token = "replacement-owner"
+    lease.path.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "token": replacement_token,
+                "port": lease.port,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    lease.release()
+
+    assert lease.path.exists()
+    assert json.loads(lease.path.read_text(encoding="utf-8"))["token"] == (
+        replacement_token
+    )
+
+    replacement = runtime.PortLease(
+        port=lease.port,
+        path=lease.path,
+        token=replacement_token,
+    )
+    replacement.release()
+    assert not lease.path.exists()
+
+
+def test_missing_npm_is_actionable_and_creates_no_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    monkeypatch.setenv("PATH", "")
+
+    with pytest.raises(runtime.FrontendRuntimeError, match="npm was not found"):
+        runtime.run_gate(environ=os.environ, repo_root=tmp_path, common_dir=common_dir)
+
+    assert not (common_dir / runtime.LEASE_DIRECTORY).exists()
+
+
+def test_missing_playwright_is_actionable(tmp_path: Path) -> None:
+    with pytest.raises(runtime.FrontendRuntimeError, match="Playwright is not installed"):
+        runtime.install_browsers(environ={}, repo_root=tmp_path)
+
+
+def test_install_browsers_runs_only_chromium(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    executable_name = "playwright.cmd" if os.name == "nt" else "playwright"
+    executable = repo_root / "web" / "node_modules" / ".bin" / executable_name
+    executable.parent.mkdir(parents=True)
+    log = tmp_path / "playwright-log"
+    if os.name == "nt":
+        executable.write_text(
+            "@echo off\r\n"
+            'echo %*^|%PLAYWRIGHT_BROWSERS_PATH%>"%PLAYWRIGHT_TEST_LOG%"\r\n'
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+    else:
+        executable.write_text(
+            f"#!{sys.executable}\n"
+            "import os, sys\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['PLAYWRIGHT_TEST_LOG']).write_text(\n"
+            "    '|'.join(sys.argv[1:]) + '|' + "
+            "os.environ['PLAYWRIGHT_BROWSERS_PATH'], encoding='utf-8'\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+    monkeypatch.setenv("PLAYWRIGHT_TEST_LOG", str(log))
+    cache = tmp_path / "shared-browser-cache"
+
+    result = runtime.install_browsers(
+        browsers_path=str(cache), environ=os.environ, repo_root=repo_root
+    )
+
+    assert result == 0
+    assert log.read_text(encoding="utf-8") == f"install|chromium|{cache}"
+
+
+def test_production_gate_command_remains_pinned() -> None:
+    assert runtime.GATE_COMMAND == (
+        "npm",
+        "run",
+        "test:e2e:gate",
+        "--prefix",
+        "web",
+    )
+
+
+def test_browser_cache_cli_path_has_highest_precedence(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    cache = runtime.resolve_browser_cache(
+        str(tmp_path / "explicit"),
+        environ={
+            "ARR_PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "arr"),
+            "PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "playwright"),
+        },
+        repo_root=repo_root,
+    )
+
+    assert cache.path == (tmp_path / "explicit").resolve()
+    assert cache.source == "explicit --browsers-path"
+
+
+def test_browser_cache_arr_path_precedes_playwright_path(tmp_path: Path) -> None:
+    cache = runtime.resolve_browser_cache(
+        environ={
+            "ARR_PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "arr"),
+            "PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "playwright"),
+        },
+        repo_root=tmp_path / "repo",
+    )
+
+    assert cache.path == (tmp_path / "arr").resolve()
+    assert cache.source == "ARR_PLAYWRIGHT_BROWSERS_PATH"
+
+
+def test_browser_cache_uses_non_hermetic_playwright_path(tmp_path: Path) -> None:
+    cache = runtime.resolve_browser_cache(
+        environ={"PLAYWRIGHT_BROWSERS_PATH": str(tmp_path / "playwright")},
+        repo_root=tmp_path / "repo",
+    )
+
+    assert cache.path == (tmp_path / "playwright").resolve()
+    assert cache.source == "PLAYWRIGHT_BROWSERS_PATH"
+
+
+def test_browser_cache_uses_platform_default(tmp_path: Path) -> None:
+    cache = runtime.resolve_browser_cache(environ={}, repo_root=tmp_path)
+
+    assert cache.path == runtime._platform_browser_cache({}).resolve()
+    assert cache.source == "platform default"
+
+
+def test_hermetic_playwright_path_warns_and_uses_default(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache = runtime.resolve_browser_cache(
+        environ={"PLAYWRIGHT_BROWSERS_PATH": "0"}, repo_root=tmp_path
+    )
+    runtime.announce_browser_cache(cache)
+    captured = capsys.readouterr()
+
+    assert cache.source == "platform default"
+    assert "PLAYWRIGHT_BROWSERS_PATH=0" in captured.err
+    assert "node_modules" in captured.err
+
+
+def test_repository_local_browser_cache_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+
+    with pytest.raises(runtime.FrontendRuntimeError, match="inside the repository"):
+        runtime.resolve_browser_cache(
+            str(repo_root / ".cache"), environ={}, repo_root=repo_root
+        )
+
+    assert not repo_root.exists()
+
+
+def test_empty_explicit_browser_cache_is_rejected_without_mutation(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(runtime.FrontendRuntimeError, match="must not be empty"):
+        runtime.resolve_browser_cache("", environ={}, repo_root=tmp_path)
+
+    assert not list(tmp_path.iterdir())

--- a/tools/test_worktree_hygiene.py
+++ b/tools/test_worktree_hygiene.py
@@ -1,0 +1,918 @@
+"""Falsification tests for the worktree hygiene deletion boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Literal
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "repo"))
+import worktree_hygiene as hygiene  # noqa: E402
+
+
+class FakeGit:
+    def __init__(
+        self,
+        root: Path,
+        ignored: set[Path] | None = None,
+        tracked: set[Path] | None = None,
+        worktrees: list[Path] | None = None,
+        common_dir: Path | None = None,
+        fail_command: str = "",
+    ) -> None:
+        self.root = root
+        self.ignored = ignored or set()
+        self.tracked = tracked or set()
+        self.worktrees = worktrees or [root]
+        self.common_dir = common_dir or root / ".git"
+        self.fail_command = fail_command
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del env
+        self.calls.append(argv)
+        if "worktree" in argv:
+            output = "".join(
+                f"worktree {worktree}\0"
+                "HEAD abc\0"
+                "branch refs/heads/test\0\0"
+                for worktree in self.worktrees
+            )
+            return subprocess.CompletedProcess(argv, 0, output, "")
+        if "--literal-pathspecs" in argv and "check-ignore" in argv:
+            path = next(
+                (value for value in (input or "").split("\0") if value),
+                "",
+            )
+            error = (
+                f"fatal: {path}: pathspec magic not supported "
+                "by this command: 'literal'"
+            )
+            return subprocess.CompletedProcess(argv, 128, "", error)
+        if self.fail_command and self.fail_command in argv:
+            error = f"{self.fail_command} fixture failure"
+            code = 2 if self.fail_command == "check-ignore" else 1
+            return subprocess.CompletedProcess(argv, code, "", error)
+        if "rev-parse" in argv:
+            output = str(self.common_dir) + "\n"
+            return subprocess.CompletedProcess(argv, 0, output, "")
+        paths = {
+            Path(value)
+            for value in (input or "").split("\0")
+            if value
+        }
+        if "ls-files" in argv:
+            paths = {
+                Path(value) for value in argv[argv.index("--") + 1 :]
+            }
+        if "ls-files" in argv and "--literal-pathspecs" not in argv:
+            paths = {
+                Path(str(path).removeprefix(":(literal)"))
+                for path in paths
+            }
+        matched = self.ignored if "check-ignore" in argv else self.tracked
+        output = "\0".join(str(path) for path in sorted(paths & matched))
+        suffix = "\0" if output else ""
+        code = 1 if "check-ignore" in argv and not output else 0
+        return subprocess.CompletedProcess(argv, code, output + suffix, "")
+
+
+class WorktreeHygieneTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = (Path(self.temp.name) / "work tree-é").resolve()
+        self.root.mkdir()
+        (self.root / ".git").mkdir()
+        self.fake = FakeGit(self.root, ignored={Path("build")})
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def candidate(self, name: str = "build", content: str = "x") -> Path:
+        path = self.root / name
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "artifact").write_text(content, encoding="utf-8")
+        return path
+
+    def clean(
+        self,
+        category: set[str] | None = None,
+        **kwargs: Any,
+    ) -> tuple[int, list[str]]:
+        return hygiene.clean(
+            self.root,
+            category or {"generated"},
+            apply=kwargs.pop("apply", True),
+            include_dependencies=kwargs.pop("include_dependencies", False),
+            protected=kwargs.pop("protected", set()),
+            runner=self.fake,
+            **kwargs,
+        )
+
+    def clean_with_reported_candidate(
+        self,
+        target: Path,
+        *,
+        protected: bool,
+    ) -> tuple[int, list[str]]:
+        """Run clean against one deliberately shaped scan candidate."""
+        report: dict[str, Any] = {
+            "git_common_dir": str(self.root / ".git"),
+            "warnings": [],
+            "worktrees": [
+                {
+                    "path": str(self.root),
+                    "candidates": [
+                        {
+                            "path": str(target),
+                            "category": "generated",
+                            "bytes": 1,
+                            "ignored": True,
+                            "protected": protected,
+                            "git_admin": False,
+                        }
+                    ],
+                }
+            ],
+        }
+        original = hygiene.scan
+
+        def reported_scan(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            del args, kwargs
+            return report
+
+        hygiene.scan = reported_scan
+        try:
+            return self.clean()
+        finally:
+            hygiene.scan = original
+
+    def assert_guard_reason(
+        self,
+        target: Path,
+        lines: list[str],
+        expected: str,
+        *,
+        phase: Literal["selection", "pre-deletion"],
+    ) -> None:
+        """Assert that *target* was rejected in the expected safety phase."""
+        display_path = str(target.parent.resolve() / target.name)
+        selected = [
+            index
+            for index, line in enumerate(lines)
+            if line.startswith(f"selected {display_path}:")
+        ]
+        all_skipped = [
+            index
+            for index, line in enumerate(lines)
+            if line.startswith(f"warning: skipped {display_path}:")
+        ]
+        all_aborted = [
+            index
+            for index, line in enumerate(lines)
+            if line.startswith(f"aborted {display_path}:")
+        ]
+        skipped = [index for index in all_skipped if expected in lines[index]]
+        aborted = [index for index in all_aborted if expected in lines[index]]
+        if phase == "selection":
+            self.assertTrue(
+                skipped,
+                f"{display_path} was not rejected during selection: {lines}",
+            )
+            self.assertEqual(skipped, all_skipped, "unexpected selection reason")
+            self.assertEqual(selected, [], "selection rejection followed selection")
+            self.assertEqual(all_aborted, [], "selection rejection appeared as an abort")
+        else:
+            self.assertTrue(selected, f"{display_path} was not selected: {lines}")
+            self.assertTrue(aborted, f"{display_path} was not aborted: {lines}")
+            self.assertEqual(aborted, all_aborted, "unexpected pre-deletion reason")
+            self.assertLess(selected[0], aborted[0])
+            self.assertEqual(all_skipped, [], "pre-deletion rejection appeared in selection")
+
+    def assert_selected_candidate(
+        self,
+        target: Path,
+        lines: list[str],
+    ) -> None:
+        """Assert that *target* passed every safety guard and was selected."""
+        display_path = str(target.parent.resolve() / target.name)
+        receipt = "\n".join(lines)
+        self.assertIn(f"selected {display_path}:", receipt)
+        self.assertNotIn(f"warning: skipped {display_path}:", receipt)
+        self.assertNotIn(f"aborted {display_path}:", receipt)
+
+    def test_clean_without_apply_deletes_nothing(self) -> None:
+        target = self.candidate()
+        code, lines = self.clean(apply=False)
+        receipt = "\n".join(lines)
+        self.assertEqual(code, 0)
+        self.assert_selected_candidate(target, lines)
+        self.assertIn("clean receipt: dry run", receipt)
+        self.assertIn("summary: selected=1", receipt)
+        self.assertTrue(target.exists())
+        self.assertIn("remaining largest candidates", receipt)
+
+    def test_clean_defaults_to_current_worktree_only(self) -> None:
+        current = self.candidate()
+        peer = self.root.parent / "peer"
+        peer.mkdir()
+        (peer / ".git").mkdir()
+        peer_candidate = peer / "build"
+        peer_candidate.mkdir()
+        (peer_candidate / "artifact").write_text("x", encoding="utf-8")
+        runner = FakeGit(
+            self.root,
+            ignored={Path("build")},
+            worktrees=[self.root, peer],
+        )
+        code, lines = hygiene.clean(
+            self.root,
+            {"generated"},
+            apply=False,
+            include_dependencies=False,
+            protected=set(),
+            runner=runner,
+        )
+        receipt = "\n".join(lines)
+        self.assertEqual(code, 0)
+        self.assertIn(str(current.resolve()), receipt)
+        self.assertNotIn(str(peer_candidate.resolve()), receipt)
+
+    def test_tracked_build_is_rejected(self) -> None:
+        target = self.candidate()
+        self.fake.tracked = {Path("build")}
+        self.fake.ignored = {Path("build")}
+        _, lines = self.clean()
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(target, lines, "tracked", phase="selection")
+
+    def test_literal_pathspec_candidate_with_tracked_content_is_rejected(self) -> None:
+        target = self.root / ":(literal)foo" / "build"
+        target.mkdir(parents=True)
+        (target / "artifact").write_text("tracked", encoding="utf-8")
+        relative = Path(":(literal)foo/build")
+        self.fake.ignored = {relative}
+        self.fake.tracked = {relative}
+        _, lines = self.clean()
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(target, lines, "tracked", phase="selection")
+
+    def test_literal_pathspec_flag_is_only_used_by_ls_files(self) -> None:
+        self.candidate()
+        hygiene.scan(self.root, runner=self.fake)
+        self.clean(apply=False)
+        ignore_calls = [
+            call for call in self.fake.calls if "check-ignore" in call
+        ]
+        tracked_calls = [call for call in self.fake.calls if "ls-files" in call]
+        self.assertTrue(ignore_calls)
+        self.assertTrue(tracked_calls)
+        self.assertTrue(
+            all("--literal-pathspecs" not in call for call in ignore_calls)
+        )
+        self.assertTrue(
+            all("--literal-pathspecs" in call for call in tracked_calls)
+        )
+
+    def test_ignored_candidate_symlink_outside_is_rejected(self) -> None:
+        outside = self.root.parent / "outside"
+        outside.mkdir()
+        (outside / "keep").write_text("keep", encoding="utf-8")
+        (self.root / "build").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+        safe = self.candidate("dist")
+        self.fake.ignored = {Path("build"), Path("dist")}
+        code, lines = self.clean()
+        self.assertEqual(code, 0)
+        self.assertTrue(outside.exists())
+        self.assertFalse(safe.exists())
+        self.assert_guard_reason(
+            self.root / "build",
+            lines,
+            "link or root escape",
+            phase="selection",
+        )
+
+    def test_mount_point_candidate_is_rejected(self) -> None:
+        target = self.candidate()
+
+        def simulated_mount(path: Path) -> bool:
+            return path == target
+
+        _, lines = self.clean(mount_check=simulated_mount)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "mount point",
+            phase="selection",
+        )
+
+    def test_nested_mount_refuses_candidate_and_continues(self) -> None:
+        target = self.candidate()
+        nested_mount = target / "data"
+        nested_mount.mkdir()
+        nested_content = nested_mount / "keep"
+        nested_content.write_text("outside data", encoding="utf-8")
+        safe = self.candidate("dist")
+        self.fake.ignored = {Path("build"), Path("dist")}
+
+        def simulated_mount(path: Path) -> bool:
+            return path == nested_mount
+
+        _, lines = self.clean(mount_check=simulated_mount)
+        self.assertTrue(target.exists())
+        self.assertTrue(nested_content.exists())
+        self.assertFalse(safe.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "mount point",
+            phase="selection",
+        )
+
+    def test_cross_device_child_refuses_candidate_and_continues(self) -> None:
+        target = self.candidate()
+        boundary = target / "data"
+        boundary.mkdir()
+        nested_content = boundary / "keep"
+        nested_content.write_text("outside data", encoding="utf-8")
+        safe = self.candidate("dist")
+        self.fake.ignored = {Path("build"), Path("dist")}
+        original_lstat = Path.lstat
+
+        def different_device(path: Path) -> os.stat_result:
+            result = original_lstat(path)
+            if path != boundary:
+                return result
+            values = list(result)
+            values[2] = result.st_dev + 1
+            return os.stat_result(values)
+
+        with mock.patch.object(Path, "lstat", different_device):
+            _, lines = self.clean(mount_check=lambda _: False)
+        self.assertTrue(target.exists())
+        self.assertTrue(nested_content.exists())
+        self.assertFalse(safe.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "filesystem boundary",
+            phase="selection",
+        )
+
+    def test_linux_mountinfo_parser_decodes_mount_point(self) -> None:
+        mountinfo = "36 25 0:32 / /tmp/work\\040tree/data rw - ext4 /dev/root rw\n"
+        self.assertEqual(
+            hygiene._parse_mountinfo(mountinfo),
+            {Path("/tmp/work tree/data").resolve()},
+        )
+
+    def test_default_mount_check_uses_one_mountinfo_snapshot(self) -> None:
+        target = self.root / "same-device-bind"
+        target.mkdir()
+        reads = 0
+        original = hygiene._linux_mount_points
+
+        def mount_points() -> set[Path]:
+            nonlocal reads
+            reads += 1
+            return {target}
+
+        hygiene._linux_mount_points = mount_points
+        try:
+            mount_check = hygiene._default_mount_check()
+        finally:
+            hygiene._linux_mount_points = original
+        self.assertTrue(mount_check(target))
+        self.assertTrue(mount_check(target))
+        self.assertEqual(reads, 1)
+
+    def test_mount_snapshot_refreshes_before_each_deletion(self) -> None:
+        target = self.candidate()
+        safe = self.candidate("dist")
+        self.fake.ignored = {Path("build"), Path("dist")}
+        snapshots = 0
+        original = hygiene._default_mount_check
+
+        def mount_snapshot() -> hygiene.MountCheck:
+            nonlocal snapshots
+            snapshots += 1
+            mounted = snapshots > 1
+            return lambda path: mounted and path == target
+
+        hygiene._default_mount_check = mount_snapshot
+        try:
+            _, lines = self.clean()
+        finally:
+            hygiene._default_mount_check = original
+        self.assertTrue(target.exists())
+        self.assertFalse(safe.exists())
+        self.assertEqual(snapshots, 3)
+        self.assert_guard_reason(
+            target,
+            lines,
+            "mount point",
+            phase="pre-deletion",
+        )
+
+    def test_selected_unregistered_and_stale_are_safe(self) -> None:
+        selected = self.root / ".." / "not registered"
+        report = hygiene.scan(self.root, [selected], self.fake)
+        self.assertIn("not registered", " ".join(report["warnings"]))
+        self.assertEqual(report["worktrees"], [])
+
+    def test_porcelain_z_preserves_quote_risk_characters(self) -> None:
+        risky = self.root / 'quote"tab\tback\\slash'
+        payload = (
+            f"worktree {risky}\0"
+            "HEAD abc\0"
+            "detached\0\0"
+        )
+        worktrees = hygiene._parse_porcelain(payload)
+        self.assertEqual(worktrees[0].path, risky.resolve())
+        self.assertTrue(worktrees[0].detached)
+
+    def test_stale_porcelain_record_is_report_only(self) -> None:
+        missing = self.root.parent / "gone"
+        worktree = hygiene.Worktree(
+            missing,
+            prunable="gitdir file points to non-existent location",
+        )
+        result = hygiene.scan_worktree(worktree)
+        self.assertEqual(result.candidates, [])
+
+    def test_unregistered_parent_selection_cannot_delete(self) -> None:
+        target = self.candidate()
+        self.fake.ignored = {Path("build")}
+        outside = self.root.parent / "not-registered"
+        code, lines = self.clean(selected=[outside])
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assertIn(
+            "selected worktree is not registered",
+            "\n".join(lines),
+        )
+
+    def test_candidate_containing_common_dir_is_not_deleted(self) -> None:
+        target = self.candidate()
+        common = target / "common-git-dir"
+        common.mkdir()
+        self.fake = FakeGit(
+            self.root,
+            ignored={Path("build")},
+            common_dir=common,
+        )
+        code, lines = self.clean()
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "git administration",
+            phase="selection",
+        )
+
+    def test_common_dir_discovery_failure_refuses_cleanup(self) -> None:
+        target = self.candidate()
+        runner = FakeGit(
+            self.root,
+            ignored={Path("build")},
+            fail_command="rev-parse",
+        )
+        code, lines = hygiene.clean(
+            self.root,
+            {"generated"},
+            apply=True,
+            include_dependencies=False,
+            protected=set(),
+            runner=runner,
+        )
+        receipt = "\n".join(lines)
+        self.assertEqual(code, 2)
+        self.assertTrue(target.exists())
+        self.assertIn("git common directory unavailable", receipt)
+        self.assertIn("refusing cleanup", receipt)
+        self.assertNotIn(f"selected {target.resolve()}:", receipt)
+
+    def test_candidate_containing_nested_git_is_not_deleted(self) -> None:
+        target = self.candidate()
+        (target / "nested" / ".git").mkdir(parents=True)
+        self.fake.ignored = {Path("build")}
+        scanned = hygiene.scan_worktree(hygiene.Worktree(self.root))
+        build = next(
+            candidate
+            for candidate in scanned.candidates
+            if candidate.path.name == "build"
+        )
+        self.assertTrue(build.git_admin)
+        code, lines = self.clean()
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "git administration",
+            phase="selection",
+        )
+
+    def test_worktree_root_git_directory_is_pruned(self) -> None:
+        hidden_candidate = self.root / ".git" / "build"
+        hidden_candidate.mkdir()
+        result = hygiene.scan_worktree(hygiene.Worktree(self.root))
+        self.assertNotIn(
+            hidden_candidate.resolve(),
+            {candidate.canonical_path for candidate in result.candidates},
+        )
+
+    def test_loop_run_inside_candidate_isolated_guard(self) -> None:
+        target = self.candidate()
+        session = target / ".loop-run"
+        session.mkdir()
+        (session / "state").write_text("active", encoding="utf-8")
+        self.fake.ignored = {Path("build")}
+        code, lines = self.clean()
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected state or lock",
+            phase="selection",
+        )
+
+    def test_lock_inside_candidate_rejects_candidate(self) -> None:
+        target = self.candidate()
+        (target / "worker.lock").write_text("held", encoding="utf-8")
+        self.fake.ignored = {Path("build")}
+        _, lines = self.clean()
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected state or lock",
+            phase="selection",
+        )
+
+    def test_protection_is_reasserted_before_each_mutation(self) -> None:
+        target = self.candidate()
+        safe = self.candidate("dist")
+        self.fake.ignored = {Path("build"), Path("dist")}
+        original = self.fake
+
+        class ProtectingGit(FakeGit):
+            def __call__(
+                inner_self,
+                argv: list[str],
+                *,
+                input: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> subprocess.CompletedProcess[str]:
+                result = original(argv, input=input, env=env)
+                if "ls-files" in argv:
+                    session = target / ".loop-run"
+                    session.mkdir(exist_ok=True)
+                return result
+
+        code, lines = hygiene.clean(
+            self.root,
+            {"generated"},
+            apply=True,
+            include_dependencies=False,
+            protected=set(),
+            runner=ProtectingGit(self.root, self.fake.ignored),
+        )
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assertFalse(safe.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected state or lock",
+            phase="pre-deletion",
+        )
+        self.assertIn("safety changed", "\n".join(lines))
+
+    def test_candidate_safety_predicate_runs_in_both_deletion_phases(self) -> None:
+        target = self.candidate()
+        calls: list[Path] = []
+        original = hygiene._candidate_safety_reason
+
+        def recording_reason(
+            candidate: hygiene.Candidate,
+            root: Path,
+            common: Path,
+            protected: set[Path],
+            mount_check: hygiene.MountCheck,
+        ) -> str:
+            calls.append(candidate.path)
+            return original(
+                candidate,
+                root,
+                common,
+                protected,
+                mount_check,
+            )
+
+        hygiene._candidate_safety_reason = recording_reason
+        try:
+            _, lines = self.clean()
+        finally:
+            hygiene._candidate_safety_reason = original
+        self.assertEqual(calls, [target, target])
+        self.assertFalse(target.exists())
+        self.assert_selected_candidate(target, lines)
+
+    def test_dependency_needs_acknowledgement(self) -> None:
+        target = self.candidate("node_modules")
+        self.fake.ignored = {Path("node_modules")}
+        code, lines = self.clean({"dependencies"})
+        self.assertEqual(code, 2)
+        self.assertTrue(target.exists())
+        self.assertIn(
+            "refusing dependency cleanup without --include-dependencies",
+            "\n".join(lines),
+        )
+
+    def test_shared_cache_category_is_refused_programmatically(self) -> None:
+        target = self.root / ".local-browsers"
+        target.mkdir()
+        (target / "revision").mkdir()
+        self.fake.ignored = {Path(".local-browsers")}
+        code, lines = self.clean({"shared_caches"})
+        receipt = "\n".join(lines)
+        self.assertEqual(code, 2)
+        self.assertTrue(target.exists())
+        self.assertIn("unsupported categories: shared_caches", receipt)
+        self.assertNotIn(f"selected {target}:", receipt)
+
+    def test_protected_category_is_refused_programmatically(self) -> None:
+        target = self.root / ".loop-run"
+        target.mkdir()
+        (target / "state").write_text("keep", encoding="utf-8")
+        self.fake.ignored = {Path(".loop-run")}
+        code, lines = self.clean({"protected"})
+        receipt = "\n".join(lines)
+        self.assertEqual(code, 2)
+        self.assertTrue(target.exists())
+        self.assertIn("unsupported categories: protected", receipt)
+        self.assertNotIn(f"selected {target}:", receipt)
+
+    def test_reported_protected_candidate_flag_is_refused(self) -> None:
+        target = self.candidate()
+        self.fake.ignored = {Path("build")}
+        _, lines = self.clean_with_reported_candidate(target, protected=True)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected state or lock",
+            phase="selection",
+        )
+
+    def test_protected_candidate_name_is_refused(self) -> None:
+        target = self.root / ".context"
+        target.mkdir()
+        (target / "state").write_text("keep", encoding="utf-8")
+        self.fake.ignored = {Path(".context")}
+        _, lines = self.clean_with_reported_candidate(target, protected=False)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected state or lock",
+            phase="selection",
+        )
+
+    def test_nested_invocation_protects_current_dependencies(self) -> None:
+        target = self.candidate("node_modules")
+        nested = self.root / "tools" / "nested"
+        nested.mkdir(parents=True)
+        runner = FakeGit(self.root, ignored={Path("node_modules")})
+        code, lines = hygiene.clean(
+            nested,
+            {"dependencies"},
+            apply=True,
+            include_dependencies=True,
+            protected=set(),
+            runner=runner,
+        )
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "protected worktree",
+            phase="selection",
+        )
+
+    def test_check_ignore_failure_skips_entire_worktree(self) -> None:
+        target = self.candidate()
+        runner = FakeGit(
+            self.root,
+            ignored={Path("build")},
+            fail_command="check-ignore",
+        )
+        code, lines = hygiene.clean(
+            self.root,
+            {"generated"},
+            apply=True,
+            include_dependencies=False,
+            protected=set(),
+            runner=runner,
+        )
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "check-ignore fixture failure",
+            phase="selection",
+        )
+
+    def test_ls_files_failure_skips_entire_worktree(self) -> None:
+        target = self.candidate()
+        runner = FakeGit(
+            self.root,
+            ignored={Path("build")},
+            fail_command="ls-files",
+        )
+        code, lines = hygiene.clean(
+            self.root,
+            {"generated"},
+            apply=True,
+            include_dependencies=False,
+            protected=set(),
+            runner=runner,
+        )
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "ls-files fixture failure",
+            phase="selection",
+        )
+
+    def test_check_ignore_exit_one_reports_individual_not_ignored_reason(self) -> None:
+        target = self.candidate("build", "x" * 10000)
+        self.fake.ignored = set()
+        _, lines = self.clean()
+        receipt = "\n".join(lines)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "not ignored",
+            phase="selection",
+        )
+        self.assertNotIn("git check-ignore failed", receipt)
+
+    def test_json_is_deterministic_and_unicode_safe(self) -> None:
+        self.candidate()
+        options = {
+            "ensure_ascii": False,
+            "sort_keys": True,
+            "separators": (",", ":"),
+        }
+        one = json.dumps(
+            hygiene.scan(self.root, runner=self.fake),
+            **options,
+        )
+        two = json.dumps(
+            hygiene.scan(self.root, runner=self.fake),
+            **options,
+        )
+        self.assertEqual(one, two)
+        self.assertIn("é", one)
+
+    def test_missing_entry_is_warning_not_failure(self) -> None:
+        result = hygiene.ScanResult(hygiene.Worktree(self.root))
+        hygiene._size(self.root / "gone", result.warnings)
+        self.assertTrue(result.warnings)
+
+    def test_traversal_and_git_calls_are_bounded(self) -> None:
+        self.candidate("build")
+        self.candidate("dist")
+        result = hygiene.scan_worktree(hygiene.Worktree(self.root))
+        self.assertEqual(result.traversals, 1)
+        self.fake.ignored = {Path("build"), Path("dist")}
+        self.clean()
+        ignore_calls = sum(
+            "check-ignore" in call for call in self.fake.calls
+        )
+        tracked_calls = sum("ls-files" in call for call in self.fake.calls)
+        self.assertEqual(ignore_calls, 1)
+        self.assertEqual(tracked_calls, 1)
+
+    def test_no_liveness_claim_is_emitted(self) -> None:
+        report = hygiene.scan(self.root, runner=self.fake)
+        encoded = json.dumps(report)
+        self.assertNotIn("live", encoded)
+        self.assertNotIn("active", encoded)
+
+    def test_hermetic_browser_directory_is_report_only(self) -> None:
+        local = self.root / ".local-browsers"
+        local.mkdir()
+        report = hygiene.scan(self.root, runner=self.fake)
+        self.assertEqual(report["shared_caches"][0]["mode"], "hermetic")
+        self.assertEqual(report["worktrees"][0]["total_local"], 0)
+        self.assertTrue(local.exists())
+
+    def test_shared_cache_outside_worktrees_is_diagnostic(self) -> None:
+        worktrees = [hygiene.Worktree(self.root)]
+        caches = hygiene._cache_diagnostics(worktrees, self.fake, [])
+        self.assertFalse(caches[0]["beneath_worktree"])
+
+    def test_duplicate_browser_revision_across_worktrees_is_reported(self) -> None:
+        first = self.root / ".local-browsers" / "chromium-1234"
+        first.mkdir(parents=True)
+        peer = self.root.parent / "peer-browser"
+        second = peer / ".local-browsers" / "chromium-1234"
+        second.mkdir(parents=True)
+        (peer / ".git").mkdir()
+        runner = FakeGit(self.root, worktrees=[self.root, peer])
+        previous = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "0"
+        try:
+            report = hygiene.scan(self.root, runner=runner)
+        finally:
+            if previous is None:
+                os.environ.pop("PLAYWRIGHT_BROWSERS_PATH", None)
+            else:
+                os.environ["PLAYWRIGHT_BROWSERS_PATH"] = previous
+        duplicates = [
+            cache
+            for cache in report["shared_caches"]
+            if cache["kind"] == "playwright-duplicate-revision"
+        ]
+        self.assertEqual(duplicates[0]["revision"], "chromium-1234")
+        self.assertEqual(
+            duplicates[0]["paths"],
+            sorted(
+                [
+                    str(first.parent.resolve()),
+                    str(second.parent.resolve()),
+                ]
+            ),
+        )
+
+    def test_installed_distribution_target_is_not_deleted(self) -> None:
+        peer = self.root.parent / "peer-installed"
+        peer.mkdir()
+        (peer / ".git").mkdir()
+        target = peer / ".venv"
+        target.mkdir()
+        (target / "artifact").write_text("x", encoding="utf-8")
+        distribution_root = target / "lib" / "example"
+        runner = FakeGit(
+            self.root,
+            ignored={Path(".venv")},
+            worktrees=[self.root, peer],
+        )
+
+        class Distribution:
+            def locate_file(self, path: str) -> Path:
+                del path
+                return distribution_root
+
+        original = hygiene.importlib.metadata.distributions
+        hygiene.importlib.metadata.distributions = lambda: [Distribution()]
+        try:
+            code, lines = hygiene.clean(
+                self.root,
+                {"dependencies"},
+                apply=True,
+                include_dependencies=True,
+                protected=set(),
+                selected=[peer],
+                runner=runner,
+            )
+        finally:
+            hygiene.importlib.metadata.distributions = original
+        self.assertEqual(code, 0)
+        self.assertTrue(target.exists())
+        self.assert_guard_reason(
+            target,
+            lines,
+            "resolves into target",
+            phase="selection",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_worktree_hygiene.py
+++ b/tools/test_worktree_hygiene.py
@@ -376,10 +376,12 @@ class WorktreeHygieneTest(unittest.TestCase):
         )
 
     def test_linux_mountinfo_parser_decodes_mount_point(self) -> None:
-        mountinfo = "36 25 0:32 / /tmp/work\\040tree/data rw - ext4 /dev/root rw\n"
+        # `/mnt`, not `/tmp`: this is mountinfo TEXT for the parser, not a real
+        # temp path, and a `/tmp` literal trips bandit B108 in required CI.
+        mountinfo = "36 25 0:32 / /mnt/work\\040tree/data rw - ext4 /dev/root rw\n"
         self.assertEqual(
             hygiene._parse_mountinfo(mountinfo),
-            {Path("/tmp/work tree/data").resolve()},
+            {Path("/mnt/work tree/data").resolve()},
         )
 
     def test_default_mount_check_uses_one_mountinfo_snapshot(self) -> None:

--- a/web/src/test/e2e/site-base.ts
+++ b/web/src/test/e2e/site-base.ts
@@ -19,8 +19,25 @@ export const SITE_BASE: string = String(webConfig.base ?? '').replace(/\/+$/, ''
 /** The docs subtree lives beneath the marketing base (docs-site sets `base` to it). */
 export const DOCS_BASE: string = `${SITE_BASE}/docs`;
 
+function previewPortFromEnvironment(value: string | undefined): number {
+  if (value === undefined || value === '') {
+    return 4321;
+  }
+
+  const requirement = 'ARR_PREVIEW_PORT must be an integer from 1 to 65535';
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${requirement}; received ${JSON.stringify(value)}`);
+  }
+
+  const port = Number(value);
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`${requirement}; received ${JSON.stringify(value)}`);
+  }
+  return port;
+}
+
 /** Port the preview server binds; shared with `playwright.config.ts`'s webServer. */
-export const PREVIEW_PORT = 4321;
+export const PREVIEW_PORT = previewPortFromEnvironment(process.env.ARR_PREVIEW_PORT);
 
 export const PREVIEW_ORIGIN = `http://localhost:${PREVIEW_PORT}`;
 

--- a/web/src/test/site-base.test.ts
+++ b/web/src/test/site-base.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function previewPort(value: string | undefined): Promise<number> {
+  vi.resetModules();
+  if (value === undefined) {
+    vi.stubEnv('ARR_PREVIEW_PORT', undefined);
+  } else {
+    vi.stubEnv('ARR_PREVIEW_PORT', value);
+  }
+  return (await import('./e2e/site-base')).PREVIEW_PORT;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe('PREVIEW_PORT', () => {
+  it('defaults to 4321 when ARR_PREVIEW_PORT is unset', async () => {
+    expect(await previewPort(undefined)).toBe(4321);
+  });
+
+  it('defaults to 4321 when ARR_PREVIEW_PORT is empty', async () => {
+    expect(await previewPort('')).toBe(4321);
+  });
+
+  it('honours a valid ARR_PREVIEW_PORT override', async () => {
+    expect(await previewPort('49152')).toBe(49152);
+  });
+
+  it.each(['not-a-number', '1.5', '0', '-1', '65536'])(
+    'rejects invalid ARR_PREVIEW_PORT %j',
+    async (value) => {
+      await expect(previewPort(value)).rejects.toThrow(
+        `ARR_PREVIEW_PORT must be an integer from 1 to 65535; received ${JSON.stringify(value)}`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
Two tasks against `docs/specs/worktree-runtime-hygiene/spec.md`.

## Why

Nine parallel worktrees share one machine. **Concurrency, not disk, is the problem** — measured before building anything:

| | |
|---|---|
| All worktrees combined | ~2% of a 402 GB volume |
| Playwright browsers | **already shared once** — one build per browser, revision pinned by `playwright-core` 1.62.0 |
| Genuinely duplicated | only `node_modules` — 569 MB × 4 bootstrapped worktrees |

So this ships measurement, a conservative deletion boundary, and collision-free concurrency — not a reclamation sweep. Byte accounting is diagnostic output.

## Task 1 — `worktree_hygiene.py` (`51135b88`, `e6a8f594`)

`scan` classifies bytes per worktree and labels whether it measured **allocated or logical** bytes, since sparse files and APFS clones diverge by >2× and an unlabelled total is a false claim.

`clean` is dry-run by default and **confined to the current worktree** — "every worktree" is deliberately inexpressible, making the cross-worktree accident *unrepresentable*. Real deletion needs `--apply` + a category; dependencies need `--include-dependencies`.

Refuses: symlink / junction / mount-point / filesystem-boundary escapes, the git common dir and nested `.git`, tracked files, non-ignored paths, `.loop-run` / `.context`, locks, protected worktrees, and paths an installed distribution resolves into.

## Task 2 — `frontend_runtime.py` + `bootstrap.py` (`7841aa80`)

`PREVIEW_PORT` reads `ARR_PREVIEW_PORT`, default 4321, **throwing** on invalid rather than falling back — a silent fallback reintroduces the collision invisibly. `playwright.config.ts` untouched; it already derives everything from that constant.

`gate` leases a port through the **Git common directory**, the one location every linked worktree shares. Proven: three concurrent wrappers take 4321 / 4322 / 4323 and release cleanly.

`bootstrap` installs exactly one profile — `web`, `docs-site`, or `sites`. No implicit "all", so a governance worktree never installs both trees.

## Three bugs that only running it could find

1. `git check-ignore` exits **1** to mean "nothing ignored" — success, not failure.
2. `git check-ignore` **rejects `--literal-pathspecs`**; only `ls-files` accepts it. A review round certified the broken version as correct; one real-repo run caught it.
3. Signalling the child tree from inside the handler **deadlocked the wrapper** — `Popen.wait()` isn't reentrant, and the handler ran on top of the main thread's own wait. The tree died and the process hung, so the lease never released. Handlers now only send.

## Verification

`ruff` · `mypy` · `bandit` (medium/medium) · **81 tests** · `tools/` 831 passed · `lint-spec-status` 0 · `lint-traceability` 0 · roster validation 7 passed (= `main` baseline)

**19 guards mutation-proven** — each disabled independently, suite goes red, tree restored byte-identical.

Real-machine exercise: 13 worktrees scanned, tracked-directory guard fired on genuinely tracked `build/` dirs, three concurrent gates got distinct ports, SIGTERM killed the grandchild and released the lease in 0.01s.

## Deferred, recorded rather than papered over

- A mutator racing the final re-assertion needs a cooperative lease.
- The probe closes its socket before Astro binds, so an unrelated machine-local listener can still take the port in between. Participating wrappers are protected; other processes aren't.
- **No real cleanup performed** — every worktree was in use, which the spec names as a valid outcome.
- The pinned gate surface (`test:e2e:gate`, `pages.yml`) is deliberately untouched; `tools/test-pages-workflow.py` fixes both.