### PR TITLE
feat(tools): validate the shared chrome destination contract before projection

### DIFF
--- a/docs/specs/site-shared-chrome/spec.md
+++ b/docs/specs/site-shared-chrome/spec.md
@@ -164,8 +164,14 @@ means only the destination architecture and vocabulary above.
   IDs, labels, targets, groups, order, and internal/external kind; it contains
   no CSS, token, breakpoint, state, or component prescription.
 - [ ] Generator validation rejects duplicate destination/group IDs, missing
-  group references, invalid target kinds, order drift, and unknown internal
-  destinations, and projects deterministic renderer-local data.
+  group references, unknown destination references in groups and in the ordered
+  header and docs-navigation lists, repeated entries in those lists, invalid
+  target kinds, and invalid internal target shape, and projects deterministic
+  renderer-local data. Drift from the approved vocabulary — labels, targets,
+  kinds, and header, group, and docs-navigation order — is rejected by a
+  merge-blocking anchor test rather than by generator logic, because AC1 makes
+  `site.toml` the sole source of that order; target resolution is rejected by
+  `tools/check-rendered-site-links.py`.
 - [ ] Marketing header and mobile disclosure emit the exact six destinations,
   order, labels, targets, and existing CTA treatment approved above.
 - [ ] Marketing and docs footers emit the exact Product, Docs, and Project

--- a/site.toml
+++ b/site.toml
@@ -138,3 +138,165 @@ label = "GitHub"
 dir = "linear"
 label = "Linear"
 
+# ---------------------------------------------------------------------------
+# Shared chrome destination contract.
+#
+# This is renderer-neutral vocabulary only. Renderer-local components decide
+# presentation, current state, focus treatment, and responsive behaviour.
+# ---------------------------------------------------------------------------
+
+[shared_chrome]
+header = [
+  "how-it-works",
+  "use-cases",
+  "catalogue",
+  "now",
+  "docs",
+  "try-the-build-loop",
+]
+docs_band = ["product", "how-it-works", "use-cases", "catalogue", "now", "docs"]
+docs_product_navigation = ["product-home", "how-it-works", "use-cases", "catalogue", "now"]
+
+[[shared_chrome.destinations]]
+id = "product"
+label = "Product"
+target = "/"
+kind = "internal"
+
+[[shared_chrome.destinations]]
+id = "product-home"
+label = "Product home"
+target = "/"
+kind = "internal"
+
+[[shared_chrome.destinations]]
+id = "how-it-works"
+label = "How it works"
+target = "/#three-loops"
+kind = "internal"
+group = "product"
+
+[[shared_chrome.destinations]]
+id = "use-cases"
+label = "Use cases"
+target = "/#use-cases"
+kind = "internal"
+group = "product"
+
+[[shared_chrome.destinations]]
+id = "catalogue"
+label = "Catalogue"
+target = "/catalogue/"
+kind = "internal"
+group = "product"
+
+[[shared_chrome.destinations]]
+id = "now"
+label = "Now"
+target = "/now/"
+kind = "internal"
+group = "project"
+
+[[shared_chrome.destinations]]
+id = "docs"
+label = "Docs"
+target = "/docs/"
+kind = "internal"
+
+[[shared_chrome.destinations]]
+id = "try-the-build-loop"
+label = "Try the build loop"
+target = "/#install"
+kind = "internal"
+
+[[shared_chrome.destinations]]
+id = "packs"
+label = "Packs"
+target = "/packs/"
+kind = "internal"
+group = "product"
+
+[[shared_chrome.destinations]]
+id = "journeys"
+label = "Journeys"
+target = "/journeys/"
+kind = "internal"
+group = "product"
+
+[[shared_chrome.destinations]]
+id = "get-started"
+label = "Get started"
+target = "/docs/getting-started/"
+kind = "internal"
+group = "docs"
+
+[[shared_chrome.destinations]]
+id = "install"
+label = "Install"
+target = "/docs/getting-started/install/"
+kind = "internal"
+group = "docs"
+
+[[shared_chrome.destinations]]
+id = "three-loops"
+label = "The three loops"
+target = "/docs/getting-started/three-loops/"
+kind = "internal"
+group = "docs"
+
+[[shared_chrome.destinations]]
+id = "all-docs"
+label = "All docs"
+target = "/docs/"
+kind = "internal"
+group = "docs"
+
+[[shared_chrome.destinations]]
+id = "changelog"
+label = "Changelog"
+target = "/docs/changelog/"
+kind = "internal"
+group = "project"
+
+[[shared_chrome.destinations]]
+id = "contributing"
+label = "Contributing"
+target = "/docs/contributing/"
+kind = "internal"
+group = "project"
+
+[[shared_chrome.destinations]]
+id = "claude-plugins"
+label = "Claude plugins"
+target = "/plugins/"
+kind = "internal"
+group = "project"
+
+[[shared_chrome.destinations]]
+id = "github"
+label = "GitHub"
+target = "https://github.com/eugenelim/agent-ready-repo"
+kind = "external"
+group = "project"
+
+[[shared_chrome.destinations]]
+id = "pypi"
+label = "PyPI"
+target = "https://pypi.org/project/agentbundle/"
+kind = "external"
+group = "project"
+
+[[shared_chrome.groups]]
+id = "product"
+label = "Product"
+destinations = ["how-it-works", "use-cases", "catalogue", "packs", "journeys"]
+
+[[shared_chrome.groups]]
+id = "docs"
+label = "Docs"
+destinations = ["get-started", "install", "three-loops", "all-docs"]
+
+[[shared_chrome.groups]]
+id = "project"
+label = "Project"
+destinations = ["now", "changelog", "contributing", "claude-plugins", "github", "pypi"]

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -46,6 +46,313 @@ _GUIDE_ONLY_FIELDS = frozenset({
 _GUIDE_SLUG_PART_RE = re.compile(r"^[a-z0-9_][a-z0-9_-]*$")
 
 
+# ---------------------------------------------------------------------------
+# Shared chrome contract
+# ---------------------------------------------------------------------------
+
+_SHARED_CHROME_KINDS = frozenset({"internal", "external"})
+_SHARED_CHROME_FIELDS = frozenset({
+    "header", "docs_band", "docs_product_navigation", "destinations", "groups",
+})
+_SHARED_DESTINATION_FIELDS = frozenset({"id", "label", "target", "kind", "group"})
+_SHARED_GROUP_FIELDS = frozenset({"id", "label", "destinations"})
+
+
+def _shared_chrome_string(value: object, field: str, identifier: str) -> str:
+    """Require a non-empty shared-chrome string field with its owning ID named."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"shared chrome {identifier} has invalid '{field}'; expected a non-empty string"
+        )
+    return value
+
+
+def _validate_internal_shared_target(target: str, destination_id: str) -> None:
+    """Require a safe root-relative page target or non-empty fragment target."""
+    identifier = f"destination '{destination_id}'"
+    if not target.startswith("/"):
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "expected a root-relative target"
+        )
+    if target.startswith("//"):
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "protocol-relative targets are not allowed"
+        )
+    if "\\" in target:
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "backslashes are not allowed"
+        )
+    if ".." in target:
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "parent-directory segments are not allowed"
+        )
+    if any(character.isspace() for character in target):
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "whitespace is not allowed"
+        )
+
+    path, separator, fragment = target.partition("#")
+    if separator:
+        if "#" in fragment:
+            raise ValueError(
+                f"shared chrome {identifier} has invalid internal target {target!r}; "
+                "expected at most one fragment"
+            )
+        if not fragment:
+            raise ValueError(
+                f"shared chrome {identifier} has invalid internal target {target!r}; "
+                "fragment must be non-empty"
+            )
+        return
+    if not path.endswith("/"):
+        raise ValueError(
+            f"shared chrome {identifier} has invalid internal target {target!r}; "
+            "expected a '/'-terminated path or '#fragment' form"
+        )
+
+
+def _reject_shared_chrome_fields(
+    record: dict, allowed: frozenset[str], identifier: str
+) -> None:
+    """Reject renderer presentation or state from the shared destination contract."""
+    for field in record:
+        if field not in allowed:
+            raise ValueError(
+                f"shared chrome {identifier} has unsupported field '{field}'; "
+                "presentation and state belong to renderer-local components"
+            )
+
+
+def _validate_shared_chrome_destination_list(
+    raw_destination_ids: object, field: str, destinations_by_id: dict[str, dict]
+) -> list[str]:
+    """Validate an ordered, duplicate-free list of declared destination IDs."""
+    if not isinstance(raw_destination_ids, list):
+        raise ValueError(
+            f"site.toml shared_chrome.{field} must be an ordered destination ID array"
+        )
+
+    destination_ids: list[str] = []
+    for raw_destination_id in raw_destination_ids:
+        destination_id = _shared_chrome_string(raw_destination_id, field, field)
+        if destination_id not in destinations_by_id:
+            raise ValueError(
+                f"shared chrome {field} references missing destination '{destination_id}'"
+            )
+        if destination_id in destination_ids:
+            raise ValueError(
+                f"shared chrome {field} repeats destination '{destination_id}'"
+            )
+        destination_ids.append(destination_id)
+    return destination_ids
+
+
+def validate_shared_chrome_contract(contract: object) -> dict:
+    """Validate and normalize the renderer-neutral shared-chrome contract.
+
+    The result contains only the fields a renderer may receive. Validation is
+    deliberately complete before projection so malformed source cannot produce
+    partial renderer data.
+    """
+    if not isinstance(contract, dict):
+        raise ValueError("site.toml shared_chrome must be a table")
+    _reject_shared_chrome_fields(contract, _SHARED_CHROME_FIELDS, "contract")
+
+    raw_destinations = contract.get("destinations")
+    raw_groups = contract.get("groups")
+    raw_header = contract.get("header")
+    raw_docs_band = contract.get("docs_band")
+    raw_docs_product_navigation = contract.get("docs_product_navigation")
+    if not isinstance(raw_destinations, list):
+        raise ValueError("site.toml shared_chrome.destinations must be an ordered table array")
+    if not isinstance(raw_groups, list):
+        raise ValueError("site.toml shared_chrome.groups must be an ordered table array")
+
+    destinations: list[dict] = []
+    destinations_by_id: dict[str, dict] = {}
+    for index, raw_destination in enumerate(raw_destinations):
+        if not isinstance(raw_destination, dict):
+            raise ValueError(f"shared chrome destination at position {index + 1} must be a table")
+        raw_id = raw_destination.get("id")
+        identifier = (
+            f"destination '{raw_id}'"
+            if isinstance(raw_id, str) and raw_id
+            else f"destination at position {index + 1}"
+        )
+        _reject_shared_chrome_fields(
+            raw_destination, _SHARED_DESTINATION_FIELDS, identifier
+        )
+        destination_id = _shared_chrome_string(raw_id, "id", identifier)
+        if destination_id in destinations_by_id:
+            raise ValueError(f"shared chrome duplicate destination ID '{destination_id}'")
+        label = _shared_chrome_string(raw_destination.get("label"), "label", identifier)
+        target = _shared_chrome_string(raw_destination.get("target"), "target", identifier)
+        kind = _shared_chrome_string(raw_destination.get("kind"), "kind", identifier)
+        if kind not in _SHARED_CHROME_KINDS:
+            raise ValueError(
+                f"shared chrome destination '{destination_id}' has unsupported kind "
+                f"'{kind}'; expected 'internal' or 'external'"
+            )
+        if kind == "internal":
+            _validate_internal_shared_target(target, destination_id)
+        group = raw_destination.get("group")
+        if group is not None and (not isinstance(group, str) or not group):
+            raise ValueError(
+                f"shared chrome destination '{destination_id}' has invalid 'group'; "
+                "expected a non-empty group ID"
+            )
+        destination = {
+            "id": destination_id,
+            "label": label,
+            "target": target,
+            "kind": kind,
+            "group": group,
+        }
+        destinations.append(destination)
+        destinations_by_id[destination_id] = destination
+
+    groups: list[dict] = []
+    groups_by_id: dict[str, dict] = {}
+    for index, raw_group in enumerate(raw_groups):
+        if not isinstance(raw_group, dict):
+            raise ValueError(f"shared chrome group at position {index + 1} must be a table")
+        raw_id = raw_group.get("id")
+        identifier = (
+            f"group '{raw_id}'"
+            if isinstance(raw_id, str) and raw_id
+            else f"group at position {index + 1}"
+        )
+        _reject_shared_chrome_fields(raw_group, _SHARED_GROUP_FIELDS, identifier)
+        group_id = _shared_chrome_string(raw_id, "id", identifier)
+        if group_id in groups_by_id:
+            raise ValueError(f"shared chrome duplicate group ID '{group_id}'")
+        label = _shared_chrome_string(raw_group.get("label"), "label", identifier)
+        raw_members = raw_group.get("destinations")
+        if not isinstance(raw_members, list):
+            raise ValueError(
+                f"shared chrome group '{group_id}' has invalid 'destinations'; "
+                "expected an ordered destination ID array"
+            )
+        members: list[str] = []
+        for raw_member in raw_members:
+            member = _shared_chrome_string(
+                raw_member, "destinations", f"group '{group_id}'"
+            )
+            if member in members:
+                raise ValueError(
+                    f"shared chrome group '{group_id}' repeats destination '{member}'"
+                )
+            members.append(member)
+        group = {"id": group_id, "label": label, "destinations": members}
+        groups.append(group)
+        groups_by_id[group_id] = group
+
+    for group in groups:
+        for member in group["destinations"]:
+            destination = destinations_by_id.get(member)
+            if destination is None:
+                raise ValueError(
+                    f"shared chrome group '{group['id']}' references missing "
+                    f"destination '{member}'"
+                )
+            if destination["group"] != group["id"]:
+                raise ValueError(
+                    f"shared chrome destination '{member}' references group "
+                    f"'{destination['group']}', not '{group['id']}'"
+                )
+
+    for destination in destinations:
+        group_id = destination["group"]
+        if group_id is None:
+            continue
+        if group_id not in groups_by_id:
+            raise ValueError(
+                f"shared chrome destination '{destination['id']}' references missing "
+                f"group '{group_id}'"
+            )
+        if destination["id"] not in groups_by_id[group_id]["destinations"]:
+            raise ValueError(
+                f"shared chrome destination '{destination['id']}' references group "
+                f"'{group_id}' but is missing from that group's destinations"
+            )
+
+    header = _validate_shared_chrome_destination_list(
+        raw_header, "header", destinations_by_id
+    )
+    docs_band = _validate_shared_chrome_destination_list(
+        raw_docs_band, "docs_band", destinations_by_id
+    )
+    docs_product_navigation = _validate_shared_chrome_destination_list(
+        raw_docs_product_navigation, "docs_product_navigation", destinations_by_id
+    )
+
+    return {
+        "header": header,
+        "docs_band": docs_band,
+        "docs_product_navigation": docs_product_navigation,
+        "destinations": destinations,
+        "groups": groups,
+    }
+
+
+def load_shared_chrome_contract(site_toml: Path) -> dict:
+    """Load and validate the shared-chrome table from the site recipe."""
+    with site_toml.open("rb") as f:
+        site = tomllib.load(f)
+    return validate_shared_chrome_contract(site.get("shared_chrome"))
+
+
+def project_shared_chrome(contract: object) -> dict[str, dict]:
+    """Create independent renderer-local data from one validated contract."""
+    canonical = validate_shared_chrome_contract(contract)
+    destinations_by_id = {
+        destination["id"]: destination for destination in canonical["destinations"]
+    }
+
+    def link(destination_id: str) -> dict:
+        destination = destinations_by_id[destination_id]
+        return {
+            "id": destination["id"],
+            "label": destination["label"],
+            "target": destination["target"],
+            "kind": destination["kind"],
+        }
+
+    def footer_projection() -> list[dict]:
+        return [
+            {
+                "id": group["id"],
+                "label": group["label"],
+                "destinations": [
+                    link(destination_id) for destination_id in group["destinations"]
+                ],
+            }
+            for group in canonical["groups"]
+        ]
+
+    marketing = {
+        "header": [link(destination_id) for destination_id in canonical["header"]],
+        "footer": footer_projection(),
+    }
+    docs = {
+        "product_orientation_band": [
+            link(destination_id) for destination_id in canonical["docs_band"]
+        ],
+        "product_navigation": [
+            link(destination_id)
+            for destination_id in canonical["docs_product_navigation"]
+        ],
+        "footer": footer_projection(),
+    }
+
+    return {"marketing": marketing, "docs": docs}
+
+
 def discover_packs(root: Path, site_toml: Path) -> list[dict]:
     """Return packs ordered by site.toml groups, ungrouped packs appended alphabetically.
 
@@ -1656,6 +1963,10 @@ def main() -> None:
     packs_dir = REPO_ROOT / "packs"
 
     changelog_src = REPO_ROOT / "docs" / "product" / "changelog.md"
+    site_toml = REPO_ROOT / "site.toml"
+    # Validate the complete shared vocabulary before either build path can
+    # project or clean renderer inputs.
+    load_shared_chrome_contract(site_toml)
 
     if args.journeys_only:
         journey_dir = REPO_ROOT / "web" / "src" / "content" / "journeys"
@@ -1682,7 +1993,6 @@ def main() -> None:
                 shutil.rmtree(d)
                 print(f"  clean {d.relative_to(REPO_ROOT)}/")
 
-    site_toml = REPO_ROOT / "site.toml"
     packs = discover_packs(REPO_ROOT, site_toml)
 
     print("build-site: copying pack READMEs …")

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1,12 +1,14 @@
 """Tests for guide-routing and /now/ projection in tools/build-site.py.
 
-Covers: frontmatter parsing, guide-metadata stripping, slug-override routing,
-alias redirect-stub generation, docs/guides/ exclusion, generation's
-independence from the marketing design-token file, and the released-changelog
-Highlights projection that feeds the public `/now/` route.
+Covers: shared-chrome contract validation and projection, frontmatter parsing,
+guide-metadata stripping, slug-override routing, alias redirect-stub generation,
+docs/guides/ exclusion, generation's independence from the marketing
+design-token file, and the released-changelog Highlights projection that feeds
+the public `/now/` route.
 """
 from __future__ import annotations
 
+import copy
 import importlib.util
 import shutil
 import subprocess
@@ -22,6 +24,54 @@ _spec.loader.exec_module(build_site)  # type: ignore[union-attr]
 
 SITE_BASE = "/agent-ready-repo/docs"
 
+_APPROVED_SHARED_CHROME_HEADER = (
+    "how-it-works", "use-cases", "catalogue", "now", "docs", "try-the-build-loop",
+)
+_APPROVED_SHARED_CHROME_DOCS_BAND = (
+    "product", "how-it-works", "use-cases", "catalogue", "now", "docs",
+)
+_APPROVED_SHARED_CHROME_DOCS_PRODUCT_NAVIGATION = (
+    "product-home", "how-it-works", "use-cases", "catalogue", "now",
+)
+_APPROVED_SHARED_CHROME_GROUPS = (
+    (
+        "product",
+        "Product",
+        ("how-it-works", "use-cases", "catalogue", "packs", "journeys"),
+    ),
+    (
+        "docs",
+        "Docs",
+        ("get-started", "install", "three-loops", "all-docs"),
+    ),
+    (
+        "project",
+        "Project",
+        ("now", "changelog", "contributing", "claude-plugins", "github", "pypi"),
+    ),
+)
+_APPROVED_SHARED_CHROME_DESTINATIONS = {
+    "product": ("Product", "/", "internal"),
+    "product-home": ("Product home", "/", "internal"),
+    "how-it-works": ("How it works", "/#three-loops", "internal"),
+    "use-cases": ("Use cases", "/#use-cases", "internal"),
+    "catalogue": ("Catalogue", "/catalogue/", "internal"),
+    "now": ("Now", "/now/", "internal"),
+    "docs": ("Docs", "/docs/", "internal"),
+    "try-the-build-loop": ("Try the build loop", "/#install", "internal"),
+    "packs": ("Packs", "/packs/", "internal"),
+    "journeys": ("Journeys", "/journeys/", "internal"),
+    "get-started": ("Get started", "/docs/getting-started/", "internal"),
+    "install": ("Install", "/docs/getting-started/install/", "internal"),
+    "three-loops": ("The three loops", "/docs/getting-started/three-loops/", "internal"),
+    "all-docs": ("All docs", "/docs/", "internal"),
+    "changelog": ("Changelog", "/docs/changelog/", "internal"),
+    "contributing": ("Contributing", "/docs/contributing/", "internal"),
+    "claude-plugins": ("Claude plugins", "/plugins/", "internal"),
+    "github": ("GitHub", "https://github.com/eugenelim/agent-ready-repo", "external"),
+    "pypi": ("PyPI", "https://pypi.org/project/agentbundle/", "external"),
+}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,6 +84,342 @@ def _make_guide(tmp_path: Path, rel: str, content: str) -> tuple[Path, Path]:
     src.parent.mkdir(parents=True, exist_ok=True)
     src.write_text(content, encoding="utf-8")
     return src, guides_root
+
+
+def _shared_chrome_fixture() -> dict:
+    """Return a fresh copy of the approved site.toml shared-chrome contract."""
+    return copy.deepcopy(
+        build_site.load_shared_chrome_contract(
+            Path(__file__).resolve().parent.parent / "site.toml"
+        )
+    )
+
+
+def _assert_shared_chrome_rejected(contract: dict, expected: str) -> None:
+    """Assert validation fails before it can return renderer projection data."""
+    try:
+        build_site.project_shared_chrome(contract)
+    except ValueError as exc:
+        assert expected in str(exc), str(exc)
+    else:  # pragma: no cover - the raise below is the failure report
+        raise AssertionError(f"shared chrome contract unexpectedly projected: {contract!r}")
+
+
+def _link(destination_id: str, label: str, target: str, kind: str) -> dict:
+    return {"id": destination_id, "label": label, "target": target, "kind": kind}
+
+
+# ---------------------------------------------------------------------------
+# Shared chrome contract — T1 of spec/site-shared-chrome
+# ---------------------------------------------------------------------------
+
+def test_shared_chrome_contract_anchor_matches_approved_vocabulary():
+    """Pin the approved IA vocabulary outside the renderer-neutral source."""
+    contract = _shared_chrome_fixture()
+
+    assert tuple(contract["header"]) == _APPROVED_SHARED_CHROME_HEADER
+    assert tuple(contract["docs_band"]) == _APPROVED_SHARED_CHROME_DOCS_BAND
+    assert (
+        tuple(contract["docs_product_navigation"])
+        == _APPROVED_SHARED_CHROME_DOCS_PRODUCT_NAVIGATION
+    )
+    assert tuple(
+        (group["id"], group["label"], tuple(group["destinations"]))
+        for group in contract["groups"]
+    ) == _APPROVED_SHARED_CHROME_GROUPS
+    assert {
+        destination["id"]: (
+            destination["label"], destination["target"], destination["kind"]
+        )
+        for destination in contract["destinations"]
+    } == _APPROVED_SHARED_CHROME_DESTINATIONS
+
+
+def _expected_renderer_projection(contract: dict) -> dict:
+    """Build projection expectations from the source contract, not a second taxonomy."""
+    destinations = {
+        destination["id"]: _link(
+            destination["id"],
+            destination["label"],
+            destination["target"],
+            destination["kind"],
+        )
+        for destination in contract["destinations"]
+    }
+    return {
+        "header": [
+            destinations[destination_id] for destination_id in contract["header"]
+        ],
+        "footer": [
+            {
+                "id": group["id"],
+                "label": group["label"],
+                "destinations": [
+                    destinations[destination_id]
+                    for destination_id in group["destinations"]
+                ],
+            }
+            for group in contract["groups"]
+        ],
+    }
+
+
+def _expected_docs_renderer_projection(contract: dict) -> dict:
+    """Build docs expectations from the source's docs-specific ordered lists."""
+    destinations = {
+        destination["id"]: _link(
+            destination["id"],
+            destination["label"],
+            destination["target"],
+            destination["kind"],
+        )
+        for destination in contract["destinations"]
+    }
+    return {
+        "product_orientation_band": [
+            destinations[destination_id]
+            for destination_id in contract["docs_band"]
+        ],
+        "product_navigation": [
+            destinations[destination_id]
+            for destination_id in contract["docs_product_navigation"]
+        ],
+        "footer": _expected_renderer_projection(contract)["footer"],
+    }
+
+
+def test_shared_chrome_projects_independently_allocated_renderer_data():
+    """Renderers receive their own ordered, separately allocated projection data."""
+    contract = _shared_chrome_fixture()
+    marketing_expected = _expected_renderer_projection(contract)
+    docs_expected = _expected_docs_renderer_projection(contract)
+
+    first = build_site.project_shared_chrome(contract)
+    second = build_site.project_shared_chrome(contract)
+    assert first == second == {"marketing": marketing_expected, "docs": docs_expected}
+    assert first["marketing"] is not first["docs"]
+    assert first["marketing"]["header"] is not first["docs"]["product_orientation_band"]
+    assert first["marketing"]["footer"] is not first["docs"]["footer"]
+
+    first["marketing"]["header"][0]["label"] = "Changed only in marketing"
+    assert first["docs"]["product_orientation_band"][1]["label"] == "How it works"
+
+
+def test_shared_chrome_rejects_duplicate_destination_ids():
+    contract = _shared_chrome_fixture()
+    duplicate = copy.deepcopy(
+        next(
+            destination
+            for destination in contract["destinations"]
+            if destination["id"] == "how-it-works"
+        )
+    )
+    contract["destinations"].append(duplicate)
+
+    _assert_shared_chrome_rejected(contract, "duplicate destination ID 'how-it-works'")
+
+
+def test_shared_chrome_rejects_duplicate_group_ids():
+    contract = _shared_chrome_fixture()
+    duplicate = copy.deepcopy(contract["groups"][0])
+    contract["groups"].append(duplicate)
+
+    _assert_shared_chrome_rejected(contract, "duplicate group ID 'product'")
+
+
+def test_shared_chrome_rejects_missing_group_members():
+    contract = _shared_chrome_fixture()
+    contract["groups"][0]["destinations"][-1] = "missing-journeys"
+
+    _assert_shared_chrome_rejected(contract, "destination 'missing-journeys'")
+
+
+def test_shared_chrome_rejects_a_group_repeating_a_member():
+    contract = _shared_chrome_fixture()
+    contract["groups"][0]["destinations"].append("how-it-works")
+
+    _assert_shared_chrome_rejected(contract, "group 'product' repeats destination 'how-it-works'")
+
+
+def test_shared_chrome_rejects_a_group_listing_a_destination_from_another_group():
+    contract = _shared_chrome_fixture()
+    contract["groups"][0]["destinations"][-1] = "all-docs"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "destination 'all-docs' references group 'docs', not 'product'",
+    )
+
+
+def test_shared_chrome_rejects_a_destination_omitted_from_its_declared_group():
+    contract = _shared_chrome_fixture()
+    contract["groups"][0]["destinations"].pop(0)
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "destination 'how-it-works' references group 'product' but is missing",
+    )
+
+
+def test_shared_chrome_rejects_destination_referencing_a_missing_group():
+    contract = _shared_chrome_fixture()
+    contract["groups"].pop(0)
+
+    _assert_shared_chrome_rejected(contract, "destination 'how-it-works' references missing group 'product'")
+
+
+def test_shared_chrome_rejects_unsupported_target_kinds():
+    contract = _shared_chrome_fixture()
+    next(
+        destination
+        for destination in contract["destinations"]
+        if destination["id"] == "how-it-works"
+    )["kind"] = "mailto"
+
+    _assert_shared_chrome_rejected(contract, "destination 'how-it-works' has unsupported kind 'mailto'")
+
+
+def test_shared_chrome_rejects_invalid_internal_target_shapes():
+    invalid_targets = {
+        "https://example.test/": "expected a root-relative target",
+        "//example.test/": "protocol-relative targets are not allowed",
+        "/docs\\getting-started/": "backslashes are not allowed",
+        "/docs/../getting-started/": "parent-directory segments are not allowed",
+        "/docs/has space/": "whitespace is not allowed",
+        "/#": "fragment must be non-empty",
+        "/docs/getting-started": "expected a '/'-terminated path or '#fragment' form",
+    }
+    for target, expected in invalid_targets.items():
+        contract = _shared_chrome_fixture()
+        contract["destinations"][0]["target"] = target
+
+        _assert_shared_chrome_rejected(contract, expected)
+
+
+def test_shared_chrome_rejects_header_references_and_duplicates():
+    contract = _shared_chrome_fixture()
+    contract["header"][0] = "missing-destination"
+
+    _assert_shared_chrome_rejected(contract, "header references missing destination 'missing-destination'")
+
+    contract = _shared_chrome_fixture()
+    contract["header"][1] = "how-it-works"
+
+    _assert_shared_chrome_rejected(contract, "header repeats destination 'how-it-works'")
+
+
+def test_shared_chrome_rejects_invalid_docs_band_entries():
+    contract = _shared_chrome_fixture()
+    contract["docs_band"] = "product"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "site.toml shared_chrome.docs_band must be an ordered destination ID array",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_band"][0] = ""
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "shared chrome docs_band has invalid 'docs_band'",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_band"][0] = "missing-destination"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "docs_band references missing destination 'missing-destination'",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_band"][1] = "product"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "docs_band repeats destination 'product'",
+    )
+
+
+def test_shared_chrome_rejects_invalid_docs_product_navigation_entries():
+    contract = _shared_chrome_fixture()
+    contract["docs_product_navigation"] = "product-home"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "site.toml shared_chrome.docs_product_navigation must be an ordered destination ID array",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_product_navigation"][0] = ""
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "shared chrome docs_product_navigation has invalid 'docs_product_navigation'",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_product_navigation"][0] = "missing-destination"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "docs_product_navigation references missing destination 'missing-destination'",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["docs_product_navigation"][1] = "product-home"
+
+    _assert_shared_chrome_rejected(
+        contract,
+        "docs_product_navigation repeats destination 'product-home'",
+    )
+
+
+def test_shared_chrome_rejects_presentation_and_state_fields():
+    contract = _shared_chrome_fixture()
+    contract["state"] = "renderer-owned"
+    _assert_shared_chrome_rejected(contract, "contract has unsupported field 'state'")
+
+    contract = _shared_chrome_fixture()
+    next(
+        destination
+        for destination in contract["destinations"]
+        if destination["id"] == "how-it-works"
+    )["breakpoint"] = "renderer-owned"
+    _assert_shared_chrome_rejected(
+        contract,
+        "destination 'how-it-works' has unsupported field 'breakpoint'",
+    )
+
+    contract = _shared_chrome_fixture()
+    contract["groups"][0]["state"] = "renderer-owned"
+    _assert_shared_chrome_rejected(contract, "group 'product' has unsupported field 'state'")
+
+    contract = _shared_chrome_fixture()
+    contract["unexpected"] = "renderer-owned"
+    _assert_shared_chrome_rejected(contract, "contract has unsupported field 'unexpected'")
+
+
+def test_journeys_only_validates_shared_chrome_before_projection(monkeypatch):
+    """A malformed contract blocks journeys-only projections before they run."""
+    def fail_validation(_site_toml: Path) -> None:
+        raise ValueError("invalid shared chrome")
+
+    def unexpected_projection(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("journeys-only projection ran before shared-chrome validation")
+
+    monkeypatch.setattr(build_site, "load_shared_chrome_contract", fail_validation)
+    monkeypatch.setattr(build_site, "sync_pack_journeys", unexpected_projection)
+    monkeypatch.setattr(build_site, "_report_now_projection", unexpected_projection)
+    monkeypatch.setattr(sys, "argv", ["build-site.py", "--journeys-only"])
+
+    try:
+        build_site.main()
+    except ValueError as exc:
+        assert str(exc) == "invalid shared chrome"
+    else:  # pragma: no cover - the raise below is the failure report
+        raise AssertionError("journeys-only build unexpectedly projected invalid shared chrome")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **T1** of `docs/specs/site-shared-chrome/plan.md` (AC1, AC2, AC10). No renderer changes — T2/T3 are the consumers.

## What

Adds the renderer-neutral `[shared_chrome]` table to `site.toml`: destination IDs, labels, targets, groups, order, and internal/external kind for the approved six-item marketing header and the Product/Docs/Project footer taxonomy (5 / 4 / 6 rows). GitHub and PyPI are the only external destinations, and their URLs are unchanged — verified against `origin/main`'s `SiteFooter.astro`.

The table carries no CSS, token, breakpoint, state, or component field, and the generator rejects any unknown field, so presentation cannot leak into shared vocabulary.

Validation runs at the top of the full-build path, **before** the `--clean` rmtree and before any projection, so malformed input fails without writing or deleting renderer inputs. The `--journeys-only` pre-build pass is deliberately unchanged.

## The AC1 / AC2 reading — please sanity-check this

AC1 makes `site.toml` the **sole** renderer-neutral source. AC2 says the generator rejects "order drift". Those can only hold together if drift is not measured against a second copy inside the generator, so responsibility is split three ways:

| Concern | Owner |
|---|---|
| Internal inconsistency (duplicates, dangling references, bad kinds, target shape) | generator, source-internal only |
| Drift from the **approved vocabulary** | `test_shared_chrome_contract_anchor_matches_approved_vocabulary` (merge-blocking) |
| Whether a target actually resolves | `check-rendered-site-links.py`, already in the build chain |

Consequence, and the point of the split: the generator now **accepts** a relabelled or reordered `site.toml`, and the anchor test **fails** until the change is made deliberately. An earlier revision of this patch inverted that — it duplicated the whole taxonomy into `build-site.py` and compared for equality, so `site.toml` could not be edited at all without also editing Python. That is the opposite of "sole source" and it has been removed.

If you would rather keep a generator-side order gate and amend AC1 instead, say so and I will flip it.

## Verification

- `make lint-ruff`, four-stage build, `SKIP_SAST=1 make build-check` green.
- 63 tests in `tools/test_build_site_routing.py`.
- **37 of 37 validation mutations raise, zero vacuous**, with the unmutated fixture passing as a control — covering duplicate destination/group IDs, repeated members, both directions of the group/destination reference, header entries naming undeclared destinations, unsupported kinds, empty required fields, unknown fields on contract/destination/group, and eight target shapes (`https://`, `//`, backslash, `..`, whitespace, bare `/docs`, `/#`, `/#one#two`).
- Relabel and header-reorder probes on the real `site.toml`, each restored `cmp`-clean: generator accepts, anchor test fails.

## Open, and worth an opinion before T2 consumes it

The spec pins labels, targets, kinds, and order, but **not** destination ID spellings or projection key names. This uses kebab-case IDs and `header`/`footer`. Nothing external depends on them yet, so they are still cheap to change.