### PR TITLE
docs(web,contracts): name journey decision gates in prose instead of internal codes

### DIFF
--- a/packs/contracts/README.md
+++ b/packs/contracts/README.md
@@ -51,7 +51,7 @@ api-contract [orders service: create, get, cancel]
   ● Error shapes consistent (Problem schema)
   ⚠ POST /orders: missing 409 Conflict for duplicate order_id
 
-  G-contract ›
+  Contract review ›
 ```
 
 ```text

--- a/web/src/content/journeys/contracts.md
+++ b/web/src/content/journeys/contracts.md
@@ -71,7 +71,7 @@ api-contract [orders service: create, get, cancel]
 
 ### 2. Review from the consumer's perspective
 
-The agent runs a consumer-perspective check against the house standard and surfaces the contract at the G-contract gate.
+The agent runs a consumer-perspective check against the house standard and surfaces the contract at the contract review gate.
 
 ```text
   Consumer-perspective check
@@ -80,7 +80,7 @@ The agent runs a consumer-perspective check against the house standard and surfa
   ● Error shapes consistent (Problem schema)
   ⚠ POST /orders: missing 409 Conflict for duplicate order_id
 
-  G-contract ›
+  Contract review ›
 ```
 
 - **You decide:** approve the contract — check error codes first; a contract covering only 200 responses is incomplete.

--- a/web/src/content/journeys/converters.md
+++ b/web/src/content/journeys/converters.md
@@ -79,5 +79,5 @@ relatedJourneys:
 ### 3. Review the output
 
 - **Agent does:** reports where the output lands and emits a brief summary of what it converted.
-- **You decide:** open the output file at the G-output gate and review it — check for truncation, structure loss, and template application; if a section is missing, re-run with an explicit instruction to include it.
+- **You decide:** open the output file at the output review gate and review it — check for truncation, structure loss, and template application; if a section is missing, re-run with an explicit instruction to include it.
 - **Output:** a verified conversion artifact ready to share or use in a downstream workflow.

--- a/web/src/content/journeys/credential-brokers.md
+++ b/web/src/content/journeys/credential-brokers.md
@@ -43,7 +43,7 @@ relatedJourneys:
 
 - **You provide:** the name of the service and the credential type it requires — API key, personal access token, or SSO cookie.
 - **Agent does:** walks you through identifying what credential type the service requires and which resolution path to use.
-- **You decide:** confirm credential type and storage location at the G-setup gate — choose where the credential will live: environment variable (CI-friendly), OS keyring (secure, persistent), or dotfile (portable); for most developer workstations, the OS keyring is the right choice.
+- **You decide:** confirm credential type and storage location at the credential setup gate — choose where the credential will live: environment variable (CI-friendly), OS keyring (secure, persistent), or dotfile (portable); for most developer workstations, the OS keyring is the right choice.
 - **Output:** an agreed credential type and resolution path.
 
 ---

--- a/web/src/content/journeys/figma.md
+++ b/web/src/content/journeys/figma.md
@@ -59,7 +59,7 @@ relatedJourneys:
 - **You provide:** the target Figma file URL or key, and a Personal Access Token if not already in credential-brokers.
 - **Agent does:** verifies the credential resolves via credential-brokers and can reach the target file.
 - **You do:** run credential-brokers setup if this is the first session, or confirm the existing token is still valid — once in place, every subsequent figma session resolves it automatically.
-- **You decide:** confirm the Figma credential at G-credential before any API call is made.
+- **You decide:** confirm the Figma credential at the credential check gate before any API call is made.
 - **Output:** a confirmed credential resolving to the target file.
 
 ---
@@ -76,5 +76,5 @@ relatedJourneys:
 
 - **Agent does:** presents the extracted artifact — rendered frame image, CSS variable set, Mermaid connector diagram, or structured property dump.
 - **You do:** check the artifact matches the intended design; for FigJam diagrams, verify all connectors and labels are preserved; for variable values, confirm they match the published design system state.
-- **You decide:** review extracted design data at G-output before passing it to the next workflow step.
+- **You decide:** review extracted design data at the design data review gate before passing it to the next workflow step.
 - **Output:** a reviewed design artifact ready to pass to the next workflow step.

--- a/web/src/content/journeys/monorepo-extras.md
+++ b/web/src/content/journeys/monorepo-extras.md
@@ -27,7 +27,7 @@ humanGates:
       - "Are the test command and test directory correct — not pointing to a parent package's test suite?"
     whatGoodLooksLike: "A package that builds from its own root, has a meaningful AGENTS.md, and follows the naming and layout conventions of the existing packages in the monorepo."
     whatBadLooksLike: "A package whose AGENTS.md still reads 'TODO: describe this package.' Or a package whose test command runs the wrong test suite because the `jest.config.js` points to the wrong root. These are the two most common post-scaffold defects."
-    consequence: "A scaffold that passes the G-review gate and then fails the first real build is the most expensive outcome — you've committed structural debt to the repo. The review gate is five minutes; fixing structural wiring after the first three PRs have extended the scaffolded pattern is much more expensive."
+    consequence: "A scaffold that passes the package review gate and then fails the first real build is the most expensive outcome — you've committed structural debt to the repo. The review gate is five minutes; fixing structural wiring after the first three PRs have extended the scaffolded pattern is much more expensive."
 typicalSession:
   agentTurns: "3–5"
   humanTouches: 1
@@ -50,7 +50,7 @@ relatedJourneys:
 ### 2. Scaffold, wire, and gate the package
 
 - **Agent does:** produces the package skeleton — directory structure, package.json (or equivalent), AGENTS.md, build configuration, and test directory; populates AGENTS.md with the package name, description, and correct build and test commands.
-- **You do:** at the G-review gate, check the two things most likely to be wrong: the AGENTS.md still has placeholder text, and the test command points to the wrong root; both are easy to catch here and expensive to fix after other packages have extended the scaffolded pattern.
+- **You do:** at the package review gate, check the two things most likely to be wrong: the AGENTS.md still has placeholder text, and the test command points to the wrong root; both are easy to catch here and expensive to fix after other packages have extended the scaffolded pattern.
 - **You decide:** review the scaffolded package before first commit.
 - **Output:** a reviewed, corrected scaffold ready for commit.
 


### PR DESCRIPTION
Closes the visible half of the `legacy-hand-authored-journey-gate-mappings` backlog item. Approved scope: fix the prose, leave the ids legacy, drop the id migration.

## The defect

The six hand-authored journey pages carry legacy `humanGates[].id` values (`G-contract`, `G-output`, `G-setup`, `G-credential`, `G-review`). Those ids are internal — they emit no HTML `id` and no `href`, verified against the built output. But adopter-facing **prose** hand-wrote the codes:

> open the output file at the **G-output** gate and review it
> at the **G-review** gate, check the two things most likely to be wrong

An adopter cannot resolve `G-output`, because nothing on the page defines it. That is the defect: an unresolvable identifier, not the identifier's existence.

## What changed

Eight references across five files, each named in plain language instead:

| File | Was | Now |
|---|---|---|
| `contracts` | `G-contract` gate | the contract review gate |
| `contracts` (fence) | `G-contract ›` | `Contract review ›` |
| `converters` | `G-output` gate | the output review gate |
| `credential-brokers` | `G-setup` gate | the credential setup gate |
| `figma` | `G-credential` | the credential check gate |
| `figma` | `G-output` | the design data review gate |
| `monorepo-extras` ×2 | `G-review` gate | the package review gate |

`user-guide-diataxis.md` is untouched — it has two gates and leaked neither.

## Also: the same code in a shipped pack README

Independent review caught `packs/contracts/README.md:54`, which I had missed. It **ships to adopters** as `dist/claude-plugins/contracts/README.md`, shows `G-contract ›` in an equivalent fenced illustration, and never defines it — the word "gate" does not appear in that file at all. Fixing the journey page alone would have left the identical unresolvable code in the shipped artifact, which is how a fact stated in two places drifts at the first edit touching one.

`packs/contracts/DESIGN.md` keeps its five references deliberately: it is **not** shipped, and it defines the gate under its own heading, so the code resolves for its reader. That is the line — a code is a leak where the reader cannot resolve it, not wherever it appears.

## Why the ids stay legacy

They are not adopter-visible: zero `id="G-…"` attributes and zero `href="#G-…"` in the emitted HTML, because these hand-authored journeys have no `decisionGateIds` and so get no fragment targets. Migrating them to semantic ids buys nothing until these journeys gain decision-gate fragments — which is a feature decision, not this cleanup. `globalGate: "G4"` likewise stays, since nothing renders it.

## Verification

- Clean `dist` rebuild, four-stage site build, `make lint-ruff`, `SKIP_SAST=1 make build-check` — all exit 0, zero `✖`, `pre-pr: ✓ agents-md hygiene`.
- All **18** emitted journey pages scanned: **0** visible internal gate codes.
- Each replacement phrase renders on its page; `dist/claude-plugins/contracts/README.md` carries `Contract review ›` and zero `G-contract`.
- Diff is 9 lines across 6 files, one-for-one. **No `id:` or `globalGate:` line changed.**
- The sweep that confirms no leak remains was run with a positive control — an earlier version used `\b` under `-E`, which POSIX ERE does not support, so it silently matched nothing and reported a false all-clear.