### PR TITLE
feat(tools): worktree runtime hygiene round 3 — import-shadowing doctor check, bounded test evidence, report-only lifecycle hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ test:
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
+	$(PYTHON) -m pytest tools/test_worktree_lifecycle_hooks.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q
 	$(PYTHON) -m pytest tools/test_bootstrap.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ test:
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
+	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q
 	$(PYTHON) -m pytest tools/test_bootstrap.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q

--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,7 @@ test:
 	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_journey_editorial_decisions.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
+	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q
 	$(PYTHON) -m pytest tools/test_bootstrap.py -q
 	$(PYTHON) -m pytest tools/test_check_artifact_contents.py -q

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -40,18 +40,20 @@ and schema shape; register a separate Makefile invocation to avoid basename coll
 ## Task 4 — bounded test-evidence lifecycle (shipped)
 
 Tests: dedicated `tools/test_playwright_evidence_lifecycle.py` invocation covering
-failed-run archival, successful-run cleanup, newest and pinned retention, age-budget
-expiry, predicate re-assertion before deletion, current-worktree refusal, and budget
-parsing.
+failed-run archival, successful-run cleanup, explicit archive-time ordering across
+two invocations, file and directory pin retention, age-budget expiry, predicate
+re-assertion before deletion, current-worktree refusal, and budget parsing.
 
 1. Wrap the existing browser-gate command in `frontend_runtime.run_gate` without
    changing its pinned command strings or Playwright diagnostics.
 2. Retain failed `web/test-results/` evidence in ignored, worktree-local storage while
    preserving that live path for the existing Pages failure-artifact upload; remove
    successful `test-results` and `playwright-report` output immediately.
-3. Keep the newest failed run and `.pinned` evidence, pruning only older unpinned runs
-   by the configurable seven-day-default age budget through the hygiene module's
-   registered-current-worktree predicate and its immediate pre-mutation recheck.
+3. Keep the newest explicitly timestamped failed run and non-symlink `.pinned`
+   evidence, pruning only older unpinned runs by the configurable seven-day-default
+   age budget through the hygiene module's registered-current-worktree predicate and
+   its immediate pre-mutation recheck. Release the preview-port lease after the
+   child gate exits and before this lifecycle work starts.
 
 ## Task 5 — worktree lifecycle hooks (shipped)
 
@@ -60,8 +62,9 @@ optional hook's Git-backed lifecycle report, the no-Orca implementation boundary
 inside import success, shadowing refusal, and the existing protection channels.
 
 1. Added optional `after-create`, `before-run`, `after-run`, and `before-remove`
-   commands that report default-branch-merged, removed, currently-active, and
-   no-merge-or-prune-signal worktrees without claiming liveness or attaching to Orca.
+   commands that report default-branch-merged, Git-backed prune-signal,
+   currently-active, and no-merge-or-prune-signal worktrees without claiming
+   liveness or attaching to Orca.
    When Git cannot determine the default branch, the merged result is undetermined.
 2. Made `before-remove` reuse AC8's isolated import-resolution measurement and refuse
    outside, absent, and inconclusive results, as well as existing protected worktrees.

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -15,12 +15,34 @@
 4. Append a dedicated pytest invocation for the new tool test; do not merge it into
    the existing basename-collision-prone invocation.
 
-## Task 2 — concurrency runtime controls (not started by this task)
+## Task 2 — concurrency runtime controls (partially shipped)
 
-1. Add a preview-port override and gate wrapper with a port lease.
-2. Add browser-cache path resolution and selective bootstrap profiles.
-3. Add a cooperative worktree lease shared by cleanup and mutating build/test entry
-   points to close the remaining check-to-delete concurrency window.
+1. Shipped: preview-port override and gate wrapper with a port lease.
+2. Shipped: browser-cache path resolution and selective bootstrap profiles.
+3. Open: add a cooperative worktree lease shared by cleanup and mutating build/test
+   entry points to close the remaining check-to-delete concurrency window.
 
-Task 2 implements AC6–AC7. It has no code change in this task and must be scheduled
-as its own implementation work rather than smuggled into scan/clean.
+AC7 is shipped. AC6 remains open: its shared cleanup/build-test lease is not
+implemented, even though the preview-port lease is present.
+
+## Task 3 — isolated agentbundle import-resolution check (this layer)
+
+Tests: focused `tools/test_worktree_import_resolution.py` cases for in-tree,
+outside-tree, absent, non-zero/unparseable, polluted stdout, environment isolation,
+and schema shape; register a separate Makefile invocation to avoid basename collisions.
+
+1. Resolve `agentbundle` once in an isolated child with `PYTHONPATH` removed and
+   bytecode writes disabled.
+2. Add the result and its provenance to scan's JSON and human report without a
+   version comparison, remediation advice, or exit-code change.
+3. Fail closed into stated absent or inconclusive findings.
+
+## Task 4 — bounded test-evidence lifecycle (planned)
+
+Plan and implement bounded retention and cleanup of test evidence without broadening
+the worktree doctor's deletion authority.
+
+## Task 5 — worktree lifecycle hooks (planned)
+
+Plan and implement lifecycle hooks that coordinate worktree creation and removal with
+the existing safety model.

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -53,7 +53,17 @@ parsing.
    by the configurable seven-day-default age budget through the hygiene module's
    registered-current-worktree predicate and its immediate pre-mutation recheck.
 
-## Task 5 — worktree lifecycle hooks (planned)
+## Task 5 — worktree lifecycle hooks (shipped)
 
-Plan and implement lifecycle hooks that coordinate worktree creation and removal with
-the existing safety model.
+Tests: dedicated `tools/test_worktree_lifecycle_hooks.py` invocation covering each
+optional hook's Git-backed lifecycle report, the no-Orca implementation boundary,
+inside import success, shadowing refusal, and the existing protection channels.
+
+1. Added optional `after-create`, `before-run`, `after-run`, and `before-remove`
+   commands that report default-branch-merged, removed, currently-active, and
+   no-merge-or-prune-signal worktrees without claiming liveness or attaching to Orca.
+   When Git cannot determine the default branch, the merged result is undetermined.
+2. Made `before-remove` reuse AC8's isolated import-resolution measurement and refuse
+   outside, absent, and inconclusive results, as well as existing protected worktrees.
+3. Kept every lifecycle command report-only: none removes a worktree, directory, or
+   branch.

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -37,10 +37,21 @@ and schema shape; register a separate Makefile invocation to avoid basename coll
    version comparison, remediation advice, or exit-code change.
 3. Fail closed into stated absent or inconclusive findings.
 
-## Task 4 — bounded test-evidence lifecycle (planned)
+## Task 4 — bounded test-evidence lifecycle (shipped)
 
-Plan and implement bounded retention and cleanup of test evidence without broadening
-the worktree doctor's deletion authority.
+Tests: dedicated `tools/test_playwright_evidence_lifecycle.py` invocation covering
+failed-run archival, successful-run cleanup, newest and pinned retention, age-budget
+expiry, predicate re-assertion before deletion, current-worktree refusal, and budget
+parsing.
+
+1. Wrap the existing browser-gate command in `frontend_runtime.run_gate` without
+   changing its pinned command strings or Playwright diagnostics.
+2. Retain failed `web/test-results/` evidence in ignored, worktree-local storage while
+   preserving that live path for the existing Pages failure-artifact upload; remove
+   successful `test-results` and `playwright-report` output immediately.
+3. Keep the newest failed run and `.pinned` evidence, pruning only older unpinned runs
+   by the configurable seven-day-default age budget through the hygiene module's
+   registered-current-worktree predicate and its immediate pre-mutation recheck.
 
 ## Task 5 — worktree lifecycle hooks (planned)
 

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -102,6 +102,21 @@ state, and silently skipped tests unrelated to the actual space problem.
   contract (`browser-gate-failure`, seven-day retention, ignore when absent) and its
   contract tests change in the same commit.
 
+- [x] **AC10 — optional lifecycle hooks report without removing.** The
+  `after-create`, `before-run`, `after-run`, and `before-remove` commands work with
+  plain Git worktrees and have no Orca dependency. They report Git-backed removed,
+  currently-active, default-branch-merged, and no-merge-or-prune-signal worktrees.
+  The latter is an observation only: it does not infer activity or liveness.
+  Currently-active means only the registered worktree containing the invocation
+  directory, not liveness. Default-branch discovery comes from Git; when it cannot be
+  determined, the merged result is explicitly undetermined. If an attachment
+  observation is ever reported, it is named `attached`, never live, active, or busy.
+  `before-remove` calls AC8's isolated import-resolution check and refuses outside,
+  absent, or inconclusive resolution, because none proves that removing the worktree
+  is safe. It also honours the existing repeatable `--protect-worktree` and
+  `WORKTREE_HYGIENE_PROTECT_WORKTREES` input. No lifecycle command removes a
+  worktree, directory, or branch.
+
 ## Limitations
 
 Linux same-filesystem bind-mount detection uses one `/proc/self/mountinfo` snapshot for
@@ -126,9 +141,10 @@ unobservable without the cooperative lease deferred to round 2.
 
 ## Testing Strategy
 
-Real `tempfile` fixtures exercise scan and clean guards. A fake subprocess runner
-supplies Git porcelain and batched responses and proves Git calls are bounded by
-worktree count; a traversal counter proves one walk per worktree. Mutations remove
+Real `tempfile` fixtures exercise scan, clean, and lifecycle-hook guards. A fake
+subprocess runner supplies Git porcelain and batched responses and proves Git
+calls are bounded by worktree count; a traversal counter proves one walk per
+worktree. Mutations remove
 each guard and must make its named falsification case fail. Python formatting, type,
 and focused pytest gates are run by the supervisor only.
 

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -93,9 +93,13 @@ state, and silently skipped tests unrelated to the actual space problem.
   `web/playwright-report/` artifacts, copies each failed run into ignored,
   current-worktree-local evidence storage while retaining the live
   `web/test-results/` output for CI, and keeps the newest failed run by default.
-  Older unpinned retained runs expire by the configurable
+  Retention orders lifecycle-owned `failed-<time_ns>` archives by that explicit
+  creation time rather than copied source metadata, and runs after a successful
+  archive so the new failure participates immediately. Older unpinned retained runs
+  expire by the configurable
   `PLAYWRIGHT_FAILURE_EVIDENCE_MAX_AGE_SECONDS` age budget (seven days by default);
-  a `.pinned` marker preserves explicitly pinned evidence. Every lifecycle mutation
+  a non-symlink `.pinned` marker (file or directory) preserves explicitly pinned
+  evidence. Every lifecycle mutation
   re-establishes the same registered-current-worktree safety predicate immediately
   before acting and refuses an inconclusive worktree, so it never touches another
   worktree. If the live failure-output path changes, the Pages workflow upload
@@ -104,13 +108,15 @@ state, and silently skipped tests unrelated to the actual space problem.
 
 - [x] **AC10 — optional lifecycle hooks report without removing.** The
   `after-create`, `before-run`, `after-run`, and `before-remove` commands work with
-  plain Git worktrees and have no Orca dependency. They report Git-backed removed,
+  plain Git worktrees and have no Orca dependency. They report Git-backed prune-signal,
   currently-active, default-branch-merged, and no-merge-or-prune-signal worktrees.
   The latter is an observation only: it does not infer activity or liveness.
   Currently-active means only the registered worktree containing the invocation
   directory, not liveness. Default-branch discovery comes from Git; when it cannot be
   determined, the merged result is explicitly undetermined. If an attachment
   observation is ever reported, it is named `attached`, never live, active, or busy.
+  A prune signal is an administrative observation, not a claim that the path is
+  absent.
   `before-remove` calls AC8's isolated import-resolution check and refuses outside,
   absent, or inconclusive resolution, because none proves that removing the worktree
   is safe. It also honours the existing repeatable `--protect-worktree` and

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -86,6 +86,22 @@ state, and silently skipped tests unrelated to the actual space problem.
   fact; an absent, failed, timed-out, or unparseable probe is explicitly reported as
   absent or inconclusive rather than silently passing.
 
+- [x] **AC9 — browser-gate failure evidence has a bounded lifecycle.** The
+  Playwright configuration retains `trace: 'retain-on-failure'` and
+  `screenshot: 'only-on-failure'`; the gate wrapper never weakens either diagnostic.
+  It immediately removes successful-run `web/test-results/` and
+  `web/playwright-report/` artifacts, copies each failed run into ignored,
+  current-worktree-local evidence storage while retaining the live
+  `web/test-results/` output for CI, and keeps the newest failed run by default.
+  Older unpinned retained runs expire by the configurable
+  `PLAYWRIGHT_FAILURE_EVIDENCE_MAX_AGE_SECONDS` age budget (seven days by default);
+  a `.pinned` marker preserves explicitly pinned evidence. Every lifecycle mutation
+  re-establishes the same registered-current-worktree safety predicate immediately
+  before acting and refuses an inconclusive worktree, so it never touches another
+  worktree. If the live failure-output path changes, the Pages workflow upload
+  contract (`browser-gate-failure`, seven-day retention, ignore when absent) and its
+  contract tests change in the same commit.
+
 ## Limitations
 
 Linux same-filesystem bind-mount detection uses one `/proc/self/mountinfo` snapshot for

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -170,3 +170,13 @@ Participating gate wrappers are coordinated by the shared lease, but the availab
 probe closes before Astro binds. An unrelated machine-local listener can therefore
 take the selected port during that interval. The wrapper does not claim an absolute
 reservation guarantee, and handing a bound socket to Astro is outside this scope.
+
+A second, pre-existing case shares that boundary. `_run_child` reaps the child's
+process group on its interrupt paths but not after a normal `wait()`, and the lease is
+released as soon as the child returns. A gate command that backgrounds the preview
+server and exits zero therefore leaves a descendant holding the port after release, so
+a peer worktree can lease it and collide. This is task 2's shipped behaviour, unchanged
+by the evidence-lifecycle work, which restored that original release ordering after
+briefly holding the lease across archival. Closing it means reaping the process group on
+the normal-exit path too, which is a change to shipped port-lease behaviour and belongs
+with AC6's cooperative lease rather than here.

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -17,27 +17,28 @@ state, and silently skipped tests unrelated to the actual space problem.
 
 ## Acceptance Criteria
 
-- [ ] **AC1 — scan has one authoritative worktree model.** `scan` discovers only
+- [x] **AC1 — scan has one authoritative worktree model.** `scan` discovers only
   `git worktree list --porcelain -z` records, including bare, detached, and prunable
   records, and emits deterministic human and JSON (`schema_version`, repository,
-  git_common_dir, measurement, worktrees, shared_caches, warnings, totals) output.
+  git_common_dir, measurement, agentbundle_import, worktrees, shared_caches, warnings,
+  totals) output.
   Paths with spaces and non-ASCII text are preserved. It performs one bounded,
   non-link-following traversal per present worktree, classifying candidates as it
   walks rather than rewalking per category.
 
-- [ ] **AC2 — byte output is honest.** Candidate byte counts use allocated blocks
+- [x] **AC2 — byte output is honest.** Candidate byte counts use allocated blocks
   when `st_blocks` exists and logical size otherwise; the selected measurement is
   labelled. Sparse files and clones therefore do not become an unqualified
   "reclaimable" claim. Human output is a compact per-worktree category table,
   followed by shared storage and only the largest candidates.
 
-- [ ] **AC3 — scan diagnoses, but does not mutate, shared state.** It reports
+- [x] **AC3 — scan diagnoses, but does not mutate, shared state.** It reports
   Playwright browser-path mode, local `.local-browsers`, duplicate browser revisions,
   npm cache placement, and worktree-local shared-cache resolution. It reports
   registered prunable records; it never removes worktrees, branches, browser caches,
   or arbitrary temporary-looking roots.
 
-- [ ] **AC4 — clean defaults to a receipt-only dry run.** `clean` deletes nothing
+- [x] **AC4 — clean defaults to a receipt-only dry run.** `clean` deletes nothing
   unless both `--apply` and one or more category switches are supplied. Expensive
   dependency cleanup additionally requires `--include-dependencies`. There is no
   all/force option. Unlike repository-wide `scan`, `clean` defaults to the current
@@ -46,7 +47,7 @@ state, and silently skipped tests unrelated to the actual space problem.
   selected and skipped candidates, reasons, measurable bytes, failures, and remaining
   largest candidates.
 
-- [ ] **AC5 — every deletion has a bounded safety proof.** Before deletion the tool
+- [x] **AC5 — every deletion has a bounded safety proof.** Before deletion the tool
   proves a known-model candidate is inside a selected registered worktree without a
   resolving link escape; rejects common-dir and `.git` administration paths, tracked
   files, non-ignored paths, `.loop-run`, `.context`, locks/leases, caller-protected
@@ -69,10 +70,21 @@ state, and silently skipped tests unrelated to the actual space problem.
   worktree lease shared by cleanup and mutating build/test entry points; only that
   shared lease can close the remaining check-to-delete concurrency window completely.
 
-- [ ] **AC7 — round 2: bootstrap and browser cache choices remain explicit.** The
+- [x] **AC7 — round 2: bootstrap and browser cache choices remain explicit.** The
   second implementation task adds a browser-cache resolver and selective bootstrap
   profiles without shared mutable dependencies, symlinked virtualenvs, or automatic
   background work.
+
+- [x] **AC8 — scan measures agentbundle import resolution.** `scan` runs exactly
+  one isolated child process with the worktree `PYTHONPATH` stripped, the cwd
+  `sys.path` entry removed (`-P`), and bytecode writes disabled, never comparing
+  versions. It reports the resolved `__file__` and provenance (interpreter, cwd, and
+  removed environment inputs) in both JSON and human output, with status invariant
+  across invocation directories. If discovery fails or no registered worktree
+  contains the invocation directory, it reports that fact as inconclusive without
+  running the child. A path outside the current worktree is reported only as that
+  fact; an absent, failed, timed-out, or unparseable probe is explicitly reported as
+  absent or inconclusive rather than silently passing.
 
 ## Limitations
 

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -32,6 +32,16 @@ from pathlib import Path
 from types import FrameType
 from typing import Any, Callable, Iterator, Mapping, Sequence
 
+# Imported two ways, so both must work: as a script (`python3
+# tools/repo/frontend_runtime.py`, where sys.path[0] is tools/repo) and as
+# `tools.repo.frontend_runtime` -- tools/repo has no __init__.py but is a PEP 420
+# namespace package, which is how tools/test_frontend_runtime.py:16 imports it.
+# Dropping either branch breaks one of those callers at collection time.
+if __package__:
+    from . import worktree_hygiene
+else:
+    import worktree_hygiene
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GATE_COMMAND = ("npm", "run", "test:e2e:gate", "--prefix", "web")
 DEFAULT_PREVIEW_PORT = 4321
@@ -40,11 +50,30 @@ LEASE_MAX_AGE_SECONDS = 24 * 60 * 60
 LEASE_RETRY_LIMIT = 20
 LEASE_RETRY_DELAY_SECONDS = 0.05
 PROCESS_TREE_EXIT_TIMEOUT_SECONDS = 5.0
+PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV = "PLAYWRIGHT_FAILURE_EVIDENCE_MAX_AGE_SECONDS"
 SignalHandler = Callable[[int, FrameType | None], Any] | int | None
 
 
 class FrontendRuntimeError(RuntimeError):
     """An actionable frontend-runtime configuration or execution error."""
+
+
+def playwright_evidence_max_age(environ: Mapping[str, str]) -> int:
+    """Read the optional bounded-retention age budget for failed test evidence."""
+    raw = environ.get(PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV)
+    if raw is None:
+        return worktree_hygiene.DEFAULT_PLAYWRIGHT_EVIDENCE_MAX_AGE_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise FrontendRuntimeError(
+            f"{PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV} must be a whole number of seconds"
+        ) from error
+    if value < 0:
+        raise FrontendRuntimeError(
+            f"{PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV} must not be negative"
+        )
+    return value
 
 
 @dataclass(frozen=True)
@@ -565,7 +594,15 @@ def run_gate(
             values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
             announce_browser_cache(cache)
             print(f"Preview port lease: {lease.port}", flush=True)
-            return _run_child(command, values, repo_root)
+            returncode = _run_child(command, values, repo_root)
+            evidence = worktree_hygiene.manage_playwright_failure_evidence(
+                repo_root,
+                gate_returncode=returncode,
+                max_age_seconds=playwright_evidence_max_age(values),
+            )
+            for line in evidence.receipt:
+                print(line, flush=True)
+            return returncode
     finally:
         lease.release()
 

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -589,22 +589,22 @@ def run_gate(
         requested,
     )
     try:
+        values["ARR_PREVIEW_PORT"] = str(lease.port)
+        values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
+        announce_browser_cache(cache)
+        print(f"Preview port lease: {lease.port}", flush=True)
         with _release_lease_on_signals(lease):
-            values["ARR_PREVIEW_PORT"] = str(lease.port)
-            values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
-            announce_browser_cache(cache)
-            print(f"Preview port lease: {lease.port}", flush=True)
             returncode = _run_child(command, values, repo_root)
-            evidence = worktree_hygiene.manage_playwright_failure_evidence(
-                repo_root,
-                gate_returncode=returncode,
-                max_age_seconds=playwright_evidence_max_age(values),
-            )
-            for line in evidence.receipt:
-                print(line, flush=True)
-            return returncode
     finally:
         lease.release()
+    evidence = worktree_hygiene.manage_playwright_failure_evidence(
+        repo_root,
+        gate_returncode=returncode,
+        max_age_seconds=playwright_evidence_max_age(values),
+    )
+    for line in evidence.receipt:
+        print(line, flush=True)
+    return returncode
 
 
 def install_browsers(

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -31,7 +31,24 @@ def _configure_stream(stream: object, errors: str) -> None:
 _configure_stream(sys.stdout, "strict")
 _configure_stream(sys.stderr, "backslashreplace")
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+IMPORT_SENTINEL = "__AGENTBUNDLE_IMPORT_RESOLUTION__="
+IMPORT_TIMEOUT_SECONDS = 10
+IMPORT_PROBE = (
+    "import json\n"
+    "try:\n"
+    "    import agentbundle\n"
+    "except ModuleNotFoundError as error:\n"
+    "    if error.name != 'agentbundle':\n"
+    "        raise\n"
+    "    result = {'state': 'absent'}\n"
+    "else:\n"
+    "    path = getattr(agentbundle, '__file__', None)\n"
+    "    if not isinstance(path, str):\n"
+    "        raise RuntimeError('agentbundle has no import path')\n"
+    "    result = {'state': 'resolved', 'path': path}\n"
+    f"print({IMPORT_SENTINEL!r} + json.dumps(result, sort_keys=True))\n"
+)
 CATEGORIES = ("dependencies", "generated", "test_artifacts")
 CLEANABLE_CATEGORIES = frozenset(CATEGORIES)
 EXPENSIVE = {"dependencies"}
@@ -132,6 +149,156 @@ def _call(
     env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return runner(argv, input=input, env=env)
+
+
+def _run_import_probe(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the isolated import measurement without writing worktree bytecode."""
+    return subprocess.run(  # nosec B603  # fixed interpreter and inline probe
+        argv,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=IMPORT_TIMEOUT_SECONDS,
+    )
+
+
+def _import_provenance(worktree: Path) -> dict[str, object]:
+    """Describe the process context used for the isolated import probe."""
+    return {
+        "interpreter": sys.executable,
+        "cwd": str(worktree.resolve()),
+        "removed_environment_inputs": [
+            "PYTHONPATH",
+            "cwd sys.path entry (-P)",
+        ],
+    }
+
+
+def _agentbundle_import_resolution(
+    worktree: Path,
+    import_runner: Callable[..., subprocess.CompletedProcess[str]] = _run_import_probe,
+) -> dict[str, object]:
+    """Measure where agentbundle resolves without this worktree's PYTHONPATH."""
+    provenance = _import_provenance(worktree)
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    try:
+        result = import_runner(
+            [sys.executable, "-P", "-c", IMPORT_PROBE],
+            cwd=worktree,
+            env=environment,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": "isolated import probe timed out",
+        }
+    except OSError as error:
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": f"isolated import probe could not run: {error}",
+        }
+    if result.returncode:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": f"isolated import probe failed: {detail}",
+        }
+    records = [
+        line.removeprefix(IMPORT_SENTINEL)
+        for line in result.stdout.splitlines()
+        if line.startswith(IMPORT_SENTINEL)
+    ]
+    if len(records) != 1:
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": "isolated import probe produced no unambiguous result",
+        }
+    try:
+        record = json.loads(records[0])
+    except json.JSONDecodeError:
+        record = None
+    if not isinstance(record, dict):
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": "isolated import probe produced an invalid result",
+        }
+    if record.get("state") == "absent":
+        return {**provenance, "status": "absent"}
+    path = record.get("path")
+    if record.get("state") != "resolved" or not isinstance(path, str):
+        return {
+            **provenance,
+            "status": "inconclusive",
+            "detail": "isolated import probe produced an invalid result",
+        }
+    resolved = Path(path).resolve()
+    return {
+        **provenance,
+        "status": "inside" if _under(resolved, worktree) else "outside",
+        "path": str(resolved),
+    }
+
+
+def _unregistered_worktree_resolution(repository: Path) -> dict[str, object]:
+    """State why an import probe cannot use a registered worktree."""
+    return {
+        **_import_provenance(repository),
+        "status": "inconclusive",
+        "detail": "no registered worktree contains the invocation directory",
+    }
+
+
+def _import_resolution_warning(resolution: dict[str, object]) -> str | None:
+    """Render only the measured import-resolution fact for scan warnings."""
+    context = (
+        f"interpreter: {resolution['interpreter']}; "
+        f"cwd: {resolution['cwd']}; removed environment inputs: "
+        f"{', '.join(resolution['removed_environment_inputs'])}"
+    )
+    status = resolution["status"]
+    if status == "outside":
+        return (
+            "agentbundle resolves outside this worktree, at "
+            f"{resolution['path']} ({context})"
+        )
+    if status == "absent":
+        return f"agentbundle is absent in isolated import measurement ({context})"
+    if status == "inconclusive":
+        return (
+            "agentbundle isolated import measurement is inconclusive: "
+            f"{resolution['detail']} ({context})"
+        )
+    return None
+
+
+def _import_resolution_human_line(resolution: dict[str, object]) -> str:
+    """Render the measured import-resolution fact for the human report."""
+    warning = _import_resolution_warning(resolution)
+    if warning:
+        return warning
+    context = (
+        f"interpreter: {resolution['interpreter']}; "
+        f"cwd: {resolution['cwd']}; removed environment inputs: "
+        f"{', '.join(resolution['removed_environment_inputs'])}"
+    )
+    return (
+        "agentbundle resolves inside this worktree, at "
+        f"{resolution['path']} ({context})"
+    )
 
 
 def _parse_porcelain(text: str) -> list[Worktree]:
@@ -341,6 +508,19 @@ def _under(path: Path, root: Path) -> bool:
     except (OSError, ValueError):
         return False
     return True
+
+
+def _containing_worktree(
+    directory: Path, worktrees: list[Worktree]
+) -> Path | None:
+    """Return the most-specific registered worktree containing a directory."""
+    current = directory.resolve()
+    matches = [
+        worktree.path
+        for worktree in worktrees
+        if _under(current, worktree.path)
+    ]
+    return max(matches, key=lambda path: len(path.parts), default=None)
 
 
 def _protected_paths(values: Iterable[str]) -> set[Path]:
@@ -625,8 +805,22 @@ def scan(
     runner: Runner = _run,
     *,
     include_ignore_status: bool = True,
+    include_import_resolution: bool = True,
+    import_runner: Callable[..., subprocess.CompletedProcess[str]] = _run_import_probe,
 ) -> dict[str, Any]:
     repo, common, worktrees, warnings = discover_worktrees(repository, runner)
+    worktree_root = _containing_worktree(repo, worktrees)
+    if include_import_resolution:
+        import_resolution = (
+            _agentbundle_import_resolution(worktree_root, import_runner)
+            if worktree_root is not None
+            else _unregistered_worktree_resolution(repo)
+        )
+        import_warning = _import_resolution_warning(import_resolution)
+        if import_warning:
+            warnings.append(import_warning)
+    else:
+        import_resolution = _import_provenance(worktree_root or repo)
     selected_roots = {path.resolve() for path in selected or []}
     if selected_roots:
         registered = {worktree.path for worktree in worktrees}
@@ -695,6 +889,7 @@ def scan(
         "repository": str(repo),
         "git_common_dir": str(common) if common is not None else None,
         "measurement": _measurement_name(),
+        "agentbundle_import": import_resolution,
         "worktrees": worktree_data,
         "shared_caches": shared,
         "warnings": sorted(set(warnings)),
@@ -707,6 +902,14 @@ def _human(report: dict[str, Any]) -> str:
         f"measurement: {report['measurement']} bytes",
         "worktree  dependencies  generated  tests  protected  total local",
     ]
+    import_resolution = report["agentbundle_import"]
+    import_warning: str | None = None
+    if "status" in import_resolution:
+        import_warning = _import_resolution_warning(import_resolution)
+        lines.append(
+            "import resolution: "
+            + _import_resolution_human_line(import_resolution)
+        )
     for worktree_data in report["worktrees"]:
         categories = worktree_data["categories"]
         values = (
@@ -755,7 +958,11 @@ def _human(report: dict[str, Any]) -> str:
         else:
             description += "; cleanup: report only"
         lines.append(description)
-    lines.extend(f"warning: {warning}" for warning in report["warnings"])
+    lines.extend(
+        f"warning: {warning}"
+        for warning in report["warnings"]
+        if warning != import_warning
+    )
     return "\n".join(lines)
 
 
@@ -899,14 +1106,8 @@ def _candidate_safety_reason(
 
 def _current_worktree(repository: Path, runner: Runner) -> Path:
     """Resolve the registered worktree containing the invocation directory."""
-    current = repository.resolve()
     _, _, worktrees, _ = discover_worktrees(repository, runner)
-    matches = [
-        worktree.path
-        for worktree in worktrees
-        if _under(current, worktree.path)
-    ]
-    return max(matches, key=lambda path: len(path.parts), default=current)
+    return _containing_worktree(repository, worktrees) or repository.resolve()
 
 
 def _append_receipt_summary(
@@ -982,6 +1183,7 @@ def clean(
         clean_selection,
         runner,
         include_ignore_status=False,
+        include_import_resolution=False,
     )
     lines.extend(f"warning: {warning}" for warning in report["warnings"])
     common_value = report["git_common_dir"]

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -57,6 +57,7 @@ PROTECTED_ROOTS = {".loop-run", ".context"}
 PLAYWRIGHT_EVIDENCE_DIRECTORY = ".playwright-failure-evidence"
 PLAYWRIGHT_EVIDENCE_PIN = ".pinned"
 DEFAULT_PLAYWRIGHT_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+PLAYWRIGHT_ARCHIVE_NAME_ATTEMPTS = 64
 NAMES = {
     "node_modules": "dependencies",
     ".venv": "dependencies",
@@ -1363,6 +1364,24 @@ def _playwright_archive_time_ns(entry: Path) -> int | None:
     return timestamp if timestamp >= 0 else None
 
 
+def _playwright_archive_destination(archive: Path) -> Path:
+    """Return an unused lifecycle-owned archive path for one failed run.
+
+    `time.time_ns()` is not a uniqueness guarantee: two failures inside the same
+    nanosecond, or a directory that already carries the generated name, made
+    `copytree` raise and lost the failure it was archiving.
+    """
+    for suffix in range(PLAYWRIGHT_ARCHIVE_NAME_ATTEMPTS):
+        stamp = time.time_ns()
+        name = f"failed-{stamp}" if suffix == 0 else f"failed-{stamp + suffix}"
+        destination = archive / name
+        if not destination.exists():
+            return destination
+    raise FileExistsError(
+        f"could not allocate an unused archive name under {archive}"
+    )
+
+
 def _playwright_retention_actions(
     archive: Path, max_age_seconds: int
 ) -> tuple[list[tuple[str, Path, tuple[Path, ...]]], list[tuple[Path, str]]]:
@@ -1376,13 +1395,20 @@ def _playwright_retention_actions(
         if archive.is_dir()
         else []
     )
+    selected_at = time.time_ns()
+    # The archive name is ordinary worktree-local state: a stray directory, or a
+    # clock stepped backwards by NTP, can carry a timestamp in the future. Such a
+    # name would hold "newest" indefinitely and, under a zero budget, get the
+    # genuine newest run pruned instead. Refuse to read it as a time at all;
+    # unrecognized archives fall into the retained bucket, never the pruned one.
     creation_times = {
         entry: timestamp
         for entry in entries
         if (timestamp := _playwright_archive_time_ns(entry)) is not None
+        and timestamp <= selected_at
     }
     newest = max(creation_times, key=creation_times.__getitem__, default=None)
-    cutoff = time.time_ns() - max_age_seconds * 1_000_000_000
+    cutoff = selected_at - max_age_seconds * 1_000_000_000
     actions: list[tuple[str, Path, tuple[Path, ...]]] = []
     retained: list[tuple[Path, str]] = []
     for entry in entries:
@@ -1499,7 +1525,7 @@ def manage_playwright_failure_evidence(
                         lines.append(f"aborted {path}: safety changed: {reason}")
                         skipped += 1
                         continue
-                    destination = archive / f"failed-{time.time_ns()}"
+                    destination = _playwright_archive_destination(archive)
                     shutil.copytree(path, destination)
                     lines.append(f"archived {path}: {bytes_} bytes to {destination}")
                     archived += 1

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -141,6 +141,14 @@ class PlaywrightEvidenceResult:
     receipt: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class LifecycleResult:
+    """Report an optional worktree lifecycle hook without mutating Git state."""
+
+    code: int
+    lines: tuple[str, ...]
+
+
 def _run(
     argv: list[str],
     *,
@@ -537,6 +545,164 @@ def _containing_worktree(
         if _under(current, worktree.path)
     ]
     return max(matches, key=lambda path: len(path.parts), default=None)
+
+
+def _default_branch_ref(
+    repository: Path, runner: Runner
+) -> tuple[str | None, str | None]:
+    """Determine one remote-tracking default branch without guessing."""
+    remotes = _call(runner, ["git", "-C", str(repository), "remote"])
+    if remotes.returncode:
+        detail = remotes.stderr.strip() or f"exit {remotes.returncode}"
+        return None, f"could not determine default branch: {detail}"
+    remote_names = [name for name in remotes.stdout.splitlines() if name]
+    if len(remote_names) != 1:
+        return None, "could not determine default branch: expected exactly one remote"
+    default = _call(
+        runner,
+        [
+            "git",
+            "-C",
+            str(repository),
+            "symbolic-ref",
+            "--quiet",
+            f"refs/remotes/{remote_names[0]}/HEAD",
+        ],
+    )
+    if default.returncode or not default.stdout.strip():
+        detail = default.stderr.strip() or f"exit {default.returncode}"
+        return None, f"could not determine default branch: {detail}"
+    return default.stdout.strip(), None
+
+
+def _merged_branches(
+    repository: Path, runner: Runner
+) -> tuple[set[str] | None, str | None]:
+    """Read branches merged into the Git-determined default branch once."""
+    default_branch, default_warning = _default_branch_ref(repository, runner)
+    if default_warning:
+        return None, default_warning
+    assert default_branch is not None
+    result = _call(
+        runner,
+        [
+            "git",
+            "-C",
+            str(repository),
+            "for-each-ref",
+            "--format=%(refname)",
+            "--merged",
+            default_branch,
+            "refs/heads",
+        ],
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        return None, f"could not determine merged worktrees: {detail}"
+    return set(result.stdout.splitlines()), None
+
+
+def _lifecycle_report(
+    repository: Path,
+    worktrees: list[Worktree],
+    warnings: list[str],
+    runner: Runner = _run,
+) -> list[str]:
+    """Classify registered worktrees from Git facts and the invocation directory."""
+    current = _containing_worktree(repository, worktrees)
+    merged, merged_warning = _merged_branches(repository, runner)
+    default_branch, _ = _default_branch_ref(repository, runner)
+    default_local = (
+        "refs/heads/" + "/".join(default_branch.split("/")[3:])
+        if default_branch
+        else None
+    )
+    if merged_warning:
+        warnings.append(merged_warning)
+    removed = [worktree.path for worktree in worktrees if worktree.prunable]
+    currently_active = [current] if current is not None else []
+    merged_paths = [
+        worktree.path
+        for worktree in worktrees
+        if (
+            merged is not None
+            and worktree.branch
+            and worktree.branch in merged
+            and worktree.path != current
+            # "merged into the default branch" is vacuous for the default
+            # branch itself; keep the primary checkout out of this bucket.
+            # The porcelain reports refs/heads/<name> while the default is a
+            # remote-tracking refs/remotes/<remote>/<name>, so compare the
+            # local form -- a bare != never matches.
+            and worktree.branch != default_local
+        )
+    ]
+    no_merge_or_prune_signal = [
+        worktree.path
+        for worktree in worktrees
+        if worktree.path not in removed
+        and worktree.path not in currently_active
+        and worktree.path not in merged_paths
+    ]
+    lines = [
+        "lifecycle report:",
+        "currently-active observation: registered worktree containing the "
+        "invocation directory; no liveness claim",
+        "no-merge-or-prune-signal observation: registered worktree without a "
+        "prune signal, default-branch merge signal, or current-invocation "
+        "containment; no activity or liveness inference",
+    ]
+    categories: list[tuple[str, list[Path] | None]] = [
+        ("merged", merged_paths if merged is not None else None),
+        ("removed", removed),
+        ("no-merge-or-prune-signal", no_merge_or_prune_signal),
+        ("currently-active", currently_active),
+    ]
+    for label, paths in categories:
+        if paths is None:
+            lines.append(f"{label}: undetermined")
+            continue
+        if paths:
+            lines.extend(f"{label}: {path}" for path in paths)
+        else:
+            lines.append(f"{label}: none")
+    lines.extend(f"warning: {warning}" for warning in sorted(set(warnings)))
+    return lines
+
+
+def lifecycle_hook(
+    command: str,
+    repository: Path,
+    *,
+    protected: set[Path] | None = None,
+    runner: Runner = _run,
+    import_runner: Callable[..., subprocess.CompletedProcess[str]] = _run_import_probe,
+) -> LifecycleResult:
+    """Run an optional hook and refuse unsafe removal without removing anything."""
+    _, _, worktrees, warnings = discover_worktrees(repository, runner)
+    lines = _lifecycle_report(repository, worktrees, warnings, runner)
+    if command != "before-remove":
+        return LifecycleResult(0, tuple(lines))
+    current = _containing_worktree(repository, worktrees)
+    resolution = (
+        _agentbundle_import_resolution(current, import_runner)
+        if current is not None
+        else _unregistered_worktree_resolution(repository)
+    )
+    lines.append("import resolution: " + _import_resolution_human_line(resolution))
+    if current is not None and current in (protected or set()):
+        lines.append(f"refusing worktree removal: protected worktree: {current}")
+        return LifecycleResult(2, tuple(lines))
+    if resolution["status"] != "inside":
+        lines.append(
+            "refusing worktree removal: agentbundle import resolution is "
+            f"{resolution['status']}, not inside this worktree"
+        )
+        return LifecycleResult(2, tuple(lines))
+    lines.append(
+        "before-remove passed: this hook does not remove worktrees or branches"
+    )
+    return LifecycleResult(0, tuple(lines))
 
 
 def _protected_paths(values: Iterable[str]) -> set[Path]:
@@ -1597,6 +1763,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Select test, coverage, lint, and bytecode artifacts.",
     )
+    for command in ("after-create", "before-run", "after-run", "before-remove"):
+        hook_parser = subparsers.add_parser(
+            command,
+            help="Report optional worktree lifecycle state without removing worktrees.",
+        )
+        if command == "before-remove":
+            hook_parser.add_argument(
+                "--protect-worktree",
+                action="append",
+                type=Path,
+                default=[],
+                help=(
+                    "Protect a worktree; repeatable and supplemented by "
+                    "WORKTREE_HYGIENE_PROTECT_WORKTREES."
+                ),
+            )
     args = parser.parse_args(argv)
     if args.command == "scan":
         selected = [args.worktree] if args.worktree else None
@@ -1613,6 +1795,13 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print(_human(report))
         return 0
+    if args.command in {"after-create", "before-run", "after-run", "before-remove"}:
+        protected = _protected_paths(
+            str(path) for path in getattr(args, "protect_worktree", [])
+        )
+        result = lifecycle_hook(args.command, Path.cwd(), protected=protected)
+        print("\n".join(result.lines))
+        return result.code
     categories = {
         category for category in CATEGORIES if getattr(args, category)
     }

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -15,6 +15,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -53,6 +54,9 @@ CATEGORIES = ("dependencies", "generated", "test_artifacts")
 CLEANABLE_CATEGORIES = frozenset(CATEGORIES)
 EXPENSIVE = {"dependencies"}
 PROTECTED_ROOTS = {".loop-run", ".context"}
+PLAYWRIGHT_EVIDENCE_DIRECTORY = ".playwright-failure-evidence"
+PLAYWRIGHT_EVIDENCE_PIN = ".pinned"
+DEFAULT_PLAYWRIGHT_EVIDENCE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 NAMES = {
     "node_modules": "dependencies",
     ".venv": "dependencies",
@@ -123,6 +127,18 @@ class GitStatus:
     ignored: set[Path]
     tracked: set[Path]
     error: str = ""
+
+
+@dataclass(frozen=True)
+class PlaywrightEvidenceResult:
+    """Account for lifecycle mutations made for browser-gate evidence."""
+
+    archived: int = 0
+    cleaned: int = 0
+    pruned: int = 0
+    skipped: int = 0
+    refused: bool = False
+    receipt: tuple[str, ...] = ()
 
 
 def _run(
@@ -1104,10 +1120,18 @@ def _candidate_safety_reason(
     return _path_component_reason(candidate, root, mount_check)
 
 
-def _current_worktree(repository: Path, runner: Runner) -> Path:
-    """Resolve the registered worktree containing the invocation directory."""
+def _registered_current_worktree(
+    repository: Path,
+    runner: Runner,
+) -> Path | None:
+    """Resolve the registered worktree containing an invocation, if known."""
     _, _, worktrees, _ = discover_worktrees(repository, runner)
-    return _containing_worktree(repository, worktrees) or repository.resolve()
+    return _containing_worktree(repository, worktrees)
+
+
+def _current_worktree(repository: Path, runner: Runner) -> Path:
+    """Resolve the clean target, retaining clean's established fallback."""
+    return _registered_current_worktree(repository, runner) or repository.resolve()
 
 
 def _append_receipt_summary(
@@ -1129,6 +1153,189 @@ def _append_receipt_summary(
         lines.append("  none")
     for size, path, reason in ordered:
         lines.append(f"  {path}: {size} bytes ({reason})")
+
+
+def _playwright_evidence_local_safety_reason(
+    path: Path,
+    root: Path,
+    common: Path,
+    mount_check: MountCheck,
+) -> str:
+    """Re-establish the local portion of the evidence safety predicate."""
+    web = root / "web"
+    archive = web / PLAYWRIGHT_EVIDENCE_DIRECTORY
+    allowed = {web / "test-results", web / "playwright-report", archive}
+    if path not in allowed and path.parent != archive:
+        return "outside Playwright evidence surface"
+    if path == archive and not path.exists():
+        return ""
+    candidate = Candidate(path, "test_artifacts", 0, path.is_dir())
+    return _candidate_safety_reason(candidate, root, common, set(), mount_check)
+
+
+def _playwright_evidence_candidates(root: Path) -> tuple[Path, Path, Path]:
+    """Return the two live Playwright outputs and retained-failure root."""
+    web = root / "web"
+    return (
+        web / "test-results",
+        web / "playwright-report",
+        web / PLAYWRIGHT_EVIDENCE_DIRECTORY,
+    )
+
+
+def manage_playwright_failure_evidence(
+    repository: Path,
+    *,
+    gate_returncode: int,
+    max_age_seconds: int,
+    runner: Runner = _run,
+    mount_check: MountCheck | None = None,
+) -> PlaywrightEvidenceResult:
+    """Retain bounded failed runs and remove artifacts from successful gates."""
+    _, common, worktrees, _ = discover_worktrees(repository, runner)
+    root = _containing_worktree(repository, worktrees)
+    if root is None or common is None:
+        return PlaywrightEvidenceResult(
+            refused=True,
+            receipt=("warning: skipped Playwright evidence: current worktree is not registered",),
+        )
+    common = common.resolve()
+    effective_mount_check = mount_check or _default_mount_check()
+    test_results, playwright_report, archive = _playwright_evidence_candidates(root)
+    actions: list[tuple[str, Path, tuple[Path, ...]]] = []
+    retained: list[tuple[Path, str]] = []
+    if gate_returncode:
+        if test_results.exists():
+            actions.append(("archive", test_results, (test_results, archive)))
+    else:
+        for path in (test_results, playwright_report):
+            if not path.exists():
+                continue
+            actions.append(("clean", path, (path,)))
+    entries = []
+    if archive.is_dir():
+        entries = sorted(
+            (
+                entry
+                for entry in archive.iterdir()
+                if entry.is_dir() and not entry.is_symlink()
+            ),
+            key=lambda entry: entry.stat().st_mtime,
+        )
+    newest = entries[-1] if entries else None
+    cutoff = time.time() - max_age_seconds
+    for entry in entries:
+        if entry == newest:
+            retained.append((entry, "newest failed run"))
+            continue
+        if (entry / PLAYWRIGHT_EVIDENCE_PIN).is_file():
+            retained.append((entry, "pinned"))
+            continue
+        if entry.stat().st_mtime >= cutoff:
+            retained.append((entry, "within age budget"))
+            continue
+        actions.append(("prune", entry, (entry,)))
+
+    candidates: dict[Path, Candidate] = {}
+    reasons: dict[Path, str] = {}
+    for _, _, paths in actions:
+        for path in paths:
+            if path in candidates:
+                continue
+            candidate = Candidate(path, "test_artifacts", 0, path.is_dir())
+            candidates[path] = candidate
+            reasons[path] = _playwright_evidence_local_safety_reason(
+                path, root, common, effective_mount_check
+            )
+    git_candidates = [
+        candidate
+        for path, candidate in candidates.items()
+        if not reasons[path]
+    ]
+    git_status = _mark_git_status(root, git_candidates, runner)
+    if git_status.error:
+        for path in candidates:
+            if not reasons[path]:
+                reasons[path] = git_status.error
+    else:
+        for path, candidate in candidates.items():
+            if reasons[path]:
+                continue
+            relative = candidate.canonical_path.relative_to(root)
+            if _is_tracked(relative, git_status.tracked):
+                reasons[path] = "tracked"
+            elif relative not in git_status.ignored:
+                reasons[path] = "not ignored"
+
+    def recheck_local(paths: tuple[Path, ...]) -> str:
+        """Recheck the local predicate after selection and before mutation."""
+        fresh_mount_check = mount_check or _default_mount_check()
+        for item in paths:
+            reason = _playwright_evidence_local_safety_reason(
+                item, root, common, fresh_mount_check
+            )
+            if reason:
+                return reason
+        return ""
+
+    archived = cleaned = pruned = skipped = failures = reclaimed = selected = 0
+    lines: list[str] = []
+    for path, reason in retained:
+        lines.append(f"warning: skipped {path}: {reason}")
+        skipped += 1
+    for kind, path, paths in actions:
+        reason = next((reasons[item] for item in paths if reasons[item]), "")
+        if reason:
+            lines.append(f"warning: skipped {path}: {reason}")
+            skipped += 1
+            continue
+        bytes_, _ = _tree_size(path, [])
+        lines.append(f"selected {path}: {bytes_} bytes")
+        selected += 1
+        reason = recheck_local(paths)
+        if reason:
+            lines.append(f"aborted {path}: safety changed: {reason}")
+            skipped += 1
+            continue
+        try:
+            if kind == "archive":
+                archive.mkdir(parents=True, exist_ok=True)
+                reason = recheck_local(paths)
+                if reason:
+                    lines.append(f"aborted {path}: safety changed: {reason}")
+                    skipped += 1
+                    continue
+                destination = archive / f"failed-{time.time_ns()}"
+                shutil.copytree(path, destination)
+                lines.append(f"archived {path}: {bytes_} bytes to {destination}")
+                archived += 1
+            else:
+                shutil.rmtree(path)
+                verb = "cleaned" if kind == "clean" else "pruned"
+                lines.append(f"{verb} {path}: {bytes_} bytes")
+                if kind == "clean":
+                    cleaned += 1
+                else:
+                    pruned += 1
+                reclaimed += bytes_
+        except OSError as exc:
+            lines.append(f"failure {path}: {exc}")
+            failures += 1
+    _append_receipt_summary(
+        lines,
+        selected=selected,
+        skipped=skipped,
+        reclaimed=reclaimed,
+        failures=failures,
+        remaining=[],
+    )
+    return PlaywrightEvidenceResult(
+        archived=archived,
+        cleaned=cleaned,
+        pruned=pruned,
+        skipped=skipped,
+        receipt=tuple(lines),
+    )
 
 
 def clean(

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -619,7 +619,7 @@ def _lifecycle_report(
     )
     if merged_warning:
         warnings.append(merged_warning)
-    removed = [worktree.path for worktree in worktrees if worktree.prunable]
+    prune_signal = [worktree.path for worktree in worktrees if worktree.prunable]
     currently_active = [current] if current is not None else []
     merged_paths = [
         worktree.path
@@ -640,7 +640,7 @@ def _lifecycle_report(
     no_merge_or_prune_signal = [
         worktree.path
         for worktree in worktrees
-        if worktree.path not in removed
+        if worktree.path not in prune_signal
         and worktree.path not in currently_active
         and worktree.path not in merged_paths
     ]
@@ -648,13 +648,15 @@ def _lifecycle_report(
         "lifecycle report:",
         "currently-active observation: registered worktree containing the "
         "invocation directory; no liveness claim",
+        "prune-signal observation: Git reported the worktree record as prunable; "
+        "this does not assert that its path has been removed",
         "no-merge-or-prune-signal observation: registered worktree without a "
         "prune signal, default-branch merge signal, or current-invocation "
         "containment; no activity or liveness inference",
     ]
     categories: list[tuple[str, list[Path] | None]] = [
         ("merged", merged_paths if merged is not None else None),
-        ("removed", removed),
+        ("prune-signal", prune_signal),
         ("no-merge-or-prune-signal", no_merge_or_prune_signal),
         ("currently-active", currently_active),
     ]
@@ -1349,6 +1351,55 @@ def _playwright_evidence_candidates(root: Path) -> tuple[Path, Path, Path]:
     )
 
 
+def _playwright_archive_time_ns(entry: Path) -> int | None:
+    """Return the creation time recorded in a lifecycle-owned archive name."""
+    prefix = "failed-"
+    if not entry.name.startswith(prefix):
+        return None
+    try:
+        timestamp = int(entry.name.removeprefix(prefix))
+    except ValueError:
+        return None
+    return timestamp if timestamp >= 0 else None
+
+
+def _playwright_retention_actions(
+    archive: Path, max_age_seconds: int
+) -> tuple[list[tuple[str, Path, tuple[Path, ...]]], list[tuple[Path, str]]]:
+    """Select retained evidence from its explicit archive creation time."""
+    entries = (
+        [
+            entry
+            for entry in archive.iterdir()
+            if entry.is_dir() and not entry.is_symlink()
+        ]
+        if archive.is_dir()
+        else []
+    )
+    creation_times = {
+        entry: timestamp
+        for entry in entries
+        if (timestamp := _playwright_archive_time_ns(entry)) is not None
+    }
+    newest = max(creation_times, key=creation_times.__getitem__, default=None)
+    cutoff = time.time_ns() - max_age_seconds * 1_000_000_000
+    actions: list[tuple[str, Path, tuple[Path, ...]]] = []
+    retained: list[tuple[Path, str]] = []
+    for entry in entries:
+        pin = entry / PLAYWRIGHT_EVIDENCE_PIN
+        if entry not in creation_times:
+            retained.append((entry, "unrecognized archive time"))
+        elif entry == newest:
+            retained.append((entry, "newest failed run"))
+        elif pin.exists() and not pin.is_symlink():
+            retained.append((entry, "pinned"))
+        elif creation_times[entry] >= cutoff:
+            retained.append((entry, "within age budget"))
+        else:
+            actions.append(("prune", entry, (entry,)))
+    return actions, retained
+
+
 def manage_playwright_failure_evidence(
     repository: Path,
     *,
@@ -1368,70 +1419,15 @@ def manage_playwright_failure_evidence(
     common = common.resolve()
     effective_mount_check = mount_check or _default_mount_check()
     test_results, playwright_report, archive = _playwright_evidence_candidates(root)
-    actions: list[tuple[str, Path, tuple[Path, ...]]] = []
-    retained: list[tuple[Path, str]] = []
+    initial_actions: list[tuple[str, Path, tuple[Path, ...]]] = []
     if gate_returncode:
         if test_results.exists():
-            actions.append(("archive", test_results, (test_results, archive)))
+            initial_actions.append(("archive", test_results, (test_results, archive)))
     else:
         for path in (test_results, playwright_report):
             if not path.exists():
                 continue
-            actions.append(("clean", path, (path,)))
-    entries = []
-    if archive.is_dir():
-        entries = sorted(
-            (
-                entry
-                for entry in archive.iterdir()
-                if entry.is_dir() and not entry.is_symlink()
-            ),
-            key=lambda entry: entry.stat().st_mtime,
-        )
-    newest = entries[-1] if entries else None
-    cutoff = time.time() - max_age_seconds
-    for entry in entries:
-        if entry == newest:
-            retained.append((entry, "newest failed run"))
-            continue
-        if (entry / PLAYWRIGHT_EVIDENCE_PIN).is_file():
-            retained.append((entry, "pinned"))
-            continue
-        if entry.stat().st_mtime >= cutoff:
-            retained.append((entry, "within age budget"))
-            continue
-        actions.append(("prune", entry, (entry,)))
-
-    candidates: dict[Path, Candidate] = {}
-    reasons: dict[Path, str] = {}
-    for _, _, paths in actions:
-        for path in paths:
-            if path in candidates:
-                continue
-            candidate = Candidate(path, "test_artifacts", 0, path.is_dir())
-            candidates[path] = candidate
-            reasons[path] = _playwright_evidence_local_safety_reason(
-                path, root, common, effective_mount_check
-            )
-    git_candidates = [
-        candidate
-        for path, candidate in candidates.items()
-        if not reasons[path]
-    ]
-    git_status = _mark_git_status(root, git_candidates, runner)
-    if git_status.error:
-        for path in candidates:
-            if not reasons[path]:
-                reasons[path] = git_status.error
-    else:
-        for path, candidate in candidates.items():
-            if reasons[path]:
-                continue
-            relative = candidate.canonical_path.relative_to(root)
-            if _is_tracked(relative, git_status.tracked):
-                reasons[path] = "tracked"
-            elif relative not in git_status.ignored:
-                reasons[path] = "not ignored"
+            initial_actions.append(("clean", path, (path,)))
 
     def recheck_local(paths: tuple[Path, ...]) -> str:
         """Recheck the local predicate after selection and before mutation."""
@@ -1446,47 +1442,88 @@ def manage_playwright_failure_evidence(
 
     archived = cleaned = pruned = skipped = failures = reclaimed = selected = 0
     lines: list[str] = []
+
+    def apply_actions(actions: list[tuple[str, Path, tuple[Path, ...]]]) -> None:
+        """Apply one selected lifecycle phase after its safety proof."""
+        nonlocal archived, cleaned, failures, pruned, reclaimed, selected, skipped
+        if not actions:
+            return
+        candidates: dict[Path, Candidate] = {}
+        reasons: dict[Path, str] = {}
+        for _, _, paths in actions:
+            for path in paths:
+                if path in candidates:
+                    continue
+                candidate = Candidate(path, "test_artifacts", 0, path.is_dir())
+                candidates[path] = candidate
+                reasons[path] = _playwright_evidence_local_safety_reason(
+                    path, root, common, effective_mount_check
+                )
+        git_candidates = [
+            candidate for path, candidate in candidates.items() if not reasons[path]
+        ]
+        git_status = _mark_git_status(root, git_candidates, runner)
+        if git_status.error:
+            for path in candidates:
+                if not reasons[path]:
+                    reasons[path] = git_status.error
+        else:
+            for path, candidate in candidates.items():
+                if reasons[path]:
+                    continue
+                relative = candidate.canonical_path.relative_to(root)
+                if _is_tracked(relative, git_status.tracked):
+                    reasons[path] = "tracked"
+                elif relative not in git_status.ignored:
+                    reasons[path] = "not ignored"
+
+        for kind, path, paths in actions:
+            reason = next((reasons[item] for item in paths if reasons[item]), "")
+            if reason:
+                lines.append(f"warning: skipped {path}: {reason}")
+                skipped += 1
+                continue
+            bytes_, _ = _tree_size(path, [])
+            lines.append(f"selected {path}: {bytes_} bytes")
+            selected += 1
+            reason = recheck_local(paths)
+            if reason:
+                lines.append(f"aborted {path}: safety changed: {reason}")
+                skipped += 1
+                continue
+            try:
+                if kind == "archive":
+                    archive.mkdir(parents=True, exist_ok=True)
+                    reason = recheck_local(paths)
+                    if reason:
+                        lines.append(f"aborted {path}: safety changed: {reason}")
+                        skipped += 1
+                        continue
+                    destination = archive / f"failed-{time.time_ns()}"
+                    shutil.copytree(path, destination)
+                    lines.append(f"archived {path}: {bytes_} bytes to {destination}")
+                    archived += 1
+                else:
+                    shutil.rmtree(path)
+                    verb = "cleaned" if kind == "clean" else "pruned"
+                    lines.append(f"{verb} {path}: {bytes_} bytes")
+                    if kind == "clean":
+                        cleaned += 1
+                    else:
+                        pruned += 1
+                    reclaimed += bytes_
+            except OSError as exc:
+                lines.append(f"failure {path}: {exc}")
+                failures += 1
+
+    apply_actions(initial_actions)
+    retention_actions, retained = _playwright_retention_actions(
+        archive, max_age_seconds
+    )
     for path, reason in retained:
         lines.append(f"warning: skipped {path}: {reason}")
         skipped += 1
-    for kind, path, paths in actions:
-        reason = next((reasons[item] for item in paths if reasons[item]), "")
-        if reason:
-            lines.append(f"warning: skipped {path}: {reason}")
-            skipped += 1
-            continue
-        bytes_, _ = _tree_size(path, [])
-        lines.append(f"selected {path}: {bytes_} bytes")
-        selected += 1
-        reason = recheck_local(paths)
-        if reason:
-            lines.append(f"aborted {path}: safety changed: {reason}")
-            skipped += 1
-            continue
-        try:
-            if kind == "archive":
-                archive.mkdir(parents=True, exist_ok=True)
-                reason = recheck_local(paths)
-                if reason:
-                    lines.append(f"aborted {path}: safety changed: {reason}")
-                    skipped += 1
-                    continue
-                destination = archive / f"failed-{time.time_ns()}"
-                shutil.copytree(path, destination)
-                lines.append(f"archived {path}: {bytes_} bytes to {destination}")
-                archived += 1
-            else:
-                shutil.rmtree(path)
-                verb = "cleaned" if kind == "clean" else "pruned"
-                lines.append(f"{verb} {path}: {bytes_} bytes")
-                if kind == "clean":
-                    cleaned += 1
-                else:
-                    pruned += 1
-                reclaimed += bytes_
-        except OSError as exc:
-            lines.append(f"failure {path}: {exc}")
-            failures += 1
+    apply_actions(retention_actions)
     _append_receipt_summary(
         lines,
         selected=selected,

--- a/tools/test_playwright_evidence_lifecycle.py
+++ b/tools/test_playwright_evidence_lifecycle.py
@@ -101,7 +101,13 @@ def evidence_root() -> Path:
 def _failed_run(
     root: Path, name: str, age_seconds: int, *, pinned: bool = False
 ) -> Path:
-    run = root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY / name
+    timestamp_ns = time.time_ns() - age_seconds * 1_000_000_000
+    run = (
+        root
+        / "web"
+        / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY
+        / f"failed-{timestamp_ns}"
+    )
     run.mkdir(parents=True)
     (run / "trace.zip").write_text(name, encoding="utf-8")
     if pinned:
@@ -192,6 +198,54 @@ def test_pinned_failed_run_survives_the_age_budget(evidence_root: Path) -> None:
 
     assert pinned.exists()
     assert newest.exists()
+
+
+def test_pinned_directory_survives_the_age_budget(evidence_root: Path) -> None:
+    git = EvidenceGit(evidence_root)
+    pinned = _failed_run(evidence_root, "pinned-directory", 120)
+    (pinned / hygiene.PLAYWRIGHT_EVIDENCE_PIN).mkdir()
+    _failed_run(evidence_root, "newest", 61)
+
+    hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert pinned.exists()
+
+
+def test_stale_live_results_do_not_expire_the_newest_archived_failure(
+    evidence_root: Path,
+) -> None:
+    git = EvidenceGit(evidence_root)
+    stale_source = evidence_root / "web" / "test-results"
+    stale_timestamp = time.time() - 100_000
+    os.utime(stale_source, (stale_timestamp, stale_timestamp))
+    older = _failed_run(evidence_root, "previous", 90_000)
+
+    first = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=1,
+        max_age_seconds=3_600,
+        runner=git,
+    )
+    archived = next(
+        (evidence_root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY).iterdir()
+    )
+    second = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=3_600,
+        runner=git,
+    )
+
+    assert first.archived == 1
+    assert first.pruned == 1
+    assert second.pruned == 0
+    assert not older.exists()
+    assert (archived / "trace.zip").read_text(encoding="utf-8") == "failure"
 
 
 def test_refuses_deletion_when_selected_entry_becomes_a_symlink(
@@ -297,11 +351,15 @@ def test_gate_wrapper_applies_lifecycle_after_the_pinned_gate(
 
     class Lease:
         port = 5432
+        released = False
 
         def release(self) -> None:
-            return None
+            self.released = True
+
+    lease = Lease()
 
     def manage(repository: Path, **kwargs: object) -> hygiene.PlaywrightEvidenceResult:
+        assert lease.released
         observed["repository"] = repository
         observed.update(kwargs)
         return hygiene.PlaywrightEvidenceResult(receipt=("cleaned test evidence",))
@@ -311,7 +369,7 @@ def test_gate_wrapper_applies_lifecycle_after_the_pinned_gate(
         "manage_playwright_failure_evidence",
         manage,
     )
-    monkeypatch.setattr(frontend_runtime, "lease_preview_port", lambda *_: Lease())
+    monkeypatch.setattr(frontend_runtime, "lease_preview_port", lambda *_: lease)
     monkeypatch.setattr(frontend_runtime, "_run_child", lambda *_: 0)
 
     assert frontend_runtime.run_gate(

--- a/tools/test_playwright_evidence_lifecycle.py
+++ b/tools/test_playwright_evidence_lifecycle.py
@@ -1,0 +1,328 @@
+"""Falsification tests for bounded Playwright failure-evidence retention."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "repo"))
+import frontend_runtime  # noqa: E402
+import worktree_hygiene as hygiene  # noqa: E402
+
+
+class EvidenceGit:
+    """Model only the Git facts the evidence lifecycle must establish."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        worktrees: list[Path] | None = None,
+        replace_before_status: Path | None = None,
+    ) -> None:
+        self.root = root
+        self.worktrees = worktrees or [root]
+        self.replace_before_status = replace_before_status
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del env
+        self.calls.append(argv)
+        if "worktree" in argv:
+            output = "".join(
+                f"worktree {worktree}\0HEAD abc\0branch refs/heads/test\0\0"
+                for worktree in self.worktrees
+            )
+            return subprocess.CompletedProcess(argv, 0, output, "")
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                argv, 0, str(self.root / ".git") + "\n", ""
+            )
+        paths = [Path(value) for value in (input or "").split("\0") if value]
+        if "ls-files" in argv:
+            paths = [Path(value) for value in argv[argv.index("--") + 1 :]]
+        ignored = [
+            path
+            for path in paths
+            if str(path).startswith("web/test-results")
+            or str(path).startswith("web/playwright-report")
+            or str(path).startswith("web/.playwright-failure-evidence")
+        ]
+        if "check-ignore" in argv:
+            if self.replace_before_status is not None:
+                target = self.replace_before_status
+                self.replace_before_status = None
+                shutil.rmtree(target)
+                target.symlink_to(
+                    self.root
+                    / "web"
+                    / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY
+                    / "failed-newest",
+                    target_is_directory=True,
+                )
+            output = "\0".join(map(str, ignored))
+            return subprocess.CompletedProcess(
+                argv,
+                0 if output else 1,
+                output + ("\0" if output else ""),
+                "",
+            )
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+
+@pytest.fixture
+def evidence_root() -> Path:
+    with tempfile.TemporaryDirectory() as directory:
+        # Canonicalise once here, not per assertion: on macOS /var is a symlink
+        # to /private/var, and the module under test resolves the paths it
+        # reports, so an unresolved fixture root never matches its receipt.
+        root = Path(directory).resolve() / "worktree"
+        (root / ".git").mkdir(parents=True)
+        (root / "web" / "test-results").mkdir(parents=True)
+        (root / "web" / "test-results" / "trace.zip").write_text(
+            "failure", encoding="utf-8"
+        )
+        yield root
+
+
+def _failed_run(
+    root: Path, name: str, age_seconds: int, *, pinned: bool = False
+) -> Path:
+    run = root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY / name
+    run.mkdir(parents=True)
+    (run / "trace.zip").write_text(name, encoding="utf-8")
+    if pinned:
+        (run / hygiene.PLAYWRIGHT_EVIDENCE_PIN).write_text("", encoding="utf-8")
+    timestamp = time.time() - age_seconds
+    os.utime(run, (timestamp, timestamp))
+    return run
+
+
+def test_failed_gate_keeps_live_ci_output_and_archives_newest_failure(
+    evidence_root: Path,
+) -> None:
+    git = EvidenceGit(evidence_root)
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=1,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    archive = evidence_root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY
+    retained = list(archive.iterdir())
+    assert result.archived == 1
+    assert any(
+        line.startswith(f"archived {evidence_root / 'web' / 'test-results'}:")
+        and " bytes to " in line
+        for line in result.receipt
+    )
+    assert (evidence_root / "web" / "test-results" / "trace.zip").exists()
+    assert len(retained) == 1
+    assert (retained[0] / "trace.zip").read_text(encoding="utf-8") == "failure"
+
+
+def test_success_removes_live_run_artifacts_but_keeps_retained_failure(
+    evidence_root: Path,
+) -> None:
+    git = EvidenceGit(evidence_root)
+    retained = _failed_run(evidence_root, "failed-old", 10)
+    report = evidence_root / "web" / "playwright-report"
+    report.mkdir()
+    (report / "index.html").write_text("success", encoding="utf-8")
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert result.cleaned == 2
+    assert f"cleaned {evidence_root / 'web' / 'test-results'}:" in "\n".join(
+        result.receipt
+    )
+    assert f"cleaned {report}:" in "\n".join(result.receipt)
+    assert not (evidence_root / "web" / "test-results").exists()
+    assert not report.exists()
+    assert retained.exists()
+
+
+def test_newest_failed_run_survives_the_age_budget(evidence_root: Path) -> None:
+    git = EvidenceGit(evidence_root)
+    oldest = _failed_run(evidence_root, "failed-oldest", 120)
+    newest = _failed_run(evidence_root, "failed-newest", 61)
+
+    hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert not oldest.exists()
+    assert newest.exists()
+
+
+def test_pinned_failed_run_survives_the_age_budget(evidence_root: Path) -> None:
+    git = EvidenceGit(evidence_root)
+    pinned = _failed_run(evidence_root, "failed-pinned", 120, pinned=True)
+    newest = _failed_run(evidence_root, "failed-newest", 61)
+
+    hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert pinned.exists()
+    assert newest.exists()
+
+
+def test_refuses_deletion_when_selected_entry_becomes_a_symlink(
+    evidence_root: Path,
+) -> None:
+    expired = _failed_run(evidence_root, "failed-expired", 120)
+    newest = _failed_run(evidence_root, "failed-newest", 61)
+    shutil.rmtree(evidence_root / "web" / "test-results")
+    git = EvidenceGit(evidence_root, replace_before_status=expired)
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert expired.is_symlink()
+    assert newest.exists()
+    # The prefix, not the reason text: the reason comes from
+    # `_candidate_safety_reason`, which `clean` owns and shares. Pinning its
+    # exact wording here would couple this test to that message. The prefix
+    # still discriminates -- with the pre-delete re-assertion removed the entry
+    # is deleted and no `aborted` line is emitted at all.
+    assert any(
+        line.startswith(f"aborted {expired}: safety changed:")
+        for line in result.receipt
+    )
+
+
+def test_git_status_work_is_bounded_for_retained_archive_entries(
+    evidence_root: Path,
+) -> None:
+    shutil.rmtree(evidence_root / "web" / "test-results")
+    git = EvidenceGit(evidence_root)
+
+    for count in (6, 12):
+        for index in range(count):
+            _failed_run(evidence_root, f"failed-old-{count}-{index}", 120)
+        _failed_run(evidence_root, f"failed-newest-{count}", 61)
+        git.calls.clear()
+
+        hygiene.manage_playwright_failure_evidence(
+            evidence_root,
+            gate_returncode=0,
+            max_age_seconds=60,
+            runner=git,
+        )
+
+        assert len(git.calls) == 4
+
+
+def test_unregistered_invocation_refuses_without_touching_peer_worktree(
+    evidence_root: Path,
+) -> None:
+    peer = evidence_root.parent / "peer"
+    (peer / ".git").mkdir(parents=True)
+    target = peer / "web" / "test-results"
+    target.mkdir(parents=True)
+    (target / "trace.zip").write_text("peer", encoding="utf-8")
+    git = EvidenceGit(evidence_root, worktrees=[peer])
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    assert result.refused
+    assert target.exists()
+
+
+def test_age_budget_is_configurable_without_a_ci_switch() -> None:
+    assert frontend_runtime.playwright_evidence_max_age({}) == 7 * 24 * 60 * 60
+    assert frontend_runtime.playwright_evidence_max_age(
+        {frontend_runtime.PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV: "60"}
+    ) == 60
+    with pytest.raises(frontend_runtime.FrontendRuntimeError, match="whole number"):
+        frontend_runtime.playwright_evidence_max_age(
+            {frontend_runtime.PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV: "one"}
+        )
+    with pytest.raises(frontend_runtime.FrontendRuntimeError, match="not be negative"):
+        frontend_runtime.playwright_evidence_max_age(
+            {frontend_runtime.PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV: "-1"}
+        )
+
+
+def test_playwright_failure_diagnostics_remain_enabled() -> None:
+    config = (Path(__file__).resolve().parent.parent / "web" / "playwright.config.ts")
+    source = config.read_text(encoding="utf-8")
+
+    assert "trace: 'retain-on-failure'" in source
+    assert "screenshot: 'only-on-failure'" in source
+
+
+def test_gate_wrapper_applies_lifecycle_after_the_pinned_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    observed: dict[str, object] = {}
+
+    class Lease:
+        port = 5432
+
+        def release(self) -> None:
+            return None
+
+    def manage(repository: Path, **kwargs: object) -> hygiene.PlaywrightEvidenceResult:
+        observed["repository"] = repository
+        observed.update(kwargs)
+        return hygiene.PlaywrightEvidenceResult(receipt=("cleaned test evidence",))
+
+    monkeypatch.setattr(
+        frontend_runtime.worktree_hygiene,
+        "manage_playwright_failure_evidence",
+        manage,
+    )
+    monkeypatch.setattr(frontend_runtime, "lease_preview_port", lambda *_: Lease())
+    monkeypatch.setattr(frontend_runtime, "_run_child", lambda *_: 0)
+
+    assert frontend_runtime.run_gate(
+        environ={frontend_runtime.PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV: "60"},
+        repo_root=tmp_path,
+        common_dir=common_dir,
+        gate_command=(sys.executable, "-c", "raise SystemExit(0)"),
+    ) == 0
+    assert observed == {
+        "repository": tmp_path,
+        "gate_returncode": 0,
+        "max_age_seconds": 60,
+    }
+    assert "cleaned test evidence" in capsys.readouterr().out

--- a/tools/test_playwright_evidence_lifecycle.py
+++ b/tools/test_playwright_evidence_lifecycle.py
@@ -168,6 +168,105 @@ def test_success_removes_live_run_artifacts_but_keeps_retained_failure(
     assert retained.exists()
 
 
+def test_future_dated_archive_does_not_starve_the_newest_run(
+    evidence_root: Path,
+) -> None:
+    # The archive name is ordinary worktree-local state, and a clock stepped
+    # backwards by NTP produces exactly this: a name whose timestamp is in the
+    # future. Read as a time it would hold "newest" forever and, with a zero
+    # budget, the genuine newest run gets pruned instead of kept.
+    git = EvidenceGit(evidence_root)
+    archive = evidence_root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY
+    archive.mkdir(parents=True)
+    future = archive / f"failed-{time.time_ns() + 10**15}"
+    future.mkdir()
+    (future / "trace.zip").write_text("FUTURE", encoding="utf-8")
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=1,
+        max_age_seconds=0,
+        runner=git,
+    )
+
+    genuine = [
+        entry
+        for entry in archive.iterdir()
+        if entry.is_dir() and entry != future
+    ]
+    assert result.archived == 1
+    assert len(genuine) == 1, "the genuine failed run must survive"
+    assert (genuine[0] / "trace.zip").read_text(encoding="utf-8") == "failure"
+    assert any("unrecognized archive time" in line for line in result.receipt)
+
+
+def test_archive_name_collision_still_archives_the_failure(
+    evidence_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A frozen clock models two failures inside one nanosecond. Before the
+    # collision-safe allocator this raised FileExistsError and lost the failure.
+    git = EvidenceGit(evidence_root)
+    archive = evidence_root / "web" / hygiene.PLAYWRIGHT_EVIDENCE_DIRECTORY
+    archive.mkdir(parents=True)
+    frozen = time.time_ns()
+    monkeypatch.setattr(hygiene.time, "time_ns", lambda: frozen)
+    taken = archive / f"failed-{frozen}"
+    taken.mkdir()
+    (taken / "trace.zip").write_text("TAKEN", encoding="utf-8")
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=1,
+        max_age_seconds=3600,
+        runner=git,
+    )
+
+    assert result.archived == 1
+    copies = [
+        entry
+        for entry in archive.iterdir()
+        if entry.is_dir()
+        and (entry / "trace.zip").read_text(encoding="utf-8") == "failure"
+    ]
+    assert len(copies) == 1
+
+
+def test_symlinked_pin_does_not_preserve_expired_evidence(
+    evidence_root: Path,
+) -> None:
+    # `.pinned` is honoured as a file or a directory, but a symlink must not
+    # count: it can point outside the worktree, so a symlinked marker would let
+    # anything outside decide what is retained here.
+    git = EvidenceGit(evidence_root)
+    expired = _failed_run(evidence_root, "failed-100", 120)
+    _failed_run(evidence_root, "failed-900", 1)
+    outside = evidence_root / "elsewhere"
+    outside.mkdir()
+    (expired / hygiene.PLAYWRIGHT_EVIDENCE_PIN).symlink_to(
+        outside, target_is_directory=True
+    )
+    shutil.rmtree(evidence_root / "web" / "test-results")
+
+    result = hygiene.manage_playwright_failure_evidence(
+        evidence_root,
+        gate_returncode=0,
+        max_age_seconds=60,
+        runner=git,
+    )
+
+    # It survives, but never as "pinned": a second, older guard refuses to
+    # recurse into any candidate containing a link. Asserting the *reason*
+    # discriminates -- drop the `not pin.is_symlink()` clause and this entry is
+    # retained as "pinned" instead, which is the bug.
+    assert any(
+        f"skipped {expired}: link inside candidate" in line
+        for line in result.receipt
+    )
+    assert not any(
+        f"skipped {expired}: pinned" in line for line in result.receipt
+    )
+
+
 def test_newest_failed_run_survives_the_age_budget(evidence_root: Path) -> None:
     git = EvidenceGit(evidence_root)
     oldest = _failed_run(evidence_root, "failed-oldest", 120)

--- a/tools/test_worktree_import_resolution.py
+++ b/tools/test_worktree_import_resolution.py
@@ -1,0 +1,425 @@
+"""Contract tests for the worktree doctor's isolated agentbundle probe."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "repo"))
+import worktree_hygiene as hygiene  # noqa: E402
+
+
+class ImportResolutionTest(unittest.TestCase):
+    INVALID_JSON_RECORD = "not-json"
+    NON_OBJECT_RECORD = "[]"
+    UNKNOWN_STATE_RECORD = '{"state": "weird"}'
+    NON_STRING_PATH_RECORD = '{"state": "resolved", "path": 7}'
+
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        (self.root / ".git").mkdir()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def completed(
+        self,
+        payload: dict[str, object] | None = None,
+        *,
+        record: str | None = None,
+        prefix: str = "",
+        returncode: int = 0,
+        stderr: str = "",
+    ) -> subprocess.CompletedProcess[str]:
+        stdout = ""
+        if record is not None:
+            stdout = prefix + hygiene.IMPORT_SENTINEL + record + "\n"
+        elif payload is not None:
+            stdout = prefix + hygiene.IMPORT_SENTINEL + json.dumps(payload) + "\n"
+        return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+    def resolution(
+        self,
+        payload: dict[str, object] | None = None,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        result = self.completed(payload, **kwargs)
+
+        def runner(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return result
+
+        return hygiene._agentbundle_import_resolution(self.root, runner)
+
+    def git_runner(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del input, env
+        if "worktree" in argv:
+            output = (
+                f"worktree {self.root}\0HEAD abc\0branch refs/heads/test\0\0"
+            )
+            return subprocess.CompletedProcess(argv, 0, output, "")
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                argv, 0, str(self.root / ".git") + "\n", ""
+            )
+        if "check-ignore" in argv:
+            return subprocess.CompletedProcess(argv, 1, "", "")
+        return subprocess.CompletedProcess(argv, 1, "", "")
+
+    def test_resolution_inside_worktree_is_in_human_report(self) -> None:
+        resolved = self.root / "agentbundle/__init__.py"
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return self.completed({"state": "resolved", "path": str(resolved)})
+
+        resolution = self.resolution({"state": "resolved", "path": str(resolved)})
+        self.assertEqual(resolution["status"], "inside")
+        self.assertIsNone(hygiene._import_resolution_warning(resolution))
+        human = hygiene._human(
+            hygiene.scan(self.root, runner=self.git_runner, import_runner=probe)
+        )
+        self.assertIn("agentbundle resolves inside this worktree", human)
+        for value in (str(resolved), sys.executable, str(self.root), "PYTHONPATH"):
+            self.assertIn(value, human)
+
+    def test_outside_resolution_is_a_json_and_human_finding(self) -> None:
+        outside = Path("/mnt/published/agentbundle/__init__.py")
+        calls = 0
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            del argv, cwd, env
+            calls += 1
+            return self.completed({"state": "resolved", "path": str(outside)})
+
+        report = hygiene.scan(self.root, runner=self.git_runner, import_runner=probe)
+        self.assertEqual(calls, 1)
+        self.assertEqual(report["schema_version"], 2)
+        self.assertEqual(
+            set(report),
+            {
+                "schema_version",
+                "repository",
+                "git_common_dir",
+                "measurement",
+                "agentbundle_import",
+                "worktrees",
+                "shared_caches",
+                "warnings",
+                "totals",
+            },
+        )
+        resolution = report["agentbundle_import"]
+        self.assertEqual(resolution["status"], "outside")
+        self.assertEqual(resolution["path"], str(outside))
+        encoded = json.dumps(report, sort_keys=True)
+        human = hygiene._human(report)
+        expected = f"agentbundle resolves outside this worktree, at {outside}"
+        self.assertIn(expected, encoded)
+        self.assertIn(expected, human)
+        self.assertEqual(human.count(expected), 1)
+        for value in (sys.executable, str(self.root), "PYTHONPATH"):
+            self.assertIn(value, encoded)
+            self.assertIn(value, human)
+
+    def test_human_output_keeps_unrelated_warnings_once(self) -> None:
+        outside = Path("/mnt/published/agentbundle/__init__.py")
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return self.completed({"state": "resolved", "path": str(outside)})
+
+        report = hygiene.scan(self.root, runner=self.git_runner, import_runner=probe)
+        unrelated_warning = "git discovery retained warning"
+        report["warnings"].append(unrelated_warning)
+        human = hygiene._human(report)
+        import_finding = f"agentbundle resolves outside this worktree, at {outside}"
+        self.assertEqual(human.count(import_finding), 1)
+        self.assertIn(f"warning: {unrelated_warning}", human)
+
+    def test_scan_status_is_independent_of_invocation_directory(self) -> None:
+        nested = self.root / "web"
+        nested.mkdir()
+        resolved = self.root / "packages/agentbundle/agentbundle/__init__.py"
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return self.completed({"state": "resolved", "path": str(resolved)})
+
+        root_report = hygiene.scan(
+            self.root, runner=self.git_runner, import_runner=probe
+        )
+        nested_report = hygiene.scan(
+            nested, runner=self.git_runner, import_runner=probe
+        )
+        self.assertEqual(root_report["agentbundle_import"]["status"], "inside")
+        self.assertEqual(
+            nested_report["agentbundle_import"]["status"],
+            root_report["agentbundle_import"]["status"],
+        )
+
+    def test_worktree_local_resolution_outside_invocation_cwd_is_inside(self) -> None:
+        nested = self.root / "web"
+        nested.mkdir()
+        captured: dict[str, Path] = {}
+        resolved = self.root / "packages/agentbundle/agentbundle/__init__.py"
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, env
+            captured["cwd"] = cwd
+            return self.completed({"state": "resolved", "path": str(resolved)})
+
+        report = hygiene.scan(nested, runner=self.git_runner, import_runner=probe)
+        self.assertEqual(report["agentbundle_import"]["status"], "inside")
+        self.assertEqual(captured["cwd"], self.root)
+
+    def test_polluted_stdout_still_uses_the_sentinel_record(self) -> None:
+        resolution = self.resolution(
+            {"state": "resolved", "path": "/mnt/published/agentbundle/__init__.py"},
+            prefix="pyenv: cannot rehash: lock is held\n",
+        )
+        self.assertEqual(resolution["status"], "outside")
+
+    def test_failed_nonzero_and_unparseable_children_are_inconclusive(self) -> None:
+        def cannot_run(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            raise OSError("child unavailable")
+
+        def times_out(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            raise subprocess.TimeoutExpired("probe", hygiene.IMPORT_TIMEOUT_SECONDS)
+
+        with self.subTest("cannot run"):
+            resolution = hygiene._agentbundle_import_resolution(self.root, cannot_run)
+            self.assertEqual(resolution["status"], "inconclusive")
+            self.assertIn("could not run", str(resolution["detail"]))
+        with self.subTest("timeout"):
+            resolution = hygiene._agentbundle_import_resolution(self.root, times_out)
+            self.assertEqual(resolution["status"], "inconclusive")
+            self.assertIn("timed out", str(resolution["detail"]))
+        with self.subTest("non-zero"):
+            resolution = self.resolution(returncode=1, stderr="probe failed")
+            self.assertEqual(resolution["status"], "inconclusive")
+            self.assertIn("probe failed", str(resolution["detail"]))
+        with self.subTest("unparseable"):
+            resolution = self.resolution(None)
+            self.assertEqual(resolution["status"], "inconclusive")
+            self.assertIn("unambiguous", str(resolution["detail"]))
+
+    def test_invalid_probe_records_are_inconclusive(self) -> None:
+        fixtures = (
+            ("invalid JSON", self.INVALID_JSON_RECORD),
+            ("non-object", self.NON_OBJECT_RECORD),
+            ("unknown state", self.UNKNOWN_STATE_RECORD),
+            ("non-string path", self.NON_STRING_PATH_RECORD),
+        )
+        for label, record in fixtures:
+            with self.subTest(label):
+                resolution = self.resolution(record=record)
+                self.assertEqual(resolution["status"], "inconclusive")
+                self.assertIn("invalid result", str(resolution["detail"]))
+
+    def test_absent_module_is_reported_distinctly(self) -> None:
+        resolution = self.resolution({"state": "absent"})
+        self.assertEqual(resolution["status"], "absent")
+        self.assertIn("absent", hygiene._import_resolution_warning(resolution) or "")
+
+    def test_probe_isolated_from_pythonpath_and_cwd_imports(self) -> None:
+        captured: dict[str, str] = {}
+        captured_argv: list[str] = []
+
+        def probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del cwd
+            captured_argv.extend(argv)
+            captured.update(env)
+            return self.completed(
+                {
+                    "state": "resolved",
+                    "path": str(self.root / "agentbundle/__init__.py"),
+                }
+            )
+
+        with mock.patch.dict(os.environ, {"PYTHONPATH": "worktree-source"}):
+            os.environ.pop("PYTHONDONTWRITEBYTECODE", None)
+            resolution = hygiene._agentbundle_import_resolution(self.root, probe)
+        self.assertEqual(
+            captured_argv,
+            [sys.executable, "-P", "-c", hygiene.IMPORT_PROBE],
+        )
+        self.assertNotIn("PYTHONPATH", captured)
+        self.assertEqual(captured["PYTHONDONTWRITEBYTECODE"], "1")
+        self.assertEqual(
+            resolution["removed_environment_inputs"],
+            ["PYTHONPATH", "cwd sys.path entry (-P)"],
+        )
+
+    def test_failed_worktree_discovery_is_an_inconclusive_finding(self) -> None:
+        def runner(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del input, env
+            if "worktree" in argv:
+                return subprocess.CompletedProcess(
+                    argv, 128, "", "fatal: not a git repository"
+                )
+            return subprocess.CompletedProcess(argv, 1, "", "")
+
+        def import_runner(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            raise AssertionError("import probe must not run without a worktree")
+
+        report = hygiene.scan(
+            self.root, runner=runner, import_runner=import_runner
+        )
+        self.assertEqual(report["agentbundle_import"]["status"], "inconclusive")
+        self.assertIn("fatal: not a git repository", report["warnings"])
+        detail = "no registered worktree contains the invocation directory"
+        self.assertEqual(report["agentbundle_import"]["detail"], detail)
+        self.assertTrue(
+            any(detail in warning for warning in report["warnings"])
+        )
+
+    def test_clean_worktree_fallback_is_unchanged(self) -> None:
+        def runner(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del input, env
+            if "worktree" in argv:
+                return subprocess.CompletedProcess(
+                    argv, 128, "", "fatal: unavailable"
+                )
+            return subprocess.CompletedProcess(argv, 1, "", "")
+
+        self.assertEqual(hygiene._current_worktree(self.root, runner), self.root)
+
+    def test_empty_worktree_discovery_is_an_inconclusive_finding(self) -> None:
+        def runner(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del input, env
+            if "worktree" in argv:
+                return subprocess.CompletedProcess(argv, 0, "HEAD abc\0\0", "")
+            if "rev-parse" in argv:
+                return subprocess.CompletedProcess(
+                    argv, 0, str(self.root / ".git") + "\n", ""
+                )
+            return subprocess.CompletedProcess(argv, 1, "", "")
+
+        def import_runner(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            raise AssertionError("import probe must not run without a worktree")
+
+        report = hygiene.scan(
+            self.root, runner=runner, import_runner=import_runner
+        )
+        self.assertEqual(report["agentbundle_import"]["status"], "inconclusive")
+        detail = "no registered worktree contains the invocation directory"
+        self.assertEqual(report["agentbundle_import"]["detail"], detail)
+        self.assertTrue(
+            any(detail in warning for warning in report["warnings"])
+        )
+
+    def test_uncontained_invocation_is_an_inconclusive_finding(self) -> None:
+        other_worktree = self.root / "other-worktree"
+        other_worktree.mkdir()
+
+        def runner(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            del input, env
+            if "worktree" in argv:
+                return subprocess.CompletedProcess(
+                    argv, 0, f"worktree {other_worktree}\0HEAD abc\0\0", ""
+                )
+            if "rev-parse" in argv:
+                return subprocess.CompletedProcess(
+                    argv, 0, str(self.root / ".git") + "\n", ""
+                )
+            return subprocess.CompletedProcess(argv, 1, "", "")
+
+        def import_runner(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            raise AssertionError("import probe must not run without a worktree")
+
+        report = hygiene.scan(
+            self.root, runner=runner, import_runner=import_runner
+        )
+        self.assertEqual(report["agentbundle_import"]["status"], "inconclusive")
+        detail = "no registered worktree contains the invocation directory"
+        self.assertEqual(report["agentbundle_import"]["detail"], detail)
+        self.assertTrue(
+            any(detail in warning for warning in report["warnings"])
+        )
+
+    def test_unmeasured_scan_emits_provenance_without_status(self) -> None:
+        report = hygiene.scan(
+            self.root,
+            runner=self.git_runner,
+            include_import_resolution=False,
+        )
+        provenance = report["agentbundle_import"]
+        self.assertEqual(provenance["interpreter"], sys.executable)
+        self.assertEqual(provenance["cwd"], str(self.root))
+        self.assertEqual(
+            provenance["removed_environment_inputs"],
+            ["PYTHONPATH", "cwd sys.path entry (-P)"],
+        )
+        self.assertNotIn("status", provenance)
+        report["warnings"] = ["first ordinary warning", "second ordinary warning"]
+        human = hygiene._human(report)
+        for warning in report["warnings"]:
+            self.assertIn(f"warning: {warning}", human)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_worktree_lifecycle_hooks.py
+++ b/tools/test_worktree_lifecycle_hooks.py
@@ -1,0 +1,377 @@
+"""Contract tests for optional, non-mutating worktree lifecycle hooks."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "repo"))
+import worktree_hygiene as hygiene  # noqa: E402
+
+
+class LifecycleHookTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name).resolve()
+        self.current = self.root / "current"
+        self.merged = self.root / "merged"
+        self.no_merge_or_prune_signal = self.root / "no-merge-or-prune-signal"
+        self.removed = self.root / "removed"
+        # A worktree on the default branch itself. `--merged <default>` always
+        # includes the default branch, so without an explicit exclusion the
+        # primary checkout lands in the disposability bucket.
+        self.default_branch_worktree = self.root / "default-branch"
+        self.observed_argv: list[list[str]] = []
+        for path in (
+            self.current,
+            self.merged,
+            self.no_merge_or_prune_signal,
+            self.default_branch_worktree,
+        ):
+            path.mkdir()
+            (path / ".git").mkdir()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def runner(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del input, env
+        self.observed_argv.append(argv)
+        if "worktree" in argv:
+            output = "\0".join(
+                (
+                    f"worktree {self.current}",
+                    "HEAD current",
+                    "branch refs/heads/current",
+                    "",
+                    f"worktree {self.merged}",
+                    "HEAD merged",
+                    "branch refs/heads/merged",
+                    "",
+                    f"worktree {self.no_merge_or_prune_signal}",
+                    "HEAD no-merge-or-prune-signal",
+                    "branch refs/heads/no-merge-or-prune-signal",
+                    "",
+                    f"worktree {self.default_branch_worktree}",
+                    "HEAD default-branch",
+                    "branch refs/heads/main",
+                    "",
+                    f"worktree {self.removed}",
+                    "HEAD removed",
+                    "branch refs/heads/removed",
+                    "prunable gitdir file points to non-existent location",
+                    "",
+                )
+            )
+            return subprocess.CompletedProcess(argv, 0, output, "")
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(argv, 0, str(self.root / ".git"), "")
+        if "remote" in argv:
+            return subprocess.CompletedProcess(argv, 0, "origin\n", "")
+        if "symbolic-ref" in argv:
+            return subprocess.CompletedProcess(
+                argv, 0, "refs/remotes/origin/main\n", ""
+            )
+        if "for-each-ref" in argv:
+            return subprocess.CompletedProcess(
+                argv, 0, "refs/heads/merged\nrefs/heads/main\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 1, "", "unexpected Git command")
+
+    def inside_probe(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del argv, cwd, env
+        payload = json.dumps(
+            {
+                "path": str(self.current / "agentbundle/__init__.py"),
+                "state": "resolved",
+            }
+        )
+        return subprocess.CompletedProcess(
+            [], 0, hygiene.IMPORT_SENTINEL + payload + "\n", ""
+        )
+
+    def outside_probe(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del argv, cwd, env
+        payload = json.dumps(
+            {
+                "path": "/mnt/published/agentbundle/__init__.py",
+                "state": "resolved",
+            }
+        )
+        return subprocess.CompletedProcess(
+            [], 0, hygiene.IMPORT_SENTINEL + payload + "\n", ""
+        )
+
+    def test_optional_hooks_report_observed_categories_without_orca(self) -> None:
+        source = Path(hygiene.__file__).read_text(encoding="utf-8").lower()
+        self.assertNotIn("orca", source)
+        for command in ("after-create", "before-run", "after-run"):
+            with self.subTest(command):
+                result = hygiene.lifecycle_hook(
+                    command, self.current, runner=self.runner
+                )
+                self.assertEqual(result.code, 0)
+                self.assertIn(f"merged: {self.merged}", result.lines)
+                self.assertIn(f"removed: {self.removed}", result.lines)
+                self.assertIn(
+                    f"no-merge-or-prune-signal: {self.no_merge_or_prune_signal}",
+                    result.lines,
+                )
+                self.assertIn(f"currently-active: {self.current}", result.lines)
+                self.assertIn(
+                    "currently-active observation: registered worktree containing "
+                    "the invocation directory; no liveness claim",
+                    result.lines,
+                )
+                self.assertIn(
+                    "no-merge-or-prune-signal observation: registered worktree "
+                    "without a prune signal, default-branch merge signal, or "
+                    "current-invocation containment; no activity or liveness "
+                    "inference",
+                    result.lines,
+                )
+
+    def test_merged_uses_the_git_determined_default_branch(self) -> None:
+        hygiene.lifecycle_hook("after-create", self.current, runner=self.runner)
+        merged_argv = next(
+            argv for argv in self.observed_argv if "for-each-ref" in argv
+        )
+        self.assertEqual(
+            merged_argv[merged_argv.index("--merged") + 1],
+            "refs/remotes/origin/main",
+        )
+
+    def test_merged_query_is_scoped_to_the_report_repository(self) -> None:
+        hygiene.lifecycle_hook("after-create", self.current, runner=self.runner)
+        merged_argv = next(
+            argv for argv in self.observed_argv if "for-each-ref" in argv
+        )
+        self.assertEqual(merged_argv[:3], ["git", "-C", str(self.current)])
+
+    def test_default_branch_worktree_is_not_reported_merged(self) -> None:
+        # The default branch is vacuously merged into itself, so listing the
+        # worktree checked out on it beside genuinely-merged feature branches
+        # invites deleting the primary checkout. It belongs in the no-signal
+        # bucket instead. The porcelain gives refs/heads/<name> while the
+        # default arrives as refs/remotes/<remote>/<name>; comparing those two
+        # directly never matches, which is how this first slipped through.
+        result = hygiene.lifecycle_hook(
+            "after-create", self.current, runner=self.runner
+        )
+        self.assertNotIn(f"merged: {self.default_branch_worktree}", result.lines)
+        self.assertIn(
+            f"no-merge-or-prune-signal: {self.default_branch_worktree}",
+            result.lines,
+        )
+
+    def test_merged_is_undetermined_when_the_remote_is_ambiguous(self) -> None:
+        # Two remotes (origin + upstream is ordinary) and zero remotes both make
+        # the default branch unknowable. Picking `remote_names[0]` would answer
+        # confidently from an arbitrary remote, or raise IndexError on none; the
+        # only honest answer is undetermined. The sibling test above covers the
+        # symbolic-ref failure, which is a different branch.
+        for label, output in (("two remotes", "origin\nupstream\n"), ("none", "")):
+            with self.subTest(label):
+
+                def runner_with_remotes(
+                    argv: list[str],
+                    *,
+                    input: str | None = None,
+                    env: dict[str, str] | None = None,
+                    _output: str = output,
+                ) -> subprocess.CompletedProcess[str]:
+                    if argv[-1] == "remote":
+                        return subprocess.CompletedProcess(argv, 0, _output, "")
+                    return self.runner(argv, input=input, env=env)
+
+                result = hygiene.lifecycle_hook(
+                    "after-create", self.current, runner=runner_with_remotes
+                )
+                self.assertIn("merged: undetermined", result.lines)
+                self.assertIn(
+                    "warning: could not determine default branch: "
+                    "expected exactly one remote",
+                    result.lines,
+                )
+
+    def test_merged_is_undetermined_when_default_branch_is_unavailable(self) -> None:
+        def runner_without_default(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            if "symbolic-ref" in argv:
+                return subprocess.CompletedProcess(argv, 1, "", "missing remote HEAD")
+            return self.runner(argv, input=input, env=env)
+
+        result = hygiene.lifecycle_hook(
+            "after-create", self.current, runner=runner_without_default
+        )
+        self.assertIn("merged: undetermined", result.lines)
+        self.assertIn(
+            "warning: could not determine default branch: missing remote HEAD",
+            result.lines,
+        )
+
+    def test_main_exposes_each_optional_lifecycle_command(self) -> None:
+        result = hygiene.LifecycleResult(0, ("lifecycle report:",))
+        with (
+            mock.patch.object(
+                hygiene, "lifecycle_hook", return_value=result
+            ) as hook,
+            redirect_stdout(io.StringIO()),
+        ):
+            for command in (
+                "after-create",
+                "before-run",
+                "after-run",
+                "before-remove",
+            ):
+                self.assertEqual(hygiene.main([command]), 0)
+        self.assertEqual(
+            [call.args[0] for call in hook.call_args_list],
+            ["after-create", "before-run", "after-run", "before-remove"],
+        )
+
+    def test_before_remove_is_report_only_for_an_inside_import(self) -> None:
+        result = hygiene.lifecycle_hook(
+            "before-remove",
+            self.current,
+            runner=self.runner,
+            import_runner=self.inside_probe,
+        )
+        self.assertEqual(result.code, 0)
+        self.assertIn(
+            "before-remove passed: this hook does not remove worktrees or branches",
+            result.lines,
+        )
+        self.assertTrue(
+            all(
+                not ("worktree" in argv and ({"remove", "prune"} & set(argv)))
+                for argv in self.observed_argv
+            )
+        )
+        self.assertTrue(self.current.exists())
+        self.assertTrue(self.merged.exists())
+        self.assertTrue(self.no_merge_or_prune_signal.exists())
+
+    def test_before_remove_reuses_its_lifecycle_discovery(self) -> None:
+        discovery_available = True
+
+        def one_discovery_runner(
+            argv: list[str],
+            *,
+            input: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> subprocess.CompletedProcess[str]:
+            nonlocal discovery_available
+            if "worktree" in argv:
+                if not discovery_available:
+                    return subprocess.CompletedProcess(
+                        argv, 1, "", "a second discovery is unavailable"
+                    )
+                discovery_available = False
+            return self.runner(argv, input=input, env=env)
+
+        result = hygiene.lifecycle_hook(
+            "before-remove",
+            self.current,
+            runner=one_discovery_runner,
+            import_runner=self.inside_probe,
+        )
+        self.assertEqual(result.code, 0)
+        self.assertIn(
+            "before-remove passed: this hook does not remove worktrees or branches",
+            result.lines,
+        )
+
+    def test_before_remove_refuses_absent_and_inconclusive_imports(self) -> None:
+        def absent_probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return subprocess.CompletedProcess(
+                [], 0, hygiene.IMPORT_SENTINEL + '{"state": "absent"}\n', ""
+            )
+
+        def inconclusive_probe(
+            argv: list[str], *, cwd: Path, env: dict[str, str]
+        ) -> subprocess.CompletedProcess[str]:
+            del argv, cwd, env
+            return subprocess.CompletedProcess([], 0, "", "")
+
+        for label, probe in (
+            ("absent", absent_probe),
+            ("inconclusive", inconclusive_probe),
+        ):
+            with self.subTest(label):
+                result = hygiene.lifecycle_hook(
+                    "before-remove",
+                    self.current,
+                    runner=self.runner,
+                    import_runner=probe,
+                )
+                self.assertEqual(result.code, 2)
+                self.assertIn(
+                    "refusing worktree removal: agentbundle import resolution is "
+                    f"{label}, not inside this worktree",
+                    result.lines,
+                )
+
+    def test_before_remove_refuses_a_shadowing_import(self) -> None:
+        result = hygiene.lifecycle_hook(
+            "before-remove",
+            self.current,
+            runner=self.runner,
+            import_runner=self.outside_probe,
+        )
+        self.assertEqual(result.code, 2)
+        self.assertIn(
+            "refusing worktree removal: agentbundle import resolution is outside, not inside this worktree",
+            result.lines,
+        )
+        self.assertTrue(self.current.exists())
+
+    def test_before_remove_refuses_an_existing_protection_channel(self) -> None:
+        result = hygiene.lifecycle_hook(
+            "before-remove",
+            self.current,
+            protected={self.current},
+            runner=self.runner,
+            import_runner=self.inside_probe,
+        )
+        self.assertEqual(result.code, 2)
+        self.assertIn(
+            f"refusing worktree removal: protected worktree: {self.current}",
+            result.lines,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_worktree_lifecycle_hooks.py
+++ b/tools/test_worktree_lifecycle_hooks.py
@@ -33,6 +33,7 @@ class LifecycleHookTest(unittest.TestCase):
             self.current,
             self.merged,
             self.no_merge_or_prune_signal,
+            self.removed,
             self.default_branch_worktree,
         ):
             path.mkdir()
@@ -137,7 +138,8 @@ class LifecycleHookTest(unittest.TestCase):
                 )
                 self.assertEqual(result.code, 0)
                 self.assertIn(f"merged: {self.merged}", result.lines)
-                self.assertIn(f"removed: {self.removed}", result.lines)
+                self.assertIn(f"prune-signal: {self.removed}", result.lines)
+                self.assertNotIn(f"removed: {self.removed}", result.lines)
                 self.assertIn(
                     f"no-merge-or-prune-signal: {self.no_merge_or_prune_signal}",
                     result.lines,

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -26,3 +26,4 @@ pnpm-debug.log*
 # playwright
 test-results/
 playwright-report/
+.playwright-failure-evidence/


### PR DESCRIPTION
Completes `docs/specs/worktree-runtime-hygiene/`'s remaining tasks plus the cross-cutting doctor check. Extends `b37055ad` (#1052); no already-merged behaviour is modified except to extend it.

## What lands

**AC8 — import-resolution check in the doctor.** `scan` answers one question: does `agentbundle` resolve to a path inside the current worktree? Measured in an isolated child with `PYTHONPATH` stripped and `-P` (so the invocation directory is off `sys.path`), because the doctor runs under `Makefile:7`'s `PYTHONPATH`, which points at the worktree and masks the exact condition. **Never a version comparison** — a guard that is red for everyone during every merge→release window gets ignored. Reports the resolved path plus provenance and stops there; no consequence is claimed, because a suite with a `conftest.py` above it on `sys.path` is immune by construction. Failed, timed-out, or unparseable probes are stated `inconclusive`, and when no registered worktree contains the invocation directory no child runs at all.

This is the diagnosis for two real failures: an editable install pointing at a deleted worktree, and a global non-editable install shadowing the tree — the latter being why `test_marketplace_envelope_parity`'s resolved-layer test fails locally on unmodified `main`.

**AC9 — bounded failure-evidence lifecycle.** `playwright.config.ts` is untouched: `trace: 'retain-on-failure'` and `screenshot: 'only-on-failure'` both stay, asserted by a test. Successful-run `web/test-results/` and `web/playwright-report/` are removed immediately; a failed run is **copied, not moved**, into ignored `web/.playwright-failure-evidence/`, so `pages.yml`'s `if: failure()` upload of `web/test-results/` still finds its files. Newest and `.pinned` runs are retained; older unpinned runs expire by `PLAYWRIGHT_FAILURE_EVIDENCE_MAX_AGE_SECONDS` (7 days default). Nothing keys on `CI`, which Actions sets in every job. Deletion follows `clean`'s established shape — one selection pass, one batched tracked/ignored query, local predicate re-asserted immediately before each mutation — and every mutation is on a printed receipt.

**AC10 — report-only lifecycle hooks.** `after-create`, `before-run`, `after-run`, `before-remove`, usable with plain `git worktree`, no orchestrator dependency, protection through the existing `--protect-worktree` and `WORKTREE_HYGIENE_PROTECT_WORKTREES`. `before-remove` calls AC8's check and refuses `outside`/`absent`/`inconclusive` alike. **Nothing is removed** — no `git worktree remove`/`prune`, no directory, no branch, under any flag.

## Claims stay inside what was observed

Three defects found by *running* the tools rather than reading them, each a confident claim about something unmeasured:

- The import check inverted with the invocation directory — a silent `inside` from `packages/agentbundle/` on a machine whose global install shadows the tree.
- `abandoned` labelled 15 of 16 worktrees, including two peers doing active work at that moment. It is now `no-merge-or-prune-signal` and states its own basis. Abandonment is as unobservable as liveness.
- Retention kept the old failure and deleted the new one, because `copytree` preserves the source directory's mtime and `web/test-results/` is reused. Archive time is now recorded in the name and read back, and a future-dated name is treated as unreadable rather than as a time.

## Verification

- **Gates:** `lint-ruff`, `lint-mypy`, six tool suites, `tools/test-pages-workflow.py`, bandit at its CI invocation over `tools packs packages tests`, `lint-nosec-form`, `lint-spec-status`, `lint-traceability`, `make worktree-doctor`, `git diff --check` — all green, re-run after the rebase onto `fe26b042`.
- **Full suite:** 1285 passed, failure set **identical to baseline** (the one pre-existing `test_marketplace_envelope_parity` failure; reproduces on clean `main`).
- **38 mutation proofs** across `worktree_hygiene.py`, `frontend_runtime.py`, and `playwright.config.ts` — each anchor-unique, byte-identical restore, all flipping their named test. Eight guards were initially unprovable (a value read from an environment the Makefile always exports; a proof asserting a call count; an `assertIn` where the bug was duplication) and were fixed.
- **Real machine:** the doctor reports the same fact from four invocation directories; all four hooks ran for real and left 16 worktrees and 32 branches intact; `before-remove` exits 2 naming the shadowing install.
- Three independent review rounds; findings shifted to fix-induced by round 3, which is where I stopped iterating.

## Sizing (RFC-0090)

2,163 raw / 140 prose / **2,023 reviewable across 7 non-prose files, median 379 → DEEP**, just past the 2,000 trigger. Delivered as dependency-ordered layers (646 / 582 / 567 reviewable), each leaving the repository working. No no-split exemption claimed.

## Known open

**AC6 did not ship and stays unticked.** The preview-port lease exists; the cooperative worktree lease shared by cleanup and mutating build/test entry points — which the spec calls the only thing that can fully close the check-to-delete window — has no implementation. The spec therefore stays `Implementing`.

A pre-existing residual is newly documented, not changed: `_run_child` reaps the child's process group on interrupt paths but not after a normal `wait()`, and the lease releases when the child returns, so a gate command that backgrounds the preview server leaves a descendant holding the port. That is `b37055ad`'s shipped behaviour; closing it belongs with AC6.

No changelog entry: the changelog is pack-release scoped and this ships no pack and bumps no pack version — consistent with #1052, which shipped this same tool.

Coordinated with `completion-boundary`, `rfc88-consumer-shaped-spikes`, and `tech-site-build-c`; zero file overlap confirmed with all responders.