### PR TITLE
docs(governance): ADR-0090/0091 and the distribution-routes programme brief from RFC-0092

### DIFF
--- a/docs/adr/0004-repo-scope-per-adapter-projection.md
+++ b/docs/adr/0004-repo-scope-per-adapter-projection.md
@@ -1,6 +1,6 @@
 # ADR-0004: Per-IDE direct writes are the repo-scope install default; dist-tree is opt-in
 
-- **Status:** Accepted
+- **Status:** Accepted — rejected alternative (2) partially superseded by [ADR-0091](0091-kiro-power-route-supersedes-rejection.md); the decision itself stands
 - **Date:** 2026-05-26
 - **Deciders:** eugenelim
 - **Supersedes:** none

--- a/docs/adr/0090-distribution-routes-separate-from-runtime-adapters.md
+++ b/docs/adr/0090-distribution-routes-separate-from-runtime-adapters.md
@@ -1,0 +1,69 @@
+# ADR-0090: Distribution routes are a layer separate from runtime adapters
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Decision-makers:** eugenelim
+- **Consulted:** adversarial review (independent, three rounds to convergence), security review, fresh-reader review
+- **Supersedes:** none
+- **Related:** [RFC-0092](../rfc/0092-first-class-distribution-routes.md) (the accepted proposal this records), [RFC-0001](../rfc/0001-bundle-distribution-by-adapter-spec.md) (the adapter contract this extends), [RFC-0008](../rfc/0008-claude-plugins-install-route-parity.md), [RFC-0010](../rfc/0010-apm-install-route-parity.md), [ADR-0021](0021-pack-manifest-source-of-truth-and-scoped-identity.md), [ADR-0072](0072-derived-plugin-manifest-mirrors-upstream-schema.md), [ADR-0079](0079-executable-plugin-branch-publisher-identity.md)
+
+## Decision summary
+
+- **Decision:** Packaging a pack for an external plugin ecosystem is a **distribution route**, a first-class concept owned separately from a **runtime adapter**. Routes are declared in their own canonical contract; `install-routes` stops being a field of `[adapter."claude-code"]`.
+- **Because:** a vendor-neutral route (`apm`) is currently modelled as a property of one vendor's adapter, and the build has to route around its own abstraction to make that work.
+- **Applies to:** `contracts/`, the build recipes and their dispatch, and every present and future package output.
+- **Tradeoff accepted:** one more concept a contributor must learn before touching the build, and a third hand-written route lands before the generic registry removes the duplication.
+- **Revisit if:** the route contract's six fields still contain `unknown` after three real routes exist, or an external consumer turns out to read `contracts/adapter.toml` as public configuration.
+
+## Context
+
+Two external packages already ship — a Claude Code plugin and an APM package — and they work. What the repository lacks is a *name* for what they are, and three places in the source pay for that:
+
+- `contracts/adapter.toml:188` declares `install-routes = ["cli", "claude-plugins", "apm"]` inside `[adapter."claude-code"]`. `apm` is a vendor-neutral package format, yet it is modelled as a property of one runtime adapter; the contract comment concedes that "Kiro, Copilot, and Codex do not declare install-routes."
+- `packages/agentbundle/agentbundle/build/main.py:669` short-circuits past the adapter table entirely for `adapter == "apm"`, because APM is not an adapter and the code knows it. There is no layer for it to be instead.
+- `packages/agentbundle/agentbundle/build/main.py:741` has the Claude plugin route rewriting projection rows from `target-path`/`mode` to `plugin-target-path`/`plugin-mode` — a packaging concern reaching into the runtime contract and editing it mid-build.
+
+The constraint that forced the decision now rather than later: three further package formats became buildable against first-party documentation at once (portable Agent Plugins 1.0.0 with vendorable schemas, a native Codex plugin package, and Kiro Powers). Each additional route makes the mis-ownership more expensive, and `install-routes` carries a closed enum in `contracts/adapter.schema.json:255` plus two contract tests — one pinning Claude's exact list, one asserting no other adapter carries the field — so the cost is enumerable rather than vague.
+
+## Decision drivers
+
+- **Ownership correctness.** A vendor-neutral concept must not be a child of one vendor's adapter.
+- **Cost of the next route.** Adding a route should not require editing an unrelated adapter's contract row.
+- **No premature abstraction.** Four of six candidate routes have undocumented lifecycle and consent semantics; a registry built today would encode `unknown` as authoritative field names.
+- **Published-output stability.** The Claude marketplace promise is one-way and must not break.
+
+## Decision
+
+**A distribution route is a first-class concept, declared in its own canonical contract, and a runtime adapter is a separate concept; both consume the same normalized pack model and neither depends on the other.**
+
+- A route is declared in `contracts/distribution-routes.toml` with six fields: identity, package layout, manifest projector, component-capability map, marketplace projector, and lifecycle trigger.
+- `install-routes` moves there from `[adapter."claude-code"]`. A route may *name* an adapter projector, but is no longer owned by one.
+- The **route contract** (data) and the **route registry** (generic dispatch code) are separate deliverables in separate phases. Declaring routes in a contract does not require a generic engine to consume them; a minimal route resolver suffices at first, and route rendering stays named, route-specific code until three real routes exist.
+
+## Consequences
+
+**Positive.** The `apm` route stops being a Claude-adapter child. Route logic stops mutating adapter contract rows. A new package format is added by declaring a route rather than by editing another vendor's contract. Runtime adapters and distribution routes become independently reviewable.
+
+**Negative, honestly.** A contributor must learn the route/adapter distinction before touching the build. The generic registry is deferred, so a third route is hand-written first and duplication temporarily increases before it decreases. The published support matrix becomes *less* flattering, because several cells turn into `unknown` or partial-support claims where prose previously implied more.
+
+**Migration cost, enumerated rather than assumed.** The `install-routes` move touches: the closed enum in `contracts/adapter.schema.json:255`; the byte-identical bundled copy under `packages/agentbundle/agentbundle/_data/` held by `tools/catalogue/check_contract_parity.py`; the two contract tests at `packages/agentbundle/tests/build_pipeline/test_contract.py:478` and `:487` — the second of which asserts no other adapter carries the field and must therefore be rewritten rather than deleted; the marker's `--install-route` values and the generated hook commands that pass them; route-name strings in install state; and the public route documentation. Published output does not change.
+
+**Revisit if:** the route contract's six fields still contain `unknown` after three real routes exist (the registry extraction would then be permanently wrong, not merely early), or an external consumer is found to read `contracts/adapter.toml` as public configuration (the `apm` re-parenting would then be a breaking change requiring an alias and a deprecation window).
+
+## Confirmation
+
+- **Mode:** lint/CI
+- **Signal:** golden fixtures pin the Claude and APM package outputs byte-for-byte across the contract move, so "published output unchanged" is a testable claim rather than an intention; `tools/catalogue/check_contract_parity.py` keeps the canonical and bundled contracts identical; the rewritten contract test asserts route ownership lives in the route contract and not on an adapter.
+- **Owner:** eugenelim
+
+## Alternatives considered
+
+1. **Do nothing — keep adding route branches inside the Claude adapter.** Cheapest today. *Rejected:* the cost is per-route and recurring, and three routes are now buildable; `apm` stays mis-parented and every new route re-touches `main.py:669` and `:741`.
+2. **Build the full generic route registry now.** The intuitive design, and RFC-0092's original brief. *Rejected on spike evidence:* a drafted six-field registry was stress-tested against all six candidate routes and argued against itself — for `agent-plugin`, `codex-plugin`, `kiro-power`, and `copilot-plugin` it would hold placeholders, and a registry that encodes `unknown` as a named field obscures missing contract acquisition instead of removing special cases.
+3. **Model package formats as a second kind of adapter.** *Rejected:* "adapter" already means a runtime target with scope and projection rules in this repository; reusing the word for a thing with a different lifecycle would make both harder to reason about.
+4. **Make portable Agent Plugins the only output, with extensions for everything else.** *Rejected on the specification's own direction:* portable v1 excludes hooks, agents, commands, rules, and LSP, and its 1.1.0 working draft explicitly keeps excluding them pending format convergence. Claude users would lose eight of the nine canonical component kinds.
+
+## References
+
+- [RFC-0092](../rfc/0092-first-class-distribution-routes.md) — the accepted proposal, including the full option analysis, the component projection matrix, the threat model, and the phased rollout.
+- Evidence cited above was verified against the tree at `b9f85230`.

--- a/docs/adr/0091-kiro-power-route-supersedes-rejection.md
+++ b/docs/adr/0091-kiro-power-route-supersedes-rejection.md
@@ -1,0 +1,69 @@
+# ADR-0091: A Kiro Power route is justified: superseding the Kiro-route rejection only
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Decision-makers:** eugenelim
+- **Consulted:** adversarial review (independent, three rounds to convergence)
+- **Supersedes:** **rejected alternative (2) only** of [ADR-0004](0004-repo-scope-per-adapter-projection.md) — its rejection of a per-IDE plugin install route for Kiro. Every other part of ADR-0004, including its actual decision that per-IDE direct writes are the repo-scope install default, stands unchanged.
+- **Related:** [RFC-0092](../rfc/0092-first-class-distribution-routes.md) D3 (the accepted proposal this records), [RFC-0012](../rfc/0012-repo-scope-per-adapter-projection.md) alternative 2 (the same rejection in its originating RFC, corrected there by Errata), [ADR-0090](0090-distribution-routes-separate-from-runtime-adapters.md) (the route layer this route lives in), [RFC-0022](../rfc/0022-kiro-adapter-split.md) (the Kiro IDE/CLI adapter split, intact)
+
+## Decision summary
+
+- **Decision:** A Kiro Power route is justified, as a **route profile** that shares the portable Agent Plugin artifact rather than emitting a package of its own. This supersedes only the rejected alternative (2) in ADR-0004.
+- **Because:** that rejection rested on a specific factual premise — "Kiro Powers has no documented install verb" — and Kiro has since documented Powers with git and local import plus a Powers marketplace.
+- **Applies to:** the `kiro-power` route profile and the published Kiro support claims; no runtime adapter changes.
+- **Tradeoff accepted:** the route is a **partial** one — it delivers runtime components but cannot trigger project adaptation or install seeds, and saying so makes the published Kiro row less flattering.
+- **Revisit if:** Kiro documents a Power-install or Power-session lifecycle event (the route stops being partial), or Kiro's required manifest fields diverge from what `pack.toml` can derive.
+
+## Context
+
+ADR-0004 and [RFC-0012](../rfc/0012-repo-scope-per-adapter-projection.md) both rejected building a per-IDE plugin install route for Kiro, in the same words and for the same reason: *"Kiro has no programmatic plugin-install API to integrate with — its extension model is Open VSX (VS Code extensions, not skill content) and Kiro Powers has no documented install verb. Building a route for which no upstream consumer exists is premature."*
+
+That was correct when written, and it was researched — RFC-0012 cites `kiro.dev/docs/editor/extension-registry/`. The premise has since expired. Kiro's current first-party documentation describes a **Power** as an Agent Plugin plus an optional `dev.kiro/` extension directory, imported from GitHub or a local folder, activated by manifest `keywords`, with a Powers marketplace and one-click installation. The rejection's load-bearing fact — no documented install verb — no longer holds.
+
+Two constraints shape *how far* this goes:
+
+- A Kiro Power is a conforming Agent Plugin plus one directory. Emitting a separate `dist/kiro-powers/` tree would duplicate an entire package to gain that directory.
+- Kiro documents no Power-install event and no Power-packaged hook contract. `dev.kiro/` documents steering files only. So the route can deliver components, and cannot run the repository's install-to-adapt chain or install adopter-owned seeds.
+
+Kiro also **rewrites MCP server names on install** (`supabase-local` becomes `power-supabase-supabase-local`), so a canonical server name is not the installed name.
+
+## Decision drivers
+
+- **Is the rejection's premise still true?** It is not; that alone reopens the question but does not settle it.
+- **Does the target have a materially distinct package contract?** No — it shares the portable artifact. Its marketplace, admission rules, and activation semantics *are* its own.
+- **Can the route honestly claim the repository's differentiating capability?** No. Whether it can be described honestly as partial decides whether it may ship at all.
+- **Bytes duplicated per directory gained.** One directory does not justify a second package.
+
+## Decision
+
+**Kiro is supported as a `kiro-power` route profile over the portable `agent-plugin` artifact, and the rejection of a Kiro route in ADR-0004 alternative (2) is superseded — that clause only.**
+
+The profile shares the portable package's bytes and owns everything genuinely its own: admission validation against Kiro's stricter required-field set (`version`, `description`, `author`, and `keywords` all mandatory, against portable v1's `$schema` and `name`), `keywords`-driven activation semantics, its marketplace and submission projection, the `dev.kiro/` extension directory, and its own runtime-verification record. A route profile is a first-class route with a shared package layout, not a lesser one.
+
+The route is published as **`components-only`**: no project adaptation, no seed installation, stated as `unsupported` rather than as a caveat.
+
+## Consequences
+
+**Positive.** Kiro adopters get skills and MCP through a first-party-documented import path, at the cost of one extension directory over a package the portable route already builds. The expired premise is corrected in the record rather than silently worked around.
+
+**Negative, honestly.** The route cannot do the thing that distinguishes this repository's packs — repository-aware adaptation — and the published Kiro row must say so. `dev.kiro/steering/` has no source in `.apm/` today, so projecting steering would mean new canonical authoring surface; the route therefore ships with an empty extension point and no invented content. Nothing may depend on a canonical MCP server name surviving installation.
+
+**Revisit if:** Kiro documents a Power-install or Power-session lifecycle event, at which point adaptation and seed parity are re-evaluated and the `components-only` claim is retired; or Kiro's required manifest fields drift beyond what `pack.toml` can derive, at which point admission validation, not the package, is what changes.
+
+## Confirmation
+
+- **Mode:** reviewer-checked, escalating to lint/CI when the route ships
+- **Signal:** the published support matrix shows Kiro as `components-only` with adaptation and seeds `unsupported`, and no Kiro row claims `runtime-verified` until a recorded manual test names the Kiro version, surface, and OS. No route may be promoted to a verified claim on documentation alone.
+- **Owner:** eugenelim
+
+## Alternatives considered
+
+1. **Keep the rejection — no Kiro Power route at all.** The status quo, and a real governance option rather than a straw one; ADR-0004 and RFC-0012 chose it once already. *Rejected:* its stated premise has expired, and the package a Kiro route needs is a byproduct of the portable route being built regardless.
+2. **Emit a separate `dist/kiro-powers/` package.** *Rejected:* a Power is a conforming Agent Plugin plus `dev.kiro/`, so this duplicates the whole package to gain one directory — one output per product, which [RFC-0092](../rfc/0092-first-class-distribution-routes.md) rejects as a justification.
+3. **Treat Kiro as fully supported once the package loads.** *Rejected:* it would claim adaptation and seed behaviour the route provably cannot deliver, which is the specific dishonesty the route/claim separation exists to prevent.
+
+## References
+
+- [RFC-0092](../rfc/0092-first-class-distribution-routes.md) D3 and P5 — the route-profile design, the projection matrix, and the partial-route claim vocabulary.
+- Kiro first-party Powers documentation (create, install), retrieved 2026-08-19; documentation-verified, not runtime-verified.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -95,6 +95,8 @@
 | 0087 | [Lints resolve Git-ignore status in one batched call over stdin](0087-batch-git-check-ignore-over-stdin.md) | Accepted |
 | 0088 | [Risk triggers have a single documented home](0088-risk-triggers-have-a-single-documented-home.md) | Accepted |
 | 0089 | [Decision weight trims the RFC pre-handoff gate: RFC-0054 D1 over its implementing spec](0089-decision-weight-trims-the-rfc-gate.md) | Accepted |
+| 0090 | [Distribution routes are a layer separate from runtime adapters](0090-distribution-routes-separate-from-runtime-adapters.md) | Accepted |
+| 0091 | [A Kiro Power route is justified: superseding the Kiro-route rejection only](0091-kiro-power-route-supersedes-rejection.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/product/briefs/distribution-routes-programme.md
+++ b/docs/product/briefs/distribution-routes-programme.md
@@ -1,0 +1,121 @@
+# Brief: Land the distribution-route layer accepted by RFC-0092
+
+- **Slug:** `distribution-routes-programme`
+- **Received:** 2026-08-20
+- **Owner:** Platform Core (`ini-002`)
+- **Status:** Draft
+
+## Outcome
+
+Packaging a pack for an external plugin ecosystem is a named, contract-declared
+**distribution route**, owned separately from the **runtime adapter** that installs
+components into a live agent's directories. A maintainer can add a package format by
+declaring a route rather than by editing another vendor's adapter contract, and every
+route states honestly which canonical primitives it carries, which it drops, and
+whether it can trigger repository-aware adaptation at all.
+
+## Success metrics
+
+- `install-routes` is declared in a route-owned contract, not under
+  `[adapter."claude-code"]`, and the vendor-neutral `apm` route is no longer a child of
+  the Claude adapter.
+- The Claude and APM package outputs are byte-identical across the contract move, proved
+  by golden fixtures rather than asserted.
+- A conforming portable Agent Plugin package is emitted for every pack that has no
+  portable-excluded primitive — 13 of the 21 buildable packs at time of writing.
+- Every route's per-primitive status is machine-readable and drives both build
+  diagnostics and the published support matrix; no route claims `runtime-verified`
+  without a recorded per-client test naming client, version, surface, and OS.
+- A pack declaring a required semantic that a route cannot preserve **fails the build**
+  for that route rather than emitting a silently degraded package.
+
+## Scope / Non-goals
+
+**In scope:**
+
+- The route contract and the minimal route resolver (Phase 0); the portable Agent Plugin
+  projection and the canonical MCP primitive (Phase 1); registry extraction once three
+  real routes exist (Phase 2); the native Codex route (Phase 3); the Kiro Power route
+  profile (Phase 4); Claude-manifest migration and public-matrix updates (Phase 5).
+- The hook semantic-compatibility model, and the support-claim and runtime-verification
+  record that the matrix reads from.
+- Carrying the Claude route *forward* through every phase — each phase records what the
+  Claude route gains, rather than migrating it to a legacy path.
+
+**Non-goals:**
+
+- Implementing a Copilot route. It is inventoried and the abstraction is stress-tested
+  against it, deliberately, so the design is not Claude-and-Codex-shaped.
+- A universal agents, commands, or rules format. Portable v1 excludes all three and its
+  1.1.0 working draft explicitly keeps excluding them.
+- Replacing `agentbundle install`. Direct installation remains the only route that can do
+  everything; plugin routes are additive.
+- Moving seeds into portable packages, or claiming adaptation or seed parity on any route
+  whose client documents no lifecycle trigger.
+- MCP servers acquired from package registries. Deferred to its own RFC, and **already
+  closed at the build boundary** rather than merely postponed — see Rabbit holes.
+- Making any generated manifest an authoring source.
+
+## Appetite
+
+A bounded, ordered programme of six phases, sequenced by dependency rather than by
+product. A phase that requires a new dependency, a new authoring surface, or a public
+compatibility break leaves this programme until an approved amendment moves the boundary.
+
+## Rabbit holes
+
+- Do not build the generic route registry before three real routes exist. A spike drafted
+  it and argued against itself: four of six candidate routes would contribute placeholder
+  lifecycle and consent fields, and a registry that encodes `unknown` as an authoritative
+  field name hides missing contract acquisition instead of removing special cases.
+- Do not treat the `apm` re-parenting as free. It touches a closed enum in
+  `contracts/adapter.schema.json`, a byte-identical bundled copy under a parity gate, and
+  two contract tests — one of which asserts that *no other adapter* carries
+  `install-routes` and must be rewritten rather than deleted.
+- Do not let the MCP admission rule reject remote servers. The bundled-command and
+  launcher prohibitions apply to `stdio` only; `streamable-http` and `sse` have no
+  `command` and are admitted on endpoint controls instead.
+- Do not rely on schema conformance to protect credentials. A secret-bearing
+  `Authorization` header validates cleanly against the official portable schema; the
+  boundary is refusing the server, and the lint is defence in depth.
+- Do not assume ADR-0079 covers a new executable route. Its decision is scoped to one
+  exact ref, and the publisher branch name is hard-coded. Each executable route lands its
+  own equivalent control as an acceptance condition.
+- Do not claim a control lives where it does not. The build does **not** currently use the
+  blessed `file_safety` helpers; symlink handling is partial and inconsistent across
+  build modules.
+- Do not project Kiro steering from an invented source. `dev.kiro/steering/` has no source
+  in `.apm/` today; ship the extension point empty rather than fabricate content.
+- Do not promote any client claim on documentation alone. Every external-client behavior
+  in RFC-0092 is documentation-verified, never runtime-verified.
+
+## Instrumentation
+
+- Golden fixtures pinning Claude and APM outputs byte-for-byte across Phase 0 and Phase 2.
+- Offline schema validation against vendored portable schemas, with licence and provenance
+  recorded alongside; no network access during a normal build.
+- Determinism, path containment, symlink behavior, file ordering, line endings, executable
+  modes, multi-pack marketplace generation, duplicate identity, and component collision
+  all fixture-pinned.
+- A per-client runtime-verification record — client, version, surface, OS, install route,
+  components tested, date, evidence, limitations — gating every support claim above
+  `documentation-verified`.
+
+## Decision authority
+
+Architecture is settled by [RFC-0092](../../rfc/0092-first-class-distribution-routes.md)
+(Accepted) and recorded durably by
+[ADR-0090](../../adr/0090-distribution-routes-separate-from-runtime-adapters.md) and
+[ADR-0091](../../adr/0091-kiro-power-route-supersedes-rejection.md). This brief sequences
+delivery; it does not reopen those decisions. RFC-0092 carries two owned open questions
+(the Claude-manifest deprecation window, and whether Kiro steering becomes a canonical
+authoring primitive) which their phases resolve.
+
+## Derived work
+
+Each phase materializes its own spec through `new-spec`; none exist yet, which is why this
+brief is `Draft` and non-dispatchable. The follow-on artifacts RFC-0092 names are the
+distribution-route contract, the portable projection, the canonical MCP primitive, the
+Codex route, hook semantic compatibility, generalized project adaptation, marketplace
+projection, the Claude-manifest migration, and the runtime-verification/support-matrix
+contract — plus a separate RFC for MCP-from-package-registries.

--- a/docs/rfc/0012-repo-scope-per-adapter-projection.md
+++ b/docs/rfc/0012-repo-scope-per-adapter-projection.md
@@ -23,6 +23,20 @@
   unchanged and still emitted for every pack, so the question is answered for
   one route, not both. Approver: eugenelim.
 
+- **2026-08-20 — alternative 2's rejection premise has expired; superseded by
+  [ADR-0091](../adr/0091-kiro-power-route-supersedes-rejection.md).**
+  *Alternatives considered* item 2 rejected a `kiro-plugins` sibling install route
+  on the grounds that "Kiro has no programmatic plugin-install API to integrate
+  with … Kiro Powers has no documented install verb." That was researched and
+  accurate when written. Kiro has since documented Powers as an Agent Plugin plus
+  an optional `dev.kiro/` extension, imported from GitHub or a local folder, with a
+  Powers marketplace — so the load-bearing fact no longer holds. ADR-0091 supersedes
+  **that rejected alternative only**, and adopts a `kiro-power` route *profile* over
+  the portable Agent Plugin artifact rather than the per-IDE sibling package this
+  item contemplated; the route is `components-only`, because Kiro documents no
+  Power-install lifecycle event. Every other conclusion in this RFC, including its
+  decision on repo-scope per-adapter projection, is intact.
+
 ## Summary
 
 **CLI surface.** `agentbundle install --pack <name> --scope repo --adapter <name> .` lands the pack at the adopter repo's per-IDE directory directly — `<repo>/.claude/skills/`, `<repo>/.kiro/skills/`, `<repo>/.agents/skills/`, or `<repo>/.github/instructions/` — instead of the current dist-tree shape (`<repo>/claude-plugins/<pack>/...` and `<repo>/apm/<pack>/...`). The `--adapter` flag, which RFC-0011 bound to `--scope user`, lifts to work at both scopes; the existing argparse `choices=` already enumerates every shipped adapter (RFC-0011's implementation widened from the user-scope-capable subset its text named; no `cli.py` edit needed for the lift). The dist-tree shape becomes opt-in via `--emit-install-routes` for catalogue-publishing workflows.

--- a/workspace.toml
+++ b/workspace.toml
@@ -141,7 +141,9 @@ executing = ""
 ready     = [
   {path = "docs/product/briefs/tech-site-completion.md", kind = "brief", source = {mode = "repo-origin", ref = "workspace.toml", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8"}, summary = "Make the public technology sites reviewably complete", needs = []},
 ]
-draft     = []
+draft     = [
+  {path = "docs/product/briefs/distribution-routes-programme.md", kind = "brief", source = {mode = "repo-origin", ref = "docs/rfc/0092-first-class-distribution-routes.md", revision = "b9f8523016bd800001347c6a8bfaeae88c006a70"}, summary = "Land the distribution-route layer accepted by RFC-0092", needs = []},
+]
 
 ["ini-002".work]
 active  = []
@@ -508,6 +510,10 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # RFC-0092 D7 deferred direction. The canonical MCP primitive stays transport-first so
+  # a typed acquisition descriptor stays possible; fetch-on-run launchers are already
+  # refused at the build boundary, so this is a permit-something RFC, not a restrict one.
+  {slug = "mcp-servers-from-package-registries", source = "rfc/0092 D7", summary = "Open an RFC for MCP servers acquired from npm, PyPI, or another registry: a typed acquisition descriptor extending the unused runtime-dependencies shape, an immutable-artifact-identity requirement before execution, a provenance trust policy, and a lifecycle-script policy"},
   # The six hand-authored journey pages retain legacy display copy but have no
   # approved semantic-ID/label mappings. Their fragments are intentionally not
   # emitted; closing this requires an approved editorial ledger extension.


### PR DESCRIPTION
## What does this change?

Lands the follow-on artifacts that acceptance of [RFC-0092](../blob/main/docs/rfc/0092-first-class-distribution-routes.md) produces: two ADRs, their bidirectional supersession annotations, a programme brief, and the queue registration. Documentation and workspace state only — no production code, contract, pack, or build behaviour.

## Why?

An accepted RFC produces follow-on artifacts; architectural decisions become ADRs. RFC-0092 named eleven follow-ons, of which two are ADRs landable now and the rest are specs requiring `new-spec` elicitation.

- **ADR-0090** — distribution routes are a layer separate from runtime adapters. Records the durable decision plus the split that made round-2 review necessary: the **route contract** is data (Phase 0), the **route registry** is generic dispatch code (Phase 2). Enumerates the real consumers of the `install-routes` move rather than calling it free — the closed enum at `contracts/adapter.schema.json:255`, the bundled `_data/` copy under `tools/catalogue/check_contract_parity.py`, and `test_contract.py:478`/`:487`, the second of which asserts *no other adapter* carries the field and must be rewritten rather than deleted.
- **ADR-0091** — supersedes **rejected alternative (2) only** of ADR-0004: its rejection of a Kiro plugin route, whose load-bearing premise ("Kiro Powers has no documented install verb") has expired now that Kiro documents Powers with git/local import and a marketplace. Kiro is adopted as a route *profile* over the portable artifact, published `components-only` because Kiro documents no Power-install lifecycle event. ADR-0004's actual decision — per-IDE direct writes as the repo-scope default — stands untouched.

Bidirectional annotation uses each record's own sanctioned mechanism, so no frozen body is edited: ADR-0004 gains a **status-line-only** pointer (the Lifecycle rule, and the line the immutability gate filters), and frozen RFC-0012 gains a fourth **append-only Errata** entry.

## How do I verify it?

```bash
python3 -c "import tomllib;tomllib.load(open('workspace.toml','rb'))"   # parses
python3 tools/lint-agents-md.py                                          # passes
python3 .claude/skills/workspace-status/scripts/workspace_status.py reconcile --root .
```

The brief reconciles as `brief_queue.draft` / `ini-002` / `kind: brief` / `dispatchable: false` with **`findings: []`**. Diffing reconcile against `origin/main`'s `workspace.toml`: 307 → 308 findings, the single delta being one `unsupported_legacy` — the classification every one of the 168 existing backlog items already receives, so the backlog entry conforms rather than regresses.

Registration destination was resolved by the intake router (`route_intake`), not chosen by hand: `brief_queue.draft`, processor `author-brief`. The source record was built by `intake_guard.workspace_source_record` rather than hand-copied.

## What did you not change that you considered?

- **No spec files.** Registering nine phantom spec paths would violate the intake skill's materialize-before-register rule. A coherent multi-spec outcome classifies as a **brief**, which is what the router returns — each phase materializes its own spec through `new-spec` later.
- **No ADR-0004 or RFC-0012 body edits.** Both are frozen; supersession is annotation plus a new record, never an edit.
- **No whole-ADR supersession.** ADR-0091 is scoped to one rejected alternative, following ADR-0089's precedent of superseding named clauses only.
- **No production code**, and no reopening of RFC-0092's settled decisions — the brief sequences delivery, it does not re-decide.
- **Two pre-existing defects still not fixed** (unchanged from the RFC PR): journal entries carrying `workflow_version: "full/code"`, and `project_knowledge` reporting a git timeout as `map_mismatch` / `retryable:false`.