### PR TITLE
docs(architecture): rebuild the architecture map around domains, flows, and state ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 This monorepo publishes a curated catalogue of portable agent-context packs — skills, subagents, commands, hooks, and seed documents — plus the `agentbundle` Python CLI that builds, installs, and verifies them across Claude Code, Codex, Cursor, Copilot, and Gemini CLI; it self-hosts those packs.
 
-Read [the architecture overview](docs/architecture/overview.md) before exploring unfamiliar areas.
+Read [the system model](ARCHITECTURE.md) and [the directory map](docs/architecture/overview.md) before exploring unfamiliar areas.
 
 ## Keeping changes minimal
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,160 @@
+# Architecture
+
+Directory map: [`docs/architecture/overview.md`](docs/architecture/overview.md).
+Normative golden path: `docs/architecture/reference.md`.
+
+## 1. Systems
+
+| System | Responsibility |
+| --- | --- |
+| Catalogue and pack authoring | Defines packs, profiles, primitives, seeds, and pack metadata. |
+| Pack projection and distribution | Renders pack sources into adapter-specific install artifacts and release outputs. |
+| Installation and upgrade | Installs, upgrades, reconciles, or removes projected content under the file-safety contract. |
+| Adapter and runtime integration | Applies the adapter contract to project primitives into each supported agent runtime. |
+| Repository governance and context | Holds contributor context, decisions, proposals, specifications, and current-state documentation. |
+| Work intake and coordination | Normalizes incoming work and routes it into the repository artifact lifecycle. |
+| Execution harness and review | Runs supervised work, records its progress, invokes gates, and hands work to review. |
+| Project knowledge | Captures observations, distils them into durable knowledge, and supports explicit enquiry. |
+| Credentials and trust boundaries | Resolves credentials outside repository content and confines credentialed operations. |
+| Documentation and site publishing | Authors and publishes current documentation; binder publishing is STATUS: PLANNED. |
+
+## 2. Responsibilities
+
+`packs/` owns portable authoring source. `profiles/` composes packs without
+adding primitives. `contracts/` defines portable schemas and adapter contracts.
+
+`packages/agentbundle/` owns the catalogue CLI, build pipeline, adapters,
+projection modes, install commands, and install state. `packages/credbroker/`
+owns in-process credential resolution and local credential storage access.
+
+`docs/`, `guides/`, and `web/` own authored documentation and site content.
+`tools/` owns repository-only validation and publication support.
+
+The core pack provides the session hooks and skills that connect adaptation,
+work intake, knowledge capture, execution, and review in an installed repo.
+
+## 3. Allowed dependency edges
+
+- Pack and profile declarations → declared pack dependencies and `contracts/`.
+- `agentbundle` commands → catalogue tooling and build orchestration.
+- Build orchestration → adapter contract → adapter implementations → projection
+  implementations.
+- Install and upgrade commands → rendered artifacts and install-state writers.
+- Adapter projections → target-runtime files. Target-runtime files do not
+  depend on build internals.
+- Credentialed primitives → `credbroker` public API and declared broker
+  configuration. They do not read credential stores directly.
+- Work-intake adapters → normalized intake → canonical repository artifacts.
+- Execution and review workflows → canonical work artifacts and recorded run
+  state.
+- Site builders and repository tools → authored content and contracts.
+
+No generated projection is an authoring dependency. No pack may infer a
+dependency from another pack's directory. No runtime adapter may become a
+dependency of pack source or of a target runtime.
+
+## 4. State ownership
+
+| State | Location | Write authority | Readers |
+| --- | --- | --- | --- |
+| Pack source and metadata | `packs/<pack>/` | Owning pack maintainers | Catalogue tooling, builders, reviewers |
+| Profile composition | `profiles/` | Profile maintainers | Catalogue and install commands |
+| Portable contracts | `contracts/` | Contract maintainers | Builders, validators, package data projection |
+| Release and self-host projections | `dist/`, `.claude/`, `.codex/`, `.agents/` | `agentbundle` build and self-host commands | Install routes, local agent runtimes, checks |
+| Catalogue configuration | `catalogue.toml` | Catalogue maintainers | Catalogue tooling and self-host build |
+| Installed-content state | install target and `.agentbundle-state.toml` | `agentbundle` install, upgrade, uninstall, and init-state commands | List, diff, reconcile, and upgrade commands |
+| Adaptation marker | `.adapt-install-marker.toml` | `agentbundle install`; `install-marker.py` for plugin and APM routes | `core` session-start hook and `adapt-to-project` |
+| Governance records | `docs/adr/`, `docs/rfc/`, and `docs/specs/` | `new-adr`, `new-rfc`, and `new-spec` | Contributors and reviewers |
+| Canonical work artifacts | `docs/product/` and `docs/specs/` | The workflow that creates the artifact | Workflows, contributors, reviewers |
+| Lifecycle index | `workspace.toml` | `work-intake` and its selected workflow | `workspace-status`, execution, review |
+| Tracker provenance | Canonical artifact and its index entry | The accepting intake workflow | Refresh and reconciliation workflows |
+| Harness phase state | `docs/specs/**/engine-state.json` (gitignored) | `loop-engine.py` | Harness operators |
+| Harness cohort state | `docs/specs/**/state.json` (gitignored) | `loop-cohort.py` | Harness operators |
+| Harness events | `.loop-run/events.jsonl` (ephemeral) | `loop-engine.py` | Harness operators and workspace MCP |
+| Knowledge records | `docs/knowledge/` | `project-knowledge/scripts/knowledge_store.py` | Capture, enquiry, review, and research workflows |
+| Credential material | OS credential store and `~/.agentbundle/credentials.env` | `credbroker` write API | Credential brokers in the invoking process |
+| Authored site content | `guides/`, `web/`, and `docs-site/` | Content maintainers | Site build and documentation checks |
+| Published site output | site build output | Site build | Link, contrast, and publication checks |
+
+## 5. Major flows
+
+1. **Pack source → projection → install.** A pack's `pack.toml`, `.apm/`,
+   plugin metadata, and seeds are discovered by `agentbundle catalogue build`
+   or `agentbundle render`. The build pipeline applies recipes, adapters, and
+   projections. `agentbundle install`, APM, or a plugin route writes the
+   projected content into its target scope.
+2. **Install marker → adaptation.** An install route writes
+   `.adapt-install-marker.toml`. The `core` `session-start.py` hook reads it on
+   a later session and directs the agent to `adapt-to-project`. The
+   `agentbundle adapt` command resolves adaptation markers and reports upstream
+   companions.
+3. **Work intake → context resolution → execution → handoff.** A tracker or
+   local request enters `work-intake`, which classifies it into canonical
+   artifacts and lifecycle membership. `workspace-status` and the execution
+   harness resolve context, `work-loop` performs approved work and gates, then
+   hands the diff and evidence to reviewers or the requesting contributor.
+4. **Scratch → knowledge capture → enquiry.** `project-knowledge` capture
+   admits a strict observation from scratch material. Its distill mode
+   reconciles pending observations into topics under `docs/knowledge/`. Its
+   enquire mode reads committed topics for an explicit question.
+5. **Source change → lint/test/build → publication.** Maintainers change
+   source or authored content. `make ci` lints, tests, and validates the
+   repository. `make build-check` validates projections and repository gates.
+   The site build renders publication output, which publication consumes.
+
+## 6. Extension points
+
+- A new pack adds a `packs/<pack>/pack.toml`, portable primitives, tests, and
+  declared dependencies.
+- A profile composes existing packs without owning new primitives.
+- An adapter is declared in `contracts/adapter.toml` and implemented through
+  the build adapter and projection interfaces.
+- A projection mode is implemented under `agentbundle.build.projections` and
+  selected by an adapter contract.
+- A credential broker implements the credentialed-primitive contract without
+  exposing secret material to repository source or agent context.
+- A work-intake adapter may acquire a source, but it must route content through
+  the normalized intake boundary before repository writes.
+- A site surface is authored in `guides/` or `web/` and published through the
+  existing site build.
+
+## 7. Mechanically enforced invariants
+
+- `agentbundle catalogue verify` verifies projected agent artifacts and adapter
+  conformance.
+- `make build-check` verifies that the self-host projection matches its source
+  inputs.
+- `tools/catalogue/check_contract_parity.py` verifies that portable contracts
+  and bundled contract copies remain byte-identical where required.
+- `tools/lint-pack-test-boundary.py` keeps pack test content out of projected
+  runtime content and keeps pack tests in their owning pack tree.
+- `tools/lint-plugin-membership.py` and `tools/lint-plugin-roster.py` enforce
+  the user-scope plugin publication boundary.
+- `tools/lint-sso-config.py` requires shipped SSO configuration to remain
+  placeholder-shaped and opt-in.
+- `tools/lint-agents-md.py` requires `CLAUDE.md` to remain a symlink to the
+  canonical root `AGENTS.md`.
+- `tools/check-rendered-site-links.py` validates internal links and fragments
+  in rendered site output.
+
+## 8. Deeper current-state pages
+
+- [Directory map](docs/architecture/overview.md)
+- [Catalogue](docs/architecture/catalogue.md) and
+  [pack layout](docs/architecture/pack-layout.md)
+- [Skill and pack format](docs/architecture/skill-and-pack-format.md) and
+  [pack manifest](docs/architecture/pack-manifest.md)
+- [AgentBundle](docs/architecture/agentbundle.md)
+- [Credentials](docs/architecture/credentials.md)
+- [Work intake and artifact routing](docs/architecture/work-intake-and-artifact-routing.md)
+- [Loop infrastructure](docs/architecture/loop-infrastructure.md) and
+  [workspace MCP](docs/architecture/workspace-mcp/design.md)
+- [Knowledge capture](docs/architecture/knowledge-capture.md)
+- [Security architecture](docs/architecture/security.md)
+- [Documentation architecture index](docs/architecture/README.md)
+
+### Planned architecture
+
+- **STATUS: PLANNED** — [Binder publishing](docs/architecture/binder-publishing/README.md)
+  is designed but not implemented. [ADR-0073](docs/adr/0073-zensical-as-the-v1-binder-renderer.md)
+  governs its renderer decision.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -65,14 +65,20 @@ below assigns every kind of doc to exactly one bucket.
                                        └────────────────────────────┘
 ```
 
-Inside `architecture/`, the two docs play opposite roles. `overview.md` is
-**descriptive** — the map of how the code is organized today, read to find
-things. `reference.md` is **normative** — the golden path (stack, building
-blocks, component stereotypes, cross-cutting standards) that new work conforms
-to, the target a feature's low-level design steers by. The map tells you where
-things are; the golden path tells you how new things should be shaped. A thin
-repo has only the map; the golden path appears once there are real architecture
-decisions to hold work to.
+`/ARCHITECTURE.md`, when present, is the concise descriptive system model:
+responsibilities, allowed dependency edges, state ownership, flows, extension
+points, enforced invariants, and deeper current-state links. It is optional;
+add it when a repo has more than one subsystem or a boundary the directory
+tree cannot make clear.
+
+Architecture documents have three roles. `overview.md` is **descriptive** —
+the map of how the code is organized today, read to find things.
+`reference.md` is **normative** — the golden path (stack, building blocks,
+component stereotypes, cross-cutting standards) that new work conforms to, the
+target a feature's low-level design steers by. The system model explains the
+system, the map tells you where things are, and the golden path tells you how
+new things should be shaped. A thin repo has only the map; the golden path
+appears once there are real architecture decisions to hold work to.
 
 The bottom layers cite the upper layers; upper layers do not know about
 lower layers. That's the whole point of the hierarchy.
@@ -99,7 +105,7 @@ maintenance rules differ:
 
 | Class | Files | Rule |
 | --- | --- | --- |
-| **Living** | `CHARTER.md`, `architecture/*`, `product/*`, `guides/*`, active `specs/*` | Must match current reality. Updated in the same PR as any change that affects them. Drift is a bug. |
+| **Living** | `CHARTER.md`, `ARCHITECTURE.md`, `architecture/*`, `product/*`, `guides/*`, active `specs/*` | Must match current reality. Updated in the same PR as any change that affects them. Drift is a bug. |
 | **Frozen** | `adr/*`, shipped `specs/*`, accepted/rejected `rfc/*` | Immutable history. Status fields can change (Accepted → Superseded), bodies cannot. |
 | **Governance** | open `rfc/*` | In flight. Updated through the RFC process, not direct edits. Closes to Frozen on acceptance/rejection. |
 
@@ -592,10 +598,17 @@ what was decided or what's proposed. Each serves a different audience:
 How the code is *currently* organized. Not why (ADRs); not what we want
 (RFCs); what is.
 
+- `ARCHITECTURE.md` — when present, the concise system model: responsibilities,
+  allowed dependency edges, state ownership, flows, extension points,
+  mechanically enforced invariants, and deeper current-state links.
 - `overview.md` — the map of the monorepo. What's in `apps/`, `packages/`,
   `tools/`, and how they relate.
 - `<subsystem>.md` — one file per non-trivial subsystem. Describes the
   structure, the entry points, and links to the ADRs that explain why.
+
+`architecture/` holds current state. A designed-but-unbuilt subtree is admitted
+only when its index carries a `STATUS: PLANNED` marker and links to its
+governing decision.
 
 **Why separate from ADRs:** ADRs accumulate; current state has to be
 reconstructed by reading them all in order. `architecture/` is the

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,51 +1,32 @@
 # Architecture
 
-How the code is *currently* organized. Not why (that's in
-[`../adr/`](../adr/)) and not what we want (that's in
-[`../rfc/`](../rfc/)) — **what is**.
+Current repository architecture. Decisions live in [ADRs](../adr/); proposals
+live in [RFCs](../rfc/).
 
-- [`overview.md`](overview.md) — the map of the monorepo. What's in
-  `packages/`, `tools/`, `packs/`, and how they relate. Read this first.
-- [`catalogue.md`](catalogue.md) — what a catalogue *is* on disk, how
-  `agentbundle` resolves one (the five-layer chain), and how to point it
-  at your own. The starting point for standing up your own catalogue.
-- [`skill-and-pack-format.md`](skill-and-pack-format.md) — the format map:
-  the agentskills.io skill standard we conform to, the pack envelope that
-  wraps it, and the projection that fans it out to every agent.
-- [`pack-layout.md`](pack-layout.md) — the canonical shape of a single
-  pack: `pack.toml`, `.claude-plugin/`, `.apm/<primitive>/`, `seeds/`.
-  What each directory contains and how the bundler reads it.
-- [`pack-manifest.md`](pack-manifest.md) — `pack.toml` as the single
-  source of truth for pack metadata, and how the build projects a lossy
-  subset into each route's manifest and the catalogue listing.
-- [`agentbundle.md`](agentbundle.md) — the `agentbundle` Python package:
-  CLI verbs, bundler internals (recipes → adapters → projections), the
-  adapter contract, and the install→adapt chain.
-- [`security.md`](security.md) — the security-review posture: all enforced frameworks
-  (OWASP Top 10:2025 through OWASP Agentic Skills Top 10 v1.0), the three-bucket
-  delegation model, Module index routing, and the shift-left secure-design pass.
-- [`credentials.md`](credentials.md) — the credential-loading subsystem:
-  three-tier storage, the `credbroker` library resolver (RFC-0023, which
-  replaced the build-projected `credentials_shim` of RFC-0013),
-  the four-broker contract (`creds` / `env` / `cli` / `sso-cookie`),
-  the credentialed-primitive model, and the substring trap.
-- [`knowledge-capture.md`](knowledge-capture.md) — the concept-first memory
-  model and its layers: shared capture, distillation, topic lifecycle,
-  file-based storage, explicit enquiry, security, and optional cross-project
-  promotion.
+- [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md) — system model and deeper links.
+- [`overview.md`](overview.md) — directory map.
+- [`catalogue.md`](catalogue.md) — catalogue source and resolution.
+- [`skill-and-pack-format.md`](skill-and-pack-format.md) — skill, pack, and projection formats.
+- [`pack-layout.md`](pack-layout.md) — pack source layout.
+- [`pack-manifest.md`](pack-manifest.md) — pack metadata projection.
+- [`agentbundle.md`](agentbundle.md) — CLI, build, install, and adaptation.
+- [`loop-infrastructure.md`](loop-infrastructure.md) — work-loop execution state and controls.
+- [`work-intake-and-artifact-routing.md`](work-intake-and-artifact-routing.md) — intake, artifacts, and workspace routing.
+- [`workspace-mcp/design.md`](workspace-mcp/design.md) — per-session workspace MCP service.
+- [`security.md`](security.md) — security-review posture.
+- [`credentials.md`](credentials.md) — brokers, storage, and trust boundaries.
+- [`knowledge-capture.md`](knowledge-capture.md) — capture, distillation, and enquiry.
 
-Add one more `<subsystem>.md` whenever a non-trivial subsystem grows up
-that doesn't fit cleanly under an existing page. Each describes the
-structure, the entry points, and links to the ADRs that explain why.
+Architecture docs are a living snapshot. Update them with layout or dependency
+changes.
 
-Architecture docs are the *rolled-up snapshot* — the answer to "what
-does this codebase look like today" without replaying ADR history.
-Lifecycle: living. Update whenever the layout or major dependencies
-change.
-
-Note for contributors: the bundle's source-of-truth split (skills,
-agents, hooks, commands, hook-wiring, and pack seeds all live under
-`packs/<pack>/`) is described in
+The bundle source-of-truth split lives in
 [`../CONVENTIONS.md` § Pack source-of-truth split](../CONVENTIONS.md#pack-source-of-truth-split).
-Anything in this directory documents the *projected* layout adopters
-end up with; the pack-side authoring rules are in CONVENTIONS.
+This directory documents projected adopter layout; pack authoring rules live in
+CONVENTIONS.
+
+## Planned architecture
+
+- **STATUS: PLANNED** — [Binder publishing](binder-publishing/README.md) is
+  designed but not implemented. [ADR-0073](../adr/0073-zensical-as-the-v1-binder-renderer.md)
+  governs its renderer decision.

--- a/docs/architecture/agentbundle.md
+++ b/docs/architecture/agentbundle.md
@@ -1,305 +1,97 @@
-# `agentbundle` — package and bundler
+# AgentBundle
 
-The reference CLI and build pipeline at
-[`packages/agentbundle/`](../../packages/agentbundle/). Stdlib-only,
-zipapp-distributable. One surface in one install: a CLI on PATH
-(`agentbundle <verb>`) that drives pack install, validation, adapt,
-and build. As of 0.2.0 the package no longer exposes a credential-
-resolution module — credentialed primitives resolve credentials through
-the pip-installable `credbroker` library (RFC-0023)
-(see [`credentials.md`](credentials.md)). This page describes the
-package as code; the spec lives in
-[`docs/specs/agent-spec-cli/spec.md`](../specs/agent-spec-cli/spec.md),
-the contract in [`contracts/adapter.toml`](../../contracts/adapter.toml),
-and the *why* in [RFC-0001](../rfc/0001-bundle-distribution-by-adapter-spec.md)
-+ [RFC-0003](../rfc/0003-spec-and-cli.md).
+## 1. Purpose and boundary
 
-## Package shape
+`agentbundle` is the reference CLI and build runtime for catalogue packs. It
+reads pack source, validates contracts, projects adapter-specific artifacts, and
+installs them into an adopter target.
 
-```
-packages/agentbundle/agentbundle/
-├── cli.py                # argparse dispatcher, verb flag rewriting
-├── catalogue.py          # pack discovery + pack.toml loading
-├── config.py             # config resolution
-├── render.py             # in-process renderer (shared with build pipeline)
-├── safety.py             # Tier-1/2/3 enforcement on writes
-├── scope.py              # scope resolution (repo vs user)
-├── version.py            # CLI_VERSION, SPEC_VERSION
-├── commands/             # one module per CLI verb
-├── build/                # the bundler — recipe loader, adapters, projections
-├── _data/                # bundled schemas + install-marker copy
-└── templates/            # canonical install-marker.py (sync source)
+It does not make generated projections authoring source. Pack source remains
+under `packs/`; generated output is rebuilt from it.
 
-(Credential resolution moved out of the wheel: first to the
-build-projected `credentials_shim` per RFC-0013, then to the
-pip-installable `credbroker` library per RFC-0023; see
-[`credentials.md`](credentials.md). The `credentials.py`, `creds/`, and
-`commands/creds.py` surfaces shipped in 0.1.x were removed in 0.2.0.)
-```
+## 2. Entrypoints
 
-## The CLI surface
+`agentbundle show --format json` is the pre-release OKF catalogue-discovery
+surface for one selected pack. `list-packs` remains the catalogue inventory
+surface.
 
-The verbs below are all stdlib-only. The catalogue *source* is never written —
-reads resolve it, and the verbs that touch a working tree write only into the
-install target, the adopter's config, or a catalogue you own. Run
-`agentbundle --help` for the authoritative surface; this table is the map.
+The CLI verbs are `adapt`, `catalogue`, `config`, `diff`, `docs`,
+`init-state`, `install`, `lint`, `list-installed`, `list-packs`,
+`list-profiles`, `list-targets`, `oplog`, `pack`, `pack-config`,
+`package-catalogue`, `reconcile`, `render`, `scaffold`, `show`,
+`uninstall`, `upgrade`, and `validate`.
 
-| Verb | What it does |
-| --- | --- |
-| `list-packs` | Enumerate packs in a catalogue URI (local path or `git+https`). |
-| `list-profiles` | Enumerate the catalogue's curated single-scope install profiles. `install --profile <name>` installs one. |
-| `list-targets` | Print the shipped adapter targets, derived from the runtime registry: `claude_code`, `codex`, `copilot`, `cursor`, `gemini`, `kiro_ide`, `kiro_cli`, and `kiro` (deprecated alias for `kiro_ide`). |
-| `list-installed` | Read state files (both scopes) and report each installed `(pack, adapter)` with its version and an up-to-date / upgrade-available / unknown status. Read-only. |
-| `show` | Show a pack's skills and agents, derived live from its `.apm/` tree; falls back to install state when the catalogue is unresolvable. |
-| `docs` | Read pack documentation from the catalogue source — `index.md` by default, `--list` to enumerate. |
-| `scaffold` | Drop a pack's `seeds/` into `--output`, honouring Tier-1/2/3 file-safety (brownfield governance). |
-| `install` | Project a pack's primitives into the target. Drops `.adapt-install-marker.toml`, chains to `adapt`. |
-| `validate` | Schema + semantic conformance against the bundled schemas. `--strict` runs fixture checks. |
-| `render` | Render a pack to `--output` via the F-build pipeline — byte-identical to `make build`. |
-| `adapt` | Deterministic non-LLM walk: substitute `<adapt:NAME>` markers, report `.upstream.*` companions. |
-| `diff` | Compare the on-disk projection against a fresh render; non-zero on drift. |
-| `upgrade` | Per-pack or per-primitive; honours the file-safety contract. |
-| `uninstall` | Per-pack removal; removes Tier-1 files, preserves Tier-2 and Tier-3. |
-| `init-state` | One-shot hashing of already-installed paths into `.agentbundle-state.toml` (closes the safety gap for APM/plugin routes). |
-| `config` | Get or set adapter-scoped user settings. |
-| `reconcile` | `--scope user` only; read-only orphan reporter over Claude Code `settings.json` and Kiro agent JSONs named in user-scope state (RFC-0005). No `--apply`. |
-| `package-catalogue` | Package a catalogue repository into an Artifactory artifact layout (maintainer/CI only). |
-| `catalogue` | Portable catalogue engine: `lint`, `verify`, `build`, `self-host`, `package`, `sync-defaults`, `init`. |
-| `lint` | Lint commands — `packs` today. |
-| `pack` | Pack-level commands — `evals run` today. |
-| `pack-config` | Per-pack configuration: `get`, `set`, `unset`, `show`. |
-| `oplog` | Pack operation log: `show`, `clear`. |
+`catalogue` provides `lint`, `verify`, `build`, `self-host`,
+`package`, `sync-defaults`, `init`, and `contracts`.
 
-There is no `creds` verb — it went out with the rest of the credential surface
-in 0.2.0 (see [Package shape](#package-shape) above).
+## 3. Owned state and write authority
 
-`show --format json` is also the pre-release OKF catalogue discovery surface for
-one selected pack. On live catalogue reads it adds `pack_metadata`,
-`skill_metadata`, and `knowledge` to the legacy inventory fields; on
-installed-state fallback those three fields are `null` because state files do
-not retain source metadata. The discovery data is excluded from `list-packs`,
-Claude marketplace output, and `catalogue-index.json`; those remain cross-pack
-inventory/publication surfaces with their existing contracts.
+The build writes Claude marketplace output and `catalogue-index.json` as
+cross-pack generated artifacts. `show --format json` discovery data is excluded
+from both outputs.
 
-OKF authoring is also pre-release and remains outside the AgentBundle runtime
-CLI. Maintainers run the `compile-okf` Skill from the `catalogue-curation` pack
-against local pack source; normal AgentBundle install, render, and adapter
-projection paths consume the resulting ordinary `.apm/skills/` files without
-adding a base runtime dependency or an OKF-specific primitive.
+| State | Location | Write authority | Readers |
+| --- | --- | --- | --- |
+| Pack source | `packs/<pack>/` | Pack maintainers | Catalogue and build commands |
+| Portable contracts | `contracts/` | Contract maintainers | Validators and build runtime |
+| Projection output | `dist/`, `.claude/`, `.codex/`, `.agents/` | Catalogue build and self-host commands | Install routes and agent runtimes |
+| Install state | `.agentbundle-state.toml` | Install, upgrade, uninstall, and init-state commands | List, diff, reconcile, and upgrade |
+| Adaptation marker | `.adapt-install-marker.toml` | `agentbundle install` or `install-marker.py` | Core session-start and adapt workflows |
 
-`cli.py` rewrites unknown verb flags into a contract-shaped error message
-("unknown flag `--foo` for `install`") so every wrapper around the CLI sees
-the same shape.
+## 4. Dependencies and allowed edges
 
-## The bundler — `agentbundle.build`
+Commands call catalogue tooling and the build runtime. The build runtime reads
+`contracts/adapter.toml`, then runs adapters and projection modes.
 
-The bundler is what turns `packs/<pack>/` source into `dist/<route>/<pack>/`
-output and into the self-host overlay on this repo. The pipeline:
+The adapter layer contains Claude Code, Codex, Copilot, Cursor, Gemini, Kiro,
+Kiro CLI, and Kiro IDE adapters. Projection implementations write target-runtime
+files; target-runtime files do not depend on build internals.
 
-```
-packs/                                dist/
-  <pack>/                               apm/<pack>/                  ← per-pack APM
-    pack.toml                           claude-plugins/<pack>/       ← per-pack plugin
-    .claude-plugin/plugin.json          claude-plugins/marketplace.json
-    .apm/{skills,agents,hooks,commands}
-    seeds/                            <repo>/.claude/ + CLAUDE.md    ← Claude self-host (claude-code)
-                                      <repo>/.codex/ + .agents/      ← Codex self-host (codex)
-                                      <repo>/.kiro/                  ← Kiro self-host (kiro-ide / kiro-cli)
-```
+Install and upgrade commands write only their target, state, and permitted
+configuration. The catalogue source is read-only to consumer commands.
 
-> Self-host output is determined by the effective adapter set. When `catalogue.toml` sets
-> `preferred-adapter` to an adapter not in the default `SELF_HOST_ADAPTERS` list (e.g. `kiro-ide`),
-> only that adapter's folder is projected and `CLAUDE.md` / `.claude-plugin/marketplace.json` are
-> omitted. When `preferred-adapter` is absent or names an adapter already in `SELF_HOST_ADAPTERS`,
-> the default set (claude-code + codex) is used.
+## 5. Primary flows
 
-1. **Recipe load.** [`build/recipes/`](../../packages/agentbundle/agentbundle/build/recipes/)
-   carries the canonical seven recipes — `per-pack-claude-plugin.toml`,
-   `per-pack-apm-package.toml`, `marketplace.toml`, `per-pack-overlay.toml`,
-   `composite-agents-md.toml`, `composite-marketplace.toml`, `self-host.toml`.
-   Each has a `type` ∈ {`per-pack`, `aggregate`, `overlay`, `composite`}.
-2. **Pack discovery.** `catalogue.py` globs `--packs-dir`, validates each
-   `pack.toml` against [`pack.schema.json`](../../packages/agentbundle/agentbundle/_data/pack.schema.json),
-   and rejects pack-internal name collisions before any adapter runs.
-3. **Per-pack render.** For each pack, the dispatcher in
-   [`build/main.py`](../../packages/agentbundle/agentbundle/build/main.py)
-   asks the contract which adapters to run, then calls
-   [`build/adapters/`](../../packages/agentbundle/agentbundle/build/adapters/)
-   (`claude_code`, `codex`, `copilot`, `cursor`, `gemini`, `kiro_ide`,
-   `kiro_cli`, and `kiro` — the deprecated alias for `kiro_ide`) which delegate to
-   [`build/projections/`](../../packages/agentbundle/agentbundle/build/projections/).
-4. **Aggregation.** `marketplace.json` lists a plugin entry for every
-   *user-capable* pack — the Claude-plugin route installs at user scope, so a
-   pack whose `allowed-scopes` omits `user` is not listed
-   (`docs/specs/claude-plugin-route-scope`).
-5. **Self-host overlay.** `make build-self` runs `self-host.toml` against
-   this repo's root. The effective adapter set — which folders are written —
-   is determined by `preferred-adapter` in `catalogue.toml`; see the diagram
-   note above for the conditionality rules.
-   `make build-check` runs the same dry-run as a CI gate that fails on
-   any byte-divergence between source and projection — the single biggest
-   source of CI noise, so the error message names the seed path you
-   should have edited. On Windows (no `make`), run the make-free repo-native
-   scripts directly: `python tools/repo/build_gate_chain.py build-self` (add
-   `--dry-run` for the diff) and
-   `python tools/repo/build_gate_chain.py build-check`. The build-check chain
-   runs portable `agentbundle catalogue verify` once, materializes `dist/` with
-   `agentbundle catalogue build`, then runs the repository pre-PR aggregator
-   without repeating portable verification, followed by the remaining ordered
-   repository policy gates. Standalone `make pre-pr` and
-   `python tools/catalogue/pre_pr_catalogue.py` remain verification-first.
-   `make build-check` delegates that complete Windows-clean sequence to the
-   Python chain, then appends ADR-0017's conditional SAST/SCA leg. The
-   Windows-incompatible scanner leg therefore remains exclusive to the Make
-   target; the reusable portable checks stay in the published engine while
-   repository-only policy wiring stays under `tools/`, as required by ADR-0056.
+1. Catalogue build discovers pack manifests, validates them, and renders
+   adapter-specific artifacts into `dist/` or the self-host overlay.
+2. Install projects selected pack content into the resolved target and records
+   install state.
+3. Every install route writes an adaptation marker. Core session start reads it
+   and routes the next session to adaptation.
+4. Upgrade, uninstall, diff, reconcile, and init-state operate against recorded
+   install state and target content.
 
-### The adapter contract
+## 6. Failure and recovery behavior
 
-The contract is published, semver'd, and lives at
-[`contracts/adapter.toml`](../../contracts/adapter.toml). Currently
-**v0.18** (Claude-plugin hook parity; v0.17 added RFC-0052's shared-prefix
-registry). No published pack targets the
-latest contract: each pins the *minimum* version whose behaviour it
-needs, and the pinned values today spread across the v0.7–v0.13 range.
-Pack versions and contract versions are independent; bumping a pack only
-matters when it consumes a feature added past its current target.
-The contract declares:
+Contract or manifest validation failure stops projection. File-safety rules
+preserve protected target content during install, upgrade, and uninstall.
 
-- **Primitives**: the pack-authored `skill`, `agent`, `hook-body`,
-  `hook-wiring`, and `command`, plus `kiro-ide-hook` (activated at v0.9
-  for the Kiro IDE adapter, per RFC-0005) and the projection-support
-  types `shared-libs`, `adapter-root-bins`, and `user-libs`. The
-  authoritative list is the `[primitive.*]` tables in the contract.
-- **Projection modes** drive how each primitive lands per adapter.
-  The schema enum at
-  [`adapter.schema.json`](../../packages/agentbundle/agentbundle/_data/adapter.schema.json)
-  is the authoritative list. Alongside the portable modes
-  (`direct-directory`, `direct-file`, `merge-json`,
-  `merge-into-agent-json`, `user-merge-json`, `instruction-file`,
-  `managed-block-inline`, `degraded-info-log`, `dropped`) it carries the
-  adapter-specific `codex-agent-toml` (v0.8), `copilot-agent-md` and
-  `copilot-hooks-json` (v0.10), and `gemini-command-toml` (v0.13).
-  `managed-block-inline` survives only as
-  the Codex one-shot migration helper in
-  [`adapters/codex.py`](../../packages/agentbundle/agentbundle/build/adapters/codex.py)
-  (scheduled for removal per RFC-0009), and `degraded-info-log` has no
-  live caller after RFC-0005 lifted Kiro `hook-wiring` out of it.
-- **`install-routes`** array per adapter — `cli`, `claude-plugins`, `apm`.
-  Only `claude-code` declares it; the other adapters install via the CLI
-  route alone.
-- **Claude-plugin route fields** (v0.18) — `hook-body.plugin-target-path`
-  places executable bodies under the plugin root, while
-  `hook-wiring.plugin-mode = "dropped"` prevents a dead settings file after
-  the wiring has been compiled into the derived plugin manifest.
-- **`[adapter.<name>.scope]`** table — `repo`, `user`, and
-  `allowed-prefixes.{repo,user}`. Every shipped adapter declares a
-  user-scope root (`~`) today; what differs is the prefix set it may write
-  beneath it — `.claude/` for `claude-code`, `.kiro/` for the Kiro
-  adapters, and the shared `.agents/skills/` home for `codex` (added in
-  v0.6 per RFC-0011), which `cursor`, `gemini`, and `copilot` joined at
-  v0.17 alongside their own native prefixes. Copilot gained its user
-  scope at v0.10 and is no longer repo-only. Every adapter also declares
-  `.agentbundle/` so credentialed packs can reach the broker.
-- **`[contract.shared-prefixes]`** registry (v0.17) — classifies each
-  allowed-prefix as *shared* (named here, with its reader cohort) or
-  *private* (absent). It is what lets one pack coexist across adapters
-  that write the same path.
-- **`[pack.install]`** table on packs — `default-scope` ∈ `{repo, user}`,
-  `allowed-scopes`, and (v0.6+) the optional `allowed-adapters` array
-  declaring which user-scope-capable adapters a pack travels with.
-  Three contract-level user-scope refusal rails (`check_seeds`,
-  `check_hooks`, `check_markers`) live in
-  [`build/scope_rails.py`](../../packages/agentbundle/agentbundle/build/scope_rails.py).
-  The per-pack-default-plus-allowance shape itself is locked by
-  [ADR-0002](../adr/0002-install-scope-per-pack-default-and-allowance.md).
+`diff` reports projection drift. `reconcile` reports user-scope orphaned
+configuration without applying changes. `adapt` reports upstream companions
+instead of silently overwriting them.
 
-### User-scope adapter resolution (RFC-0011)
+## 7. Observability and evidence
 
-At install time, when `--scope user` is requested, the CLI picks
-which adapter's home tree receives the pack via a six-step lookup
-in
-[`commands/install.py:_resolve_user_scope_target_adapter`](../../packages/agentbundle/agentbundle/commands/install.py):
+`list-installed`, `show`, `diff`, `reconcile`, and `validate` expose
+installed state, source content, drift, orphaned configuration, and conformance.
 
-1. **Publisher-vs-installer drift refusal** — every entry in the
-   pack's `allowed-adapters` must be both shipped by the bundled
-   contract and user-scope-capable. A mismatch refuses with a pinned
-   message that names the pack, the offending adapter, the contract
-   version, and the CLI version.
-2. **`--adapter <name>`** — explicit adopter override, validated
-   against the pack's `allowed-adapters` (or the live contract's
-   user-scope-capable set when the pack omits the field). Bound to
-   `--scope user`; rejected at repo scope.
-3. **State-hint short-circuit** — on upgrade, `PackState.adapter`
-   from `~/.agentbundle/state.toml` wins when admissible. This is
-   what stops the cross-adapter refusal at
-   [`upgrade.py`](../../packages/agentbundle/agentbundle/commands/upgrade.py)
-   from firing when an adopter populates a second `~/.<ide>/`
-   between install and upgrade.
-4. **Per-adapter probe** — walk `allowed-adapters` in declared order
-   against the populated `~/.<ide>/` homes (`~/.claude/`, `~/.kiro/`,
-   and either `~/.codex/` or `~/.agents/skills/` for codex — the
-   OR-probe handles both CLI shapes); first match wins.
-5. **Greenfield fallback** — `DEFAULT_USER_SCOPE_ADAPTER` in
-   [`scope.py`](../../packages/agentbundle/agentbundle/scope.py)
-   (default `"claude-code"`) if it's in the pack's set, else
-   `allowed-adapters[0]`.
-6. **Legacy heuristic** — `< 0.6` packs and v0.6+ packs omitting
-   `allowed-adapters` fall through to the original
-   `.apm/agents/`-presence inference: pack ships agents ⇒ Kiro;
-   otherwise Claude Code.
+Build output, self-host projections, manifests, and install-state files provide
+the durable evidence record.
 
-The resolved adapter is recorded on the state file unconditionally
-for every user-scope install (not just hook-bearing kiro installs as
-in earlier contract versions), so projection and state agree on
-which IDE owns the pack.
+## 8. Mechanical invariants
 
-The schemas at [`_data/`](../../packages/agentbundle/agentbundle/_data/) —
-`adapter.schema.json`, `pack.schema.json`, `plugin-manifest.schema.json` —
-let third-party validators check conformance without importing this
-package. The invariant `default-scope ∈ allowed-scopes` is enforced in
-the pack schema's `if`/`then`, not just in code.
+- `agentbundle catalogue verify` verifies projected agent artifacts and
+  adapter conformance.
+- The self-host drift gate raises `CAT-V-015` for source/projection drift and
+  `CAT-V-014` for generated `dist/` drift.
+- `tools/catalogue/check_contract_parity.py` requires portable contract schemas
+  and TOML to match their `agentbundle/_data/` counterparts.
+- `agentbundle lint packs` (`make lint-packs`) checks pack conformance.
 
-## The install→adapt chain
+## 9. Relevant ADRs
 
-Three install routes share one mechanism: each route drops
-`.adapt-install-marker.toml` at the scope-correct root; `core`'s
-`session-start.py` hook reads it and nudges the agent into
-`adapt-to-project` on the next session.
+- [ADR-0002 — Per-pack install scope](../adr/0002-install-scope-per-pack-default-and-allowance.md)
 
-| Route | Marker writer | Trigger |
-| --- | --- | --- |
-| `agentbundle install` (CLI) | The CLI command writes it in-process and chains to `agentbundle adapt`. | Run by user. |
-| `claude plugin install` | A `SessionStart` hook derived into each **published** pack's `.claude-plugin/plugin.json` runs the canonical writer template. | First session after install. |
-| `apm install` | `.apm/hooks/install-marker.{json,py}` projected via APM's `HookIntegrator`, same template. | First session after install. |
+## 10. Last verified against commit
 
-> **Dormant on the user-scope path.** The marker is still written for every
-> published pack, but both readers of `.adapt-install-marker.toml` —
-> `packs/core/.apm/hooks/session-start.py` and the `adapt-to-project` skill —
-> live in `core`, which is repo-scoped and therefore not published to the
-> Claude-plugin route (`docs/specs/claude-plugin-route-scope`). So on that route
-> the automatic nudge fires only for an adopter who *also* has `core` installed
-> at repo scope. RFC-0008's design is unchanged; the user-scope path re-lights
-> when a user-capable pack ships a session-start hook.
-
-The writer template lives at
-[`packages/agentbundle/templates/install-marker.py`](../../packages/agentbundle/templates/install-marker.py)
-— **the canonical copy**. The drift gate keeps three copies in lockstep:
-the template, the bundled
-[`_data/install-marker.py`](../../packages/agentbundle/agentbundle/_data/install-marker.py),
-and every `dist/<route>/<pack>/.../install-marker.py` projection. Edit
-the template; `make build` syncs the rest. The writer takes a required
-`--install-route {claude-plugins,apm}` flag and resolves the data
-directory via a portability shim (`${CLAUDE_PLUGIN_DATA}` →
-`${PLUGIN_ROOT}/.data` → `${CURSOR_PLUGIN_ROOT}/.data` → exit 0).
-
-## Where to read next
-
-- [`credentials.md`](credentials.md) — the secret-handling subsystem inside
-  this package.
-- [`docs/specs/agent-spec-cli/spec.md`](../specs/agent-spec-cli/spec.md) —
-  authoritative spec for the CLI verbs.
-- [`docs/specs/distribution-adapters/spec.md`](../specs/distribution-adapters/spec.md) —
-  authoritative spec for the contract, primitives, and projection modes.
-- [`guides/_shared/explanation/install-routes.md`](../../guides/_shared/explanation/install-routes.md) —
-  adopter-facing companion to this page.
+`c8cf4b37`

--- a/docs/architecture/binder-publishing/README.md
+++ b/docs/architecture/binder-publishing/README.md
@@ -3,15 +3,9 @@
 > Design for `binder-publishing`: a portable pack that compiles selected Markdown
 > artifacts into a coherent, reader-oriented static HTML binder.
 >
-> **Status:** Draft — pre-RFC, and **no live verification gate is outstanding**.
-> Ten cold-review rounds ran; the tree is internally consistent and a specification
-> can be written from any file in it. Z1–Z4 executed 2026-08-06, Z5 and Z6 on
-> 2026-08-07, and V6 — the last renderer-independent gate — was answered the same
-> day. (`verified-findings.md` still carries unrun **V2** and **V5** rows and a
-> part-run **V4**; all three are retained *Quarto* evidence for a future PDF adapter,
-> and none gates anything here.) Between them the gates corrected several specified controls, the last of
-> which — the diagram accessible name (Z6d/Z6e) — **would have passed CI while the
-> feature was broken**, and is replaced by **D46**. [`history.md`](history.md) records what changed and why.
+> **STATUS: PLANNED** — This subtree is not current state and is not implemented;
+> no binder pack exists in `packs/`. [ADR-0073](../../adr/0073-zensical-as-the-v1-binder-renderer.md)
+> governs the renderer decision. [`history.md`](history.md) holds the review history.
 
 ## The one-paragraph version
 

--- a/docs/architecture/binder-publishing/binder-recipe.md
+++ b/docs/architecture/binder-publishing/binder-recipe.md
@@ -71,22 +71,8 @@ a versioned public contract whose validator hard-errors on unknown keys,
 
 ### What `[policy]` no longer contains
 
-D-A removed `[policy] profile` and D-B removed `[policy] shortcodes`. Neither is
-deprecated: both are **unknown keys**, and a recipe carrying either is exit 4 with
-the ordinary unknown-field message.
-
-That is deliberate rather than harsh. A deprecation warning implies the key once
-did something the author might still want; these two named a trust relaxation that
-no longer exists and a renderer behaviour that no longer exists. Warning would
-suggest a migration path where there is none — the honest message is "this key is
-not in the schema", plus the nearest-valid-key suggestion the validator already
-emits.
-
-**`[policy]` is now purely resolution semantics** — what to do about a missing
-required artifact, an ambiguous selector, an unknown status, a draft, a
-cross-section duplicate. Nothing in it reaches trust, and nothing in it reaches a
-path. That is what makes the substitution rule below simple enough to state in one
-line.
+`[policy] profile` and `[policy] shortcodes` are unknown keys and exit 4. `[policy]`
+contains resolution semantics only; it cannot change trust or path authority.
 
 ### Parameter substitution — a closed surface
 

--- a/docs/architecture/binder-publishing/editorial-model.md
+++ b/docs/architecture/binder-publishing/editorial-model.md
@@ -5,21 +5,11 @@
 
 ## Pack and skill shape
 
-### The constraint that decides it
+### Skill boundary
 
-Skills are strictly self-contained: no cross-skill reads or imports, including
-between siblings in the same pack, and `.apm/shared-libs/` is not available for
-skill code. Therefore **any design with two skills sharing the resolver is
-impossible without either duplicating it or introducing a new pip package.**
-
-The brief offered four shapes. Evaluated against that constraint:
-
-| Shape | Verdict |
-|---|---|
-| One workflow skill | **Selected.** |
-| `assemble-binder` + `publish-binder` | Rejected — forces duplicated core or a new pip package, and buys nothing that script verbs of one skill do not already provide. |
-| Deterministic skill + chief-editor subagent | **Partially adopted** — see below. |
-| Other repository-native composition | A `binderkit` pip package alongside a thin skill (the `credbroker` pattern). Rejected for v1 — it adds a PyPI release channel, a version-skew surface, and an install step, to solve a code-sharing problem that only exists if there are two skills. Recorded as the escape hatch if a second skill is ever genuinely required. |
+`publish-binder` is the sole workflow skill. Skills do not share resolver code
+across skill boundaries. A future second skill requires a separately governed
+shared package or duplicated implementation.
 
 ```
 packs/binder-publishing/
@@ -53,26 +43,11 @@ packs/binder-publishing/
      repository's shipped guide tree, per the two-tree convention)
 ```
 
-### Sizing `binder.py`, and where the v1 cut-line is
+### V1 boundary
 
-"One stdlib-only file" understates what is being asked for, and the comparison
-table already scores this option ○ on both maintenance burden and new machinery
-without ever putting a number on it. The v1 surface is: a hand-written TOML
-validator with edit-distance suggestions, a JSON-Schema parity harness, the
-resolver with Kahn ordering and cycle detection, the source scanner, the
-Markdown transformer and its line offset, link rewriting, the Zensical adapter and
-its TOML emitter, two lock protocols, near-atomic publication, and nine verbs.
-
-**D-A and D-B took real code out of that list, not just prose.** Gone: the trust
-lattice and its grant matching, the eight-step transformer's four Quarto-specific
-steps and the breakpoint `line-map` they required, the digest-verified downloader
-with tar and zip extraction, the toolchain lock, and the consent-token machinery.
-Added: nothing. This is the clearest available measure of what the two decisions
-bought.
-
-So the decomposition is stated up front rather than discovered. `scripts/` holds
-sibling modules at one level — permitted, since the depth rule is about *nesting*,
-not file count, and none of them is a cross-skill import:
+V1 includes validation, resolution, strict scanning, transformation, link
+rewriting, the Zensical adapter, two locks, near-atomic publication, and all
+declared verbs. `scripts/` holds sibling modules at one level:
 
 ```
 scripts/binder.py            # argv, verb dispatch, exit codes
@@ -84,21 +59,12 @@ scripts/render_zensical.py   # staging, transformation, zensical.toml, invocatio
 scripts/fsutil.py            # confinement, locks, near-atomic publish
 ```
 
-`scripts/toolchain.py` — detection, version range, and the install ladder — is
-gone. What survives of it is two lines inside `render_zensical.py`:
-`importlib.util.find_spec("zensical")` and
-`importlib.metadata.version("zensical")` (Z1c).
+`render_zensical.py` detects the renderer with `importlib.util.find_spec` and
+checks its pin with `importlib.metadata.version` (Z1c).
 
-**Two things move out of v1 outright**, because the earlier draft protected every
-optional mechanism while scoring itself ○ on new machinery — which is not a
-trade-off, just a preference:
-
-- **`[[sections.items.figures]]` and caption binding → Phase 2.** Captions are the
-  only reason `fence-sha256`, the ordinal-plus-hash protocol, and the drift
-  warning exist. Level-0 diagrams render uncaptioned and unnumbered, which is a
-  complete v1 story; captions arrive with the rest of the metadata layer.
-- **`--if-stale` → Phase 2.** Incremental rebuild is an optimisation for a build
-  nobody has yet found slow.
+V1 excludes `[[sections.items.figures]]`, caption binding, `fence-sha256`, and
+`--if-stale`. Level-0 diagrams render without captions. `check --published`
+remains the source-hash consumer.
 
 That leaves `check --published` as the **single** consumer of source hashes — and
 it is the CI contract, so the hashes stay and their justification is no longer
@@ -153,32 +119,12 @@ catalogue-level interface, promoting them into `contracts/` with a README row an
 a governing RFC is an additive move — but that is an RFC decision, not a
 directory choice this design gets to make.
 
-### The editorial model: why the editor is not an agent in v1
+### Editorial procedure
 
-Six properties decide agent-versus-skill:
-
-| Property | Skill | Agent | This case |
-|---|---|---|---|
-| Who invokes it | user | orchestrator dispatches | "build a binder for the review board" is a user utterance → **skill** |
-| Can it reach other capabilities? | can invoke skills and scripts | a subagent has no Skill tool | the editorial pass must end in resolve+build → **skill** |
-| Context economics | input ≈ output | reads many, returns little | reads N candidates, returns one recipe → **agent** |
-| Independence from the author | — | must not mark its own homework | authoring, not reviewing → neutral |
-| Tool restriction as a control | — | tool set is declarable | **usable here** — see below |
-| Charter pressure | — | *"Not a marketplace of specialized agents"* | → **skill** |
-
-Skill wins four of six. The one the agent wins — context economics — is real at
-scale, and the repository already has the resolution for exactly this split. The
-`work-loop` orchestrator inlines `security-checklists` modules into the
-`security-reviewer` brief precisely because *"subagent has no Skill tool."*
-
-**Decision.** The editorial pass is a *procedure*, owned by the skill, living in
-`references/editorial-pass.md`. The skill runs it inline by default. When the
-candidate set is large, the skill dispatches a subagent **restricted to `Read`,
-`Grep`, and `Glob`** — no `Bash`, no `Write`, no `Edit` — with that reference
-inlined into the brief, and receives a recipe as its return value. One source of
-truth; no duplication; the seam for a named `binder-editor` agent stays open at
-zero cost, because the procedure already lives in a file that is inlined either
-way.
+The editorial pass is a procedure in `references/editorial-pass.md`. The skill
+runs it inline by default. For a large candidate set, it may dispatch a subagent
+restricted to `Read`, `Grep`, and `Glob`, with no `Bash`, `Write`, or `Edit`. The
+subagent returns a recipe and editorial prose; it does not render a binder.
 
 **Withholding `Bash` matters, but it is a convention, not a mechanism.** Lacking a
 Skill tool alone would not stop a subagent shelling out to

--- a/docs/architecture/binder-publishing/examples.md
+++ b/docs/architecture/binder-publishing/examples.md
@@ -1,31 +1,26 @@
 # Worked examples
 
-> Concrete recipes, errors, and an end-to-end scenario.
+> V1 recipes, staging output, and portability fixtures.
 > Part of [binder publishing architecture](README.md).
 
-## Concrete examples
+## Portable repository layout
 
-### Portable repository layout
-
-```
+```text
 project/
 ├── binder.toml
 ├── binders/
 │   ├── architecture-review.binder.toml
-│   ├── release-readiness.binder.toml
-│   └── editorial/
-│       └── payments-exec-summary.md
+│   └── editorial/payments-exec-summary.md
 ├── docs/ · notes/
 └── .binder-work/            # gitignored
 ```
 
-### User-scoped use in an unrelated directory
+## User-scoped use in an unrelated directory
 
-```bash
-# ~/clients/acme/discovery — no Git, no pack.toml, no site.toml
-cat > ~/clients/acme/discovery/binder.toml <<'TOML'
+```toml
+# ~/clients/acme/discovery/binder.toml — no Git, pack.toml, or site.toml
 schema-version = "1"
-id    = "acme-discovery"
+id = "acme-discovery"
 title = "Acme Discovery Pack"
 
 [[sections]]
@@ -37,198 +32,57 @@ path = "interviews/summary.md"
 
 [[sections.items]]
 path = "analysis/opportunities.md"
-TOML
+```
 
+```bash
 python scripts/binder.py build binder.toml --root=$HOME/clients/acme/discovery
-# → ~/clients/acme/discovery/build/binders/acme-discovery/index.html
 ```
 
-### `binder.toml` with semantic selectors (Phase 2)
+The publication is `build/binders/acme-discovery/index.html` beneath the content
+root.
 
-```toml
-schema-version = "1"
-id      = "architecture-review"
-title   = "Architecture Review — ${subject}"
-purpose = "Everything the review board needs to decide on ${subject}."
+## Per-file transformation
 
-source-roots = ["docs"]
-
-required-params = ["subject"]
-
-[params]
-# no default for `subject` — it is in required-params, so the caller must supply it
-
-[[sections]]
-id    = "evidence"
-title = "Context and evidence"
-
-[[sections.items]]
-select = { kind = "research", subject = "${subject}" }
-pick   = "all"
-order  = "date"
-
-[[sections]]
-id    = "decisions"
-title = "Decisions"
-
-[[sections.items]]
-select = { kind = "adr", subject = "${subject}", status = "current" }
-pick   = "all"
-
-[[exclude]]
-select = { status = "retired" }
-```
-
-Run against a Phase-0/1 build, this produces the *not-yet-implemented key* error
-shown earlier — never a silent partial resolution.
-
-### A dynamic overlay (Phase 3)
-
-```toml
-schema-version = "1"
-id      = "payments-board-2026-08"
-extends = "binders/architecture-review.binder.toml"
-title   = "Payments Migration — Review Board Packet"
-audience = ["architecture review board", "security reviewer"]
-
-[params]
-subject = "payments-migration"
-
-[[sections]]
-id       = "summary"
-title    = "Executive summary"
-kind     = "editorial"
-position = "first"
-
-[[sections.items]]
-path = "binders/editorial/payments-exec-summary.md"
-role = "executive-summary"
-
-# Both competing proposals, explicitly — a required item may not be a query
-[[sections.overrides]]
-section = "proposal"
-
-[[sections.overrides.items]]
-path     = "docs/rfc/0091-payments-migration.md"
-required = true
-label    = "Proposal A — ledger service"
-
-[[sections.overrides.items]]
-path     = "docs/rfc/0093-payments-strangler.md"
-required = true
-label    = "Proposal B — strangler migration"
-
-[[exclude]]
-path   = "docs/rfc/0088-payments-migration-draft.md"
-reason = "superseded by RFC-0091"
-```
-
-Overlay semantics: `extends` deep-merges; `[[sections]]` with a new `id` are added
-at `position`; `[[sections.overrides]]` replaces a named section's items;
-`[[exclude]]` entries accumulate and always win. An overlay may **not** convert a
-required exact reference into a selector, and may not introduce a key the schema
-does not define — which the unknown-field rule already covers.
-
-> An earlier version added "and may not set `[policy] profile` less strictly than
-> its base". D-A removed the key: it is now an unknown field, exit 4, at every
-> level. [`binder-recipe.md`](binder-recipe.md) is the authority on the surface.
-
-### The per-file transformation, worked — and the diagram that is not transformed
-
-Source (`docs/design/payments/design.md`, unchanged on disk):
+Source (`docs/design/payments/design.md`) remains unchanged:
 
 ````markdown
- 1  ---
- 2  title: Payments migration design
- 3  status: Draft
- 4  css: /tmp/evil.css
- 5  ---
- 6
- 7  # Payments migration design
- 8
- 9  The ledger boundary is shown below.
-10
-11  ```mermaid
-12  flowchart LR
-13    A[Gateway] --> B["Ledger<br/>service"]
-14    B --> C[(Postgres)]
-15  ```
+---
+title: Payments migration design
+css: /tmp/evil.css
+---
+
+# Payments migration design
+
+```mermaid
+flowchart LR
+  A[Gateway] --> B["Ledger<br/>service"]
+```
 ````
 
 Staged (`docs/011-docs-design-payments-design.md`):
 
 ````markdown
- 1  ---
- 2  title: "Payments migration design"
- 3  ---
- 4
- 5  The ledger boundary is shown below.
- 6
- 7  ```{.mermaid data-a11y-name="Diagram 11.1"}
- 8  flowchart LR
- 9    A[Gateway] --> B["Ledger<br/>service"]
-10    B --> C[(Postgres)]
-11  ```
+---
+title: "Payments migration design"
+---
+
+```{.mermaid data-a11y-name="Diagram 11.1"}
+flowchart LR
+  A[Gateway] --> B["Ledger<br/>service"]
+```
 ````
 
-**The fence *body* is byte-identical to the source's, and the fence is still one
-line.** No `` ```{mermaid} `` rewrite, no injected `%%| label:` line, no
-caption-binding protocol, no fence content-hash — because Z3a verified Zensical
-reads the portable fence directly and emits `<pre class="mermaid"><code>…`. Z3e
-verified the `<br/>` inside the node label survives, entity-escaped in the HTML and
-decoded by the browser as the `<pre>`'s text content, exactly as Q28 recorded under
-Quarto.
+Source frontmatter is discarded. Fresh frontmatter and the chapter H1 replace it.
+The Mermaid fence body is byte-identical. The opening delimiter receives the D46
+attribute as a same-line edit. The adapter records the resulting scalar
+`line-offset` in `renderer-plan.json`; it does not write transformation data to
+the index.
 
-**The opening delimiter carries the accessibility attribute (D46), and that is why
-it is on line 7 in both columns.** The annotation is a same-line rewrite: the theme
-lifts `data-a11y-name` into the Mermaid source as an `accTitle:` in the reader's
-browser, so nothing is inserted into the staged file and the offset below stays
-constant. The value is `Diagram <chapter-ordinal>.<n>` — all of it compiler-owned,
-none of it from the diagram body — and allowlist-reduced, because Z6h found an
-`attr_list` value containing a quote terminates the attribute and admits raw markup.
-A descriptive name and a `data-a11y-desc` arrive with `figures[]` in Phase 2.
-
-Emitted into `renderer-plan.json` (**not** the index — invariant 22):
-
-```json
-"line-offset": -4
-```
-
-Reading it: the frontmatter rebuild (steps 1–2) shortens by 2, the duplicate-H1
-drop (step 3) shortens by a further 2, and **nothing below that changes** — the
-link/asset rewrite (step 4) and the fence annotation (step 5) both edit within a
-line. Source 9 → staged 5, source 12 → staged 8, source 15 → staged 11 — one delta,
-every line.
-
-**This is the property that decided D46.** The first replacement drafted for the
-falsified accessible-name mechanism wrapped each fence in a `<figure>` with a
-`<figcaption>`, which would have inserted lines *here*, between the head and the
-tail of this very file — reintroducing exactly the per-diagram divergence the
-paragraph below describes. The offset staying scalar is not a happy accident of the
-chosen mechanism; it is the constraint the mechanism was chosen to satisfy.
-
-**This example used to be the proof that a scalar offset was impossible.** Under
-Quarto the deltas were 0, −4, −4, −3 across this one file, because the fence
-transform and its injected cell option shifted the body relative to the head; that
-is why round 1 replaced `line-offset` with a `line-map` breakpoint array, and why
-this example existed. D-B removed the transformation that made the array
-necessary, and the same example now demonstrates the opposite. That is worth
-noticing rather than quietly editing: the array was correct for the renderer it
-was designed against.
-
-Two security-relevant things still happen, and one no longer needs to. The `css:`
-key — a source-controlled renderer-configuration channel — is **discarded with the
-rest of the frontmatter**, not filtered out; a source cannot reach renderer
-configuration whatever the renderer is. The H1 is dropped because it duplicated
-the chapter title. What is *not* needed any more is a shortcode pass: Z3f verified
-`{{< env … >}}` and `${…}` pass through as literal escaped text. **The source file
-on disk is byte-identical to before.**
-
-### Minimal `binder.toml` — Level 0
+## Minimal `binder.toml` — Level 0
 
 ```toml
 schema-version = "1"
-id    = "payments-review"
+id = "payments-review"
 title = "Payments Migration Review"
 
 [[sections]]
@@ -246,142 +100,52 @@ title = "Proposal"
 path = "docs/design/payments-migration.md"
 ```
 
----
+## V1 walkthrough
 
-## Worked scenario: payments migration review
-
-Using this repository's actual pack, skill, and artifact shapes.
-
-### Candidate artifacts
-
-| Artifact | Producer | Metadata level |
-|---|---|---|
-| `docs/product/research/payments-landscape-survey.md` | `desk-research` (standard mode) | Level 1 — YAML frontmatter |
-| `docs/product/intents/payments-migration.md` | `product-engineering` `frame-intent` | Level 1 |
-| `docs/rfc/0091-payments-migration.md` | `governance-extras` `new-rfc` | **Level 0** — bold `**Status:** Accepted`, no frontmatter → sidecar |
-| `docs/rfc/0093-payments-strangler.md` | `governance-extras` `new-rfc` | Level 0 → sidecar |
-| `docs/rfc/0088-payments-migration-draft.md` | `governance-extras` `new-rfc` | Level 0, superseded |
-| `docs/design/payments-migration/design.md` | `architect` `architect-design` | Level 0, contains Mermaid |
-| `docs/adr/0044-ledger-boundary.md` | `governance-extras` `new-adr` | Level 0 → sidecar |
-| `docs/adr/0045-dual-write-window.md` | `governance-extras` `new-adr` | Level 0 → sidecar |
-| `docs/specs/payments-migration/spec.md` + `plan.md` | `core` `new-spec` | Level 0 |
-| `notes/security-assessment-payments.md` | hand-written | none |
-| `notes/vendor-comparison.md` | external workflow | none |
-
-**Eight of eleven carry no YAML frontmatter.** That is not a contrived fixture — it
-is what this repository actually looks like, and it is why Level 0 is the primary
-path.
-
-> **Phase labels.** Path A below uses selectors (**Phase 2**) and Path B an
-> `extends` overlay (**Phase 3**). Under v1 they produce the *not-yet-implemented
-> key* error, by design. The **v1 walkthrough is Path A0**, immediately below;
-> the later paths show where the same recipe goes once the metadata and
-> composition layers land.
-
-### Path A0 — the v1 walkthrough, explicit paths only
-
-`binders/payments-review.binder.toml` as printed in *Worked recipe*: every item an
-explicit `path`, one `[[exclude]] path`, no `source-roots` needed for the explicit
-references. Run:
+`binders/payments-review.binder.toml` contains exact `path` items and any
+explicit `[[exclude]] path` entries. It contains no selectors, overlays, or
+`extends` key.
 
 ```bash
-python scripts/binder.py build binders/payments-review.binder.toml \\
+python scripts/binder.py build binders/payments-review.binder.toml \
   --root=/Users/dev/proj
 ```
 
-Resolution: **12 nodes — 9 source, 2 editorial, 1 generated.** The nine source
-artifacts are named by path; the two editorial nodes are the executive summary and
-the `context` section's introduction; the generated node is the source inventory.
-`0088` excluded by the explicit `[[exclude]]` rule with its reason recorded.
-`notes/security-assessment-payments.md` is listed by path and resolves, because an
-explicit path needs no `source-roots` entry (D33). No gaps, no ambiguity, nothing
-deferred — this is the whole v1 feature set exercised end to end.
+Explicit paths resolve without `source-roots` (D33). A recipe may combine source
+artifacts, editorial files, and the generated source inventory. A required item
+is always an exact reference.
 
-This is the same 12-node count the build summary in
-[`resolution.md`](resolution.md), the sequence diagram in
-[`editorial-model.md`](editorial-model.md), and the missing-dependency error in
-[`zensical-adapter.md`](zensical-adapter.md) all print. The *Worked recipe*
-in [`binder-recipe.md`](binder-recipe.md) is an abridged excerpt of this fixture
-and says so.
+## Staged project
 
-### Path A — committed recipe with selectors (Phase 2)
-
-`binders/architecture-review.binder.toml`, parameterized by `subject`. Run:
-
-```bash
-python scripts/binder.py build binders/architecture-review.binder.toml \
-  --root=/Users/dev/proj --param=subject=payments-migration
-```
-
-Resolution: 9 nodes selected; `0088` excluded by `[[exclude]]`; `0093` not
-selected (the committed recipe's `proposal` section takes the one `current` RFC);
-`notes/*` absent because this recipe declares `source-roots = ["docs"]` and its
-items are **selectors**, which scan only declared roots — an explicit `path` to a
-`notes/` file would have resolved fine. The security-assessment gap is reported.
-
-### Path B — dynamic overlay for a specific audience (Phase 3)
-
-The overlay above adds the executive summary, forces **both** competing proposals
-as required exact references, adds `notes` as a source root so the security
-assessment resolves, and keeps the exclusion of `0088`.
-
-Resolution: 13 nodes. Both proposals present and labelled. Superseded draft
-excluded with a recorded reason. Security assessment now resolves. Rollback risk
-emphasized by an editorial section introduction. One unreviewed editorial node
-flagged in the summary.
-
-### Staged project
-
-```
-.binder-work/payments-board-2026-08/c41d7e0a/stage/
-├── zensical.toml                                   # generated entirely from the index
+```text
+.binder-work/payments-review/<content-key>/stage/
+├── zensical.toml                         # generated from the index
 ├── theme/
-│   ├── main.html                                   # injects the vendored mermaid.min.js
-│   └── assets/javascripts/mermaid.min.js           # vendored — Zensical does not bundle it
+│   ├── main.html
+│   └── assets/javascripts/mermaid.min.js
 ├── docs/
-│   ├── index.md                                    # generated cover
-│   ├── 001-executive-summary.md                    # editorial
-│   ├── 002-part-evidence.md                        # generated part page
-│   ├── 003-docs-product-research-payments-landscape-survey.md
-│   ├── 004-docs-product-intents-payments-migration.md
-│   ├── 005-notes-vendor-comparison.md
-│   ├── 006-part-proposals.md
-│   ├── 007-context-intro.md                        # editorial section intro
-│   ├── 008-docs-rfc-0091-payments-migration.md
-│   ├── 009-docs-rfc-0093-payments-strangler.md
-│   ├── 010-docs-adr-0044-ledger-boundary.md
-│   ├── 011-docs-adr-0045-dual-write-window.md
-│   ├── 012-docs-design-payments-migration-design.md   # 3 mermaid diagrams
-│   ├── 013-docs-specs-payments-migration-spec.md
-│   ├── 014-notes-security-assessment-payments.md
-│   ├── 900-source-inventory.md                     # generated appendix
-│   └── assets/n008/ledger-topology.png             # copied, confined, rewritten
-├── .cache/                                         # Zensical's
-└── site/                                           # render output; published from here
+│   ├── index.md                          # generated cover
+│   ├── 001-executive-summary.md          # editorial
+│   ├── 002-part-evidence.md              # generated part page
+│   ├── 003-docs-research-payments.md     # source
+│   └── 900-source-inventory.md           # optional generated appendix
+├── .cache/                               # Zensical cache
+└── site/                                 # publication source
 ```
 
-`docs/` and `site/` are Zensical's default `docs_dir` and `site_dir`, and both are
-resolved relative to `zensical.toml` (Z1d, Z1e) — which is why placing the config
-in `stage/` keeps every byte the renderer writes inside the workspace.
+`docs/` and `site/` resolve relative to `zensical.toml`. Publishing copies from
+`stage/site/` through the near-atomic replacement path.
 
-### Final HTML information architecture
+## Final HTML information architecture
 
-Cover (title, purpose, audience, subject, binder status) →
-Executive summary *(marked editorial, unreviewed)* → **Part I Evidence** (survey,
-intent, vendor comparison) → **Part II Proposals and decisions** (section intro,
-Proposal A, Proposal B, ADR-0044, ADR-0045, the design with three diagrams, the
-spec, the security assessment) → Appendix: source inventory and provenance.
-Sidebar, search, previous/next, and per-page TOC throughout.
+Cover → executive summary (marked editorial) → named parts and chapters → optional
+source inventory. The renderer provides sidebar navigation, local search,
+previous/next links, and per-page contents.
 
-**Two parts, matching the two part pages in the staged tree above** —
-`002-part-evidence.md` and `006-part-proposals.md`. An earlier version described a
-third, *Architecture and delivery*, which no part page in the tree corresponded
-to; the architecture and delivery chapters sit in Part II.
+## The same mechanism in a clean directory
 
-### The same mechanism in a clean directory
-
-```
-~/scratch/vendor-eval/
+```text
+scratch/vendor-eval/
 ├── binder.toml
 ├── overview.md
 ├── option-a.md
@@ -389,10 +153,6 @@ to; the architecture and delivery chapters sit in Part II.
 └── recommendation.md
 ```
 
-`binder.toml` lists four explicit paths in four sections. No Git, no `pack.toml`,
-no `site.toml`, no frontmatter, no installed source packs. One command produces
-`build/binders/vendor-eval/index.html` with the same navigation, search, and
-theme. **This is the same code path** — the difference between it and the
-thirteen-node board packet is entirely in the recipe.
-
----
+Four explicit paths in four sections produce
+`build/binders/vendor-eval/index.html`. This is the same Level-0 resolution and
+build path as the repository example.

--- a/docs/architecture/binder-publishing/history.md
+++ b/docs/architecture/binder-publishing/history.md
@@ -1,202 +1,36 @@
 # History (non-normative)
 
-> **Nothing here is a specification.** It records what was considered and
-> rejected, so a future maintainer asking "was this thought about?" gets an answer
-> without the normative files carrying the answer inline. Where this file
-> disagrees with any other, **the other file governs.**
->
-> Merged from three files — `open-decisions.md`, `renderer-choice.md`, and
-> `review-history.md` — which together carried 868 lines of reasoning around
-> decisions now recorded in [`decisions.md`](decisions.md).
+> Review and verification chronology. Normative files and
+> [`decisions.md`](decisions.md) govern when this record differs.
 
----
+## Shape decisions
 
-## The two shape decisions
+| Decision | Change |
+| --- | --- |
+| D-A / D39 | Removed the trusted profile, policy files, grants, and six authority flags. Strict is the only profile. |
+| D41 | Removed caller-named write destinations. Each verb derives its write location. |
+| D-B / D40 | Replaced Quarto with Zensical as the v1 renderer. ADR-0073 holds the renderer decision. |
+| D42 | Replaced cross-pack template discovery with producer-written recipes in the adopter `recipes_dir`. |
+| D43 | Removed profile from the index and content key. |
+| D44 | Moved chapter numbering to compiler-emitted `data-ordinal` attributes. |
+| D46 | Replaced fence-attribute accessibility with theme-lifted Mermaid `accTitle:` and `accDescr:` directives. |
+| D47 | Changed `--root` from required to recommended on measured agent surfaces; retained the installed-pack guard. |
 
-Ten cold-review rounds ran. Rounds 1–8 kept finding defects in two areas; rounds
-9–10 removed both areas rather than fixing them again.
+## Review chronology
 
-### D-A — collapse the trust surface instead of routing it
+| Period | Result |
+| --- | --- |
+| Cold reviews 1–5 | Identified contradictory contracts, write-side confinement failures, emitted-string injection, and incomplete trust routing. |
+| Cold reviews 6–8 | Required execution against the real renderer configuration and separated the neutral index from renderer plans. |
+| Cold reviews 7–10 | Split the draft into this tree; D-A and D-B removed the repeated trust and renderer defect classes. |
+| 2026-08-06 | Z1–Z4 corrected version probing, font suppression, Mermaid delivery, config behavior, and navigation validation. |
+| 2026-08-07 | Z5 confirmed network-denied build behavior. Z6 replaced the accessible-name mechanism with D46. V6 changed the `--root` requirement to D47. |
 
-Five rounds each found a *different* unrouted input surface — `--profile`,
-`$BINDER_POLICY_FILE`, `--quarto`, `--replace-foreign-dir`, `publication-dir`,
-`--out`, `--root`, `--from-index`, `--force-unlock`. Each time the answer was one
-more rule in the authority lattice.
+## Rejected implementation shapes
 
-**A router that must wrap nine surfaces is evidence the surface is too large.** So
-the surfaces were cut: the `trusted` profile, `binder-policy.toml` at every tier,
-every grant, and six flags. What survives is `--root`, guarded by refusal rules
-rather than by a lattice.
-
-**The cost is real and accepted.** A team whose repository legitimately contains
-raw HTML in prose cannot publish those files without editing or excluding them.
-Accepted for v1 because the corpus gate will say empirically how often it bites,
-because the case that actually appeared (`<br/>` in Mermaid labels) is verified to
-work under strict, and because **a profile added later on evidence is a better
-profile than one designed against a hypothetical.**
-
-Recorded as D39, extended by D41 (no verb takes a caller-named write destination).
-
-### D-B — the renderer
-
-**The decision and its full reasoning are
-[ADR-0073](../../adr/0073-zensical-as-the-v1-binder-renderer.md).** Zensical at an
-exact pin, chosen for foundation continuity rather than footprint — the ADR
-carries the measurements, the shared-fixture comparison against Quarto and
-mkdocs-material, the MkDocs 2.0 evidence and its independent corroboration, and
-the revisit conditions.
-
-What belongs here is only the path the design took to get there, because it went
-wrong twice and both errors are instructive:
-
-1. **Quarto was selected on documented behaviour and never spiked.** It drove most
-   of the design's complexity — the fence transformation, the shortcode scanner,
-   the install ladder, the toolchain cache — and every one of those was renderer
-   management wearing the shape of architecture.
-2. **The first reopening recommended owning a small renderer**, reasoning that
-   `binder-index.json` already supplies the structure a static-site generator
-   exists to derive. The spike reversed it: Zensical deletes two whole design
-   areas that owning a renderer would not have.
-3. **The second reopening kept the answer and replaced the argument.** The
-   selection had been made on weight, and measurement did not support it —
-   mkdocs-material's wheel is *smaller*, and the two are behaviourally
-   interchangeable on every criterion that had decided the question. The real
-   argument was foundation, not size. See the ADR.
-
-Recorded as D40.
-
----
-
-## The ten review rounds
-
-| Round | Verdict | Blockers | Majors | Minors | Nits |
-|---|---|---|---|---|---|
-| 1 | MAJOR REWRITE | 5 | 11 | 15 | 0 |
-| 2 | MAJOR REWRITE | 5 | 12 | 20 | 0 |
-| 3 | MAJOR REWRITE | 3 | 10 | 17 | 2 |
-| 4 | MAJOR REWRITE | 3 | 11 | 11 | 2 |
-| 5 | MAJOR REWRITE | 3 | 10 | 14 | 4 |
-| 6 | SHIP WITH CHANGES | 2 | 10 | 10 | 2 |
-| 7–9 | MAJOR REWRITE → the tree split, then D-A and D-B | | | | |
-| 10 | SHIP WITH CHANGES | 3 | 12 | 13 | 4 |
-
-**No finding was ever declined** except round 1's finding 13, which was adopted in
-a different form than offered (the digest-verified install was kept and reordered
-rather than removed — moot now, since D-B deleted it).
-
-### What each round changed that mattered
-
-**Round 1.** Shortcode handling was specified two contradictory ways and the
-escape mechanism was invented; `line-offset` as a scalar was disproved by the
-document's own worked example; the trust lattice was bypassable by
-`--profile trusted`; environment scrubbing was a denylist that passed
-`AWS_SECRET_ACCESS_KEY` — the design's own exfiltration example. Three
-load-bearing claims were marked UNVERIFIED and gated.
-
-**Round 2.** The "renderer-neutral" index was not neutral — it carried `.qmd`
-filenames, a line map, and pandoc anchors that `resolve` could not have produced.
-**Split into `binder-index.json` and an adapter-owned `renderer-plan.json`, with
-invariant 22.** This is the change that later made the renderer swap a one-file
-edit. Also: a YAML injection surface via recipe `title`; two more open trust
-channels; caption binding was ordinal binding with an extra step.
-
-**Round 3.** All three blockers were writes — the read side had been scrutinised
-and the write side had not. Publication replacement could `rmtree` an arbitrary
-user directory; the published index disclosed exclusion reasons, gaps, and every
-source path to review boards and vendors (replaced by a purpose-built
-`binder-stamp.json`); the confinement root was specified two incompatible ways.
-
-**Round 4.** Emitted strings bypassed the scanner — the scanner reads bodies, but
-titles reach renderer metadata. Two controls were absolute in prose with a channel
-left open.
-
-**Round 5.** `check --published` had no input, making exit 9 unreachable and
-collapsing the justification for recording source hashes at all. The execution
-control was stated two incompatible ways. The provenance appendix republished what
-the stamp had just removed.
-
-**Round 6.** The finding that mattered told the author to stop writing about a
-gate and run it. V1 confirmed Mermaid survives execution-off **and produced Q26** —
-the reader-toggle the security model used as a second layer destroys every diagram
-— **and Q27**, the stock theme fetching a typeface from Google at read time. Two
-findings the gate was not looking for.
-
-**Rounds 7–9.** Produced the two shape diagnoses above: the trust surface was too
-large to route, and the renderer had been chosen on paper and never spiked. The
-single-file draft was split into this tree at the same time, because patching one
-section reliably broke another repeating the same fact.
-
-**Round 10 — the first round against the propagated tree.** Blockers fell to
-three, and **none was a trust-model or renderer finding** — those areas no longer
-exist to be found wrong. What replaced them was ordinary contract drift: the
-content-key hashed the renderer version though `resolve` runs renderer-free;
-`--editorial=DIR` was a surviving caller-named write destination; and one file
-still enforced `[policy] profile`. The majors were dominated by **the same
-contract published in two files with different values** — which is the defect the
-tree split exists to prevent, and which recurs because propagation touches many
-files at once.
-
----
-
-## The gate runs — 2026-08-06 and 2026-08-07
-
-Not review rounds. The rounds above found what the tree said; these found what the
-renderer and the harness *do*.
-
-**2026-08-06 — Z1–Z4.** Ran against `zensical==0.0.53` and a transcription of the
-config the adapter is specified to emit. Several specified controls were wrong, each
-inferred from the shape of a configuration surface rather than executed: the
-version probe named an attribute that does not exist, the font-suppression form
-requested a typeface literally named `False`, and Mermaid turned out not to be
-bundled at all.
-
-**2026-08-07 — Z5, Z6, and V6.** The three that had been left as "needs a
-network-isolated runner" or "needs a headless browser". Two came back confirming
-the design and one falsified it.
-
-- **Z5 confirmed more than it was asked.** The question was whether the build
-  reaches the network; the answer is that it makes **no attempt at all**, measured
-  with `SIGKILL` armed on any outbound operation. The instructive part was needing
-  a kernel-level instrument rather than a Python-level one: `zensical` ships a
-  compiled extension that links network symbols, so a source grep would have
-  reported clean for the wrong reason.
-- **Z6 is the round's real finding, and it is a new failure mode for this tree.**
-  The three earlier corrections were about configuration; this one was about a
-  *runtime*. The design reasoned about the HTML the compiler emits and never asked
-  what the client-side bundle does to it — and the bundle replaces the element the
-  accessibility attributes were on. Worse, Z6e found the mechanism fails
-  **inverted**: the name is present exactly when the diagram is broken, so the
-  static CI check the design had specified would have read green forever. D46
-  replaces it with attributes on the fence delimiter that the theme lifts into the
-  Mermaid source, verified in a browser — a `<figure>` wrapper was drafted first and
-  rejected for inserting lines per diagram.
-- **V6 removed a defensive requirement rather than confirming one.** The agent's
-  working directory is the project root on both adapters measured, so `--root`
-  stopped being effectively required. The guard was kept, because the remaining
-  adapters could not be measured — the honest shape for a relaxation drawn from a
-  partial sample.
-
-**What the runs say about the review rounds.** Ten cold reviews did not catch any
-of the corrected controls, and could not have: every one of them was a claim
-about external behaviour that reads as entirely plausible on the page. That is the
-argument for gates being executed before the RFC rather than after, and it is the
-reason Z1–Z6 become CI assertions rather than retiring once green.
-
----
-
-## Alternatives considered and rejected
-
-Twelve were assessed. The four that were close are above and in
-[`overview.md`](overview.md); the rest, briefly:
-
-| Alternative | Rejected because |
-|---|---|
-| Quarto-specific schema, no neutral index | Fails the interop requirement — every producing pack's integration point becomes renderer configuration. The right answer if that requirement were dropped |
-| Extend `site.toml` / `tools/build-site.py` | Repository-specific Astro sidebar recipe: no schema, no versioning, no portability, needs npm, cannot install into an unrelated directory |
-| Ship Astro/Starlight inside the pack | Ships `node_modules` or hundreds of transitive npm dependencies; the pack becomes a frontend application |
-| Custom Python static-site generator | Sidebar, search, prev/next, TOC, cross-references, and accessible theming are individually modest and collectively a product. Still the fallback if the renderer choice fails |
-| Chief editor copies and orders files directly | Non-deterministic, unreviewable, and either mutates sources or produces copies that go stale. This is the status quo the design displaces |
-| `binder.toml` as a repository-specific format | A format that lands in adopter repositories is public whether documented as one or not |
-| Repository scope only / user scope only | Each forecloses a leading use case; supporting both is nearly free given one implementation |
-| `binder-index.json` as an internal detail | A contract with two consumers and no stability guarantee is a contract that breaks |
-| Author `_quarto.yml` (or `zensical.toml`) directly | Renderer configuration as the authored contract lets source-adjacent files set the surfaces the trust model must own — the failure invariant 12 exists to prevent |
+| Shape | Recorded outcome |
+| --- | --- |
+| Renderer-specific contract | Replaced by the neutral index and adapter plan split. |
+| Repository docs-site integration | Deferred behind index consumption or static mounting. |
+| Custom static-site generator | Not selected for v1. |
+| Cross-pack template scanning | Replaced by D42. |

--- a/docs/architecture/binder-publishing/invocation.md
+++ b/docs/architecture/binder-publishing/invocation.md
@@ -49,7 +49,7 @@ paths still resolve from the project root or the explicit `--root` value.
 > use. `binder.py` still resolves its own realpath and skips content-root inference
 > when its CWD is beneath the installed pack, exiting 4 with the message naming
 > `--root` — retained for the adapters V6 could not measure.
-> [`overview.md`](overview.md#what-repository-scope-means-outside-git) carries the
+> [`overview.md`](overview.md#runtime-and-ownership-boundary) carries the
 > full four-rule resolution order and the coverage caveat;
 > [`verified-findings.md`](verified-findings.md) carries the measurement.
 >
@@ -128,11 +128,10 @@ what would have been derived. `recipe write <name>` now derives
 `<recipes_dir>/<name>.binder.toml` and `<recipes_dir>/editorial/<slug>.md`. See
 [`outline-and-templates.md`](outline-and-templates.md#3-recipe-write--the-editorial-write-path).
 
-### The six cut flags, and where their job went
+### Destination and profile rules
 
-D-A cut these. They are listed because a reader arriving from an earlier draft, a
-committed `Makefile`, or a stale CI job needs to know they are gone rather than
-renamed.
+The following rules are closed. The listed flags do not exist, so a stale
+`Makefile` or CI job receives a clear answer rather than an alternate route.
 
 | Cut | Where the job went |
 |---|---|
@@ -143,15 +142,11 @@ renamed.
 | `--force-unlock` | `clean --stale`. Deleting state deliberately is a different act from being handed a flag that breaks another process's lock. |
 | `--from-index=PATH` | Nowhere. `build` always resolves. Invariant 21 means identical inputs give a byte-identical index, so "the thing I approved" is still what gets built — which was the flag's only real purpose, obtained for free. |
 
-There is no `install-quarto` verb. There is no install verb at all: the renderer
-is one pinned pip package and the ladder is a single command, in
+The command surface has no install verb; renderer dependency handling is in
 [`zensical-adapter.md`](zensical-adapter.md).
 
-**Every destination is derived, not supplied.** That is the property D-A was
-actually reaching for, and it is stronger than routing `--out` through a lattice
-would have been: there is no unbounded write primitive reachable from the
-invocation string because there is no caller-named write target anywhere in the
-contract.
+**Every destination is derived, not supplied.** No invocation argument can select
+an unbounded write target.
 
 ### Path resolution
 

--- a/docs/architecture/binder-publishing/outline-and-templates.md
+++ b/docs/architecture/binder-publishing/outline-and-templates.md
@@ -137,31 +137,16 @@ which left the ecosystem seam asserted rather than specified.
 
 ### The design this replaces, and why it could not ship
 
-The previous version had `binder.py` **walk the installed skill roots for the
-active adapter**, globbing `*/assets/binders/*.binder.toml` across every pack the
-adopter had installed, and identifying each hit as `<pack>/<name>`.
-
-**That violates `author-a-skill.md` § *Three rules to get right the first time*,
-third bullet**, which is unambiguous:
+Template discovery must not cross a skill boundary. `author-a-skill.md` § *Three
+rules to get right the first time*, third bullet, states:
 
 > *"Each skill is self-contained. Never read from, import from, or **assume the
 > presence of files in another skill's directory** — including sibling skills in
 > the same pack. Skills are projected independently to each adapter; cross-skill
 > paths that look valid in the source tree do not survive projection."*
 
-This is not a technicality, and it is not a rule the design can weigh against
-convenience — it is the **same rule [`editorial-model.md`](editorial-model.md)
-cites, from the same paragraph, to justify the one-skill pack shape.** A design
-that invokes self-containment to reject the two-skill option and then walks other
-skills' directories for templates is applying one rule in two directions.
-
-The rule's own stated reason is also the operational one. Skills are projected
-independently, per adapter, at whichever scope the adopter chose. A walk over
-"installed skill roots" would have to know seven adapters × three scopes of layout
-— exactly the knowledge `references/invocation.md` exists to keep out of the skill
-body — and would still miss a producing pack installed at a different scope, find
-nothing on a fresh machine, and silently return a different list per adapter. **A
-discovery mechanism whose results depend on the adapter is not a seam.**
+Skills project independently per adapter and scope, so another skill's directory
+is not a portable template-discovery seam.
 
 ### Discovery, restricted
 
@@ -228,15 +213,10 @@ adopter looks for what a pack offers anyway.
 
 ### Why not a manifest key
 
-`[pack.integrations]` exists and could declare a binder-template seam. It is still
-not used, and the reason survives the redesign: **a producing pack must be able to
-participate with `tomllib` and nothing else.** A manifest key would mean a pack
-shipping a template must know *this* pack's schema for declaring it — and it would
-reintroduce the discovery step, since something would then have to read those
-manifests.
-
-Writing a file to `recipes_dir` requires knowing one path and one format, both of
-which the producing pack must know anyway to author the template at all.
+**A producing pack must be able to participate with `tomllib` and nothing else.**
+Writing to `recipes_dir` requires one path and one format it already needs to know.
+`[pack.integrations]` is not used because it would add this pack's manifest schema
+and reintroduce discovery.
 
 ### What a template may and may not contain
 

--- a/docs/architecture/binder-publishing/overview.md
+++ b/docs/architecture/binder-publishing/overview.md
@@ -1,599 +1,180 @@
-# Overview
+# Binder publishing architecture
 
-> Problem, goals, product boundary, and why this shape won.
+> Implementation architecture for `binder-publishing`.
 > Part of [binder publishing architecture](README.md).
 
-## TL;DR
+## Scope
 
-Ship **one new user-scope-default pack, `binder-publishing`, carrying one
-script-backed skill, `publish-binder`**, that compiles a portable `binder.toml`
-recipe into a deterministic `binder-index.json` and renders that index to a static
-HTML binder through a Zensical staging adapter.
+`binder-publishing` is a user-scope-default pack with one script-backed skill,
+`publish-binder`. It resolves a portable `binder.toml` recipe into a deterministic
+`binder-index.json` and renders the index as a static HTML binder through the
+Zensical adapter.
 
-The recommendation rests on one structural claim: **the resolved index, not the
-renderer, is the interoperability contract.** A producing pack must be able to
-emit a binder recipe with `tomllib` and nothing else — no import of this pack's
-code, no knowledge of its install path, and no dependency on the renderer. That
-requirement forces the two-artifact split, and everything else follows from it.
+`binder.toml` is the producer handoff format. `binder-index.json` is the public,
+versioned renderer interface. Producers need only `tomllib` to emit a recipe;
+they do not import this pack or select a renderer.
 
-Three things are settled and carried by other files:
+V1 excludes deployment and serving, executable documents, automatic dependency
+installation, print-format correctness, figure and section cross-reference
+syntax, source mutation, mandatory producer migration, a central content
+inventory, and status parsing from Markdown prose. The adapter invokes
+`python -m zensical build --strict`; it never invokes `serve`.
 
-- **The renderer is Zensical, pinned exactly** — chosen for foundation continuity
-  rather than footprint. **[ADR-0073](../../adr/0073-zensical-as-the-v1-binder-renderer.md)**
-  is the decision and its evidence.
-- **The trust surface is collapsed, not routed.** Strict is the only profile,
-  there is no policy file at any tier, there are no grants, and six flags are cut.
-  [`security-profile.md`](security-profile.md) carries the model in one sentence.
-- **Every renderer claim has been executed**, not inferred.
-  [`verified-findings.md`](verified-findings.md) carries Z1–Z6 and V6 — all run —
-  and they found several of the adapter's own assertions wrong — the last of them
-  (Z6d/Z6e) a control that would have passed CI while the feature was broken, now
-  replaced by D46.
+The resolver and runtime work without Git, `site.toml`, `pack.toml`, a docs site,
+source packs, frontmatter, or an agent-ready-repo checkout. `binder.py` uses the
+standard library only. The Zensical dependency is explicit and never installed
+silently.
 
----
+## Runtime and ownership boundary
 
-## Context and problem statement
+The pack installs at `user` scope by default. `repo` and `local` are allowed.
+Scope changes pack location and default-configuration location only; it does not
+change resolution, validation, staging, or renderer invocation.
 
-Skills, packs, humans, scripts, and external workflows produce Markdown artifacts
-continuously: research surveys, product intents, RFCs, ADRs, architecture designs,
-specs, plans, security assessments, review records.
+| Scope | Defaults | Recipe location | Constraint |
+| --- | --- | --- | --- |
+| User | `~/.agentbundle/agentbundle-layout.toml` | caller-selected | Git-free runtime |
+| Repo | `<root>/agentbundle-layout.toml` | `binders/` | shared capability |
+| Local | repo defaults | uncommitted | Git working tree required |
 
-Each is written where its producing workflow puts it. `desk-research` writes
-`<topic-slug>-survey.md` under a configured `output_dir`; `architect-design` writes
-`<output_dir>/<topic-slug>/design.md`; `governance-extras` writes
-`docs/rfc/NNNN-*.md` and `docs/adr/NNNN-*.md`; `new-spec` writes
-`docs/specs/<feature>/spec.md` and `plan.md`.
+Resolve the content root in this order:
 
-**The source hierarchy is not the reader hierarchy.** A reviewer preparing for an
-architecture review board needs *Executive summary → Context and evidence →
-Proposal → Alternatives → Decisions → Architecture → Implementation approach →
-Verification → Risks → Appendices*. No directory tree is organized that way, and
-none should be — the producing workflows have their own correct reasons for their
-layout.
+1. `--root=<path>`, after confinement and refusal checks.
+2. The nearest ancestor containing `binder.toml`, `binders/`, or `agentbundle-layout.toml`.
+3. The nearest ancestor containing `.git`.
+4. The current directory when it is outside the installed pack.
 
-Today the only ways to close that gap are to hand-assemble a document (stale the
-moment a source changes), to point the reader at a list of file paths (not a
-publication), or to build a one-off script per audience (not reusable, not
-reviewable).
+Rules 2–4 never run when the working directory is beneath the installed pack.
+In that case the command exits 4 and names `--root`. `--root` remains
+refusal-grade: node reads accept only `*.md`, `*.markdown`, and `*.mmd`; a root
+equal to the user home or filesystem root, or an ancestor of `~/.agentbundle/` or
+the pack, exits 6. D-A keeps the strict profile as the only profile and retains
+no grants or policy file.
 
-What is missing is a **portable, versioned way to declare a reading order over
-artifacts that already exist**, and a deterministic compiler that turns that
-declaration into a publication without touching the sources.
+`binder.py` resolves its own directory at startup and refuses a write resolving
+inside the installed pack.
 
-**Why now.** Five packs already write durable Markdown to an adopter-configured
-`output_dir` resolved through `agentbundle-layout.toml` (`architect`,
-`desk-research`, `experience-design`, `product-engineering`, `product-strategy`).
-The producer side is solved and growing. The consumer side does not exist.
-
----
-
-## Goals and non-goals
-
-### Goals
-
-1. A **minimal binder is publishable from explicit local Markdown paths alone** —
-   in a directory with no Git repository, no `pack.toml`, no `site.toml`, no
-   agent-ready-repo checkout, no installed source packs, and no frontmatter.
-2. `binder.toml` is a **versioned, portable handoff format** any producer can
-   author, and that this pack validates and consumes without caring who wrote it.
-3. `binder-index.json` is a **public, versioned renderer interface** sufficient for
-   any renderer to produce a publication without rediscovering repository files.
-4. **One compilation path** for committed and dynamically generated recipes alike.
-5. A **mechanically enforced strict trust profile** suitable for AI-produced,
-   mixed-provenance, and externally supplied Markdown.
-6. **The installed pack is read-only at runtime.** Every byte written goes to a
-   caller-owned location.
-7. **Source Markdown is never modified.**
-8. **Mermaid renders from portable GitHub-style fences**, and the staged fence
-   *body* is byte-identical to the source's (Z3a) — the opening delimiter carries
-   compiler-emitted accessibility attributes (D46), at no line-count cost. Under
-   Quarto this goal needed the body rewritten; here it needs one same-line
-   annotation, which is why the diagram source a reader copies out is the source
-   the author wrote.
-9. **A published binder makes no network request when read.** A *goal*, not a
-   property inherited from the renderer — Zensical's defaults fetch from four
-   CDNs, and Z4 is what closes them.
-10. Dependency installation is **never silent**, and resolution works with no
-    renderer installed at all.
-
-### Non-goals for v1
-
-| Excluded | Why |
-|---|---|
-| Replacing the Astro/Starlight docs site | Different job. That site is the catalogue and technical-documentation surface; a binder is a bounded, audience-targeted publication. Both persist. |
-| Hosted service, daemon, database, control plane | Charter Principle 3. A binder build is a command, not a system. |
-| Deployment; serving | Rendering and publishing are different acts with different blast radii. The argv contains `build`; Zensical's `serve` is never invoked. |
-| Notebooks, executable computational documents | The threat model treats source Markdown as untrusted content. Execution is the thing we are switching off. |
-| Automatic dependency installation | Tier-3 banned. Consented install is offered; silent install never is. |
-| PDF/Typst/EPUB/DOCX correctness | Print formats have different diagram, pagination, and font requirements. Letting them shape v1 would distort the HTML design. Declared extension points — and that path goes through a Quarto adapter, not by replacing this one. |
-| Figure and section cross-reference syntax | Zensical has no `@fig-`/`@sec-` equivalent. Document-level links resolve; ordinals arrive in Phase 2 with captions. |
-| Mutation of source Markdown | Invariant. The whole staging layer exists so this holds. |
-| Mandatory migration of any pack | Level 0 must be sufficient forever, not just at launch. |
-| A central maintained content inventory | Every pack updating one shared file is a merge-conflict engine and a coupling point. |
-| Prose-parsing of status markers from document bodies | A sidecar solves the same need without inventing a Markdown-prose schema. |
-
----
-
-## Product boundary
-
-### One product, three scopes
-
-The pack installs at **`user`** scope by default, with `repo` and `local` allowed.
-`local` scope (RFC-0080 / ADR-0070) lands files in the working tree exactly as
-`repo` does but excludes them from Git via `.git/info/exclude`; it refuses to
-install outside a Git working tree. The *runtime* remains Git-free at every scope.
-
-There is exactly **one implementation**. Scope changes where the *pack* lives and
-which *configuration file* supplies defaults. It never changes the resolver, the
-schema, the validator, the staging adapter, or the renderer invocation.
-
-| | User scope | Repository scope | Local scope |
-|---|---|---|---|
-| Skill lands at | per-adapter user home — `~/.claude/skills/`, `~/.agents/skills/` (codex, cursor, gemini, copilot), `~/.kiro/skills/` | the same per-adapter layout beneath `<repo>/` | as repo, Git-excluded |
-| Defaults from | `~/.agentbundle/agentbundle-layout.toml` | `<root>/agentbundle-layout.toml` | as repo |
-| Recipes | wherever the caller points | committed under `binders/` | uncommitted |
-| Typical use | one install, many unrelated directories | shared team capability, CI | trying it out without touching *tracked files* |
-
-Because the skill has **no single install path** across seven adapters, the
-invocation contract is skill-relative rather than absolute — see
-[`invocation.md`](invocation.md).
-
-### What "repository scope" means outside Git
-
-**Git presence is not the test.** The pack resolves a **content root** by this
-order, and "repository scope" means only "the content root supplied repo-style
-configuration":
-
-1. `--root=<path>` → that path, resolved and confined, subject to the refusal
-   rules below.
-2. Otherwise, the nearest ancestor containing `binder.toml`, `binders/`, or
-   `agentbundle-layout.toml`.
-3. Otherwise, the nearest ancestor containing `.git`.
-4. Otherwise — only when the working directory is outside the installed pack —
-   the current working directory.
-
-Rule 2 precedes rule 3 deliberately: a directory carrying repository-style local
-configuration **is** a repository for this pack's purposes, whether or not Git has
-ever been run in it. Nothing about the runtime requires Git.
-
-**Rules 2–4 apply only when the process working directory is outside the installed
-pack — and on both adapters gate V6 could measure, it is.** Measured 2026-08-07:
-on `claude-code` and on `codex` an agent runs a script with the CWD of the
-**session's project root**, which is the content root, not the skill directory. So rule 4
-resolves correctly on the agent surface and **`--root` is not required** there; it
-remains the recommended form because it makes the resolution explicit rather than
-positional, which is what a `Makefile` or a CI step wants.
-
-The guard stays anyway, and it is now cheap insurance rather than the load-bearing
-rule: `binder.py` resolves its own realpath and skips rules 2–4 when its CWD is
-beneath the installed pack, exiting 4 with the message naming `--root`. The
-remaining adapters were not measured — `copilot`, `cursor`, and `gemini` were not
-installed, and the `kiro` binary is the IDE launcher with no headless agent CLI, so
-neither `kiro-ide` nor `kiro-cli` could be driven — so an adapter that does behave
-differently degrades to a clear error naming its own fix, instead of resolving a
-content root the caller did not intend.
-
-> **The old text said `--root` was "effectively required", and V6 removed the
-> premise.** It was written defensively because nothing in `author-a-skill.md`, the
-> skill-script conventions, or the adapter contract documents the CWD, and
-> `markdown-to-html`'s shipped interface implies the opposite. That reading of
-> `markdown-to-html` turned out to be right about the *documentation* and wrong
-> about the *behaviour*: its `node scripts/render.js` form does not resolve from an
-> agent session at all. See [`verified-findings.md`](verified-findings.md) V6.
-
-### `--root` is refusal-grade, and D-A withdrew the grant that would have changed that
-
-Two mechanical rules guard it, both always on: **every node read is
-extension-checked** (`*.md`, `*.markdown`, `*.mmd`, explicit paths included), and
-**a resolved content root that is the user home, a filesystem root, or an ancestor
-of `~/.agentbundle/` or the pack is exit 6.**
-
-An earlier draft observed — correctly — that a blacklist is not a lattice. Those
-rules do not stop `--root=$HOME/Documents/other-client` with
-`path = "engagements/acme-terms.md"`. It concluded that `--root` needed a grant,
-`[roots] allowed`, in a user policy file.
-
-**D-A withdraws that grant, and the argument with it.** The argument ran: *four
-flags are closed through the lattice, so the fifth must be too.* When that
-conclusion arrives for the fifth time, the surface is the problem. The other four
-were cut instead, and the premise dissolved — there is no lattice for `--root` to
-be inconsistent with.
-
-**The residual is real and stated:** a caller who points the tool at a directory
-gets what they pointed it at, provided every named file is Markdown beneath it.
-Two things make that acceptable here. The blast radius is *a read of Markdown the
-invoking user can already read* — `binder.py` runs with the caller's privileges, so
-`--root` grants nothing the caller lacks. And the proposed remedy was inert: it
-protected only users who had written a policy file, which the design's own text
-conceded was not the common case. **A grant the common case does not have is
-documentation, not a control.**
-
-### Ownership: what the pack owns, what the caller owns
-
-The installed pack directory is **read-only at runtime** — a mechanical control,
-not a convention: `binder.py` resolves the realpath of its own directory at
-start-up and refuses any write resolving within it.
-
-| Artifact | Owner | Lifetime | Git |
-|---|---|---|---|
-| `binder.toml`, `binders/*.binder.toml` | caller | durable | committed |
-| Editorial Markdown (`binders/editorial/*.md`) | caller | durable | committed |
-| `binder-index.json` | caller workspace | per run | ignored; **not** published |
-| `binder-stamp.json` | published tree | until replaced | with the publication |
-| `renderer-plan.json` | caller workspace | per run | ignored; never published |
-| Staging project (`stage/`, incl. its `site/` and `.cache/`) | caller workspace | per run | ignored |
-| Rendered publication | caller, configurable **beneath the content root** | until replaced | usually ignored |
-
-**One row is gone: the downloaded toolchain.** ADR-0073 replaced it with a pip
-package living wherever the user's Python environment lives — outside this table
-entirely, because the pack neither downloads nor owns it. That also removed the
-only thing the pack wrote outside a repository, which is why the write set is four
-items rather than seven.
-
----
-
-## Pack placement and charter fit
-
-| Principle | Assessment |
-|---|---|
-| **1. Universal across tech stacks** | **Clears.** Markdown artifacts and reader-oriented publications are language- and framework-neutral. The renderer is a pip package with 12 platform wheels. |
-| **2. Substantive, not duplicative** | **Clears** — argued below against `converters`. |
-| **3. A habit, not a tool** | **Clears** — see below (D45). |
-| **4. Used often enough to stick** | **Clears.** Architecture review, release readiness, incident review, and implementation handoff each recur; a team running any two reaches for this monthly. |
-
-### Principle 3, resolved
-
-The bar reads *"A habit, not a tool. Captures a way of working, not a piece of
-infrastructure."* The "not" is doing work, so the test is which one the pack is
-*about*.
-
-**Its subject is a habit** — assembling a decision dossier for a review forum. The
-machinery exists to make that habit reproducible and reviewable, exactly as
-`work-loop` ships scripts, `new-spec` ships a validator, and `iac-terraform` ships
-scaffolding. **Shipping a mechanism does not make the habit a tool**; a habit that
-recurs at a team of fifty needs one.
-
-The counter-reading is real and was weighed: two versioned schemas, a resolver, a
-trust scanner, and a renderer adapter is infrastructure by any ordinary measure,
-and the Charter's "does not" list opens by warning that most candidates fail at
-least one principle. The decision (D45) is that the machinery serves the habit
-rather than being the product.
-
-Note that the Charter's **accelerator-pack carve-out does not apply**: those packs
-clear the remaining three principles *instead of Principle 1*, not instead of
-Principle 3. There is no side door, and none was used.
-
-### Why a new pack rather than a ninth `converters` skill
-
-`converters` ships eight skills, and `markdown-to-html` already produces sidebar
-navigation, syntax highlighting, callouts, Mermaid, and print-ready output — so
-the overlap is real and must be argued.
-
-**The distinguishing axis is arity and selection, not output format:**
-
-| | `converters` | `binder-publishing` |
-|---|---|---|
-| Input | one named file | a *recipe* naming or querying many files |
-| Selection | none — the user names the file | resolution with ordering, exclusions, ambiguity, supersession |
-| Intermediate contract | none | `binder-index.json`, a public renderer interface |
-| Interop surface | none | `binder.toml` — other packs emit it |
-| Trust model | per-file conversion | strict scan over mixed-provenance corpora |
-
-**The dependency-weight half of this argument has evaporated, and saying so is
-more useful than keeping it.** An earlier version leaned on "a 236 MB external
-dependency" as a reason not to attach this to a pack most adopters install for
-`file-to-markdown`. A 12.2 MB pip wheel is lighter than `converters`' own npm
-surface. What survives is the table above — which is what the decision should have
-rested on all along.
-
-**RFC-0036 is the governing precedent** and chose `converters` over a new Office
-pack. Its skills are one-file-in/one-file-out converters with no selection
-semantics and no intermediate contract; they belong where they went. This design
-differs on all four axes above. RFC-0036's Axis A also rejected
-"Convert-from-Markdown (Pandoc/Quarto)" because *"the converter owns the output
-structure"* — answered by inverting the relationship: **the binder model owns
-structure and hands it to the adapter**, which receives an explicit chapter list,
-order, and part tree.
-
-If reviewers disagree, the fallback is a `converters` skill with the identical
-internal design — only the pack boundary changes, and no other decision depends on
-it. Recorded as U3.
-
----
+| Artifact | Owner | Lifetime | Publication |
+| --- | --- | --- | --- |
+| `binder.toml`, `binders/*.binder.toml` | caller | durable | caller-controlled |
+| `binders/editorial/*.md` | caller | durable | caller-controlled |
+| `binder-index.json`, `renderer-plan.json` | caller workspace | per run | never published |
+| `stage/`, including `site/` and `.cache/` | caller workspace | per run | never published |
+| `binder-stamp.json` | published tree | until replacement | published |
+| Rendered binder | caller | until replacement | beneath content root |
 
 ## Portability requirements
 
-The portable core must work in a directory with **no** `site.toml`, **no**
-documentation site, **no** `pack.toml`, **no** agent-ready-repo checkout, **no**
-source packs installed, **no** Git, and **no** frontmatter on any source file.
-
-Two facts make that concrete rather than theoretical:
-
-- **This catalogue's own governance artifacts carry no YAML frontmatter.** RFCs,
-  ADRs, specs, and architecture docs all open with an H1 followed by a bold-label
-  list. Frontmatter appears only where `contracts/guide.schema.json` applies — and
-  not even everywhere under `guides/`.
-- Therefore **the dogfooding repository is itself a Level-0 consumer** for most of
-  its artifacts. If Level 0 were second-class, this design would fail on the first
-  repository it was tried in. That is the strongest available argument for making
-  explicit paths the primary path rather than a fallback.
-
-**The pack depends on no npm, no Node, no Astro, no Starlight, no `site.toml`, and
-no `tools/build-site.py`.** `binder.py` is standard library only, consistent with
-`agentbundle`'s stdlib-only posture.
-
----
+The portable core accepts explicit local Markdown paths in a directory with no
+Git repository or metadata. Source Markdown is never modified. A published
+binder makes no network request when read. Dependency resolution works when the
+renderer is absent.
 
 ## Architectural invariants
 
-The brief proposed twenty; all are adopted, three with amendment, and two were
-added. The eight this tree restates normatively are listed here so they resolve
-from inside it; the other twelve are adopted verbatim from the brief.
+Twenty-two invariants govern this design. Eight are restated below. The
+originating brief containing the remaining fourteen is absent from this
+repository and must be recovered before implementation. There is no invariant
+23.
 
 | # | Invariant |
-|---|---|
-| 3 | Renderers consume the index and never rediscover or reorder — enforced by a single `read_node_source(node)` accessor that rejects any path not in the index |
-| 8 | Build state is caller-owned and isolated **per (binder-id, content-key)**, with a separate lock on the resolved publication directory — see the amendment below |
-| 10 | No global mutable binder state file |
-| 12 | Pack-produced Markdown is content, not trusted renderer configuration — the load-bearing security claim |
-| 13 | The first renderer is not the canonical model |
-| 18 | The strict trust profile is mechanically enforced |
-| 21 | `binder-index.json` is byte-reproducible for identical inputs |
-| 22 | `binder build` writes no field of `binder-index.json` |
+| --- | --- |
+| 3 | Renderers consume the index and never rediscover or reorder. Every adapter source read uses `read_node_source(node)`, which rejects a path absent from the index. |
+| 8 | Build state is isolated per `(binder-id, content-key)` and the resolved publication directory has a separate lock. |
+| 10 | No global mutable binder state file exists. |
+| 12 | Pack-produced Markdown is content, not trusted renderer configuration. |
+| 13 | The first renderer is not the canonical model. |
+| 18 | The strict trust profile is mechanically enforced. |
+| 21 | `binder-index.json` is byte-reproducible for identical inputs. It contains no timestamps, run IDs, host names, or absolute paths. |
+| 22 | `binder build` writes no field of `binder-index.json`. Adapter-generated data belongs in its plan file. |
 
-**There is no invariant 23.** An earlier draft added *"every input is classified
-by origin before it is trusted"* to serve the authority lattice; D39 deleted the
-lattice and origin classification with it.
+D-A removes origin classification and policy/grant inputs. D39 therefore leaves
+no authority lattice to implement. Invariant 13 permits a renderer replacement
+without changing the recipe, index, resolver, or scanner. D-B removes the
+downloaded toolchain from the pack write set.
 
-**Amended — #8.** "Isolated per binder *or* run" is too loose to be testable. The
-design commits to *per (binder-id, content-key)* isolation for the workspace **and
-a separate lock on the resolved publication directory**, because those are two
-distinct shared resources.
+D34 requires renderer scanner rules to be declarative and available to `resolve`
+and `inventory`. D45 fixes the pack boundary; the implementation is the
+`binder-publishing` pack and its `publish-binder` skill.
 
-**Amended — #13.** The brief wrote "Quarto is the first renderer, not the
-canonical model". **Demonstrated rather than asserted:** the renderer then
-changed, and the index, schema, resolver, and scanner did not.
-
-**Amended — #18.** D-A made strict the *only* profile, so "mechanically enforced"
-no longer needs the qualifier "at the level the policy file authorizes".
-
-**Added — #21. `binder-index.json` is byte-reproducible for identical inputs.** No
-timestamps, run IDs, host names, or absolute paths. Run metadata lives in a
-separate `run.json`. This makes the index diffable in CI and testable without
-golden-file churn, and it is a harder anti-receipt-theatre constraint than "avoid
-audit fields" — it makes ceremonial fields structurally impossible.
-
-> D-A strengthened this by deleting its exception. The previous version had to
-> qualify *inputs* to include the resolved trust profile, so only "the same
-> machine always reproduces" could be promised. With one profile and no policy
-> file, **reproducibility is now machine-independent**.
-
-**Added — #22. `binder build` writes no field of `binder-index.json`.** The index
-is complete when `resolve` returns and carries no renderer-shaped field. Anything
-an adapter must invent — staged filenames, line offsets, emitted ordinals — goes
-in that adapter's own plan file. Invariant 3 stops the adapter reaching back into
-the sources; this one stops it reaching back into the contract.
-
----
-
-## Current-state analysis
-
-| Surface | Relevance |
-|---|---|
-| `packs/converters` | Overlapping on output, disjoint on arity — argued above |
-| `tools/build-site.py` + `docs-site/` | The catalogue surface. Different audience, different lifecycle, npm-dependent. Untouched |
-| `site.toml` | Repository- and Astro-specific. Not a binder format and must not become one |
-| `agentbundle-layout.toml` | **The mechanism this pack uses** — with one correction below |
-| `.apm/skills/<name>/{scripts,references,assets,evals}` | The only four blessed skill subdirectories; fixes the pack's shape |
-| Skill self-containment (`author-a-skill.md`) | **Decides the pack shape** *and* the template seam — see [`outline-and-templates.md`](outline-and-templates.md) |
-| Skill path discipline (linter-enforced) | **Decides the invocation contract** |
-| Three-tier dependency policy | Satisfied with no deviation: a pinned pip install is Tier 2 as written |
-| `safe_io.py` in `converters` | The blessed path-confinement pattern to reproduce (not import — self-containment forbids that) |
-| Adapter contract v0.17 (current contract v0.18) | Fixes both the invocation contract and the manifest's minimum version |
-| RFC-0080 / ADR-0070 | `--scope local`; auto-allowed with `repo` |
-| RFC-0036 | The placement precedent, addressed above |
-
-**Correction: how `agentbundle-layout.toml` defaults actually work.** Verified
-against `install.py::_append_layout_section`: the appender reads
-**`[pack.layout.<scope>].parent`**, not `output_dir`; it appends a table named
-`[<pack-name>]`, not a semantic section name; and with `parent` absent it returns
-early — a no-op. All five current consumers declare `output_dir` and no `parent`,
-so **the install-time append has never fired for any of them.** The sections their
-skills read are hand-written by adopters.
-
-So: **`[binder]` is an adopter-hand-written section**, and `[pack.layout.repo]
-output_dir` is declared for parity and as machine-readable documentation of the
-default — not because it causes an append. Recorded as U12.
-
-**Documented drift found during this analysis.**
-`guides/_shared/reference/skill-script-conventions.md` (line 62) tells authors to
-put shared code in `.apm/shared-libs/`, while
-`guides/_shared/how-to/author-a-skill.md` (line 77) says that path must **not** be
-used for skill code. This design follows the stricter statement. Flagged, not
-worked around — recorded as U11.
-
----
-
-## Alternatives
-
-Twelve were assessed. The architecture choice and the renderer choice are
-independent axes, and separating them is what bounded the renderer reversal to one
-of them.
-
-- **Axis A — architecture:** renderer-independent compiler with a neutral index
-  (**selected**), versus a renderer-specific schema, extending `site.toml`, or no
-  compiler at all.
-- **Axis B — renderer under architecture 1:** **[ADR-0073](../../adr/0073-zensical-as-the-v1-binder-renderer.md)**.
-
-**Axis A, scored.** Legend: ● strong · ◐ partial · ○ weak.
-
-| Criterion | 1 Selected | 2 Renderer-schema | 3 site.toml | 7 No compiler |
-|---|---|---|---|---|
-| Pack interoperability | ● | ○ | ○ | ○ |
-| Deterministic composition | ● | ◐ | ○ | ○ |
-| Mechanically closable security | ● | ◐ | ○ | ○ |
-| Schema evolution | ● | ○ | ○ | ○ |
-| Renderer flexibility | ● | ○ | ○ | ○ |
-| Inspectability | ● | ◐ | ◐ | ○ |
-| Existing-site integration | ● | ◐ | ● | ○ |
-| Maintenance burden | ○ | ◐ | ◐ | ● |
-| New machinery | ○ | ◐ | ◐ | ● |
-
-Architecture 1 wins on **pack interoperability** and **mechanically closable
-security** — the two the brief made non-negotiable, and neither retrofittable onto
-options 2, 3, or 7 without those becoming option 1. It is the most expensive on
-maintenance burden and new machinery. That is the trade.
-
-**Axis A was predicted to survive a renderer change, and did.** The swap moved the
-adapter, its plan file, the dependency contract, and the staged layout; the index,
-schema, resolver, and scanner did not change. The remaining eight alternatives and
-the reasons they lost are in [`history.md`](history.md).
-
----
-
-## Proposed component architecture
+## Component architecture
 
 ```mermaid
 flowchart TB
-  subgraph sources["Caller-owned content (untrusted)"]
-    MD["Ordinary Markdown<br/>(any origin, no frontmatter required)"]
-    PK["Pack outputs<br/>(surveys, RFCs, ADRs, designs, specs)"]
-    ED["Editorial Markdown<br/>(exec summary, section intros)"]
+  subgraph sources["Caller-owned content"]
+    MD["Markdown artifacts"]
+    ED["Editorial Markdown"]
   end
-
-  subgraph recipe["Editorial intent (caller-owned, committed)"]
-    BT["binder.toml<br/>binders/*.binder.toml"]
+  BT["binder.toml"]
+  subgraph core["Portable core"]
+    VAL["Validate"]
+    DISC["Discover + normalize"]
+    SCAN["Trust scan"]
+    RES["Resolve"]
+    IDX["binder-index.json"]
   end
-
-  subgraph core["Portable core — renderer-neutral"]
-    VAL["Validation<br/>schema + policy"]
-    DISC["Discovery + normalization<br/>bounded scan, identity, metadata"]
-    SCAN["Trust scanner<br/>core floor + adapter-declared rules"]
-    RES["Deterministic resolver<br/>selection, order, conflicts"]
-    IDX["binder-index.json<br/>PUBLIC versioned contract"]
+  subgraph adapter["Zensical adapter"]
+    REV["Re-verify sha256"]
+    STAGE["Stage docs, config, theme"]
+    NAV["Assert nav targets"]
+    INV["zensical build --strict"]
   end
-
-  subgraph adapter["Zensical adapter — renderer-specific"]
-    REV["Re-verify vs recorded sha256"]
-    STAGE["Staging<br/>docs/*.md + zensical.toml + theme"]
-    NAV["Assert every nav target exists"]
-    INV["python -m zensical build --strict"]
-    DIAG["Diagnostics<br/>staged → source mapping"]
-  end
-
-  OUT["Static HTML binder<br/>caller-owned publication"]
-
+  OUT["Static HTML binder"]
   MD --> DISC
-  PK --> DISC
   ED --> DISC
   BT --> VAL --> DISC --> SCAN --> RES --> IDX
   IDX --> REV --> STAGE --> NAV --> INV --> OUT
-  INV -.render errors.-> DIAG
-  DIAG -.mapped to source path + line.-> OUT
-
-  style core fill:#eef4fb,stroke:#4a72a8
-  style adapter fill:#f6eefb,stroke:#8a5aa8
-  style sources fill:#fbf4ee,stroke:#a8794a
 ```
 
-**The claim this diagram carries, at the strength it holds:** the adapter reads
-source files only through an index-derived path allowlist, and links no discovery
-module. It *does* read caller-owned sources — staging must — and the index does
-carry `content-root`, so the weaker claim that it "is never given a source root"
-would be false.
+The core owns identity, source roots, sections, parts, artifact references,
+selection, ordering, exclusions, conflicts, supersession, editorial
+classification, provenance, publication profile, renderer selection, and
+namespaced renderer options. The adapter owns staged paths, generated
+`zensical.toml`, `nav`, theme assets, invocation, source-to-stage diagnostics,
+ordinals, and staged link rewriting.
 
-What makes invariant 3 mechanical is narrower and testable: every source read in
-the adapter goes through a single `read_node_source(node)` accessor that **rejects
-any path not enumerated in the index**. There is no glob, no walk, and no selection
-code reachable from `render_zensical.py`. An adapter cannot reorder or re-select
-because it has no way to name a file the resolver did not choose — not because it
-was denied a variable.
+The adapter has no discovery or selection path. It reads a caller-owned source
+only through `read_node_source(node)`. The accessor enforces invariant 3 by
+rejecting a source path not enumerated by the index.
 
-### Ownership and boundaries
-
-| Owned by the **binder model** (renderer-neutral) | Owned by the **Zensical adapter** |
-|---|---|
-| identity, title, purpose, audience, subject, scope | staged file paths and names |
-| source roots | generated `zensical.toml` |
-| sections, parts, exact artifact references | the `nav` array and its nesting |
-| semantic selection, ordering, exclusions | theme: `main.html`, CSS, vendored `mermaid.min.js` |
-| conflict and supersession policy | the `build` invocation and argv |
-| editorial material and its classification | diagnostics interpretation and ANSI stripping |
-| provenance and publication profile | ordinal emission (Z2h) and its CSS rendering |
-| renderer selection | link rewriting to staged filenames |
-| **namespaced** safe renderer options | everything under `stage/` |
-
-### Namespacing renderer options without contaminating the core
+### Renderer options
 
 ```toml
 [renderers.zensical]
 mermaid-theme = "neutral"
-toc-depth     = 3
+toc-depth = 3
 ```
 
-Three rules keep this from becoming a leak:
+The core validates the selected renderer table as scalars or arrays of scalars,
+copies it into the index, and does not interpret its contents. The Zensical
+adapter owns a closed allowlist and rejects unknown keys. Every allowed key has
+an emission point in [`zensical-adapter.md`](zensical-adapter.md); D15 forbids a
+recipe key with no effect.
 
-1. **The core never reads inside `[renderers.*]`.** It validates that the selected
-   renderer's sub-table is present and that every value is a scalar or array of
-   scalars, copies it into the index verbatim, and never interprets it.
-2. **Each adapter owns a closed allowlist of its own option keys.** An unknown key
-   is a validation error from the adapter, not a silent pass-through — and every
-   allowlisted key has a named emission point in
-   [`zensical-adapter.md`](zensical-adapter.md), because a recipe key with nowhere
-   to land is the silently-ignored key D15 forbids.
-3. **No option may reach a security-relevant renderer key.** The allowlist
-   mechanically excludes `custom_dir`, `extra_javascript`, `extra_css`,
-   `markdown_extensions`, `docs_dir`, `site_dir`, `site_url`, `hooks`, and
-   `plugins`. Because the allowlist is positive, a new renderer option cannot
-   become reachable by accident.
+The allowlist excludes `custom_dir`, `extra_javascript`, `extra_css`,
+`markdown_extensions`, `docs_dir`, `site_dir`, `site_url`, `hooks`, and
+`plugins`. No recipe option can reach a security-relevant renderer setting.
 
-**The first two exclusions matter most and are excluded for a specific reason**,
-not as part of a general sweep: `custom_dir` and `extra_javascript` are exactly
-what the adapter uses for the offline hardening. **A recipe that could set either
-could swap the vendored Mermaid for a remote one**, undoing Z4 from repository
-content.
+## Existing-site and reader boundary
 
----
+`docs-site/` remains separate. V1 supports links from that site to a separately
+built binder. If a site later needs binder selection or ordering, it reads the
+index rather than duplicating resolver behavior.
 
-## Existing-site integration boundary
+| Reader element | Owner |
+| --- | --- |
+| Cover metadata, source attribution, provenance, source inventory | compiler |
+| Executive summary and transitions | editorial Markdown |
+| Parts, chapters, cross-document targets, superseded-material handling | binder semantics |
+| Chapter and appendix ordinals | compiler `data-ordinal`; never title text or search-index text (D44) |
+| Navigation, search, responsive layout, print CSS | Zensical and pack theme |
+| Artifact-kind and lifecycle badges | compiler metadata and pack theme |
+| Decision, risk, and open-question callouts | recipe-assigned `admonition` blocks |
+| Mermaid fence body | source bytes, unchanged |
+| Mermaid accessible name | compiler attributes and theme lift into SVG (D46) |
 
-The Astro/Starlight site at `docs-site/` remains the permanent catalogue and
-technical-documentation surface. This design does not replace, modify, or depend
-on it.
-
-| Boundary | Assessment |
-|---|---|
-| **Link out** — the site links to a separately built binder | **Selected for v1.** Zero coupling, zero new code, works today |
-| Mount — copy a rendered binder into the site's static tree | Deferred, and **cheaper than it was**: Z4e found every asset reference document-relative, so it needs a copy step and a `site_url`, not the base-path rewriting Quarto's output required |
-| Site builder consumes `binder-index.json` | Deferred, and **enabled by construction** — the index is a public versioned contract precisely so this is a later addition rather than a later redesign |
-| Shared content-graph layer serving both | Rejected for the foreseeable future. It would require the site and the compiler to agree on identity, metadata, and lifecycle semantics — a large shared abstraction justified by no current requirement |
-
-**Binder selection and ordering semantics are never duplicated inside
-`build-site.py`.** If the site ever needs them, it reads the index.
-
----
-
-## Binder reader experience
-
-| Aspect | Owner |
-|---|---|
-| Cover page; purpose, audience, subject, scope, status | **Compiler-generated** from the index |
-| Executive summary | **Editor-generated**, marked |
-| Named parts, chapter ordering | **Binder semantics** → the emitted nested `nav` |
-| Chapter numbers and appendix letters | **Compiler-generated as a `data-ordinal` attribute, rendered by theme CSS** — the renderer numbers nothing (Z2h), and the number stays out of the title text so it never reaches the search index or the browser tab (D44) |
-| Section introductions, transitions | **Editor-generated**, marked |
-| Sidebar, search, previous/next, per-page TOC, responsive layout | **Renderer-native** (Z2a, Z2e, Z4e) |
-| Artifact-kind and lifecycle-status badges | **Compiler-generated** from index metadata, as `admonition` blocks and `attr_list` spans; the **pack theme** styles them. Verified (Z2b) — no gate outstanding |
-| Source attribution | **Compiler-generated**, one restrained line per chapter — artifact kind and status only, **never the repository-relative path** |
-| Decision / risk / open-question callouts | **`admonition` blocks**, emitted where the recipe assigns a `role`; **not** inferred from prose |
-| Cross-document links | **Binder semantics** (target resolution) + **renderer-native** URL shaping (Z2b) |
-| Mermaid diagrams | **Binder semantics** (constraints) + **compiler-generated** accessible naming, as allowlisted `attr_list` attributes on the fence delimiter that the **pack theme** lifts into the Mermaid source, so the SVG itself carries `<title>`/`<desc>` (D46 — Z6d found attributes left *on* the fence are destroyed at render time) + **the vendored bundle** rendering client-side (Z6a). The compiler performs **no transformation of the fence body** (Z3a) |
-| Appendices; source inventory and provenance | **Compiler-generated**, and the inventory is **opt-in** |
-| Superseded material | **Binder semantics** — dropped, or gathered into an appendix |
-| Conflicting material | **Editor-generated** commentary; the compiler surfaces both, never adjudicates |
-| Semantic headings, visible focus, accessible diagram names, reduced motion, system-font stack | **Pack theme** + compiler-emitted names |
-| Print stylesheet | **Pack theme**, best-effort — PDF correctness is a non-goal |
-
-**Producer-pack implementation detail is deliberately not surfaced.** A reader sees
-"Architecture design · Accepted", not "produced by `architect-design` v0.14.2 into
-`docs/design/`" — and not the source path either.
+Mermaid uses portable GitHub-style fences. The compiler does not transform a
+fence body. It rejects Mermaid directives, click/callback forms, and unsupported
+node-label syntax. The theme uses vendored `mermaid.min.js`; remote asset loading
+is not permitted. A source attribution contains artifact kind and status, never
+a repository-relative source path.

--- a/docs/architecture/binder-publishing/rollout.md
+++ b/docs/architecture/binder-publishing/rollout.md
@@ -1,459 +1,148 @@
-# Rollout, testing, and open questions
+# Testing, CI, and open questions
 
-> Phases, test strategy, CI wiring, unresolved decisions.
+> Test requirements, CI wiring, extension constraints, and unresolved decisions.
 > Part of [binder publishing architecture](README.md).
 
-## Testing and eval strategy
-
-Tests live at `packs/binder-publishing/tests/skills/publish-binder/`, outside the
-`.apm/` runtime boundary. Evals live at `.apm/skills/publish-binder/evals/`.
-
-### Unit
-
-Schema parsing · `schema-version` behaviour · unknown-field error and
-`--allow-unknown-fields` · **`[policy] profile` and `[policy] shortcodes` are
-unknown fields (exit 4), not deprecated keys** · **not-yet-implemented key class,
-per phase** · `[x-vendor]` passthrough · content-root resolution in all four
-branches · **content-root refusal list — home, filesystem root, an ancestor of
-`~/.agentbundle/` or of the pack itself, each exit 6** · **every node read is
-extension-checked, explicit `path` included** · configuration precedence ·
-identity normalization and case collision ·
-status-map normalization and unknown status · stable ordering · weight sorting ·
-`before`/`after` topological order · **cross-section constraint is exit 4** ·
-cycle detection · ambiguity · missing required vs optional · duplicate handling ·
-supersession · exclusion beating inclusion · excluded-required erroring ·
-**duplicate `id` and colliding publication dir** · child-binder cycle detection ·
-frontmatter discard-and-rebuild · **executable-cell fence neutralization, with a
-` ```mermaid ` fence *body* asserted byte-identical to its source and its opening
-delimiter asserted line-count-neutral after the D46 annotation** · Mermaid
-directive/click/callback rejection and the `<br>`/`<|--`/`<-->` label allowlist ·
-link rewriting to staged `.md` filenames · **`line-offset` accuracy, property-tested
-against randomly generated sources, including the CRLF and BOM cases** ·
-staged-name determinism and hash disambiguation · **`emitted-ordinal` numbering,
-including that an unnumbered chapter emits `null` and that the ordinal appears as
-a `data-ordinal` attribute and never inside a title string or the search index** · path traversal · absolute
-paths · symlink escape · asset allowlist · resource ceilings · self-path write
-refusal · **argv construction — a list, never a shell string, `-f` the only path
-element, `--strict` always present** · **environment allowlist construction —
-assert a planted `AWS_SECRET_ACCESS_KEY` is absent from the child env** · **TOML
-injection — a recipe `title` containing `"` and a newline is rejected at
-validation, and with the validator stubbed out the emitter still yields a
-`zensical.toml` whose parsed form has no injected sibling key** · **renderer-
-interpretable syntax in an emitted string — a recipe `title` of `"{{< env HOME >}}"`
-is exit 4, the same as a source H1 is exit 6 with fallback to the file stem** ·
-**label resolution across all four rules, including a source H1 carrying a control
-character falling through to the file stem** · **parameter substitution confined
-to the closed key list, single-pass, erroring on an unresolved `${name}`** ·
-**publication-ownership check — a foreign directory is exit 4 and is not renamed**
-· **`publication-dir` absolute or `..`-escaping is exit 6** · **heading shift
-clamps at H6 and warns** · **scan exclusions warned,
-`scan-exclusions-override` re-admits** · **invariant 22 — a golden index from
-`resolve` is byte-identical to the index after `build`** · **the index carries no
-`profile` key** · **cross-device publication detected at validation** ·
-**version probe — `importlib.metadata.version` is used and a stubbed
-`zensical.__version__` is never read (Z1c)** · exit-code mapping including 9 and 130.
-
-**Deleted from this list, and worth naming rather than silently shortening:** the
-trust-lattice suite (recipe cannot grant, repo policy cannot grant,
-`--profile trusted` exits 6, grant matching resists a planted symlink), the
-`--quarto`-beneath-the-content-root test, the shortcode
-reject/escape/idempotence tests, the `--out` confinement test, and the
-`_quarto.yml` two-profile golden files. Each tested a mechanism D-A or D-B
-removed. **A test suite that outlives its mechanism is how a design keeps paying
-for a decision it already reversed.**
-
-### Integration
-
-**Gates Z1–Z4 against the single shared fixture** (all required in CI as
-regression assertions) · **Z4's zero-remote-*subresource* assertion over the built
-tree — no `src=`, stylesheet or preconnect `href=`, `@import`, or off-host `url()`;
-NOT a zero-`https://` string match, which Z4d showed unsatisfiable** · renderer
-detection present/absent/wrong-version, **including that the probe is
-`importlib.metadata.version`** · generated `zensical.toml` against a golden file
-(**one file — there is no second profile to differ from**) · successful HTML render
-· parts render as nested nav groups · search index generated and local · prev/next
-present · **Mermaid renders from an untransformed portable fence, and the vendored
-`mermaid.min.js` is referenced from `<head>` ahead of the theme bundle** · invalid
-Mermaid mapped to the source line through `line-offset`, **with ANSI stripped
-first (Z1f)** · **a `nav` entry with no staged file is exit 7 before the renderer
-is invoked (Z2g)** · **a `--strict` build reporting issues is exit 7, and a build
-without `--strict` is never trusted to have succeeded (Z1b)** · idempotent rebuild
-produces a byte-identical index · `check --published` returns 0 fresh / 9 stale /
-10 on a pack-version change · interrupted build leaves no corrupt state · **two
-concurrent different binders both succeed** · two concurrent identical builds
-serialize on the workspace lock · **two different recipes targeting the same
-publication dir are rejected at validation, and the publication lock serializes
-the case that slips through** · near-atomic publication replacement, **including
-the cross-device copy path** · **`binder-stamp.json` present in the published tree
-while `binder-index.json` is absent from it, the stamp carrying no `diagnostics`
-key, and `check --published` returning 9 after a source edit** · **nothing is
-written outside `stage/`, the publication, and its three named siblings — asserted
-by a recursive hash of the content root before and after, which is what catches
-`site/` or `.cache/` landing somewhere unexpected** · `clean` confinement.
-
-Renderer-dependent tests skip with a clear reason when `zensical` is absent and
-are **required** in CI, where the pipeline installs it.
-
-### CI provisioning — the wiring this needs, named
-
-This repository wires pack tests by **explicit enumeration** —
-`.github/workflows/catalogue-tooling-ci-gates.yml` runs
-`python -m pytest packs/core/tests/ packs/product-documentation/tests/ -q` — so a
-new pack's tests do not run until someone adds them. "Required in CI" is a change
-to a file, not a property that arrives by itself:
-
-| Change | Where |
-|---|---|
-| Add `packs/binder-publishing/tests/` to the pytest invocation | `catalogue-tooling-ci-gates.yml` |
-| Add `python -m pip install zensical==0.0.53` as an ordinary step | same workflow |
-| **Provision a headless browser for the Z6 assertions** — the one dependency the design otherwise avoids, and non-negotiable: Z6e is a mechanism that fails in the direction a static check reads as green | same workflow |
-| **Provision a Linux egress detector for Z5, with its own negative control** — `sandbox-exec` is macOS-only, so the executed instrument does not port; a namespace or seccomp filter is needed, and **a denial mechanism that silently fails open turns Z5 into a green light** | same workflow |
-
-**Four rows. Two of them are the two most expensive gates, and they are named here
-rather than assumed** — an earlier version of this section said "two rows" while the
-same file committed Phase 1 to converting Z1–Z6, which would have left the two gates
-that need real provisioning as the ones nobody had budgeted. If the browser and the
-Linux detector slip, **say so and ship Z1–Z4 as the CI floor**; do not let "required
-in CI" quietly mean four of six.
-
-**The first two rows were the whole story when this said so.** Quarto
-provisioning was a ~236 MB download per job, which forced the render gates behind
-a path filter, split the suite into "runs always" and "runs when the pack
-changes", and needed a separate V4 platform-matrix job to prove an install command
-worked verbatim on three operating systems.
-
-**All of that is gone.** A 12.2 MB wheel with 12 platform wheels — including
-Windows, musl, and armv7 — is an ordinary pipeline dependency. The Z-gates run on
-**every PR**, alongside the unit tests, because there is no longer a cost worth
-optimising against. The path filter was never a good property; it meant the render
-gates did not run when a *shared* change broke them, and it existed only because
-the renderer was expensive.
-
-### The portability acceptance test — the most important one
-
-1. Create a clean temp directory. **No Git, no `pack.toml`, no `site.toml`, no
-   agent-ready-repo files, no docs site.**
-2. Write four ordinary Markdown files, one containing a portable ` ```mermaid `
-   fence, plus a `binder.toml` referencing them by explicit path.
-3. Expose the pack from a read-only copy of its projected form.
-4. `resolve` → assert `binder-index.json` exists and matches a golden file byte
-   for byte.
-5. `build` → assert `index.html`, per-chapter HTML, a local `search.json`, and a
-   `<pre class="mermaid">` block whose content is byte-identical to the source
-   fence all exist.
-6. **Assert every source file's SHA-256 is unchanged.**
-7. **Assert the pack directory tree is unchanged** — recursive hash before and
-   after.
-8. **Assert nothing was written outside the temp directory at all.** The previous
-   version said "outside the temp directory *and the toolchain cache*"; D-B
-   deleted the cache, so the assertion is now unqualified — which is a strictly
-   stronger test and a better headline for the acceptance case.
-9. **Assert the built tree makes no remote subresource request** — the Z4
-   assertion, run here too, because an air-gapped adopter is exactly the person
-   the clean-directory case is for.
-
-### The multi-pack fixture
-
-A fixture repository combining: a `desk-research`-shaped `<slug>-survey.md` with
-YAML frontmatter; an RFC and an ADR in this repository's **frontmatter-free**
-bold-marker style, each with a `.binder.toml` sidecar; an `architect-design`
-design doc containing Mermaid; a `new-spec` spec and plan; and two hand-written
-Markdown files with no metadata at all. A producing pack **writes** a recipe
-template into the fixture's `recipes_dir`, and `binder build` resolves it as an
-ordinary recipe — **importing nothing from it and reading nothing inside its skill
-directory**, which is the seam as redesigned in
-[`outline-and-templates.md`](outline-and-templates.md). Level-0, Level-1, and
-sidecar items resolve in the same run.
-
-**One assertion is added and it is the point of the fixture:** that
-`binder.py` opens no path beneath any other skill's directory during the whole
-run. Without it, the self-containment property is a claim the fixture illustrates
-rather than tests — and the previous seam is proof that the claim can drift.
-
-### Accessibility smoke checks
-
-Parsed from the rendered HTML: every `<img>` carries an `alt` attribute — **present, possibly empty**, since a source `![](x.png)` gives the compiler nothing to invent and a fabricated description is worse than an explicit null; a missing attribute is a failure, an empty one is recorded in diagnostics; heading levels never skip
-**except where a clamped H6 shift was warned, which the check reads from
-`renderer-plan.json` — the clamp is transformation step 3, so recording it in the
-index would violate invariant 22**; `<html lang>` present; skip-link present;
-focus-visible styling present in the theme CSS. Not a full audit — a regression
-net for the theme.
-
-**The Mermaid accessible-name check moves out of the HTML parse, because there is
-no SVG to parse.** Quarto rendered diagrams server-side into the output; Zensical
-emits `<pre class="mermaid"><code>…` and the vendored bundle renders it in the
-reader's browser (Z3a, Z3c). A static check over the built tree therefore cannot
-see an `<svg>` at all, and a check asserting one would have failed on every build
-— or worse, been quietly deleted.
-
-Two checks replace it, and between them they cover the same concern honestly:
-
-- **Static:** every `<pre class="mermaid">` carries `data-a11y-name` (and
-  `data-a11y-desc` once Phase 2 gives it a source), HTML-escaped and rejected on
-  `%%{` or a newline, emitted by the compiler from values it owns — never from the
-  fence body (D46).
-
-  > **In v1 that name is an ordinal — `Diagram <n>.<m>` — and nothing more.** The
-  > index carries no per-diagram text until `figures[]` lands, so there is nothing
-  > descriptive to emit and `accDescr` is not emitted at all. **This check therefore
-  > verifies that diagrams are identifiable, not that they are described**, and the
-  > distinction is worth keeping visible: by the `<img alt>` reasoning above, an
-  > ordinal is the honest null rather than a description. The descriptive alternative
-  > is Phase 2 work, not a gap this check closes. Assertable over
-  the built HTML, and the part the compiler actually controls. **Where no name is
-  derivable the attributes are absent**, which is recorded in diagnostics and is not
-  a failure — the same reasoning as the `<img alt>` rule above, and the reason this
-  check asserts *consistency with `renderer-plan.json`* rather than mere presence.
-- **Z6, run 2026-08-07:** that the name reaches the reader. It does, **on the
-  graphic itself** — measured `role='graphics-document'` carrying both the name and
-  the description, with real `<title>`/`<desc>` inside the SVG, diagram rendered and
-  egress blocked. The theme lifts the attributes into the Mermaid source before the
-  bundle mounts; [`zensical-adapter.md`](zensical-adapter.md) has the mechanism.
-
-> **What Z6 falsified was not the attributes but the belief that they were enough.**
-> The old text read: *every `<pre class="mermaid">` block carries an accessible name
-> in its `attr_list` attributes* — and stopped there, treating the built HTML as the
-> reader's HTML. The bundle replaces that `<pre>` with a fresh `div` carrying only
-> `class`, so the attributes never reach the diagram (Z6d), **and the check would
-> have passed anyway**, because the name is present exactly when the diagram *fails*
-> to render (Z6e). A static assertion that reads green precisely when the feature is
-> broken is worse than no assertion — the argument for having spent a headless
-> browser here. D46 keeps the attributes, which are cheap and add no lines, and adds
-> the theme-side step that carries them into the SVG.
-
-The graceful-degradation property is worth stating because it is unusually good
-here, and Z6k measured it rather than assuming it: if the vendored bundle fails to
-load, the reader sees the diagram's own Mermaid source as preformatted text rather
-than a blank space.
-
-### Activation evals
-
-`evals/eval_queries.json` covers positive triggers ("publish these documents as a
-binder", "build the architecture review packet", "compile these into one
-navigable document") and near-miss negatives that must **not** trigger — "convert
-this Markdown to HTML" (→ `markdown-to-html`), "render this for review" (→
-`render-proof`), "render these Mermaid diagrams to PNG" (→ `mermaid-renderer`),
-"write a design doc" (→ `architect-design`). The negatives matter more than the
-positives, because three neighbouring skills already exist in `converters`.
-
----
-
-## Phased rollout
-
-**Phase 0 — the architectural seam. No renderer.**
-Schema v1 + JSON Schema files (in the skill's `assets/`; **not** mirrored to `contracts/` — see *Canonical schema publication*) ·
-validator including the unknown-field and not-yet-implemented classes ·
-**the trust scanner's core floor *and the Zensical rule table*** — both belong
-here, not in Phase 1: D34 makes the rule set declarative so registering a
-renderer's rules needs no adapter, and Phase 0 ships `resolve` and `inventory`,
-which read source bodies. Shipping the floor alone would let a Phase-0 `resolve`
-admit content Phase 1 then rejects · Level-0 resolver (explicit paths, sections,
-parts, weight, before/after, exclusions, dedup) · `binder-index.json` v1 ·
-`outline`, `templates`, `check`, `resolve`, `explain`, `inventory` ·
-configuration precedence · path confinement and the content-root refusal list ·
-unit tests.
-
-*Ships nothing a user can read — and establishes every contract that is expensive
-to change later.* Independently valuable: the index is consumable by anyone who
-wants to write a renderer.
-
-**The Zensical rule table is three rows**, against Quarto's much longer one: the
-`%%{init:}%%` directive, `click … callback`/`call`, and the Mermaid node-label
-allowlist. Everything the Quarto table carried about shortcodes and raw pandoc
-blocks has no subject here.
-
-**Phase 1 — v1 completes. First readable binder.**
-Zensical staging adapter · the strict scanner · Mermaid constraints, the vendored
-bundle, and the accessible-name mechanism (D46) — compiler-emitted `data-a11y-name`
-fence attributes carrying `Diagram <n>.<m>`, plus the theme-side `accTitle:` lift;
-descriptive names and `accDescr` wait on `figures[]` in Phase 2 · theme assets and the
-offline hardening · compiler-emitted numbering · cover, part pages, source
-inventory, provenance · link rewriting and asset copying · diagnostics mapping ·
-`build`, `recipe write`, `clean`, `check --published` · **two** locks,
-concurrency, near-atomic publication · **the clean-directory portability fixture
-and the multi-pack fixture** · activation evals · guides · **converting Z1–Z6 into
-CI assertions**, which is the one place Phase 1 needs a headless browser.
-
-**Phase 0 + Phase 1 = v1.**
-
-**No gate remains.** Z1–Z4 ran 2026-08-06, Z5 and Z6 on 2026-08-07, and V6 — the
-last renderer-independent one — was answered the same day. Phase 1 opens with every
-renderer question settled rather than gated, which is the difference between the
-decisions being made and being merely written down. What Phase 1 inherits from the
-gates is work, not uncertainty: a falsified accessibility mechanism replaced
-(D46), and the Z-gates to convert into regression tests.
-
-**Phase 2 — metadata and refinement.** Frontmatter and sidecar ingestion ·
-**`sidecar init`** · `select` queries · status maps · `pick = "one"`
-disambiguation · richer conflict presentation · **Mermaid captions and
-`fence-sha256` binding** · **`--if-stale`**.
-
-**Phase 3 — composition.** Overlays and `extends` · child binders ·
-`pick = "latest"` · producer conventions (`[pack.metadata.binder]`) · the named
-`binder-editor` subagent if measurement justifies it · recipe-template libraries.
-
-**Phase 4 — more consumers.** A second renderer · site mounting or index
-consumption · PDF/Typst.
-
-### Decisions required before implementation
-
-**U1 is resolved (D45), so nothing on this list is a stop-or-go.** Everything
-below is a shaping decision for the RFC.
-
-Domain fit and pack placement (U2, U3) · **`binders/` and
-`.binder-work/` as new top-level directories in this repository, which
-`AGENTS.md` § *Check before acting* requires be proposed via RFC** · **taking a
-runtime dependency on an alpha-versioned package (`zensical==0.0.53`), which
-`AGENTS.md` § *Check before acting* requires be recorded in the pack's `AGENTS.md`
-or an ADR before it is added** · pack and skill names · the `binder.toml` schema
-and its version-1 surface · the index schema and its stability guarantee ·
-identity rules · the security control set and which are mechanical · the renderer
-pin and its upgrade procedure · configuration precedence · workspace and
-publication layout · the two-lock concurrency model · exit codes.
-
-**The gate outcomes left this list — they are results now, not pending
-decisions.** Z5, Z6, and V6 all ran; what they produced that the RFC still has to
-ratify is folded into the items above and into **D46**, the accessible-name
-mechanism Z6 forced. The one thing the RFC should read as a *finding* rather than a
-decision is Z6e: a specified check that passes when the feature is broken, which is
-the argument for the headless-browser dependency in Phase 1's CI.
-
-**Three items left this list, and one joined it.** The Tier-2 policy amendment
-(U5), the Quarto version range, and the install-ladder ordering all went with D-B.
-The alpha-dependency record is new: `zensical` at `0.0.53` is a dependency the
-repository's own rules say must be argued for before it is added, and burying that
-in a rollout list would be exactly the omission those rules exist to prevent.
-
-### Safe as extension points
-
-Additional renderers · additional output formats · selector expressiveness ·
-overlay semantics beyond exclusion and addition · child binders · artifact-kind
-and status vocabularies · producer declarations · site integration depth · theme
-customization surface.
-
----
-
-## Unresolved questions
-
-**U1 — RESOLVED (D45): the pack clears Charter Principle 3.** Its *subject* is a
-habit — assembling a decision dossier for a review forum; the machinery makes that
-habit reproducible and reviewable. The reasoning, including the counter-reading
-that was weighed and the accelerator-pack carve-out that does **not** apply, is in
-[`overview.md`](overview.md#principle-3-resolved).
-
-Note that D-A and D-B did not decide this. They make the pack materially smaller,
-but "smaller infrastructure" is still infrastructure and Principle 3 is about
-*kind*, not size. The decision turns on which one the pack is *about*.
-
-**U2 — does the pack sit inside the Charter's Domain?** Distinct from U1 and
-decided on different evidence. `docs/CHARTER.md` § Domain is the *"machine-readable
-scope anchor"* — "software engineering / SDLC… code quality, architecture,
-testing, CI/CD, project governance, and engineering process", explicitly excluding
-personal productivity and PKM. **Recommendation: in scope.** Every binder this
-design targets is an SDLC governance artifact bundle — architecture review,
-release readiness, incident review, implementation handoff — and none of the
-excluded categories is served. The reason to name it separately is that a generic
-"compile Markdown into a publication" framing would read as PKM, and the pack must
-be positioned against project governance to stay inside the anchor. If reviewers
-read it the other way, D45's Principle-3 argument does not save the placement —
-a pack outside the Domain anchor fails regardless of which principle it clears.
-
-**U3 — new pack versus a ninth `converters` skill.** Argued in *Pack placement*;
-the fallback costs nothing but the pack boundary. Named separately from U1 because
-a "yes" to U1 and a "no" to U3 is a coherent outcome.
-**Recommendation: new pack.**
-
-**U4 — pack name.** `binder-publishing` versus `publishing` versus `binder`.
-**Recommendation: `binder-publishing`** — `publishing` is too broad for a
-catalogue that may later publish other things, and `binder` names the noun rather
-than the capability. The skill name `publish-binder` follows the verb-noun
-convention and is not in the banned label set.
-
-**U5 — WITHDRAWN by D-B.** *Was: the Tier-2 policy amendment for the
-digest-verified Quarto install.* It asked the catalogue to sanction a pack
-fetching and extracting a 236 MB third-party binary, and round 6 escalated it to
-"a blocking dependency for a named platform segment" because PEP 668
-externally-managed interpreters refuse `pip install --user` and the managed
-install was that population's only in-pack route.
-
-**There is no longer anything to amend.** `zensical` is an ordinary pip package
-that `author-a-skill.md` § *What counts as a dependency* already sanctions in its
-own words. PEP 668 does not bite: a system-Python user creates a virtualenv or
-uses `pipx`/`uv`, which is the normal answer for any pip dependency and needs no
-policy change. Withdrawn, not deferred — the amendment is not wanted later either.
-
-**U6 — WITHDRAWN by D-B.** *Was: gate V1, Mermaid under execution-off.* A Quarto
-question. Zensical executes nothing, and Z3a settles diagram rendering directly.
-
-**U7 — SUPERSEDED by Z5, and CLOSED by it.** *Was: gate V2, render-time network
-access.* The question was renderer-independent, moved to **Z5** against
-`zensical build`, and answered 2026-08-07: **no outbound operation is attempted at
-all**, cold cache or warm, with the output byte-identical to a network-allowed
-build. The posture in [`security-profile.md`](security-profile.md) is unchanged —
-we still constrain the input rather than the process — but the residual is a
-measured-empty channel under the pin rather than an unexamined one.
-
-**U8 — WITHDRAWN by D-B.** *Was: gate V3, fenced divs under `-raw_attribute`.* A
-pandoc reader-toggle question with no counterpart here. The badge and editorial-
-marker mechanism is `admonition` plus `attr_list`, verified by Z2b, and its
-plain-label fallback is retired with the gate.
-
-> **Four questions closed by one decision, and none by argument.** U5–U8 were each
-> live enough to need a gate or a policy amendment; all four turned out to be
-> questions *about Quarto* rather than about binder publishing. That is the
-> clearest measure available of how much of the design was renderer management
-> wearing the shape of architecture.
-
-**U9 — default publication directory.** `build/binders` collides with the generic
-`build/` gitignore in many repositories, which is convenient (ignored by default)
-and confusing (mixed with compiler output). **Recommendation: keep
-`build/binders`** — being ignored by default is the property that matters most for
-a directory regenerated on every build; `docs/binders/` invites accidental commits
-of rendered HTML. Low-stakes, but hard to change once adopters have it.
-
-**U10 — should `binder.toml` at the content root be special?** The design treats
-it as a conventional default for `build` with no argument.
-**Recommendation: keep it** — the two-file quick start is what makes the clean-
-directory case a two-minute demonstration, and the alternative buys explicitness
-nobody asked for.
-
-**U11 — guides drift on `.apm/shared-libs/`.** `skill-script-conventions.md` and
-`author-a-skill.md` contradict each other. Out of scope; flagged for a separate
-fix. If it resolves the *other* way, the two-skill shape becomes viable and this
-pack shape should be revisited.
-
-**U13 — alpha dependency, newly raised.** `zensical` is
-`Development Status :: 3 - Alpha` at `0.0.53`, and the pack would ship a
-*published, versioned* binder contract on top of it. Three things bound the risk
-and one does not.
-
-Bounded: the dependency surface is narrow (`nav`, theme, `superfences`, search —
-not the plugin API); invariant 22 makes swapping renderers a one-file change; and
-Z1–Z4 are CI regression assertions, so an upgrade that changes any of the four
-behaviours the adapter relies on fails loudly rather than silently.
-
-Not bounded: **the Z-gates found three wrong assertions in one afternoon**, two of
-them about behaviour that looked settled (the version attribute, the font key).
-That is what an alpha renderer feels like, and it is an argument for the pin being
-exact and for the gates being required rather than for the choice being wrong.
-**The recording obligation is discharged:
-[ADR-0073](../../adr/0073-zensical-as-the-v1-binder-renderer.md) is Accepted and
-records the dependency**, per `AGENTS.md` § *Check before acting*. What remains
-for the RFC is ratifying the alpha pin itself — and the ADR carries a standing
-revisit cadence rather than a one-off condition, because a project shipping three
-releases a month is not a decision that stays made.
-
-**U12 — `[pack.layout]` schema versus installer behaviour, and a data-loss half.**
-The schema accepts `output_dir`; `_append_layout_section` reads only `parent`, so
-five shipped packs declare `output_dir` and get a silent no-op. **Worse than a
-no-op:** when the appender *does* fire — the moment any pack declares
-`[pack.layout.<scope>].parent` — it re-emits `agentbundle-layout.toml` preserving
-only `parent` per section and dropping every off-schema key, which would silently
-delete an adopter's hand-written `[binder] output_dir / workspace_dir /
-recipes_dir` block. Pre-existing and out of scope to fix here, but it bears
-directly on this design: either binder paths move to a
-dedicated adopter-owned config file (**not** a policy file — D39 removed that concept), or the pack's guide must tell adopters to re-add `[binder]` after
-such an upgrade. **Recommendation: raise it with the RFC** rather than design
-around a bug.
-
----
+## Test and eval layout
+
+Tests live at `packs/binder-publishing/tests/skills/publish-binder/`, outside
+the `.apm/` runtime boundary. Activation evals live at
+`.apm/skills/publish-binder/evals/`.
+
+## Unit tests
+
+Unit coverage must include:
+
+- schema versioning; unknown fields; `--allow-unknown-fields`; `[x-vendor]`
+  passthrough; and rejection of `[policy] profile` and `[policy] shortcodes`;
+- all content-root resolution branches; exit 6 for home, filesystem root, and
+  ancestors of `~/.agentbundle/` or the installed pack; extension checks on every
+  node read, including explicit paths;
+- configuration precedence; identity normalization; case collisions; status-map
+  normalization; deterministic ordering; weights; `before`/`after`; cycles;
+  ambiguity; missing required and optional sources; duplicates; supersession;
+  exclusions; duplicate IDs; colliding publication directories; and child-binder
+  cycles;
+- frontmatter discard-and-rebuild; executable-fence neutralization; byte-identical
+  Mermaid fence bodies; D46 opening-delimiter annotation; Mermaid
+  directive/click/callback rejection; and allowed label forms;
+- staged-name determinism; link rewriting; line-offset mapping over generated,
+  CRLF, and BOM input; asset allowlists; resource ceilings; path traversal;
+  absolute paths; symlink escape; and self-path write refusal;
+- emitted ordinals, including `null` for an unnumbered chapter and
+  `data-ordinal` exclusion from title and search-index text;
+- list-form renderer argv with `-f` as its only path element and mandatory
+  `--strict`; child-environment allowlisting that excludes planted secrets;
+- TOML injection rejection and emitter resilience; renderer-interpretable title
+  rejection; source-H1 fallback for invalid labels; closed single-pass parameter
+  substitution; and unresolved substitution failure;
+- publication ownership, `publication-dir` confinement, heading-shift warnings,
+  scan-exclusion handling, cross-device publication detection, exit-code mapping,
+  and a golden index unchanged by `build` (invariant 22);
+- renderer-version lookup through `importlib.metadata.version`, never
+  `zensical.__version__`.
+
+## Integration tests
+
+Run Z1–Z4 regression assertions against one shared fixture. The built tree must
+contain no remote subresource reference in `src`, stylesheet or preconnect
+`href`, `@import`, or off-host `url()`.
+
+Integration coverage must test renderer present, absent, and wrong version;
+generated `zensical.toml`; nested part navigation; local search; previous/next
+links; an untransformed Mermaid fence; vendored `mermaid.min.js` loaded before
+the theme bundle; ANSI-stripped diagnostic mapping; and exit 7 before invoking
+the renderer for a missing nav target or reported strict-build issue.
+
+Test idempotent rebuilds, stale publication checks, pack-version changes,
+interrupted builds, workspace-lock serialization, concurrent different binders,
+publication-lock serialization, and cross-device replacement. Assert that the
+published tree contains `binder-stamp.json` but not `binder-index.json`, that the
+stamp contains no diagnostics, and that a source edit makes `check --published`
+return 9.
+
+Hash the content root before and after a build. Only `stage/`, the publication,
+and its three named siblings may change. `clean` must remain confined.
+
+Renderer-dependent tests skip with a clear reason when Zensical is absent. CI
+installs Zensical and runs them as required tests.
+
+## CI provisioning
+
+The repository enumerates pack test roots. Add
+`packs/binder-publishing/tests/` to the pytest invocation in
+`.github/workflows/catalogue-tooling-ci-gates.yml`.
+
+| Requirement | CI change |
+| --- | --- |
+| Pack tests | Add the pack test root to the pytest command. |
+| Renderer | Install `zensical==0.0.53`. |
+| Browser assertions | Provision a headless browser for Z6. |
+| Egress assertions | Provision a Linux egress detector and a negative control that proves denial is effective. |
+
+Z1–Z4 are the CI floor if browser or egress provisioning is unavailable. Do not
+claim Z5 or Z6 as CI coverage until their instruments run in the workflow.
+
+## Portability acceptance test
+
+1. Create a clean temporary directory with no Git repository, `pack.toml`,
+   `site.toml`, docs site, or catalogue files.
+2. Write four Markdown files, including one portable Mermaid fence, and a
+   `binder.toml` using explicit paths.
+3. Expose the pack from a read-only projected copy.
+4. Run `resolve` and compare `binder-index.json` with a byte-identical golden.
+5. Run `build` and assert `index.html`, chapter HTML, local `search.json`, and a
+   Mermaid block with source-identical fence content.
+6. Assert every source SHA-256 and the pack tree hash are unchanged.
+7. Assert that no path outside the temporary directory changed.
+8. Assert that the built tree has no remote subresource request.
+
+## Multi-pack fixture
+
+Build one fixture from a frontmatter survey, frontmatter-free RFC and ADR with
+`.binder.toml` sidecars, an architecture design containing Mermaid, a spec and
+plan, and unannotated Markdown. A producer writes a template into the fixture
+`recipes_dir`; `binder build` resolves it as an ordinary recipe.
+
+The run must import nothing from a producing pack and open no path beneath any
+other skill directory. Level-0, Level-1, and sidecar items must resolve in the
+same binder.
+
+## Accessibility smoke checks
+
+Parse rendered HTML to require an `alt` attribute on every image, `<html lang>`,
+a skip link, focus-visible theme styling, and non-skipping headings except a
+recorded H6 clamp. Empty image alt text is valid and recorded in diagnostics.
+
+Static Mermaid checks require compiler-owned, HTML-escaped `data-a11y-name` on
+each named diagram and reject `%%{` and newlines in that value. The static check
+must compare attribute presence with `renderer-plan.json`; it must not claim an
+absent derivable name is valid. V1 names diagrams by ordinal only. D46 requires
+the theme to lift those attributes into the rendered SVG; Z6 verifies the
+reader-visible result in a browser. If the vendored bundle fails, the fence source
+remains visible as preformatted text.
+
+## Activation evals
+
+`evals/eval_queries.json` covers positive binder requests and near misses routed
+to `markdown-to-html`, `render-proof`, `mermaid-renderer`, and
+`architect-design`. Negative activation cases are required because neighbouring
+converter skills overlap on Markdown rendering.
+
+## Safe extension points
+
+Additional renderers, output formats, selector expressiveness, overlay semantics,
+child binders, artifact-kind and status vocabularies, producer declarations, site
+integration depth, and theme customization may extend the design without changing
+the v1 core contract.
+
+## Open questions
+
+- **U2:** Confirm that the pack belongs within the Charter domain.
+- **U3:** Confirm a new `binder-publishing` pack rather than a `converters` skill.
+- **U4:** Confirm the pack name `binder-publishing` and skill name `publish-binder`.
+- **U9:** Confirm the default publication directory, currently `build/binders`.
+- **U10:** Confirm whether a content-root `binder.toml` is the argument-less build default.
+- **U11:** Resolve the `.apm/shared-libs/` guidance conflict before fixing the pack shape.
+- **U12:** Resolve the `agentbundle-layout.toml` schema/appender mismatch before documenting adopter configuration.
+- **U13:** Ratify the exact alpha Zensical pin for the published binder contract.

--- a/docs/architecture/binder-publishing/runtime.md
+++ b/docs/architecture/binder-publishing/runtime.md
@@ -298,8 +298,8 @@ publication root). There is no `--toolchain`: D-B removed the cache it swept.
 
 ## Compatibility and migration
 
-Nothing to migrate. No existing artifact changes; no pack changes; no source file
-changes. A repository adopts the pack by adding one `binder.toml`.
+Nothing migrates: existing artifacts, packs, and sources remain unchanged. Adopt
+the pack by adding one `binder.toml`.
 
 | Change | Impact |
 |---|---|
@@ -308,10 +308,9 @@ changes. A repository adopts the pack by adding one `binder.toml`.
 | `tools/build-site.py`, `site.toml`, `docs-site/` | None. Not read, not written, not imported. |
 | `.gitignore` | Offered, on consent: `.binder-work/`, and the publication dir if inside the repository. |
 | `agentbundle-layout.toml` | An adopter adds a `[binder]` section by hand; the installer's append does not create it (see the current-state correction). |
-| `contracts/` | **None.** The schemas ship in the skill's `assets/` and are published from there; see *Canonical schema publication* for why mirroring them into `contracts/` would invert RFC-0076 D1's authority model and pull a binder schema into the CLI's bundled `_data/`. |
+| `contracts/` | **None.** Schemas ship and are published from skill `assets/`; mirroring them into `contracts/` would invert RFC-0076 D1's authority model and add a binder schema to the CLI's bundled `_data/`. |
 
-A pack that later wants to participate does so by shipping a recipe template
-under its own `assets/`, or documenting its frontmatter — both additive, neither
-requiring a change to this pack.
+A participating pack ships a recipe template in its assets or documents its
+frontmatter; neither changes this pack.
 
 ---

--- a/docs/architecture/binder-publishing/security-profile.md
+++ b/docs/architecture/binder-publishing/security-profile.md
@@ -60,18 +60,8 @@ one designed against a hypothetical.**
 
 ## Why this file leads with a corpus
 
-The previous draft's strict profile was a denylist written from the renderer's
-threat surface and validated against nothing. Three separate review rounds found
-it rejecting legitimate, widespread constructs:
-
-- `<br/>` in Mermaid node labels — **45 occurrences in the design document
-  itself**, and `architect-diagram`'s own reference tells authors to use it.
-- `<|--` and `<-->` in Mermaid class and architecture diagrams — standard syntax.
-- `{{<` anywhere — which rejects any document *about* Quarto, including this one.
-
-A rule that rejects the first real corpus it meets has the rule wrong, not the
-corpus. So the profile now carries a **corpus gate**, and every rule is stated in
-a form that can actually be implemented without a parser the pack refuses to build.
+Scanner rules are constrained by the corpus gate below. They must admit valid
+Mermaid labels such as `<br/>`, `<|--`, and `<-->`, and prose containing `{{<`.
 
 ### The corpus gate
 

--- a/docs/architecture/binder-publishing/verified-findings.md
+++ b/docs/architecture/binder-publishing/verified-findings.md
@@ -1,337 +1,87 @@
-# Verified findings and gates
+# Renderer constraints and future-adapter evidence
 
-> Every renderer claim with source and confidence; the gates and their results.
+> Build constraints established for the Zensical adapter and retained Quarto
+> evidence for a possible future PDF or EPUB adapter.
 > Part of [binder publishing architecture](README.md).
 
-**Two renderers appear here, and only one of them is live.** Z1–Z6 are the
-**Zensical** gates — the v1 renderer under D-B — and they, with the
-renderer-independent V6, are the ones a spec author builds against. Q1–Q28 are **Quarto** findings, retained because a future
-PDF or EPUB adapter would go through Quarto and would be built against them.
-Where the two disagree about a behaviour, they are not in conflict: they describe
-different renderers.
+## Zensical adapter constraints
 
----
+D-B selects Zensical for v1. The constraints below define the adapter contract
+under that decision.
 
-## Zensical findings and the Z-gates
+### Invocation and staging
 
-Run against `zensical==0.0.53` in a clean virtualenv on macOS/arm64 — **Z1–Z4 on
-2026-08-06, Z5 and Z6 on 2026-08-07** — using the same discipline V1 established:
-**a real fixture and the real emitted `zensical.toml`**, not a hand-written config
-the pack never emits. The fixture is a five-chapter binder with a nested `nav`, a
-`custom_dir` theme, a generated cover, fresh per-file frontmatter, a portable
-` ```mermaid ` fence with a `<br/>` node label, a class diagram using `<|--`, a
-literal `{{< env … >}}`, a `${HOME}`, an admonition, and a cross-document `.md`
-link. The Z5/Z6 run extended it with the vendored `mermaid.min.js` delivered
-through `main.html`'s `{% block extrahead %}`, which is what Z6 needed a browser
-for.
+- Invoke Zensical as `[sys.executable, "-m", "zensical", "build", "-f",
+  "<stage>/zensical.toml", "--strict"]`. Do not use a shell string or any
+  caller-supplied argv element.
+- Probe the renderer with `importlib.metadata.version("zensical")`. Do not read
+  `zensical.__version__`.
+- `site_dir` and `docs_dir` are relative to the generated config. Keep both
+  beneath the staging project and distinct. Zensical writes `site/` and `.cache/`
+  there.
+- Strip ANSI SGR sequences before parsing staged-file diagnostics. Map their
+  line/column values through the adapter plan.
+- Assert that every emitted `nav` target exists before invoking the renderer.
+  Zensical otherwise renders a dead link without a strict-build failure.
 
-`[high]` throughout means direct execution against that fixture.
+### Config and offline assets
 
-> **The emitted config is transcribed, not generated, and that is the one soft
-> spot in this evidence.** `binder.py` does not exist yet, so "the real emitted
-> `zensical.toml`" means the block in
-> [`zensical-adapter.md`](zensical-adapter.md#generated-zensicaltoml) transcribed
-> byte-faithfully. It is still far better than a config invented for the test, but
-> the gates become genuinely airtight only once the adapter emits the file and CI
-> runs them against it.
+- Emit the complete `markdown_extensions` allowlist. Zensical replaces its
+  scaffold extension set rather than merging it.
+- Use a pack-owned `custom_dir` and `main.html` `extrahead` block for vendored
+  Mermaid. `extra_javascript` loads after the theme bundle and is not safe for
+  this ordering.
+- Treat the theme directory as a publication surface. Only pack-owned assets may
+  enter it.
+- Disable remote fonts with `[project.theme] font = false`. Do not emit
+  `[project.theme.font] text = false, code = false`.
+- The offline assertion is zero remote subresource references, not zero
+  `https://` strings. Local search and document-relative assets must work from
+  `file://`.
+- The build path must not make an outbound request. CI needs a kernel-level Linux
+  egress detector with a negative control; a Python tracer is supplementary only.
 
-### Z1 — invocation, version probe, and where output lands
+### Markdown and Mermaid
 
-| # | Finding | Confidence |
-|---|---|---|
-| Z1a | **`zensical build` takes no positional directory.** Its only path input is `-f/--config-file PATH`; the other flags are `-c/--clean` and `-s/--strict`. The argv is therefore `[sys.executable, "-m", "zensical", "build", "-f", "<stage>/zensical.toml", "--strict"]` — list-form, no shell, no caller-supplied element. | **High — VERIFIED** |
-| Z1b | **`--strict` is required, not optional.** Without it a build that emits warnings still **exits 0**. Verified exit codes: `--strict` with issues → **1**; `--strict` clean → **0**; no `--strict` with issues → **0**. A compiler that reported success on a warned build would publish a binder with dead links. | **High — VERIFIED** |
-| Z1c | **`zensical.__version__` does not exist.** The module exposes `build`, `serve`, and `version` — and `zensical.version` is a *built-in function*, not a string, so a naive probe stringifies a function object rather than failing. The version probe is `importlib.metadata.version("zensical")`, which returns `"0.0.53"`. `python -m zensical --version` also prints it. | **High — VERIFIED** |
-| Z1d | **`site_dir` and `docs_dir` are configurable and default to `site` and `docs`**, and Zensical itself rejects either resolving outside the project root, or the two being equal. Output is `site/`, not `_output/`. | **High — VERIFIED** (`zensical/config.py`) |
-| Z1e | **Output and cache land relative to the config file's directory, not the process CWD.** Building `-f cachetest/zensical.toml` from a parent directory wrote `cachetest/site/` and `cachetest/.cache/`. `.cache/` is an undeclared write the design had not accounted for; it is inside the staging directory and therefore inside the workspace. | **High — VERIFIED** |
-| Z1f | **`NO_COLOR=1` is not honoured** — diagnostics still carry ANSI SGR sequences. The adapter must strip them before parsing or re-emitting. Diagnostics are reported as `<staged-file>.md:LINE:COL`, which is exactly the anchor the `line-offset` mapping needs. | **High — VERIFIED** |
+- Preserve portable ` ```mermaid ` fence bodies byte-for-byte. Reject Mermaid
+  directives, click/callback forms, and unsupported node-label syntax. `<br/>`,
+  `<|--`, `<|..`, and `<-->` remain valid label content.
+- Vendor a pinned, digest-recorded `mermaid.min.js` before the theme bundle. The
+  renderer bundle otherwise fetches Mermaid at reader time.
+- Zensical emits no chapter or appendix numbering. Emit the compiler ordinal as
+  `data-ordinal`; D44 keeps it out of title and search-index text.
+- D46 emits accessible-name attributes on the opening fence delimiter. HTML-escape
+  values and reject `%%{` and newlines before the theme lifts them into Mermaid
+  `accTitle:` and `accDescr:` source. Do not inject lines into the fence body.
+- Browser tests must confirm that a rendered SVG carries the accessible name and
+  description. A static check of the pre-render `<pre>` is invalid because the
+  bundle replaces that element.
 
-### Z2 — the config surface the adapter emits
+## Regression evidence
 
-| # | Finding | Confidence |
-|---|---|---|
-| Z2a | **The nested `nav` form is correct.** `{ "Part I — Evidence" = [ {…}, {…} ] }` renders as a titled sidebar group containing its children. The generator is told the structure and derives none of it. | **High — VERIFIED** |
-| Z2b | **`markdown_extensions` REPLACES the scaffold set — it does not merge.** With the closed allowlist emitted, `pymdownx.tilde`, `pymdownx.caret`, `pymdownx.details`, `pymdownx.emoji`, `pymdownx.keys`, and `pymdownx.arithmatex` were all inert and their syntax rendered as literal text. This is the answer the design needed: **excluding `arithmatex` and `emoji` genuinely removes the MathJax and twemoji references**, rather than leaving a default in place underneath. | **High — VERIFIED** |
-| Z2c | **Quoted dotted keys are accepted.** `"pymdownx.superfences" = { … }` parses to the extension named `pymdownx.superfences`. The scaffold's unquoted `pymdownx.superfences = { … }` is a TOML *dotted key* producing a nested table; both forms reach the same extension, and the quoted form is what the adapter emits because it is unambiguous. | **High — VERIFIED** |
-| Z2d | **`custom_dir` works, and a `main.html` extending `base.html` can inject into `{% block extrahead %}`** — which lands in `<head>`, ahead of the bundle. Non-template files in the custom directory are **copied verbatim into `site/`**; template files are consumed. So the theme directory is a publication surface and only pack-owned assets may go in it. | **High — VERIFIED** |
-| Z2e | **The `features` strings are accepted as given**, and `navigation.footer` does produce prev/next. | **High — VERIFIED** |
-| Z2f | **`pymdownx.snippets` is commented out in the scaffold, not active.** An earlier claim that it was one of three defaults the allowlist removes was wrong about this one; `arithmatex` and `emoji` *are* scaffold defaults, `snippets` is not. Excluding it is still correct — it reads arbitrary files from disk — but it is a precaution, not a removal. | **High — VERIFIED** |
-| Z2g | **A `nav` entry naming a file that does not exist produces no warning, even under `--strict`, and renders a dead sidebar link.** A missing chapter is silently navigable. **The adapter must assert every `nav` target exists on disk before invoking** — Zensical will not tell it. | **High — VERIFIED** |
-| Z2h | **Zensical numbers nothing.** No chapter numbers, no appendix lettering, no `.unnumbered` equivalent. Q17's automatic appendix lettering is a *Quarto* behaviour with no counterpart here, so **`numbered` is compiler-emitted** — see [`binder-recipe.md`](binder-recipe.md). | **High — VERIFIED** |
+The Zensical adapter regression suite covers strict invocation, version probing,
+staging paths, complete config emission, missing-nav refusal, offline assets,
+network-denied build, vendored Mermaid rendering, and D46 browser accessibility.
+`rollout.md` defines the required unit, integration, browser, and egress tests.
 
-### Z3 — Mermaid, and whether it is bundled
+## Retained Quarto evidence
 
-> **The answer is no.** The vendored `mermaid.min.js` and its delivery problem
-> both stand.
+This section gates nothing today. It is retained for a possible future PDF or
+EPUB adapter using Quarto.
 
-| # | Finding | Confidence |
-|---|---|---|
-| Z3a | **The portable ` ```mermaid ` fence is read directly** and emitted as `<pre class="mermaid"><code>…</code></pre>`. No transformation, no line-count change, no cell-option injection. This is what deletes the Quarto staging transform. | **High — VERIFIED** |
-| Z3b | **Mermaid itself is NOT bundled.** The theme bundle contains `it("https://unpkg.com/mermaid@11/dist/mermaid.min.js")` and fetches it **from the reader's browser at read time** whenever a `.mermaid` element mounts. A binder with a single diagram phones out to unpkg. | **High — VERIFIED** |
-| Z3c | **Vendoring is supported, by a guard in the bundle itself:** `typeof mermaid == "undefined" || mermaid instanceof Element ? fetch(unpkg) : skip`. If a global `mermaid` is already defined, **no request is made.** So shipping `mermaid.min.js` in the pack's theme assets and defining the global before the bundle runs suppresses the fetch. | **High — VERIFIED** (source inspection of the emitted bundle) |
-| Z3d | **`extra_javascript` is emitted *after* the bundle**, so using it for the vendored file is an execution-order race. **`custom_dir` + `{% block extrahead %}` is the deterministic form** — verified to place the script in `<head>`, before the bundle. This is why the adapter vendors through the theme rather than through `extra_javascript`. | **High — VERIFIED** |
-| Z3e | **`<br/>` in a node label survives**, entity-escaped inside the `<pre>` and decoded by the browser as text content — the same mechanism Q28 recorded under Quarto. `<\|--`, `<\|..`, and `<-->` pass through unharmed. The label allowlist in [`security-profile.md`](security-profile.md) is verified under both renderers. | **High — VERIFIED** |
-| Z3f | **`{{< env AWS_SECRET_ACCESS_KEY >}}` and `${HOME}` pass through as literal escaped text.** Confirms the Q11 attack surface does not exist here. | **High — VERIFIED** |
-
-### Z4 — offline hardening, and V2b restated
-
-| # | Finding | Confidence |
-|---|---|---|
-| Z4a | **`[project.theme.font] text = false, code = false` DOES NOT suppress Google Fonts — it emits a request for a typeface named `False`.** The rendered head carried `https://fonts.googleapis.com/css?family=False:300,300i,…%7CFalse:400,…`. The design specified this form and it is wrong. | **High — VERIFIED** |
-| Z4b | **The correct form is scalar `font = false` on the theme table.** `base.html` guards the block with `{% if config.theme.font != false %}`. With `[project.theme] font = false`, both the `fonts.googleapis.com` stylesheet and the `fonts.gstatic.com` preconnect disappear. | **High — VERIFIED** |
-| Z4c | **With `font = false` and the closed extension allowlist, the only `https://` strings left in the built HTML are one `zensical.org` attribution `<a href>`** — a link, not a fetch — **and two Font Awesome licence-comment URLs in the CSS.** Neither issues a request. | **High — VERIFIED** |
-| Z4d | **V2b as previously written is unsatisfiable.** "Zero `https://` references anywhere in `_output/`, CSS included" cannot pass against a licence comment and an attribution anchor. Restated below as zero remote **subresource** references, which is the property that actually matters and is testable. | **High — VERIFIED** |
-| Z4e | **Search is local and offline** — `site/search.json`, 1.7 KB for the fixture — and every asset reference is document-relative (`./assets/…`, `../assets/…`), so a published binder opens from `file://` with no server. | **High — VERIFIED** |
-
-### Z5 — telemetry: does `zensical build` reach the network?
-
-> **No — and the stronger form of no.** Not "the build survives offline": **no
-> outbound operation is attempted on any path this build exercises**, native or
-> Python. Z5a states the scope precisely and it is the row to quote.
-
-| # | Finding | Confidence |
-|---|---|---|
-| Z5a | **No code path exercised by a build of the emitted config attempts an outbound request.** Measured with `sandbox-exec` denying `network-outbound` **and sending `SIGKILL` on any attempt**, so an attempt is fatal rather than merely failed: the build exits **0** on both a cold and a warm cache. A kernel-level detector was chosen precisely because a Python-level one cannot see the compiled extension. Stated that way deliberately — the instrument is indifferent to *which* code path attempts egress, but it can only speak for the paths this fixture executes, so it is evidence about `build` on the emitted config, not a proof that no fetching code exists in the package. | **High — VERIFIED** |
-| Z5b | **The isolation was validated before it was trusted, four ways** — DNS resolution blocked, IP-literal `connect` refused with `EPERM`, the same request succeeding unsandboxed, and local file IO still permitted. And the kill-on-egress profile was validated three ways: a trivial process survives (no false positive), an IP-literal `create_connection` is killed, a DNS-based `urlopen` is killed. **A gate whose negative control was never run proves nothing**, which is the discipline Z4a's failure argues for. | **High — VERIFIED** |
-| Z5c | **A Python-level tracer over `getaddrinfo`, `create_connection`, `socket.connect`, `socket.connect_ex`, `urllib.request.urlopen`, and `http.client.HTTPConnection.request` logged zero calls during the build** — injected via `PYTHONPATH` so the real `python -m zensical build` argv was preserved. Its self-test logged 9 hits for a known request, so the zero is a measurement rather than a broken probe. | **High — VERIFIED** |
-| Z5d | **The output is byte-identical with and without network access.** `diff -r` over the two `site/` trees from a network-allowed build and a network-denied build reports no difference, so nothing fetched contributes to the artifact. `--clean` also exits 0 under denial. | **High — VERIFIED** |
-| Z5e | **`zensical` ships a compiled `zensical.abi3.so`, and it does link `_socket`, `_getaddrinfo`, and `_recv` from libSystem** — so network *capability* is present and a source-only grep would have missed it. The capability is consistent with the `serve` verb, which needs a listening socket; `serve` is never invoked. There are no hardcoded remote URL strings in the extension and no telemetry, analytics, or update-check code in the Python sources; **the extension itself is covered by Z5a rather than by inspection**, which is the honest split given that this row's whole point is that a source grep cannot see into it. **Z5a is what covers this**, and it is the reason the gate needed a kernel-level instrument rather than a library-level one. | **High — VERIFIED** |
-| Z5f | **`zensical/extensions/macros.py` shells out to `git log` and `git rev-parse` via `subprocess.check_output`.** It registers as the `macros` extension, which is **outside the closed allowlist**, so it is inert under the emitted config — independent support for the allowlist being a replacement (Z2b) rather than an addition. Not a network finding, and recorded here because a `git` subprocess in the renderer is exactly the kind of thing the design's *no path to poison* argument should be checked against. | **High — VERIFIED** |
-| Z5g | **The installed dependency set matches the design's list exactly** — `click`, `deepmerge`, `jinja2`, `markdown`, `pygments`, `pymdown-extensions`, `pyyaml`, `tomli`. `importlib.metadata.version("zensical")` returned `0.0.53`, re-confirming Z1c. | **High — VERIFIED** |
-
-### Z6 — does vendored Mermaid render in a real browser with egress blocked?
-
-> **Rendering: yes. The accessible name: no.** The vendoring mechanism
-> [`zensical-adapter.md`](zensical-adapter.md) specifies works exactly as
-> specified. The *accessibility* claim built on top of it does not, and the way it
-> fails is worse than a plain absence.
-
-Three headless-Chromium runs over the built fixture from `file://`, every
-non-`file://` request logged and aborted in the blocked runs. The positive control
-ran **first**, so both detectors were shown to work before the gate run was
-trusted:
-
-| Run | Vendored | Egress | unpkg | Diagrams | Accessible name |
-|---|---|---|---|---|---|
-| positive control | no | allowed | **2 requests** | 2 rendered | empty |
-| degraded | no | blocked | 1 attempt, `net::ERR_FAILED` | 0 | **present** |
-| **gate** | **yes** | **blocked** | **none** | **2 rendered** | **empty** |
-
-| # | Finding | Confidence |
-|---|---|---|
-| Z6a | **The vendored bundle renders the diagrams with egress blocked, and issues no request of any kind.** The gate run produced two real SVGs — `role="graphics-document document"`, `aria-roledescription="flowchart-v2"`, laid out at 423 px and 73 px — with **zero remote requests**, unpkg or otherwise. Z3c/Z3d were verified by source and by emitted HTML; this is the browser confirming them. | **High — VERIFIED** |
-| Z6b | **The guard is suppressed because mermaid's own distribution defines the global.** `mermaid@11`'s last line is `globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default`, so a plain `<script src>` satisfies `typeof mermaid == "undefined"` → false. Worth stating because the file's *first* line assigns into an esbuild namespace, and a reader checking only that would conclude vendoring cannot work. | **High — VERIFIED** |
-| Z6c | **`extrahead` places the vendored script in `<head>` and the theme bundle loads from `<body>`** — verified in the built page, so the ordering Z3d established by inspection holds at runtime. | **High — VERIFIED** |
-| Z6d | **The accessible name does NOT survive into the rendered SVG, and `attr_list` on the fence is the wrong mechanism.** The bundle mounts a diagram with `e.replaceWith(r)` where `r = A("div",{class:"mermaid"})` — **a fresh `div` carrying only `class`** — so every attribute on the `<pre>` is discarded. Measured live: `div attrs: {"class":"mermaid"}` for every diagram. The SVG then lands in `attachShadow({mode:"closed"})`, confirmed by `div.shadowRoot === null` from page script. | **High — VERIFIED** |
-| Z6e | **The failure inverts, which is why it would have shipped.** In the degraded run the name **is** in the accessibility tree — `('image', 'Diagram 3.2: ledger write path')` — because the `<pre>` is still there. Under the specified mechanism **a named diagram and a rendered diagram are mutually exclusive**: the check passes exactly when the feature is broken. A CI assertion written against the static HTML would have stayed green forever. | **High — VERIFIED** |
-| Z6f | **Three replacement routes were measured, and the adopted one names the graphic itself at zero line cost.** The compiler emits `data-a11y-name` / `data-a11y-desc` on the fence's opening delimiter via `attr_list`, and the pack's theme lifts them into the Mermaid source as `accTitle:` / `accDescr:` before the bundle mounts. Measured: `role='graphics-document'` with **name** `'Diagram 3.1 — ledger write path (RFC-0091)'` **and description** `'Client calls the API gateway, …'`, real `<title>`/`<desc>` inside the shadow SVG, diagram rendered, **zero remote requests**. This is D46. | **High — VERIFIED** |
-| Z6g | **Both rejected routes work and both cost something the adopted one does not.** *Injecting `accTitle:` into the staged fence body* names the graphic identically but writes into the body, which is the transformation this adapter does not do. *A `<figure role="group" aria-label>` wrapper* survives `replaceWith` and was measured naming a region (`role='group'` with the right name, diagram rendered) — but it names a **container, not the graphic**, has no `accDescr` equivalent, needs a duplicate literal in the `<figcaption>`, and **inserts lines around every diagram**, which breaks the single-integer `line-offset` the whole per-file transformation rests on. | **High — VERIFIED** |
-| Z6h | **An unescaped `attr_list` value is an HTML-injection channel; escaping closes it completely.** A value containing `"` **terminates the attribute** and the remainder becomes markup — a label of `Diagram & "3.1" <script>x</script>` emitted a **live `<script>x</script>`** into the published page. HTML-escaping the value (`&`, `<`, `>`, `"`, `'`) closes it and **round-trips exactly**: `Ledger & payments "3.1" — l'architecture réseau` reached the accessible name character-for-character, ampersand, quotes, em dash, apostrophe and accents intact. | **High — VERIFIED** |
-| Z6i | **The hazard that escaping does *not* close is the value's real sink: Mermaid source.** The theme lifts the value into an `accTitle:` line, so the value is evaluated by Mermaid, not only by an HTML parser. Measured with escaping applied throughout: international text is safe — `Diagram 3.1 — Réseau : l'architecture 漢字` round-trips exactly, and so does `<b>angle</b>`, which does **not** truncate. But **`%%{init:{"theme":"dark"}}%%` was consumed as a Mermaid directive** — stripped from the accessible name and processed by the renderer, which is precisely the construct the scanner rejects in *authored* fence bodies. And **an embedded newline destroyed the diagram** — that fence produced no `graphics-document` at all while its siblings rendered. So the control is escape-for-HTML **plus reject-for-Mermaid** on `%%{` and newlines, and **an ASCII allowlist is the wrong control** — it would mangle `Réseau` and drop 漢字 to nothing for no gain, in the one kind of string that exists to be read aloud. | **High — VERIFIED** |
-| Z6j | **The theme step has no ordering race, and its failure mode is a missing name rather than a missing diagram.** A `MutationObserver` registered in `<head>` processes each `pre.mermaid` as the parser inserts it — strictly before `DOMContentLoaded`, so strictly before any mount. **Re-measured with the `DOMContentLoaded` fallback removed**, so the result is attributable to the observer alone and not to a belt-and-braces pair, and on a **sixty-edge fence** as well as a two-line one, so it is not an artifact of a diagram small enough to arrive in a single parse chunk. Both named, both rendered, no page errors, zero remote requests. With the step absent the diagram still renders, unnamed (Z6a is that case). | **High — VERIFIED** |
-| Z6k | **The graceful degradation is confirmed, not merely hoped.** With the bundle unreachable the reader sees the diagram's own source as visible preformatted text — measured `flowchart TD\n    A[Client] --> B[API gateway]\n …` — because the mount strips the `mermaid` class before awaiting the loader and never reaches the replacement. | **High — VERIFIED** |
-| Z6l | **The vendored file is copied verbatim into `site/assets/javascripts/`, merging with Zensical's own asset directory, and adds 3.5 MB to every published binder.** A consequence of Z2d's "the theme directory is a publication surface", now measured. Not a defect — it is the price of offline Mermaid — but it belongs in the size expectations rather than being discovered by an adopter. | **High — VERIFIED** |
-| Z6m | **The version the bundle asks for is the floating `mermaid@11` tag**, which resolved to 11.16.1 during this run. An unpinned input, recorded as a risk rather than a cost: the guard-suppression mechanism (Z6b) is a property of the esbuild distribution, not of a patch version, but the pack should vendor a pinned version with a recorded digest. | **High — VERIFIED** |
-| Z6n | **D46 rests on two upstream behaviours that are neither documented contracts nor stability promises, and they are named here rather than left implicit.** (i) Mermaid's `accTitle:` / `accDescr:` directives and the `<title>`/`<desc>` they generate; (ii) the theme bundle mounting diagrams *after* parse, which is what lets a `<head>`-registered observer precede it. Both are verified against `zensical==0.0.53` and `mermaid@11.16.1`, both sit under an alpha pin, and **a change in either breaks the accessible name while leaving the diagram rendering perfectly** — the Z6e failure shape again. This is the specific reason Z6 has regression duty rather than retiring green. | **High — VERIFIED** as behaviour; **explicitly not** a stability guarantee |
-
-### The findings that changed the design
-
-**Z3b deletes a simplification that had been assumed.** The renderer-choice spike
-recorded Mermaid as "renders from the portable fence" and stopped there; it did
-not ask *where the JavaScript comes from*. It comes from unpkg, at read time, in
-the reader's browser. The vendored `mermaid.min.js` stays, and Z3c/Z3d turn "we
-will vendor it somehow" into a specified mechanism with a verified guard.
-
-**Z4a is a specified control that does not work.** The design named a font-
-suppression form, called it "required, not optional", and it emits a broken
-request instead. This is the Q26 class of finding exactly: a control asserted from
-the shape of a configuration surface rather than from running it.
-
-**Z2b is the good news.** The closed extension allowlist behaves the way the
-design needed — replacement, not merge — so the two CDN-bearing extensions are
-genuinely gone rather than shadowed.
-
-**Z2g is a gap in the renderer, not in the design, and the adapter has to cover
-it.** A nav entry pointing at a file that was never staged is silently rendered as
-a working-looking sidebar link. The adapter asserts nav-target existence itself.
-
-**Z6d is the most instructive of the corrected controls, because it is the only one
-that was wrong about a *runtime*.** Z1c and Z4a were both wrong about a
-*configuration surface* — the design read a key's shape and inferred its behaviour.
-Z6d is a different mistake: the design reasoned about the HTML the compiler emits
-and never asked what the client-side bundle does to it. It replaces the element the
-attributes are on. And Z6e is the part that earns the gate its cost — the mechanism
-fails in the direction that *passes* a static check, so the only instrument that
-could have caught it is the browser this gate finally ran.
-
-**Z6h and Z6i have the widest reach, and neither was what the gate went looking
-for.** Chasing a replacement for Z6d turned up that unescaped `attr_list` values
-terminate on a quote, so any compiler-emitted attribute is an HTML-injection channel
-— and `attr_list` is how this design emits `data-ordinal` (D44) and its badge and
-marker spans too. **The first control drafted for it was wrong, and re-measuring is
-what caught that**: escaping was dismissed as double-encoding and an ASCII allowlist
-specified instead, when in fact a single escape round-trips the value exactly,
-accents and CJK included, and the allowlist would have silently mangled the one class
-of string that exists to be read aloud. The hazard escaping genuinely cannot reach is
-the *second* hop — the value becomes a line of Mermaid source — where `%%{init:}%%`
-is consumed as a **directive**, arriving through a channel the scanner never
-inspects. Escape for HTML, reject for Mermaid. **A control asserted from the shape of
-a pipeline rather than run through it: the Q26 class of error, committed while
-documenting a gate whose whole subject is that class of error.**
-
-### Z-gate status
-
-| Gate | Claim | Status | Result |
-|---|---|---|---|
-| **Z1** | Invocation contract, version probe, exit codes, output location | **PASSED** 2026-08-06 | Argv, `--strict` necessity, and exit codes settled. **Corrected the design:** `zensical.__version__` does not exist (Z1c). |
-| **Z2** | The emitted config — nav, `custom_dir`, `features`, `markdown_extensions` | **PASSED** 2026-08-06 | All four accepted as specified. **Settled the open question:** extensions replace, not merge (Z2b). **Surfaced Z2g and Z2h.** |
-| **Z3** | Mermaid from the portable fence, and whether it is bundled | **PASSED with a finding** 2026-08-06 | Fence read directly; **Mermaid is not bundled** (Z3b). Vendoring mechanism verified (Z3c/Z3d). |
-| **Z4** | Offline hardening | **RUN, FAILED, then FIXED** 2026-08-06 | The specified font form is wrong (Z4a); the correct one is verified (Z4b). V2b restated (Z4d). |
-| **Z5** | Telemetry — does `zensical build` make any outbound request during the build? | **PASSED** 2026-08-07 | **No attempt is made at all**, not merely "the build survives offline": exits 0 with `SIGKILL` armed on any outbound operation, cold and warm cache, and the output is byte-identical to a network-allowed build (Z5a, Z5d). Isolation validated by seven controls before the result was accepted (Z5b). No fallback was needed. **Surfaced Z5e** (the compiled extension links network symbols — capability present, unused) **and Z5f** (`macros` shells to `git`, and is outside the allowlist). |
-| **Z6** | Vendored Mermaid actually renders a diagram in a browser with egress blocked | **PASSED on rendering; FALSIFIED the accessible-name claim** 2026-08-07 | The vendoring mechanism works: two diagrams render from the vendored copy with **zero remote requests** (Z6a–Z6c), and the degradation fallback is confirmed benign rather than assumed (Z6j). **Corrected the design:** attributes on the `<pre>` are destroyed at render time, so the specified `attr_list` accessible name never reaches the SVG (Z6d) — and it survives only when the diagram *fails* (Z6e). A replacement that names the graphic itself, adds no lines, and leaves the fence body untouched is verified and adopted as **D46** (Z6f, Z6i), with the two rejected routes and their costs recorded (Z6g). **Surfaced Z6h** — `attr_list` values terminate on a quote, which is an injection channel wider than this gate's subject. |
-| **V6** | Whether an agent's process working directory is the skill directory | **ANSWERED — no** 2026-08-07 | **It is the session's project root, which is the content root.** Measured on `claude-code` — the shipped `mermaid-renderer` skill's own documented `python scripts/render_mermaid.py --check` **fails** with the skill actively loaded, while the same script via the harness-supplied absolute base directory succeeds — and on `codex`, whose session header prints `workdir: <project-root>` and whose `pwd` returns it. **Unmeasured: `copilot`, `cursor`, `gemini`** (not installed) **and `kiro-ide` / `kiro-cli`** (the `kiro` binary is the IDE launcher; no headless agent CLI). So rules 2–4 are not skipped in practice, rule 4 does the work, and **`--root` is no longer effectively required** — see [`invocation.md`](invocation.md) and [`overview.md`](overview.md). The self-realpath guard is retained for the unmeasured adapters. |
-
-**Regression duty.** Z1–Z6 become CI assertions in
-`tests/skills/publish-binder/integration/` once implemented, on every PR — they
-need a 12.2 MB pip install, not a 236 MB toolchain, so there is no path filter to
-argue about. **Z5 and Z6 need more than the others, and Z5's instrument does not
-port.** Z5 was measured with `sandbox-exec`, which is macOS-only — a Linux runner
-needs a network namespace or a seccomp filter instead, **and its own negative
-control**, because a denial mechanism that silently fails open turns this gate into
-a green light. Z6 needs a headless browser, the one dependency the design otherwise
-avoids. Both are worth it, and Z6e is the argument: the mechanism it caught fails in
-the direction a static assertion reads as green.
-
-**What the executed Z5/Z6 run cost, since the gates were nearly deferred to
-implementation.** Under two hours, and it closed the last renderer question,
-falsified a specified accessibility control, and replaced it with a verified
-mechanism. The alternative was discovering Z6d when a reader with a screen reader
-opened a published binder.
-
----
-
-## Retained Quarto findings — evidence for a future PDF adapter
-
-> **Not live design.** Everything below describes Quarto, which D-B removed from
-> v1. It is retained because Q5, Q10a, Q11, Q17, Q18, Q26, Q27, and Q28 are
-> hard-won by direct execution and are exactly what a future PDF or EPUB adapter
-> would be built against. Read it as history, not as specification.
-
-## Verified Quarto findings
-
-Every claim below was checked against an official primary source on
-**2026-08-06**. Confidence is stated per claim. Claims that could not be verified
-are marked **UNVERIFIED**, are never load-bearing on their own, and each has a
-gate in *Pre-implementation verification gates*.
-
-| # | Finding | Confidence | Source |
-|---|---|---|---|
-| Q1 | Current stable release is **1.10.18** (2026-07-24). 1.11.x exists but is pre-release. | High | GitHub releases API, `quarto-dev/quarto-cli` |
-| Q2 | Book projects use `project: type: book` with `book: chapters: […]`; `part:` nests `chapters:` and accepts either a `.qmd` file or a bare string title; `appendices:` is a sibling key. | High | quarto.org/docs/books/book-structure.html |
-| Q3 | **`index.qmd` is required** — "because Quarto books also produce a website in HTML format". | High | ibid. |
-| Q4 | You can link to unnumbered chapters but **cannot cross-reference** figures or tables inside them. | High | ibid. |
-| Q5 | Mermaid requires the executable-cell fence `` ```{mermaid} ``. The portable GitHub fence `` ```mermaid `` is **not** recognized as a diagram. | High | quarto.org/docs/authoring/diagrams.html |
-| Q6 | Diagram cell options use `%%\|` comments immediately after the opening fence; `%%\| label: fig-x` + `%%\| fig-cap: "…"` give figure numbering and `@fig-x` cross-references. | High | ibid. |
-| Q7 | HTML output renders Mermaid via bundled JavaScript. PDF/DOCX render via PNG through Chrome/Edge. `mermaid-format` ∈ `{js, png, svg}`. | High | ibid. |
-| Q8 | Diagram code is hidden by default; `%%\| echo: true` shows it. | High | ibid. |
-| Q9 | `engine: markdown` specifies that **no execution engine is used**. Engine selection is otherwise driven by the presence of `{r}` / `{python}` / other executable blocks. | High | quarto.org/docs/computations/execution-options.html |
-| Q10 | *"Engine extensions do not allow control over the cell language handlers for diagrams like mermaid and dot."* | High **as quoted** | quarto.org/docs/extensions/engine.html |
-| Q10a | Mermaid **does** render under `engine: markdown` **and** `execute: enabled: false`: the diagram cell handler runs independently of the execution engine, emitting a numbered figure (`Figure 2.1`) wrapping `<pre class="mermaid mermaid-js">`. | **High — VERIFIED**, gate V1 executed 2026-08-06 | Quarto 1.10.18 rendering the real generated `_quarto.yml` (book project, both keys set) |
-| Q11 | Body-level shortcodes are processed independently of execution: `{{< include >}}`, **`{{< env >}}`**, `{{< meta >}}`, `{{< var >}}`, `{{< embed >}}`, `{{< contents >}}`, and others. | High | quarto.org/docs/authoring/shortcodes.html |
-| Q12 | HTML format accepts `include-in-header`, `include-before-body`, `include-after-body`, `css`, `theme`, `filters`, and `from` (with per-extension pandoc toggles). | High | quarto.org/docs/reference/formats/html.html |
-| Q13 | The official PyPI package `quarto-cli` (1.10.18) is **sdist-only, 4.6 KB**. Its `setup.py` performs an unauthenticated `urllib.request.urlretrieve` of the platform release tarball from GitHub with **no checksum or signature verification**, and declares runtime dependencies `jupyter`, `nbclient`, `wheel`. Console script `quarto` shells to the bundled binary. | High | PyPI JSON API + inspection of `quarto_cli-1.10.18.tar.gz` |
-| Q14 | No `@quarto/cli` npm package exists. | High | npm registry |
-| Q15 | The Homebrew cask installs `quarto-1.10.18-macos.pkg` — a macOS package requiring administrator authorization. | High | formulae.brew.sh cask API |
-| Q16 | Release assets are large: **236 MB** macOS tarball, ~140 MB Linux/Windows. Every asset carries a published SHA-256 (in `quarto-<ver>-checksums.txt` and in the GitHub API asset `digest` field). | High | GitHub releases API |
-| Q17 | An **unnumbered book chapter** is produced by the `.unnumbered` class on its main heading — *"If you want a chapter to be unnumbered simply add the `.unnumbered` class to its main heading"*, e.g. `# Preface {.unnumbered}`. Appendices are auto-numbered uppercase-alpha with an inserted prefix. | High | quarto.org/docs/books/book-structure.html |
-| Q18 | A shortcode is **escaped by extra braces** — *"Escape the shortcode reference with extra braces like this: `{{{< var version >}}}`"*. A `shortcodes=false` attribute on a code block also prevents processing. | High | quarto.org/docs/extensions/shortcodes.html |
-| Q19 | Whether `quarto render` performs network access for a pure-Markdown HTML book with bundled Mermaid | **UNVERIFIED** — gate **V2** | — |
-| Q20 | Fenced divs and attributed spans **do** survive `-raw_attribute` and `-raw_html`: `::: {.callout-note}` renders as `callout-note` and `[x]{.badge}` as `<span class="badge">` with every `from:` variant tested. The structural inference was correct — `raw_attribute` governs `` ```{=format} `` only. | **High — VERIFIED**, gate V3 executed 2026-08-06 | as Q10a |
-| Q21 | `pip install` supports `--no-deps`, `--user`, and `--require-hashes`. | High | `python -m pip install --help`, pip as shipped with Python 3.13 |
-| Q22 | **`uv tool install` has no `--no-deps` flag** (uv 0.11.33). It offers `--excludes <requirements-file>`, `--constraints`, and `--overrides`; dependency exclusion therefore requires a requirements file rather than a bare flag. `pipx` uses `--pip-args`. | High for `uv` (`uv tool install --help`, uv 0.11.33); the `pipx` form is **unverified** and is therefore never printed as an exact command — see rung 3 | — |
-| Q23 | The `quarto-cli==1.10.18` sdist's SHA-256 is `20b8b672384ce9bf8a05fcc9e23f1e1f3ad6b9cb7657a476756da8f427101571`, and **pip reads `--hash` only from a requirements file** — `pip install --require-hashes <spec>` on the command line fails with "Hashes are required in --require-hashes mode". | High | obtained by running `python -m pip install --require-hashes 'quarto-cli==1.10.18' --dry-run`, which prints the hash in its error |
-| Q24 | `python -m pip install --no-deps --user quarto-cli==1.10.18` installs a working Quarto on macOS and places the console script at `~/.local/bin/quarto`, reporting `1.10.18`. Behaviour on a **PEP 668 externally-managed interpreter** and on Windows remains **UNVERIFIED** — gate **V4** covers those two. | Medium — macOS verified 2026-08-06; other platforms gated | direct execution |
-| Q26 | **`from: markdown-raw_html` breaks Mermaid.** Quarto's diagram handler emits its output *as raw HTML*, so disabling `raw_html` at the pandoc reader causes the emitted `<pre class="mermaid">` to be escaped and rendered as literal text inside an otherwise-correct figure. Isolated by bisection: `from: markdown-raw_attribute-raw_tex` → diagram renders; `from: markdown-raw_html` → diagram destroyed. Callouts and spans are unaffected either way. | **High — VERIFIED** 2026-08-06 | direct execution; see *The `from:` string, corrected by gate* |
-| Q27 | **The stock Bootstrap theme imports Google Fonts at read time.** `site_libs/bootstrap/bootstrap-*.min.css` in a rendered book contains `@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro…")`. Bootstrap's icon font is local; the typeface is not. The published HTML itself carries **zero** absolute `src=`/`href=` references. | **High — VERIFIED** 2026-08-06 | grep over a rendered `_output/` tree |
-| Q28 | **`<br/>` inside a Mermaid node label survives and renders** under the corrected `from: markdown-raw_attribute-raw_tex`: pandoc entity-escapes it in the HTML source, the browser decodes it back as the `<pre>`'s text content, and Mermaid renders a line break. A **literal newline** inside a quoted label collapses to a space, and a backtick markdown-string label is passed through verbatim — so rewriting `<br/>` to `\n` would *silently lose* the break rather than preserve it. | **High — VERIFIED** 2026-08-06 | direct execution, three-label fixture |
-| Q25 | Whether Quarto expands shortcodes (`{{< … >}}`) inside `title` / `book.title` metadata, as opposed to document bodies | **UNVERIFIED** — gate **V5**. Not relied upon: the emitted-string validator rejects the syntax regardless, so the control holds whichever way V5 resolves | — |
-
-### The three findings that changed the design
-
-**Q5 makes staging mandatory.** If Quarto accepted GitHub-style fences, a design
-that copied sources verbatim would be viable. It does not, so every source file
-must be transformed. Once transformation is unavoidable, it costs nothing extra
-to make transformation the security boundary — which is why the scanner lives in
-staging rather than in a pre-flight validator.
-
-**Q11 destroys the comfortable assumption.** The brief warns *"Do not claim that
-disabling Quarto execution alone neutralizes all unsafe input,"* and it is
-correct. `{{< env >}}` renders an environment variable's value into the output
-HTML — an AI-authored or externally supplied Markdown file containing
-`{{< env AWS_SECRET_ACCESS_KEY >}}` exfiltrates a secret into a published
-document with execution fully disabled. `{{< include ../../../.ssh/id_rsa >}}`
-reads outside the content root. Neither is an execution-engine concern, and the
-documentation offers no global disable switch. **Shortcode neutralization must
-therefore be performed by this pack.** This single finding is the strongest
-argument in the design for owning a staging scanner rather than delegating trust
-to renderer configuration.
-
-**Q10a is an inference, and the headline feature rests on it.** The natural worry
-with `engine: markdown` is that switching execution off also switches Mermaid
-off, forcing a choice between security and diagrams. Q10 makes that unlikely —
-diagram cell handlers are described as outside the engine-extension surface — but
-Q10 is a statement about the extension API, not about the `engine` or `execute`
-YAML keys, and it says nothing at all about `execute: enabled: false`. Mermaid is
-a v1 goal and is part of why Quarto was chosen over MkDocs, so **the inference is
-gated (V1) rather than assumed**, with a named fallback.
-
----
-
-## Pre-implementation verification gates — Quarto
-
-> **Historical.** V1–V6 gated *Quarto* claims. D-B retired the renderer, and with
-> it V2 (render-time network), V4 (the install-command platform matrix), and V5
-> (shortcode expansion in metadata) — none of which has a subject any more. V2b's
-> *concern* survives as **Z4**, restated; V2's own concern survives as **Z5**, run
-> and closed; V6 (agent CWD) is renderer-independent and was answered on
-> 2026-08-07. The rest is kept as the record a PDF adapter inherits.
-
-**Three of these have been run, not deferred.** V1, V3, and V4-on-macOS were
-executed against Quarto 1.10.18 on 2026-08-06, because a renderer decision resting
-on an inference the author had marked UNVERIFIED is a decision the RFC cannot
-ratify. Running them cost under an hour and **changed the design** — see Q26.
-
-**One fixture, several assertions.** Testing each claim in isolation would verify
-configurations the pack never emits. The gates run against **the real generated
-`_quarto.yml`** — a book project with `engine: markdown`, `execute: enabled:
-false`, the emitted `from:` string, the shipped theme, a `{mermaid}` cell, a
-callout div, and an attributed span — because the interaction of the reader
-toggles with diagram-cell output is precisely what no Q-row covered, and it is
-precisely what broke.
-
-| Gate | Claim | Status | Result / fallback |
-|---|---|---|---|
-| **V1** | Q10a — Mermaid renders with `engine: markdown` **and** `execute: enabled: false` | **PASSED** 2026-08-06 | The diagram handler runs independently of the execution engine, producing a numbered figure. Both keys stay. **The run also surfaced Q26** — the `-raw_html` reader toggle destroys the emitted diagram — which is the finding that changed the design. |
-| **V1b** | The **exact v1 Mermaid emission** — `%%\| label:` with no `fig-cap:` | **PASSED** 2026-08-06 | Renders as a numbered figure (`Figure 2.1`) with class `quarto-uncaptioned` and no crossref warning. This corrected the design: numbering does **not** require a caption, as an earlier draft claimed. |
-| **V1c** | Q28 — `<br/>` in a Mermaid node label | **PASSED** 2026-08-06 | Survives and renders; a literal-newline rewrite does not. Drove the label allowlist. |
-| **V3** | Q20 — fenced divs and attributed spans survive the reader toggles | **PASSED** 2026-08-06 | `callout-note` and `<span class="badge">` render under every `from:` variant tested. Badges and editorial markers use callouts and fenced divs as planned; the plain-label fallback is not needed. |
-| **V4** | Q24 — the printed rung-1 command installs a working `quarto` | **RETIRED by D-B** (was PARTIAL — macOS passed 2026-08-06) | `python -m pip install --no-deps --user quarto-cli==1.10.18` produced `~/.local/bin/quarto` reporting `1.10.18`. **Still to run:** a PEP 668 externally-managed interpreter, and Windows. Fallback unchanged: surface the interpreter's own message, never add `--break-system-packages`, fall through to rung 2. **The residue is retired, not outstanding:** the PEP 668 and Windows runs would have gated a *Quarto* install command that no longer exists on any code path. A future PDF adapter inherits both the finding and the unrun cases. |
-| **V2** | Q19 — no network access *during* render | **NOT RUN against Quarto; SUPERSEDED by Z5** | Never run against `quarto render`, and it will not be — D-B retired the renderer. The question itself was renderer-independent, moved to **Z5**, and answered there on 2026-08-07. Recorded this way for the same reason V2b is: a row reading only `NOT RUN` invites a reader to think the concern is still open. |
-| **V2b** | Q27 — no network access *at read time*, from the published tree | **RUN, FAILED** 2026-08-06 | The rendered HTML carries zero absolute `src=`/`href=` references — but the stock Bootstrap CSS contains `@import url("https://fonts.googleapis.com/…Source+Sans+Pro…")`, so a reader's browser phones out. **This is a design requirement, not a gate failure to accept:** a binder for an air-gapped review board or a privacy-sensitive client cannot fetch a typeface from a third party. **Superseded by Z4** under Zensical, which found the same class of leak, a different suppression key, and that the "zero `https://` anywhere" form of the assertion is unsatisfiable (Z4d). |
-| **V5** | Q25 — shortcode expansion in `title` / `book.title` metadata | **NOT RUN** | Render the fixture with a `book.title` containing a literal `{{< env HOME >}}`, injected by the test to bypass the validator, and assert the value does not appear in the output. No fallback needed — the emitted-string validator (D36) rejects this input on every real path; V5 tells us whether the validator is the only thing standing between a title and an environment variable. |
-| **V6** | Whether an agent's process working directory is the skill directory | **MOVED, then ANSWERED** 2026-08-07 — see the Z-gate status table above | Renderer-independent, so it did not retire with Quarto. Listed with the live gates rather than under this section's "not live design" heading, and answered there. |
-
-**What the executed gates changed.** V1 was expected to confirm a fact and instead
-produced Q26, which removed a security layer the design had claimed and forced the
-`from:` string to change. V2b was expected to be a formality and instead found that
-the default theme leaks a read-time request to a third party. Both are the kind of
-finding that surfaces two days into implementation if the gates are treated as
-paperwork — which is the argument for running them before the RFC rather than
-after.
-
-**Regression duty.** All gates remain CI assertions in
-`tests/skills/publish-binder/integration/` after they pass; settling a question and
-guarding it are different jobs. See *CI provisioning* for which run on a path
-filter.
-
----
+- Quarto requires executable-style Mermaid fences; portable GitHub fences need a
+  staging transform.
+- Mermaid can render with `engine: markdown` and execution disabled.
+- Shortcodes remain active independently of execution. A future adapter must
+  neutralize them before rendering. D36 also rejects shortcode syntax in emitted
+  strings that bypass the source-body scanner.
+- Quarto automatic appendix and figure behavior differs from the Zensical
+  adapter; do not reuse Zensical ordinal assumptions.
+- `from: markdown-raw_html` destroys Quarto Mermaid output. Fenced divs and
+  attributed spans survive the relevant reader toggles.
+- The stock Quarto theme imports Google Fonts at read time.
+- `<br/>` in Mermaid labels survives; replacing it with a literal newline loses
+  the break.
+- Quarto dependency installation, render-time network behavior, and metadata
+  shortcode expansion require fresh verification before an adapter depends on
+  them.

--- a/docs/architecture/binder-publishing/zensical-adapter.md
+++ b/docs/architecture/binder-publishing/zensical-adapter.md
@@ -25,20 +25,12 @@ writes no field of the index (invariant 22); anything it must invent goes in
 > Stated that way deliberately. "It is given no source root" would be the stronger
 > claim and it would be false — staging must read caller-owned sources, and the
 > index does carry the root. The mechanical guarantee is the accessor, not a
-> withheld variable. See [`overview.md`](overview.md#proposed-component-architecture).
+> withheld variable. See [`overview.md`](overview.md#component-architecture).
 
-## Why this adapter is small
+## Adapter staging boundary
 
-The Quarto adapter was large because Quarto needed working around. Three of its
-areas do not exist here:
-
-| Quarto needed | Zensical |
-|---|---|
-| ` ```mermaid ` → `` ```{mermaid} `` transformation, label injection, caption binding, `line-map` | **Reads the portable fence directly.** The fence *body* is never rewritten and the opening delimiter gains attributes on its own line (step 5, D46) — so no line-count change, so no line map |
-| Shortcode neutralization (Q11) | **Does not interpret `{{< … >}}`.** Passes it through as text |
-| A reader-toggle layer that broke diagrams (Q26) | Not applicable |
-
-What remains is genuinely a *staging* step: copy, rewrite links, write config.
+The adapter stages sources, rewrites links, emits configuration, reads portable
+Mermaid fences without rewriting their bodies, and treats `{{< … >}}` as text.
 
 ## Staging
 
@@ -305,24 +297,10 @@ rather than of a patch version, so this is not fragile, but **the pack vendors a
 pinned version with a recorded digest**, for the same reason `zensical` itself is
 pinned exactly.
 
-### The accessible name — Z6 falsified the specified mechanism
+### Accessible diagram naming
 
-**Attributes on the `<pre>` do not survive rendering.** The bundle mounts a
-diagram with `e.replaceWith(r)` where `r = A("div",{class:"mermaid"})` — **a fresh
-`div` carrying only `class`** — and puts the SVG in `attachShadow({mode:"closed"})`.
-Measured live: `div attrs: {"class":"mermaid"}` for every diagram, and
-`div.shadowRoot === null` from page script (Z6d). So an `aria-label` emitted onto
-the fence through `attr_list` is discarded before the reader ever sees the
-diagram.
-
-> **Of the specified controls the Z-gates found wrong, this is the only one that was
-> wrong about a *runtime*.** Z1c and Z4a both came from reading a key's shape; this
-> one came from reasoning about the HTML the compiler emits and never asking what
-> the client-side bundle does to it. Worse, it fails *inverted*: Z6e found the name
-> is present in the accessibility tree **only when the diagram fails to render**,
-> because the `<pre>` is still there. A named diagram and a rendered diagram were
-> mutually exclusive, and a static assertion over the built HTML would have read
-> green forever.
+The theme replaces the staged `<pre>`. Accessibility metadata must therefore reach
+Mermaid before mounting and be asserted on the rendered SVG, not on the `<pre>`.
 
 **The mechanism is two halves that meet in the browser, and it is verified (D46).**
 The compiler emits the name and description as `attr_list` attributes on the
@@ -543,10 +521,7 @@ ERROR  Mermaid diagram failed to parse
 
 ## The dependency contract
 
-The whole of it. **This file used to have a 211-line sibling** describing an
-install ladder, consent tokens, digest verification, PEP 668 handling, a toolchain
-cache with its own lock, and a platform gate — all of it machinery for managing a
-236 MB external CLI. ADR-0073 deleted the CLI, so it deleted the machinery.
+The runtime dependency contract is:
 
 ```toml
 [[pack.runtime-dependencies]]
@@ -618,9 +593,8 @@ Z-gates — the same discipline that caught Q26 and Q27, and that caught three
 errors in this file — and the fact that swapping renderers touches this file and
 nothing else.
 
-## What a future Quarto adapter would need
+## Future Quarto adapter (not v1)
 
-Retained deliberately: [`verified-findings.md`](verified-findings.md) carries
-Q1–Q28, all of it hard-won by direct execution. A PDF or EPUB path would go
-through Quarto, and Q5, Q10a, Q17, Q18, Q26, and Q28 are exactly what that adapter
-would be built against. The findings are evidence, not history.
+Not v1 work. A PDF or EPUB adapter using Quarto must implement the constraints in
+[`verified-findings.md`](verified-findings.md), including fence transformation,
+shortcode neutralization, reader-toggle behavior, numbering, and label handling.

--- a/docs/architecture/catalogue.md
+++ b/docs/architecture/catalogue.md
@@ -42,9 +42,8 @@ excluded — see `docs/specs/claude-plugin-route-scope`. How a pack's
 
 Every source verb — `install`, `upgrade`, `list-packs`, `list-profiles`,
 `list-installed` — takes an optional trailing catalogue argument. When you
-omit it, the CLI resolves one through a five-layer, first-match-wins chain
-(RFC-0046 / ADR-0036, in
-[`source_defaults.resolve_default_source`](../../packages/agentbundle/agentbundle/source_defaults.py)):
+omit it, the CLI resolves one through a five-layer, first-match-wins chain in
+[`source_defaults.resolve_default_source`](../../packages/agentbundle/agentbundle/source_defaults.py):
 
 | Layer | Source | Set by |
 | --- | --- | --- |

--- a/docs/architecture/credentials.md
+++ b/docs/architecture/credentials.md
@@ -1,596 +1,127 @@
-# Credentials
+# Credentials and trust boundaries
 
-> **Refreshed 2026-08-05.** The `creds` resolver is the standalone,
-> pip-installable [`credbroker`](../rfc/0023-credential-manager-broker.md)
-> library imported in-process ([RFC-0023](../rfc/0023-credential-manager-broker.md)),
-> which replaced the build-projected `credentials_shim`. The `sso-cookie`
-> broker ([RFC-0035](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md)) now has
-> its own section. The convention lint moved from a shell script into
-> `agentbundle catalogue lint` (**CAT-L031**).
+## 1. Purpose and boundary
 
-The secret-handling subsystem for credentialed primitives in this
-catalogue. Defines how a credentialed primitive — a `jira`, `figma`,
-or `confluence-publisher` CLI — acquires a credential at runtime without
-ever putting it on argv, in env-var echoes, or in agent transcripts.
-Authoritative specs:
-[`docs/specs/credential-broker-contract/spec.md`](../specs/credential-broker-contract/spec.md)
-(current contract); the predecessor
-[`docs/specs/skill-secrets/spec.md`](../specs/skill-secrets/spec.md)
-(historical, three-tier model). *Why*:
-[RFC-0013](../rfc/0013-credential-broker-contract.md) +
-[RFC-0006](../rfc/0006-skill-secrets-storage.md).
+Credentialed primitives obtain credentials at runtime without placing secret bytes
+on argv, in process-visible shell history, or in agent transcripts. The
+subsystem protects against accidental exposure and cross-user access at rest.
 
-## Threat model — what this subsystem does and does not defend against
+It does not protect against a hostile process running as the same OS principal.
+That process can read local stores, alter adopter configuration, or invoke the
+engine. A human login page is different: an agent-influenced destination could
+harvest credentials the agent did not already have. Headed capture therefore
+remains operator-only.
 
-The tier model predates coding agents. It was built for a world where the
-adversary is *another user*, an accidental `echo`, a process list, a shell
-history file, or a `git add .`. Against those it works, and every control here
-earns its place.
+## 2. Entrypoints
 
-It was **not** built for an adversary running as the *same OS principal*, and it
-cannot be retrofitted to. If an agent executes as you, then by construction it
-can read `~/.agentbundle/credentials.env`, call the keychain with your
-credentials, edit `~/.agentbundle/sso-profiles/*.toml`, and invoke
-`~/.agentbundle/bin/sso-broker.py` directly. No tier, no `0600`, and no
-in-process guard changes that — they are all inside the boundary the adversary
-already occupies.
+- Credentialed primitives declare one broker in `SKILL.md`: `creds`, `env`,
+  `cli`, or `sso-cookie`.
+- `credbroker.load_credentials` resolves `creds` in-process.
+- `credbroker.load_sso_cookies`, `refresh_sso_session`, and
+  `register_sso_session` are the consumer SSO API.
+- `sso-broker.py` provides `get-cookies`, `test`, `rm`,
+  `list-profiles`, `register`, and `refresh`.
+- `credential-setup` reads `references/creds-schema.toml`, prompts with
+  `getpass` or `input`, writes the highest available tier, and reports it on
+  stderr.
+- [Credentialed-skill authoring guidance](../../guides/credential-brokers/how-to/add-a-credentialed-skill.md)
+  covers broker and primitive declarations, not operator setup.
 
-**Defends against**
+## 3. Owned state and write authority
 
-- A secret reaching argv, a process list, a shell history, or a transcript.
-- A secret entering the agent's *context* — consumers receive a path or a
-  resolved value inside their own subprocess, never bytes the model sees.
-- A secret at rest being read by another user, or committed to git.
-- Silent degradation: resolution fails closed rather than falling through.
+| State | Location | Write authority | Readers |
+| --- | --- | --- | --- |
+| Tokens | OS credential store or `~/.agentbundle/credentials.env` | `credbroker` write API | Credentialed primitive subprocesses |
+| SSO profile and jar | `~/.agentbundle/sso-profiles/` and SSO store | `sso-broker.py` | `credbroker` and the engine |
+| Materialised cookie jar | `~/.agentbundle/sso-cookies/<profile>.jar` | `sso-broker.py get-cookies` | Credentialed primitive |
+| Profile lock | `~/.agentbundle/sso-locks/<profile>.lock` | `sso-broker.py` | Store-touching SSO verbs |
 
-**Does not defend against**
+Consumers receive a jar path, never cookie bytes. SSO lockfiles contain no
+credential material and are never deleted.
 
-- A same-principal process reading the store directly.
-- A same-principal process editing an adopter config that names a destination.
-- A same-principal process invoking the engine itself.
+## 4. Dependencies and allowed edges
 
-That distinction matters because the dominant real failure mode is an agent that
-*misbehaves* — leaks a value into a log, echoes it into a transcript, pastes it
-into an issue — not one that is *adversarial*. This subsystem substantially
-closes the first and does not close the second. Documenting a stronger boundary
-than exists is how a design ends up resting on a control it never had.
+Skills orchestrate credentialed primitives but never read credentials. A
+`credentialed-cli` refuses value-shaped credential flags such as `--token`,
+`--api-key`, `--bearer`, `--pat`, and `--password`. An MCP server may
+accept header-naming flags but never value-shaped flags.
 
-### The accepted profile, and the one carve-out
-
-This catalogue **accepts** the same-principal limit rather than pretending to
-close it. The accepted profile is:
-
-> **The subsystem defends against an agent that errs, not an agent that is
-> hostile.** A hostile same-principal process already has everything on the box.
-
-That acceptance is not new and not specific to SSO — it has always been true of
-the token path. An adversarial agent can read the Tier-3 dotfile, call the
-keychain, or invoke the engine directly. Any control we add *inside* that
-boundary is theatre, so we do not add it, and we do not claim it.
-
-**The consequence for feature design is liberating, with one exception.** Once
-the profile is accepted, a new capability is only worth arguing about if it gives
-a hostile agent something it *did not already have*. Most do not: a convenience
-verb that reads a store the agent could read anyway, or spawns an engine the
-agent could spawn anyway, adds no reachable capability. Those ship.
-
-The exception is **any flow that puts a human in front of a login page whose
-destination the agent could influence.** That is categorically different: it does
-not read what is already on the box, it *harvests a credential the agent cannot
-otherwise obtain* — the operator's IdP password and MFA, which unlock far more
-than the tool being configured. The blast radius leaves the machine.
-
-So the boundary is not a verb and not a subsystem. It is:
-
-| | Human types credentials? | Verdict |
-|---|---|---|
-| Automated re-auth against a warm browser session | no | ships — no marginal capability |
-| Any flow that renders a login page to a human | **yes** | the one place a real control is worth its cost |
-
-Where a control is warranted, it must satisfy the anchor test below — integrity
-protection for the destination fields specifically, not for the whole config.
-
-[RFC-0084](../rfc/0084-sso-destination-trust-boundary.md) applies that test to
-the supported deployment and finds that no qualifying component can be shipped
-inside the user-scoped Python package and projected-script envelope. Generic
-headed cookie capture therefore remains operator-only and carries an accepted
-same-principal destination-poisoning limitation; no baseline enforcement work
-is deferred. A protocol-backed mode or privileged installation class requires a
-new proposal tied to a concrete consumer and deployment path.
-
-**What actually closes the same-principal case**, from a survey of comparable
-projects (see the references below), is always a trust anchor the agent's process
-cannot forge or reach:
-
-| Anchor | Example |
-|---|---|
-| Another machine / network boundary | credential-injecting egress proxies — the secret is never on the agent's host |
-| Another privilege level | `sudo`-gated wrappers; a root-owned config the agent cannot write |
-| OS-mediated human presence | biometric / WebAuthn approval prompts |
-| Platform attestation | SPIFFE/SPIRE — identity asserted by the kernel or orchestrator, not the caller |
-| Cryptographic binding at issuance | authorization bound into a token by a human, un-widenable at call time |
-
-Everything that fails does so the same way: it tries to enforce the boundary
-*inside* the process the adversary controls — validation, allowlists, config
-guards, prose rules, in-band confirmation. Any future control added here should
-be checked against that test first.
-
-## Two-layer architecture
-
-The repo distinguishes two things that often get conflated:
-
-- **Skills** never read credentials. They drive UX, planning, and
-  shell-out patterns, but they don't talk to authenticated APIs
-  themselves.
-- **Credentialed primitives** read credentials. Every primitive
-  declares its broker via `SKILL.md` frontmatter:
-
-  ```yaml
-  metadata:
-    credentialed: true
-    primitive-class: credentialed-cli   # or: mcp-server
-    auth: creds                         # or: env / cli / sso-cookie
-    namespace: <namespace>
-    keys: ["<KEY>"]
-  ```
-
-  - `credentialed-cli` — a Python module invoked via subprocess that
-    reads credentials inside its own process. **Refuses** any
-    value-shaped credential flag (`--token`, `--api-key`, `--bearer`,
-    `--pat`, `--password`).
-  - `mcp-server` — an MCP server holding the secret. May accept
-    *header-naming* flags (`--bearer-header`, `--auth-header`) but
-    never value-shaped flags.
-
-The `auth:` field selects which broker the primitive uses:
-
-| Broker | Credential | Section |
-| --- | --- | --- |
-| `creds` | a token resolved through three storage tiers | [The `creds` broker](#the-creds-broker) |
-| `sso-cookie` | a captured web session (cookie jar) | [The `sso-cookie` broker](#the-sso-cookie-broker) |
-| `env` | a value the environment already holds | see the contract spec |
-| `cli` | delegated to a vendor CLI's own login | see the contract spec |
-
-A primitive may declare a fallback. `jira` carries `auth: sso-cookie`
-with `auth-fallback: creds`, so the lint requires **both** brokers'
-Don't-block phrase sets in its Security section.
-
-### What the lint enforces
-
-`agentbundle catalogue lint` — **CAT-L031**, implemented as
-`_check_credentialed_skills` in
-[`agentbundle/catalogue_tooling/lint.py`](../../packages/agentbundle/agentbundle/catalogue_tooling/lint.py)
-and run by `make build-check`. It checks the argv ban, the presence of
-each declared broker's Don't-block phrases under the
-`### Security rules (non-negotiable)` heading (matched
-whitespace-normalised, so the phrases may wrap), refusal to read the
-dotfile, and per-broker AST walks over the primitive's scripts — e.g.
-`auth: creds` requires a `credbroker` resolver import, and `auth:
-sso-cookie` requires resolution via `load_sso_cookies`. A primitive that
-genuinely must read credentials directly opts out with the
+No `get` verb or tool returns cleartext to the model. A primitive calls
+`load_credentials` inside its own subprocess and uses the value only in an
+outbound HTTP header. Direct credential reads require the explicit
 `# credentialed-primitive: reads-creds-directly` marker.
 
-## The three tiers
+`credbroker` imports no SSO engine code. It subprocesses `sso-broker.py`;
+the engine never imports `credbroker`. Consumers call the library and do not
+construct broker argv or subprocesses themselves.
 
-| Tier | Storage | Use case |
+The `creds` broker uses first-hit-wins per required key. `env` consumes an
+already-present environment value. `cli` delegates to the vendor CLI.
+A fallback declaration requires both brokers' security phrases.
+
+## 5. Primary flows
+
+1. `creds` resolves each required key through Tier 1, Tier 2, then Tier 3.
+2. `sso-cookie` loads a stored session, materialises a jar path, and passes
+   that path to the consumer.
+3. An expired typed SSO session may trigger one headless refresh and one
+   re-probe. First capture and re-registration are operator actions.
+4. A credentialed primitive uses the resolved value inside its own process for
+   the outbound request.
+
+## 6. Failure and recovery behavior
+
+### Three storage tiers
+
+| Tier | Storage | Refusal or boundary |
 | --- | --- | --- |
-| **Tier 1** | `<NAMESPACE>_<KEY>` env var (`JIRA_API_TOKEN`, `JIRA_BASE_URL`, …) | CI runners, wrapper scripts that inject secrets per-command. |
-| **Tier 2** | OS keyring (macOS Keychain, Windows Credential Manager) | Interactive developer machine. The default. |
-| **Tier 3** | `~/.agentbundle/credentials.env`, mode `0600` + parent `0700` | Locked-down environments where Tier 2 isn't available; opt-in fallback. |
-
-`credbroker`'s Tier-2 dispatch is `sys.platform`-gated to `darwin` and
-`win32` only, so **Linux has no Tier 2** and falls through to Tier 3.
-libsecret support is deferred to a follow-up RFC.
-
-### Tier 2 backends — stdlib only
-
-- **macOS** (`credbroker`'s `_keychain_macos.py`) —
-  `subprocess.run(["/usr/bin/security", ...])`. The write path passes
-  the token via **child stdin**, never argv. Service =
-  `"agentbundle"`, account = `"<namespace>:<key>"`.
-- **Windows** (`credbroker`'s `_credman_windows.py`) —
-  `ctypes` against `advapi32.{CredReadW, CredWriteW, CredDeleteW,
-  CredFree}`. In-process, no subprocess. `CRED_TYPE_GENERIC`,
-  `CRED_PERSIST_LOCAL_MACHINE`, target-name
-  `agentbundle:<namespace>:<key>`.
-
-The backend label is selected at module-load time per `sys.platform`.
-A documented set of Win32 hard-fail codes raises `Tier2HardFailError`
-and does **not** fall through to Tier 3. Silent degradation is the
-security smell, not the dotfile.
-
-### Tier 3 — the dotfile
-
-A stdlib `.env` parser (`parse_env_file` in `credbroker`'s `_core`)
-handles `KEY=value`, quoted values, and `#` comments. It rejects
-`export ` prefix, variable expansion, and multi-line values — `.env`
-is not bash. POSIX: enforces mode `0600` on the file and `0700` on
-`~/.agentbundle/`. Windows: DACL-verified via `icacls`.
-`PermissiveAclError` on either failure.
-
-Where `credbroker[crypto]` is installed (a pip layer, never the stdlib
-floor), Tier 3 upgrades from the plaintext dotfile to an AEAD-encrypted
-**vault** (Argon2id → KEK → AES-256-GCM, `credbroker`'s `_vault`); the
-vendored floor stays stdlib-only and plaintext. See
-[RFC-0023](../rfc/0023-credential-manager-broker.md).
-
-## The `creds` broker
-
-The `creds` broker resolves credentials through the three-tier model
-below. Since [RFC-0023](../rfc/0023-credential-manager-broker.md) the
-implementation is the standalone, pip-installable **`credbroker`**
-library ([`packages/credbroker/`](../../packages/credbroker/)), imported
-**in-process** — it replaced the build-projected `credentials_shim` that
-earlier dropped a byte-identical copy (plus the Tier-2 backends
-`_keychain_macos.py` / `_credman_windows.py`, now `credbroker`'s own
-modules) into every consumer's `scripts/`. Consumers import the absolute
-package form:
-
-```python
-from credbroker import (
-    CredentialsMissingError,
-    Tier2HardFailError,
-    load_credentials,
-)
-
-creds = load_credentials(
-    namespace="jira",
-    required_keys=["API_TOKEN", "BASE_URL", "EMAIL"],
-)
-creds.API_TOKEN  # str
-```
-
-Returns an immutable dataclass; attribute access on a key not in
-`required_keys` raises `AttributeError`. Single responsibility:
-*resolve* — schema validation is the `credential-setup` skill's
-job, not the loader's. The loader walks **first-hit-wins per key**
-(a key resolved at Tier 1 is not re-checked at lower tiers; mixing
-tiers across keys within one namespace is permitted).
-
-### How `credbroker` reaches the interpreter — the layered delivery
-
-`import credbroker` resolves through a `sys.path` precedence stack fed by
-two delivery layers (full author-facing detail in the
-[how-to](../../guides/credential-brokers/how-to/add-a-credentialed-skill.md#how-credbroker-reaches-syspath--the-layered-model)):
-
-- **Vendored floor (zero-pip, user scope).** A user-scope install of the
-  `credential-brokers` pack delivers a byte-faithful, stdlib-base copy of
-  the package source to `~/.agentbundle/lib/credbroker/`, which every
-  credentialed skill appends to `sys.path` at **lowest** precedence — so a
-  no-repo install resolves Tier-1/2/3 with no pip. The floor is drift-gated
-  byte-for-byte against `packages/credbroker/credbroker/` — **one shared
-  copy**, not the N-per-skill projection the shim used. The projection is
-  performed by `agentbundle`'s build pipeline
-  ([`build/user_libs.py`](../../packages/agentbundle/agentbundle/build/user_libs.py)),
-  which copies *files*; it holds no knowledge of `credbroker`'s API.
-- **pip (corporate / PyPI).** A `pip install credbroker` (internal index,
-  local wheel, or PyPI) lands in site-packages, which precedes the floor on
-  `sys.path` — so it wins and unlocks the encrypted `[crypto]` vault.
-
-The `credentials_shim` source is **kept** at
-[`packs/credential-brokers/.apm/shared-libs/credentials_shim.py`](../../packs/credential-brokers/.apm/shared-libs/credentials_shim.py),
-but only as the companion shim that rides the `adapter-root-bins` →
-`~/.agentbundle/bin/` projection for `sso-broker.py`; no consumer skill
-imports it for `creds` resolution any more.
-
-## The `sso-cookie` broker
-
-> **Added by [RFC-0035](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md);
-> consumer resolution placed in `credbroker` by
-> [ADR-0026](../adr/0026-sso-consumer-resolution-in-credbroker.md);
-> recapture added by
-> [`docs/specs/jira-check-sso-auto-login/spec.md`](../specs/jira-check-sso-auto-login/spec.md).**
-
-For a Data Center instance behind corporate SSO there is no token to
-resolve — the credential is a **captured web session**. The `sso-cookie`
-broker covers that case. It is the only broker whose acquisition step
-needs a human and a browser, which is what shapes everything below.
-
-### Engine and library — the dependency direction
-
-Two components, and the direction between them is load-bearing:
-
-- **`sso-broker.py`** — the *engine*. Ships via `adapter-root-bins` to
-  `~/.agentbundle/bin/`. Stdlib-only for `get-cookies` / `test` / `rm` /
-  `list-profiles`; `register` and `refresh` additionally require **playwright**
-  and exit non-zero when it is absent. `register` drives a **headed** Chromium
-  for interactive capture; `refresh` drives a **headless** one with a bounded
-  silent-completion window and returns a distinct exit code rather than showing a
-  login page, so an automated consumer can never put one in front of an operator.
-  Both store the jar (see below), and `get-cookies` answers with a **path, never
-  bytes**.
-- **`credbroker`** — the *library* consumers import. It **subprocesses**
-  the engine.
-
-So `credbroker` → `sso-broker.py`, never the reverse. The engine cannot
-import `credbroker`; anything both need — notably the profile grammar
-below — is duplicated deliberately and pinned equal by test.
-
-**The engine's exit codes are the interface between the two**, and they are
-per-verb: the same number means different things, which is why a consumer can
-never read one generically.
-
-| Exit | Verb | Meaning | Library raises | Recoverable? |
-|---|---|---|---|---|
-| `0` | any | success | — | — |
-| `2` | `get-cookies`, `test` | no usable session | session-unavailable | **yes** |
-| `3` | any | engine failure — playwright absent, a sign-in not completed, a rejected profile, a corrupt store | recapture-failed / broker-unavailable | no |
-| `4` | `refresh` | the profile was never registered | profile-not-registered | **yes** |
-| `5` | `refresh` | the flow needs a human, and no browser was shown | interaction-required | no |
-| `6` | `get-cookies`, `test`, `rm`, `refresh`, `register` | another process holds this profile's store lock | store-contended | **yes** |
-
-Only the three recoverable rows may reach a consumer's auto-recovery, and
-`6` recovers differently from the other two: `2` and `4` mean re-authenticate,
-while `6` means the session is fine and the store is merely busy — back off and
-retry the same call. `3` is
-returned from a dozen distinct sites, which is why not-registered has a code of
-its own: without the split, an internal engine failure would trigger a browser
-recapture while the stored session is perfectly valid. `4` and `5` are new —
-[RFC-0035](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md) and
-[RFC-0013](../rfc/0013-credential-broker-contract.md) carry the errata.
-
-### Consumer API
-
-Consumers never resolve the broker path, build its argv, or call
-`subprocess` themselves:
-
-> **Status:** all five ship in `credbroker` 0.5.0.
-
-```python
-import credbroker
-
-credbroker.validate_sso_profile(profile)        # grammar guard
-jar_path = credbroker.load_sso_cookies(profile) # path, never bytes
-credbroker.refresh_sso_session(profile)         # re-capture an expired session
-credbroker.register_sso_session(profile, login_url=..., ...)  # first-time capture
-credbroker.derive_sso_destination(base_url, strategies=())     # ask the resource (first capture only)
-```
-
-`refresh_sso_session` takes **only a profile** — deliberately. That
-signature is how **destination pinning** is enforced: it is structurally
-incapable of forwarding a sign-in destination, so an automated recovery
-path cannot choose where the browser goes. The engine reads the
-destination from `~/.agentbundle/sso-profiles/<profile>.toml`, which only
-a completed, operator-authorised `register` writes.
-`register_sso_session` is the sole function that accepts a destination.
-**The guarantee is a property of this API, not of the system:** the engine binary
-is directly invokable by any process running as the operator, so a caller with
-shell access can hand it a destination regardless. Consumers are expected to
-reach `register_sso_session` only from an operator-typed action, which is a
-convention enforced by each consumer's own skill rules — not by this library.
-
-Keeping the spawn inside `credbroker` also keeps the cross-platform
-parts — timeout, process-tree kill (POSIX process groups vs Windows),
-and environment composition — in one type-checked, CI-exercised place
-rather than copied into each consumer skill.
-
-### Where the jar actually lives
-
-Two storage surfaces, and conflating them hides real bugs:
-
-- **Primary store.** On Tier-2-capable platforms (macOS, Windows)
-  `_store_cookie_jar` writes the jar into the **OS keychain**, chunked across
-  continuation credentials when it exceeds the per-credential blob limit. Where
-  Tier 2 is deferred by policy (Linux), it writes a `0600` file under
-  `~/.agentbundle/sso-cookies/`.
-- **Materialisation surface.** Consumers never receive bytes, so `get-cookies`
-  writes the jar it just loaded to `~/.agentbundle/sso-cookies/<profile>.jar`
-  and prints that path. On Linux the two surfaces are the same file; on
-  macOS/Windows they are not — which is why the materialisation must be
-  unconditional. A `get-cookies` that skips the rewrite when the file already
-  exists serves a stale jar after every keychain-backed re-capture.
-
-### Serialising the store transition
-
-Every path that mutates a profile's jar runs under one exclusive interprocess
-lock, taken on a dedicated lockfile at `~/.agentbundle/sso-locks/<profile>.lock`
-— never on the jar itself, because Windows byte-range locks are *mandatory* and
-would deny readers outright. Four verbs acquire it (`register`/`refresh` via
-`_capture`, `get-cookies`, `rm`, `test`); `_store_cookie_jar` asserts it is held
-rather than acquiring, so a forgotten wrap fails loudly.
-
-Three things about it are easy to get wrong and are settled here:
-
-- **`list-profiles` is deliberately unserialised.** It is advisory display, it
-  sits outside `_GRAMMAR_GUARDED_VERBS`, and it may briefly report `no-jar` for a
-  profile mid-transition. That is an accepted cosmetic race, not a missed wiring
-  site.
-- **Lockfiles are never deleted — including by `rm`.** Unlinking a locked file
-  lets one process hold a lock on the unlinked inode while another creates a
-  fresh file and locks that: two simultaneous holders, which is the failure the
-  lock exists to prevent. So an empty `<profile>.lock` outlives the profile it
-  named. It holds no credential material. On POSIX the directory is `0700` and
-  repaired to `0700` on every acquisition; on Windows the confidentiality of that
-  profile-name list rests on `%USERPROFILE%` ACLs and on no control this
-  subsystem adds.
-- **An untimed keychain call inside the lock amplifies.** The macOS Tier-2
-  backend shells out to `/usr/bin/security` with no timeout, so a holder blocked
-  on a keychain prompt now stalls *every* concurrent invocation for that profile
-  until each burns its budget and exits `6` — where before this lock existed it
-  stalled only itself. Measured cost is linear in continuation slots; see
-  `sso-keychain-call-timeouts`.
-- **The guarantee is asserted for a local filesystem**, and the two ways a
-  network home breaks it are opposites. On POSIX, `flock` over CIFS or some NFS
-  configurations may be emulated per-host or silently ignored: no error is
-  reported, and the serialisation quietly degrades to the pre-lock behaviour.
-  On Windows, a `%USERPROFILE%` redirected to SMB surfaces *unsupported locking*
-  as the same `EACCES` that means *contended*, so every store-touching verb
-  returns a permanent exit `6` on that machine. Neither is engine-detectable —
-  this paragraph is the only operator-facing explanation of either.
-
-### Confinement controls
-
-The engine's captured jar is deliberately over-broad, so the library
-adds the controls above it — `validate_https_url`,
-`validate_root_relative_endpoint`, `domain_in_cookie_domains`,
-`filter_jar_to_domains`, `require_host_in_cookie_domains` — single-sourced
-in `credbroker` so they cannot drift between consumers. On top of those:
-
-- **Profile grammar.** `profile` is interpolated into filesystem paths
-  and a keychain target name, so it is confined to
-  `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` via `re.fullmatch` (**not**
-  `re.match`, whose `$` admits a trailing newline), excluding
-  case-insensitive Windows reserved device names (`CON`, `NUL`, …) —
-  on Windows `CON.toml` resolves to the console device regardless of
-  directory. The engine enforces the same grammar independently, plus
-  resolved-path containment (canonicalize-then-verify-parent).
-- **No secret on argv.** No cookie value, cookie name, or jar path ever
-  crosses a command line, in either direction.
-
-### Destination derivation — defence in depth, on first capture only
-
-The **automatic** recapture path takes no destination at all (see the Consumer
-API above), so it needs no derivation. Derivation exists for the one path that
-*does* accept one — an operator-typed first capture — where
-`credbroker.derive_sso_destination(base_url, *, strategies=())` asks the
-**resource server** where to authenticate, in a vendor-agnostic strategy chain,
-returning the first **origin** it resolves — `scheme://host:port`, the port
-always explicit and an IPv6 host bracketed, so an implicit and an explicit
-`:443` compare equal:
-
-| Tier | Mechanism | Applies to |
-|---|---|---|
-| 1 | **RFC 9728** Protected Resource Metadata — `401` → `WWW-Authenticate: … resource_metadata` → `/.well-known/oauth-protected-resource` → authorization server metadata | modern OAuth resources (MCP adopted it) |
-| 2 | **OIDC Discovery / RFC 8414** — `/.well-known/openid-configuration` → `authorization_endpoint` | most OIDC-protected on-prem tools |
-| 3 | **Vendor probe** — a registered per-consumer strategy; Atlassian/Seraph is `GET {base_url}/login.jsp`, redirects unfollowed, read `Location` | Jira / Confluence / Bitbucket DC |
-| 4 | none | SAML-only SPs — their metadata names the SP, never the IdP |
-
-Tier 3 exists because SAML has no discovery equivalent; tier 4 is a real
-outcome, not a failure to handle. A consumer that cannot derive **refuses** and
-does not fall back to the configured value.
-
-**What derivation does not do.** Two limits, and neither is a caveat.
-
-It does **not** close config poisoning: the derivation target (`base_url`) lives
-in the same adopter- and agent-writable file as the value being attested, so one
-write moves both and the comparison passes. AWS's equivalent works only because
-its host suffix is hardcoded to `*.amazonaws.com`; there is no comparable
-invariant here. Consent for first capture therefore rests on the operation being
-**operator-typed**, not on attestation.
-
-And attestation is **partial, not universal**. Comparison is topology-aware,
-because plain host equality would refuse the majority Jira DC configuration: in
-SP-initiated SAML the configured sign-in host *is* the instance host. That branch
-is accepted **and short-circuits — no derivation request is made** — so it
-verifies nothing, and within-host path and query are unconstrained. A
-re-register command therefore *attempts* attestation and only achieves it on
-IdP-host topologies; describe it that way rather than as "the attested path". A
-vendor's own setup helper performs none at all. Only the origin is compared —
-scheme, host and port, never the path or query; every tier's URL carries
-per-request `state` / `SAMLRequest` / `nonce`.
-
-**Bounds — this is an outbound fetch on the credential path.** Every hop is
-`https` only (including URLs read from a `resource_metadata` header or an
-`authorization_servers` list); redirects are not followed (hop cap 0); 5 s
-connect + 5 s read under a ≤15 s total budget; a 64 KiB body cap before parsing;
-strict certificate verification that never honours an `--insecure`-style flag and
-never reuses a consumer's own TLS context; and no `Authorization`, `Cookie`, or
-proxy-auth header on any derivation request.
-
-### Auto-recovery contract
-
-A consumer's `check` verb may self-heal an **expired** session: on a typed
-session-unavailable signal it calls `refresh_sso_session` once and re-probes.
-That call is **headless** — it succeeds only when the browser profile can
-complete the IdP flow unaided, waits a bounded window for the redirect chain to
-land, and otherwise returns engine exit `5` rather than presenting a login page.
-It must key on that typed signal, never on a generic auth error — a `403`, a
-failed confinement check, a missing engine, or a broker timeout are terminal,
-and re-authenticating cannot fix them. A timeout in particular is *not* an
-expired session: mapping it to the recoverable type would open a browser
-whenever a keychain was slow.
-
-**The re-probe, not the exit code, is the success criterion.** `refresh` returns
-`0` whenever the success-URL pattern matched, so it can succeed while leaving
-nothing resolvable. Exactly one recapture, and exactly one retry, per process.
-
-First-time capture stays an explicit human action.
-
-### What this costs the operator
-
-Two very different experiences, and the split is the point — the path that runs
-unattended is the one that is structurally safe.
-
-| | Who acts | What they see | How often |
-|---|---|---|---|
-| **First capture** | operator, explicitly | a real sign-in page in a fresh browser context, and the destination host on stderr before it opens | **once per machine, per profile** |
-| **Silent refresh** | nobody | nothing — `refresh` is headless | whenever the app session expires and the IdP session is still valid |
-| **Re-registration prompt** | operator, unplanned | an exit-2 message, **not** a login page — the engine returns `5`, headless `refresh` having failed fast, and the consumer names its *re-register* command, which is the path that *attempts* destination attestation | when the **IdP** session has also expired — typically first use of the day |
-
-The middle row is the common case and is safe by construction:
-`refresh_sso_session(profile)` accepts no destination, so an automated caller
-cannot choose where the browser goes. The first row accepts a destination and is
-therefore deliberately **not** automated — see the trust limits above.
-
-The third row is why `refresh` is headless. An unattended refresh that could open
-a headed browser would leave an agent-influenced login page in front of whoever
-happens to be at the machine — the one exposure whose blast radius leaves the box.
-A headless refresh instead fails fast and tells the caller a human is needed;
-interactive capture is reachable only from an operator-typed command.
-
-## Setting up credentials
-
-The `credential-setup` skill — source at
-[`packs/credential-brokers/.apm/skills/credential-setup/`](../../packs/credential-brokers/.apm/skills/credential-setup/),
-installed into whichever adapter path the adopter's install targets —
-replaces the prior `agentbundle creds setup <namespace>` CLI. The skill:
-
-- Reads the consumer's `references/creds-schema.toml` to know which
-  keys to prompt for.
-- Walks each key via `getpass` (secret) or `input` (non-secret
-  sibling like `BASE_URL`).
-- Writes to the highest-available tier (Keychain → Credential Manager
-  → dotfile), announces the chosen tier on stderr, and refuses to
-  fall back to Tier 3 without `--allow-insecure-fallback`.
-
-There is no `get` verb. The LLM is never given a tool that returns
-cleartext. Anything that needs the credential reads it via
-`load_credentials` inside the primitive's own subprocess and writes
-it to an outbound HTTP header.
-
-To verify resolution, invoke the consumer primitive's own `check` verb —
-e.g. `python scripts/jira.py check` walks the same Tier 1 → 2 → 3
-ladder and exits 0 when every declared key resolves. On a primitive whose
-`auth:` is `sso-cookie`, `check` instead validates the captured session
-and may self-heal it per the auto-recovery contract above.
-
-## Per-primitive schema declaration
-
-Every credentialed primitive ships `references/creds-schema.toml`
-declaring its namespace and keys — a `[namespace]` table plus one
-`[[namespace.keys]]` entry per key:
-
-```toml
-[namespace]
-name = "jira"
-
-[[namespace.keys]]
-name = "BASE_URL"
-label = "Jira base URL (Cloud: https://<site>.atlassian.net; Server: https://jira.corp.example.com)"
-secret = false
-
-[[namespace.keys]]
-name = "API_TOKEN"
-label = "Cloud API token or Server Personal Access Token"
-secret = true
-```
-
-The env-var shape is `<NAMESPACE>_<KEY>` — `JIRA_BASE_URL`,
-`JIRA_API_TOKEN`. `label` is the prompt text the `credential-setup` skill
-issues. `secret` distinguishes which keys go to keyring storage from
-non-secret siblings like `BASE_URL`. The canonical reference is
-[`packs/atlassian/.apm/skills/jira/references/creds-schema.toml`](../../packs/atlassian/.apm/skills/jira/references/creds-schema.toml).
-
-## The substring trap
-
-Refuse-guards inside a primitive's script that **literally name** the
-substring `.agentbundle/credentials.env` trip the same
-[`conventions-check`](../../.claude/commands/conventions-check.md) rule
-that catches credential *reads*, unless the script carries the
-`# credentialed-primitive: reads-creds-directly` opt-out marker.
-
-Compose path checks via basename + `Path.parts`, never the literal
-full string:
+| 1 | `<NAMESPACE>_<KEY>` environment variable | Used as supplied for CI or wrappers. |
+| 2 | macOS Keychain or Windows Credential Manager | Linux has no Tier 2. Documented hard failures raise `Tier2HardFailError` and do not fall through. macOS writes by child stdin, never argv. |
+| 3 | `~/.agentbundle/credentials.env` | Opt-in fallback. POSIX requires file `0600` and parent `0700`; Windows verifies the DACL. Permission failures raise `PermissiveAclError`. |
+
+The Tier-3 parser rejects `export ` prefixes, variable expansion, and
+multiline values. Optional `credbroker[crypto]` uses an encrypted vault;
+the stdlib floor remains plaintext. `credential-setup` refuses Tier-3 fallback
+without `--allow-insecure-fallback`.
+
+SSO exit code `2` means no usable session, `4` means an unregistered
+profile, and `6` means a contended store. Only those are recoverable:
+`2` and `4` require re-authentication, while `6` retries the same call.
+Engine failure (`3`) and required human interaction (`5`) are terminal.
+
+Automatic refresh takes only a profile, never a destination. It is headless and
+returns `5` rather than displaying a login page. Consumers recover only from
+the typed session-unavailable signal, refresh once, and re-probe once. A generic
+authentication error, timeout, confinement failure, or missing engine is not an
+expired-session signal.
+
+Every SSO mutation uses a per-profile lock. `list-profiles` is advisory and
+unlocked. `get-cookies`, `test`, `rm`, `register`, and `refresh` share that
+lock. `get-cookies` rewrites the materialised jar after each retrieval to avoid
+serving a stale keychain-backed session. The lockfile is retained to prevent
+split locking. Locking is only guaranteed on a local filesystem; unsupported
+network-home locking can degrade serialization or report permanent contention.
+
+Profile names match `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` with
+`re.fullmatch`, reject Windows reserved device names, and pass resolved-path
+containment. Cookie values, names, and jar paths never cross argv.
+
+First capture may derive an HTTPS destination from protected-resource metadata,
+OIDC discovery, or a registered vendor probe. Failure to derive refuses; it
+never falls back to configured input. Derivation compares only origin and does
+not close same-principal configuration poisoning. Some same-host topologies
+short-circuit derivation and provide no attestation.
+
+Every derivation request uses HTTPS, follows no redirects, has a 5-second
+connect and read limit within a 15-second total budget, caps bodies at 64 KiB,
+verifies certificates, accepts no insecure flag, and sends no authorization,
+cookie, or proxy-authentication header.
+
+### The substring trap
+
+A primitive's defensive path check must not literally name
+`.agentbundle/credentials.env`; the credential-read rule treats that as a
+direct read unless the primitive carries its direct-read opt-out marker.
 
 ```python
 # Correct
@@ -603,67 +134,31 @@ if str(suspect) == ".agentbundle/credentials.env":
     refuse(...)
 ```
 
-This applies to any primitive script that mentions the dotfile
-defensively.
+## 7. Observability and evidence
 
-## Prior art and threat references
-The controls above are shaped by these; each is cited where the reasoning depends
-on it rather than as a reading list.
+`sso-broker.py` returns per-verb exit codes. SSO refusals and lock contention
+are observable without returning cookie bytes. Credential resolution exposes
+success or typed failure to the invoking primitive, not to the agent context.
 
-- **Confused deputy / designation with authority** — the 1988 confused-deputy paper;
-  [*Capability Myths Demolished*](https://papers.agoric.com/assets/pdf/papers/capability-myths-demolished.pdf).
-  Why the automatic path takes **no** destination parameter instead of validating
-  one.
-- **Config file as a trust boundary** —
-  [CVE-2024-52006 / GHSA-qm7j-c969-7j4q](https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q)
-  (Git credential helper): *"configuration-file-supplied URLs receive the same
-  credential access as explicitly user-provided URLs, despite having different
-  trustworthiness profiles."*
-- **Host pinning vs config-supplied tenant** — AWS CLI
-  [IAM Identity Center](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html):
-  `sso_start_url` is config-supplied, but the browser endpoint is derived from
-  `sso_region` and is always `*.amazonaws.com`.
-- **Resource-served destination discovery** —
-  [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.pdf) (Protected Resource
-  Metadata) and OIDC Discovery / RFC 8414, tiers 1–2 above. The
-  [MCP authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization/security-considerations)
-  adopts RFC 9728 and notes the residual limit: issuer validation *"provides no
-  protection if the expected issuer was obtained from an unvalidated source."*
-- **The approval channel must be one the agent cannot write** — OWASP Top 10 for
-  Agentic Applications 2026, **ASI09** (Human-Agent Trust Exploitation) and
-  **ASI02**; OWASP Agentic Skills **AST03**. Why an in-prompt or agent-owned-TTY
-  confirmation is not a control.
-- **Trust-on-first-use does not close first-contact poisoning** —   *Why TOFU Doesn't Work* (TOFU critique).
-- **Well-formed arguments defeat schema gating** —
-  [*Capability Gates Are Not Authorization*](https://arxiv.org/html/2606.28679v1)
-  (arXiv 2606.28679).
-- **Privilege separation is what actually protects an agent-editable config** —
-  *Locking down `gh`* (practitioner writeup):
-  the same failure shape for `gh auth setup-git`, mitigated with `sudo`-gated
-  wrappers rather than validation.
-- **Derive the destination from live browser state** — 1Password's extension
-  model injects only when the browser is already on the matching origin, with a
-  biometric approval prompt that is genuinely out of an agent's reach.
+A consumer primitive's `check` verb verifies its declared credential ladder
+and exits zero only when every required key resolves. An `sso-cookie` check
+validates the captured session and may use the bounded auto-recovery flow.
 
-## Where to read next
+## 8. Mechanical invariants
 
-- [`docs/specs/credential-broker-contract/spec.md`](../specs/credential-broker-contract/spec.md) —
-  the broker contract.
-- [`docs/rfc/0023-credential-manager-broker.md`](../rfc/0023-credential-manager-broker.md) —
-  the `credbroker` library that replaced the projected shim for `auth: creds`
-  (and its layered-delivery amendment); [`docs/specs/credbroker/spec.md`](../specs/credbroker/spec.md)
-  + [`docs/specs/credbroker-user-scope/spec.md`](../specs/credbroker-user-scope/spec.md)
-  are the implementing specs.
-- [`docs/rfc/0035-sso-cookie-auth-for-atlassian-pack.md`](../rfc/0035-sso-cookie-auth-for-atlassian-pack.md) —
-  the `sso-cookie` broker; [`docs/adr/0026-sso-consumer-resolution-in-credbroker.md`](../adr/0026-sso-consumer-resolution-in-credbroker.md)
-  places consumer resolution in `credbroker`, and
-  [`docs/specs/jira-check-sso-auto-login/spec.md`](../specs/jira-check-sso-auto-login/spec.md)
-  extends it from resolution-only to resolution-plus-recapture.
-- [`docs/rfc/0013-credential-broker-contract.md`](../rfc/0013-credential-broker-contract.md) —
-  the broker design rationale (the predecessor shim model).
-- [`docs/specs/skill-secrets/spec.md`](../specs/skill-secrets/spec.md) —
-  the predecessor spec (kept for historical context).
-- [`guides/credential-brokers/explanation/credentialed-skills.md`](../../guides/credential-brokers/explanation/credentialed-skills.md) —
-  the adopter-facing companion.
-- [`guides/credential-brokers/how-to/add-a-credentialed-skill.md`](../../guides/credential-brokers/how-to/add-a-credentialed-skill.md) —
-  the step-by-step procedure for authoring a new credentialed primitive.
+- `agentbundle catalogue lint` (`CAT-L031`) checks declared credential
+  brokers, broker security phrases, argv bans, dotfile-read refusals, and
+  broker-specific primitive resolution patterns.
+- `tools/lint-sso-config.py` requires shipped `sso-config.toml` files to be
+  placeholder-shaped: no real instance configuration, captured cookie value,
+  or non-`creds` default may ship upstream.
+
+## 9. Relevant ADRs
+
+- [ADR-0003 — Credential broker contract](../adr/0003-credential-broker-contract.md)
+- [ADR-0026 — SSO consumer resolution in credbroker](../adr/0026-sso-consumer-resolution-in-credbroker.md)
+- [ADR-0080 — Generic headed SSO capture remains operator-only](../adr/0080-generic-headed-sso-capture-remains-operator-only.md)
+
+## 10. Last verified against commit
+
+`c8cf4b37`

--- a/docs/architecture/knowledge-capture.md
+++ b/docs/architecture/knowledge-capture.md
@@ -1,819 +1,92 @@
-# Knowledge capture architecture
+# Knowledge capture
 
-> How `core` turns repository experience into durable, reviewable project
-> knowledge without treating remembered prose as instructions.
+## 1. Purpose and boundary
 
-## Purpose
+`project-knowledge` captures reusable repository practice, distils it into
+file-backed knowledge, and returns bounded evidence for an explicit question.
+It does not replace canonical artifacts, preserve arbitrary scratch, or grant
+authority to retrieved knowledge.
 
-Agents repeatedly rediscover lessons a repository has already paid for: an
-unusual verification order, a failed repair strategy, a hidden coupling, or a
-constraint that matters only under one scope. Project knowledge preserves the
-reusable practice residue after stronger repository artifacts have taken what
-they own.
+Enquiry reads committed active topics as bounded untrusted evidence. It cannot
+grant permission, approve a change, select a tool, or override a canonical
+artifact, instruction, or runtime control.
 
-Retaining more text is not the goal. Transcripts combine durable observations
-with temporary plans, guesses, secrets, tool output, and untrusted
-instructions. The architecture keeps capture narrow, makes durable knowledge
-reviewable, and retrieves it only for a declared task question.
+## 2. Entrypoints
 
-## Current behavior
+- `project-knowledge --capture` loads `references/capture-mode.md` and may
+  call only `capture_observation`.
+- `project-knowledge --distill` loads `references/distill-mode.md` and may
+  call its bounded journal, topic, source, and guarded-mutation helpers.
+- `project-knowledge --enquire` loads `references/enquire-mode.md` and may
+  call only committed-topic, map, and current-source read helpers.
 
-The shipped lifecycle belongs to producer workflows and `project-knowledge`:
+## 3. Owned state and write authority
 
-1. Workflow scratch stays local and free-form until a semantic gate.
-2. A producer-owned semantic gate routes, discards, or shapes one strict
-   captured observation.
-3. `project-knowledge --capture` appends a pending observation journal event.
-4. `project-knowledge --distill` records terminal dispositions and may propose
-   one reviewed topic/map mutation.
-5. `project-knowledge --enquire` reads only active topics in the committed map
-   and returns bounded evidence with a receipt.
-
-Normal session start does not load project knowledge. Legacy
-`docs/knowledge/patterns.jsonl` is read-only after a coherent v1 topic map is
-activated. Observation journals are durable handoff records and are never
-ordinary enquiry input.
-
-The writer resolves a Git repository root with Git relocation variables
-removed, proves the knowledge root stays beneath the worktree, validates
-fields, takes an exclusive lock, derives identities from canonical request or
-mutation bytes, writes temporary postimages beside their targets, and
-atomically replaces declared files. Publication is still a normal Git commit:
-working-tree topics and maps are proposals until committed.
-
-The integrated authoring producers are `receive-brief`, `new-rfc`, `new-adr`,
-and `work-loop` for approved specs and locked plans. `author-brief` Draft and
-`new-spec` Draft/Drafting are explicit non-gates. Producers own only their
-transient scratch and exact gate timing; they invoke the public progressive
-skill and never locate journals, import the private writer, derive capture
-identities, select partitions, or create fallback storage.
-
-## Lifecycle in one view
-
-```mermaid
-flowchart LR
-    W[Workflow activity] --> S[Free-form scratch]
-    S --> G{Semantic gate triage}
-    G -->|noise or fully owned elsewhere| X[Discard]
-    G -->|reusable practice residue| C[project-knowledge --capture]
-    C --> O[Captured observation event<br/>durable, non-queryable]
-    O --> D[project-knowledge --distill]
-    D -->|duplicate, routed, or unsupported| J[Disposition event]
-    D -->|judgment required| H[Surface; topic unchanged]
-    D -->|unambiguous| T[Canonical topic JSON<br/>working-tree proposal]
-    T --> J
-    T --> V[Verify, review, commit]
-    V --> P[Published topic map<br/>one Git snapshot]
-    P --> Q[Explicit enquire]
-    Q --> E[Bounded untrusted evidence]
-    P --> R{Embodied in stronger artifact?}
-    R -->|partly| N[Narrow topic]
-    R -->|fully| Z[Retire with destination pointer]
-```
-
-Captured observation journals and topics have different jobs. Journals are the
-durable, untrusted handoff from producers to distillation and are never an
-enquiry source. Topic files and their deterministic map are reconciled project
-knowledge. The working tree is the authoring surface; the committed Git tree is
-the durable handoff and publication surface.
-
-## Vocabulary and authority
-
-| Concept | Meaning | Not this |
-| --- | --- | --- |
-| Working context | Messages and tool results needed in the current run | Durable knowledge |
-| Scratch | Free-form agent-authored notes kept for the current workflow | A schema, transcript, or enquiry source |
-| Captured observation | Strict typed evidence admitted by a workflow and persisted as an event | A topic or enquiry result |
-| Occurrence | One attributable observation supporting or challenging a topic | Current truth by itself |
-| Topic | One stable, narrow lesson with current synthesis, scope, status, freshness, and occurrences | A category bucket or raw event stream |
-| Distil | Reconcile an observation with topics and owning sources | Summarize a transcript |
-| Enquire | Retrieve a bounded evidence bundle for a concrete task question | Prime every session with memory |
-| Freshness | Evidence that a topic still matches its source and scope | Recency alone |
-| Canonical source | The artifact authorized to define a concern | A knowledge observation |
-| Memory bank | A future separately governed multi-project store | An implicit global pool |
-
-The authority ordering is fixed:
-
-| Surface | Typical lifetime | Authority |
-| --- | --- | --- |
-| Conversation, tool output, and scratch | Current workflow | Untrusted working data |
-| Captured observation event | Cross-session until retention | Repository-published untrusted evidence; not queryable |
-| Active topic in the committed map | Cross-session | Repository-published untrusted evidence |
-| Architecture, ADR, convention, skill, spec, guide, code, test, lint, and CI | Governed by its own lifecycle | Canonical for its declared concern |
-| System, developer, user, and runtime permission controls | Current execution | Instruction and authorization authority |
-
-A topic never grants permission, selects a tool, approves a change, or
-overrides a higher-priority instruction. Persistence and repeated occurrence do
-not amplify authority.
-
-## Capture remains workflow-owned
-
-### Free-form scratch
-
-Scratch can be a fragment, bullet, failed assumption, or review reminder. It
-does not need a schema. A workflow guides the agent to preserve enough detail
-for later triage:
-
-- what changed the approach;
-- the conditions under which the lesson applies;
-- the repository evidence or source; and
-- the future competency question the lesson might answer.
-
-When discovery was expensive, scratch also records a bounded friction signal:
-how many failed or redirected attempts preceded the stable route and what
-starting point would have avoided them. This is explicit scratch, not a
-reconstruction from tool history.
-
-Mechanical checks still do not invoke capture or distillation. They may add explicit
-scratch when a verification oracle is missing, noisy, expensive, or available
-but undiscoverable. The next semantic gate classifies that note with
-`CQ-VERIFY` and either wires the existing check into the loop, routes a real
-tooling gap through normal work intake, or discards it.
-
-A useful note can be short:
-
-```text
-CQ-DIAGNOSE — Generated projections can mask source edits.
-Observed during build verification; the pack source, not its projection, owns
-the change. Checking the source first avoided repairing generated output.
-```
-
-Scratch is allowed to disappear. The portable core does not claim it survives
-an abrupt session end or deletion of a worktree.
-
-### Semantic gates
-
-Triage runs when a workflow reaches a stable meaning boundary:
-
-- RFC completion or approval;
-- ADR acceptance;
-- spec approval;
-- plan approval;
-- a completed and verified implementation slice;
-- completed review; and
-- work-loop closeout, explicit handoff, or a known pre-compaction boundary.
-
-Mechanical checks such as lint, typecheck, or an individual test do not run
-triage. A long workflow may reach several semantic gates; each pass considers
-only scratch accumulated since the previous one.
-
-The gate performs four decisions in order:
-
-1. **Discard:** remove disproved, task-local, obvious, vague, unsafe, or
-   duplicate scratch.
-2. **Route:** keep normative content in its owning RFC, ADR, spec, architecture
-   page, code, test, CI rule, convention, skill, or guide.
-3. **Admit:** retain only independently reusable practice residue that could
-   change a future approach and answer a plausible competency question.
-4. **Shape:** construct a `CapturedObservation` and invoke
-   `project-knowledge --capture`.
-
-Any observation-journal edit returns through the workflow's next verification,
-review, and commit barrier. At a terminal gate, the workflow attempts
-`project-knowledge --distill` for the gate's capture receipts. Irreducible
-judgment remains explicitly pending and is surfaced with its receipt; a core
-maintainer can later page it through `--distill --pending`. Topic/map edits
-also return through normal verification and review.
-
-The gate reads explicit scratch, not the transcript. If a note is already
-fully embodied by the artifact just completed, no topic is created merely to
-duplicate it.
-
-### Shipped authoring integrations
-
-The shipped
-[`project-knowledge-authoring-integrations`](../specs/project-knowledge-authoring-integrations/spec.md)
-slice applies this gate model to five artifact workflows. Its producer-owned
-gates are exact:
-
-| Artifact | Producer-owned stable gate | Semantic gate name | Gate mode |
+| State | Location | Write authority | Readers |
 | --- | --- | --- | --- |
-| Brief | `receive-brief` completes the Ready DoR, Ready write-back, and durable workspace move; zero specs and no confirmed slice cut remain eligible | `brief-ready` | Capture, then receipt-scoped distillation |
-| RFC | `new-rfc` completes every mandatory clean pre-handoff check | `rfc-handoff-ready` | Capture, then receipt-scoped distillation |
-| ADR | `new-adr` records decision-maker sign-off and the `Proposed` to `Accepted` transition | `adr-accepted` | Capture, then receipt-scoped distillation |
-| Spec | `work-loop` observes `Status: Approved` and completes `spec-approved` | `spec-approved` | Capture only; receipts remain pending at this nonterminal gate |
-| Plan | `work-loop` completes `plan-approved`, seals the unchanged baseline, and completes `plan-locked` | `plan-locked` | Capture, then receipt-scoped distillation using only plan-gate receipts |
+| Workflow scratch | Producer workflow context | Owning workflow | Its current workflow |
+| Knowledge store | `docs/knowledge/` | `packs/core/.apm/skills/project-knowledge/scripts/knowledge_store.py` | Project-knowledge modes and reviewers |
+| Published knowledge | Committed Git tree | Normal Git commit workflow | `--enquire` |
+| Store lock | Knowledge worktree | `knowledge_store.py` | Capture and distill operations |
 
-The producing workflow owns transient scratch and timing. It may construct the
-published request and invoke the public progressive skill, but it does not
-locate journals, import the private writer, invent identities, choose
-partitions, or persist a fallback. Any source-byte read for provenance or a
-freshness digest first discovers the repository root with Git relocation
-variables removed, rejects lexical traversal, and proves native real-path
-containment beneath that root; a safely rooted committed Git blob identity is
-the read-free alternative. Normative
-brief, RFC, ADR, spec, and plan content remains solely in its owning artifact.
-Optional enquiry is a separately declared, task-scoped evidence operation, not
-an automatic consequence of reaching a capture gate.
+The store contains `topics/`, `observations/`, `topics.index.json`,
+`patterns.jsonl`, and `README.md`.
 
-Each producer first discards noise and routes normative content back to its
-owning artifact. A brief's requirements and readiness state stay in the brief;
-an RFC's proposal, evidence argument, recommendation, and open questions stay
-in the RFC; an ADR's decision, rationale, alternatives, and consequences stay
-in the ADR; and approved spec behavior or locked plan sequencing stay in those
-artifacts. Only reusable supporting practice or evidence residue can enter a
-captured observation.
+## 4. Dependencies and allowed edges
 
-Missing project knowledge emits the named `project-knowledge unavailable`
-skip and never creates a fallback file. A terminal gate can distil only the
-`{capture_id, partition}` receipts returned by its own capture invocation.
-Spec-approval receipts remain pending until a later explicit operation; plan
-locking cannot guess those IDs or drain direct-maintainer pending work.
+Producer workflows may submit a strict observation through `--capture`. Capture
+records an observation and does not read or mutate topics. Distill reads bounded
+observations and may write dispositions, topics, and the topic map. Enquire reads
+committed eligible topics and never reads journals or invokes a writer.
 
-Any journal, topic, or map diff returns through the producer's applicable
-verification and review barrier before the producer reports knowledge
-persistence or reconciliation and emits its final completion handoff.
+Knowledge code may read confined repository sources for provenance and freshness.
+It has no network, arbitrary-command, credential, or permission-management
+authority. Canonical artifacts retain authority for their concerns.
 
-Optional authoring enquiry is declared before its decision point with an
-explicit competency question: `CQ-DESIGN` for brief, RFC, and ADR framing;
-`CQ-CHANGE` for spec approval; and `CQ-VERIFY` for plan locking. Each enquiry
-is task-scoped, bounded to one query plus at most one refinement, and treated
-as untrusted evidence. It can abstain, but it cannot grant authority, change
-permissions, widen scope, or override repository instructions.
+## 5. Primary flows
 
-### Review and research authority
+1. A workflow submits explicit reusable residue to `--capture`, which records
+   an observation receipt.
+2. `--distill` reconciles bounded observations, records a disposition, and may
+   propose a topic and map mutation for review and commit.
+3. `--enquire` resolves a task question against the committed topic map and
+   returns a bounded evidence receipt or abstains.
 
-Review is a non-writing knowledge consumer, not a capture producer. Architecture,
-adversarial, security, and quality review may declare one consequential
-`CQ-REVIEW` enquiry after the target, scope, and rubric or checklist route are
-known and before substantive judgment begins. The bounded result is delimited
-as untrusted data and reduced to candidate checks. Every finding remains
-independently grounded in the current target and governing rubric/checklist;
-every factual claim also resolves to a current canonical source. Retrieved
-knowledge cannot supply permission, redirect scope, suppress a finding, change
-severity or verdict, or corroborate itself.
+## 6. Failure and recovery behavior
 
-Reviewer scratch, findings, security conclusions, quality verdicts, citations,
-and recommendations remain in their owning review artifact. Reviewer completion
-performs no capture or distillation. An outer producer such as `work-loop` may
-later triage only its own explicit reusable process residue at a gate it already
-owns, and may distil only receipts returned by that outer gate. Provider
-discovery failure yields `project-knowledge unavailable`; a successful query
-with no eligible topic yields zero candidate checks; and matched consequential
-topics without a verified owning source yield `abstained: true`. Stale,
-quarantined, malformed, irrelevant, or privacy-refused material remains excluded
-or refused by the existing public contract. None of these outcomes creates
-fallback storage or weakens the review.
+Invalid privacy, provenance, schema, path, or size input is refused before a
+body is persisted. Refusals use redacted diagnostics.
 
-Research remains a separate authority surface. Its cited products and raw source
-corpora, multi-phase workflow, independent source-verification duty, and possible
-configured personal output roots are governed by the research producer, not by
-project knowledge. Quick and non-survey session work plus project start, digest,
-check, status, incomplete, and abandoned paths are no-integration. Only complete
-repository-contained standard, applied, and deep surveys and complete project
-synthesis may offer independently reusable practice or sanitized evidence
-residue at their exact terminal gates. Personal and external roots are
-capture-ineligible rather than assigned fabricated repository provenance.
+A lock loss, stale precondition, malformed store, or inconsistent postimage
+stops mutation. The next writer revalidates state and completes only an
+idempotent missing step or refuses recovery.
 
-Research products, corpora, quotations, citations, claims, confidence judgments,
-counter-evidence, verdicts, and governance conclusions remain solely in their
-owning artifacts. Counter-evidence review may consume one bounded `CQ-REVIEW`
-enquiry as candidate checks, with independent direct-source verification and no
-reviewer capture or distillation. Retrieved knowledge cannot choose sources,
-substantiate a claim, become a citation, strengthen confidence, suppress
-counter-evidence, change a verdict, or corroborate itself.
+Uncertain, stale, retired, malformed, or out-of-scope topics are excluded from
+ordinary enquiry. Enquiry abstains when it cannot verify eligible evidence.
 
-### CapturedObservation
+## 7. Observability and evidence
 
-The published request contract normalizes inputs from different workflows. A
-versioned strict-JSON shape includes:
+Capture returns receipts. Distillation records dispositions and proposed store
+changes. Enquiry returns selected topic identifiers, source pointers, limits,
+and abstention state.
 
-- no producer-chosen storage identity;
-- concise lesson;
-- practice kind: `pattern`, `gotcha`, or `antipattern`;
-- structural repository or subproject scope;
-- competency-question facets;
-- destination hint;
-- normalized repository-relative provenance and evidence digest where
-  available;
-- source-relative freshness anchor; and
-- producer workflow and semantic-gate kind;
-- observation time as an RFC 3339 UTC instant;
-- semantic privacy attestation; and
-- optional bounded friction evidence and the stable route discovered.
+The store, committed topic map, Git history, and redacted refusal diagnostics
+provide the durable evidence trail.
 
-Constructing the contract does not mean the observation will become a topic.
-Successful capture persists an immutable `observation.captured` event and
-returns a receipt. Distillation can later mark it duplicate, routed, rejected,
-superseded, or promoted.
+## 8. Mechanical invariants
 
-After all strict syntax, schema, provenance, and privacy admission checks pass,
-core derives `capture_id` as
-`kco-YYYYMM-<64 lowercase hex>` from observation month plus SHA-256 over the
-canonical UTF-8/JCS request, excluding the derived ID. Producer workflows never
-choose storage identity; exact canonical replay derives the same ID and receipt.
+- `tools/lint-knowledge-surface-parity.py` prevents silent drift among the
+  duplicated knowledge-surface taxonomy copies used by architecture skills.
 
-Observation events are grouped by validated classification and the immutable
-UTC observation month from the request under `docs/knowledge/observations/`.
-Writer wall-clock time never changes the partition. Producer workflow is provenance,
-not file ownership. The capture writer derives the path, verifies that any existing
-event body still hashes to its `capture_id`, and returns the existing receipt for an
-exact replay.
+The mode authority boundary is documented here. This page does not claim a
+named command enforces it.
 
-Legacy `docs/knowledge/patterns.jsonl` cutover is staged before activation.
-The migration command strictly decodes every JSONL row as UTF-8 and accounts
-for every input row as active import, review-required import, or refused before
-writing any staged topic. Staged topics and the body-free map live outside the
-canonical topic tree until a coherent current-tree snapshot is activated.
-While that staged map exists, both the legacy append path and the v1 writers
-refuse so there is no dual-writer window. After activation, legacy JSONL is
-read-only; reverting before the first v1 capture can restore the legacy path,
-but once a v1 observation exists, recovery is a reviewed forward change that
-keeps v1 journals and topics intact.
+## 9. Relevant ADRs
 
-Journals make normal Git handoff possible without assuming a writable user
-directory, memory API, or service. They cannot preserve scratch lost before a
-semantic gate or an uncommitted capture discarded with its worktree.
+- [ADR-0081 — Canonical project knowledge uses per-topic JSON](../adr/0081-canonical-project-knowledge-uses-per-topic-json.md)
+- [ADR-0082 — Project-knowledge modes separate authority](../adr/0082-project-knowledge-modes-separate-authority.md)
 
-Source digests are versioned. Committed evidence uses a Git blob identity with
-the repository's declared object format. Other file evidence uses
-`sha256-bytes-v1`, lowercase SHA-256 over exact bytes with separately checked
-byte length. Readers never decode, normalize, or re-serialize the preimage.
+## 10. Last verified against commit
 
-Capture derives identity before applying the time window, so an aged exact
-replay still returns its receipt. A new
-capture must be within seven days before and five minutes after writer UTC time
-and not before the v1 activation commit. A changed request derives a distinct
-capture ID and is reconciled during distillation; SHA-256 collision resistance
-avoids an unbounded retained scan. General historical import is out of
-scope; this prevents request-controlled dates from consuming arbitrary monthly
-partitions.
+`c8cf4b37`
 
-A capture is explicitly pending until it has at most one terminal disposition.
-Terminal workflows attempt distillation for their receipts; unresolved semantic
-judgment remains enumerable to core maintainers through bounded cursor-paged
-`--distill --pending` runs. Its versioned opaque cursor binds the scope/filter,
-ordered retained-partition names, the exact content digests of the immediately
-preceding complete partition window, and the next partition offset. A page
-emits no capture from a partition until it has read and reconciled that whole
-partition, so cursors advance only between partitions. A single partition over
-the page event or byte cap refuses without partial output. Bound-partition drift
-returns `cursor_stale` and restarts safely. Direct maintainer
-drains declare scope and cursor; workflow handoffs can select only their own
-receipt IDs. The receipt makes the selection mode and counts visible. V1 caps
-one partition at 32 MiB/50,000 events,
-journals at 240 partitions/512 MiB, and a pending page at six partitions,
-10,000 events, or 16 MiB. Capacity refusal is explicit.
-
-### Progressive project-knowledge modes
-
-Core exposes one `project-knowledge` skill with separately loaded modes:
-
-- `--capture` validates and records one observation without reading topics;
-- `--distill` reads bounded pending observations, records dispositions, and may
-  reconcile them into topics; and
-- `--enquire` reads eligible committed topics without reading journals or
-  invoking a writer.
-
-Other workflows discover this skill through their adapter's normal skill
-catalogue and make an agent-mediated handoff. Optional cross-pack integrations
-declare the seam in `pack.toml`; the declaration neither dispatches nor grants
-authority. A producer never locates a writer script or creates a fallback file.
-
-## Distillation owns semantic mutation
-
-The skill and script responsibilities are deliberately different.
-
-### Agent-owned semantic work
-
-`project-knowledge --distill`:
-
-1. selects a bounded set of captured observations and verifies their events;
-2. reads the body-free working-tree topic map;
-3. opens only a bounded set of relevant topic bodies and named sources;
-4. decides whether the observation is new evidence, a duplicate, a
-   contradiction, an over-broad topic, or content owned elsewhere;
-5. synthesizes one proposed disposition and optional topic mutation; and
-6. surfaces provenance or semantic judgment cases instead of
-   applying them.
-
-### Script-owned deterministic work
-
-One private writer serves the mode-specific mutations:
-
-- parses strict JSON and enforces schemas and resource limits;
-- resolves and confines repository-relative paths after symlink resolution;
-- checks privacy, provenance, lifecycle, and stale-precondition invariants;
-- validates that capture can append only a capture event and that a proposed
-  distillation touches only its declared observation, disposition, and topic;
-- locks the current worktree's knowledge mutation boundary;
-- atomically replaces topic files; and
-- deterministically rebuilds and verifies the prospective topic map.
-
-The script does not infer the lesson, classify a contradiction, invent a
-synthesis, or decide retirement. Those are semantic judgments whose evidence
-must appear in the proposed repository diff.
-
-An unambiguous mutation does not require a separate interactive approval. It is
-a non-queryable working-tree proposal governed with the rest of the workflow's
-changes. The repository's normal commit/review policy controls publication, and
-ordinary enquiry reads only the committed topic/map snapshot. When judgment is
-irreducible, the topic stays unchanged and the workflow surfaces the issue at
-its gate.
-
-## Topic model
-
-A topic is one independently verifiable claim, such as
-`build/generated-projections-follow-source`, rather than a broad category such
-as `build`.
-
-Each topic holds:
-
-- immutable `topic_key` and mutable human-readable title;
-- one current observation-shaped synthesis;
-- one or more structural scopes and competency-question facets;
-- lifecycle and source-relative freshness;
-- zero or one owning canonical source;
-- supporting-source references and integrity digests where available;
-- occurrences with producer, gate, source, time, and disposition; and
-- retirement or supersession references where applicable.
-
-One observation may create a topic with one occurrence. Independent recurrence
-attaches another occurrence. New evidence may revise the synthesis without
-erasing earlier provenance. An exact duplicate with no new evidence is
-discarded.
-
-### Lifecycle
-
-- `active` — eligible for ordinary enquiry only when referenced by the
-  committed topic map;
-- `needs_review` — contradictory, unverifiable, privacy-uncertain, or stale;
-  excluded from ordinary enquiry; and
-- `retired` — obsolete or fully absorbed by a stronger artifact; retained for
-  history and diagnostics.
-
-Unknown states fail closed. Saving a topic does not publish it; inclusion in one
-committed topic/map snapshot does.
-
-### Source-relative freshness
-
-Freshness is evaluated against the source or condition that justified the
-topic:
-
-- a source digest changed or disappeared;
-- current code or configuration contradicts the synthesis;
-- a canonical artifact superseded the lesson;
-- a human-set verification deadline passed; or
-- repeated use produced conflicting evidence.
-
-Age is a review-priority hint, not truth. A stable old constraint can remain
-fresh; a new observation can become stale immediately.
-
-### Intentional retirement
-
-Project memory is the residue after canonical routing:
-
-| Knowledge shape | Owner |
-| --- | --- |
-| Product outcome or required behavior | Brief or spec |
-| Supporting evidence | Owning RFC `NNNN-notes/`, spec `notes/`, or cited product research |
-| Current solution structure | Architecture documentation |
-| Decision and rationale | ADR |
-| Repeating procedure | Skill or convention |
-| Enforceable invariant | Code, test, lint, or CI |
-| User-facing operation | Guide |
-| Independently reusable practice residue | Topic |
-
-When a stronger artifact fully and effectively embodies a topic, distillation
-records the destination and retires it. An accepted spec absorbs a normative
-requirement, not an unshipped behavior; operational claims wait for current
-architecture, code, tests, CI, skills, conventions, or guides. Partial
-absorption narrows the synthesis and leaves the remaining residue active. The
-owning artifact changes through its own workflow; knowledge tooling never edits
-it automatically.
-
-Repeated independent occurrences in one structural scope, or one verified
-high-friction episode with several failed or redirected attempts, can trigger a
-`CQ-ROUTE` suggestion for a scoped agent task map. That map belongs in the
-nearest canonical `AGENTS.md`, `AGENTS.local.md`, or repository-declared
-equivalent and states where to start, what is generated, and how to verify.
-Platform-specific instruction files are projections when repository convention
-says so; knowledge tooling never edits a projection directly. Prefer a test,
-lint, or CI rule when the lesson is mechanically enforceable.
-
-Do not turn `AGENTS.md` into a backlog. Missing verification capability belongs
-in the repository's work tracker and then a spec/plan; the agent instruction may
-name the accepted tool once it exists. A topic stays active while the gap is
-real and retires as `enforced` only after the test, lint, CI check, contract
-probe, or diagnostic tool is effective and used by the loop.
-
-## Canonical storage
-
-### Legacy
-
-```text
-docs/knowledge/
-├── README.md
-└── patterns.jsonl
-```
-
-JSONL is a good record-at-a-time bootstrap. It is easy to append and process
-line by line. It is less suitable for reconciled topics because updating
-current synthesis, freshness, or lifecycle either rewrites an arbitrary line
-or appends a new revision that every reader must replay.
-
-### V1 storage
-
-```text
-docs/knowledge/
-├── README.md
-├── patterns.jsonl          # legacy during reviewed migration
-├── observations/
-│   ├── pattern/
-│   │   └── YYYY-MM.jsonl
-│   ├── gotcha/
-│   │   └── YYYY-MM.jsonl
-│   └── antipattern/
-│       └── YYYY-MM.jsonl
-├── topics/
-│   └── <namespace>/
-│       └── <stable-topic-key>.json
-└── topics.index.json       # deterministic topic map / commit manifest; no bodies
-```
-
-Classification/month JSONL journals are the append-oriented handoff from
-capture to distillation. They contain immutable capture and terminal
-disposition events, are not a current-state model, and are never queried by
-enquiry. One pretty-printed JSON object per topic exposes reconciled current
-state directly to an agent and reviewer. Occurrences preserve evidence history.
-This confines event replay and retention concerns to the observation boundary
-instead of imposing them on topic readers.
-
-The topic map is committed because it gives every supported agent a portable,
-dependency-free way to select topic files. It records stable identity, path,
-routing headers, schema version, and the Git blob identity expected for each
-topic. A builder deterministically produces prospective map bytes from valid
-working-tree topics. Topic files remain the semantic authority; disagreement is
-an integrity failure. Richer lexical or semantic indexes, if ever justified,
-live outside Git and can be discarded.
-
-### Concurrency and consistency
-
-All capture and distillation writes use one coarse, worktree-local knowledge
-mutation lock. It is implemented with portable exclusive file creation,
-bounded wait, random ownership token plus file identity, conservative stale
-reclaim, and lost-lock detection. A malformed, foreign, symlinked, or
-non-regular lock is never reclaimed automatically. Release removes only the
-lock file whose token and identity the current process still owns.
-
-The lock begins before the deterministic read that controls a write. Capture
-re-reads and validates the target partition under the lock, checks idempotency,
-and atomically replaces the journal postimage. Distillation re-reads the
-observation and current disposition, one declared topic, named sources, and the
-map, then verifies preconditions. It applies idempotent ordered postimages:
-topic first, complete map second, terminal disposition last. The canonical
-proposal uses an acyclic digest graph: the occurrence stores a deterministic
-`mutation_id` hashed from capture identity, target topic, and canonical
-semantic mutation fields excluding derived values, alongside its ordinary
-evidence digest; the complete topic postimage containing that ID is hashed; the
-proposal stores topic pre/postimage digests; and its own SHA-256 covers
-canonical UTF-8/JCS bytes with only the self-digest omitted. There is no random
-replay input. Recovery without the canonical proposal refuses as
-`replay_required`; exact proposal replay deterministically reconstructs the ID. The next
-writer can rebuild a missing map or append the matching disposition only when
-the current topic is the exact expected postimage; otherwise it refuses. A
-`promoted` disposition is invalid unless its exact topic occurrence and
-matching map already exist. Multi-topic split is surfaced as a normal repository edit rather than
-partially applied by the writer.
-
-Filesystem replacement is not the publication transaction. Ordinary enquiry
-reads `topics.index.json` and topic blobs from the same committed Git tree. Git
-publishes that multi-file tree as one snapshot, so working-tree interruption can
-make authoring unavailable but cannot expose a half-written corpus to enquiry.
-The next writer repairs or refuses an inconsistent working tree. Separate
-worktrees do not share this lock; Git merge and review are the cross-worktree
-contention boundary.
-
-The shared topic map is mechanically hot across branches even when topic files
-do not overlap. A map-only merge conflict is discarded and deterministically
-rebuilt from the merged topic tree. A same-topic conflict is resolved
-semantically first, then the map is rebuilt. Hand-merging derived map entries is
-never the recovery path.
-
-Observation partitions have their own merge rule. A private deterministic
-helper reads the three Git stage blobs for one conflicted confined journal,
-strictly parses them, collapses exact event replays, and groups by `capture_id`
-within that partition. It refuses differing capture bodies, orphan dispositions, or
-competing terminal dispositions. It also re-derives kind and month from every
-capture body and refuses an event that does not belong to the conflicted
-partition. Valid output sorts by capture ID, with capture before disposition. Tests
-cover distinct captures, exact replay, conflicting bodies, and conflicting
-dispositions across two worktrees.
-
-Git conflicts on the same topic are meaningful semantic contention. Splitting
-a topic is appropriate only when its claims are independently verifiable, not
-as a mechanical conflict-avoidance trick.
-
-## Enquiry
-
-`project-knowledge --enquire` is a read-only, explicit capability. Ordinary mode resolves
-the checked-out worktree's `HEAD` once to immutable commit and tree identities;
-agent and skill callers cannot select another revision. Historical or alternate
-tree lookup is a separate explicit human diagnostic mode whose output never
-enters ordinary agent context. Enquiry requires:
-
-- a bounded task summary;
-- resolved project or subproject scope;
-- one free-form question for a direct human call or a known
-  `knowledge-competency-questions-v1` ID for a skill call; and
-- a risk declaration, defaulting to consequential when missing.
-
-The reader opens the topic map from the resolved `HEAD` tree and compares its
-complete path/blob-identity set with that tree without opening every topic body.
-Hard project, scope, lifecycle, privacy, and freshness filters then run before
-ranking. Only selected topic bodies are opened and their declared digests are
-verified. Their source-relative anchors are compared with current confined
-worktree sources, so an uncommitted source change suppresses stale committed
-knowledge without publishing an uncommitted topic. Enquiry never falls back to
-working-tree topics, scratch, legacy JSONL, `needs_review`, retired,
-out-of-project, or malformed records.
-
-| Question | Decision moment |
-| --- | --- |
-| `CQ-ORIENT` — What local constraints affect this task? | Plan or orientation |
-| `CQ-DESIGN` — What prior lessons shape this tradeoff? | RFC, ADR, or design |
-| `CQ-CHANGE` — What couplings and failure modes matter? | Before implementation |
-| `CQ-DIAGNOSE` — What similar symptoms, causes, and failed approaches exist? | Diagnosis |
-| `CQ-REVIEW` — What recurring risks should review inspect? | Review planning |
-| `CQ-VERIFY` — What proves the change correct, and where is verification insufficient? | Gate design and gap capture |
-| `CQ-OPERATE` — What build, release, recovery, or operational lessons apply? | Operation |
-| `CQ-ROUTE` — Which stronger artifact or scoped agent task map should own this knowledge? | Distillation |
-| `CQ-RETIRE` — Has a stronger artifact absorbed it? | Knowledge maintenance |
-
-Humans may enquire directly. A skill may enquire only at a declared decision
-moment, must use a known v1 ID, declares its query/refinement budget, and makes
-the invocation visible. The returned receipt names the question, selected topic
-IDs, verified sources, budget, immutable commit/tree IDs, abstention, and caller
-workflow. It cannot know whether evidence changed the approach before use. The
-caller may add that post-use outcome to explicit scratch for later semantic-gate
-triage; enquiry itself stays read-only. Capture and distillation do not
-implicitly enquire, and session-start or status surfaces never load knowledge.
-
-The result is a bounded evidence envelope, not a prompt prelude. It includes
-topic identity, synthesis, scope, freshness, provenance, limitations, and
-source pointers. Consequential enquiry requires and verifies a resolvable,
-digest-bearing owning source or abstains. Retrieved text cannot grant permission, approve an action,
-select a tool, or write itself back.
-Routing may read the complete body-free map up to its independent 32 MiB
-ceiling. Only after routing does the 1 MiB/12-topic body-read ceiling apply.
-
-Structural scopes serialize portably as NFC-normalized repository-relative
-components separated by `/`; this does not assume a POSIX host. The runtime
-normalizes native separators, rejects Windows drive/UNC/device and reserved-name
-aliases, resolves symlinks or reparse points, applies native case semantics, and
-compares path components rather than string prefixes. Linux, macOS, and Windows
-therefore produce the same stored scope for the same repository-relative tree.
-
-## Security and privacy
-
-Persisted knowledge is a Tier-C agent-memory integrity surface. A poisoned
-observation can influence future work long after its originating session.
-
-Controls apply at every boundary:
-
-- reject known secrets, personal data, private locators, account identifiers,
-  organization hostnames, unsafe Unicode, control payloads, and unbounded text;
-- store paraphrased observations and repository-relative source pointers, not
-  source instructions or transcript excerpts;
-- require a semantic privacy attestation and deterministic checks for known
-  secret patterns, email addresses, absolute/user paths, private locators, and
-  account/person/private identifier-shaped values in content/provenance fields;
-  typed identity fields allow only validated Git commit/tree/blob and
-  contract/capture/mutation/topic IDs, and either layer's uncertainty refuses the
-  write;
-- require independently checkable provenance for consequential claims;
-- parse strict JSON with duplicate-key and non-finite-number rejection;
-- resolve the worktree and knowledge roots, then verify the knowledge root and
-  every read/write target remain confined after symlink resolution;
-- cap files, bytes, occurrences, opened bodies, output, and elapsed work;
-- treat model-produced synthesis as untrusted output until deterministic
-  validation and publication in a coherent Git snapshot;
-- suppress `needs_review`, retired, and malformed topics from ordinary enquiry;
-  and
-- never give knowledge code network, arbitrary-command, credential, or
-  permission-management authority.
-
-The portable checks and semantic attestation are the minimum supported privacy
-coverage. A sanctioned scanner may strengthen them. Missing optional tooling is
-not silently presented as coverage; any unresolved uncertainty refuses the
-observation body. The baseline does not persist raw quarantine that the
-environment may be unable to protect or delete.
-
-Every refusal uses a strict redacted diagnostic envelope with an allowlisted
-reason code, safe relative locator, retryability, and recovery action. It never
-echoes a body, source excerpt, absolute path, raw exception, or secret-shaped
-value. This makes lock loss, capacity, stale cursor, replay requirement, map
-mismatch, and staged activation observable without widening disclosure.
-Parsing, schema, provenance, privacy, unsafe-Unicode, and size failures occur
-before any request-derived identity can be returned. Only an exact replay of an
-already admitted capture or a post-admission recovery failure may expose its
-persisted `capture_id`.
-
-## Migration
-
-`patterns.jsonl` is the current curated corpus, not discarded scratch. Migration
-preserves each admitted legacy identifier and source as an occurrence; refused
-rows contribute only to redacted accounting:
-
-1. parse the complete JSONL corpus with the strict UTF-8 JSON decoder used by
-   new contracts; reject duplicate keys, non-finite numbers, non-object rows,
-   unsafe Unicode, or malformed lines with redacted path/line diagnostics, then
-   assign every non-empty row exactly `active_import`,
-   `needs_review_import`, or `refused`;
-2. propose narrow topic groupings and surface ambiguous merges or splits;
-3. build a complete staged topic tree and deterministic index while JSONL
-   remains canonical;
-4. verify the three disposition counts sum to the input row count, every
-   imported legacy record maps exactly once, and refused rows persist no body;
-5. review the resulting files as an ordinary repository change;
-6. publish the topic tree and map in one normal Git commit, which activates the
-   new layout for that repository; admitted legacy rows become occurrences
-   directly and are not duplicated into observation journals; and
-7. freeze or later remove the legacy file only after count-preserving review.
-
-An interrupted or merely staged migration leaves the committed legacy corpus
-canonical and blocks both capture and distillation rather than choosing between
-two write paths.
-Ordinary enquiry continues from the last valid committed v1 snapshot if one
-exists; it is unavailable in a legacy-only repository. Topic readers activate
-the new layout only when a valid v1 topic map and all of its topic blobs occur in
-the same `HEAD` tree. Legacy-only repositories continue the old append path
-until migration; after activation JSONL is read-only evidence. The process needs
-no durable external candidate store.
-Activation may be reverted only before a v1 observation is persisted. After
-that point, automatic reverse migration refuses and recovery moves forward
-while preserving journals/topics and legacy read-only state; running pre-v1
-tooling is outside the supported rollback contract because removed guards
-cannot protect the new corpus.
-
-## Progressive rollout
-
-1. **Foundation:** published capture contract, capture journals, progressive
-   mode boundaries, terminal dispositions, topic files, map, migration,
-   explicit enquiry, work-loop cutover, tests, and docs.
-2. **Authoring skill integrations (shipped):** gate-time scratch triage for
-   brief, RFC, ADR, spec, and plan producers. Each integration owns capture and
-   does not gain an implicit enquiry path.
-3. **Review integrations (shipped):** bounded `CQ-REVIEW` enquiry for selected
-   reviewers, with independent grounding and no reviewer capture or
-   distillation.
-4. **Research integrations (shipped):** the
-   [`project-knowledge-research-integrations`](../specs/project-knowledge-research-integrations/spec.md)
-   slice keeps one spec with three ordered tasks. Quick, non-survey
-   typed, scaffold, digest, check, and status paths remain no-integration;
-   complete episodic surveys and project synthesis may capture only reusable
-   practice or sanitized residue at exact terminal gates. Counter-evidence
-   review alone may consume one sanitized, outer-target-bounded `CQ-REVIEW`
-   envelope while retaining independent direct-source verification. Research
-   products and direct-source authority remain in research, and personal or
-   external output roots remain capture-ineligible rather than acquiring
-   fabricated repository provenance.
-5. **Engineering and operational integrations:** separately shape explicit
-   enquiry or producer-owned capture at demonstrated stable gates.
-6. **Portable-lifecycle adoption closeout:** audit coverage, precision,
-   abstention, privacy, growth, and routing before any conditional expansion.
-7. **Measured acceleration:** add disposable local indexes only if file-based
-   routing violates published budgets.
-8. **Optional capture backend:** separately govern deferred observations only
-   where an approved durable user-state or service capability exists.
-9. **Multi-project bank:** separately govern export, tenancy, privacy,
-   provenance, deletion, and project-local adoption.
-
-## Failure modes
-
-| Failure | Behavior |
-| --- | --- |
-| Session ends before a semantic gate | Untriaged scratch may be lost; no false durability claim |
-| Observation fails privacy or provenance | Refuse it and surface a bounded reason; persist no body |
-| Captured observation adds no knowledge | Record one bounded terminal `duplicate`, `routed`, `rejected`, or `superseded` disposition; never expose it to enquiry |
-| Reconciliation requires judgment | Leave topic unchanged and surface at the gate |
-| Capture is replayed | Return the existing receipt for an exact replay; refuse a stored event whose body does not match its derived identity |
-| Writer loses its lock | Stop before replacing another postimage; the next writer revalidates the capture, proposal, ordered postimages, topic, and map, then completes only an idempotent missing step or refuses recovery |
-| Topic source drifts | Mark or propose `needs_review`; ordinary enquiry abstains |
-| Working-tree map is missing or stale | Repair explicitly; enquiry continues to use the last coherent committed snapshot |
-| Committed map/topic identity mismatch | Enquiry fails closed; run the full corpus lint and publish a repaired snapshot |
-| Migration is interrupted | Legacy JSONL remains canonical |
-| Worktree is deleted before changes are integrated | Topic diff is lost like any other unmerged repository change |
-| Corpus outgrows budgets | Measure first; propose a disposable index or backend separately |
-
-## Current component map
-
-| Component | Source | Status |
-| --- | --- | --- |
-| Work-loop closeout capture guidance | `packs/core/.apm/skills/work-loop/SKILL.md` | Shipped |
-| Published captured-observation contract | `contracts/jsonschema/knowledge-captured-observation.schema.json` | Shipped |
-| Progressive capture, distillation, and enquiry modes | `packs/core/.apm/skills/project-knowledge/` | Shipped |
-| Private journal/topic writer and corpus validation | `packs/core/.apm/skills/project-knowledge/scripts/knowledge_store.py` | Shipped |
-| Repository's legacy observations and explicit curation render | `docs/knowledge/patterns.jsonl`; `tools/hooks/session-start.py --show-knowledge` | Live until coherent v1 activation |
-| Brief/RFC/ADR/spec/plan integrations | `packs/core/.apm/skills/receive-brief/`; `packs/core/.apm/skills/work-loop/`; `packs/governance-extras/.apm/skills/new-rfc/`; `packs/governance-extras/.apm/skills/new-adr/` | Shipped |
-| Architecture/adversarial/security/quality review enquiry | `packs/architect/.apm/skills/architect-review/`; `packs/core/.apm/skills/work-loop/`; `packs/core/.apm/agents/` | Shipped |
-
-## Architectural decisions
-
-1. Canonical project knowledge uses per-topic JSON with a deterministic,
-   body-free topic map published in the same Git snapshot; JSONL is
-   legacy/interchange rather than reconciled current state.
-2. One progressive `project-knowledge` skill keeps capture, distillation, and
-   enquiry as mode-specific authority boundaries. The portable baseline
-   persists admitted observations in non-queryable classification/month
-   journals; distillation alone may promote them into topics.

--- a/docs/architecture/loop-infrastructure.md
+++ b/docs/architecture/loop-infrastructure.md
@@ -1,164 +1,79 @@
-# Loop Infrastructure — Phase 1
+# Loop infrastructure
 
-The work-loop's execution machinery is split across two purpose-built scripts
-with a hard boundary: `loop-engine.py` is a read-only FSM phase tracker;
-`loop-cohort.py` is the sole writer of cohort execution state.
+## 1. Purpose and boundary
 
-## Key references
+The execution harness tracks work-loop phases and cohort state for one spec
+directory. `loop-engine.py` advances the finite-state machine.
+`loop-cohort.py` records cohort execution state.
 
-- **Decision (why):** [`docs/adr/0061-loop-infrastructure-phase-1.md`](../adr/0061-loop-infrastructure-phase-1.md)
-- **Feature contract (what):** [`docs/specs/loop-infrastructure-phase-1/spec.md`](../specs/loop-infrastructure-phase-1/spec.md)
-- **Implementation plan (how):** [`docs/specs/loop-infrastructure-phase-1/plan.md`](../specs/loop-infrastructure-phase-1/plan.md)
-- **State field reference:** [`packs/core/.apm/skills/work-loop/references/state-schema.md`](../../packs/core/.apm/skills/work-loop/references/state-schema.md)
+The harness does not create requirements or implement work. It consumes approved
+specification and plan artifacts.
 
-## Components
+## 2. Entrypoints
 
-### `loop-engine.py` (FSM phase tracker)
+- `loop-engine.py`: `init`, `transition`, `status`, and `reset`.
+- `loop-cohort.py`: `init`, `identity`, `status`, `approve-plan`,
+  `schedule`, `check`, wave, and review commands.
+- `check-spec-status.py`: validates a requested status in `spec.md` or
+  `plan.md`.
 
-Owns `engine-state.json` (gitignored at `docs/specs/**/engine-state.json`).
-Read-only except for `init`, `transition`, and `reset`.
+## 3. Owned state and write authority
 
-```
-loop-engine init <spec-dir> --mode {code|spec-plan} [--json]
-loop-engine transition <spec-dir> <event> [--wave-index <n>]
-loop-engine status <spec-dir> [--json]
-loop-engine reset <spec-dir>
-```
+| State | Location | Write authority | Readers |
+| --- | --- | --- | --- |
+| FSM phase state | `docs/specs/**/engine-state.json` (gitignored) | `loop-engine.py` | Harness operators |
+| Cohort state | `docs/specs/**/state.json` (gitignored) | `loop-cohort.py` | Harness operators and engine guards |
+| Transition events | `.loop-run/events.jsonl` (ephemeral) | `loop-engine.py` | Harness operators and workspace MCP |
 
-**FSM modes (Phase 1):**
+## 4. Dependencies and allowed edges
 
-`code` — ten-state lifecycle with spec/plan drafting, two human-approval gates, and implementation waves:
+`loop-engine.py` reads spec and plan status, then invokes `loop-cohort.py`
+identity and schedule checks before guarded transitions. `check-spec-status.py`
+imports the canonical status parser from `lint-spec-status.py`.
 
-```
-SPEC-PLAN-DRAFTING → (spec-ready)       → SPEC-PLAN-REVIEW
-SPEC-PLAN-REVIEW   → (reviewers-clean)  → SPEC-HUMAN-GATE
-SPEC-PLAN-REVIEW   → (findings-remain)  → SPEC-PLAN-DRAFTING
-SPEC-HUMAN-GATE    → (spec-approved)    → PLAN-HUMAN-GATE      guard: spec.md Status==Approved
-SPEC-HUMAN-GATE    → (spec-rejected)    → SPEC-PLAN-DRAFTING
-PLAN-HUMAN-GATE    → (plan-approved)    → SPEC-PLAN-APPROVED   guard: plan.md Status==Approved
-PLAN-HUMAN-GATE    → (plan-rejected)    → SPEC-PLAN-DRAFTING
-SPEC-PLAN-APPROVED → (plan-locked)      → CODE-IMPLEMENTATION  guard: spec.md Status==Approved + schedule
-CODE-IMPLEMENTATION  → (wave-complete) → CODE-VERIFICATION
-CODE-VERIFICATION    → (wave-passed)   → CODE-IMPLEMENTATION   [requires --wave-index]
-CODE-VERIFICATION    → (gates-clean)   → CODE-REVIEW
-CODE-VERIFICATION    → (gates-failed)  → CODE-IMPLEMENTATION
-CODE-REVIEW          → (reviewers-clean) → CODE-HUMAN-GATE
-CODE-REVIEW          → (findings-remain) → CODE-IMPLEMENTATION
-CODE-HUMAN-GATE      → (done)          → DONE
-CODE-HUMAN-GATE      → (blocker-applied) → CODE-IMPLEMENTATION
-```
+The engine reads cohort state but does not write it. The cohort tool does not
+advance FSM phase state.
 
-`spec-plan` — six-state lifecycle terminating at DONE on plan-locked (no code phase):
+## 5. Primary flows
 
-```
-SPEC-PLAN-DRAFTING → (spec-ready)       → SPEC-PLAN-REVIEW
-SPEC-PLAN-REVIEW   → (reviewers-clean)  → SPEC-HUMAN-GATE
-SPEC-PLAN-REVIEW   → (findings-remain)  → SPEC-PLAN-DRAFTING
-SPEC-HUMAN-GATE    → (spec-approved)    → PLAN-HUMAN-GATE      guard: spec.md Status==Approved
-SPEC-HUMAN-GATE    → (spec-rejected)    → SPEC-PLAN-DRAFTING
-PLAN-HUMAN-GATE    → (plan-approved)    → SPEC-PLAN-APPROVED   guard: plan.md Status==Approved
-PLAN-HUMAN-GATE    → (plan-rejected)    → SPEC-PLAN-DRAFTING
-SPEC-PLAN-APPROVED → (plan-locked)      → DONE                 guard: spec.md Status==Approved
-```
+1. `loop-engine.py init` creates FSM state and emits a run identifier.
+   `loop-cohort.py init` adopts that identifier.
+2. A guarded engine transition verifies required artifact status and cohort
+   identity. Code transitions also verify the scheduled plan remains current.
+3. `loop-cohort.py` records plan approval, scheduling, attempts, waves, and
+   review evidence. `loop-engine.py` records phase transitions and events.
 
-Human-wait states: `SPEC-HUMAN-GATE`, `PLAN-HUMAN-GATE`, `CODE-HUMAN-GATE`
-(all report `pending_human_wait: true`). `SPEC-PLAN-APPROVED` is not a
-human-wait state — it is a durable intermediate state between both approvals
-and the `plan-locked` cohort-seal step.
+## 6. Failure and recovery behavior
 
-**G-plan sequence (code mode):**
+A failed guard blocks the transition. A run-identifier mismatch blocks cohort
+mutation. A changed plan blocks code transitions until scheduling is current.
 
-```bash
-# 1. Spec approver writes Status: Approved in spec.md.
-python3 scripts/loop-engine.py transition docs/specs/<feature> spec-approved
-# → SPEC-HUMAN-GATE exits; engine enters PLAN-HUMAN-GATE
+Both state writers use `tempfile.mkstemp` and `os.replace` in the target
+directory. A crash leaves either the previous JSON or the replacement JSON.
+`reset` is the explicit recovery action.
 
-# 2. Plan approver writes Status: Approved in plan.md.
-python3 scripts/loop-engine.py transition docs/specs/<feature> plan-approved
-# → PLAN-HUMAN-GATE exits; engine enters SPEC-PLAN-APPROVED
+## 7. Observability and evidence
 
-# 3. Cohort records the approved baseline:
-python3 scripts/loop-cohort.py approve-plan docs/specs/<feature> --expect-run-id <run_id>
+Both tools expose `status --json`. `engine-state.json`, `state.json`, and
+`.loop-run/events.jsonl` record phase, cohort, and transition evidence.
+Workspace MCP reads the event stream.
 
-# 4. Schedule waves:
-python3 scripts/loop-cohort.py schedule docs/specs/<feature> --expect-run-id <run_id>
+## 8. Mechanical invariants
 
-# 5. Seal and hand off:
-python3 scripts/loop-engine.py transition docs/specs/<feature> plan-locked
-# → CODE-IMPLEMENTATION; write Status: Implementing before any code
-```
+- `check-spec-status.py` blocks guarded transitions unless the requested
+  `spec.md` or `plan.md` status is present.
+- `loop-engine.py` checks cohort identity before every transition.
+- `loop-engine.py` checks the current schedule before code transitions except
+  `done`.
+- `loop-cohort.py` requires `--expect-run-id` for cohort mutations.
 
-**Guards** fire before each transition to enforce pre-conditions. The engine
-runs `loop-cohort identity --expect-run-id` as a preflight on every transition
-to confirm the cohort `run_id` matches. CODE-* transitions (except `done`)
-additionally run `loop-cohort schedule check-current` to verify plan.md hasn't
-changed since scheduling. Event-specific guards are detailed in the spec.
+## 9. Relevant ADRs
 
-### `loop-cohort.py` (sole state.json writer)
+- [ADR-0061 — Loop infrastructure](../adr/0061-loop-infrastructure-phase-1.md)
+- [ADR-0064 — Events JSONL as FSM event source](../adr/0064-events-jsonl-as-fsm-event-source.md)
+- [ADR-0074 — Work loop owns its state lock](../adr/0074-the-work-loop-owns-its-state-lock.md)
 
-Owns `state.json` (gitignored at `docs/specs/**/state.json`). All cohort
-mutations are explicit verbs with `--expect-run-id` for identity safety.
+## 10. Last verified against commit
 
-**Phase 1 verb surface:**
+`c8cf4b37`
 
-```
-init <spec-dir> --run-id <uuid>
-identity <spec-dir> [--expect-run-id <uuid>] [--json]
-status <spec-dir> [--json]
-reset <spec-dir>
-approve-plan <spec-dir> --expect-run-id <uuid>
-plan check-current <spec-dir> [--require-schedule]
-schedule <spec-dir> --expect-run-id <uuid>
-schedule check-current <spec-dir>
-check <spec-dir> --phase {implement|gates-failed|review}
-record-attempt <spec-dir> --phase implement --cycle-id <run_id>:<seq> --expect-run-id <uuid>
-wave check <spec-dir> --expect {more|last} [--wave-index <n>]
-wave advance <spec-dir> --from-index <n> --expect-run-id <uuid>
-review inspect <spec-dir> --report <path> [--json]
-review record <spec-dir> (--fingerprint <hex> ... | --report <path>) --expect-run-id <uuid>
-```
-
-**Disabled in Phase 1** (exit non-zero with "disabled in Phase 1" message):
-`dispatch-decision`, `worktree {add, record, list, merge, cleanup, preflight}`, `auto-parallel`.
-
-### `check-spec-status.py` (status guard)
-
-Called by `loop-engine` as the guard for multiple transitions. Imports
-`parse_status` from `lint-spec-status.py` via `importlib` to share a single
-canonical status parser.
-
-```
-check-spec-status.py <spec-dir> [--expect <status>] [--file <filename>]
-```
-
-- `--expect` omitted → defaults to `Shipped`.
-- `--file` omitted → defaults to `spec.md`.
-- `--file plan.md --expect Approved` → reads `<spec-dir>/plan.md`, checks `Status: Approved`.
-
-Used by `spec-approved` guard (`--expect Approved`), `plan-approved` guard
-(`--expect Approved --file plan.md`), `plan-locked` guard (`--expect Approved`),
-and `reviewers-clean` guard (`--expect Shipped`, default).
-
-## Init pair
-
-Both tools must be initialized before use; the engine generates the `run_id`
-that cohort adopts:
-
-```bash
-run_id=$(python3 scripts/loop-engine.py init docs/specs/<feature> \
-    --mode code --json | python3 -c "import sys,json; print(json.load(sys.stdin)['run_id'])")
-python3 scripts/loop-cohort.py init docs/specs/<feature> --run-id "$run_id"
-```
-
-## Atomic write guarantee
-
-Both scripts write state through `tempfile.mkstemp` + `os.replace` in the same
-directory as the target file. A crash mid-write cannot produce malformed JSON;
-the target either carries the previous content or the new content, never a
-partial write.
-
-## Phase 2 (deferred)
-
-Parallel fan-out (`dispatch-decision`, worktrees, `auto-parallel`), token-budget
-tracking, consecutive-error detection, and cross-session resumption identifiers
-are reserved for Phase 2.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,7 @@
 # Architecture Overview
 
-> The map of this monorepo. Read this first when exploring. Updated whenever
-> the directory layout or major dependencies change.
+> The directory map of this monorepo. For its systems, boundaries, flows, and
+> state ownership, read [`ARCHITECTURE.md`](../../ARCHITECTURE.md).
 
 ## Layout
 
@@ -48,98 +48,7 @@ straight into the adopter's own repo without needing to expose `dist/`.
 Edit seeds under `packs/<pack>/.apm/...`, not these projections. See
 [`AGENTS.local.md`](../../AGENTS.local.md) for the full drift workflow.
 
-## The catalogue
-
-`packs/` is the source catalogue. Each pack owns its manifest, portable
-primitives, tests, seeds, README, and journey; `profiles/` composes those packs
-without introducing new primitives. The complete current inventory belongs to
-the [generated catalogue](https://eugenelim.github.io/agent-ready-repo/catalogue/)
-and [technical pack reference](https://eugenelim.github.io/agent-ready-repo/docs/packs/),
-not to a hand-maintained architecture table.
-
-[`core`](../../guides/core/explanation/core-pack.md) is the flagship build
-system. Other packs may depend on it, integrate with it, or remain independently
-useful; composition is declared in `pack.toml`, not inferred from directory
-adjacency. Each pack's full metadata lives in that manifest and is projected
-into catalogue listings — see [`pack-manifest.md`](pack-manifest.md).
-
-What it means for `core` to be load-bearing: its
-`session-start.py` is the single read-side of the install→adapt chain —
-every install route (CLI, APM, Claude plugins) drops the same
-`.adapt-install-marker.toml`, and `core`'s hook is what surfaces it to the
-agent on next session. Pull `core` out and the chain doesn't close.
-
 ## Subsystems
 
-One file per non-trivial subsystem:
-
-- [`workspace-mcp/design.md`](workspace-mcp/design.md) — the per-session MCP
-  server shipped with `core`: spawn forms (trusted / CI), session modes, ACP
-  adapter classes, notification contract, FSM observability, and security
-  constraints. Harness operators should read this alongside the operator
-  how-to guide at
-  [`guides/core/how-to/run-headless-session.md`](../../guides/core/how-to/run-headless-session.md).
-- [`pack-layout.md`](pack-layout.md) — the canonical shape of a single
-  pack: `pack.toml`, `.claude-plugin/`, `.apm/<primitive>/`, `seeds/`,
-  and how the bundler reads them.
-- [`agentbundle.md`](agentbundle.md) — the Python package: CLI verbs,
-  build pipeline (recipes → adapters → projections), the adapter contract
-  at v0.18 (Claude-plugin hook parity adds route-scoped hook-body and
-  hook-wiring fields; RFC-0052 added the shared-prefix registry and routed the
-  cursor/gemini/copilot skill cohort to the shared `.agents/skills/` home;
-  RFC-0031 carries the enriched-manifest projection at v0.14; RFC-0011
-  added `[adapter.codex.scope]` and the user-scope adapter resolver),
-  self-host overlay.
-- [`credentials.md`](credentials.md) — the credentialed-resolver model
-  (the `credbroker` library since RFC-0023, formerly the build-projected
-  `credentials_shim`, RFC-0013), three-tier storage
-  (env / OS keyring / `~/.agentbundle/credentials.env`), the four
-  brokers (`creds` / `env` / `cli` / `sso-cookie`), the
-  credentialed-primitive contract, and the substring trap.
-- [`knowledge-capture.md`](knowledge-capture.md) — the `core` pack's current
-  capture and read boundaries plus the target lifecycle: free-form scratch,
-  semantic-gate triage, typed observation journals, progressive capture,
-  topic distillation, file-based storage, explicit enquiry, and intentional
-  retirement.
-- [`work-intake-and-artifact-routing.md`](work-intake-and-artifact-routing.md)
-  — the implemented architecture for separating source intake, canonical
-  intents/briefs/specs/defects, lifecycle membership in `workspace.toml`, and
-  processor dispatch. Jira, Jira Align, Linear, and GitHub adapters now converge
-  on its `normalized-intake.v1` boundary: acquisition and versioned profile
-  hints stay tracker-specific, while content classification and every repository
-  write stay in `work-intake`. Tracker intake is read-only; refresh conflicts,
-  execution locks, and tracker write-back remain later integrations.
-
-## Packages
-
-- [`packages/agentbundle/`](../../packages/agentbundle/) — the reference
-  CLI and build pipeline. Stdlib-only, distributed as a zipapp and as
-  an editable pip install. As of 0.2.0 it no longer ships a credential-
-  resolution module; credentialed primitives in the `atlassian` and
-  `figma` packs resolve credentials through the pip-installable
-  `credbroker` library (RFC-0023), not the agentbundle wheel. See
-  [`agentbundle.md`](agentbundle.md) and [`credentials.md`](credentials.md).
-- [`packages/_example/`](../../packages/_example/) — a minimal package
-  template the `new-package` skill (in `monorepo-extras`) copies when an
-  adopter scaffolds a new package.
-
-## Where to start
-
-1. Read [`docs/CHARTER.md`](../CHARTER.md) — mission, scope, four principles.
-2. Read this file.
-3. Pick a recent spec under [`docs/specs/`](../specs/) and read its
-   `spec.md` + `plan.md` next to the resulting code under
-   `packages/agentbundle/` or `packs/`. The
-   [`agent-spec-cli`](../specs/agent-spec-cli/spec.md),
-   [`distribution-adapters`](../specs/distribution-adapters/spec.md),
-   and [`skill-secrets`](../specs/skill-secrets/spec.md) specs are the
-   three load-bearing ones.
-4. Skim the two ADRs —
-   [ADR-0001](../adr/0001-adopt-agents-md-and-doc-hierarchy.md)
-   (AGENTS.md + the doc hierarchy this repo runs on) and
-   [ADR-0002](../adr/0002-install-scope-per-pack-default-and-allowance.md)
-   (the per-pack default-plus-allowance install-scope model) — plus the
-   most recent accepted RFCs ([0008](../rfc/0008-claude-plugins-install-route-parity.md),
-   [0010](../rfc/0010-apm-install-route-parity.md)) for current direction.
-5. Run `make build-check` once — it's the self-host drift gate, and
-   tripping it explains the seed/projection split better than prose can.
+The subsystem index and deeper links are in
+[`ARCHITECTURE.md` § 8](../../ARCHITECTURE.md#8-deeper-current-state-pages).

--- a/docs/architecture/pack-layout.md
+++ b/docs/architecture/pack-layout.md
@@ -123,9 +123,8 @@ the pack targets. Three required tables:
   pipeline reads these and emits derived per-tool metadata into
   `dist/apm/<pack>/apm.yml` and
   `dist/claude-plugins/<pack>/.claude-plugin/plugin.json` — for user-capable
-  packs only; the Claude-plugin route installs at user scope. Since
-  **enriched-pack-manifest** (RFC-0031 / ADR-0021, contract v0.14),
-  `[pack]` also accepts optional rich metadata — `readme`, `display_name`,
+  packs only; the Claude-plugin route installs at user scope. `[pack]` also
+  accepts optional rich metadata — `readme`, `display_name`,
   `license`, `categories` (≤5, soft vocabulary), `keywords` (≤5),
   `catalogue`, an opaque `[pack.metadata.<tool>]` table, plus the
   `[[pack.maintainers]]` array and the `[pack.links]` table
@@ -137,15 +136,12 @@ the pack targets. Three required tables:
   route — see [`pack-manifest.md`](pack-manifest.md). Every enriched field
   is optional; a pack that omits them projects exactly as before.
 - **`[pack.adapter-contract]`** — `version`, must reference a
-  published contract version. The contract is at **v0.18** today
-  (Claude-plugin hook parity); a pack pins the *minimum* version whose
-  behaviour it needs, not necessarily the latest. When authoring a new
-  pack, copy the value from a sibling with the same scope shape rather
-  than the contract.
+  published contract version. A pack pins the minimum behavior it needs. The
+  current version lives in [`contracts/adapter.toml`](../../contracts/adapter.toml).
 - **`[pack.install]`** — `default-scope` ∈ `{repo, user}`,
-  `allowed-scopes`, optional `user-scope-hooks` (v0.3+, RFC-0005),
-  and optional `allowed-adapters` (v0.6+, RFC-0011 — array of
-  user-scope-capable adapter names like `["claude-code", "kiro-ide",
+  `allowed-scopes`, optional `user-scope-hooks`, and optional
+  `allowed-adapters` (an array of user-scope-capable adapter names like
+  `["claude-code", "kiro-ide",
   "codex"]`; declared order drives the greenfield fallback). The
   `default-scope ∈ allowed-scopes` invariant is enforced in
   [`_data/pack.schema.json`](../../packages/agentbundle/agentbundle/_data/pack.schema.json)'s
@@ -175,11 +171,8 @@ The pack-authored primitives declared in the adapter contract
 | `hook-wiring` | `.apm/hook-wiring/<name>.toml` | Declarative binding of a body to an editor event. |
 | `command` | `.apm/commands/<name>.md` | Slash-command primitive (Claude Code today; other harnesses degrade per the contract). |
 
-One more pack-authored primitive — `kiro-ide-hook`, for native Kiro
-IDE-event hooks — was designed in
-[RFC-0005](../rfc/0005-user-scope-hook-support.md) and activated in
-`adapter.toml` at v0.9, when the `kiro` adapter split into `kiro-ide` and
-`kiro-cli`. Its source path is `.apm/kiro-ide-hooks/<name>.kiro.hook`; the
+One pack-authored primitive, `kiro-ide-hook`, provides native Kiro IDE-event
+hooks. Its source path is `.apm/kiro-ide-hooks/<name>.kiro.hook`; the
 `kiro-ide` adapter projects it; every other adapter either declares it
 `dropped` or omits it. The contract also declares `shared-libs`,
 `adapter-root-bins`, and `user-libs` — pack-authored source paths under

--- a/docs/architecture/pack-manifest.md
+++ b/docs/architecture/pack-manifest.md
@@ -5,8 +5,7 @@ The build derives a smaller, schema-compliant **subset** from it and projects
 that into each distribution route's manifest, alongside the pack's `README.md`.
 This page describes that model. The on-disk *shape* of a pack lives in
 [`pack-layout.md`](pack-layout.md); the decision record is
-[ADR-0021](../adr/0021-pack-manifest-source-of-truth-and-scoped-identity.md)
-(RFC-0031).
+[ADR-0021](../adr/0021-pack-manifest-source-of-truth-and-scoped-identity.md).
 
 ## Why a source-of-truth + projection split
 
@@ -21,7 +20,7 @@ simply aren't emitted there.
 ## What `pack.toml` carries
 
 Beyond the required `name` / `version` / `description`, `[pack]` accepts the
-optional enriched fields (all introduced at adapter-contract **v0.14**):
+optional enriched fields:
 
 | Field | Shape | Notes |
 | --- | --- | --- |
@@ -35,9 +34,8 @@ optional enriched fields (all introduced at adapter-contract **v0.14**):
 | `[pack.links]` | object | `homepage` / `repository` / `documentation` / `changelog` / `issues` / `icon` |
 | `[pack.metadata.<tool>]` | object | opaque passthrough — the build reads only namespaces it knows |
 
-Every enriched field is **optional**. A pack that declares none of them builds
-and validates exactly as it did before v0.14 — the projected output is
-byte-identical (the *emit-only-when-present* rule below makes this provable).
+Every enriched field is **optional**. A pack that declares none of them emits
+no enriched projection fields.
 
 ## The projectable subset
 
@@ -77,9 +75,8 @@ each `marketplace.json` entry validates against
 [`marketplace-entry.schema.json`](../../contracts/marketplace-entry.schema.json)
 (the derived schema plus required `source` and permitted `category`). The
 source-shape [`plugin-manifest.schema.json`](../../contracts/plugin-manifest.schema.json)
-admits the same named subset. Until 2026-08, marketplace entries were validated
-by nothing at all — which is how an invalid `source` shape reached adopters. Both keep `additionalProperties: false` — a
-genuinely unknown key is still rejected.
+admits the same named subset. Both schemas keep `additionalProperties: false`;
+a genuinely unknown key is rejected.
 
 The pack's `README.md` is copied verbatim into both the claude-plugins and APM
 route directories, so the `readme = "README.md"` pointer resolves relative to
@@ -94,13 +91,11 @@ pack.
 `@<catalogue>/<pack>` when `[pack].catalogue` is set, and the bare `<pack>`
 otherwise. This is **declaration + rendering only** — there is no
 multi-catalogue *resolution* path; single-catalogue resolution in `list-packs`
-and `install` is unchanged. Cross-catalogue resolution is a follow-on
-(RFC-0031's index-contract / virtual-catalogue roadmap).
+and `install` is unchanged. There is no cross-catalogue resolution.
 
 ## What is intentionally *not* here
 
-- No hosted registry, persisted index, or `agentbundle search` (RFC-0031 scopes
-  these out).
+- No hosted registry, persisted index, or `agentbundle search`.
 - No per-tool field routing into the Codex / Copilot / Cursor manifests yet —
   the subset projects only into the claude-plugins + APM `plugin.json` /
   `marketplace.json` surface (a deferred follow-on).

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -22,7 +22,7 @@ backs both the **spec-stage secure-design pass** (is the control specified?) and
 ## Enforced frameworks
 
 All framework rows source their "Driving module(s)" from the [`security-checklists` Module
-index](../../../packs/core/.apm/skills/security-checklists/SKILL.md#module-index) —
+index](../../packs/core/.apm/skills/security-checklists/SKILL.md#module-index) —
 the authoritative boundary→module routing table. Rows without a runtime module are
 always-on passes in the reviewer body or spec-stage-only.
 
@@ -101,7 +101,7 @@ The audit reviewed ~60 skills across 14 packs. Findings and their status:
 | `research` skill did not explicitly state that fetched content is treated as data not instructions | Concern | AST05 | Added "Trust posture — retrieved content is untrusted data" section to `research/SKILL.md` |
 | `confluence-crawler` and `jira` skills did not declare SSRF containment for user-supplied base URLs | Concern | AST06 | Added agent pre-flight check note to Security rules in both `confluence-crawler/SKILL.md` and `jira/SKILL.md`. The scripts validate only the URL scheme (`http://`/`https://`); the host pre-flight check (reject private-IP ranges and cloud-metadata endpoints) is the agent's responsibility. On the token path `follow_redirects=True` is active — verify before invoking. |
 | Non-credentialed boundary-crossing skills carried no security metadata in frontmatter | Concern | AST10 | Added `metadata.boundaries` lists to: `assimilate-primitive`, `assimilate-repo`, `propose-catalogue-pack` (catalogue-curation; `export-catalogue` has since been removed — its CLI replacement carries this in the engine); `file-to-markdown`, `msg-to-markdown`, `markdown-to-docx`, `markdown-to-html`, `markdown-to-pptx`, `markdown-to-xlsx`, `mermaid-renderer` (converters); `release-loop` (release-engineering); `research`, `source-map` (research) |
-| `assimilate-primitive` Phase 1 lacked an explicit AST01-AST10 review step for ingested candidates | Concern | AST01-AST10 | Added step 5 (AST01-AST10 agentic-skills security review) to `assimilate-primitive/SKILL.md` Phase 1; `assimilate-repo` Never-do updated to name this gate |
+| Ingested candidates | Concern | AST01-AST10 | `assimilate-primitive` requires an AST01-AST10 agentic-skills security review; `assimilate-repo` names the same gate |
 
 ### Security metadata convention — `metadata.boundaries`
 

--- a/docs/architecture/work-intake-and-artifact-routing.md
+++ b/docs/architecture/work-intake-and-artifact-routing.md
@@ -1,367 +1,89 @@
 # Work intake and artifact routing
 
-> **Current architecture.** Core implements the standalone intake, canonical
-> artifact, deterministic workspace-index, and processor boundaries described
-> here. Tracker-owned refresh remains unavailable until a compatible adapter
-> implements the refresh contract.
+## 1. Purpose and boundary
 
-`work-intake` answers one basic question: given some work, what is the first
-local artifact worth creating? The route comes from content and altitude, not a
-tracker label or whichever downstream skill the user happened to name.
+`work-intake` turns local or tracker-supplied work into a canonical repository
+artifact and lifecycle entry. It classifies content by its delivery role rather
+than by a tracker label.
 
-This paper sets a common model. [RFC-0083](../rfc/0083-work-intake-and-artifact-routing.md) adopts it. [ADR-0077](../adr/0077-feature-projection-and-tracker-authority.md) refines part 2 of [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md): an app-scale feature no longer becomes a brief by default, and tracker authority follows explicit lifecycle rules. [ADR-0078](../adr/0078-standalone-intake-and-deterministic-workspace-index.md) records standalone intake, deterministic workspace indexing, and the shared layout boundary. [ADR-0033](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md)'s decision on `Level` and `Scale` remains intact. So do [ADR-0009](../adr/0009-product-brief-layer-and-plan-owned-lld.md)'s brief layer and plan-owned LLD.
+It does not replace a tracker or provide tracker refresh. Refresh remains
+adapter-owned and does not write repository state until a compatible adapter
+implements its contract.
 
-The decisions are straightforward: use `work-intake` as the single standalone front door; create briefs only when they earn their keep; index artifacts rather than requirements in `workspace.toml`; and say who owns tracker-imported fields at each lifecycle stage.
+## 2. Entrypoints
 
-## Goals and boundaries
+- `work-intake` accepts standalone work and routes it to an intent, brief,
+  spec, defect, or non-dispatchable capture.
+- `workspace-status` reads artifact and lifecycle state to report next work,
+  blocking references, and reconciliation findings.
+- Tracker adapters acquire and normalize source data before routing it through
+  `work-intake`.
 
-This design should let an adopter bring in work without knowing the local skill names or tracker vocabulary. It should leave a real artifact behind before anything becomes dispatchable. A later session should be able to see what is ready, what is blocked, and why, without guessing from old comments.
+## 3. Owned state and write authority
 
-The result is testable: every dispatchable entry resolves to a spec and plan; deleting or rewriting comments does not change routing; and two sessions reading the same files report the same ready, blocked, active, and reconciliation sets.
-
-It does not build a tracker replacement, a cross-repo control plane, or a new
-product-process mandate. It does not make every team create intents before
-writing a spec. Tracker refresh is a separate adapter-owned capability and does
-not mutate repository state while unavailable.
-
-## The model
-
-An **intent** is one recursive artifact. It is tagged with a `Level`. The recognized starting set is:
-
-```text
-product-vision → product-strategy → capability → feature
-```
-
-The set is open. An organization can add `initiative`, `epic`, `solution`, or another useful rung. Decompose one level at a time. `feature` is the last intent level.
-
-A **spec** (or slice) is what a feature produces for delivery. It is not another intent level. A spec is one independently shippable, verifiable behavioural contract. Its plan says how to build and verify that one contract.
-
-Do not blend the following ideas:
-
-| Term | What it answers |
-| --- | --- |
-| `Level` | At what product altitude is this decision? |
-| `Scale` | Does this concern one app or a business unit? |
-| `Kind` | Is this an outcome or opportunity traceability role? |
-| Workspace type | Which operating route should handle it? |
-| Tracker object type | What does an external tool happen to call it? |
-
-In particular, a workspace initiative is a coordination scope. It is not proof that an intent has `Level: initiative`.
-
-```mermaid
-flowchart LR
-  accTitle: Canonical artifact and requirements flow
-  accDescr: Evidence and governance feed a level-tagged intent tree, feature projection creates a brief or spec, and only a spec with a plan reaches work-loop; workspace and tracker links are non-authoritative references.
-  R[Study / research] --> I[Intent tree]
-  F[RFC] --> I
-  I --> G{Feature gate}
-  G -->|one repo, one change| S[Spec]
-  G -->|many slices or repos| B[Repo brief]
-  B --> S
-  S --> P[Plan]
-  P --> W[work-loop]
-  X[workspace.toml] -. indexes .-> I
-  X -. indexes .-> B
-  X -. indexes .-> S
-  T[Tracker: outside repo trust boundary] -. source or projection .-> I
-  T -. source or projection .-> B
-```
-
-The solid arrows are the requirements path. The dotted arrows are references, provenance, or a controlled import/export. A tracker can be the source of imported fields without becoming the repository's source of truth for everything.
-
-## When a feature needs a brief
-
-A brief earns its place when it holds something a spec cannot: the shared outcome and cut across several specs, or the local slice of a cross-repo effort.
-
-| Situation | Create |
-| --- | --- |
-| One independently shippable change in one repo | A spec |
-| Several independently shippable changes in one repo | A brief, then specs |
-| One feature spanning component repos | One brief per affected repo, then specs |
-| One repository's single-spec slice of a cross-repo feature | A brief is allowed only when it preserves shared identity, sibling ordering, or closure |
-
-This is a deliberate refinement of the current “app-scale feature intent is a brief” rule in [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md). Ordinary provenance belongs on the spec. A one-spec brief is justified only by a concrete cross-repo identity, ordering, or closure need.
-
-Cross-repo status is never read live during local dispatch. Each repo brief keeps a reviewed coordination receipt for a remote prerequisite, and the parent feature intent keeps reviewed closure receipts for its repo briefs. A receipt pins the remote locator, revision, terminal status, reviewer, and date. Its stable ID is local to the containing artifact. Accepting a new receipt revision updates matching local dependency pins atomically; rejection changes neither. That gives reconciliation durable local evidence without copying remote requirements or making one workspace authoritative for another.
-
-Start with shippability, not components. “The API” and “the screen” are not separate specs unless each can ship and be useful on its own. Likewise, a milestone, board, sprint, cycle, or JQL result is not a brief just because it contains several issues. It becomes one only when those issues serve one feature-level outcome and require several specs.
-
-## What each artifact is for
-
-| Artifact | Its job |
-| --- | --- |
-| Study/research | Hold evidence |
-| RFC | Propose a cross-cutting change and its governance constraints |
-| ADR | Record a durable architectural decision |
-| Intent | Hold an outcome, opportunity, assumptions, and product decomposition |
-| Brief | Hold a repo's multi-spec or cross-repo projection envelope |
-| Spec | Define one shippable, verifiable behaviour |
-| Plan | Explain how to implement and verify one spec |
-| Defect context | Record expected and observed behavior, reproduction evidence, provenance, and a durable citation proving the expectation is already intended |
-| Tracker object | Represent upstream demand or external coordination |
-| `workspace.toml` | Index artifacts, lifecycle, hard dependencies, provenance, and short display summaries |
-
-Names from other methods do not decide this. A BRD, PRD, FRD, SRS, or Jira Story can contain different kinds of work. Route the content instead:
-
-- A product outcome or opportunity becomes an intent at the right level.
-- A repo outcome that needs several specs becomes a brief.
-- One shippable contract becomes a spec.
-- A cross-cutting proposal becomes an RFC.
-- Evidence becomes study/research.
-- A deviation from cited intended behavior becomes a defect context; without
-  that durable evidence, it remains unresolved intake or becomes a Draft spec.
-
-`workspace.toml` is not another requirements document. Its comments are for people reading the file. Routing ignores them, and a later agent must never have to reconstruct a full spec from a comment.
-
-## Tracker profiles, not tracker ontology
-
-Different tools cut work at different places. Their names are hints, not local truth.
-
-| Local unit | Common tracker profiles |
-| --- | --- |
-| Product vision or strategy | Initiative, theme, strategy, roadmap item |
-| Capability | Initiative or portfolio epic |
-| Feature intent | Linear Project, Jira Align Feature, Jira Software Epic, GitHub Milestone |
-| Spec/slice | Linear Issue, Jira Story/Task, GitHub Issue |
-| Defect | A bug or defect workflow |
-
-The profile still has to pass the coherence and shippability test. A board is usually a scheduling view. A sprint is usually a time box. Neither tells us whether we should write a brief.
-
-## `work-intake`: one front door
-
-`work-intake` is the proposed standalone core front door. It does not depend on another pack, a particular tracker, or a pre-existing intent tree. It works from the material in front of it:
-
-- “Start/do this” creates or processes an intent, brief, spec, or defect.
-- “Remember this for later” records a capture without pretending it is ready to build.
-- “Where are we?” shows lifecycle, blocked work, broken references, and the next action.
-- “Refresh this from the tracker” fetches source data and applies a permitted reviewed change.
-
-If the input is a product outcome or opportunity, `work-intake` can route or materialize an intent. It does not need special installation state to do so. It also does not invent an intent when the direct answer is a brief, spec, defect, or capture.
-
-Shared intake owns only a minimal intent contract. It uses the existing `[core]` layout configuration with an in-repository parent; `docs/product/intents/` is the default, not a dependency on another workflow bundle. Keeping the parent in the repo lets every workspace entry use the same repository-relative path rule.
-
-This replaces `capture-work` in the target design. RFC-0083 keeps a temporary compatibility alias for two minor catalogue releases counted from the first write-new release and at least 90 days, then removes it after the migration gates pass. `work-intake` is the sole public intake surface throughout; the old name only forwards to it.
-
-```mermaid
-flowchart LR
-  accTitle: Adopter-facing work intake
-  accDescr: Start and remember may create artifacts, refresh reviews a delta against an existing artifact, and status reads the workspace without creating work.
-  A[Start / remember] --> X[Acquire source]
-  F[Refresh tracker] --> X
-  S[Where are we] --> R[Read workspace + artifacts]
-  X -. tracker trust boundary .-> N[Normalize]
-  N -->|start / remember| K[Classify delivery unit]
-  K --> M[Make canonical artifact]
-  M --> W[Register structured entry]
-  N -->|refresh| D[Resolve existing artifact]
-  D --> J[Invoke refresh processor]
-  J --> U[Review delta + guarded update]
-  W --> P[Selected processor]
-  U --> P
-  R --> T[workspace-status]
-```
-
-The creation path is simple: acquire the source, normalize it, decide whether it is an intent or a delivery unit, make the right local artifact, register that artifact, then call the processor that owns the next step. Refresh instead resolves an existing artifact and invokes the configured refresh processor, which reviews the delta and updates only after acceptance. Intake copies only required fields, redacts secrets and unnecessary sensitive data, and stops if the destination is more visible than the source. Status is read-only; its source is the workspace index and the artifacts it names.
-
-## Who owns imported requirements?
-
-There are two modes.
-
-- **Repo-origin.** The local intent, brief, or spec is authoritative. The tracker is a projection.
-- **Tracker-origin.** The tracker owns the fields imported from it until the local team accepts them.
-
-Tracker-origin does not mean “the tracker overwrites the repository.” Ownership is per field and recorded as provenance. Refresh is always a reviewed delta, not a blind sync.
-
-This lifecycle follows imported requirements through local acceptance and into a spec. A brief has its own, simpler lifecycle in the next section.
-
-```mermaid
-stateDiagram-v2
-  accTitle: Tracker-origin authority lifecycle
-  accDescr: Source-owned fields may refresh after review in Draft, require conflict resolution after local acceptance, lock during implementation, and allow trace-only writes after shipping.
-  [*] --> Draft: source crosses trust boundary
-  Draft --> Draft: refresh allowed after review
-  Draft --> Accepted: intent accepted
-  Draft --> Ready: brief accepted
-  Draft --> Approved: direct spec approved
-  Accepted --> Ready: feature projects to brief
-  Accepted --> Approved: feature projects to direct spec
-  Accepted --> Accepted: resolve conflict first
-  Ready --> Ready: resolve conflict first
-  Ready --> Approved: selected spec and plan approved
-  Approved --> Approved: resolve conflict first
-  Approved --> Implementing: local spec takes control
-  Implementing --> Shipped: verified delivery
-  Implementing --> Implementing: requirements refresh locked
-  Shipped --> Shipped: links, status, comments, PR, closure only
-```
-
-In Draft, source-owned fields can refresh after a reviewed delta. After an intent is Accepted, a brief is Ready, or a spec is Approved, a refresh needs explicit conflict resolution. While the spec is Implementing, it is authoritative and requirement refresh is locked. The containing brief is Executing during that time. After execution, tracker writes are limited to trace links, status, comments, PR links, and closure.
-
-This explains [linear-brief-sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md): it is a tracker-origin refresh before execution, not a mysterious exception to “trackers are one-way renders.” Repo-origin remains useful when a team authors locally and only publishes a tracker view.
-
-## What happens after a brief is received
-
-A brief is a durable planning envelope, not a dispatchable work item. It may stay Ready for as long as the team wants, with no specs or plans yet. Only the slices chosen for delivery move into specs and plans.
-
-```mermaid
-flowchart LR
-  accTitle: Brief-to-delivery lifecycle
-  accDescr: A brief may remain Ready until slices are selected; each slice becomes an approved spec and plan before it can enter work-loop.
-  B[Draft brief exists] --> V[Validate outcome and scope]
-  V --> R[Ready brief can wait]
-  R --> C[Choose and confirm current slices]
-  C --> S[Create spec.md + plan.md per slice]
-  S --> A[Review + approve each spec and plan]
-  A --> I[Index each spec in workspace.toml]
-  I --> Q[Queue or activate specs]
-  Q --> W[work-loop reads the spec]
-  W --> D{Brief has more work?}
-  D -->|yes| R
-  D -->|no| H[Ship the brief]
-```
-
-That flow gives each stage a concrete result:
-
-1. `work-intake` or `author-brief` writes the brief file and registers its path in `brief_queue.draft`.
-2. `receive-brief` fills the load-bearing gaps. Once the brief itself is accepted, it moves to Ready. The flow may stop here without creating delivery work.
-3. When the team chooses work from the brief, `receive-brief` shows the slice cut for that delivery and waits for confirmation.
-4. `new-spec` creates a `spec.md` and `plan.md` for each selected slice. Each spec carries its `Brief:` back-link and source provenance.
-5. A human reviews each contract and plan. Only an Approved spec is added to `work.queue`; each entry names the existing `spec.md`, its brief as the source artifact, a display summary, and any hard `needs` edges.
-6. Claiming the first active child moves the work entry to active, the spec to Implementing, and the brief to Executing as one guarded change. Further child claims retain Executing. Each completion retains Executing while another child remains active; the last returns the brief to Ready. It moves to Shipped only through a separate explicit close event when no scope remains and every materialized child spec is shipped.
-
-Deferred or future work stays in the brief's own scope and decomposition, where it can be reviewed. It does not need a placeholder work entry. If another slice is chosen later, create its spec and plan, then register it. Do not leave a proposed slice in a queue comment for a future session to interpret.
-
-Brief lifecycle follows these conditions. If stored membership disagrees with them, `workspace-status` reports drift instead of guessing:
-
-| Brief state | Condition |
-| --- | --- |
-| Draft | The brief exists, but its load-bearing fields or acceptance are incomplete. |
-| Ready | The brief is accepted and has no active child spec. It may have zero, queued, or shipped child specs and may remain here indefinitely. |
-| Executing | At least one child spec is active and not all children are shipped. |
-| Shipped | The brief is explicitly closed, has no remaining in-scope work, and every materialized child spec is shipped. It moves to `brief_queue.shipped` so the workspace keeps a structured history. |
-
-The children come from structured links: each derived spec's `Brief:` metadata and its workspace `source.artifact`. Remaining scope stays in the brief itself. Comments cannot add a child, change the cut, or move the brief between states.
-
-The target shape looks like this. The exact TOML syntax belongs to the RFC, but the references and meanings do not:
-
-```toml
-["ini-002".brief_queue]
-ready = [
-  { path = "docs/product/briefs/account-recovery.md", kind = "brief", source = { mode = "tracker-origin", ref = "PROJ-123", revision = "42" }, summary = "Make account recovery self-service", needs = [] },
-]
-
-["ini-002".work]
-queue = [
-  { path = "docs/specs/self-service-reset/spec.md", kind = "spec", source = { mode = "tracker-origin", artifact = "docs/product/briefs/account-recovery.md", ref = "PROJ-123", revision = "42" }, summary = "Let a user reset access without support", needs = [] },
-]
-```
-
-The brief holds the shared outcome, decomposition, and anything intentionally deferred. The spec holds a selected delivery contract. The plan holds its build strategy. `workspace.toml` holds only the index and lifecycle facts needed to find and sequence them. A Ready brief with no work entries is valid and non-dispatchable.
-
-## What the existing skills should do
-
-| Surface | Target responsibility |
-| --- | --- |
-| `work-intake` | Standalone entry point for start, capture, status, and refresh routing |
-| `capture-work` | Temporary compatibility alias that forwards to `work-intake` until the migration gates pass |
-| `author-brief` | Turn unstructured multi-spec input into a Draft brief |
-| `receive-brief` | Validate an existing brief and leave it Ready; when delivery is chosen, confirm the current cut and produce specs |
-| `new-spec` | Materialize one shippable contract, including provenance |
-| `work-loop` | Execute an existing spec and plan; never rebuild requirements from workspace comments |
-| `workspace-status` | Show lifecycle, next actions, and reconciliation failures |
-| Tracker adapters | Read and normalize source data, then route by local unit |
-| Tracker status/triage skills | Inspect or improve tracker state without creating repo artifacts by default |
-| Linear sync | Refresh source-owned fields before execution |
-
-The important boundary is between acquisition and routing. An adapter knows how to fetch a tracker object. It does not get to decide that every issue or collection deserves a brief. Defects stay on the defect route unless the input shows a different need.
-
-## The `workspace.toml` contract
-
-Every entry points to a real artifact. Queue membership is lifecycle state, not a substitute for the artifact. Given the same files and parsed TOML, two sessions must reach the same routing result.
-
-```text
-path:     repository-relative artifact path
-kind:     intent | research | design | brief | spec | defect
-source:   origin mode, durable locator and revision, parent / coordination reference
-summary:  display only
-needs:    hard dependencies
-```
-
-Routing may use only the structured entry, whether the referenced file exists, machine-readable artifact status, and explicit `needs`. It must not depend on comment text, list order, nearby prose, or what a previous session happened to know.
-
-The RFC will choose exact field names and migration details. It must preserve these rules:
-
-- Dispatchable work points to an existing `spec.md`; its sibling `plan.md` must also exist before execution.
-- A brief queue entry points to an existing brief.
-- A shaping entry points to an intent, research artifact, or design artifact.
-- A missing artifact is a reconciliation failure, or it is a non-dispatchable capture.
-- Comments do not affect routing.
-- A queue entry never authorizes an agent to infer the complete contract from surrounding comments.
-- A spec derived from a brief has the same brief path in its `Brief:` metadata and workspace source index. A mismatch is a reconciliation failure.
-- `needs` contains hard artifact dependencies only. Priority, affinity, suggested ordering, and rationale belong elsewhere.
-- A cross-repo `needs` condition points to a reviewed coordination receipt in the local brief. Dispatch checks its pinned revision and Shipped status from local files; it never reads another repository live.
-- A defect dependency is satisfied only by a closed defect whose structured resolution is `fixed`; declined or superseded defects remain history but do not unblock work.
-- Unknown kinds, malformed entries, duplicate lifecycle membership, and impossible transitions fail closed as reconciliation findings. The parser never falls back to comments.
-
-Provenance records identifiers and links, not credentials or a copied tracker payload. Refresh happens on an explicit request; this design does not add a polling service or webhook.
-
-Field ownership lives only in the canonical artifact's source-authority record. `workspace.toml` mirrors the mode, locator, and revision needed for routing and display; it is not a second authority map.
-
-After every completed refresh comparison, the artifact's compared revision and its workspace mirror advance atomically even when the human keeps local requirements; accepted requirements and dependency pins do not change. A failed acquisition or comparison advances neither.
-
-Shipped entries may leave the active workspace index only after no live dependency or open parent refers to them. Their canonical artifacts and Git history remain. ADR-0051's threshold still applies: 50 or more active specs across initiatives requires a fresh scale decision rather than an ever-growing single-file assumption.
-
-`workspace-status` should report broken references and inconsistent brief/spec links. A dispatcher should not start work until the referenced spec, plan, and hard dependencies exist. A capture without an artifact can remain visible; it cannot quietly become dispatchable work.
-
-## Other shapes we could choose
-
-We could keep the current rule that every feature becomes a brief. It is easy to explain, but it leaves a one-spec change with a wrapper that adds no useful information.
-
-We could make tracker objects the local model. That would reduce translation at first, but a Jira Epic, a Jira Align Feature, a Linear Project, and a GitHub Milestone do not mean the same thing. The local model would change every time a team changed tools.
-
-We could let `workspace.toml` comments carry enough detail for a later session to write a spec. That makes capture feel cheap, but it removes the acceptance criteria, provenance, and review point that make a spec safe to dispatch.
-
-## Risks and how to contain them
-
-The feature gate is a judgment call. A loose outcome can make unrelated tracker issues look coherent. The RFC should include routing examples and evaluations for one spec, many specs, cross-repo work, collections, and defects.
-
-Tracker-origin refresh can create difficult conflicts. Keep the first version small: record field ownership, show the delta, require an explicit decision, and lock requirement refresh once execution starts.
-
-Migration can leave old queue entries pointing nowhere. Treat each missing path as a visible reconciliation failure or an explicitly non-dispatchable capture. Do not silently promote it.
-
-A Ready brief can sit untouched long enough for its source or assumptions to age. `workspace-status` should keep it visible without calling it build-ready, and tracker-origin refresh rules still apply before a deferred slice is materialized.
-
-The operational failure to watch is a broken reference at session start. `workspace-status` needs to show it plainly, and dispatch needs to stop before an agent starts work from a comment.
-
-## What the migration resolves
-
-This table preserves the pre-migration evidence and the resolution implemented
-by this architecture.
-
-| Topic | Evidence | What it means | Proposed fix |
+| State | Location | Write authority | Readers |
 | --- | --- | --- | --- |
-| Raw brief input | [receive-brief](../../packs/core/.apm/skills/receive-brief/SKILL.md) says it receives PRDs/packets and accepts pasted documents, links, and verbal sketches. Its anti-pattern says raw email or Linear input must first use `author-brief`. | The entry rule is unclear. | `author-brief` makes Draft briefs from unstructured multi-spec input; `receive-brief` processes an existing brief. |
-| Captures | Before this migration, `capture-work` wrote only `workspace.toml`, created no spec, and asked for comments sufficient to write a full spec later. | Comments could become the real requirements store. | `work-intake` now materializes an artifact first; captures stay non-dispatchable until that artifact exists, and `capture-work` is only a compatibility alias. |
-| One issue | The [tracker guide](../../guides/_shared/how-to/choose-a-tracker-integration.md) says one issue is not a brief. The proposed [PM journey](../product/journeys/pm-intakes-from-tracker.md) and [RFC-0064](../rfc/0064-ini-001-ai-native-ecosystem.md) describe issue-to-brief intake. | Container names are doing too much routing work. | Use outcome coherence and shippability, not the object name. |
-| Feature equals brief | [ADR-0019](../adr/0019-product-intent-ontology-and-brief-projection.md) and [decompose-intent](../../packs/product-engineering/.apm/skills/decompose-intent/SKILL.md) make an app-scale feature a brief. | A one-spec change gets an empty wrapper. | Adopt the feature gate through an ADR refinement. |
-| Tracker authority | The [intent reference](../../guides/product-engineering/reference/intent-fields-and-modes.md) calls trackers one-way renders. [Linear sync](../../packs/linear/.apm/skills/linear-brief-sync/SKILL.md) imports reviewed deltas and locks at Executing. | “One-way” does not explain the Linear path. | Name repo-origin and tracker-origin modes. |
-| Registration | `author-brief`, `receive-brief`, and [Linear intake](../../packs/linear/.apm/skills/linear-brief-intake/SKILL.md) explicitly update `brief_queue`; [Jira](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md), [Jira Align](../../packs/atlassian/.apm/skills/jira-align-brief-intake/SKILL.md), and [GitHub](../../packs/github/.apm/skills/github-brief-intake/SKILL.md) stress file creation and handoff. | Queue visibility depends on the adapter. | Routing registers every materialized artifact. |
-| Collections | [Jira intake](../../packs/atlassian/.apm/skills/jira-brief-intake/SKILL.md) accepts a board, sprint, or JQL result as a brief story list without a confirmed common outcome. | A scheduling/query view can masquerade as one body of work. | Check shared outcome and multi-spec need before creating a brief. |
+| Canonical work artifacts | `docs/product/` and `docs/specs/` | The workflow that creates the artifact | Workflows, contributors, reviewers |
+| Lifecycle index | `workspace.toml` | `work-intake` and its selected workflow | `workspace-status`, execution, review |
+| Tracker provenance | Canonical artifact and its index entry | The accepting intake workflow | Refresh and reconciliation workflows |
 
-## Order the implementation this way
+`workspace.toml` indexes artifacts and lifecycle facts. It is not a
+requirements store.
 
-1. **RFC and ADR refinement.** Done when RFC-0083 settles routing, provenance, authority, and compatibility; one new ADR refines ADR-0019's projection and tracker rules; and another records standalone intake, the in-repo `[core]` layout consumer, deterministic workspace indexing, and the ADR-0051/ADR-0076 refinements.
-2. **Normalized intake and workspace contract.** Done when both have a versioned contract for path, kind, provenance, display summary, and hard `needs`.
-3. **Parser, status, and work-loop checks.** Done when broken references are visible and no dispatcher or work-loop run can get a contract from comments.
-4. **Standalone `work-intake` and core boundaries.** Done when start, remember, and status independently route normalized input, refresh delegates fail-closed until its processors land, and the `capture-work` alias is in place.
-5. **Tracker adapters.** Jira, Jira Align, Linear, and GitHub can change in parallel once they all normalize input, run the feature gate, and register artifacts the same way.
-6. **Refresh and write-back.** Done when reviewed deltas, conflicts, the execution lock, and allowed post-execution writes are implemented and tested.
-7. **Migration and guides.** Done when old entries are reconciled or marked as captures, aliases are documented if kept, and routing evaluations cover one spec, many specs, cross-repo work, collections, and defects.
+## 4. Dependencies and allowed edges
 
-Roll this out in those phases, not as a big-bang rewrite. Each phase can be reverted by retaining the old reader or alias until the next contract is proven. The maintainer group that accepts the RFC owns the rollout window and decides when an old compatibility path can be removed.
+Tracker adapters may acquire and normalize external input. Only the local intake
+route classifies it and writes canonical artifacts. Processors consume an
+existing artifact and workspace entry; they do not reconstruct a contract from
+index comments.
 
-RFC-0083 resolves the migration judgment: `capture-work` becomes a temporary alias that reads old state but writes only the new contract. Rollout is reader-first so the release immediately before write-new remains a dual-reader rollback target. Core maintainers own rollback from a reversible migration manifest; canonical artifacts are never deleted to make an old writer happy. The alias remains for two minor catalogue releases counted from the first write-new release and at least 90 days, then is removed only after the RFC's fixture, documentation, release-note, and Approver gates pass.
+The repository artifact is authoritative for repo-origin work. Imported
+tracker fields remain source-owned until local acceptance. This ownership rule is
+documented; this page does not claim a command enforces it.
 
-## Checks before adopting it
+## 5. Primary flows
 
-An RFC based on this paper should challenge six things: did we give two artifacts the same job; did we skip an intent level; did a tracker label become canonical; did `workspace.toml` become a second requirements store; did we create a brief with no added value; and is refresh authority obvious at every lifecycle state?
+1. `work-intake` acquires supplied material, normalizes it, classifies its
+   delivery role, writes the canonical artifact, and registers lifecycle state.
+2. `workspace-status` resolves indexed artifacts and reports ready, blocked,
+   active, and reconciliation states.
+3. A dispatchable spec has an existing `spec.md` and `plan.md`; execution
+   receives those files rather than tracker payloads or index comments.
+
+## 6. Failure and recovery behavior
+
+A missing artifact, malformed lifecycle entry, or inconsistent reference is a
+reconciliation finding. `workspace-status` reports it instead of guessing.
+
+Unavailable tracker refresh leaves repository state unchanged. A capture without
+a dispatchable artifact remains visible but cannot enter execution.
+
+## 7. Observability and evidence
+
+`workspace.toml`, canonical artifacts, and `workspace-status` provide the
+observable routing and lifecycle record. Provenance records the source locator
+and revision without copying credentials or a tracker payload.
+
+## 8. Mechanical invariants
+
+These skill scripts run in the finish-time checklist and can run as fail-closed
+CI gates where a PR event and Python exist. They do not fail closed inside an
+arbitrary adopter repository.
+
+- `lint-spec-status.py` checks `docs/specs/*/spec.md` metadata against the
+  status contract in `CONVENTIONS.md` §4.
+- `lint-traceability.py` flags structural orphans across the product chain.
+- `lint-brief-coverage.py` rolls each brief's Spec map from `Brief:` back-links
+  and requires a non-empty map of shipped specs for delivery.
+
+## 9. Relevant ADRs
+
+- [ADR-0009 — Product brief layer and plan-owned LLD](../adr/0009-product-brief-layer-and-plan-owned-lld.md)
+- [ADR-0019 — Product intent ontology and brief projection](../adr/0019-product-intent-ontology-and-brief-projection.md)
+- [ADR-0033 — Intent-level open recognized set decoupled from scale](../adr/0033-intent-level-open-recognized-set-decoupled-from-scale.md)
+- [ADR-0077 — Feature projection and tracker authority](../adr/0077-feature-projection-and-tracker-authority.md)
+- [ADR-0078 — Standalone intake and deterministic workspace index](../adr/0078-standalone-intake-and-deterministic-workspace-index.md)
+
+## 10. Last verified against commit
+
+`c8cf4b37`

--- a/docs/architecture/workspace-mcp/design.md
+++ b/docs/architecture/workspace-mcp/design.md
@@ -1,462 +1,98 @@
-# workspace-mcp
-
-**Status:** Stage 1 Implementing — `agentbundle` 0.29.1 (code present; behavioral integration tests are stubs, per spec deferral note)
-**RFC:** [0078](../../rfc/0078-workspace-mcp.md) · Accepted
-**Last updated:** 2026-08-04
-**Reviewers:** TBD
-
-> Renamed from `workspace-agent` to avoid collision with Claude Code subagents in `.claude/agents/`.
-
----
-
-## What it is
-
-`workspace-mcp` is a per-session MCP server that makes any agentbundle-equipped repo
-observable and controllable by ACP-compliant control planes. It bridges loop-engine FSM
-transitions, workspace queue state, human-gate events, and git operations to the MCP/ACP
-surface — without changing how skills run when no control plane is present.
-
-It runs as a sidecar to the AI agent process: one instance per session, stdio transport,
-no port binding. It exits when the session ends.
-
----
-
-## Why
-
-A control plane dispatching Claude Code via ACP receives free-form text output. It cannot
-distinguish a `SPEC-HUMAN-GATE` from normal output, a completed artifact write from a
-failed run, or which item in the workspace queue is ready to dispatch next.
-
-Three gaps block reliable unattended operation:
-
-1. **No FSM visibility.** The control plane cannot observe work-loop phase transitions. It
-   can't tell when a gate is pending, what the reviewer found, or whether the run succeeded
-   or abandoned.
-
-2. **No workspace discovery.** The control plane must know the repo's queue layout in
-   advance to dispatch work. Without a structured query surface, it is tightly coupled to
-   the repo's internal structure.
-
-3. **No git scoping.** Without guardrails, the AI may commit or push files outside the
-   dispatched item's scope — silently corrupting unrelated work.
-
-Elicitation (routing mid-session questions to the human) is **not** the primary gap — a
-control plane can receive questions through ACP's elicitation protocol (MCP
-`elicitation/create` request from server to client) without workspace-mcp, via Claude
-Code's built-in `AskUserQuestion` tool or turn-based HITL. workspace-mcp adds uniform elicitation across all skills via the session instruction,
-but the channel itself exists independently.
-
----
-
-## End-to-end flow
-
-```mermaid
-flowchart LR
-    CP["Control plane"]
-
-    subgraph acpsession["ACP session"]
-        ACA["ACP adapter"]
-        CC["AI agent"]
-    end
-
-    subgraph wmcp["workspace-mcp (per-session, stdio)"]
-        EB["Event bridge<br/>(polls events.jsonl)"]
-        TS["Tools<br/>workspace_status / elicit / git_*"]
-        AW["Artifact watcher<br/>(Stage 3+)"]
-    end
-
-    subgraph repofs["Repo"]
-        LE["loop-engine"]
-        EJ["events.jsonl"]
-        WT["workspace.toml"]
-        SD["artifact dirs"]
-        GIT["git"]
-    end
-
-    CP -->|"session/new + session/prompt"| ACA
-    ACA -->|"spawns, injects MCP config"| CC
-    CC -->|"MCP"| EB
-    CC -->|"MCP"| TS
-    CC -->|"CLI"| LE
-    LE --> EJ
-    EB -->|"tail-poll 200ms"| EJ
-    EB -->|"skill-state-change<br/>human-gate-pending"| CC
-    CC -->|"elicit()"| TS
-    TS -->|"elicitation/create (MCP request)"| ACA
-    ACA -->|"routes to human"| CP
-    CP -->|"JSON-RPC response (same request ID)"| ACA
-    ACA -->|"answer"| CC
-    TS -->|"reads"| WT
-    AW -->|"watches"| SD
-    AW -->|"artifact-created"| CC
-    CC -->|"session/update"| ACA
-    ACA --> CP
-    CC -->|"git_*"| TS
-    TS --> GIT
-```
-
-**Four primary flows:**
-
-| Flow | Path |
-|---|---|
-| **Progress** | loop-engine appends to `events.jsonl` → event bridge tail-polls → emits `skill-state-change` |
-| **Human gates** | Event bridge detects `*-HUMAN-GATE` → emits `human-gate-pending` with reviewer findings + gate question |
-| **Elicitation** | `elicit()` → MCP `elicitation/create` request (server→client JSON-RPC) → harness routes to human → harness returns JSON-RPC response to the request → `elicit()` unblocks |
-| **Git** | AI calls `git_*` tools → workspace-mcp validates against lifecycle manifest → subprocess |
-
-> **Observability caveat — Stage 1:** `claude-agent-acp@0.64.x` does not relay custom
-> JSON-RPC notification frames (the bridge's `case "notification": break` clause drops them).
-> workspace-mcp emits `_agentbundle.core/skill-state-change`, `_agentbundle.core/human-gate-pending`,
-> and related custom-method frames — not standard `notifications/message`. Gates surface as
-> `elicitation/create` requests instead; for FSM state reconciliation, open a separate
-> `WORKSPACE_MCP_SPEC_PATH`-bound session and call `workspace_status()`. The notification
-> definitions below are the target relay contract; relay support requires a future adapter update.
-
----
-
-## Adapter classes
-
-| Class | Adapters | MCP injection | elicitation/create | Session instruction |
-|---|---|---|---|---|
-| **A** | Claude Code, Codex | Per-session via `session/new.mcpServers` | Claude Code: ✓. Codex: ✗ (fallback). | `session/new._meta.systemPrompt` |
-| **B** | Kiro CLI (terminal binary) | Static `.kiro/settings/mcp.json` | Unconfirmed (fallback assumed) | Embedded in agent file |
-| **Deferred** | Kiro IDE, Copilot CLI, Gemini CLI, OpenCode | Incompatible | — | — |
-
-### Class A — Per-session injection
-
-The control plane injects workspace-mcp at `session/new.mcpServers`. Two spawn forms:
-
-```json
-// Trusted checkout (local developer):
-{
-  "mcpServers": [
-    {
-      "name": "workspace-mcp",
-      "command": "python3",
-      "args": [".claude/skills/workspace-status/scripts/workspace_mcp_server.py"],
-      "env": [{ "name": "WORKSPACE_MCP_SPEC_PATH", "value": "docs/specs/my-feature" }]
-    }
-  ]
-}
-
-// CI / untrusted checkout — module mode (-I flag, see Security):
-// Note: isolated-mode engine lookup is deferred to Stage 2; the guard in
-// _load_workspace_status_engine raises RuntimeError when sys.flags.isolated
-// is True and the engine file is not found via package-relative paths.
-{
-  "mcpServers": [
-    {
-      "name": "workspace-mcp",
-      "command": "python3",
-      "args": ["-I", "-m", "agentbundle.workspace_mcp"],
-      "env": [{ "name": "WORKSPACE_MCP_SPEC_PATH", "value": "docs/specs/my-feature" }]
-    }
-  ]
-}
-```
-
-The projection root for `args[0]` varies by adapter: `.claude/skills/` (Claude Code),
-`.agents/skills/` (Codex).
-
-Because workspace-mcp is injected per-session by the control plane, it is absent from
-every session the control plane did not create. Interactive editor sessions — a developer
-using Claude Code directly, not through a harness — never see the MCP server or the
-session instruction unless the user manually adds workspace-mcp to their global MCP
-config (not the intended deployment model). The exception is Class B adapters (see
-below): a Kiro CLI repo with workspace-mcp in `.kiro/settings/mcp.json` loads
-workspace-mcp in every terminal session, including interactive ones.
-
-**Session mode** is set by which env var is provided:
-
-| Env var | Value | Mode |
-|---|---|---|
-| `WORKSPACE_MCP_SPEC_PATH` | `docs/specs/<dir>` | FSM (work-loop items) |
-| `WORKSPACE_MCP_DISPATCHED_ITEM` | `{ini_slug}/{type}:{slug}` | Non-FSM (shaping, research, etc.) |
-| *(neither)* | — | Discovery — read-only; mutating git tools disabled |
-
-**Discovery mode** solves the bootstrapping problem: the control plane opens a short-lived
-session with no env var, calls `workspace_status()` to get the ready queue, then opens a
-bound session for the chosen item.
-
-**`WORKSPACE_MCP_DISPATCHED_ITEM` format** includes `ini_slug` because two active
-initiatives may legally have entries with the same `type` + `slug`. Omitting it would
-produce identical branch names and artifact scopes for distinct items.
-Example: `initiative-a/shape:initiative-x`.
-
-**Headless permissions.** Claude Code prompts for MCP tool approval before calling each
-tool. Pre-approve the six workspace-mcp tools so headless sessions don't hang:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "mcp__workspace-mcp__workspace_status",
-      "mcp__workspace-mcp__elicit",
-      "mcp__workspace-mcp__git_status",
-      "mcp__workspace-mcp__git_branch",
-      "mcp__workspace-mcp__git_commit",
-      "mcp__workspace-mcp__git_push"
-    ]
-  }
-}
-```
-
-Add these manually to `.claude/settings.json` (repo-scope) or `.claude/settings.local.json`
-(user-scope). `agentbundle install --pack core` will automate this once the additive-merge
-projection target ships (open item).
-
-### Class B — Kiro CLI (terminal binary)
-
-Kiro CLI (terminal binary) ignores `session/new.mcpServers` and reads from
-`.kiro/settings/mcp.json`. Configure once per repo; every session in that repo has
-workspace-mcp automatically. Concurrent FSM sessions are not supported.
-
-> **Note:** The installed `kiro` binary on most machines is Kiro IDE (GUI editor), not
-> the Kiro CLI terminal binary — these are separate products. Kiro IDE has no headless
-> ACP mode and is Deferred. Only the standalone Kiro CLI terminal binary is Class B.
-
-```json
-{
-  "mcpServers": {
-    "workspace-mcp": {
-      "command": "python3",
-      "args": [".kiro/skills/workspace-status/scripts/workspace_mcp_server.py"],
-      "env": { "WORKSPACE_MCP_SPEC_PATH": "docs/specs/my-feature" }
-    }
-  }
-}
-```
-
-Set `WORKSPACE_MCP_SPEC_PATH` for FSM (work-loop) sessions; omit it for non-FSM sessions.
-
-**Agent format.** Kiro CLI terminal binary uses JSON agents (`.kiro/agents/<name>.json`).
-Markdown agent support and `elicitation/create` capability depend on the installed CLI
-version — unconfirmed; response-file fallback assumed.
-
-**Mode detection (Stage 2c — planned, not implemented in 0.28.2).** The following describes
-the design for when Class B support ships; it is not present in the current codebase.
-Because the config is static, workspace-mcp will run two detectors concurrently
-(no per-session env var to determine mode):
-
-- **FSM detector:** polls for `engine-state.json` files strictly newer than the
-  process-start sentinel file. Wins over the non-FSM detector.
-- **Non-FSM detector:** reads the current branch at session start; binds on first
-  `git_branch()` call.
-
-If `WORKSPACE_MCP_SPEC_PATH` is set, gate-resume scanning will be scoped to that spec.
-If absent, the gate scan will be skipped — preventing a stale gate from a prior run from
-hijacking a new session.
-
-**Known limitation (design).** If the prior session ended on a feature branch and the new
-session starts on the same branch for a different item, workspace-mcp would bind the old
-slug. Workaround: check out the new item's branch before starting the session.
-
-**What differs from Class A:**
-
-- `_kiro.dev/mcp/server_initialized` fires before the first `session/prompt` — a reliable
-  readiness signal Class A adapters don't provide.
-- Session instruction is static (committed to the agent file), not per-dispatch.
-
-**What is identical:** all notifications, all tools, the reactive git model, lifecycle
-manifest. The workspace-mcp binary does not change between classes.
-
-### Deferred
-
-| Adapter | Reason |
-|---|---|
-| Kiro IDE | GUI editor — no headless ACP mode |
-| Copilot CLI | MCP transport incompatibility: Copilot CLI only supports HTTP and SSE MCP transports; workspace-mcp is stdio-only (confirmed v1.0.78 `mcpCapabilities: {http: true, sse: true}`) |
-| Gemini CLI | Inverts the MCP direction |
-| OpenCode | Ignores `mcpServers` entirely |
-
----
-
-## Components
-
-### Event bridge
-
-Tail-polls `.loop-run/events.jsonl` at 200ms using position-based reads (seek to last
-offset). Never misses a line regardless of transition rate.
-
-On each valid line whose `run_id` matches the session:
-
-- Skips `seq ≤ last_emitted_seq` (idempotent replay guard).
-- Emits `_agentbundle.core/skill-state-change`.
-- If `to` ends in `*-HUMAN-GATE`, also emits `_agentbundle.core/human-gate-pending`
-  enriched with reviewer output and gate question from `engine-state.json`.
-
-**Crash recovery.** On each poll, if file size < saved offset or inode changed (from a
-`cmd_reset` + `cmd_init` cycle), the bridge resets offset and re-enters lazy `run_id`
-discovery.
-
-**Torn-write recovery.** The bridge holds partial final lines at the current offset until
-the next poll. loop-engine prepends a bare `\n` when appending a new event if the file
-doesn't end with one — terminating the partial record without corrupting the new event.
-
-**loop-engine outbox protocol.** A naive write-then-append loses events on crash between
-the two writes. `cmd_transition` uses an outbox:
-
-1. Write pending event to `.loop-run/events.pending` (truncate-and-rewrite)
-2. Atomically rename `engine-state.json.tmp` → `engine-state.json`
-3. Append the pending event to `events.jsonl`
-4. Delete `.loop-run/events.pending`
-
-On startup, if `events.pending` exists: if `engine-state.json` shows `state == pending.to`
-AND `seq` matches, replay (append + delete). Otherwise discard.
-
-### workspace_status()
-
-Returns a DAG-resolved view of `workspace.toml`: ready items, shaping items, blocked items
-(with named unmet `needs:` edges), and active items. Also returns FSM state fields:
-`current_state`, `gate_pending`, `gate`, `gate_question`, `review_findings`.
-
-The control plane uses `workspace_status()` to:
-
-1. Discover which items to dispatch (discovery mode).
-2. Poll FSM state, replacing push notifications while relay support is pending.
-
-### Elicitation
-
-Every skill elicits from the user at informal moments (clarifying questions, option
-selection) as well as formal gate states. Restricting elicitation to gate states alone
-leaves the control plane blind to most of a session.
-
-**Delivery path** is chosen at MCP handshake time from the host's `capabilities.elicitation`:
-
-| Host declares `elicitation` | Path | Notes |
-|---|---|---|
-| Yes | MCP `elicitation/create` request (server→client JSON-RPC) — harness replies to the same request ID with the answer | Confirmed for Claude Code via `claude-agent-acp@0.64.2` (`elicitation.ts`). The ACP SDK wraps this as `unstable_createElicitation()` — marked unstable; no separate "complete" call. |
-| No | Response-file fallback | workspace-mcp writes to a `O_EXCL 0600` temp file. Control plane reads `response_path` from `_agentbundle.core/elicitation-pending` and writes response via atomic rename. |
-
-workspace-mcp never advertises `elicitation` in its own `ServerCapabilities` — that field
-belongs to the client.
-
-**Session instruction** tells the AI to call `elicit()` for all questions rather than
-emitting text to the user. Injected once at `session/new._meta.systemPrompt` (Class A) or
-embedded in the V3 agent file (Class B). Persists for the session lifetime — no per-turn
-re-injection required.
-
-```
-You are operating in a workspace managed by workspace-mcp. Follow these rules for this
-entire session — they apply to every turn, including follow-up user messages.
-
-1. If the `workspace_status` tool is available, call workspace_status() at session start
-   to understand the current queue before doing any work.
-2. Do not call git commands directly. Use the git_* tools provided by workspace-mcp.
-   Exception: if you are running the work-loop skill and an active FSM run is underway,
-   work-loop owns its git lifecycle — do not intercept it via git_* tools.
-3. When you would ask the user a question, request approval, show options, or elicit any
-   response — check if the `elicit` workspace-mcp tool is available. If it is, call
-   elicit(message, context, options) and wait for the returned response instead of emitting
-   text to the user.
-4. The workspace-mcp tools remain available for the duration of the session.
-5. Before writing artifacts for a non-FSM item, call git_branch(<ini_slug>/<type>/<slug>)
-   if not already on the item's feature branch.
-6. When instructed to commit and push, call git_status() to identify uncommitted files,
-   git_commit(message) to stage and commit matching paths, then git_push(branch).
-```
-
-### Git tools
-
-`git_status`, `git_branch`, `git_commit`, `git_push` — executed via subprocess, scoped to
-the dispatched item's `output_pattern` from the lifecycle manifest. `git_commit` intersects
-the working tree against the item's output pattern: unrelated **unstaged** files are silently
-excluded (not staged); **pre-staged** files outside the output paths cause a hard refusal (the
-call returns an error; no bridge-warning notification is emitted in Stage 1).
-
-Push target is validated against the dispatched item's manifest branch.
-Discovery mode and FSM mode disable all mutating tools.
-
-### Lifecycle manifest
-
-Maps workspace item types to `output_pattern`, `dispatch_skill`, and git behaviour.
-Built-in defaults cover the known type taxonomy. Third-party packs extend by projecting
-files to `workspace-types.d/` (additive, no clobber).
-
-### Artifact watcher *(Stage 3+)*
-
-Polls each dispatched item's `output_pattern` directory at 200ms using recursive listing
-snapshot diffs. Emits `_agentbundle.core/artifact-created` when a new file appears.
-
----
-
-## Notification contract
-
-All notifications are custom JSON-RPC 2.0 notification frames with `_agentbundle.core/`-namespaced
-method names (e.g. `_agentbundle.core/skill-state-change`), not standard MCP `notifications/message`.
-
-| Notification | When | Key payload fields |
-|---|---|---|
-| `skill-state-change` | Each FSM transition | `seq`, `run_id`, `spec`, `from`, `event`, `to`, `at` |
-| `human-gate-pending` | FSM enters `*-HUMAN-GATE` | `gate`, `spec_path`, `review_findings`, `question` |
-| `gate-pr-ready` | `pr_url` appears in `engine-state.json` during `CODE-HUMAN-GATE` | `gate`, `spec_path`, `pr_url` |
-| `run-complete` | FSM reaches `DONE` or `ABANDONED` | `run_id`, `outcome`, `spec_path`, `pr_url` |
-| `elicitation-pending` | `elicit()` called — fallback path only | `message`, `context`, `options`, `session_id`, `elicit_seq`, `correlation_id`, `response_path` |
-| `artifact-created` | New file in watched output dir *(Stage 3+)* | `path`, `item_slug`, `item_type`, `session_id` |
-| `skill-complete` | `git_push` returns for non-FSM item | `item_slug`, `item_type`, `committed_paths`, `branch`, `pushed` |
-| `bridge-warning` | Bridge or watcher detects a problem | `reason`, reason-specific fields |
-
-**`pr_url` ordering.** work-loop opens the PR *after* the `CODE-HUMAN-GATE` transition.
-`human-gate-pending` fires at the transition; `gate-pr-ready` fires seconds later when
-`pr_url` appears in `engine-state.json`. The control plane must not block on `pr_url` in
-`human-gate-pending`.
-
-**Gate vs. elicitation.** `human-gate-pending` and `elicitation-pending` are distinct.
-A gate blocks the FSM until resolved; an elicitation is an informal question. Both are
-resolved via `elicit()`. The join key: `elicitation-pending.correlation_id ==
-human-gate-pending.gate`.
-
----
-
-## Security
-
-| Constraint | Why |
-|---|---|
-| `-I` flag required for untrusted checkouts | Without it, a repo-provided `agentbundle/` directory shadows the installed wheel and achieves RCE in the control plane process. |
-| Response-file: `mkdtemp(0700)` + `O_EXCL 0600` | Prevents pre-seeding by a different-uid process; same-uid isolation is not guaranteed — documented limitation in `_ElicitTool`. |
-| Response-file write: atomic rename only | Direct write risks workspace-mcp reading a partial file. |
-| Git push validated against manifest branch | Rejects pushes to unexpected branches. Routing-only — not authentication. |
-| Slug safety: `^[a-zA-Z0-9._-]+$`, rejects `.` / `..` / leading `-` | Prevents path traversal in output_pattern glob construction. |
-
----
-
-## Decisions
-
-Full rationale and alternatives in each ADR. Summary:
-
-| Decision | ADR |
-|---|---|
-| Session instruction over per-skill gate modification | ADR-0063 |
-| Per-session process, not a daemon | ADR-0062 |
-| `events.jsonl` as event source (not in-process IPC) | ADR-0064 |
-| `elicit()` + `elicitation/create` + response-file fallback | ADR-0065 |
-| Reactive git at TurnEnd (not declarative `git_managed` flag) | ADR-0066 |
-| Lifecycle manifest: built-in defaults + `workspace-types.d/` | ADR-0067 |
-| Notification namespace: `_agentbundle.core/` | ADR-0068 |
-| Threading: daemon threads + bounded pool (not asyncio) | ADR-0069 |
-
----
-
-## Rollout
-
-| Stage | Scope | Status |
-|---|---|---|
-| **0 — Spikes** | Five design spikes | **Closed** — see `docs/rfc/0078-notes/spike-results.md` |
-| **1 — Claude Code, work-loop** | Single adapter, FSM sessions | **Implementing** — agentbundle 0.29.1; behavioral integration tests are stubs (spec deferral note); PR #860 |
-| **2a — Codex** | Response-file elicitation fallback, headless permissions | Not started |
-| **2b — Codex** | Response-file elicitation fallback, headless permissions | Not started |
-| **2c — Kiro CLI (terminal)** | Static `.kiro/settings/mcp.json` config, agent format, `elicitation/create` | Not started |
-| **3 — Non-FSM skills** | Artifact watcher, desk-research, PE, XD | Not started |
-| **4 — Multi-instance, worktrees** | Concurrent sessions, convergence | Future scope |
-
----
-
-## Open items
-
-| Item | Blocking | Notes |
-|---|---|---|
-| Additive-merge `permissions.allow` projection in agentbundle Claude adapter | Automated install | Manual workaround: add entries to `.claude/settings.json` directly |
-| Kiro CLI (terminal) Markdown agent + `elicitation/create` confirmation | Stage 2c | Depends on installed CLI version; response-file fallback assumed |
-| Copilot CLI stdio transport | Deferred indefinitely | Confirmed incompatible (v1.0.78): HTTP/SSE only, no stdio |
-| Behavioral test suite (`workspace-mcp-stage1-behavioral-tests`) | AC3–AC16, AC21–AC22 | Tracked in `workspace.toml` backlog |
-| ACP notification relay (`case "notification": break` in `claude-agent-acp`) | Push-based FSM observability | Upstream `claude-agent-acp` |
+# Workspace MCP
+
+## 1. Purpose and boundary
+
+`workspace-mcp` is a per-session, stdio MCP server for an
+agentbundle-equipped repository. It exposes workspace status, controlled
+elicitation, scoped Git operations, and loop-state observations to an ACP
+control plane.
+
+It exits with its session and binds no network port. It reads loop events but
+does not write the event stream.
+
+## 2. Entrypoints
+
+- `python3 -m agentbundle.workspace_mcp` starts the server.
+- `workspace_status` reads workspace and bound-loop state.
+- `elicit` sends a client elicitation request or uses the response-file
+  fallback.
+- `git_status`, `git_branch`, `git_commit`, and `git_push` provide
+  lifecycle-scoped Git operations.
+- `WORKSPACE_MCP_SPEC_PATH` binds an FSM session.
+  `WORKSPACE_MCP_DISPATCHED_ITEM` binds a non-FSM item. Neither enables
+  mutating tools in discovery mode.
+
+## 3. Owned state and write authority
+
+| State | Location | Write authority | Readers |
+| --- | --- | --- | --- |
+| Session process state | Server process | `workspace_mcp.py` | ACP client and agent |
+| Event offset | Per-session server state | `workspace_mcp.py` | Event bridge |
+| Response file | Per-elicitation temporary directory | ACP client response writer | `elicit` |
+| Loop events | `.loop-run/events.jsonl` | `loop-engine.py` | Workspace MCP event bridge |
+| Workspace lifecycle | `workspace.toml` and artifacts | Owning workflow | `workspace_status` and Git tools |
+
+## 4. Dependencies and allowed edges
+
+Workspace MCP reads `workspace.toml`, lifecycle artifacts, and
+`.loop-run/events.jsonl`. It tails events by byte offset and never writes them.
+
+The server invokes loop and Git operations through its bounded tool surface.
+Git tools validate the dispatched lifecycle manifest before subprocess use.
+Third-party pack types may extend `workspace-types.d/` additively.
+
+## 5. Primary flows
+
+1. The control plane starts a bound or discovery session and the agent calls
+   `workspace_status`.
+2. The event bridge tails matching loop events and emits namespaced state and
+   human-gate notifications.
+3. `elicit` sends `elicitation/create` when the client supports it; otherwise
+   it waits for an atomically published response file.
+4. Git tools validate output paths and branch before status, branch, commit, or
+   push operations.
+
+## 6. Failure and recovery behavior
+
+If an event file shrinks or its inode changes, the bridge resets its offset and
+rediscovers the run identifier. It holds a partial final event until the next
+poll.
+
+Response files use a private directory, exclusive creation, and atomic rename.
+A partial or different-UID pre-seeded response cannot be consumed. Same-UID
+isolation is not guaranteed.
+
+Pre-staged files outside the dispatched output pattern cause a Git refusal.
+Discovery and FSM modes disable mutating Git tools. Invalid slugs are rejected
+before output-pattern construction: they must match `^[a-zA-Z0-9._-]+$` and
+cannot be `.`, `..`, or begin with `-`. Manifest branch validation routes pushes
+but does not authenticate them.
+
+Untrusted checkouts start with Python `-I`. Isolated mode prevents a
+repository-provided `agentbundle/` directory from shadowing the installed wheel.
+
+## 7. Observability and evidence
+
+`workspace_status` returns ready, shaping, blocked, and active items with
+unmet dependencies and bound FSM fields. The event bridge emits
+`_agentbundle.core/` notifications and records its byte-offset progress.
+
+Git tool results, response paths, lifecycle artifacts, and the loop event stream
+provide the session evidence record.
+
+## 8. Mechanical invariants
+
+None. No supplied command mechanically verifies workspace-MCP's runtime
+security boundaries or notification delivery.
+
+## 9. Relevant ADRs
+
+- [ADR-0062 — Workspace MCP per-session constraint](../../adr/0062-workspace-mcp-per-session-only-constraint.md)
+- [ADR-0064 — Events JSONL as FSM event source](../../adr/0064-events-jsonl-as-fsm-event-source.md)
+- [ADR-0065 — Elicit create response-file fallback](../../adr/0065-elicit-elicitation-create-response-file-fallback.md)
+- [ADR-0068 — Notification namespace x-core](../../adr/0068-notification-namespace-x-core.md)
+- [ADR-0069 — Threading model: daemon threads and bounded pool](../../adr/0069-threading-model-daemon-threads-bounded-pool.md)
+
+## 10. Last verified against commit
+
+`c8cf4b37`

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -65,14 +65,20 @@ below assigns every kind of doc to exactly one bucket.
                                        └────────────────────────────┘
 ```
 
-Inside `architecture/`, the two docs play opposite roles. `overview.md` is
-**descriptive** — the map of how the code is organized today, read to find
-things. `reference.md` is **normative** — the golden path (stack, building
-blocks, component stereotypes, cross-cutting standards) that new work conforms
-to, the target a feature's low-level design steers by. The map tells you where
-things are; the golden path tells you how new things should be shaped. A thin
-repo has only the map; the golden path appears once there are real architecture
-decisions to hold work to.
+`/ARCHITECTURE.md`, when present, is the concise descriptive system model:
+responsibilities, allowed dependency edges, state ownership, flows, extension
+points, enforced invariants, and deeper current-state links. It is optional;
+add it when a repo has more than one subsystem or a boundary the directory
+tree cannot make clear.
+
+Architecture documents have three roles. `overview.md` is **descriptive** —
+the map of how the code is organized today, read to find things.
+`reference.md` is **normative** — the golden path (stack, building blocks,
+component stereotypes, cross-cutting standards) that new work conforms to, the
+target a feature's low-level design steers by. The system model explains the
+system, the map tells you where things are, and the golden path tells you how
+new things should be shaped. A thin repo has only the map; the golden path
+appears once there are real architecture decisions to hold work to.
 
 The bottom layers cite the upper layers; upper layers do not know about
 lower layers. That's the whole point of the hierarchy.
@@ -99,7 +105,7 @@ maintenance rules differ:
 
 | Class | Files | Rule |
 | --- | --- | --- |
-| **Living** | `CHARTER.md`, `architecture/*`, `product/*`, `guides/*`, active `specs/*` | Must match current reality. Updated in the same PR as any change that affects them. Drift is a bug. |
+| **Living** | `CHARTER.md`, `ARCHITECTURE.md`, `architecture/*`, `product/*`, `guides/*`, active `specs/*` | Must match current reality. Updated in the same PR as any change that affects them. Drift is a bug. |
 | **Frozen** | `adr/*`, shipped `specs/*`, accepted/rejected `rfc/*` | Immutable history. Status fields can change (Accepted → Superseded), bodies cannot. |
 | **Governance** | open `rfc/*` | In flight. Updated through the RFC process, not direct edits. Closes to Frozen on acceptance/rejection. |
 
@@ -592,10 +598,17 @@ what was decided or what's proposed. Each serves a different audience:
 How the code is *currently* organized. Not why (ADRs); not what we want
 (RFCs); what is.
 
+- `ARCHITECTURE.md` — when present, the concise system model: responsibilities,
+  allowed dependency edges, state ownership, flows, extension points,
+  mechanically enforced invariants, and deeper current-state links.
 - `overview.md` — the map of the monorepo. What's in `apps/`, `packages/`,
   `tools/`, and how they relate.
 - `<subsystem>.md` — one file per non-trivial subsystem. Describes the
   structure, the entry points, and links to the ADRs that explain why.
+
+`architecture/` holds current state. A designed-but-unbuilt subtree is admitted
+only when its index carries a `STATUS: PLANNED` marker and links to its
+governing decision.
 
 **Why separate from ADRs:** ADRs accumulate; current state has to be
 reconstructed by reading them all in order. `architecture/` is the

--- a/tests/roster/test_adapt_reference_architecture.py
+++ b/tests/roster/test_adapt_reference_architecture.py
@@ -160,7 +160,7 @@ def _conventions_added_block() -> str:
     added — the lines the adopter-clean grep must be scoped to (the document at
     large legitimately names RFC/ADR/docs paths elsewhere)."""
     body = CONVENTIONS_SEED.read_text(encoding="utf-8")
-    start_marker = "Inside `architecture/`, the two docs play opposite roles"
+    start_marker = "`/ARCHITECTURE.md`, when present, is the concise descriptive system model"
     end_marker = "The bottom layers cite the upper layers"
     assert start_marker in body, (
         f"CONVENTIONS gloss {start_marker!r} moved — update this slice"

--- a/tools/lint-agents-md.py
+++ b/tools/lint-agents-md.py
@@ -325,6 +325,7 @@ def main() -> int:
     # 9. Stale living-doc check (warn-only)
     living_docs = (
         "docs/CHARTER.md",
+        "ARCHITECTURE.md",
         "docs/architecture/overview.md",
         "docs/product/roadmap.md",
     )


### PR DESCRIPTION
## What and why

`docs/architecture/` was carrying four jobs at once: a directory map, a catalogue explainer, adapter-version and RFC history, and onboarding. Three pages carried RFC bodies outright — `work-intake-and-artifact-routing.md` still argued *"Other shapes we could choose"* and *"Order the implementation this way"*, `knowledge-capture.md` carried Migration and Progressive rollout, `loop-infrastructure.md` was titled Phase 1 with a deferred Phase 2.

**Net −3,600 lines.**

## The root model

New `ARCHITECTURE.md` answers eight questions in order: what systems exist, their responsibilities, which direction dependencies may flow, who owns each kind of state, the five end-to-end flows, the extension points, which invariants are mechanically enforced, and where each subsystem's deeper page is.

`docs/architecture/overview.md` stays as the directory map — ADR-0010's descriptive/normative split is preserved, and `reference.md` remains the unwritten normative golden path.

## Subsystem pages

Six load-bearing pages moved onto a current-state contract (purpose and boundary, entrypoints, owned state and write authority, dependencies and allowed edges, primary flows, failure and recovery, observability, mechanical invariants, relevant ADRs, last verified against commit):

| Page | Before | After |
|---|---:|---:|
| `knowledge-capture.md` | 819 | 91 |
| `credentials.md` | 669 | 164 |
| `workspace-mcp/design.md` | 462 | 97 |
| `work-intake-and-artifact-routing.md` | 367 | 89 |
| `agentbundle.md` | 305 | 89 |
| `loop-infrastructure.md` | 164 | 78 |

§8 lists only invariants with a **named enforcer**. Where a boundary is documented but unenforced, the page says so rather than implying a gate exists.

## binder-publishing

4,100 lines of design for unbuilt work. It keeps its place — it is intended for implementation — but now carries a literal `STATUS: PLANNED` marker, and CONVENTIONS admits such a subtree only with that marker plus a link to its governing decision (ADR-0073). Prose cut against one test: *would an implementer need this to write correct code?* Every control, argv, allowlist, exit code and `D-n` reference survives.

## Two gaps surfaced, recorded rather than papered over

- **The binder design cites an originating brief that is absent from this repository.** Fourteen of its twenty-two invariants are therefore unrecoverable from the tree. `overview.md` now says so plainly. **That brief needs recovering before anyone builds this.**
- `docs/architecture/README.md` indexed nine of twelve pages. Now indexes all of them.

## Verification

- `make build-check` (incl. SAST) — clean
- `pytest tests/` — 410 passed, 46 subtests
- `packs/core/tests/` — per-directory, all passing
- `lint-agents-md` / `lint-ruff` / `lint-mypy` — clean
- Every link and anchor across the tree resolves (verified by enumeration)

The roster suite caught three real regressions from this trim and all three are fixed: a test anchored on a CONVENTIONS sentence this PR replaces, and `agentbundle.md` losing `pre-release` / `marketplace` / `catalogue-index.json`. The one-line test-anchor change is **mutation-proved** — injecting `RFC-1234` into the guarded block fails `test_conventions_added_block_is_adopter_clean`, so the adopter-clean grep still has teeth under the new anchor.

## Notes for review

- `docs/CONVENTIONS.md` is a **generated projection** of `packs/core/seeds/docs/CONVENTIONS.md`. The seed is the edit target here; the projection was regenerated.
- One line in `tools/lint-agents-md.py`: the warn-only staleness watch now covers `ARCHITECTURE.md`.
- Rebased onto `db5a4ed0` (the AGENTS.md simplification). The `AGENTS.md` conflict was resolved in favour of that PR's terser register, carrying only the new pointer; 83 lines against its 120 cap.

Related: ADR-0010, ADR-0073