### PR TITLE
fix(profiles,agentbundle): cite only what the scaffold ships

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -124,6 +124,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   internals, and — for a sensitive package — to list the change categories that
   require an architecture decision record.
 
+### [agentbundle][0.38.6] — 2026-08-20
+
+#### Fixed
+
+- **Profile authors can now reach the schema their instructions name.** New
+  catalogues direct them to the bundled profile contract through the installed
+  CLI, rather than a path that exists only in this repository.
+
 ### [agentbundle][0.38.5] — 2026-08-20
 
 #### Changed

--- a/docs/specs/profiles-agents-adopter-resolvable-citations/plan.md
+++ b/docs/specs/profiles-agents-adopter-resolvable-citations/plan.md
@@ -1,0 +1,127 @@
+# Plan: profiles-agents-adopter-resolvable-citations
+
+- **Status:** Done
+- **Spec:** [`spec.md`](spec.md)
+
+## Assumption trio
+
+- **Files touched:** `profiles/AGENTS.md` (source of the sync pair);
+  `packages/agentbundle/agentbundle/_data/catalogue-scaffold/profiles/AGENTS.md`
+  and `.../catalogue-scaffold/manifest.json` (both written only by
+  `sync_authoring_scaffold.py --write`);
+  `packages/agentbundle/tests/integration/test_scaffold_projection.py`;
+  release surfaces `packages/agentbundle/pyproject.toml`,
+  `packages/agentbundle/agentbundle/version.py`,
+  `packages/agentbundle/CHANGELOG.md`, `packages/agentbundle/README-pypi.md`,
+  `docs/product/changelog.md`, `tests/roster/test_okf_catalogue_discovery.py`.
+- **Tests that demonstrate done:** the generalized guard fails on the
+  reintroduced hyperlink and on the reintroduced `tools/` citation, and passes on
+  the corrected text; `sync_authoring_scaffold.py --check` exits 0; the roster
+  release-metadata test passes under the Makefile `PYTHONPATH`; `make ci`.
+- **Not changing:** the profile schema, `contracts/`, any CLI verb or flag, the
+  `agentbundle catalogue contracts` implementation, `packs/AGENTS.md`,
+  `packs/README.md`, `guides/_shared/reference/catalogue-authoring-standards.md`,
+  and the `profiles/README.md` sibling.
+
+### Tempted and declined
+
+- **A blanket "no unshipped path in any scaffold Markdown" lint.** Prototyped
+  against `b4dae24d`: it flags twelve citations in the guides authoring-standards
+  hub that a ratified acceptance criterion deliberately admitted. Declined — it
+  reverses a decision instead of enforcing one.
+- **Adding `profiles/AGENTS.local.md` to re-home the sync command.**
+  `AGENTS.local.md:35-37` already names `profiles/` and that script by route.
+  Declined — a scoped copy would give one load-bearing fact a second home.
+- **Shipping `contracts/` in the scaffold so the original link resolves.**
+  Declined — the profile schema is package-internal by design and already
+  readable through `catalogue contracts show`; shipping a second copy creates a
+  parity surface with nothing to keep it honest.
+- **Fixing the identical defect in `packs/README.md`.** Declined — `workspace.toml`
+  records it as blocked with measured reasoning.
+
+## Verification mode
+
+- Tasks 1-3: **goal-based check + TDD.** The guard is the test; AC4's mutation is
+  its red state.
+- Task 4: **visual / manual QA.** Run the real CLI verb the new text tells an
+  adopter to run and record its observed output.
+- Task 5: **goal-based check.** Release-surface pins.
+
+## Tasks
+
+1. **Generalize the citation guard.** (`Depends on: none`)
+   Retain `test_packs_agents_md_cites_only_paths_it_ships`, because
+   `workspace.toml` names that live test directly. Extract
+   `_assert_cites_only_shipped_paths` from it and add the sibling
+   `test_profiles_agents_md_cites_only_paths_it_ships`; both delegate to the
+   helper, which retains the shipped-set construction, `rooted` prefixes,
+   `<`-placeholder exclusion, and `optional_by_design` carve-out. This keeps the
+   established workspace reference valid and gives each file an isolated failure
+   name.
+   **Tests:** this task *is* the test. Red state: it must fail on unmodified
+   `profiles/AGENTS.md`, naming `contracts/profile.schema.json` and
+   `tools/catalogue/sync_authoring_scaffold.py`.
+
+2. **Correct `profiles/AGENTS.md`.** (`Depends on: 1`)
+   § *Validation and ownership*: keep the ownership sentence, name the schema
+   `profile.schema.json`, route the reader with
+   `agentbundle catalogue contracts show profile.schema.json`, and keep the
+   source/projection sentence unchanged in meaning.
+   § *Deeper pointers*: keep `profiles/_example/profile.toml` (it ships) and drop
+   the repo-only script path without restating the obligation.
+   **Tests:** task 1's guard turns green; `tools/lint-agents-md.py` passes; the
+   file stays under the 80-line scoped cap.
+
+3. **Rewrite the projection.** (`Depends on: 2`)
+   `python3 tools/catalogue/sync_authoring_scaffold.py --write`, then `--check`.
+   **Done when:** `--check` exits 0 and `manifest.json` digests match.
+
+4. **Prove the guard and the route.** (`Depends on: 3`)
+   Mutation A: reintroduce the hyperlink in the scaffold copy; guard fails naming
+   `contracts/profile.schema.json`. Mutation B: reintroduce the `tools/` citation;
+   guard fails naming it. Restore both by editing, never by `git checkout`.
+   Then run `agentbundle catalogue contracts show profile.schema.json` from the
+   built artifact and record its observed output.
+   **Tests:** recorded pass/fail transcript for each mutation.
+
+5. **Move the release surfaces together.** (`Depends on: 3`)
+   Bump to `0.38.5` (`0.38.3` and `0.38.4` are claimed in-repo, PyPI's max is
+   `0.38.2`, and no open PR claims a version). Update all six surfaces; add the
+   `## [0.38.5]` section to the package changelog and the
+   `### [agentbundle][0.38.5]` heading above `0.38.4` inside `## [Unreleased]`.
+   **Done when:** `tests/roster/test_okf_catalogue_discovery.py` passes under the
+   Makefile `PYTHONPATH`, and the topmost `### [agentbundle][…]` heading equals
+   `version.py`.
+
+6. **Correct the decision record.** (`Depends on: 2`)
+   Rewrite the falsified premises in `workspace.toml`'s
+   `packs-agents-normative-pointer` entry. Assert each anchor is unique before
+   replacing, and re-parse the file with `tomllib` afterwards.
+   **Done when:** the file parses, and no surviving sentence in that entry
+   contradicts the tree.
+
+## Constraints
+
+- The commit needs an `Engine-Change-RFC:` trailer. The curation guard protects
+  `packages/agentbundle/**` and carves out only
+  `agentbundle/build/recipes/` and any path containing `/tests/`; the scaffold
+  copy, `manifest.json`, and the four release surfaces under that prefix are all
+  hits. Use the `n/a -- <reason>` form; do not invent an RFC number.
+- `sync_authoring_scaffold.py --write` must be run by the supervisor: the worker's
+  policy refuses bare-interpreter invocations.
+
+## Risks
+
+- Bare `pytest tests/roster/` fails on this host because an installed
+  `agentbundle 0.38.1` shadows the worktree source. Measured on `b4dae24d`:
+  1 failed under bare pytest, 3 passed under the Makefile `PYTHONPATH`. Judge the
+  release-surface pin only under `PYTHONPATH`.
+- Editing a construction-test module in `packages/agentbundle/tests/` can void a
+  byte-pin elsewhere. Confirm no digest test covers
+  `test_scaffold_projection.py` before committing.
+
+## Changelog
+
+- `[agentbundle][0.38.5]` — the bundled authoring scaffold's `profiles/AGENTS.md`
+  routes to the profile schema with a command instead of a path an adopter's tree
+  does not contain.

--- a/docs/specs/profiles-agents-adopter-resolvable-citations/spec.md
+++ b/docs/specs/profiles-agents-adopter-resolvable-citations/spec.md
@@ -1,0 +1,128 @@
+# Spec: profiles-agents-adopter-resolvable-citations
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Contract:** none. Instruction prose plus one generalized construction test; no
+  schema, CLI, or behaviour change.
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+<!-- Mode: light (no risk trigger fired). Checked each trigger explicitly.
+Unfamiliar: no — the sibling file `packs/AGENTS.md` already solved this exact
+problem and its guard is the artifact being generalized. Governance surface: no
+— every obligation the file states survives with the same meaning; only the
+route a reader takes to the schema changes. Structural / public-interface: no —
+no new module, boundary, dependency, or CLI verb; `agentbundle catalogue
+contracts show` already ships. Destructive: no. New dependency: no. -->
+
+## Objective
+
+`profiles/AGENTS.md:13` points an adopter at `../contracts/profile.schema.json`
+as a Markdown hyperlink. `catalogue init` writes the scaffold, and the scaffold
+ships `guides/ manifest.json packs/ profiles/ tests/` — no `contracts/`. So the
+one place the file names the authority for profile validation is unreachable in
+every adopter tree, and `profiles/AGENTS.md:31` points at
+`tools/catalogue/sync_authoring_scaffold.py`, which no adopter has either.
+
+Neither dangles in this repository, so nothing fails. The sibling `packs/AGENTS.md`
+is already guarded against exactly this by
+`test_packs_agents_md_cites_only_paths_it_ships`; that guard names one file
+literally, which is why `profiles/AGENTS.md` drifted.
+
+Success: an adopter reading the shipped `profiles/AGENTS.md` can reach the profile
+schema with a command they have, still learns that the schema owns validation, and
+the guard that would have caught this covers both files.
+
+## Acceptance Criteria
+
+- [x] **AC1 — the ownership statement survives, with a route that resolves in
+  both trees.** `profiles/AGENTS.md` still states that the profile schema owns
+  fields and semantic validation, and still states that profile TOML is the
+  source and that profiles are scaffold sources not projected by `catalogue
+  self-host`. It names the schema as `profile.schema.json` and routes the reader
+  to it with `agentbundle catalogue contracts show profile.schema.json` — the
+  installed CLI carries the schema as package data and this verb prints it.
+
+- [x] **AC2 — no repo-only path survives in the shipped file.**
+  `profiles/AGENTS.md` cites no path under `contracts/`, `tools/`, or `docs/`.
+  The scaffold-sync obligation is not restated with a path; it keeps its
+  canonical maintainer home in `AGENTS.local.md`, which already names `profiles/`
+  by that route.
+
+- [x] **AC3 — the guard covers both sync-paired instruction files.**
+  `test_packs_agents_md_cites_only_paths_it_ships` is retained and delegates to
+  `_assert_cites_only_shipped_paths`; a second
+  `test_profiles_agents_md_cites_only_paths_it_ships` delegates to the same
+  helper, preserving per-file failure isolation. The helper uses the same
+  shipped-file set, rooted prefixes, placeholder exclusion, and
+  `optional_by_design` exception for each file, with a bounded rooted-path token
+  extraction that also recognizes bare paths, reference-style destinations, HTML
+  `href` destinations, fragments, and nested directory citations.
+
+- [x] **AC4 — the generalized guard is proven to fail.** Reintroducing the
+  hyperlink `[`contracts/profile.schema.json`](../contracts/profile.schema.json)`
+  into the scaffold copy of `profiles/AGENTS.md` makes the guard fail and name
+  that path; restoring the corrected text by editing makes it pass. The same
+  mutation is run for the `tools/` citation, and for one instance of each
+  citation form the extraction recognizes — bare path, reference-style
+  destination, HTML `href`, fragment-carrying path, and nested directory. Each
+  mutation is injected alone, and the file is restored by editing to
+  byte-identical content, never by `git checkout`.
+  `test_packs_agents_md_cites_only_paths_it_ships` stays green throughout, which
+  is what proves the two files fail independently.
+
+- [x] **AC5 — both copies of the sync pair agree.**
+  `tools/catalogue/sync_authoring_scaffold.py --check` exits 0, and
+  `manifest.json` digests match, after the repo-root source is edited and the
+  projection is rewritten by that script's `--write` mode. The scaffold copy is
+  never hand-edited.
+
+- [x] **AC6 — the release surfaces move together.** The change alters package
+  data that ships in the wheel, so per the `packages/AGENTS.md` version-bump rule
+  the package moves to the next free version, and every surface pinned to it
+  moves with it: `pyproject.toml`, `agentbundle/version.py`,
+  `packages/agentbundle/CHANGELOG.md`, `README-pypi.md` (`What's new in <v>`),
+  the `### [agentbundle][<v>]` heading in `docs/product/changelog.md`, and the
+  literal pin in `tests/roster/test_okf_catalogue_discovery.py`. The topmost
+  `### [agentbundle][…]` heading equals the package version.
+
+- [x] **AC7 — the decision record stops asserting what is no longer true.** The
+  `packs-agents-normative-pointer` entry in `workspace.toml` states that
+  `profiles/AGENTS.md` names `contracts/profile.schema.json` and that no test
+  covers that file, and instructs that the assertion be extended "in the same
+  change". All three claims are corrected to match the tree, the `packs/` half is
+  left open with its `(a)`-vs-`(b)` decision intact, and the entry's stale
+  150-line budget note is corrected to the 80-line cap the linter enforces.
+
+## Boundaries
+
+### Never do
+
+- Never delete the ownership statement to make the link problem go away. AC5 of
+  `docs/specs/contracts-readme-governance-sweep/spec.md` added this pointer so a
+  reader could tell which artifact wins; that obligation is preserved and only
+  its reachability changes.
+- Never widen the guard to all scaffold-shipped Markdown. Measured on
+  `b4dae24d`: `guides/_shared/reference/catalogue-authoring-standards.md` carries
+  twelve such citations, which AC9 of
+  `docs/specs/catalogue-wave1-contract-convergence/spec.md` deliberately admitted
+  as plain-text contract names. A blanket guard reddens `make ci` and reverses a
+  ratified decision.
+- Never hand-edit `packages/agentbundle/agentbundle/_data/catalogue-scaffold/`.
+- Never fix the same defect class in `packs/README.md`. `workspace.toml` records
+  that entry as blocked with its reasoning; this spec does not reopen it.
+
+## Assumptions
+
+- The profile schema does not need to reach an adopter as a file. Verified:
+  `agentbundle/catalogue_tooling/verify.py:422` loads it with
+  `_load_bundled_json("profile.schema.json")` and
+  `agentbundle/commands/profile.py:69-77` resolves it at
+  `_data/profile.schema.json`, whose docstring states the profile schema "is
+  internal and lives only" there. `_data/profile.schema.json` is byte-identical
+  to `contracts/profile.schema.json`, is listed in `_data/public-contracts.txt`,
+  and `agentbundle catalogue contracts show profile.schema.json` prints it. So an
+  adopter validates with `agentbundle catalogue lint` / `verify` and reads the
+  contract with `contracts show` — a `contracts/` copy is not required for either.

--- a/packages/agentbundle/CHANGELOG.md
+++ b/packages/agentbundle/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 the package targets pre-1.0 semver as documented in `docs/CONVENTIONS.md`
 — a minor bump on a 0.x release MAY be breaking.
 
+## [0.38.6] — 2026-08-20
+
+### Fixed
+
+- The bundled profile-authoring instructions now direct catalogue authors to
+  the packaged profile schema through a command available in initialized
+  catalogues, rather than a repository-only path.
+
 ## [0.38.5] — 2026-08-20
 
 ### Changed

--- a/packages/agentbundle/README-pypi.md
+++ b/packages/agentbundle/README-pypi.md
@@ -14,6 +14,12 @@ python -m pip install agentbundle
 
 Requires Python 3.11+. Runs on macOS, Linux, and Windows.
 
+## What's new in 0.38.6
+
+Catalogue authors can now read the profile schema from initialized catalogues
+with `agentbundle catalogue contracts show profile.schema.json`. The bundled
+profile-authoring instructions no longer direct them to a repository-only path.
+
 ## What's new in 0.38.5
 
 The bundled authoring scaffold now says how to write pack tests that survive a

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/manifest.json
@@ -9,7 +9,7 @@
     "packs/_example/.claude-plugin/plugin.json": "7f94084a56260eed225ec47ac82042fe9029c594557cca760a459885d03ccc26",
     "packs/_example/README.md": "ef130c9c1f97a75a07cc59fc55fc5b3bf71846dd2f06c3cddf5a1154023b6ef6",
     "packs/_example/pack.toml": "f19a0be9fca99a6a0e3ce2d5cd188bf98000f0a4f186954fb42a0c99c6859701",
-    "profiles/AGENTS.md": "648e780f121fd81f25d8c7371784a681f8a553f3d1f3fff27be2643b03d9899e",
+    "profiles/AGENTS.md": "34fba229a4e8bd1b6efc948d3e1d51d9d47f88826897c259909e0a1fd2672a5e",
     "profiles/README.md": "a0b0268edc57fc575f7fea08f3363ba7da9f6e67dc4a0a6f8bd38c9668c97922",
     "profiles/_example/README.md": "164494df049ddce3e57cb44ed604cb3d39be0a6ec2072e609ea3fa4bbfc74c72",
     "profiles/_example/profile.toml": "68af18cf50fa0327a9776b029c92bb1cf82710c649691b3ac889eb8537b8eac7",

--- a/packages/agentbundle/agentbundle/_data/catalogue-scaffold/profiles/AGENTS.md
+++ b/packages/agentbundle/agentbundle/_data/catalogue-scaffold/profiles/AGENTS.md
@@ -10,9 +10,9 @@ is its identifier. Reserved `_` children are authoring assets, not active profil
 
 ## Validation and ownership
 
-[`contracts/profile.schema.json`](../contracts/profile.schema.json) owns fields and
-semantic validation. Profile TOML is the source; profiles are scaffold sources but
-are not projected by `catalogue self-host`.
+`profile.schema.json` owns fields and semantic validation. Read it with
+`agentbundle catalogue contracts show profile.schema.json`. Profile TOML is the
+source; profiles are scaffold sources but are not projected by `catalogue self-host`.
 
 - A pack name appears at most once in a profile.
 - Packs with a declared `conflicts` relationship do not share a profile.
@@ -27,5 +27,4 @@ agentbundle list-profiles <catalogue>
 
 ## Deeper pointers
 
-Start from `profiles/_example/profile.toml`. Synchronize scaffold projections after
-profile-source changes with `tools/catalogue/sync_authoring_scaffold.py`.
+Start from `profiles/_example/profile.toml`.

--- a/packages/agentbundle/agentbundle/version.py
+++ b/packages/agentbundle/agentbundle/version.py
@@ -14,7 +14,7 @@ import tomllib
 from importlib.resources import files
 from pathlib import Path
 
-CLI_VERSION = "0.38.5"
+CLI_VERSION = "0.38.6"
 
 _HERE = Path(__file__).resolve().parent
 

--- a/packages/agentbundle/pyproject.toml
+++ b/packages/agentbundle/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentbundle"
-version = "0.38.5"
+version = "0.38.6"
 description = "npm for your coding agent. Install packs of skills, subagents, and hooks into any repo, for every major agent."
 requires-python = ">=3.11"
 dependencies = []

--- a/packages/agentbundle/tests/integration/test_scaffold_projection.py
+++ b/packages/agentbundle/tests/integration/test_scaffold_projection.py
@@ -4,6 +4,7 @@ byte-identical to the repo-root scaffold sources.
 Also verifies:
 - scaffold_root() returns a readable directory.
 - packs/AGENTS.md in the _data copy is the portable version (no `make build-self`).
+- packs/AGENTS.md and profiles/AGENTS.md cite only paths the scaffold ships.
 - profiles/AGENTS.md is present and non-empty.
 """
 
@@ -14,6 +15,10 @@ from pathlib import Path
 
 _DATA_SCAFFOLD = (
     Path(__file__).resolve().parents[2] / "agentbundle" / "_data" / "catalogue-scaffold"
+)
+_ROOTED_CITATION = re.compile(
+    r"(?<![\w/])((?:\.\./|\./)?(?:tools|docs|contracts|guides|packs|profiles)/"
+    r"(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_.-]+/?(?:#[A-Za-z0-9_.-]+)?)"
 )
 
 
@@ -47,7 +52,7 @@ def test_packs_agents_md_is_portable():
     )
 
 
-def test_packs_agents_md_cites_only_paths_it_ships():
+def _assert_cites_only_shipped_paths(relative_path: str) -> None:
     """Every path this file points an adopter at must exist in their tree.
 
     The scaffold is what `catalogue init` writes, so a reference to a
@@ -56,8 +61,7 @@ def test_packs_agents_md_cites_only_paths_it_ships():
     do not have, or a pointer to a file they cannot open. The rule itself has to
     carry its own weight in the shipped copy.
     """
-    agents_md = _DATA_SCAFFOLD / "packs" / "AGENTS.md"
-    text = agents_md.read_text(encoding="utf-8")
+    text = (_DATA_SCAFFOLD / relative_path).read_text(encoding="utf-8")
     shipped = {
         str(p.relative_to(_DATA_SCAFFOLD)).replace("\\", "/")
         for p in _DATA_SCAFFOLD.rglob("*")
@@ -70,9 +74,8 @@ def test_packs_agents_md_cites_only_paths_it_ships():
     # and every reference to it is conditional on the adopter having created one.
     optional_by_design = {"packs/AGENTS.local.md"}
     cited = {
-        ref.split("#")[0].lstrip("./").removeprefix("../")
-        for ref in re.findall(r"`([^`\n]+?\.(?:py|md|json|toml|sh|yml))`", text)
-        + re.findall(r"\]\(([^)]+)\)", text)
+        ref.split("#", 1)[0].rstrip("/").lstrip("./").removeprefix("../")
+        for ref in _ROOTED_CITATION.findall(text)
     }
     dangling = sorted(
         ref for ref in cited
@@ -82,10 +85,18 @@ def test_packs_agents_md_cites_only_paths_it_ships():
         and ref not in optional_by_design
     )
     assert not dangling, (
-        "packs/AGENTS.md points an adopter at paths the scaffold does not ship: "
+        f"{relative_path} points an adopter at paths the scaffold does not ship: "
         + ", ".join(dangling)
         + "\nState the rule without the citation, or ship the file."
     )
+
+
+def test_packs_agents_md_cites_only_paths_it_ships():
+    _assert_cites_only_shipped_paths("packs/AGENTS.md")
+
+
+def test_profiles_agents_md_cites_only_paths_it_ships():
+    _assert_cites_only_shipped_paths("profiles/AGENTS.md")
 
 
 def test_profiles_agents_md_present_and_non_empty():

--- a/profiles/AGENTS.md
+++ b/profiles/AGENTS.md
@@ -10,9 +10,9 @@ is its identifier. Reserved `_` children are authoring assets, not active profil
 
 ## Validation and ownership
 
-[`contracts/profile.schema.json`](../contracts/profile.schema.json) owns fields and
-semantic validation. Profile TOML is the source; profiles are scaffold sources but
-are not projected by `catalogue self-host`.
+`profile.schema.json` owns fields and semantic validation. Read it with
+`agentbundle catalogue contracts show profile.schema.json`. Profile TOML is the
+source; profiles are scaffold sources but are not projected by `catalogue self-host`.
 
 - A pack name appears at most once in a profile.
 - Packs with a declared `conflicts` relationship do not share a profile.
@@ -27,5 +27,4 @@ agentbundle list-profiles <catalogue>
 
 ## Deeper pointers
 
-Start from `profiles/_example/profile.toml`. Synchronize scaffold projections after
-profile-source changes with `tools/catalogue/sync_authoring_scaffold.py`.
+Start from `profiles/_example/profile.toml`.

--- a/tests/roster/test_okf_catalogue_discovery.py
+++ b/tests/roster/test_okf_catalogue_discovery.py
@@ -37,7 +37,7 @@ def _assert_show_schema(response: dict[str, object]) -> None:
 
 def test_release_metadata_moves_together_for_okf_catalogue_discovery() -> None:
     """Public show JSON changes must move repository release surfaces together."""
-    expected = "0.38.5"
+    expected = "0.38.6"
     pyproject = tomllib.loads(
         (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     )

--- a/workspace.toml
+++ b/workspace.toml
@@ -1716,9 +1716,10 @@ open = [
   # reverted it.
   #
   # The gap is real: neither packs/AGENTS.md nor packs/README.md names
-  # contracts/pack.schema.json, while profiles/AGENTS.md:18 names
-  # contracts/profile.schema.json. Independently recorded at
-  # docs/product/research/catalogue-audience-discovery.md:276.
+  # contracts/pack.schema.json. Independently recorded at
+  # docs/product/research/catalogue-audience-discovery.md:276. profiles/AGENTS.md
+  # used to name contracts/profile.schema.json and no longer does — see the
+  # SECOND INSTANCE note below.
   #
   # WHY THE OBVIOUS FIX FAILS. packs/AGENTS.md and packs/README.md are both
   # projected into the authoring scaffold
@@ -1734,10 +1735,15 @@ open = [
   # packs/README.md has NO equivalent assertion, so a pointer added there lands
   # green — and is just as false for the adopter. Do not take the green as licence.
   #
-  # SECOND INSTANCE, found the same way: profiles/AGENTS.md already carries the
-  # dangling form, and no test covers profiles/AGENTS.md (test_scaffold_projection
-  # asserts only that it exists and is non-empty). So the file this entry called the
-  # precedent to mirror is a second occurrence of the same defect, not the pattern.
+  # SECOND INSTANCE — RESOLVED 2026-08-20 by
+  # spec/profiles-agents-adopter-resolvable-citations. profiles/AGENTS.md carried the
+  # dangling form and no test covered it. That file now names profile.schema.json
+  # without a path and routes the reader to
+  # `agentbundle catalogue contracts show profile.schema.json`, which resolves in
+  # both trees; test_profiles_agents_md_cites_only_paths_it_ships now holds it
+  # there. Option (b) below, taken for profiles/ only. packs/README.md is still open,
+  # and the decision for packs/ is still (a)-vs-(b) — profiles/ setting a precedent
+  # does not settle it, because pack.toml offline validation is a different question.
   #
   # Fix requires a decision, which is why this is not mechanical:
   #   (a) ship contracts/pack.schema.json (and profile.schema.json) in the scaffold,
@@ -1749,11 +1755,13 @@ open = [
   #       No such mechanism exists in _SYNC_PAIRS (it is byte-identity), so this is
   #       the most expensive option.
   # Recommend (a) if an adopter is ever expected to validate pack.toml offline,
-  # otherwise (b). Either way, extend the cites-only-paths-it-ships assertion to
-  # profiles/AGENTS.md in the same change, or the second instance survives.
+  # otherwise (b). The cites-only-paths-it-ships assertion now covers
+  # profiles/AGENTS.md, so a regression there fails; a packs/README.md fix still
+  # needs its own assertion, because no test reads that file.
   #
-  # Also still true, and unchanged: packs/AGENTS.md is at exactly 150 lines against
-  # the 150-line subdirectory cap, so any wording change must be net-zero.
+  # The line-budget note this entry used to carry is stale: lint-agents-md.py caps a
+  # scoped AGENTS.md at 80 lines and packs/AGENTS.md is 50, so a wording change no
+  # longer has to be net-zero.
   {slug = "packs-agents-normative-pointer", source = "spec/contracts-readme-governance-sweep AC6"},
 
   # docs-site-design-refresh deferral (spec Assumptions). The SCA half


### PR DESCRIPTION
## What does this change?

`profiles/AGENTS.md` pointed an adopter at `../contracts/profile.schema.json`, a path that
exists in this repository and in no catalogue created by `catalogue init` — that root ships
only `guides/ packs/ profiles/ tests/`. The pointer is replaced by a route that resolves in
both trees, the second dangling citation in the same file is removed, and the guard that
already protected `packs/AGENTS.md` from exactly this now covers `profiles/AGENTS.md` too.

## Why?

- Implements: `docs/specs/profiles-agents-adopter-resolvable-citations/spec.md`
- Accepted-decision implementation, per `docs/CONVENTIONS.md` §3: *"Bug fix, performance
  work, behavior-preserving refactor, or accepted-decision implementation → PR; cite the
  decision."* The decision is recorded in `workspace.toml`'s `packs-agents-normative-pointer`
  entry, which enumerates three options, recommends **(b)** "state the rule without a path in
  both trees… then correct `profiles/AGENTS.md` to match", and adds: *"Either way, extend the
  cites-only-paths-it-ships assertion to `profiles/AGENTS.md` in the same change, or the
  second instance survives."* This PR is that instruction executed.
- Also §3: *"Conventions maintenance that preserves an obligation → PR."* AC5 of
  `docs/specs/contracts-readme-governance-sweep/spec.md` added this pointer so a reader could
  tell which artifact wins. That obligation is unchanged; only its reachability moved. §3's
  *"Evidence only, never sufficient: … public visibility … or a governed-document pathname"*
  is why "it ships to adopters" does not by itself escalate this to an RFC.
- Corroborating: AC9 of `docs/specs/catalogue-wave1-contract-convergence/spec.md` —
  "the `contracts/` directory does not exist in the scaffold".

**Adopters do not need a `contracts/` copy to run their catalogues.** The profile schema
travels inside the wheel: `verify.py` loads it with `_load_bundled_json("profile.schema.json")`
and `commands/profile.py` resolves `_data/profile.schema.json`, whose docstring states the
profile schema "is internal and lives only" there. That copy is byte-identical to
`contracts/profile.schema.json` and is listed in `_data/public-contracts.txt`, so
`agentbundle catalogue contracts show profile.schema.json` prints it. `catalogue init`'s own
"Next steps" already advertises `catalogue contracts list`.

## How do I verify it?

Adopter simulation — the claim end to end:

```bash
agentbundle catalogue init --name demo-cat /tmp/demo
ls /tmp/demo                      # catalogue.toml guides packs profiles tests — no contracts/
sed -n '11,16p' /tmp/demo/profiles/AGENTS.md
cd /tmp/demo
agentbundle catalogue contracts show profile.schema.json   # rc=0, 1147 bytes
agentbundle catalogue verify --root .                      # "catalogue verify: ok"
```

The only rooted path the adopter's file still cites is `profiles/_example/profile.toml`,
which exists in their tree.

Gates:

```bash
make lint-ruff && python3 tools/lint-agents-md.py
python3 tools/catalogue/sync_authoring_scaffold.py --check
python3 tools/lint-catalogue-curation-guard.py --base origin/main
python3 -m pytest packages/agentbundle/tests/integration/test_scaffold_projection.py \
                  tools/test_scaffold_projection.py -q          # 13 passed
PYTHONPATH=packages/agentbundle:packages/credbroker python3 -m pytest tests/roster/ -q
                                                                # 532 passed, 46 subtests
FORCE=1 make build-self && rm -rf dist && make build && make build-check   # SAST leg included
```

Mutation proof for the guard — each form injected alone into the scaffold copy, then restored
by editing and verified byte-identical. `test_packs_agents_md_cites_only_paths_it_ships`
stayed green throughout, which is what proves the two files fail independently:

| Injected citation form | Guard |
|---|---|
| `[...](../contracts/profile.schema.json)` (the original defect) | fails, names it |
| `` `tools/catalogue/sync_authoring_scaffold.py` `` | fails, names it |
| bare rooted path in prose | fails |
| reference-style destination | fails |
| HTML `href` destination | fails |
| path carrying a `#fragment` | fails |
| nested directory citation | fails |

The extractor was also probed against 5 false-positive traps — `profiles/` as prose,
`profiles/<id>.toml`, absolute GitHub URLs, root-only `docs/`, a word-joined path — with zero
false positives.

## What did you not change that you considered?

- **A blanket "no unshipped path in any scaffold Markdown" lint.** Prototyped: it flags twelve
  citations in `guides/_shared/reference/catalogue-authoring-standards.md` that AC9
  deliberately admitted as plain-text contract names. That reverses a ratified decision rather
  than enforcing one, so the guard stops at the two `AGENTS.md` files.
- **Shipping `contracts/` in the scaffold** so the original link resolved. The profile schema
  is package-internal by design and already readable through `catalogue contracts show`; a
  second copy would create a parity surface with nothing keeping it honest.
- **Adding `profiles/AGENTS.local.md`** to re-home the sync command. `AGENTS.local.md` already
  names `profiles/` and that script; a scoped copy would give one load-bearing fact two homes.
- **The same defect in `packs/README.md`.** `workspace.toml` records it as blocked with
  measured reasoning and an open (a)-vs-(b) decision. `profiles/` taking (b) does not settle
  it, because offline `pack.toml` validation is a different question. Left open.
- **Renaming the guard test.** `test_packs_agents_md_cites_only_paths_it_ships` is cited by
  name in `workspace.toml`, so the body was extracted to a helper and the name kept.

## Known pre-existing failure (not from this PR)

`make ci` fails locally at
`tools/test_marketplace_envelope_parity.py::test_resolved_layer_fails_loudly_when_the_package_is_unimportable`.
Reproduced at clean `origin/main` (`14147061`) in a throwaway worktree with an identical
message: a non-editable `agentbundle` in site-packages resolves ahead of the tree under audit.
Already tracked on `main` as `pre-existing-roster-catalogue-index-and-okf-release-metadata`,
which names this exact test — so the duplicate entry this branch had drafted was dropped
during the rebase.

---

## Checklist

- [x] Tests pass locally (`make ci` — one pre-existing failure, documented above)
- [x] Lint and typecheck pass (`make lint-ruff`, `make build-check` incl. SAST)
- [x] Self-review run via an independent reviewer that did not write the code; its one Concern
  (extractor blind spots) was fixed and proven, its one Nit (plan drift) corrected
- [x] Spec and code agree (spec authored in this PR; AC3/AC4 amended to match what shipped)
- [x] Living docs match reality:
  - [x] `docs/product/changelog.md` updated
  - [ ] `guides/` — n/a, no user-facing behaviour, config, or interface changed
  - [ ] `docs/architecture/` — n/a, no structural change
  - [ ] `docs/product/roadmap.md` — n/a
- [x] No new top-level directories
- [x] Conventional commit format, with `Engine-Change-RFC: n/a` for the curation guard
- [x] Learnings captured
