### PR TITLE
feat(core): accept and adopt RFC-0093 — intent-scoped completion

### DIFF
--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -534,7 +534,11 @@ Dispatch reviewers the diff warrants; don't run all by default. Select each via 
 
 - **`frontend-reviewer`** — primary HTML/CSS/JS output diffs (full-mode only). Pass diff + surface's evidence manifest state. Lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance + Target Size, CWV regression signals. Fallback absent: named skip.
 
-**When ALL warranted reviewers are clean (or are named skips)** — write `Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one reviewer produced a clean report, record it (transition first; record is non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit count already moved; guard requires Status: Shipped):
+**When ALL warranted reviewers are clean (or are named skips)** — normally write
+`Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one
+reviewer produced a clean report, record it (transition first; record is
+non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit
+count already moved; the default guard requires Status: Shipped):
 ```
 python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean
 # If at least one reviewer produced a clean report:
@@ -544,7 +548,22 @@ python scripts/loop-cohort.py review record docs/specs/<feature> \
 python scripts/loop-cohort.py review record docs/specs/<feature> \
     --all-skipped --expect-run-id <run_id>
 ```
-Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human response:
+For an intermediate review unit under an accepted intent that remains incomplete,
+leave `spec.md` at `Status: Implementing` and declare that boundary explicitly:
+```
+python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean \
+    --intent-incomplete
+```
+This opt-in accepts `Implementing` only; it does not disable the status guard or
+permit another status. The next in-intent unit still returns through
+`blocker-applied` and receives GATES, REVIEW, and a human gate of its own. This
+intermediate human gate is not a finish: do not mark the spec `Shipped`, run
+`done` (which refuses until the spec is `Shipped`), or apply the Finish
+checklist's intent-completion item. After the human
+gate, fire `blocker-applied` to begin the next unit.
+Engine is now in `CODE-HUMAN-GATE`. For a final unit, **before waiting: complete
+the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human
+response:
 - **Approved (merge confirmed):** fire `done`.
   ```
   python scripts/loop-engine.py transition docs/specs/<feature> done

--- a/.agents/skills/work-loop/SKILL.md
+++ b/.agents/skills/work-loop/SKILL.md
@@ -557,6 +557,11 @@ Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish check
   python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
   # Re-run GATES → fire gates-clean or gates-failed → re-enter REVIEW.
   ```
+- **Further in-intent review unit:** when an included discovery needs its own
+  independently reviewed unit, use the same `blocker-applied` return edge,
+  then apply that unit, fire `wave-complete`, and run GATES, REVIEW, and the
+  human gate again. A separate review unit does not defer or complete the
+  original accepted intent.
 
 If a specialist reviewer returns findings, first exit `CODE-REVIEW` via `findings-remain` and record the fingerprints (same as the adversarial-findings path above), then apply the fixes, fire `wave-complete` to reach `CODE-VERIFICATION`, re-run GATES, then re-enter REVIEW:
 ```
@@ -579,14 +584,39 @@ python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
 
 ## Step 5. DECIDE
 
-Route each reviewer finding into `apply` (fix in this PR) or `defer` (capture as follow-up) — the work-loop's interpretation of reviewer output; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+Route each implementation or reviewer discovery by intent fit before deciding
+whether it belongs in the current review unit. The work-loop interprets the
+result; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+Only the owner may narrow or waive an accepted intent. A matching discovery
+may share the current review unit only when the accepted contract authorizes it
+and it qualifies under the bundled-fixes tiers. Otherwise, it is the next
+independently reviewed unit in the same session: use the existing human-gate
+`blocker-applied` return edge, then run GATES, REVIEW, and the human gate again.
 
 **Execution-path check.** Before routing any finding to `apply`: confirm the fix reaches a live code path — grep for callers or trace the entry point. A guard that no caller exercises doesn't close a finding; a test that drives a mock seam instead of the real entry point doesn't count.
 
-- **Blockers** → `apply`. Re-run GATES and REVIEW after each fix.
-- **Concerns** → `apply` if mechanical and in scope (default for any Concern whose fix meets the bundled-fixes gates). `defer` if the fix crosses files outside the plan, requires a design call, or changes user-visible behavior the spec didn't authorize. Don't let Concerns rot in chat — every Concern resolves into one of the two.
-- **Nits** → `apply` if they meet the bundled-fixes gates (land in `Bundled fixes:`). Otherwise `defer` — one line in `Deferred:`. Every Nit resolves into one of the two; the `Deferred:` line is the acknowledgement that the loop saw it and chose not to fix.
-- **Deferred items** → before recording, ask: *"Could this be delivered in this PR without crossing scope or introducing unreviewed risk?"* Only defer if genuinely no. Record in `workspace.toml [backlog].open` as `{slug = "...", source = "spec/<name> ACn"}` with a cold-start-sufficient TOML comment. Add `(deferred: <slug>)` to the spec criterion that defers. PR description keeps only a one-line pointer in a standalone `Deferred:` section (alongside `Bundled fixes:`; append below standard template content, don't modify the template). After recording, prompt: *"Does this look like an RFC candidate or roadmap intent? If so, add a row to `docs/product/findings/rfc-candidates.md` or `docs/product/findings/roadmap-intents.md`."* Skip if neither file exists.
+- **Blockers** → include the correction required by the accepted intent. Re-run
+  GATES and REVIEW after each fix; use the next review unit when it cannot
+  safely share this one.
+- **Concerns and Nits** → apply now only when their inclusion is authorized by
+  the accepted contract and they qualify under the bundled-fixes tiers. A
+  matching discovery that cannot share this unit remains incomplete and moves
+  to the next review unit in the same session. An out-of-intent discovery is
+  excluded unless the owner explicitly changes scope.
+- **Excluded work** → acknowledge it in the PR's *What did you not change that
+  you considered?* answer. Do not create a durable follow-on by default. If
+  the owner explicitly asks to remember it, route the request through
+  `work-intake`; do not create a `[backlog].open` entry or `(deferred: <slug>)`
+  marker merely because this loop did not include the work.
 
 **Scratch note.** After routing each finding: if it revealed a non-obvious trap — something that would have changed your approach — save a one-line note to your IDE's native scratch (Claude Code: memory file; Codex: `.context/` scratch). Format: `[kind] title — what triggered it`. These feed [Capture learnings](#capture-learnings).
 
@@ -596,9 +626,9 @@ When gates are green and the mode's review requirements are satisfied → procee
 
 Stop when **any** of these is true:
 
-1. **Gates green AND the mode's review requirements are satisfied** — normal exit. Proceed to [Finish checklist](#finish-checklist).
+1. **Gates green AND the mode's review requirements are satisfied for the current review unit** — proceed to [Finish checklist](#finish-checklist). A merged or clean review unit does not complete the accepted intent while matching work remains for a later unit.
 2. **`scripts/loop-cohort.py check` exits non-zero** — except the expected `plan_review_status: pending` in PLAN (step 10 above), which is the cue to run pre-EXECUTE reviewers, not a stop signal. All other non-zero exits stop the current iteration and surface. Fires on: implementation retry cap (`check --phase gates-failed`), review retry cap (`check --phase review`). The exit message identifies the condition.
-   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately; do not run another review round.
+   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately for human replanning; do not run another review round. A retry cap or stasis never completes the accepted intent or creates backlog work automatically.
 3. **Diff is shrinking but findings aren't** — spot-fixing without addressing root cause. Stop and rethink the approach (back to PLAN).
 
 If you hit any of these and the work isn't done: stop, write down what you learned, re-plan. Never silently expand scope to make a finding go away.
@@ -610,9 +640,13 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] GATES were clean (lint, typecheck, tests).
 - [ ] **If the change ships something a user invokes** (CLI, library API, agent, UI): the real built artifact was exercised end-to-end through its documented happy path and the observed result recorded — a passing unit gate alone does not satisfy this. Trust the running artifact, not the build exit code.
 - [ ] **Full mode:** every warranted reviewer (`adversarial-reviewer` always; `security-reviewer` on security-boundary diffs; `quality-engineer` per the REVIEW trigger; `experience-reviewer` on user-facing diffs; `frontend-reviewer` on HTML/CSS/JS primary-output diffs) returned `Clean — ready to commit.` or is a named skip — **except missing `security-reviewer` on infra-flavored work, which blocks**. Silent skips are not allowed.
-- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an `apply` or `defer` disposition; applied fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
+- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an intent-fit and session-decision disposition; included fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
 - [ ] Whole-spec `quality-engineer` pass (final loop of a multi-loop spec only): same select-or-note rule.
 - [ ] The resolve-vs-surface disposition record exists and every REVIEW finding is resolved. In light mode "every REVIEW finding" means the single bounded `adversarial-reviewer` pass's findings; a surviving Blocker escalates to full mode.
+- [ ] The original accepted intent is complete, or its owner explicitly narrowed
+  or waived the remaining matching work. A merged PR, retry cap, or review
+  stasis alone is not completion; excluded work needs no backlog entry unless
+  the owner explicitly requested capture through `work-intake`.
 - [ ] `git status` shows no uncommitted or untracked files (except gitignored scratch).
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.

--- a/.agents/skills/work-loop/scripts/loop-engine.py
+++ b/.agents/skills/work-loop/scripts/loop-engine.py
@@ -740,9 +740,26 @@ def _guard_check_phase_review(spec_dir: Path, engine_state: dict, _) -> str | No
     )
 
 
-def _guard_check_spec_status(spec_dir: Path, engine_state: dict, _) -> str | None:
+def _guard_check_spec_status(
+    spec_dir: Path, engine_state: dict, event_args: dict
+) -> str | None:
+    """Require the status declared by the review unit's intent boundary."""
+    expect = "Implementing" if event_args.get("intent_incomplete", False) else "Shipped"
     return _guard_reason(
         "check-spec-status failed",
+        _guards().check_artifact_status(spec_dir, filename="spec.md", expect=expect),
+    )
+
+
+def _guard_done(spec_dir: Path, engine_state: dict, _) -> str | None:
+    """Guard done: the accepted intent's spec must be Shipped.
+
+    Before intent-scoped completion this held transitively — the only route into
+    CODE-HUMAN-GATE required Shipped. An intermediate unit may now enter that
+    state at Implementing, so DONE asserts completion explicitly instead.
+    """
+    return _guard_reason(
+        "check-spec-status --expect Shipped failed",
         _guards().check_artifact_status(spec_dir, filename="spec.md", expect="Shipped"),
     )
 
@@ -829,6 +846,7 @@ _GUARDS: dict[tuple[str, str], object] = {
     ("code", "gates-clean"): _guard_wave_check_last,
     ("code", "findings-remain"): _guard_check_phase_review_on_code_review,
     ("code", "reviewers-clean"): _guard_check_spec_status_on_code_review,
+    ("code", "done"): _guard_done,
 }
 
 # ── engine-state.json helpers ──────────────────────────────────────────────
@@ -1149,6 +1167,7 @@ def cmd_transition(args: argparse.Namespace) -> int:
 
     event = args.event
     wave_index = args.wave_index
+    intent_incomplete = args.intent_incomplete
 
     # Validate --wave-index usage
     if event == "wave-passed":
@@ -1157,6 +1176,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
     else:
         if wave_index is not None:
             return stop(f"transition {event!r} does not accept --wave-index")
+    if intent_incomplete and event != "reviewers-clean":
+        return stop("transition --intent-incomplete requires reviewers-clean")
 
     # recover at command start — before any early-exit check.
     # _recover_engine_state_tmp promotes crash-left .tmp → engine-state.json.
@@ -1191,6 +1212,9 @@ def cmd_transition(args: argparse.Namespace) -> int:
     current_state = state["state"]
     run_id = state["run_id"]
 
+    if intent_incomplete and current_state != "CODE-REVIEW":
+        return stop("transition --intent-incomplete requires CODE-REVIEW")
+
     # Step 0: run_id preflight (all transitions)
     err = _run_id_preflight(spec_dir, run_id)
     if err:
@@ -1217,6 +1241,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
         event_args = {}
         if wave_index is not None:
             event_args["wave_index"] = wave_index
+        if intent_incomplete:
+            event_args["intent_incomplete"] = True
         err = guard_fn(spec_dir, state, event_args)
         if err:
             return stop(err)
@@ -1304,6 +1330,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("spec_dir")
     sp.add_argument("event")
     sp.add_argument("--wave-index", type=int, dest="wave_index", default=None)
+    sp.add_argument(
+        "--intent-incomplete",
+        action="store_true",
+        help="declare reviewers-clean is an intermediate unit of an incomplete intent",
+    )
     sp.set_defaults(func=cmd_transition)
 
     sp = sub.add_parser("status", help="read engine-state.json + pending_human_wait")

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -534,7 +534,11 @@ Dispatch reviewers the diff warrants; don't run all by default. Select each via 
 
 - **`frontend-reviewer`** — primary HTML/CSS/JS output diffs (full-mode only). Pass diff + surface's evidence manifest state. Lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance + Target Size, CWV regression signals. Fallback absent: named skip.
 
-**When ALL warranted reviewers are clean (or are named skips)** — write `Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one reviewer produced a clean report, record it (transition first; record is non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit count already moved; guard requires Status: Shipped):
+**When ALL warranted reviewers are clean (or are named skips)** — normally write
+`Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one
+reviewer produced a clean report, record it (transition first; record is
+non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit
+count already moved; the default guard requires Status: Shipped):
 ```
 python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean
 # If at least one reviewer produced a clean report:
@@ -544,7 +548,22 @@ python scripts/loop-cohort.py review record docs/specs/<feature> \
 python scripts/loop-cohort.py review record docs/specs/<feature> \
     --all-skipped --expect-run-id <run_id>
 ```
-Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human response:
+For an intermediate review unit under an accepted intent that remains incomplete,
+leave `spec.md` at `Status: Implementing` and declare that boundary explicitly:
+```
+python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean \
+    --intent-incomplete
+```
+This opt-in accepts `Implementing` only; it does not disable the status guard or
+permit another status. The next in-intent unit still returns through
+`blocker-applied` and receives GATES, REVIEW, and a human gate of its own. This
+intermediate human gate is not a finish: do not mark the spec `Shipped`, run
+`done` (which refuses until the spec is `Shipped`), or apply the Finish
+checklist's intent-completion item. After the human
+gate, fire `blocker-applied` to begin the next unit.
+Engine is now in `CODE-HUMAN-GATE`. For a final unit, **before waiting: complete
+the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human
+response:
 - **Approved (merge confirmed):** fire `done`.
   ```
   python scripts/loop-engine.py transition docs/specs/<feature> done

--- a/.claude/skills/work-loop/SKILL.md
+++ b/.claude/skills/work-loop/SKILL.md
@@ -557,6 +557,11 @@ Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish check
   python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
   # Re-run GATES → fire gates-clean or gates-failed → re-enter REVIEW.
   ```
+- **Further in-intent review unit:** when an included discovery needs its own
+  independently reviewed unit, use the same `blocker-applied` return edge,
+  then apply that unit, fire `wave-complete`, and run GATES, REVIEW, and the
+  human gate again. A separate review unit does not defer or complete the
+  original accepted intent.
 
 If a specialist reviewer returns findings, first exit `CODE-REVIEW` via `findings-remain` and record the fingerprints (same as the adversarial-findings path above), then apply the fixes, fire `wave-complete` to reach `CODE-VERIFICATION`, re-run GATES, then re-enter REVIEW:
 ```
@@ -579,14 +584,39 @@ python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
 
 ## Step 5. DECIDE
 
-Route each reviewer finding into `apply` (fix in this PR) or `defer` (capture as follow-up) — the work-loop's interpretation of reviewer output; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+Route each implementation or reviewer discovery by intent fit before deciding
+whether it belongs in the current review unit. The work-loop interprets the
+result; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+Only the owner may narrow or waive an accepted intent. A matching discovery
+may share the current review unit only when the accepted contract authorizes it
+and it qualifies under the bundled-fixes tiers. Otherwise, it is the next
+independently reviewed unit in the same session: use the existing human-gate
+`blocker-applied` return edge, then run GATES, REVIEW, and the human gate again.
 
 **Execution-path check.** Before routing any finding to `apply`: confirm the fix reaches a live code path — grep for callers or trace the entry point. A guard that no caller exercises doesn't close a finding; a test that drives a mock seam instead of the real entry point doesn't count.
 
-- **Blockers** → `apply`. Re-run GATES and REVIEW after each fix.
-- **Concerns** → `apply` if mechanical and in scope (default for any Concern whose fix meets the bundled-fixes gates). `defer` if the fix crosses files outside the plan, requires a design call, or changes user-visible behavior the spec didn't authorize. Don't let Concerns rot in chat — every Concern resolves into one of the two.
-- **Nits** → `apply` if they meet the bundled-fixes gates (land in `Bundled fixes:`). Otherwise `defer` — one line in `Deferred:`. Every Nit resolves into one of the two; the `Deferred:` line is the acknowledgement that the loop saw it and chose not to fix.
-- **Deferred items** → before recording, ask: *"Could this be delivered in this PR without crossing scope or introducing unreviewed risk?"* Only defer if genuinely no. Record in `workspace.toml [backlog].open` as `{slug = "...", source = "spec/<name> ACn"}` with a cold-start-sufficient TOML comment. Add `(deferred: <slug>)` to the spec criterion that defers. PR description keeps only a one-line pointer in a standalone `Deferred:` section (alongside `Bundled fixes:`; append below standard template content, don't modify the template). After recording, prompt: *"Does this look like an RFC candidate or roadmap intent? If so, add a row to `docs/product/findings/rfc-candidates.md` or `docs/product/findings/roadmap-intents.md`."* Skip if neither file exists.
+- **Blockers** → include the correction required by the accepted intent. Re-run
+  GATES and REVIEW after each fix; use the next review unit when it cannot
+  safely share this one.
+- **Concerns and Nits** → apply now only when their inclusion is authorized by
+  the accepted contract and they qualify under the bundled-fixes tiers. A
+  matching discovery that cannot share this unit remains incomplete and moves
+  to the next review unit in the same session. An out-of-intent discovery is
+  excluded unless the owner explicitly changes scope.
+- **Excluded work** → acknowledge it in the PR's *What did you not change that
+  you considered?* answer. Do not create a durable follow-on by default. If
+  the owner explicitly asks to remember it, route the request through
+  `work-intake`; do not create a `[backlog].open` entry or `(deferred: <slug>)`
+  marker merely because this loop did not include the work.
 
 **Scratch note.** After routing each finding: if it revealed a non-obvious trap — something that would have changed your approach — save a one-line note to your IDE's native scratch (Claude Code: memory file; Codex: `.context/` scratch). Format: `[kind] title — what triggered it`. These feed [Capture learnings](#capture-learnings).
 
@@ -596,9 +626,9 @@ When gates are green and the mode's review requirements are satisfied → procee
 
 Stop when **any** of these is true:
 
-1. **Gates green AND the mode's review requirements are satisfied** — normal exit. Proceed to [Finish checklist](#finish-checklist).
+1. **Gates green AND the mode's review requirements are satisfied for the current review unit** — proceed to [Finish checklist](#finish-checklist). A merged or clean review unit does not complete the accepted intent while matching work remains for a later unit.
 2. **`scripts/loop-cohort.py check` exits non-zero** — except the expected `plan_review_status: pending` in PLAN (step 10 above), which is the cue to run pre-EXECUTE reviewers, not a stop signal. All other non-zero exits stop the current iteration and surface. Fires on: implementation retry cap (`check --phase gates-failed`), review retry cap (`check --phase review`). The exit message identifies the condition.
-   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately; do not run another review round.
+   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately for human replanning; do not run another review round. A retry cap or stasis never completes the accepted intent or creates backlog work automatically.
 3. **Diff is shrinking but findings aren't** — spot-fixing without addressing root cause. Stop and rethink the approach (back to PLAN).
 
 If you hit any of these and the work isn't done: stop, write down what you learned, re-plan. Never silently expand scope to make a finding go away.
@@ -610,9 +640,13 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] GATES were clean (lint, typecheck, tests).
 - [ ] **If the change ships something a user invokes** (CLI, library API, agent, UI): the real built artifact was exercised end-to-end through its documented happy path and the observed result recorded — a passing unit gate alone does not satisfy this. Trust the running artifact, not the build exit code.
 - [ ] **Full mode:** every warranted reviewer (`adversarial-reviewer` always; `security-reviewer` on security-boundary diffs; `quality-engineer` per the REVIEW trigger; `experience-reviewer` on user-facing diffs; `frontend-reviewer` on HTML/CSS/JS primary-output diffs) returned `Clean — ready to commit.` or is a named skip — **except missing `security-reviewer` on infra-flavored work, which blocks**. Silent skips are not allowed.
-- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an `apply` or `defer` disposition; applied fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
+- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an intent-fit and session-decision disposition; included fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
 - [ ] Whole-spec `quality-engineer` pass (final loop of a multi-loop spec only): same select-or-note rule.
 - [ ] The resolve-vs-surface disposition record exists and every REVIEW finding is resolved. In light mode "every REVIEW finding" means the single bounded `adversarial-reviewer` pass's findings; a surviving Blocker escalates to full mode.
+- [ ] The original accepted intent is complete, or its owner explicitly narrowed
+  or waived the remaining matching work. A merged PR, retry cap, or review
+  stasis alone is not completion; excluded work needs no backlog entry unless
+  the owner explicitly requested capture through `work-intake`.
 - [ ] `git status` shows no uncommitted or untracked files (except gitignored scratch).
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.

--- a/.claude/skills/work-loop/scripts/loop-engine.py
+++ b/.claude/skills/work-loop/scripts/loop-engine.py
@@ -740,9 +740,26 @@ def _guard_check_phase_review(spec_dir: Path, engine_state: dict, _) -> str | No
     )
 
 
-def _guard_check_spec_status(spec_dir: Path, engine_state: dict, _) -> str | None:
+def _guard_check_spec_status(
+    spec_dir: Path, engine_state: dict, event_args: dict
+) -> str | None:
+    """Require the status declared by the review unit's intent boundary."""
+    expect = "Implementing" if event_args.get("intent_incomplete", False) else "Shipped"
     return _guard_reason(
         "check-spec-status failed",
+        _guards().check_artifact_status(spec_dir, filename="spec.md", expect=expect),
+    )
+
+
+def _guard_done(spec_dir: Path, engine_state: dict, _) -> str | None:
+    """Guard done: the accepted intent's spec must be Shipped.
+
+    Before intent-scoped completion this held transitively — the only route into
+    CODE-HUMAN-GATE required Shipped. An intermediate unit may now enter that
+    state at Implementing, so DONE asserts completion explicitly instead.
+    """
+    return _guard_reason(
+        "check-spec-status --expect Shipped failed",
         _guards().check_artifact_status(spec_dir, filename="spec.md", expect="Shipped"),
     )
 
@@ -829,6 +846,7 @@ _GUARDS: dict[tuple[str, str], object] = {
     ("code", "gates-clean"): _guard_wave_check_last,
     ("code", "findings-remain"): _guard_check_phase_review_on_code_review,
     ("code", "reviewers-clean"): _guard_check_spec_status_on_code_review,
+    ("code", "done"): _guard_done,
 }
 
 # ── engine-state.json helpers ──────────────────────────────────────────────
@@ -1149,6 +1167,7 @@ def cmd_transition(args: argparse.Namespace) -> int:
 
     event = args.event
     wave_index = args.wave_index
+    intent_incomplete = args.intent_incomplete
 
     # Validate --wave-index usage
     if event == "wave-passed":
@@ -1157,6 +1176,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
     else:
         if wave_index is not None:
             return stop(f"transition {event!r} does not accept --wave-index")
+    if intent_incomplete and event != "reviewers-clean":
+        return stop("transition --intent-incomplete requires reviewers-clean")
 
     # recover at command start — before any early-exit check.
     # _recover_engine_state_tmp promotes crash-left .tmp → engine-state.json.
@@ -1191,6 +1212,9 @@ def cmd_transition(args: argparse.Namespace) -> int:
     current_state = state["state"]
     run_id = state["run_id"]
 
+    if intent_incomplete and current_state != "CODE-REVIEW":
+        return stop("transition --intent-incomplete requires CODE-REVIEW")
+
     # Step 0: run_id preflight (all transitions)
     err = _run_id_preflight(spec_dir, run_id)
     if err:
@@ -1217,6 +1241,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
         event_args = {}
         if wave_index is not None:
             event_args["wave_index"] = wave_index
+        if intent_incomplete:
+            event_args["intent_incomplete"] = True
         err = guard_fn(spec_dir, state, event_args)
         if err:
             return stop(err)
@@ -1304,6 +1330,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("spec_dir")
     sp.add_argument("event")
     sp.add_argument("--wave-index", type=int, dest="wave_index", default=None)
+    sp.add_argument(
+        "--intent-incomplete",
+        action="store_true",
+        help="declare reviewers-clean is an intermediate unit of an incomplete intent",
+    )
     sp.set_defaults(func=cmd_transition)
 
     sp = sub.add_parser("status", help="read engine-state.json + pending_human_wait")

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -440,12 +440,17 @@ mechanical rule.
   ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
-- **Deferral token.** A criterion that ships *unmet on purpose* is not left
-  unchecked and silent — it carries an inline `(deferred: <slug>)` marker whose
-  `<slug>` resolves to a `slug` field in `workspace.toml [backlog].open`, the
-  durable register of open work. Form: `- [ ] <outcome> (deferred: <slug>)`. A
-  deferral recorded only in a PR comment rots; the register is version-controlled
-  and greppable. Run `workspace-status` to see all open backlog items.
+- **Deferral token.** A criterion that ships *unmet on purpose* because
+  genuinely deferred in-scope work remains is not left unchecked and silent —
+  it carries an inline `(deferred: <slug>)` marker whose `<slug>` resolves to a
+  `slug` field in `workspace.toml [backlog].open`, the durable register of open
+  work. Form: `- [ ] <outcome> (deferred: <slug>)`. This is not the default
+  disposition for an excluded out-of-scope discovery: acknowledge that work in
+  the PR's *What did you not change that you considered?* answer instead. If
+  its owner explicitly asks to remember it, route that capture through
+  `work-intake`. A deferral recorded only in a PR comment rots; the register is
+  version-controlled and greppable. Run `workspace-status` to see all open
+  backlog items.
 - **Brief back-link (optional).** A spec derived from a product brief carries a
   `- **Brief:**` header naming that brief by its repository-relative path
   (`docs/product/briefs/<slug>.md` — the brief file's real path, which
@@ -664,7 +669,7 @@ right now?"
   here because shaping artifacts are decisions, not corpora — they belong in
   the version-controlled tree alongside ADRs and specs.
 - `findings/` (optional) — structured governance registers: `rfc-candidates.md`
-  (candidate RFCs surfaced by work-loop scope-deferrals or `frame-situation`
+  (candidate RFCs surfaced by owner-requested capture or `frame-situation`
   escalations) and `roadmap-intents.md` (deferred roadmap items). `rfc-status`
   surfaces the candidate count at session start.
 - `initiatives/` (optional) — initiative brief artifacts and their
@@ -897,7 +902,7 @@ the `work-loop` skill; this section is the why.
 declare victory when they *feel* done. Mechanical gates (lint, typecheck,
 tests) plus an adversarial review pass replace "feel" with verifiable
 termination. The loop keeps going until both kinds of check are satisfied —
-or until it hits a hard cap.
+or it pauses for human replanning.
 
 **Why think before acting.** The cost of a wrong start is higher than the
 cost of thinking. For high-stakes changes (architectural choices, multi-file
@@ -912,12 +917,39 @@ loses the planning context. We do it the other way only when fresh context
 is the *point* — an unattended, fresh-session-per-iteration loop (see the
 work-loop skill).
 
-**Why a hard iteration cap.** Without one, you're hoping. The implementation and review retry caps live as data in `state.json` (see below) and are enforced by the `work-loop` skill's `scripts/loop-cohort.py` through `loop-cohort check --phase gates-failed` and `--phase review`; if you hit one, the task is bigger than you thought — stop, re-plan, or split.
+**Why a hard iteration cap.** Without one, you're hoping. The implementation and review retry caps live as data in `state.json` (see below) and are enforced by the `work-loop` skill's `scripts/loop-cohort.py` through `loop-cohort check --phase gates-failed` and `--phase review`; if you hit one, the task is bigger than you thought — pause for human replanning, then stop, re-plan, or split. A cap never declares the accepted intent complete or creates follow-on work automatically.
 
 **Why capture learnings.** A loop that finishes without updating *some*
 doc, skill, or note has wasted what it learned. The next agent (or a
 human) will pay for it again. The work-loop skill enumerates where each
 kind of learning belongs.
+
+### Intent-scoped completion
+
+Completion answers to the original accepted intent, not to the current pull
+request. A pull request is a review unit: one accepted intent may need more
+than one independently reviewed unit in the same session. Only the owner may
+narrow or waive that intent.
+
+For every implementation or review discovery, determine intent fit before the
+session decision:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+An included discovery shares the current review unit only when the accepted
+contract authorizes it and it qualifies under the bundled-fixes tiers. A
+distinct design, behavior, or semantic change becomes the next review unit in
+the same session. An excluded discovery is acknowledged by the PR's *What did
+you not change that you considered?* answer; create a durable follow-on only
+when the owner explicitly requests capture, then route it through `work-intake`.
+Retry caps and review stasis pause for human replanning; they neither complete
+the accepted intent nor create backlog work automatically.
 
 ### Light and full modes
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [core][2.10.2] — 2026-08-20
+
+#### Changed
+
+- **Completion now follows the intent you accepted, not the size of one PR.**
+  Work that belongs to that intent can continue as a separately reviewed unit;
+  work outside it is acknowledged in the PR and remembered only when you ask.
+
 ### [core][2.10.1] — 2026-08-20
 
 #### Added

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Completion now follows the intent you accepted, not the size of one PR.**
   Work that belongs to that intent can continue as a separately reviewed unit;
   work outside it is acknowledged in the PR and remembered only when you ask.
+- **Intermediate review units can now reach the human gate honestly.** Declare an
+  incomplete accepted intent explicitly and the review guard requires
+  `Implementing`; the final `done` transition independently requires `Shipped`.
 
 ### [core][2.10.1] — 2026-08-20
 
@@ -260,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-line summary and a worked example.** Each shows an abbreviated session so
   you can see the shape of the exchange, and where your decisions fall in it,
   before committing to the journey.
+
 
 ### [core][2.9.5] — 2026-08-19
 

--- a/docs/product/findings/README.md
+++ b/docs/product/findings/README.md
@@ -5,14 +5,14 @@ registers that surface work and decisions that overflow the normal
 `docs/specs/` → ADR pipeline.
 
 **Purpose (per CONVENTIONS.md §5b):** governance registers — candidate
-RFCs surfaced by scope-deferrals and `frame-situation` escalations, and
+RFCs surfaced by owner-requested capture and `frame-situation` escalations, and
 deferred roadmap items that are not yet specs.
 
 ## Registers (coming in M3)
 
 The following register files are created by M3:
 
-- `rfc-candidates.md` — candidate RFCs surfaced by scope-deferrals and
+- `rfc-candidates.md` — candidate RFCs surfaced by owner-requested capture and
   `frame-situation` escalations.
 - `roadmap-intents.md` — deferred roadmap items.
 
@@ -25,9 +25,9 @@ directory's purpose ahead of that work.
 
 ## How entries get here
 
-- **`work-loop`:** when the loop defers something out of scope, the
-  `Deferred:` entry in the PR description names the slug tracked in
-  `workspace.toml [backlog].open`.
+- **`work-loop`:** an out-of-scope finding reaches a register only when its
+  owner explicitly decides to record it; otherwise the PR acknowledges the
+  exclusion without a durable follow-on.
   A `frame-situation` escalation or a pattern that warrants an RFC is
   promoted into `rfc-candidates.md` (M3).
 - **`workspace-status`** (after M3 ships): surfaces the candidate count

--- a/docs/product/findings/rfc-candidates.md
+++ b/docs/product/findings/rfc-candidates.md
@@ -1,13 +1,12 @@
 # RFC Candidates
 
-Candidate RFCs surfaced by work-loop scope-deferrals and `frame-situation`
+Candidate RFCs surfaced by owner-requested capture and `frame-situation`
 escalations. Each entry represents a pattern, gap, or design question that
 recurred enough to warrant community input before implementation.
 
-**How entries arrive here:** when `work-loop` defers something out of scope
-and the item looks RFC-shaped, the agent prompts "Add to
-`rfc-candidates.md` or `roadmap-intents.md`?" This is the register for the
-RFC branch of that prompt.
+**How entries arrive here:** when an owner explicitly decides to record an
+out-of-scope finding that looks RFC-shaped, or through a `frame-situation`
+escalation. This is the register for that RFC candidate.
 
 **How entries leave:** when a candidate is accepted into `docs/rfc/`, update
 `Disposition` to `→ RFC-NNNN`. When a candidate is rejected or absorbed,

--- a/docs/product/findings/roadmap-intents.md
+++ b/docs/product/findings/roadmap-intents.md
@@ -3,11 +3,9 @@
 Deferred roadmap items that are not yet specs — things the team intends to
 build but has not yet shaped or scheduled.
 
-**How entries arrive here:** when `work-loop` defers something out of scope
-and the item looks like a future feature or improvement (not an RFC-level
-proposal), the agent prompts "Add to `roadmap-intents.md` or
-`rfc-candidates.md`?" This is the register for the roadmap branch of that
-prompt.
+**How entries arrive here:** when an owner explicitly decides to record an
+out-of-scope finding that looks like a future feature or improvement (not an
+RFC-level proposal). This is the register for that roadmap intent.
 
 **How entries leave:** when an item is scoped into a brief and spec, update
 `Disposition` to `→ spec/<slug>`. When an item is dropped, note the reason.

--- a/docs/rfc/0093-intent-scoped-completion.md
+++ b/docs/rfc/0093-intent-scoped-completion.md
@@ -123,7 +123,7 @@ existing human-gate return edge for a further independently reviewed unit:
 ([`packs/core/.apm/skills/work-loop/scripts/loop-engine.py:552`](../../packs/core/.apm/skills/work-loop/scripts/loop-engine.py)),
 after which the unit runs GATES, REVIEW, and the human gate again. The
 work-loop currently documents that edge only as “Changes requested”
-([`packs/core/.apm/skills/work-loop/SKILL.md:553`](../../packs/core/.apm/skills/work-loop/SKILL.md)); it must also instruct its use for either kind of further in-intent review unit. Intent-scoped completion therefore needs no new engine state, transition, or guard.
+([`packs/core/.apm/skills/work-loop/SKILL.md:553`](../../packs/core/.apm/skills/work-loop/SKILL.md)); it must also instruct its use for either kind of further in-intent review unit. Intent-scoped completion therefore needs no new engine state, transition, or guard: the existing human-gate return edge carries the doctrine. The owner additionally chose to make the existing status guard intent-aware; see Q1's resolution.
 
 The implementation uses existing plan and session surfaces for included work,
 and the PR or final summary's "What did you not change?" answer for excluded
@@ -241,9 +241,15 @@ optional rather than automatic.
   Thus a later planned or post-review unit begins after an earlier unit has
   already marked the spec `Shipped`, even when the accepted intent remains
   incomplete. This pre-existing tension is surfaced, not created, here.
-  **Recommended default:** retain the guard's current behavior and carry the
-  doctrine instructionally; any change to the guard is a separate decision.
-  **Owner:** eugenelim. **Decide by:** the follow-on work-loop implementation.
+  **Resolution (owner decision):** the owner reversed this RFC's recommended
+  default. The code-review guard is intent-aware through an explicit
+  intermediate-unit declaration: absent that declaration it still requires
+  `Shipped`; when declared it requires `Implementing` and no other status. This
+  makes the human-gate transition honest for a review unit whose accepted intent
+  remains incomplete while failing closed for every existing caller. The final
+  `done` transition independently requires `Shipped`, so only a completed
+  accepted intent can reach `DONE`.
+  **Owner:** eugenelim. **Decided:** 2026-08-20.
 
 ## Follow-on artifacts
 

--- a/docs/rfc/0093-intent-scoped-completion.md
+++ b/docs/rfc/0093-intent-scoped-completion.md
@@ -1,0 +1,265 @@
+# RFC-0093: Intent-scoped completion
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** eugenelim
+- **Date opened:** 2026-08-19
+- **Date closed:** 2026-08-20
+- **Decision weight:** heavy
+- **Related:** [RFC-0090](0090-change-sizing-and-decomposition.md);
+  [RFC-0083](0083-work-intake-and-artifact-routing.md)
+
+## Reviewer brief
+
+- **Decision:** Make completion answer to the original accepted intent rather
+  than to one pull request, and make durable follow-on capture opt-in.
+- **Recommended outcome:** Accept.
+- **Change if accepted:** Define **intent fit** (whether a discovery belongs to
+  the accepted intent) and dispositions; allow separate **review units**
+  (independently reviewable changes) within one session; remove mandatory
+  backlog capture for work not included.
+- **Affected surface:** The adopter-facing conventions and the `work-loop`
+  workflow that turns review findings into action or deferral.
+- **Stakes:** Costly but reversible: this changes an obligation shipped to
+  adopters, while retaining existing safety stops.
+- **Review focus:** Whether the proposal preserves a truthful completion test
+  without turning adjacent work into an automatic queue.
+- **Not in scope:** A new backlog type, workspace schema field, lint, or
+  durable completion artifact.
+
+## The ask
+
+Approve **intent-stable, review-unit-flexible, capture-by-request** (durable
+follow-ons are created only when their owner asks to remember them): an accepted
+intent remains the completion boundary even when delivery needs more than one
+review unit, and a finding outside the chosen work is remembered only when its
+owner explicitly requests capture.
+
+The current workflow treats inability to fit a finding into the current pull
+request as durable deferral. That confuses reviewer-sized delivery with whether
+the accepted outcome is complete, and it manufactures follow-ons from
+otherwise excluded improvements.
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | What is the completion boundary? | The original accepted intent. | A review unit is a delivery boundary, not the outcome's boundary. | RFC acceptance | Approve or amend the boundary. |
+| D2 | How is a discovery dispositioned? | Capture only on explicit request. | Excluding work is an acknowledgement, not an obligation to create a queue item. | RFC acceptance | Approve or amend the disposition rule. |
+| D3 | Where does an included discovery land? | In the current unit when authorized by the accepted contract and eligible under RFC-0090 D6's ride-along tiers; otherwise in the next review unit of the same session. | Review safety does not require ending the session. | RFC acceptance | Approve or amend the separation. |
+| D4 | What does repeated review discovery mean? | In-scope correctness remains blocking; safety caps pause for human judgment, never declare completion or create backlog automatically. | Bounded autonomy must not falsify completion. | RFC acceptance | Approve or amend the stopping rule. |
+| D5 | What machinery is required? | Reuse plan/session and PR-summary surfaces; route explicit capture through `work-intake`. | A ledger would create the queue this proposal removes. | RFC acceptance | Confirm the deliberately small implementation. |
+
+This is an RFC rather than an ADR because the owner explicitly asked to
+circulate this proposal, which §3 names as an RFC trigger. It also changes an
+obligation shipped to adopters; §3 routes conventions maintenance to a PR only
+when it preserves an obligation, while a changed obligation uses the RFC test.
+
+## Problem & goals
+
+A **completion boundary** is the condition that determines whether the work the
+owner accepted is complete. The current loop instead makes a single pull
+request do double duty as that boundary. A **review unit** is the independently
+reviewable semantic commit, pull request, or stack layer; it may be smaller
+than the accepted outcome.
+
+This causes two failures. First, a required correction that cannot safely ride
+in the current pull request is treated as future work even when it still
+belongs to the original outcome. Second, a legitimate but out-of-intent
+improvement is automatically made durable, creating follow-on work without an
+owner choosing it.
+
+The goals are to preserve truthful completion, retain reviewable units, and
+make scope disposition explicit. Non-goals are expanding an accepted intent by
+proximity, weakening blocking correctness or review retry safeguards, and
+creating a second queue or tracking schema.
+
+## Proposal
+
+The **session scope** is the set of work performed in one uninterrupted agent
+run. It may contain multiple review units but cannot silently change the
+original accepted intent. **Intent fit** asks whether a discovery is required
+by that intent and its constraints. **Capture-by-request** means a durable
+follow-on is created only when the user explicitly asks to remember it.
+
+For every implementation or review discovery, first determine intent fit, then
+make the session decision:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+Only the owner may narrow or waive an accepted intent; absent that explicit
+decision, a matching discovery that is not included leaves the work incomplete.
+
+An included discovery may stay in the current review unit only when it is
+authorized by the accepted contract and qualifies under RFC-0090 D6's
+reproducible, provably inert, or small hand-made ride-along tiers
+([`docs/rfc/0090-change-sizing-and-decomposition.md:40`](0090-change-sizing-and-decomposition.md)). A
+design call, behavior change, or distinct semantic change gets a separate
+commit or pull request, but remains in the current session when it fits the
+accepted intent. RFC-0090 D1 already says one specification may deliver more
+than one pull request and that a specification is an objective, not a mandated
+review boundary ([`docs/rfc/0090-change-sizing-and-decomposition.md:35`](0090-change-sizing-and-decomposition.md)).
+For this proposal, D6's relevant condition is that ride-alongs fail closed on
+design calls and behavior changes
+([`docs/rfc/0090-change-sizing-and-decomposition.md:40`](0090-change-sizing-and-decomposition.md)).
+
+A review finding that shows the current change is incorrect or unsafe remains
+blocking. One required by the original intent but needing its own review unit
+becomes the next unit in the same session. An out-of-intent improvement is
+excluded and forgotten unless capture is requested. Review retry caps and
+stasis pause for human replanning; they neither make the intent complete nor
+produce a backlog entry.
+
+Waves are execution cohorts within one review cycle, not review units: wave
+routing occurs after gates, and only the final wave fires `gates-clean` and
+proceeds to REVIEW ([`packs/core/.apm/skills/work-loop/SKILL.md:402-412`](../../packs/core/.apm/skills/work-loop/SKILL.md)).
+Both planned multi-unit delivery and a post-review in-intent discovery use the
+existing human-gate return edge for a further independently reviewed unit:
+`blocker-applied` moves `CODE-HUMAN-GATE` to `CODE-IMPLEMENTATION`
+([`packs/core/.apm/skills/work-loop/scripts/loop-engine.py:552`](../../packs/core/.apm/skills/work-loop/scripts/loop-engine.py)),
+after which the unit runs GATES, REVIEW, and the human gate again. The
+work-loop currently documents that edge only as “Changes requested”
+([`packs/core/.apm/skills/work-loop/SKILL.md:553`](../../packs/core/.apm/skills/work-loop/SKILL.md)); it must also instruct its use for either kind of further in-intent review unit. Intent-scoped completion therefore needs no new engine state, transition, or guard.
+
+The implementation uses existing plan and session surfaces for included work,
+and the PR or final summary's "What did you not change?" answer for excluded
+work. An explicit request to remember work is routed through `work-intake`.
+
+## Options considered
+
+### D1 — Completion-boundary axis
+
+- **Current pull request:** Too narrow; it conflates reviewer readability with
+  outcome completion.
+- **Physical area:** Too broad; every nearby defect becomes scope.
+- **Original accepted intent (recommended):** Fixes the outcome and constraints
+  while permitting one or more review units.
+- **Do nothing:** Preserves follow-on proliferation.
+
+### D2 — Discovery-disposition axis
+
+- **Mandatory capture:** Preserves an audit trail but manufactures backlog work.
+- **Capture-by-request (recommended):** Leaves a durable record only for an
+  explicitly owned follow-on; the PR summary acknowledges the exclusion.
+- **Do nothing:** Retains mandatory deferral and backlog creation.
+
+### D3 — Included-discovery placement axis
+
+- **Current review unit when authorized:** Appropriate only when the accepted
+  contract authorizes it and it qualifies under RFC-0090 D6's existing
+  ride-along tiers.
+- **Separate review unit in the same session (recommended when behavior or
+  design changes):** Preserves independent review without declaring the intent
+  deferred.
+- **Do nothing:** Treats every separate pull request as deferred work.
+
+### D4 — Cap-or-stasis meaning axis
+
+The alternatives answer one exclusive question: what does a review cap or
+stasis mean for completion?
+
+- **Completion:** Treat the cap as proof that the current intent is done;
+  maximally bounded, but it makes a safety control falsely determine truth.
+- **Pause for human replanning (recommended):** Bound autonomy while leaving
+  completion unresolved until the accepted intent is satisfied, narrowed, or
+  abandoned.
+- **Automatic backlog creation:** Preserve a durable follow-on automatically;
+  this retains the queue-manufacturing behavior the proposal removes.
+- **Do nothing:** Preserve the current stop-and-defer behavior.
+
+### D5 — Operational-surface axis
+
+- **New completion ledger or schema:** Durable, but creates another queue.
+- **Prose only:** Lightweight, but easy to miss during operation.
+- **Existing plan, session, and summary surfaces (recommended):** Makes
+  inclusion operational while keeping exclusion lightweight.
+- **Do nothing:** Leaves the current behavior unchanged.
+
+## Risks & what would make this wrong
+
+The principal risk is that separating session scope from review units becomes a
+pretext for scope creep. The mitigation is the intent-fit decision table:
+out-of-intent inclusion requires an explicit scope change, and unclear fit
+requires owner direction.
+
+The riskiest assumption was that RFC-0090 D6 prevents same-session completion
+of a behavior-changing discovery. It is falsified: D1 permits an objective to
+produce multiple review units, while D6 restricts what can share the current
+unit. [Commit `4e81d407`](https://github.com/eugenelim/agent-ready-repo/commit/4e81d407) is the worked case: its
+projected-AGENTS scope-declaration fix changed linter behavior by adding the
+frontmatter-skipping `_body_lines` path in `tools/lint-agents-md.py` (24
+changed lines: 23 additions and one deletion) and a new
+`tools/test_lint_agents_md_frontmatter_scope.py` regression test, so it
+correctly took its own pull request (#1054) without a backlog entry.
+
+This is reversible by restoring mandatory capture if adopters lose important
+work through non-capture. Adopter compatibility is an intentional behavior
+change: adopters no longer must create a `[backlog].open` item for every
+excluded finding, so the follow-on convention and its workflow instruction must
+ship together. No security review applies because this changes neither a
+security boundary nor a trust model. The governance choice itself is not
+empirical, but whether non-capture loses work that mattered is. Observe the
+existing PR or final-summary exclusions alongside `work-intake` captures and
+post-closure corrections: a confirmed case where an excluded, uncaptured
+finding is later required to satisfy the original accepted intent is the
+signal. That result restores mandatory capture; no new ledger, schema, or
+instrumentation is required.
+
+## Evidence & prior art
+
+The current work-loop requires each deferred item to be recorded in
+`workspace.toml [backlog].open` ([`packs/core/.apm/skills/work-loop/SKILL.md:590`](../../packs/core/.apm/skills/work-loop/SKILL.md)); its review retry cap and
+stasis rule instead say to stop and surface ([`packs/core/.apm/skills/work-loop/SKILL.md:601-602`](../../packs/core/.apm/skills/work-loop/SKILL.md)). This proposal changes the former obligation, not the latter safety control.
+
+RFC-0083 defines a shipped brief as explicitly closed with no in-scope work
+remaining ([`docs/rfc/0083-work-intake-and-artifact-routing.md:512`](0083-work-intake-and-artifact-routing.md)). The technical-site brief likewise defines a bounded programme and sends feature expansion outside it unless approved
+([`docs/product/briefs/tech-site-completion.md:61-66`](../product/briefs/tech-site-completion.md)). Those boundaries make intent fit decidable.
+
+[The Kanban Guide](https://kanbanguides.org/the-kanban-guide/) requires a
+workflow to define work items, start and finish points, WIP control, and
+explicit flow policies; it permits multiple Definitions of Workflow at different
+levels. That supports distinct completion and review boundaries. [Google
+Engineering Practices](https://google.github.io/eng-practices/review/reviewer/pushback.html)
+requires complexity introduced by the current change to be cleaned up before
+submission, while surrounding problems that cannot be addressed may be filed
+separately. This RFC tightens the latter practice by making that recording
+optional rather than automatic.
+
+## Open questions
+
+- **Q1 — How should the hardcoded `Shipped` guard interact with an intent that
+  spans multiple review units?** `reviewers-clean` on the code-review edge
+  requires `spec.md` to be `Shipped`
+  ([`packs/core/.apm/skills/work-loop/scripts/loop-engine.py:746`](../../packs/core/.apm/skills/work-loop/scripts/loop-engine.py),
+  [`packs/core/.apm/skills/work-loop/scripts/loop-engine.py:802-805`](../../packs/core/.apm/skills/work-loop/scripts/loop-engine.py),
+  [`packs/core/.apm/skills/work-loop/scripts/loop-engine.py:831`](../../packs/core/.apm/skills/work-loop/scripts/loop-engine.py)),
+  while RFC-0090 D1 permits one specification to deliver multiple pull requests.
+  Thus a later planned or post-review unit begins after an earlier unit has
+  already marked the spec `Shipped`, even when the accepted intent remains
+  incomplete. This pre-existing tension is surfaced, not created, here.
+  **Recommended default:** retain the guard's current behavior and carry the
+  doctrine instructionally; any change to the guard is a separate decision.
+  **Owner:** eugenelim. **Decide by:** the follow-on work-loop implementation.
+
+## Follow-on artifacts
+
+Follow-on work will update the source-of-truth
+`packs/core/seeds/docs/CONVENTIONS.md` seed and
+`packs/core/.apm/skills/work-loop/SKILL.md` to apply intent-scoped completion
+and capture-by-request, including instructional coverage of the existing
+human-gate return edge for any further in-intent review unit. It will also
+perform the required core-pack version bump, changelog update, and
+generated-projection regeneration. Because the retired mandatory-capture rule
+is restated in adopter-facing and maintainer-facing documentation, the work
+also corrects the core how-to guide's DECIDE step, the core pack design
+document, and the findings registers' descriptions of how entries arrive.
+Removing work-loop's own `workspace.toml [backlog].open` write moves the pinned
+finish-checklist contract hash in `tools/test_workspace_status.py` with the
+reviewed prose; it strengthens, rather than relaxes, the existing invariant
+that `workspace-status` (not work-loop) owns `workspace.toml`
+queue/active/shipped updates (AC3g invariant). Acceptance creates no backlog type,
+workspace schema field, lint, or new artifact.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -94,6 +94,7 @@
 | [0090](0090-change-sizing-and-decomposition.md) | Change sizing and decomposition | Accepted | 2026-08-19 | 2026-08-19 |
 | [0091](0091-right-size-rfc-governance.md) | Right-size RFC governance | Accepted | 2026-08-19 | 2026-08-19 |
 | [0092](0092-first-class-distribution-routes.md) | First-class distribution routes — portable Agent Plugins, native Claude/Codex packages, and Kiro Powers from one pack model | Accepted | 2026-08-19 | 2026-08-20 |
+| [0093](0093-intent-scoped-completion.md) | Intent-scoped completion | Accepted | 2026-08-19 | 2026-08-20 |
 
 ## Adding a new RFC
 

--- a/guides/core/how-to/plan-and-execute-non-trivial-work.md
+++ b/guides/core/how-to/plan-and-execute-non-trivial-work.md
@@ -106,7 +106,7 @@ The full procedure lives in [the `work-loop` SKILL.md](../../../packs/core/.apm/
 - **EXECUTE** — implements task by task. TDD-mode tasks run red-green-refactor; goal-based tasks run the `Done when:` one-liner; manual-QA tasks record the visual check.
 - **GATES** — lint, typecheck, tests. Mechanical, ordered, no editing the gate to make it pass.
 - **REVIEW** — `adversarial-reviewer` reads the diff cold against `AGENTS.md` + `CONVENTIONS.md` + `spec.md`. Findings come back as Blockers / Concerns / Nits with one-sentence fixes. The loop records each pass's finding fingerprints to `state.json` via `loop-cohort review record`, which is what enables stasis detection in the next phase. Specialist reviewers (`security-reviewer`, `quality-engineer`) run when the diff warrants.
-- **DECIDE** — each finding routes to `apply` (fix in this PR) or `defer` (one-line entry under `Deferred:` in the PR body). Stasis detection fires if the same findings come back two iterations in a row — stop and surface to a human rather than spinning a third pass.
+- **DECIDE** — intent fit decides each finding: in-intent work that cannot share this unit becomes the next review unit in the same session; excluded work is acknowledged in the PR and captured only if its owner asks. Stasis detection fires if the same findings come back two iterations in a row — stop and surface to a human rather than spinning a third pass.
 
 For the end-to-end narrative with the parts in context, read [core-pack.md § How they tie together](../explanation/core-pack.md#how-they-tie-together).
 

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -534,7 +534,11 @@ Dispatch reviewers the diff warrants; don't run all by default. Select each via 
 
 - **`frontend-reviewer`** — primary HTML/CSS/JS output diffs (full-mode only). Pass diff + surface's evidence manifest state. Lens: CSS token drift, ARIA mutation completeness, state coverage regression, WCAG 2.2 Focus Appearance + Target Size, CWV regression signals. Fallback absent: named skip.
 
-**When ALL warranted reviewers are clean (or are named skips)** — write `Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one reviewer produced a clean report, record it (transition first; record is non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit count already moved; guard requires Status: Shipped):
+**When ALL warranted reviewers are clean (or are named skips)** — normally write
+`Status: Shipped` in spec.md, then fire `reviewers-clean` and, if at least one
+reviewer produced a clean report, record it (transition first; record is
+non-idempotent — recording first then crashing leaves CODE-REVIEW with the audit
+count already moved; the default guard requires Status: Shipped):
 ```
 python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean
 # If at least one reviewer produced a clean report:
@@ -544,7 +548,22 @@ python scripts/loop-cohort.py review record docs/specs/<feature> \
 python scripts/loop-cohort.py review record docs/specs/<feature> \
     --all-skipped --expect-run-id <run_id>
 ```
-Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human response:
+For an intermediate review unit under an accepted intent that remains incomplete,
+leave `spec.md` at `Status: Implementing` and declare that boundary explicitly:
+```
+python scripts/loop-engine.py transition docs/specs/<feature> reviewers-clean \
+    --intent-incomplete
+```
+This opt-in accepts `Implementing` only; it does not disable the status guard or
+permit another status. The next in-intent unit still returns through
+`blocker-applied` and receives GATES, REVIEW, and a human gate of its own. This
+intermediate human gate is not a finish: do not mark the spec `Shipped`, run
+`done` (which refuses until the spec is `Shipped`), or apply the Finish
+checklist's intent-completion item. After the human
+gate, fire `blocker-applied` to begin the next unit.
+Engine is now in `CODE-HUMAN-GATE`. For a final unit, **before waiting: complete
+the [Finish checklist](#finish-checklist) and open the PR.** Then wait for human
+response:
 - **Approved (merge confirmed):** fire `done`.
   ```
   python scripts/loop-engine.py transition docs/specs/<feature> done

--- a/packs/core/.apm/skills/work-loop/SKILL.md
+++ b/packs/core/.apm/skills/work-loop/SKILL.md
@@ -557,6 +557,11 @@ Engine is now in `CODE-HUMAN-GATE`. **Before waiting: complete the [Finish check
   python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
   # Re-run GATES → fire gates-clean or gates-failed → re-enter REVIEW.
   ```
+- **Further in-intent review unit:** when an included discovery needs its own
+  independently reviewed unit, use the same `blocker-applied` return edge,
+  then apply that unit, fire `wave-complete`, and run GATES, REVIEW, and the
+  human gate again. A separate review unit does not defer or complete the
+  original accepted intent.
 
 If a specialist reviewer returns findings, first exit `CODE-REVIEW` via `findings-remain` and record the fingerprints (same as the adversarial-findings path above), then apply the fixes, fire `wave-complete` to reach `CODE-VERIFICATION`, re-run GATES, then re-enter REVIEW:
 ```
@@ -579,14 +584,39 @@ python scripts/loop-engine.py transition docs/specs/<feature> wave-complete
 
 ## Step 5. DECIDE
 
-Route each reviewer finding into `apply` (fix in this PR) or `defer` (capture as follow-up) — the work-loop's interpretation of reviewer output; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+Route each implementation or reviewer discovery by intent fit before deciding
+whether it belongs in the current review unit. The work-loop interprets the
+result; the reviewer keeps its narrow Blockers / Concerns / Nits contract:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+Only the owner may narrow or waive an accepted intent. A matching discovery
+may share the current review unit only when the accepted contract authorizes it
+and it qualifies under the bundled-fixes tiers. Otherwise, it is the next
+independently reviewed unit in the same session: use the existing human-gate
+`blocker-applied` return edge, then run GATES, REVIEW, and the human gate again.
 
 **Execution-path check.** Before routing any finding to `apply`: confirm the fix reaches a live code path — grep for callers or trace the entry point. A guard that no caller exercises doesn't close a finding; a test that drives a mock seam instead of the real entry point doesn't count.
 
-- **Blockers** → `apply`. Re-run GATES and REVIEW after each fix.
-- **Concerns** → `apply` if mechanical and in scope (default for any Concern whose fix meets the bundled-fixes gates). `defer` if the fix crosses files outside the plan, requires a design call, or changes user-visible behavior the spec didn't authorize. Don't let Concerns rot in chat — every Concern resolves into one of the two.
-- **Nits** → `apply` if they meet the bundled-fixes gates (land in `Bundled fixes:`). Otherwise `defer` — one line in `Deferred:`. Every Nit resolves into one of the two; the `Deferred:` line is the acknowledgement that the loop saw it and chose not to fix.
-- **Deferred items** → before recording, ask: *"Could this be delivered in this PR without crossing scope or introducing unreviewed risk?"* Only defer if genuinely no. Record in `workspace.toml [backlog].open` as `{slug = "...", source = "spec/<name> ACn"}` with a cold-start-sufficient TOML comment. Add `(deferred: <slug>)` to the spec criterion that defers. PR description keeps only a one-line pointer in a standalone `Deferred:` section (alongside `Bundled fixes:`; append below standard template content, don't modify the template). After recording, prompt: *"Does this look like an RFC candidate or roadmap intent? If so, add a row to `docs/product/findings/rfc-candidates.md` or `docs/product/findings/roadmap-intents.md`."* Skip if neither file exists.
+- **Blockers** → include the correction required by the accepted intent. Re-run
+  GATES and REVIEW after each fix; use the next review unit when it cannot
+  safely share this one.
+- **Concerns and Nits** → apply now only when their inclusion is authorized by
+  the accepted contract and they qualify under the bundled-fixes tiers. A
+  matching discovery that cannot share this unit remains incomplete and moves
+  to the next review unit in the same session. An out-of-intent discovery is
+  excluded unless the owner explicitly changes scope.
+- **Excluded work** → acknowledge it in the PR's *What did you not change that
+  you considered?* answer. Do not create a durable follow-on by default. If
+  the owner explicitly asks to remember it, route the request through
+  `work-intake`; do not create a `[backlog].open` entry or `(deferred: <slug>)`
+  marker merely because this loop did not include the work.
 
 **Scratch note.** After routing each finding: if it revealed a non-obvious trap — something that would have changed your approach — save a one-line note to your IDE's native scratch (Claude Code: memory file; Codex: `.context/` scratch). Format: `[kind] title — what triggered it`. These feed [Capture learnings](#capture-learnings).
 
@@ -596,9 +626,9 @@ When gates are green and the mode's review requirements are satisfied → procee
 
 Stop when **any** of these is true:
 
-1. **Gates green AND the mode's review requirements are satisfied** — normal exit. Proceed to [Finish checklist](#finish-checklist).
+1. **Gates green AND the mode's review requirements are satisfied for the current review unit** — proceed to [Finish checklist](#finish-checklist). A merged or clean review unit does not complete the accepted intent while matching work remains for a later unit.
 2. **`scripts/loop-cohort.py check` exits non-zero** — except the expected `plan_review_status: pending` in PLAN (step 10 above), which is the cue to run pre-EXECUTE reviewers, not a stop signal. All other non-zero exits stop the current iteration and surface. Fires on: implementation retry cap (`check --phase gates-failed`), review retry cap (`check --phase review`). The exit message identifies the condition.
-   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately; do not run another review round.
+   **Stasis** (same findings two review rounds in a row) is detected by `review inspect` returning `matches_previous_round=True` — not by `check`. Surface immediately for human replanning; do not run another review round. A retry cap or stasis never completes the accepted intent or creates backlog work automatically.
 3. **Diff is shrinking but findings aren't** — spot-fixing without addressing root cause. Stop and rethink the approach (back to PLAN).
 
 If you hit any of these and the work isn't done: stop, write down what you learned, re-plan. Never silently expand scope to make a finding go away.
@@ -610,9 +640,13 @@ Refuse to declare done until every item is true. (**Light mode:** `quality-engin
 - [ ] GATES were clean (lint, typecheck, tests).
 - [ ] **If the change ships something a user invokes** (CLI, library API, agent, UI): the real built artifact was exercised end-to-end through its documented happy path and the observed result recorded — a passing unit gate alone does not satisfy this. Trust the running artifact, not the build exit code.
 - [ ] **Full mode:** every warranted reviewer (`adversarial-reviewer` always; `security-reviewer` on security-boundary diffs; `quality-engineer` per the REVIEW trigger; `experience-reviewer` on user-facing diffs; `frontend-reviewer` on HTML/CSS/JS primary-output diffs) returned `Clean — ready to commit.` or is a named skip — **except missing `security-reviewer` on infra-flavored work, which blocks**. Silent skips are not allowed.
-- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an `apply` or `defer` disposition; applied fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
+- [ ] **Light mode:** the single bounded `adversarial-reviewer` pass ran (or its absence is a named skip); every finding received an intent-fit and session-decision disposition; included fixes passed GATES. A Blocker received exactly one re-review; a surviving Blocker escalated to full mode. If `AGENTS.md` declares the external-quality-gate exception, `quality-engineer` also ran and returned Clean or is an allowed named skip.
 - [ ] Whole-spec `quality-engineer` pass (final loop of a multi-loop spec only): same select-or-note rule.
 - [ ] The resolve-vs-surface disposition record exists and every REVIEW finding is resolved. In light mode "every REVIEW finding" means the single bounded `adversarial-reviewer` pass's findings; a surviving Blocker escalates to full mode.
+- [ ] The original accepted intent is complete, or its owner explicitly narrowed
+  or waived the remaining matching work. A merged PR, retry cap, or review
+  stasis alone is not completion; excluded work needs no backlog entry unless
+  the owner explicitly requested capture through `work-intake`.
 - [ ] `git status` shows no uncommitted or untracked files (except gitignored scratch).
 - [ ] **Doc-drift invariants hold**: spec `**Status:**` set to `Shipped` (code mode) or `Approved` (spec-plan mode, which ends after plan approval without proceeding to EXECUTE); **full mode:** also `plan.md` `**Status:**` `Done` — use spec vocabulary only (`Draft | Approved | Implementing | Shipped | Archived`; plan vocabulary `Drafting/Executing/Done` is invalid and will fail `lint-spec-status.py`); every AC is `[x]` or `(deferred: <slug>)`; each deferral resolves in `[backlog].open`; intra-repo references the change touches resolve. Run `scripts/lint-spec-status.py` where Python is available.
 - [ ] Conventional commit format used; no force-push to shared branches.

--- a/packs/core/.apm/skills/work-loop/scripts/loop-engine.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-engine.py
@@ -740,9 +740,26 @@ def _guard_check_phase_review(spec_dir: Path, engine_state: dict, _) -> str | No
     )
 
 
-def _guard_check_spec_status(spec_dir: Path, engine_state: dict, _) -> str | None:
+def _guard_check_spec_status(
+    spec_dir: Path, engine_state: dict, event_args: dict
+) -> str | None:
+    """Require the status declared by the review unit's intent boundary."""
+    expect = "Implementing" if event_args.get("intent_incomplete", False) else "Shipped"
     return _guard_reason(
         "check-spec-status failed",
+        _guards().check_artifact_status(spec_dir, filename="spec.md", expect=expect),
+    )
+
+
+def _guard_done(spec_dir: Path, engine_state: dict, _) -> str | None:
+    """Guard done: the accepted intent's spec must be Shipped.
+
+    Before intent-scoped completion this held transitively — the only route into
+    CODE-HUMAN-GATE required Shipped. An intermediate unit may now enter that
+    state at Implementing, so DONE asserts completion explicitly instead.
+    """
+    return _guard_reason(
+        "check-spec-status --expect Shipped failed",
         _guards().check_artifact_status(spec_dir, filename="spec.md", expect="Shipped"),
     )
 
@@ -829,6 +846,7 @@ _GUARDS: dict[tuple[str, str], object] = {
     ("code", "gates-clean"): _guard_wave_check_last,
     ("code", "findings-remain"): _guard_check_phase_review_on_code_review,
     ("code", "reviewers-clean"): _guard_check_spec_status_on_code_review,
+    ("code", "done"): _guard_done,
 }
 
 # ── engine-state.json helpers ──────────────────────────────────────────────
@@ -1149,6 +1167,7 @@ def cmd_transition(args: argparse.Namespace) -> int:
 
     event = args.event
     wave_index = args.wave_index
+    intent_incomplete = args.intent_incomplete
 
     # Validate --wave-index usage
     if event == "wave-passed":
@@ -1157,6 +1176,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
     else:
         if wave_index is not None:
             return stop(f"transition {event!r} does not accept --wave-index")
+    if intent_incomplete and event != "reviewers-clean":
+        return stop("transition --intent-incomplete requires reviewers-clean")
 
     # recover at command start — before any early-exit check.
     # _recover_engine_state_tmp promotes crash-left .tmp → engine-state.json.
@@ -1191,6 +1212,9 @@ def cmd_transition(args: argparse.Namespace) -> int:
     current_state = state["state"]
     run_id = state["run_id"]
 
+    if intent_incomplete and current_state != "CODE-REVIEW":
+        return stop("transition --intent-incomplete requires CODE-REVIEW")
+
     # Step 0: run_id preflight (all transitions)
     err = _run_id_preflight(spec_dir, run_id)
     if err:
@@ -1217,6 +1241,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
         event_args = {}
         if wave_index is not None:
             event_args["wave_index"] = wave_index
+        if intent_incomplete:
+            event_args["intent_incomplete"] = True
         err = guard_fn(spec_dir, state, event_args)
         if err:
             return stop(err)
@@ -1304,6 +1330,11 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("spec_dir")
     sp.add_argument("event")
     sp.add_argument("--wave-index", type=int, dest="wave_index", default=None)
+    sp.add_argument(
+        "--intent-incomplete",
+        action="store_true",
+        help="declare reviewers-clean is an intermediate unit of an incomplete intent",
+    )
     sp.set_defaults(func=cmd_transition)
 
     sp = sub.add_parser("status", help="read engine-state.json + pending_human_wait")

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/DESIGN.md
+++ b/packs/core/DESIGN.md
@@ -303,10 +303,12 @@ Items flow left to right: from backlog → shaping → work → done. `workspace
 
 **Every session starts with `workspace-status`.** It replaces reading multiple product docs by hand — you get a ready/blocked/done summary in one shot.
 
-**Every session ends with `work-intake remember`.** Follow-ons, deferred scope,
-and discovered issues become canonical Draft artifacts plus schema-valid,
-non-dispatchable `workspace.toml` entries, so they survive the session without
-making comments or chat history the requirements store.
+**A session closes captured follow-ons with `work-intake remember`.** An owner
+explicitly requests capture when a follow-on, excluded scope, or discovered
+issue should survive the session; it then becomes a canonical Draft artifact
+plus a schema-valid, non-dispatchable `workspace.toml` entry. Work excluded
+without that request is acknowledged in the PR or final summary, not made
+durable by default.
 
 This orient/close discipline is the habit that makes workspace.toml accurate over time. A workspace.toml that is only written once and never updated is stale within a week.
 
@@ -430,8 +432,8 @@ All reviewers use the same three severity levels:
 | Label | Meaning |
 |-------|---------|
 | **Blocker** | Must fix before merge. The loop iterates. |
-| **Concern** | Should address; human decides whether to apply or defer. |
-| **Nit** | Optional cleanup; agent applies if trivial; otherwise defers. |
+| **Concern** | Should address; human decides whether it belongs in the accepted intent and current review unit. |
+| **Nit** | Optional cleanup; agent applies if trivial and in scope; otherwise excludes it unless the owner requests capture. |
 
 ### The surface message
 

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.10.1"
+version = "2.10.2"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -440,12 +440,17 @@ mechanical rule.
   ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
-- **Deferral token.** A criterion that ships *unmet on purpose* is not left
-  unchecked and silent — it carries an inline `(deferred: <slug>)` marker whose
-  `<slug>` resolves to a `slug` field in `workspace.toml [backlog].open`, the
-  durable register of open work. Form: `- [ ] <outcome> (deferred: <slug>)`. A
-  deferral recorded only in a PR comment rots; the register is version-controlled
-  and greppable. Run `workspace-status` to see all open backlog items.
+- **Deferral token.** A criterion that ships *unmet on purpose* because
+  genuinely deferred in-scope work remains is not left unchecked and silent —
+  it carries an inline `(deferred: <slug>)` marker whose `<slug>` resolves to a
+  `slug` field in `workspace.toml [backlog].open`, the durable register of open
+  work. Form: `- [ ] <outcome> (deferred: <slug>)`. This is not the default
+  disposition for an excluded out-of-scope discovery: acknowledge that work in
+  the PR's *What did you not change that you considered?* answer instead. If
+  its owner explicitly asks to remember it, route that capture through
+  `work-intake`. A deferral recorded only in a PR comment rots; the register is
+  version-controlled and greppable. Run `workspace-status` to see all open
+  backlog items.
 - **Brief back-link (optional).** A spec derived from a product brief carries a
   `- **Brief:**` header naming that brief by its repository-relative path
   (`docs/product/briefs/<slug>.md` — the brief file's real path, which
@@ -664,7 +669,7 @@ right now?"
   here because shaping artifacts are decisions, not corpora — they belong in
   the version-controlled tree alongside ADRs and specs.
 - `findings/` (optional) — structured governance registers: `rfc-candidates.md`
-  (candidate RFCs surfaced by work-loop scope-deferrals or `frame-situation`
+  (candidate RFCs surfaced by owner-requested capture or `frame-situation`
   escalations) and `roadmap-intents.md` (deferred roadmap items). `rfc-status`
   surfaces the candidate count at session start.
 - `initiatives/` (optional) — initiative brief artifacts and their
@@ -897,7 +902,7 @@ the `work-loop` skill; this section is the why.
 declare victory when they *feel* done. Mechanical gates (lint, typecheck,
 tests) plus an adversarial review pass replace "feel" with verifiable
 termination. The loop keeps going until both kinds of check are satisfied —
-or until it hits a hard cap.
+or it pauses for human replanning.
 
 **Why think before acting.** The cost of a wrong start is higher than the
 cost of thinking. For high-stakes changes (architectural choices, multi-file
@@ -912,12 +917,39 @@ loses the planning context. We do it the other way only when fresh context
 is the *point* — an unattended, fresh-session-per-iteration loop (see the
 work-loop skill).
 
-**Why a hard iteration cap.** Without one, you're hoping. The implementation and review retry caps live as data in `state.json` (see below) and are enforced by the `work-loop` skill's `scripts/loop-cohort.py` through `loop-cohort check --phase gates-failed` and `--phase review`; if you hit one, the task is bigger than you thought — stop, re-plan, or split.
+**Why a hard iteration cap.** Without one, you're hoping. The implementation and review retry caps live as data in `state.json` (see below) and are enforced by the `work-loop` skill's `scripts/loop-cohort.py` through `loop-cohort check --phase gates-failed` and `--phase review`; if you hit one, the task is bigger than you thought — pause for human replanning, then stop, re-plan, or split. A cap never declares the accepted intent complete or creates follow-on work automatically.
 
 **Why capture learnings.** A loop that finishes without updating *some*
 doc, skill, or note has wasted what it learned. The next agent (or a
 human) will pay for it again. The work-loop skill enumerates where each
 kind of learning belongs.
+
+### Intent-scoped completion
+
+Completion answers to the original accepted intent, not to the current pull
+request. A pull request is a review unit: one accepted intent may need more
+than one independently reviewed unit in the same session. Only the owner may
+narrow or waive that intent.
+
+For every implementation or review discovery, determine intent fit before the
+session decision:
+
+| Intent fit | Session decision | Disposition |
+| --- | --- | --- |
+| Matches | Include now | Add it to the current plan or session. |
+| Matches | Do not include | Stop incomplete unless the owner explicitly narrows or waives the intent. |
+| Does not match | Include now | Obtain an explicit scope change; it then becomes accepted intent. |
+| Does not match | Do not include | Exclude it with no durable follow-on by default. |
+| Unclear | — | Ask the owner before acting. |
+
+An included discovery shares the current review unit only when the accepted
+contract authorizes it and it qualifies under the bundled-fixes tiers. A
+distinct design, behavior, or semantic change becomes the next review unit in
+the same session. An excluded discovery is acknowledged by the PR's *What did
+you not change that you considered?* answer; create a durable follow-on only
+when the owner explicitly requests capture, then route it through `work-intake`.
+Retry caps and review stasis pause for human replanning; they neither complete
+the accepted intent nor create backlog work automatically.
 
 ### Light and full modes
 

--- a/packs/core/tests/skills/work-loop/test_loop_engine.py
+++ b/packs/core/tests/skills/work-loop/test_loop_engine.py
@@ -1658,12 +1658,78 @@ def test_legal_reviewers_clean_code_to_human_gate(tmp: Path) -> None:
         ok(name)
 
 
+@pytest.mark.parametrize(
+    ("status", "expected_rc"),
+    [
+        ("Implementing", 0),
+        ("Draft", 1),
+        ("Approved", 1),
+        ("Archived", 1),
+        ("Shipped", 1),
+    ],
+)
+def test_reviewers_clean_intent_incomplete_requires_implementing(
+    tmp: Path, status: str, expected_rc: int
+) -> None:
+    """The intermediate-unit declaration narrows, rather than bypasses, the guard.
+
+    Mutation proof: changing the engine's opt-in expectation from ``Implementing``
+    to ``Shipped`` makes the Implementing case refuse and the Shipped case admit,
+    flipping both assertions below.
+    """
+    name = f"reviewers-clean-intent-incomplete-{status.lower()}"
+    spec_dir, _ = make_code_review_run(tmp, name)
+    write_spec(spec_dir, status=status)
+
+    rc, _, err = run_engine(
+        "transition", str(spec_dir), "reviewers-clean", "--intent-incomplete"
+    )
+    if rc != expected_rc:
+        fail(name, f"expected exit {expected_rc}; got {rc}: {err.strip()}")
+        return
+
+    state = json.loads((spec_dir / "engine-state.json").read_text())
+    expected_state = "CODE-HUMAN-GATE" if expected_rc == 0 else "CODE-REVIEW"
+    if state.get("state") != expected_state:
+        fail(name, f"expected {expected_state}; got {state.get('state')!r}")
+    else:
+        ok(name)
+
+
+@pytest.mark.parametrize("status", ["Draft", "Approved", "Implementing", "Archived"])
+def test_done_refuses_non_shipped_spec(tmp: Path, status: str) -> None:
+    """done must not make an incomplete accepted intent terminal.
+
+    Mutation proof: removing the ``("code", "done")`` guard entry admits this
+    transition, so the assertion that engine state remains CODE-HUMAN-GATE flips.
+    """
+    name = f"done-refuses-{status.lower()}"
+    run_id = str(uuid.uuid4())
+    spec_dir = make_spec_dir(tmp, name)
+    write_spec(spec_dir, status=status)
+    write_engine_state(
+        spec_dir, minimal_engine_state(run_id, name, "code", "CODE-HUMAN-GATE")
+    )
+    write_cohort_state(spec_dir, minimal_cohort_state(run_id, name))
+
+    rc, _, err = run_engine("transition", str(spec_dir), "done")
+    if rc == 0:
+        fail(name, "expected done to refuse a non-Shipped spec")
+        return
+    state = json.loads((spec_dir / "engine-state.json").read_text())
+    if state.get("state") != "CODE-HUMAN-GATE":
+        fail(name, f"expected CODE-HUMAN-GATE; got {state.get('state')!r}: {err.strip()}")
+    else:
+        ok(name)
+
+
 def test_legal_done_from_code_human_gate(tmp: Path) -> None:
-    """CODE-HUMAN-GATE → done → DONE. No pre-guard (done is exempt)."""
+    """CODE-HUMAN-GATE → done → DONE when spec.md Status is Shipped."""
     name = "legal-done-code"
     run_id = str(uuid.uuid4())
     spec_dir = make_spec_dir(tmp, name)
-    # done is exempt from schedule pre-guard, and no specific guard for "done"
+    # done skips the schedule pre-guard but fires its Shipped-status guard.
+    write_spec(spec_dir, status="Shipped")
     write_engine_state(spec_dir, minimal_engine_state(run_id, name, "code", "CODE-HUMAN-GATE"))
     write_cohort_state(spec_dir, minimal_cohort_state(run_id, name))
     rc, _, err = run_engine("transition", str(spec_dir), "done")
@@ -1830,7 +1896,10 @@ def test_done_exempt_from_schedule_precheck(tmp: Path) -> None:
     name = "done-exempt-from-schedule-precheck"
     run_id = str(uuid.uuid4())
     spec_dir = make_spec_dir(tmp, name)
-    # No plan.md, no schedule — done must still succeed
+    # No plan.md, no schedule — done must still succeed. spec.md is present and
+    # Shipped only to satisfy done's status guard; this case is about the
+    # schedule exemption, which the missing plan.md still exercises.
+    write_spec(spec_dir, status="Shipped")
     write_engine_state(spec_dir, minimal_engine_state(run_id, name, "code", "CODE-HUMAN-GATE"))
     write_cohort_state(spec_dir, minimal_cohort_state(run_id, name))
     rc, _, err = run_engine("transition", str(spec_dir), "done")

--- a/packs/core/tests/skills/work-loop/test_loop_guards.py
+++ b/packs/core/tests/skills/work-loop/test_loop_guards.py
@@ -2103,6 +2103,28 @@ def test_check_artifact_status_branches(g, spec) -> None:
     assert not r.ok and "no **Status:** line" in r.reason
 
 
+@pytest.mark.parametrize(
+    "status, expected_ok",
+    [
+        ("Implementing", True),
+        ("Draft", False),
+        ("Approved", False),
+        ("Archived", False),
+        ("Shipped", False),
+    ],
+)
+def test_check_artifact_status_expect_implementing_is_exact(g, spec, status, expected_ok) -> None:
+    """The existing API can enforce an intermediate review unit without widening it.
+
+    Mutation proof: making ``check_artifact_status`` return success for a status
+    mismatch flips each non-Implementing assertion.
+    """
+    result = g.check_artifact_status(
+        spec(spec_status=status), filename="spec.md", expect="Implementing"
+    )
+    assert result.ok is expected_ok
+
+
 def test_check_artifact_status_filename_is_one_component(g, spec) -> None:
     """AC9. A single component is what makes the confinement honest.
 

--- a/tests/roster/test_security_checklists_okf_projection.py
+++ b/tests/roster/test_security_checklists_okf_projection.py
@@ -103,8 +103,8 @@ def test_core_version_and_okf_declaration_are_synchronized() -> None:
         (PACK_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
 
-    assert pack["pack"]["version"] == "2.10.1"
-    assert plugin["version"] == "2.10.1"
+    assert pack["pack"]["version"] == "2.10.2"
+    assert plugin["version"] == "2.10.2"
     assert pack["pack"]["metadata"]["okf"]["profile"] == "agentbundle-okf/v1"
     bundle = pack["pack"]["metadata"]["okf"]["bundles"][0]
     assert bundle["id"] == "security-checklists"

--- a/tools/test_workspace_status.py
+++ b/tools/test_workspace_status.py
@@ -1503,7 +1503,7 @@ _WORK_LOOP_CONTRACT_HASH = (
     "98952b12f942d880ba40beb8ed928d197f2e884da66542b7200f595388164d22"
 )
 _WORK_LOOP_FINISH_HASH = (
-    "7a6ac4f28a6aeee56dc608867213efdc6b29646ceb35e090c60bf97a6b764baa"
+    "87dd027827ef2bf9fbb72616f3eff5902f69d870e309ddff78a7555e7b28185a"
 )
 _WORK_LOOP_MD = (
     Path(__file__).resolve().parent.parent


### PR DESCRIPTION
Accepts and implements RFC-0093, then resolves its own open question — three
review units on one branch. That shape is the doctrine applied to its own
delivery: one intent, one session, several independently reviewed units.

## What does this change?

Completion answers to the **original accepted intent**, not to whether work fits
the current PR. One intent may need more than one independently reviewed unit in
the same session. Work excluded from the intent is acknowledged in the PR and
gets no durable follow-on unless its owner explicitly asks for capture.

Core rule: **intent-stable, review-unit-flexible, capture-by-request.**

This replaces work-loop's `apply | defer` binary, under which anything that
could not enter the current PR was forced into `workspace.toml [backlog].open` —
the mechanism behind follow-on accumulation.

| Commit | Unit |
| --- | --- |
| `docs(rfc)` | RFC-0093 accepted |
| `feat(core)` | doctrine adopted in the conventions seed and `work-loop` |
| `feat(core)` | Q1 resolved — the code-review and `done` guards become intent-aware |

## Why?

`docs/rfc/0093-intent-scoped-completion.md` (Accepted). It is an RFC rather than
an ADR on the two grounds `CONVENTIONS.md` §3 gives: an explicit request to
circulate, and a **changed** obligation shipped to adopters rather than
conventions maintenance that preserves one.

## The guard change, and why it needed a second guard

`reviewers-clean` on the `CODE-REVIEW → CODE-HUMAN-GATE` edge hardcoded an
expected `Shipped` status, so every unit reaching the human gate had to assert
`Shipped` even when the intent was unsatisfied. A new `--intent-incomplete`
declaration narrows that expectation to `Implementing` for an intermediate unit.
It narrows rather than disables: without the flag it still requires `Shipped`;
with it, `Implementing` and no other status; and it is rejected on any other
event or state. There is no free-form status override.

Admitting `Implementing` into `CODE-HUMAN-GATE` broke an invariant that had held
**transitively** — because the only route in required `Shipped`, reaching `DONE`
implied a `Shipped` spec. Nothing guarded `done`, so the engine could reach
`DONE` with the spec still `Implementing`, leaving prose as the only control.
A new `("code", "done")` guard restores it explicitly. `done` was never exempt
from event guards, only from the schedule pre-guard, so this adds a guard where
none existed rather than overriding an exemption.

## How do I verify it?

- `make build-check` (with SAST), `make lint-ruff`, `make lint-mypy` — clean
- `packs/core/tests/skills/work-loop/test_loop_engine.py` — 153 passed
- `test_loop_guards.py` 130 passed; `test_loop_guards_parity.py` 50 passed
  **untouched**, so the API/CLI surfaces and their pre-change goldens needed no
  movement. No golden was regenerated to make a test pass.
- `tools/test_workspace_status.py` — 220 passed
- `dist/` rebuilt through the gate chain, so generated-output parity is proved

**Mutation proofs** — each applied, observed failing, and restored by editing:

| Mutation | Observed |
| --- | --- |
| Opt-in expectation → `Shipped` | 2 of 5 cases flip |
| Default expectation → `Implementing` | 2 cases flip |
| Remove the `("code", "done")` entry | all 4 refusals flip |
| `pack.toml` version reverted | roster version test fails |

Two existing tests were **updated, not weakened**:
`test_legal_done_from_code_human_gate` now writes a `Shipped` spec and its stale
"no specific guard for done" premise is corrected;
`test_done_exempt_from_schedule_precheck` also writes one but still omits
`plan.md`, so its success still proves no schedule precheck ran.

Reviewed by three independent adversarial sessions, none of which wrote the
artifact under review, plus a fresh-reader readability pass on the RFC given only
the RFC text. All returned `Clean — ready to commit.` with evidence lines.

## What did you not change that you considered?

**Checks that were still correct.** An existing `(deferred: <slug>)` marker must
still resolve in `[backlog].open`, so `lint-spec-status.py`, the
`adversarial-reviewer` metadata invariants, and the spec template keep their
rules. What changed is *when a deferral is created at all*.

**Historical records.** Past RFCs, shipped specs, older changelog entries, and
the work-loop test fixture corpora keep their original wording.

**`_loop_guards.py` and `check-spec-status.py`.** Both already accepted an exact
expected status, so the change lives in the engine's dispatch alone.

One pinned hash moved: removing work-loop's own `workspace.toml` write changed
the finish-checklist contract window in `tools/test_workspace_status.py`. It
**strengthens** the AC3g invariant that `workspace-status`, not work-loop, owns
`workspace.toml` — the old DECIDE step instructed exactly the write AC3g forbids.
`workspace_status_engine.py` needed no change and the Step-0 anchor is
byte-identical.

## Notes for the reviewer

**Numbering.** This began as RFC-0091 and is now 0093: both intervening ordinals
were taken while it was in flight — 0091 by the RFC-governance right-sizing,
0092 by first-class distribution routes. Rebased onto the latter, so core moves
`2.10.1 → 2.10.2`.

**One pre-existing failure, unrelated to this branch.**
`tools/test_marketplace_envelope_parity.py::test_resolved_layer_fails_loudly_when_the_package_is_unimportable`
fails locally because a non-editable `agentbundle` in site-packages shadows the
tree under audit — the exact scenario the test's own error message describes. It
fails identically on a clean checkout of `main`, so it is environmental and not
introduced here.
