### PR TITLE
fix(agents): restore the privacy obligations the simplification deleted

### DIFF
--- a/AGENTS.local.md
+++ b/AGENTS.local.md
@@ -26,8 +26,9 @@ Never install this repo's own packages. The Makefile puts live worktree source o
 Once per machine, install `ruff`, `mypy`, `pytest`, and `-r tools/requirements.txt`;
 a `.venv` is optional for tool-version isolation. Once per worktree, run `npm ci
 --prefix docs-site`; `make test` reports that command when it is missing.
-For bare `python -m agentbundle` or `pytest packages/credbroker`, export
+For bare `python -m agentbundle`, `pytest packages/credbroker`, or `pytest tests/`, export
 `PYTHONPATH=packages/agentbundle:packages/credbroker` instead of installing.
+A global install can silently shadow the tree, so a domain-looking error may be a stale import.
 
 ## Sources and projections
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ make ci
 
 Never commit personal information or credentials. Use generic placeholders in all
 repository artifacts. Follow the security workflow for security-boundary changes.
+See [Privacy in CONVENTIONS](docs/CONVENTIONS.md#privacy) for the complete policy.
 
 **Blessed security tools/helpers:**
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1356,6 +1356,27 @@ must respect:
 
 ---
 
+## Privacy
+
+**Never commit personal information to any file in this repo.** This includes:
+
+- Real names, email addresses, usernames, or account identifiers.
+- Org-specific domains, subdomains, or employer hostnames.
+- AAD/UUID identifiers tied to real people.
+- Device names, profile paths, or user-specific filesystem paths.
+- Names of personal service providers or platforms that identify account relationships.
+
+Use generic placeholders everywhere: `user@example.com`, `colleague@example.com`, `Example User`,
+`https://mail.yourorg.com/`, `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`, `example-service`,
+and `[service type]`.
+
+**This rule covers all git artifacts** — code, comments, docs, specs, commit messages,
+PR titles, PR bodies, and PR comments are permanent record. Never use real service or
+vendor names as examples; use `example-service` or `[service type]` instead. When
+authoring governance docs (ADRs, RFCs, specs), GitHub handles used for author/decider
+fields are not PII — they are public project identifiers.
+Do not infer them from session context.
+
 ## When this file is wrong
 
 If a convention here is causing friction, **say so in an RFC**. Don't quietly

--- a/docs/adr/0014-rigor-scales-with-risk-work-loop-modes.md
+++ b/docs/adr/0014-rigor-scales-with-risk-work-loop-modes.md
@@ -1,6 +1,6 @@
 # ADR-0014: Rigor scales with risk — `work-loop` light/full modes
 
-- **Status:** Accepted <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
+- **Status:** Accepted (superseded in part by ADR-0088 — the risk-trigger block's documentation homes; its trigger set and light/full mode selection stand) <!-- Proposed | Accepted | Deprecated | Superseded by ADR-NNNN -->
 - **Date:** 2026-06-05
 - **Deciders:** eugenelim
 - **Supersedes:** none

--- a/docs/adr/0088-risk-triggers-have-a-single-documented-home.md
+++ b/docs/adr/0088-risk-triggers-have-a-single-documented-home.md
@@ -1,0 +1,24 @@
+# ADR-0088: Risk triggers have a single documented home
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Decision-makers:** eugenelim
+- **Supersedes:** ADR-0014 (in part — the documentation homes of the risk-trigger block; its trigger set and light/full mode selection stand)
+- **Related:** RFC-0025
+
+## Context
+
+The risk-trigger block was duplicated across four prose homes and a lint required
+byte equality. Duplication was a maintenance hazard, and equality could not detect
+deletion of the canonical copy.
+
+## Decision
+
+The `work-loop` skill source is the sole documented home for the risk-trigger
+block. Other surfaces name the skill. The lint rejects markers outside the
+canonical source and fails when its block is missing or truncated.
+
+## Consequences
+
+Mode selection is unchanged. A copied block now fails CI. Frozen governance
+directories remain exempt so historical records may quote the block.

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -75,6 +75,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you can see the shape of the exchange, and where your decisions fall in it,
   before committing to the journey.
 
+### [core][2.9.4] — 2026-08-19
+
+#### Changed
+
+- **Privacy obligations restored.** Seed conventions again prohibit personal
+  identifiers in all git artifacts, preserve the public-handle carve-out, and
+  direct root guidance to the canonical privacy policy.
+- **Risk-trigger documentation is explicitly single-sourced.** ADR-0088 records
+  the `work-loop` skill as the sole block home without changing mode selection.
+
 ### [core][2.9.2] — 2026-08-19
 
 #### Changed

--- a/docs/specs/work-loop-light-mode/plan.md
+++ b/docs/specs/work-loop-light-mode/plan.md
@@ -1,7 +1,7 @@
 # Plan: work-loop-light-mode
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Done <!-- Drafting | Executing | Done -->
+- **Status:** Done (superseded in part by ADR-0088 — the risk-trigger block's documentation homes; everything else stands) <!-- Drafting | Executing | Done -->
 
 > **Plan contract:** this is the implementation strategy. Unlike the spec, this
 > document is allowed to change as you learn. When it changes substantially

--- a/docs/specs/work-loop-light-mode/spec.md
+++ b/docs/specs/work-loop-light-mode/spec.md
@@ -1,6 +1,6 @@
 # Spec: work-loop-light-mode
 
-- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (superseded in part by ADR-0088 — the risk-trigger block's documentation homes; everything else stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0014, RFC-0025

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.9.2",
+  "version": "2.9.4",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.9.2"
+version = "2.9.4"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/AGENTS.md
+++ b/packs/core/seeds/AGENTS.md
@@ -59,6 +59,7 @@ workflow or reference documentation; commit and pull-request conventions live in
 
 Never commit personal information or credentials. Use generic placeholders in
 repository artifacts and follow the security workflow for security-boundary changes.
+The complete privacy convention is in [docs/CONVENTIONS.md](docs/CONVENTIONS.md#privacy).
 
 **blessed security tools/helpers:** list this repository's sanctioned helpers by
 boundary here. This declaration takes precedence over inferred alternatives.

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -1356,6 +1356,27 @@ must respect:
 
 ---
 
+## Privacy
+
+**Never commit personal information to any file in this repo.** This includes:
+
+- Real names, email addresses, usernames, or account identifiers.
+- Org-specific domains, subdomains, or employer hostnames.
+- AAD/UUID identifiers tied to real people.
+- Device names, profile paths, or user-specific filesystem paths.
+- Names of personal service providers or platforms that identify account relationships.
+
+Use generic placeholders everywhere: `user@example.com`, `colleague@example.com`, `Example User`,
+`https://mail.yourorg.com/`, `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`, `example-service`,
+and `[service type]`.
+
+**This rule covers all git artifacts** — code, comments, docs, specs, commit messages,
+PR titles, PR bodies, and PR comments are permanent record. Never use real service or
+vendor names as examples; use `example-service` or `[service type]` instead. When
+authoring governance docs (ADRs, RFCs, specs), GitHub handles used for author/decider
+fields are not PII — they are public project identifiers.
+Do not infer them from session context.
+
 ## When this file is wrong
 
 If a convention here is causing friction, **say so in an RFC**. Don't quietly

--- a/tests/roster/test_security_checklists_okf_projection.py
+++ b/tests/roster/test_security_checklists_okf_projection.py
@@ -103,8 +103,8 @@ def test_core_version_and_okf_declaration_are_synchronized() -> None:
         (PACK_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
 
-    assert pack["pack"]["version"] == "2.9.2"
-    assert plugin["version"] == "2.9.2"
+    assert pack["pack"]["version"] == "2.9.4"
+    assert plugin["version"] == "2.9.4"
     assert pack["pack"]["metadata"]["okf"]["profile"] == "agentbundle-okf/v1"
     bundle = pack["pack"]["metadata"]["okf"]["bundles"][0]
     assert bundle["id"] == "security-checklists"


### PR DESCRIPTION
## What does this change?

Restores eight prose-only privacy obligations that `#1049`'s AGENTS.md simplification deleted from both the live root and the adopter-facing core seed, and records the supersession that change created. Also closes a stale-import gap in `AGENTS.local.md`.

## Why?

`#1049` compressed a 19-line `## Privacy` section to two sentences. Eight obligations survived **nowhere** in the repository — verified with literal `git grep` using control phrases to prove the method:

the five-category enumeration of what counts as personal information (`Org-specific domains`, `employer hostnames`, `identifiers tied to real people`, `personal service providers`, real names/accounts) · the all-git-artifacts scope (`PR titles, PR bodies` … permanent record) · `vendor names as examples` · the governance-doc carve-out (`are public project identifiers`) · the anti-inference rule (`from session context`)

**35 green CI checks said nothing.** A lint that enforces line caps, scope declarations, link fragments and duplication has no opinion about whether a deleted sentence carried an obligation. And `#1049`'s own directive said to *relocate* the privacy examples to a scoped policy — they were deleted and the destination was never built.

Two of the eight break behaviour in the **opposite** direction from a leak: the handles carve-out stops an agent over-refusing and scrubbing a legitimate ADR author field; the anti-inference rule stops it deriving author/decider identity from the conversation.

The placeholder vocabulary was **not** lost (`Example User` survives in 15 files) and is not treated as missing here.

## How do I verify it?

Restoration lands in `packs/core/seeds/docs/CONVENTIONS.md`, which is byte-identical to `docs/CONVENTIONS.md` and installs into adopter repos — so one source edit repairs both surfaces through the existing projection. A dedicated seed file was rejected: `lint.py`'s fail-loud unknown-seed rule would require registering it under `packages/agentbundle/`, turning a docs fix into an engine change.

| gate | result |
|---|---|
| `make build-check` (with SAST) | exit 0, zero `[ERROR]` |
| `pytest tests/` | 410 passed, 46 subtests, 0 failed |
| `pytest packs/core/tests/{pack,hooks}` | 36 passed |
| release-metadata roster gates + pack suite | 41 passed, 12 subtests |
| `lint-agents-md` · `lint-spec-status` · `lint-ruff` · `scaffold --check` · `lint-knowledge` | all 0 |

All nine strings (eight clauses + the governance-doc qualifier) verified present in **both** the seed and the projection after rebasing onto current `main`.

### Governance

`docs/adr/0088-…` records that the risk-trigger block has one documented home. It supersedes ADR-0014 **in part** — only the block's documentation homes moved; its trigger set and light/full mode selection stand. `grep` for "byte-identical"/"four homes"/"four docs" in ADR-0014 returns zero, so the four-home rule was only ever a spec acceptance criterion.

Per `CONVENTIONS.md § Superseding a frozen document`: ADR-0014 gains the forward pointer, the frozen spec and plan gain scoped pointers, all three bodies are unchanged (1 insertion / 1 deletion each), and ADR-0088 does **not** cite the spec — the spec end is deliberately one-way. Status lines use the parenthesised form; `lint-spec-status.py` truncates only at ` (`, ` →`, `<!--`, so a comma form failed invariant (i) with `status 'Shipped,' not in {…}`.

## What did you not change that you considered?

- **Did not restore the enumeration into either `AGENTS.md`.** They keep a one-line invariant and a differently worded pointer. Putting the list back in the files we just slimmed would undo the point.
- **Did not paraphrase for the new context.** I initially told the implementer to make "any file in this repo" read naturally as a convention; review caught that the paraphrase weakened it, and the original wording is restored. Same for `placeholders everywhere`.
- **Did not certify the wider deletion.** `#1049` removed ~1050 lines; I extracted 177 obligation-bearing lines and tried three times to auto-verify their survival. Every attempt's own normalization produced ~165 false positives. The privacy result is literal-grep solid; the rest is **not certified**, and the reliable method is a reviewer diff, not a script. Flagged rather than claimed.
- **Did not bump agentbundle.** Nothing under `packages/agentbundle/` changes.

### Review

Independent adversarial review across three passes caught three real dilutions in what was described as a verbatim restoration: the carve-out widened from governance docs to any author/decider field; `any file in this repo` → `any repository artifact`; `placeholders everywhere` lost its adverb. All corrected. I then disclosed two residuals I found myself and asked whether further findings were coming from my own edits rather than the artifact; the reviewer returned **REVIEW_CLEAN** and judged that further iteration would be polish, not defect repair.

### Release impact

core 2.9.2 → **2.9.4** (2.9.3 is claimed by an in-flight change in another lane), changelog entry at the top of the live `###` list, two roster pins moved. `Engine-Change-RFC: n/a`.

Cut fresh from `main` rather than reusing the `#1049` branch: that PR was squash-merged, so the old branch's unsquashed history made GitHub compute a 47-file diff that would have re-proposed the entire merged change.
