### PR TITLE
feat(web,tools): marketing chrome consumes the approved destination contract

### DIFF
--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -34,6 +34,9 @@ SITE_BASE = "/agent-ready-repo/docs"
 NOW_PROJECTION = (
     REPO_ROOT / "web" / "src" / "lib" / "now-highlights.generated.json"
 )
+MARKETING_SHARED_CHROME_PROJECTION = (
+    REPO_ROOT / "web" / "src" / "lib" / "shared-chrome.generated.json"
+)
 # Seven calendar days ending on launch day, inclusive (brief decision 19): the
 # launch date itself plus the six dates before it.
 NOW_WINDOW_DAYS = 7
@@ -351,6 +354,31 @@ def project_shared_chrome(contract: object) -> dict[str, dict]:
     }
 
     return {"marketing": marketing, "docs": docs}
+
+
+def generate_marketing_shared_chrome_projection(
+    contract: object,
+    output: Path = MARKETING_SHARED_CHROME_PROJECTION,
+    dry_run: bool = False,
+) -> dict:
+    """Project the marketing chrome input before and after its site build."""
+    payload = project_shared_chrome(contract)["marketing"]
+    if not dry_run:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def assert_marketing_shared_chrome_projection_current(
+    contract: object, output: Path = MARKETING_SHARED_CHROME_PROJECTION
+) -> None:
+    """Reject a committed marketing input that no longer matches ``site.toml``."""
+    expected = project_shared_chrome(contract)["marketing"]
+    actual = json.loads(output.read_text(encoding="utf-8"))
+    if actual != expected:
+        raise ValueError(
+            f"{output} is stale — run `python3 tools/build-site.py --journeys-only`"
+        )
 
 
 def discover_packs(root: Path, site_toml: Path) -> list[dict]:
@@ -1966,7 +1994,7 @@ def main() -> None:
     site_toml = REPO_ROOT / "site.toml"
     # Validate the complete shared vocabulary before either build path can
     # project or clean renderer inputs.
-    load_shared_chrome_contract(site_toml)
+    shared_chrome_contract = load_shared_chrome_contract(site_toml)
 
     if args.journeys_only:
         journey_dir = REPO_ROOT / "web" / "src" / "content" / "journeys"
@@ -1980,6 +2008,9 @@ def main() -> None:
         # `npm run build --prefix web`, and the full pass only afterwards, so a
         # projection emitted solely by the full pass would always be one build
         # stale for the renderer that consumes it.
+        generate_marketing_shared_chrome_projection(
+            shared_chrome_contract, dry_run=args.dry_run
+        )
         _report_now_projection(changelog_src, dry_run=args.dry_run)
         return
 
@@ -2039,6 +2070,11 @@ def main() -> None:
 
     print("build-site: projecting released changelog highlights …")
     _report_now_projection(changelog_src, dry_run=args.dry_run)
+
+    print("build-site: projecting marketing shared chrome …")
+    generate_marketing_shared_chrome_projection(
+        shared_chrome_contract, dry_run=args.dry_run
+    )
 
     print("build-site: copying changelog …")
     changelog_dst = SITE_DOCS / "changelog.md"

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
 import shutil
 import subprocess
 import sys
@@ -203,6 +204,45 @@ def test_shared_chrome_projects_independently_allocated_renderer_data():
 
     first["marketing"]["header"][0]["label"] = "Changed only in marketing"
     assert first["docs"]["product_orientation_band"][1]["label"] == "How it works"
+
+
+def test_marketing_shared_chrome_projection_writes_the_marketing_contract(tmp_path):
+    """The pre-build marketing input contains no docs renderer projection."""
+    output = tmp_path / "shared-chrome.generated.json"
+    contract = _shared_chrome_fixture()
+
+    payload = build_site.generate_marketing_shared_chrome_projection(contract, output)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+    assert payload == build_site.project_shared_chrome(contract)["marketing"]
+    assert "product_orientation_band" not in payload
+
+
+def test_marketing_shared_chrome_projection_dry_run_does_not_write(tmp_path):
+    """Dry runs calculate the marketing projection without changing its input file."""
+    output = tmp_path / "shared-chrome.generated.json"
+
+    build_site.generate_marketing_shared_chrome_projection(
+        _shared_chrome_fixture(), output, dry_run=True
+    )
+
+    assert not output.exists()
+
+
+def test_marketing_shared_chrome_projection_rejects_a_seeded_stale_literal(tmp_path):
+    """AC1 guard: hand-edited renderer input cannot drift from the sole source."""
+    output = tmp_path / "shared-chrome.generated.json"
+    contract = _shared_chrome_fixture()
+    payload = build_site.generate_marketing_shared_chrome_projection(contract, output)
+    payload["header"][0]["label"] = "Stale marketing literal"
+    output.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        build_site.assert_marketing_shared_chrome_projection_current(contract, output)
+    except ValueError as exc:
+        assert "is stale" in str(exc)
+    else:  # pragma: no cover - the raise below is the failure report
+        raise AssertionError("a stale marketing shared-chrome literal passed consistency")
 
 
 def test_shared_chrome_rejects_duplicate_destination_ids():
@@ -411,6 +451,9 @@ def test_journeys_only_validates_shared_chrome_before_projection(monkeypatch):
 
     monkeypatch.setattr(build_site, "load_shared_chrome_contract", fail_validation)
     monkeypatch.setattr(build_site, "sync_pack_journeys", unexpected_projection)
+    monkeypatch.setattr(
+        build_site, "generate_marketing_shared_chrome_projection", unexpected_projection
+    )
     monkeypatch.setattr(build_site, "_report_now_projection", unexpected_projection)
     monkeypatch.setattr(sys, "argv", ["build-site.py", "--journeys-only"])
 
@@ -420,6 +463,33 @@ def test_journeys_only_validates_shared_chrome_before_projection(monkeypatch):
         assert str(exc) == "invalid shared chrome"
     else:  # pragma: no cover - the raise below is the failure report
         raise AssertionError("journeys-only build unexpectedly projected invalid shared chrome")
+
+
+def test_journeys_only_emits_marketing_shared_chrome_before_the_web_build(monkeypatch):
+    """The pre-web-build path emits the generated marketing renderer input."""
+    contract = _shared_chrome_fixture()
+    calls: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(build_site, "load_shared_chrome_contract", lambda _path: contract)
+    monkeypatch.setattr(build_site, "sync_pack_journeys", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(
+        build_site,
+        "generate_marketing_shared_chrome_projection",
+        lambda received, **kwargs: calls.append(("shared_chrome", (received, kwargs))),
+    )
+    monkeypatch.setattr(
+        build_site,
+        "_report_now_projection",
+        lambda *_args, **_kwargs: calls.append(("now", None)),
+    )
+    monkeypatch.setattr(sys, "argv", ["build-site.py", "--journeys-only", "--dry-run"])
+
+    build_site.main()
+
+    assert calls == [
+        ("shared_chrome", (contract, {"dry_run": True})),
+        ("now", None),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1470,6 +1540,9 @@ def test_the_window_does_not_filter_the_projection():
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CHANGELOG = _REPO_ROOT / "docs" / "product" / "changelog.md"
 _PROJECTION = _REPO_ROOT / "web" / "src" / "lib" / "now-highlights.generated.json"
+_MARKETING_SHARED_CHROME_PROJECTION = (
+    _REPO_ROOT / "web" / "src" / "lib" / "shared-chrome.generated.json"
+)
 _EMITTED_CHANGELOG = _REPO_ROOT / "build" / "docs" / "changelog" / "index.html"
 
 # The day `/now/` launched. A historical fact, deliberately pinned rather than
@@ -1495,6 +1568,13 @@ def test_the_committed_now_projection_matches_the_changelog_source():
     assert committed == expected, (
         "web/src/lib/now-highlights.generated.json is stale — "
         "run `python3 tools/build-site.py --journeys-only`"
+    )
+
+
+def test_the_committed_marketing_shared_chrome_projection_matches_site_toml():
+    """The committed marketing renderer input remains derived from site.toml."""
+    build_site.assert_marketing_shared_chrome_projection_current(
+        _shared_chrome_fixture(), _MARKETING_SHARED_CHROME_PROJECTION
     )
 
 
@@ -1698,8 +1778,8 @@ def test_release_anchors_match_the_emitted_page_one_for_one_in_order():
         assert got_anchors.index(base) < got_anchors.index(anchor)
 
 
-def test_the_public_work_surface_is_gone_from_the_marketing_source():
-    """`/work/` is removed outright — no page, no component, no exporter, no redirect.
+def test_the_public_work_surface_is_gone_from_marketing_inputs():
+    """`/work/` is removed from routes and the generated marketing input.
 
     Asserted over source rather than the build so it holds in the required suite,
     which runs without a site build.
@@ -1715,11 +1795,31 @@ def test_the_public_work_surface_is_gone_from_the_marketing_source():
     present = [str(p.relative_to(_REPO_ROOT)) for p in forbidden if p.exists()]
     assert not present, f"retired work-index surface still present: {present}"
 
-    nav = (
-        _REPO_ROOT / "web" / "src" / "components" / "layout" / "SiteNav.astro"
-    ).read_text(encoding="utf-8")
-    assert "/work/" not in nav
-    assert "withBase('/now/')" in nav
+    projection = json.loads(
+        _MARKETING_SHARED_CHROME_PROJECTION.read_text(encoding="utf-8")
+    )
+    destinations = [
+        link
+        for section in (
+            projection["header"],
+            *(group["destinations"] for group in projection["footer"]),
+        )
+        for link in section
+    ]
+    assert all(link["target"] != "/work/" for link in destinations)
+    assert any(link["id"] == "now" and link["target"] == "/now/" for link in destinations)
+
+    # The projection check above cannot see a hand-written literal reintroduced
+    # into a component, and the emitted-output check that would runs only when a
+    # build exists. Keep a source-level scan so the required suite still fails.
+    layout = _REPO_ROOT / "web" / "src" / "components" / "layout"
+    marketing_chrome = [layout / "SiteNav.astro", layout / "SiteFooter.astro"]
+    with_work = [
+        str(path.relative_to(_REPO_ROOT))
+        for path in marketing_chrome
+        if "/work/" in path.read_text(encoding="utf-8")
+    ]
+    assert not with_work, f"marketing chrome reintroduced a /work/ literal: {with_work}"
 
 
 # Git blob hashes of the frozen m6 artifacts, recorded from `origin/main` at

--- a/web/src/components/layout/SiteFooter.astro
+++ b/web/src/components/layout/SiteFooter.astro
@@ -1,42 +1,16 @@
 ---
 // Footer — dark zone. Labelled column groups rather than a flat link row: this
 // is the last thing on every marketing page, and a three-link strip was
-// carrying none of the site's navigable surface. Every href below resolves to
-// a route that exists in the build; do not add a column entry without one.
-import { withBase } from '../../lib/paths';
+// carrying none of the site's navigable surface. The generated projection is
+// the renderer-local input derived from the approved destination contract.
+import marketingChrome from '../../lib/shared-chrome.generated.json';
+import { chromeHref, currentState, type ChromeLink } from '../../lib/shared-chrome';
+
 const year = new Date().getFullYear();
 
-const columns = [
-  {
-    label: 'Product',
-    links: [
-      { text: 'How it works', href: withBase('/#three-loops') },
-      { text: 'Use cases', href: withBase('/#use-cases') },
-      { text: 'Catalogue', href: withBase('/catalogue/') },
-      { text: 'Packs', href: withBase('/packs/') },
-      { text: 'Journeys', href: withBase('/journeys/') },
-    ],
-  },
-  {
-    label: 'Docs',
-    links: [
-      { text: 'Get started', href: withBase('/docs/getting-started/') },
-      { text: 'Install', href: withBase('/docs/getting-started/install/') },
-      { text: 'The three loops', href: withBase('/docs/getting-started/three-loops/') },
-      { text: 'All docs', href: withBase('/docs/') },
-    ],
-  },
-  {
-    label: 'Project',
-    links: [
-      { text: 'Changelog', href: withBase('/docs/changelog/') },
-      { text: 'Contributing', href: withBase('/docs/contributing/') },
-      { text: 'Claude plugins', href: withBase('/plugins/') },
-      { text: 'GitHub', href: 'https://github.com/eugenelim/agent-ready-repo' },
-      { text: 'PyPI', href: 'https://pypi.org/project/agentbundle/' },
-    ],
-  },
-];
+const columns = marketingChrome.footer;
+const current = (link: ChromeLink) =>
+  currentState(link, Astro.url.pathname, import.meta.env.BASE_URL);
 ---
 
 <footer class="footer">
@@ -51,8 +25,12 @@ const columns = [
         <div class="footer__col">
           <h2 class="footer__collabel">{col.label}</h2>
           <ul class="footer__list">
-            {col.links.map((l) => (
-              <li><a href={l.href} rel="noopener">{l.text}</a></li>
+            {col.destinations.map((link) => (
+              <li>
+                <a href={chromeHref(link)} aria-current={current(link)}>
+                  {link.label}{link.kind === 'external' && <><span aria-hidden="true"> ↗</span><span class="visually-hidden"> external</span></>}
+                </a>
+              </li>
             ))}
           </ul>
         </div>
@@ -123,6 +101,13 @@ const columns = [
   .footer__list a:hover {
     color: var(--ds-accent);
     text-decoration: none;
+  }
+
+  .footer__list a[aria-current] {
+    color: var(--ds-hero-fg);
+    font-weight: var(--ds-weight-semibold);
+    text-decoration: underline;
+    text-underline-offset: 0.3em;
   }
 
   .footer__copy {

--- a/web/src/components/layout/SiteNav.astro
+++ b/web/src/components/layout/SiteNav.astro
@@ -2,17 +2,16 @@
 // Primary navigation. Dark zone — continuous with the hero below it, no gap.
 // Mobile menu is a <details>/<summary> disclosure: zero JavaScript.
 // Nav structure:
-//   Logo | How it works | Use cases | Catalogue | Now | Docs ↗ | [Try the build loop →]
+//   Logo | approved shared destinations | [Try the build loop →]
 import { withBase } from '../../lib/paths';
-const links = [
-  { label: 'How it works', href: withBase('/#three-loops') },
-  { label: 'Use cases', href: withBase('/#use-cases') },
-  { label: 'Catalogue', href: withBase('/catalogue/') },
-  { label: 'Now', href: withBase('/now/') },
-];
+import marketingChrome from '../../lib/shared-chrome.generated.json';
+import { chromeHref, currentState, splitHeader, type ChromeLink } from '../../lib/shared-chrome';
+
 const homeHref = withBase('/');
-const docsHref = withBase('/docs/');
-const installHref = withBase('/#install');
+// The CTA is selected by its stable ID, not by falling last in the order.
+const { links, cta } = splitHeader(marketingChrome.header);
+const current = (link: ChromeLink) =>
+  currentState(link, Astro.url.pathname, import.meta.env.BASE_URL);
 ---
 
 <nav class="nav" aria-label="Primary">
@@ -21,15 +20,10 @@ const installHref = withBase('/#install');
 
     <ul class="nav__links">
       {links.map((l) => (
-        <li><a class="nav__link" href={l.href}>{l.label}</a></li>
+        <li><a class="nav__link" href={chromeHref(l)} aria-current={current(l)}>{l.label}</a></li>
       ))}
       <li>
-        <a class="nav__link nav__link--docs" href={docsHref} rel="noopener">
-          Docs <span aria-hidden="true">↗</span>
-        </a>
-      </li>
-      <li>
-        <a class="nav__cta" href={installHref}>Try the build loop <span aria-hidden="true">→</span></a>
+        <a class="nav__cta" href={chromeHref(cta)}>{cta.label} <span aria-hidden="true">→</span></a>
       </li>
     </ul>
 
@@ -39,15 +33,10 @@ const installHref = withBase('/#install');
       </summary>
       <ul class="nav__drawer">
         {links.map((l) => (
-          <li><a class="nav__link" href={l.href}>{l.label}</a></li>
+          <li><a class="nav__link" href={chromeHref(l)} aria-current={current(l)}>{l.label}</a></li>
         ))}
         <li>
-          <a class="nav__link nav__link--docs" href={docsHref} rel="noopener">
-            Docs <span aria-hidden="true">↗</span>
-          </a>
-        </li>
-        <li>
-          <a class="nav__cta" href={installHref}>Try the build loop <span aria-hidden="true">→</span></a>
+          <a class="nav__cta" href={chromeHref(cta)}>{cta.label} <span aria-hidden="true">→</span></a>
         </li>
       </ul>
     </details>
@@ -102,8 +91,11 @@ const installHref = withBase('/#install');
     text-decoration: none;
   }
 
-  .nav__link--docs {
-    color: var(--ds-hero-fg-muted);
+  .nav__link[aria-current] {
+    color: var(--ds-hero-fg);
+    font-weight: var(--ds-weight-semibold);
+    text-decoration: underline;
+    text-underline-offset: 0.3em;
   }
 
   .nav__cta {

--- a/web/src/lib/shared-chrome.generated.json
+++ b/web/src/lib/shared-chrome.generated.json
@@ -1,0 +1,150 @@
+{
+  "header": [
+    {
+      "id": "how-it-works",
+      "label": "How it works",
+      "target": "/#three-loops",
+      "kind": "internal"
+    },
+    {
+      "id": "use-cases",
+      "label": "Use cases",
+      "target": "/#use-cases",
+      "kind": "internal"
+    },
+    {
+      "id": "catalogue",
+      "label": "Catalogue",
+      "target": "/catalogue/",
+      "kind": "internal"
+    },
+    {
+      "id": "now",
+      "label": "Now",
+      "target": "/now/",
+      "kind": "internal"
+    },
+    {
+      "id": "docs",
+      "label": "Docs",
+      "target": "/docs/",
+      "kind": "internal"
+    },
+    {
+      "id": "try-the-build-loop",
+      "label": "Try the build loop",
+      "target": "/#install",
+      "kind": "internal"
+    }
+  ],
+  "footer": [
+    {
+      "id": "product",
+      "label": "Product",
+      "destinations": [
+        {
+          "id": "how-it-works",
+          "label": "How it works",
+          "target": "/#three-loops",
+          "kind": "internal"
+        },
+        {
+          "id": "use-cases",
+          "label": "Use cases",
+          "target": "/#use-cases",
+          "kind": "internal"
+        },
+        {
+          "id": "catalogue",
+          "label": "Catalogue",
+          "target": "/catalogue/",
+          "kind": "internal"
+        },
+        {
+          "id": "packs",
+          "label": "Packs",
+          "target": "/packs/",
+          "kind": "internal"
+        },
+        {
+          "id": "journeys",
+          "label": "Journeys",
+          "target": "/journeys/",
+          "kind": "internal"
+        }
+      ]
+    },
+    {
+      "id": "docs",
+      "label": "Docs",
+      "destinations": [
+        {
+          "id": "get-started",
+          "label": "Get started",
+          "target": "/docs/getting-started/",
+          "kind": "internal"
+        },
+        {
+          "id": "install",
+          "label": "Install",
+          "target": "/docs/getting-started/install/",
+          "kind": "internal"
+        },
+        {
+          "id": "three-loops",
+          "label": "The three loops",
+          "target": "/docs/getting-started/three-loops/",
+          "kind": "internal"
+        },
+        {
+          "id": "all-docs",
+          "label": "All docs",
+          "target": "/docs/",
+          "kind": "internal"
+        }
+      ]
+    },
+    {
+      "id": "project",
+      "label": "Project",
+      "destinations": [
+        {
+          "id": "now",
+          "label": "Now",
+          "target": "/now/",
+          "kind": "internal"
+        },
+        {
+          "id": "changelog",
+          "label": "Changelog",
+          "target": "/docs/changelog/",
+          "kind": "internal"
+        },
+        {
+          "id": "contributing",
+          "label": "Contributing",
+          "target": "/docs/contributing/",
+          "kind": "internal"
+        },
+        {
+          "id": "claude-plugins",
+          "label": "Claude plugins",
+          "target": "/plugins/",
+          "kind": "internal"
+        },
+        {
+          "id": "github",
+          "label": "GitHub",
+          "target": "https://github.com/eugenelim/agent-ready-repo",
+          "kind": "external"
+        },
+        {
+          "id": "pypi",
+          "label": "PyPI",
+          "target": "https://pypi.org/project/agentbundle/",
+          "kind": "external"
+        }
+      ]
+    }
+  ]
+}

--- a/web/src/lib/shared-chrome.ts
+++ b/web/src/lib/shared-chrome.ts
@@ -1,0 +1,69 @@
+// Marketing-local consumption rules for the generated shared-chrome projection.
+// Renderer-local by design: docs consumes the same canonical contract through
+// its own renderer-native code. Nothing here is shared with docs-site.
+import { withBase } from './paths';
+import marketingChrome from './shared-chrome.generated.json';
+
+export type ChromeLink = (typeof marketingChrome.header)[number];
+
+/** The header's call-to-action, selected by its stable ID rather than position. */
+export const CTA_ID = 'try-the-build-loop';
+
+/**
+ * Resolve a destination's href from its DECLARED kind.
+ *
+ * `withBase` branches on the target's scheme, which would make internal/external
+ * handling hostname-derived. The spec requires kind to come from canonical data,
+ * so the branch is made here on `link.kind` and `withBase` only ever sees a target
+ * already known to be internal.
+ */
+export function chromeHref(link: ChromeLink): string {
+  return link.kind === 'internal' ? withBase(link.target) : link.target;
+}
+
+/**
+ * Split the header into its ordered plain destinations and its CTA.
+ *
+ * Selecting the CTA by ID keeps an approved reordering of the header from
+ * silently promoting whichever destination happens to land last.
+ */
+export function splitHeader(header: readonly ChromeLink[]): {
+  links: ChromeLink[];
+  cta: ChromeLink;
+} {
+  const cta = header.find((link) => link.id === CTA_ID);
+  if (!cta) {
+    throw new Error(
+      `shared-chrome header is missing its '${CTA_ID}' call-to-action destination`
+    );
+  }
+  return { links: header.filter((link) => link.id !== CTA_ID), cta };
+}
+
+/**
+ * Current-location state for a destination on the page at `pathname`.
+ *
+ * Homepage fragment destinations never claim current state: a fragment needs
+ * client-side route evidence the static build does not have.
+ */
+export function currentState(
+  link: ChromeLink,
+  pathname: string,
+  baseUrl: string
+): 'page' | 'location' | undefined {
+  if (link.kind !== 'internal' || link.target.includes('#')) return undefined;
+
+  const basePath = baseUrl.replace(/\/$/, '');
+  const routePath = pathname.startsWith(basePath)
+    ? pathname.slice(basePath.length) || '/'
+    : pathname;
+
+  if (routePath === link.target) return 'page';
+  if (
+    link.id === 'catalogue' &&
+    (routePath.startsWith('/packs/') || routePath.startsWith('/journeys/'))
+  ) {
+    return 'location';
+  }
+  return undefined;
+}

--- a/web/src/test/rendered-output.test.ts
+++ b/web/src/test/rendered-output.test.ts
@@ -38,6 +38,7 @@ const DOCS_BASE_PATH = '/agent-ready-repo/docs/';
 const DOCS_HOME = join(DOCS_ROOT, 'index.html');
 const NOW_PAGE = join(BUILD_ROOT, 'now', 'index.html');
 const NOW_PROJECTION = join(REPO_ROOT, 'web/src/lib/now-highlights.generated.json');
+const SHARED_CHROME_PROJECTION = join(REPO_ROOT, 'web/src/lib/shared-chrome.generated.json');
 const NESTED_GUIDE = join(DOCS_ROOT, 'guides/core/how-to/start-a-project/index.html');
 
 function walk(dir: string, match: (name: string) => boolean, out: string[] = []): string[] {
@@ -431,6 +432,94 @@ describe.skipIf(!webBuilt)('built marketing output', () => {
     expect(now.length).toBeGreaterThanOrEqual(2); // desktop list + mobile drawer
     for (const link of now) expect(link.label).toBe('Now');
     expect(navHrefs.some((l) => l.href?.endsWith('/work/'))).toBe(false);
+  });
+
+  it('shared chrome AC3/AC4/AC7/AC8: marketing navigation and footer render the approved contract', () => {
+    const expected = JSON.parse(readFileSync(SHARED_CHROME_PROJECTION, 'utf8'));
+    const d = doc(homePage);
+    const base = '/agent-ready-repo';
+    const expectedHeader = expected.header.map((link: { label: string; target: string }) => ({
+      label: link.label,
+      href: `${base}${link.target}`,
+    }));
+
+    for (const selector of ['.nav__links', '.nav__drawer']) {
+      const links = [...d.querySelectorAll<HTMLAnchorElement>(`${selector} a`)];
+      expect(links.map((link) => ({
+        label: link.textContent?.replace(/\s+/g, ' ').trim().replace(/ →$/, ''),
+        href: link.getAttribute('href'),
+      }))).toEqual(expectedHeader);
+      expect(links.at(-1)?.classList.contains('nav__cta')).toBe(true);
+      expect(links.filter((link) => link.hasAttribute('rel'))).toEqual([]);
+    }
+
+    const columns = [...d.querySelectorAll('footer .footer__col')];
+    expect(columns.map((column) => column.querySelector('h2')?.textContent?.trim())).toEqual(
+      expected.footer.map((column: { label: string }) => column.label)
+    );
+    for (const [index, column] of columns.entries()) {
+      const expectedColumn = expected.footer[index];
+      const links = [...column.querySelectorAll<HTMLAnchorElement>('a')];
+      expect(links.map((link) => link.textContent?.replace(/\s+/g, ' ').trim().replace(/ external$/, '').replace(/ ↗$/, ''))).toEqual(
+        expectedColumn.destinations.map((link: { label: string }) => link.label)
+      );
+      for (const [linkIndex, link] of links.entries()) {
+        const expectedLink = expectedColumn.destinations[linkIndex];
+        expect(link.getAttribute('href')).toBe(
+          expectedLink.kind === 'internal' ? `${base}${expectedLink.target}` : expectedLink.target
+        );
+        expect(link.hasAttribute('rel')).toBe(false);
+        expect(link.getAttribute('target')).toBeNull();
+        const glyph = link.querySelector('[aria-hidden="true"]');
+        if (expectedLink.kind === 'external') {
+          // The glyph must be hidden from assistive technology and the accessible
+          // name must read "<label> external" — not "<label> ↗ external".
+          expect(glyph?.textContent?.trim()).toBe('↗');
+          expect(link.querySelector('.visually-hidden')?.textContent?.trim()).toBe('external');
+          const accessibleName = [...link.childNodes]
+            .filter((node) => !(node as Element).getAttribute?.('aria-hidden'))
+            .map((node) => node.textContent)
+            .join('')
+            .replace(/\s+/g, ' ')
+            .trim();
+          expect(accessibleName).toBe(`${expectedLink.label} external`);
+        } else {
+          expect(link.textContent?.includes('↗')).toBe(false);
+          expect(glyph).toBeNull();
+          expect(link.querySelector('.visually-hidden')).toBeNull();
+        }
+      }
+    }
+    expect(d.querySelector('.footer__brand')?.textContent?.trim()).toBe('agent-ready-repo');
+    expect(d.querySelector('.footer__tag')?.textContent?.trim()).toBe(
+      'The supervised AI operating model for software teams.'
+    );
+  });
+
+  it('shared chrome AC8: current states are route-specific and fragments stay non-current', () => {
+    const readPage = (path: string) => doc(join(BUILD_ROOT, path, 'index.html'));
+    const home = doc(homePage);
+    expect(home.querySelectorAll('[href*="#"][aria-current]').length).toBe(0);
+    expect(readPage('now').querySelectorAll('[href$="/now/"][aria-current="page"]').length).toBeGreaterThan(1);
+    expect(readPage('catalogue').querySelectorAll('[href$="/catalogue/"][aria-current="page"]').length).toBeGreaterThan(1);
+    // `/packs/` itself is a redirect stub with no chrome; the pack and journey
+    // descendants that carry chrome are the ones the category-current rule owns.
+    for (const descendant of ['packs/core', 'journeys', 'journeys/core']) {
+      expect(readPage(descendant).querySelectorAll('[href$="/catalogue/"][aria-current="location"]').length)
+        .toBeGreaterThan(1);
+    }
+
+    // AC8 applies the same semantics in footers. Scoped to `footer` because the
+    // desktop nav and mobile drawer alone satisfy any whole-document count, so a
+    // footer that dropped `aria-current` would pass every assertion above.
+    const footerCurrent = (path: string, selector: string) =>
+      readPage(path).querySelectorAll(`footer ${selector}`).length;
+    expect(footerCurrent('now', '[href$="/now/"][aria-current="page"]')).toBe(1);
+    expect(footerCurrent('catalogue', '[href$="/catalogue/"][aria-current="page"]')).toBe(1);
+    expect(footerCurrent('packs/core', '[href$="/catalogue/"][aria-current="location"]')).toBe(1);
+    expect(footerCurrent('journeys/core', '[href$="/catalogue/"][aria-current="location"]')).toBe(1);
+    // Fragment destinations stay non-current in the footer too.
+    expect(footerCurrent('now', '[href*="#"][aria-current]')).toBe(0);
   });
 
   it('now AC3–AC4: every release group names its package, version, date and changelog source', () => {

--- a/web/src/test/shared-chrome.test.ts
+++ b/web/src/test/shared-chrome.test.ts
@@ -1,0 +1,101 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type * as SharedChrome from '../lib/shared-chrome';
+
+// `paths.ts` reads `import.meta.env.BASE_URL` at module load, and under vitest it
+// defaults to '/'. With that base, base-qualifying and not base-qualifying are the
+// same string, so the kind-vs-hostname distinction this file exists to prove would
+// be invisible. Stub a real base and import once here — warmed outside any timed
+// test body, deliberately not the per-test `resetModules` + dynamic-import shape
+// that makes `site-base.test.ts` time out under load.
+let chromeHref: typeof SharedChrome.chromeHref;
+let currentState: typeof SharedChrome.currentState;
+let splitHeader: typeof SharedChrome.splitHeader;
+let CTA_ID: typeof SharedChrome.CTA_ID;
+
+beforeAll(async () => {
+  vi.stubEnv('BASE_URL', '/agent-ready-repo/');
+  vi.resetModules();
+  ({ chromeHref, currentState, splitHeader, CTA_ID } = await import('../lib/shared-chrome'));
+});
+
+type Link = Parameters<typeof SharedChrome.chromeHref>[0];
+const link = (over: Partial<Link>): Link =>
+  ({ id: 'x', label: 'X', target: '/x/', kind: 'internal', ...over }) as Link;
+
+describe('chromeHref', () => {
+  it('base-qualifies an internal target', () => {
+    expect(chromeHref(link({ target: '/catalogue/' }))).toBe('/agent-ready-repo/catalogue/');
+  });
+
+  it('leaves an external target alone', () => {
+    const target = 'https://github.com/eugenelim/agent-ready-repo';
+    expect(chromeHref(link({ kind: 'external', target }))).toBe(target);
+  });
+
+  // The discriminating case. `withBase()` decides by URL scheme, so for today's
+  // two https externals a hostname-driven renderer and a kind-driven one emit
+  // identical output. The generator shape-validates internal targets only
+  // (`_validate_internal_shared_target` is called under `if kind == "internal"`),
+  // so a declared-external target without an http(s) scheme is admissible data —
+  // and it is the input on which the two rules diverge. Kind must win.
+  it('does not base-qualify a declared-external target that lacks an http scheme', () => {
+    expect(chromeHref(link({ kind: 'external', target: '/not-ours/' }))).toBe('/not-ours/');
+  });
+});
+
+describe('splitHeader', () => {
+  // The CTA's ID is written out literally rather than read from `CTA_ID`: taking
+  // it from the module under test would make these assertions agree with whatever
+  // the code says instead of with the approved contract.
+  const plain = () => link({ id: 'catalogue', target: '/catalogue/' });
+  const ctaLink = () => link({ id: 'try-the-build-loop', target: '/#install' });
+
+  it('exports the approved CTA ID', () => {
+    expect(CTA_ID).toBe('try-the-build-loop');
+  });
+
+  it('selects the CTA by ID and keeps the remaining order', () => {
+    const { links, cta } = splitHeader([plain(), ctaLink()]);
+    expect(cta.id).toBe('try-the-build-loop');
+    expect(links.map((l) => l.id)).toEqual(['catalogue']);
+  });
+
+  // Positional selection (`header.at(-1)`) would silently promote `now` to CTA
+  // and render the real CTA as a plain link.
+  it('still finds the CTA when it is not last', () => {
+    const reordered = [ctaLink(), plain(), link({ id: 'now', target: '/now/' })];
+    const { links, cta } = splitHeader(reordered);
+    expect(cta.id).toBe('try-the-build-loop');
+    expect(links.map((l) => l.id)).toEqual(['catalogue', 'now']);
+  });
+
+  it('fails loudly rather than rendering a header with no CTA', () => {
+    expect(() => splitHeader([plain()])).toThrow(/missing its 'try-the-build-loop'/);
+  });
+});
+
+describe('currentState', () => {
+  const base = '/agent-ready-repo/';
+  const at = (l: Link, path: string) => currentState(l, path, base);
+
+  it('marks an exact route as the current page', () => {
+    expect(at(link({ id: 'now', target: '/now/' }), '/agent-ready-repo/now/')).toBe('page');
+  });
+
+  it('marks catalogue as current location on pack and journey descendants', () => {
+    const catalogue = link({ id: 'catalogue', target: '/catalogue/' });
+    expect(at(catalogue, '/agent-ready-repo/packs/core/')).toBe('location');
+    expect(at(catalogue, '/agent-ready-repo/journeys/core/')).toBe('location');
+  });
+
+  it('never claims current state for a homepage fragment', () => {
+    for (const target of ['/#three-loops', '/#use-cases', '/#install']) {
+      expect(at(link({ target }), '/agent-ready-repo/')).toBeUndefined();
+    }
+  });
+
+  it('never claims current state for an external destination', () => {
+    const github = link({ id: 'github', kind: 'external', target: 'https://github.com/x' });
+    expect(at(github, 'https://github.com/x')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
T2 of `spec/site-shared-chrome`. Follows #1055 (T1), which made `site.toml`'s `[shared_chrome]` table the sole renderer-neutral source of the shared destination vocabulary.

## What this changes

T1 landed the contract, its validation, and `project_shared_chrome` — but nothing consumed it. The projection function had no caller, and `SiteNav`/`SiteFooter` still carried their own hardcoded literals.

This wires the marketing half up:

- **`tools/build-site.py`** emits the marketing projection to `web/src/lib/shared-chrome.generated.json`, in the `--journeys-only` pre-build phase *and* the full pass. The ordering is load-bearing: `npm run build --prefix web` runs between the two, so a projection emitted only by the full pass would always be one build stale for the renderer that consumes it. Both writes honour `--dry-run`.
- **`SiteNav.astro` / `SiteFooter.astro`** read that projection instead of their own literals.
- **`web/src/lib/shared-chrome.ts`** holds the marketing-local consumption rules.

### Contract corrections this pulls in

Three ways the emitted chrome disagreed with the approved contract:

| | Before | Now |
|---|---|---|
| Footer **Project** group | missing `Now` | Now, Changelog, Contributing, Claude plugins, GitHub, PyPI |
| **Docs** header link | external `↗` + `rel="noopener"` | internal, no glyph, no rel |
| Internal footer links | all carried `rel="noopener"` | no external-only relationship metadata |

GitHub and PyPI are now the only external treatments — same tab, `aria-hidden` `↗`, visually hidden "external".

### Two design points worth flagging

`chromeHref` branches on the destination's **declared `kind`**, not on what `withBase` infers from the URL scheme. The spec requires kind to come from canonical data; and this is reachable rather than theoretical, because `_validate_internal_shared_target` is called only under `if kind == "internal"` — a declared-external target without an http scheme is admissible data, and is exactly the input on which the two rules diverge.

`splitHeader` selects the CTA by its stable ID `try-the-build-loop` rather than by position. Positional selection would silently promote whichever destination landed last if the approved order ever changed.

## Scope

Renderer-local by construction. Docs consumes the same canonical contract through its own renderer-native code in T3 — no shared CSS, components, tokens, breakpoints, focus implementation, disclosure state, or JS. No new dependency. No route change; `/work/` stays absent.

## Verification

Four-stage build clean (s1–s4 rc=0). `npm run test --prefix web` **124/124** across 18 files. `pytest tools/test_build_site_routing.py` 71 passed. `make lint-ruff`, `SKIP_SAST=1 make build-check`, `lint-ci-parity` all green. `check-rendered-site-links.py` clean — 58035 links across 269 pages.

Emitted `aria-current`, measured from the build:

```
/journeys/            3 location   1 page
/journeys/core/       3 location
/packs/core/          3 location
/catalogue/           3 page
/now/                 3 page
/packs/               redirect stub — no chrome
```

### Mutation proofs

Every new guard was mutated and each flipped the named assertion; all restored by editing.

| Mutation | Assertion that caught it |
|---|---|
| `chromeHref` → hostname-driven | `does not base-qualify a declared-external target that lacks an http scheme` |
| `splitHeader` → `header.at(-1)` | `still finds the CTA when it is not last` |
| `/work/` literal into SiteNav | `test_the_public_work_surface_is_gone_from_marketing_inputs` |
| hand-edit the committed projection | `test_the_committed_marketing_shared_chrome_projection_matches_site_toml` |
| drop footer `aria-current` | AC8 footer-scoped count (`expected +0 to be 1`) |
| expose the glyph to AT | AC3/AC4/AC7/AC8 accessible-name assertion |

## Review

Two independent adversarial review rounds, neither by the implementer. Round 1 returned **CHANGES REQUESTED** with 5 findings (2 Major, 3 Minor) — all accepted and fixed in this diff: hostname-derived link handling, positional CTA selection, a weakened `/work/` guard, unproven footer current-state, and an unasserted `aria-hidden` on the glyph. Round 2, given origin-attribution instructions, returned **CLEAN** with no original defects and no fix-induced regressions.

## Known unrelated failure

`web/src/test/site-base.test.ts > PREVIEW_PORT` intermittently times out at 5000ms under machine contention. Untouched by this diff (last changed by #1052); passes 8/8 in isolation at 64ms import vs ~114s under load. Root cause is a per-test `resetModules()` + dynamic import against vitest's default timeout, with no `testTimeout` set in `web/vitest.config.ts`. Independently confirmed from source by the session owning `worktree-runtime-hygiene`, which is carrying it as a follow-up in that spec rather than here.