### PR TITLE
fix(tools): read the scope declaration past frontmatter in projected AGENTS.md

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -369,6 +369,7 @@ jobs:
           python -m pytest tools/test_lint_agents_md_diataxis_block.py \
             tools/test_lint_agents_md_legacy_block.py \
             tools/test_lint_agents_md_risk_block.py \
+            tools/test_lint_agents_md_frontmatter_scope.py \
             tools/test_catalogue_curation_guard.py \
             tools/test_contract_parity.py \
             tools/test_marketplace_envelope_parity.py \

--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,7 @@ test:
 		tools/test_lint_agents_md_diataxis_block.py \
 		tools/test_lint_agents_md_legacy_block.py \
 		tools/test_lint_agents_md_risk_block.py \
+		tools/test_lint_agents_md_frontmatter_scope.py \
 		tools/test_catalogue_curation_guard.py \
 		tools/test_contract_parity.py \
 		tools/test_marketplace_envelope_parity.py \

--- a/tools/lint-agents-md.py
+++ b/tools/lint-agents-md.py
@@ -45,6 +45,28 @@ _SEED_VENDOR_ROOT_BACKLOG = frozenset({
 })
 
 
+def _body_lines(text: str) -> list[str]:
+    """Return the document body, skipping a leading YAML frontmatter block.
+
+    Projected copies of an AGENTS.md carry frontmatter where the source carries
+    an ATX heading. Without this, the opening `---` is the first non-heading
+    line and the scope-declaration check reads the delimiter instead of the
+    declaration, so a correct projection fails while the check never inspects
+    the sentence it exists to enforce.
+    """
+    lines = text.splitlines()
+    # A YAML document marker sits at column zero. Accepting an indented `---`
+    # would treat a leading Markdown horizontal rule as frontmatter and skip
+    # past it, so a document that declares nothing would pass a check the
+    # unindented form correctly fails.
+    if not lines or lines[0].rstrip() != "---":
+        return lines
+    for index, line in enumerate(lines[1:], start=1):
+        if line.rstrip() in ("---", "..."):
+            return lines[index + 1:]
+    return lines
+
+
 def _is_seed(path: Path) -> bool:
     return (
         path.name == "AGENTS.md"
@@ -231,7 +253,7 @@ def main() -> int:
         first_content = next(
             (
                 line
-                for line in text.splitlines()
+                for line in _body_lines(text)
                 if line.strip() and not line.lstrip().startswith("#")
             ),
             "",

--- a/tools/test_lint_agents_md_frontmatter_scope.py
+++ b/tools/test_lint_agents_md_frontmatter_scope.py
@@ -1,0 +1,116 @@
+"""Regression checks for the scope-declaration lint on projected AGENTS.md files.
+
+A projected copy of an AGENTS.md carries YAML frontmatter where the repository
+source carries an ATX heading. The scope-declaration check reads the first
+non-heading line, so before frontmatter was skipped it read the opening `---`
+delimiter: a correct projection failed, and the check never inspected the
+sentence it exists to enforce.
+
+These assert stderr because scratch repositories intentionally fail unrelated
+structure checks; the scope-declaration diagnostic is the signal under test.
+Each case builds its own scratch repository so no case can be made to pass or
+fail by another case's fixture.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LINTER = REPO_ROOT / "tools" / "lint-agents-md.py"
+# File-specific: a scratch repository emits unrelated "is missing" diagnostics
+# (absent charter, Diátaxis directories), so a bare substring would match noise
+# and let a case pass or fail for the wrong reason.
+MARKER = "web/AGENTS.md is missing"
+DECLARATION = (
+    "Applies to `web/`. Inherits the root `AGENTS.md`. Scope-specific deltas only."
+)
+
+
+def run(root: Path) -> str:
+    result = subprocess.run(
+        [sys.executable, str(LINTER)],
+        cwd=root,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return result.stderr
+
+
+def scratch(root: Path, scoped_body: str) -> None:
+    (root / "AGENTS.md").write_text("# AGENTS.md\n", encoding="utf-8")
+    (root / "CLAUDE.md").symlink_to("AGENTS.md")
+    scoped = root / "web" / "AGENTS.md"
+    scoped.parent.mkdir(parents=True)
+    scoped.write_text(scoped_body, encoding="utf-8")
+
+
+FRONTMATTER = '---\ntitle: "AGENTS.md — `web/`"\n---\n\n'
+
+
+class FrontmatterScopeDeclarationTests(unittest.TestCase):
+    def test_projected_file_with_declaration_is_silent(self) -> None:
+        """The defect under repair: this correct projection used to fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scratch(root, f"{FRONTMATTER}{DECLARATION}\n")
+            self.assertNotIn(MARKER, run(root))
+
+    def test_source_file_with_declaration_is_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scratch(root, f"# AGENTS.md — `web/`\n\n{DECLARATION}\n")
+            self.assertNotIn(MARKER, run(root))
+
+    def test_projected_file_missing_the_declaration_still_fails(self) -> None:
+        """Skipping frontmatter must not turn the check into one that cannot fail."""
+        for body in (
+            "An opening sentence that declares nothing.",
+            "Applies to `web/`. Scope-specific deltas only.",
+            "Inherits the root `AGENTS.md`. Scope-specific deltas only.",
+        ):
+            with self.subTest(body=body), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                scratch(root, f"{FRONTMATTER}{body}\n")
+                self.assertIn(MARKER, run(root))
+
+    def test_source_file_missing_the_declaration_still_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scratch(root, "# AGENTS.md — `web/`\n\nDeclares nothing.\n")
+            self.assertIn(MARKER, run(root))
+
+    def test_indented_horizontal_rule_is_not_frontmatter(self) -> None:
+        """A YAML document marker sits at column zero.
+
+        Treating an indented `---` as frontmatter would skip past a leading
+        Markdown horizontal rule and accept a document that declares nothing —
+        loosening the check in a case that has no frontmatter at all.
+        """
+        # The body below carries a VALID declaration on purpose. Treating the
+        # indented rule as frontmatter would skip to that line and pass; only
+        # the column-zero rule leaves ` --- ` as the first content and fails.
+        # A body that declares nothing would fail either way and prove nothing.
+        for opener, closer in ((" --- ", " --- "), ("\t---", "\t---")):
+            with self.subTest(opener=opener), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                scratch(root, f"{opener}\nA rule, not frontmatter\n{closer}\n\n{DECLARATION}\n")
+                self.assertIn(MARKER, run(root))
+
+    def test_unterminated_frontmatter_does_not_crash(self) -> None:
+        """An unclosed block falls back to the whole document rather than raising."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scratch(root, f'---\ntitle: "x"\n\n{DECLARATION}\n')
+            self.assertIn(MARKER, run(root))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The finding

`docs-site/src/content/docs/guides/AGENTS.md` carries the required scope declaration, correctly, on **line 5**. The check reported it missing.

It reads the first non-blank line that does not start with `#`. In that file — a Starlight projection — the source's ATX heading is replaced by YAML frontmatter, so that line is the opening `---`. The check read the delimiter and reported the declaration absent.

**The parse bug is the small half. The coverage gap is the finding:** that file's scope declaration has never actually been evaluated, by anyone, anywhere. The control ran, reported, and never reached the thing it governs. It is also the **only** frontmatter-bearing `AGENTS.md` in the linter's entire glob — 29 files, one instance — so nothing else was masking it and nothing else is affected.

## Why nobody saw it

Not "CI-invisible" in the loose sense. Precisely:

- The file is gitignored (`docs-site/.gitignore:7`) and untracked, so it is **absent** from a fresh clone.
- `build-check.yml` runs no docs-site build ahead of the `agents-md` step, so it is absent in CI too.
- It therefore manifests only for someone holding a complete local `docs-site` build — which is how it failed `make build-check` locally while main stayed green.

Absent, not excluded. There is no exclusion list and no cwd difference behind it, so the frontmatter parse is the whole fix rather than a patch over a second hole. A peer independently reproduced this from a different machine state (29 AGENTS files, 0 frontmatter-bearing, file absent because no docs-site build had run).

## The fix

Skip a leading frontmatter block before locating the declaration. The opener and closer must sit at **column zero**, because a YAML document marker does — accepting an indented `---` would treat a leading Markdown horizontal rule as frontmatter and skip past it, so a document declaring nothing would pass a check the unindented form correctly fails. An unclosed block falls back to the whole document, so a malformed projection still fails rather than silently passing.

The column-zero requirement came from independent review; the first version of this fix used `.strip()` and had that hole.

## Verification

- `make build`, `make lint-ruff`, the new test, and `lint-ci-parity` all green; `SKIP_SAST=1 make build-check` green with `pre-pr: ✓ agents-md hygiene` and zero `✖`.
- Rebased onto current `main` with a clean `rm -rf dist && make build` (`#1051` moves core seeds, so a stale `dist` would trip `CAT-V-014`).
- Mutation proofs, each restoration `cmp`-verified:
  - declaration removed from a frontmatter file → **fails**
  - `Inherits the root` alone removed → **fails**
  - non-frontmatter file missing the declaration → **fails** (no regression)
  - unterminated frontmatter → **fails**, no crash
  - indented `---` rule with a *valid* declaration below → **fails** (column-zero rule)
  - reverting the parse fix → fails only the projected-file case
  - reverting column-zero → fails only the indented-rule case, both subcases

The indented-rule fixture carries a valid declaration deliberately. My first attempt used a body that declared nothing, which fails under both the loose and strict readings — it passed against the mutant and proved nothing until the fixture was changed to distinguish them.

## Note on the test marker

The marker is the file-specific `web/AGENTS.md is missing`. A scratch repository emits unrelated `is missing` diagnostics (absent charter, Diátaxis directories); a bare substring let three cases pass for the wrong reason during development.