### PR TITLE
feat(tools,web,ci): land the two worktree residuals, and measure Windows lock semantics

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -124,6 +124,42 @@ jobs:
         working-directory: packages/credbroker
         run: python -m pytest
 
+  lock-semantics-windows:
+    name: byte-range lock semantics (windows)
+    # DELIBERATELY NOT in build-check-windows's `needs`. This job MEASURES a
+    # platform behaviour that a deferred design depends on
+    # (workspace.toml [backlog].open, slug worktree-cooperative-lease): whether a
+    # claim lock held after writing a payload is observable by a prober, given that
+    # `msvcrt.locking` locks one byte at the CURRENT FILE POSITION while `flock`
+    # covers the whole open file description. Getting that wrong is not a
+    # degradation -- an invisible lock means every liveness probe reads NOT_LIVE, a
+    # live peer's claim is reclaimed, and `clean --apply` deletes under a live
+    # mutator.
+    #
+    # It reports rather than gates because the design it informs has not landed
+    # yet; wire it into `needs` in the same change that lands the lease, so the
+    # invariant is enforced once something depends on it.
+    runs-on: windows-latest
+    timeout-minutes: 5
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: python -m pip install pytest
+
+      - name: Measure byte-range lock semantics
+        # `-s` so the MEASURED line reaches the log: the measurement is the point,
+        # and a pass alone would not tell us which way the platform answered.
+        run: python -m pytest tools/test_windows_lock_semantics.py -q -s
+
   build-check-windows:
     name: make build-check (windows)
     if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ test:
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
+	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
 	$(PYTHON) -m pytest tools/test_worktree_lifecycle_hooks.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q

--- a/docs/specs/worktree-runtime-hygiene/plan.md
+++ b/docs/specs/worktree-runtime-hygiene/plan.md
@@ -1,6 +1,6 @@
 # Plan: worktree-runtime-hygiene
 
-- **Status:** Executing
+- **Status:** Done
 - **Spec:** [`spec.md`](spec.md)
 
 ## Task 1 — scan and safe clean (this implementation)
@@ -19,6 +19,11 @@
 
 1. Shipped: preview-port override and gate wrapper with a port lease.
 2. Shipped: browser-cache path resolution and selective bootstrap profiles.
+3. Split out: the cooperative worktree lease. It was built to completion and then
+   removed from this spec under review — see `spec.md` AC6's deferral note and
+   `docs/specs/worktree-cooperative-lease/`. What landed here instead are the two
+   residuals that were always independent of it: the normal-exit process-group reap
+   and the preview-port test's cold-transform flake.
 3. Open: add a cooperative worktree lease shared by cleanup and mutating build/test
    entry points to close the remaining check-to-delete concurrency window.
 
@@ -70,3 +75,49 @@ inside import success, shadowing refusal, and the existing protection channels.
    outside, absent, and inconclusive results, as well as existing protected worktrees.
 3. Kept every lifecycle command report-only: none removes a worktree, directory, or
    branch.
+
+## Task 6 — the two residuals (this layer)
+
+**Depends on:** Task 1, Task 2, Task 3, Task 4, Task 5 (all shipped)
+
+Owns AC11 and AC12. Both were documented residuals of earlier rounds and neither
+depends on the cooperative lease, which is why they land while it does not.
+
+Tests: `tools/test_managed_child.py` gets its own Makefile pytest invocation;
+`web/src/test/site-base.test.ts` extends the existing vitest suite. Additions to
+`tools/test_frontend_runtime.py` reuse its existing invocation.
+
+### Measured, so the design is evidence rather than assertion
+
+- `os.getpgid` on an unreaped zombie raises `ProcessLookupError`, 15 of 15, so the
+  group cannot be looked up after the child exits and is captured at spawn instead
+  (20 of 20, equal to the pid).
+- `killpg` on a group whose only member is the caller's own unreaped zombie answers
+  `EPERM` on macOS — 12 of 12 with signal 0, 8 of 8 with `SIGTERM`, 6 of 6 again
+  when re-measured — while it succeeds 4 of 4 with a live grandchild present. A
+  group-drain probe therefore cannot distinguish "empty but for my zombie" from
+  "not my group", so the design omits the probe: signal, grace, escalate, reap.
+  After a successful ownership proof the group is provably ours, so `EPERM` there
+  means no signalable live member, which is success.
+- That measurement is macOS only. On Linux a zombie is a signalable member of its
+  own group, so `killpg` is expected to succeed and the grace to fire on every run;
+  the grace is kept short for that reason and the comment says so rather than
+  claiming it is free.
+- `Popen.send_signal` calls `poll()`, and `poll()` reaps an exited child, after
+  which the ownership proof correctly refuses and signals nothing. Nothing may poll
+  or wait before the reap; a test pins it.
+- vitest: first case 1536 ms and 2247 ms across two runs, later cases 7-52 ms; an
+  instrumented probe put 1817.9 ms in the dynamic import and 0.1 ms in
+  `vi.resetModules()`. With the warm-up hook, first case 9-11 ms. The hook needs an
+  explicit budget because vitest's default hook timeout is 10000 ms and a loaded
+  full-suite run measured that import at ~114 s.
+
+### Tempted and declined
+
+- Landing the cooperative lease with this change. Declined: three independent
+  reviewers found failure modes AC6 does not enumerate, including a Windows
+  byte-range defect in the claim lock that would let `clean --apply` delete under a
+  live mutator. Shipping it behind a criterion that does not describe it would have
+  been worse than shipping nothing.
+- Widening AC6 to cover what was built. Declined: the operator asked for a split, and
+  a criterion amended to match its implementation stops being a contract.

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -1,6 +1,6 @@
 # Spec: worktree-runtime-hygiene
 
-- **Status:** Implementing
+- **Status:** Shipped
 - **Owner:** repository maintainers
 - **Plan:** [`plan.md`](plan.md)
 - **Contract:** none <!-- no REST/event/RPC surface; the `scan --json` shape is a command-output contract held in code and tests, not a published interface -->
@@ -64,11 +64,15 @@ state, and silently skipped tests unrelated to the actual space problem.
   `__pycache__` is a correctness cleanup because stale bytecode can violate CAT-V-014
   during a run.
 
-- [ ] **AC6 — round 2: concurrent operations are explicitly leased.** The second
+- [ ] **AC6 — round 2: concurrent operations are explicitly leased.** (deferred: worktree-cooperative-lease) The second
   implementation task adds a caller-selected preview-port override and a gate wrapper
   that leases it without binding the shared default port. It also adds the cooperative
   worktree lease shared by cleanup and mutating build/test entry points; only that
   shared lease can close the remaining check-to-delete concurrency window completely.
+  The lease was built and then split out under review: three independent reviewers
+  found that it carries more failure modes than this criterion enumerates, including a
+  Windows byte-range defect that would let `clean --apply` delete under a live
+  mutator. It gets its own spec rather than a wider version of this one.
 
 - [x] **AC7 — round 2: bootstrap and browser cache choices remain explicit.** The
   second implementation task adds a browser-cache resolver and selective bootstrap
@@ -122,6 +126,38 @@ state, and silently skipped tests unrelated to the actual space problem.
   is safe. It also honours the existing repeatable `--protect-worktree` and
   `WORKTREE_HYGIENE_PROTECT_WORKTREES` input. No lifecycle command removes a
   worktree, directory, or branch.
+
+- [x] **AC11 — a gate child's process group is reaped on the normal-exit path.**
+  The shared child runner reaps the child's process group after an ordinary exit, not
+  only on its interrupt paths, so a gate command that backgrounds a preview server and
+  exits zero does not leave a descendant of that group holding the leased port after
+  the lease is released. Exactly one implementation of the spawn, forward, reap and
+  escalate sequence exists and both the gate wrapper and any future caller use it.
+
+  Ownership is proved before any group signal on the normal-exit path: the runner
+  waits for the child's exit without reaping it, so the identity it signals cannot
+  have been recycled, and it does not reap until after the final escalation. A process
+  the runner did not spawn is never signalled. The interrupt paths carry a different
+  and equally explicit argument — they signal while the child is still unreaped — and
+  no proof that blocks is ever attempted inside a signal handler: the handler only
+  sends, while escalation and every wait stay in the main flow.
+
+  The group is captured at spawn, while the child is certainly alive, and carried into
+  the reap as a parameter, because it cannot be looked up afterwards. Any outcome other
+  than a completed reap is reported on stderr rather than degrading silently.
+
+- [x] **AC12 — the preview-port unit test pays no cold module transform inside a
+  timed assertion.** `web/src/test/site-base.test.ts` imports its subject once in a
+  warm-up hook carrying an explicit budget sized for a cold transform, so no case pays
+  that cost. The warm-up sets a known-valid `ARR_PREVIEW_PORT` before importing and
+  restores the environment afterwards, because the module throws at load on an invalid
+  value and a hook abort would replace eight readable per-case failures with one
+  unreadable failure. Every case keeps the default per-test budget and no case carries
+  a timeout of its own: widening the budget of an assertion whose real cost does not
+  vary is what hides the defect. What the suite proves is unchanged — `PREVIEW_PORT`
+  stays a module-level constant exercised through `vi.resetModules()` and re-import.
+  The contract is checked mechanically, because a timing assertion cannot be the
+  contract for a flake.
 
 ## Limitations
 

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -38,8 +38,9 @@ from typing import Any, Callable, Iterator, Mapping, Sequence
 # namespace package, which is how tools/test_frontend_runtime.py:16 imports it.
 # Dropping either branch breaks one of those callers at collection time.
 if __package__:
-    from . import worktree_hygiene
+    from . import managed_child, worktree_hygiene
 else:
+    import managed_child
     import worktree_hygiene
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -49,13 +50,12 @@ LEASE_DIRECTORY = "agent-ready-repo-port-leases"
 LEASE_MAX_AGE_SECONDS = 24 * 60 * 60
 LEASE_RETRY_LIMIT = 20
 LEASE_RETRY_DELAY_SECONDS = 0.05
-PROCESS_TREE_EXIT_TIMEOUT_SECONDS = 5.0
+PROCESS_TREE_EXIT_TIMEOUT_SECONDS = managed_child.PROCESS_TREE_EXIT_TIMEOUT_SECONDS
 PLAYWRIGHT_EVIDENCE_MAX_AGE_ENV = "PLAYWRIGHT_FAILURE_EVIDENCE_MAX_AGE_SECONDS"
 SignalHandler = Callable[[int, FrameType | None], Any] | int | None
 
 
-class FrontendRuntimeError(RuntimeError):
-    """An actionable frontend-runtime configuration or execution error."""
+FrontendRuntimeError = managed_child.ManagedChildError
 
 
 def playwright_evidence_max_age(environ: Mapping[str, str]) -> int:
@@ -408,139 +408,11 @@ def _require_npm() -> None:
         )
 
 
-def _spawn_child(
-    command: Sequence[str], env: Mapping[str, str], cwd: Path
-) -> subprocess.Popen[Any]:
-    """Spawn the gate in a process group dedicated to its complete descendant tree."""
-    if os.name == "nt":
-        creation_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-        return subprocess.Popen(
-            tuple(command),
-            cwd=cwd,
-            env=dict(env),
-            creationflags=creation_flags,
-        )
-    return subprocess.Popen(
-        tuple(command),
-        cwd=cwd,
-        env=dict(env),
-        start_new_session=True,
-    )
-
-
-@dataclass(frozen=True)
-class _ProcessTreeSignal:
-    """Information the main flow needs after a handler signals the process tree."""
-
-    process_group: int | None = None
-    taskkill: subprocess.Popen[Any] | None = None
-
-
-def _signal_process_tree(
-    child: subprocess.Popen[Any], signum: int
-) -> _ProcessTreeSignal:
-    """Signal the gate tree without waiting, polling, or sleeping."""
-    if os.name == "nt":
-        try:
-            taskkill = subprocess.Popen(
-                ("taskkill", "/T", "/F", "/PID", str(child.pid)),
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            return _ProcessTreeSignal(taskkill=taskkill)
-        except OSError:
-            pass
-    else:
-        try:
-            process_group = os.getpgid(child.pid)
-            os.killpg(process_group, signum)
-            return _ProcessTreeSignal(process_group=process_group)
-        except ProcessLookupError:
-            return _ProcessTreeSignal()
-        except OSError:
-            pass
-    with contextlib.suppress(OSError):
-        child.send_signal(signum)
-    return _ProcessTreeSignal()
-
-
-def _reap_process_tree(
-    child: subprocess.Popen[Any], tree_signal: _ProcessTreeSignal
-) -> None:
-    """Wait for a signalled tree and escalate from the main flow only."""
-    if tree_signal.taskkill is not None:
-        try:
-            tree_signal.taskkill.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
-        except subprocess.TimeoutExpired:
-            tree_signal.taskkill.kill()
-            tree_signal.taskkill.wait()
-    try:
-        child.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
-    except subprocess.TimeoutExpired:
-        if tree_signal.process_group is not None:
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(tree_signal.process_group, signal.SIGKILL)
-        else:
-            with contextlib.suppress(OSError):
-                child.kill()
-        child.wait()
-
-    if tree_signal.process_group is None:
-        return
-    try:
-        os.killpg(tree_signal.process_group, 0)
-    except ProcessLookupError:
-        return
-    with contextlib.suppress(ProcessLookupError):
-        os.killpg(tree_signal.process_group, signal.SIGKILL)
-
-
-def _run_child(command: Sequence[str], env: Mapping[str, str], cwd: Path) -> int:
-    """Run a gate child, forwarding supported termination signals."""
-    interrupted: list[int] = []
-    tree_signals: list[_ProcessTreeSignal] = []
-    previous_handlers: dict[int, SignalHandler] = {}
-    child: subprocess.Popen[Any] | None = None
-
-    def forward(signum: int, _frame: FrameType | None) -> None:
-        interrupted.append(signum)
-        if child is not None:
-            tree_signals.append(_signal_process_tree(child, signum))
-
-    if threading.current_thread() is threading.main_thread():
-        for name in ("SIGINT", "SIGTERM"):
-            signum = getattr(signal, name, None)
-            if signum is not None:
-                previous_handlers[signum] = signal.getsignal(signum)
-                signal.signal(signum, forward)
-
-    try:
-        if interrupted:
-            return 128 + interrupted[0]
-        try:
-            child = _spawn_child(command, env, cwd)
-        except FileNotFoundError as error:
-            raise FrontendRuntimeError(
-                f"gate executable {command[0]!r} was not found"
-            ) from error
-        if interrupted:
-            if not tree_signals:
-                tree_signals.append(_signal_process_tree(child, interrupted[0]))
-            _reap_process_tree(child, tree_signals[-1])
-            return 128 + interrupted[0]
-        try:
-            returncode = child.wait()
-        except KeyboardInterrupt:
-            tree_signal = _signal_process_tree(child, signal.SIGINT)
-            _reap_process_tree(child, tree_signal)
-            return 130
-        if interrupted:
-            _reap_process_tree(child, tree_signals[-1])
-            return 128 + interrupted[0]
-        return returncode
-    finally:
-        for signum, handler in previous_handlers.items():
-            signal.signal(signum, handler)
+_spawn_child = managed_child.spawn_child
+_ProcessTreeSignal = managed_child.ProcessTreeSignal
+_signal_process_tree = managed_child.signal_process_tree
+_reap_process_tree = managed_child.reap_process_tree
+_run_child = managed_child.run_child
 
 
 @contextlib.contextmanager

--- a/tools/repo/managed_child.py
+++ b/tools/repo/managed_child.py
@@ -6,6 +6,7 @@ import contextlib
 import os
 import signal
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -15,10 +16,21 @@ from types import FrameType
 from typing import Any, Callable, Mapping, Sequence
 
 PROCESS_TREE_EXIT_TIMEOUT_SECONDS = 5.0
-# Paid only when SIGTERM actually reached a live descendant -- the no-descendant
-# case returns before this -- so it costs nothing on a healthy gate run and buys a
-# real chance to flush for the one case this reap exists to clean up.
-PROCESS_TREE_REAP_GRACE_SECONDS = 2.0
+# A best-effort flush window before escalation, NOT a guarantee, and NOT free on
+# every platform.
+#
+# Measured on macOS, 6 runs of 6: with the child exited but deliberately unreaped,
+# `killpg` on its group answers EPERM, so the no-descendant case returns before
+# this sleep and a healthy run pays nothing. That is a macOS observation. On Linux
+# a zombie is a signalable member of its own group under the same uid, so `killpg`
+# is expected to SUCCEED there and this sleep to fire on every wrapped target --
+# which an earlier version of this comment wrongly claimed was impossible. It was
+# not verified on Linux; nothing here should be read as measured on that platform.
+#
+# The budget is therefore kept short. The descendants this reap exists to clean up
+# are servers still holding a leased port, so the trade is a brief flush window
+# against seconds added to every gate run, on a host that has run at load 160.
+PROCESS_TREE_REAP_GRACE_SECONDS = 0.5
 SignalHandler = Callable[[int, FrameType | None], Any] | int | None
 
 
@@ -229,7 +241,21 @@ def run_child(command: Sequence[str], env: Mapping[str, str], cwd: Path) -> int:
             reap_process_tree(child, tree_signals[-1])
             return 128 + interrupted[0]
         try:
-            reap_normal_exit_process_tree(child, process_group)
+            disposition = reap_normal_exit_process_tree(child, process_group)
+            if disposition is not ReapDisposition.REAPED:
+                # AC13 requires the runner to SAY SO rather than degrade silently.
+                # The return value used to be discarded, so every disposition test
+                # asserted an enum the only caller threw away -- and the ordinary
+                # fast-exit path (`query_process_group` returning None once the
+                # child has already gone) produced INCONCLUSIVE with no reap and no
+                # word of it.
+                print(
+                    "WARNING: normal-exit process-group reap did not complete "
+                    f"({disposition.value}); a descendant may still hold resources "
+                    "the child was using",
+                    file=sys.stderr,
+                    flush=True,
+                )
         except KeyboardInterrupt:
             tree_signal = signal_process_tree(child, signal.SIGINT)
             reap_process_tree(child, tree_signal)

--- a/tools/repo/managed_child.py
+++ b/tools/repo/managed_child.py
@@ -1,0 +1,243 @@
+"""Spawn, forward signals to, and reap one managed child process tree."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import FrameType
+from typing import Any, Callable, Mapping, Sequence
+
+PROCESS_TREE_EXIT_TIMEOUT_SECONDS = 5.0
+# Paid only when SIGTERM actually reached a live descendant -- the no-descendant
+# case returns before this -- so it costs nothing on a healthy gate run and buys a
+# real chance to flush for the one case this reap exists to clean up.
+PROCESS_TREE_REAP_GRACE_SECONDS = 2.0
+SignalHandler = Callable[[int, FrameType | None], Any] | int | None
+
+
+class ManagedChildError(RuntimeError):
+    """An actionable error while starting a managed child process."""
+
+
+class ReapDisposition(Enum):
+    """The explicit result of a normal-exit process-group reap attempt."""
+
+    REAPED = "reaped"
+    NOT_OWN_CHILD = "not-own-child"
+    UNAVAILABLE = "unavailable"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True)
+class ProcessTreeSignal:
+    """Information the main flow needs after a handler signals the process tree."""
+
+    process_group: int | None = None
+    taskkill: subprocess.Popen[Any] | None = None
+
+
+def pid_is_alive(pid: int) -> bool:
+    """Return whether a process id still identifies a live process."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def spawn_child(
+    command: Sequence[str], env: Mapping[str, str], cwd: Path
+) -> subprocess.Popen[Any]:
+    """Spawn a child in a dedicated process group for its descendant tree."""
+    if os.name == "nt":
+        creation_flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        return subprocess.Popen(
+            tuple(command), cwd=cwd, env=dict(env), creationflags=creation_flags
+        )
+    return subprocess.Popen(tuple(command), cwd=cwd, env=dict(env), start_new_session=True)
+
+
+def query_process_group(child: subprocess.Popen[Any]) -> int | None:
+    """Query a live child's process group, or return ``None`` if it cannot be.
+
+    This MUST be called while the child is still running. Measured on macOS,
+    15 runs of 15: once a child has exited, `os.getpgid` raises
+    ProcessLookupError even though the pid is still allocated as an unreaped
+    zombie. Querying after exit therefore fails for exactly the fast-exiting
+    child the normal-exit reap exists to clean up after, which is why the group
+    is captured at spawn and carried rather than looked up later.
+
+    Queried immediately after spawn it is reliable: 20 of 20, and equal to the
+    child's pid, as `start_new_session` implies. It is still a query rather than
+    an assumption, because a wrong assumption here would signal a group we never
+    established we own.
+    """
+    try:
+        return os.getpgid(child.pid)
+    except OSError:
+        return None
+
+
+def signal_process_tree(
+    child: subprocess.Popen[Any], signum: int
+) -> ProcessTreeSignal:
+    """Send a signal to the child tree without waiting, polling, or sleeping."""
+    if os.name == "nt":
+        try:
+            taskkill = subprocess.Popen(
+                ("taskkill", "/T", "/F", "/PID", str(child.pid)),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return ProcessTreeSignal(taskkill=taskkill)
+        except OSError:
+            pass
+    else:
+        try:
+            process_group = os.getpgid(child.pid)
+            os.killpg(process_group, signum)
+            return ProcessTreeSignal(process_group=process_group)
+        except ProcessLookupError:
+            return ProcessTreeSignal()
+        except OSError:
+            pass
+    with contextlib.suppress(OSError):
+        child.send_signal(signum)
+    return ProcessTreeSignal()
+
+
+def reap_process_tree(child: subprocess.Popen[Any], tree_signal: ProcessTreeSignal) -> None:
+    """Wait for an interrupted tree and escalate only from the main flow."""
+    if tree_signal.taskkill is not None:
+        try:
+            tree_signal.taskkill.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            tree_signal.taskkill.kill()
+            tree_signal.taskkill.wait()
+    try:
+        child.wait(timeout=PROCESS_TREE_EXIT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        if tree_signal.process_group is not None:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(tree_signal.process_group, signal.SIGKILL)
+        else:
+            with contextlib.suppress(OSError):
+                child.kill()
+        child.wait()
+
+
+def reap_normal_exit_process_tree(
+    child: subprocess.Popen[Any], process_group: int | None
+) -> ReapDisposition:
+    """Reap a normal-exit child group without risking recycled process identities.
+
+    ``process_group`` must have been captured by `query_process_group` while the
+    child was still alive. It is a parameter rather than a lookup so that the
+    ordering requirement is visible in the signature: a group looked up here,
+    after the child has exited, is unobtainable on macOS.
+    """
+    waitid = getattr(os, "waitid", None)
+    wnowait = getattr(os, "WNOWAIT", None)
+    if os.name == "nt" or waitid is None or wnowait is None:
+        child.wait()
+        return ReapDisposition.UNAVAILABLE
+
+    if process_group is None:
+        child.wait()
+        return ReapDisposition.INCONCLUSIVE
+
+    try:
+        waitid(os.P_PID, child.pid, os.WEXITED | wnowait)
+    except ChildProcessError:
+        child.wait()
+        return ReapDisposition.NOT_OWN_CHILD
+
+    # EPERM here is the ORDINARY no-descendant case, not an error and not an
+    # ambiguity. Measured on macOS, 8 runs of 8: with the child exited but
+    # deliberately unreaped, the group's only member is that zombie and
+    # `killpg` answers EPERM; with a live grandchild present it succeeds, 4 of
+    # 4. Reading EPERM as inconclusive therefore reported every clean gate run
+    # as inconclusive.
+    #
+    # It is sound to read it as success ONLY because the ownership proof above
+    # already succeeded: `process_group` came from `os.getpgid` on our own
+    # child, and that child is still unreaped, so the group is definitionally
+    # ours and cannot have been recycled. A descendant that changed user id is
+    # the one case this would misreport; it is named in the spec's Limitations
+    # rather than silently assumed away.
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        child.wait()
+        return ReapDisposition.REAPED
+    except PermissionError:
+        child.wait()
+        return ReapDisposition.REAPED
+
+    time.sleep(PROCESS_TREE_REAP_GRACE_SECONDS)
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(process_group, signal.SIGKILL)
+    child.wait()
+    return ReapDisposition.REAPED
+
+
+def run_child(command: Sequence[str], env: Mapping[str, str], cwd: Path) -> int:
+    """Run a child, forwarding supported termination signals to its process group."""
+    interrupted: list[int] = []
+    tree_signals: list[ProcessTreeSignal] = []
+    previous_handlers: dict[int, SignalHandler] = {}
+    child: subprocess.Popen[Any] | None = None
+
+    def forward(signum: int, _frame: FrameType | None) -> None:
+        interrupted.append(signum)
+        if child is not None:
+            tree_signals.append(signal_process_tree(child, signum))
+
+    if threading.current_thread() is threading.main_thread():
+        for name in ("SIGINT", "SIGTERM"):
+            signum = getattr(signal, name, None)
+            if signum is not None:
+                previous_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, forward)
+
+    try:
+        if interrupted:
+            return 128 + interrupted[0]
+        try:
+            child = spawn_child(command, env, cwd)
+        except FileNotFoundError as error:
+            raise ManagedChildError(f"gate executable {command[0]!r} was not found") from error
+        # Captured here, while the child is certainly alive, and never looked up
+        # again -- see query_process_group for why a later lookup cannot work.
+        process_group = query_process_group(child)
+        if interrupted:
+            if not tree_signals:
+                tree_signals.append(signal_process_tree(child, interrupted[0]))
+            reap_process_tree(child, tree_signals[-1])
+            return 128 + interrupted[0]
+        try:
+            reap_normal_exit_process_tree(child, process_group)
+        except KeyboardInterrupt:
+            tree_signal = signal_process_tree(child, signal.SIGINT)
+            reap_process_tree(child, tree_signal)
+            return 130
+        if interrupted:
+            reap_process_tree(child, tree_signals[-1])
+            return 128 + interrupted[0]
+        return child.wait()
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)

--- a/tools/test_managed_child.py
+++ b/tools/test_managed_child.py
@@ -1,0 +1,410 @@
+"""Construction tests for the shared managed child-process runner."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.repo import frontend_runtime, managed_child
+
+
+@pytest.fixture
+def normal_exit_tree() -> tuple[Path, tuple[str, ...]]:
+    """Provide a child command that leaves one sleeping descendant behind."""
+    root = Path(tempfile.mkdtemp()).resolve()
+    grandchild_pid = root / "grandchild.pid"
+    child_code = (
+        "import subprocess,sys;"
+        "from pathlib import Path;"
+        "grandchild=subprocess.Popen((sys.executable,'-c','import time; time.sleep(30)'));"
+        "Path(sys.argv[1]).write_text(str(grandchild.pid));"
+    )
+    return root, (sys.executable, "-c", child_code, str(grandchild_pid))
+
+
+@pytest.fixture
+def signalable_child(tmp_path: Path) -> subprocess.Popen[str]:
+    """Start one independently addressable child process group."""
+    child = subprocess.Popen(
+        (sys.executable, "-c", "import time; time.sleep(30)"),
+        cwd=tmp_path.resolve(),
+        start_new_session=True,
+        text=True,
+    )
+    yield child
+    if child.poll() is None:
+        child.kill()
+    child.wait()
+
+
+@pytest.fixture
+def group(signalable_child: subprocess.Popen[str]) -> int | None:
+    """The child's process group, captured while it is certainly still alive.
+
+    Fixtures resolve before the test body, and ``signalable_child`` sleeps, so
+    this is the ordering `query_process_group` documents. Capturing inside a body
+    that has already signalled the child would fail.
+    """
+    return managed_child.query_process_group(signalable_child)
+
+
+@pytest.fixture
+def managed_cwd(tmp_path: Path) -> Path:
+    """Return a canonical working directory for fake and real child runs."""
+    return tmp_path.resolve()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_normal_exit_reaps_a_real_grandchild(
+    normal_exit_tree: tuple[Path, tuple[str, ...]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A zero-exit child cannot leave its original process group behind."""
+    root, command = normal_exit_tree
+    monkeypatch.setattr(managed_child, "PROCESS_TREE_REAP_GRACE_SECONDS", 0.01)
+
+    assert managed_child.run_child(command, {}, root) == 0
+
+    grandchild_pid = int((root / "grandchild.pid").read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and managed_child.pid_is_alive(grandchild_pid):
+        time.sleep(0.01)
+    assert not managed_child.pid_is_alive(grandchild_pid)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX waitid is required")
+def test_normal_exit_refuses_an_unowned_group_but_reaps_an_owned_one(
+    signalable_child: subprocess.Popen[str], managed_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ownership refusal is observed through sends, with a positive control."""
+    sends: list[tuple[int, int]] = []
+    original_killpg = os.killpg
+
+    def record_killpg(process_group: int, signum: int) -> None:
+        sends.append((process_group, signum))
+        original_killpg(process_group, signum)
+
+    monkeypatch.setattr(managed_child.os, "killpg", record_killpg)
+    monkeypatch.setattr(managed_child, "PROCESS_TREE_REAP_GRACE_SECONDS", 0.01)
+
+    class NotOurChild:
+        pid = os.getpid()
+
+        def wait(self) -> int:
+            return 0
+
+    try:
+        refusal = managed_child.reap_normal_exit_process_tree(NotOurChild(), os.getpgid(os.getpid()))
+        assert refusal is managed_child.ReapDisposition.NOT_OWN_CHILD
+        assert sends == []
+
+        # Positive control. The child exits on its own and leaves a LIVE
+        # grandchild, so `killpg` genuinely succeeds and a send is observable.
+        #
+        # It must not be signalled with Popen.send_signal to get it to exit:
+        # send_signal calls poll(), poll() REAPS an already-exited child, and a
+        # reaped pid makes os.waitid raise ChildProcessError -- so the ownership
+        # proof would correctly refuse and emit no send. Under load the child
+        # loses that race, which is what made an earlier version of this test
+        # flake. Letting the child exit by itself removes the race entirely.
+        owned = managed_child.spawn_child(
+            (
+                sys.executable,
+                "-c",
+                "import subprocess,sys;"
+                "subprocess.Popen((sys.executable,'-c','import time; time.sleep(30)'));"
+                "raise SystemExit(0)",
+            ),
+            dict(os.environ),
+            managed_cwd,
+        )
+        owned_group = managed_child.query_process_group(owned)
+        assert (
+            managed_child.reap_normal_exit_process_tree(owned, owned_group)
+            is managed_child.ReapDisposition.REAPED
+        )
+        assert owned.returncode == 0
+        assert sends, "positive control observed no send, so the refusal proves nothing"
+    finally:
+        if signalable_child.poll() is None:
+            signalable_child.kill()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_an_already_reaped_child_refuses_rather_than_signalling(
+    managed_cwd: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child reaped before the call cannot be proved ours, so nothing is sent.
+
+    This pins an invariant the production path depends on: nothing may poll or
+    wait on the child before the reap runs. ``Popen.send_signal`` and
+    ``Popen.poll`` both reap an exited child, and a reaped pid can be recycled,
+    so the ownership proof must fail closed rather than signal a group it can no
+    longer prove it owns. A future edit that polls first would otherwise
+    silently disable the reap while every other test stayed green.
+    """
+    sends: list[int] = []
+    monkeypatch.setattr(
+        managed_child.os, "killpg", lambda _group, signum: sends.append(signum)
+    )
+    child = managed_child.spawn_child(
+        (sys.executable, "-c", "raise SystemExit(0)"), dict(os.environ), managed_cwd
+    )
+    assert child.wait() == 0  # reaps it, exactly as a stray poll() would
+
+    disposition = managed_child.reap_normal_exit_process_tree(child, group)
+
+    # Two refusals are reachable and which one fires is not ours to fix. Usually
+    # the pid is gone, so `os.getpgid` fails and the answer is INCONCLUSIVE. If
+    # the pid has already been recycled, `os.getpgid` succeeds against a stranger
+    # and the ownership proof rejects it as NOT_OWN_CHILD. Asserting one of them
+    # specifically made this test fail intermittently for a reason that had
+    # nothing to do with the invariant.
+    #
+    # The invariant is that it fails CLOSED and signals nothing, so that is what
+    # is asserted. `sends == []` is the load-bearing half: a recycled pid must
+    # never receive a signal.
+    assert disposition is not managed_child.ReapDisposition.REAPED
+    assert disposition in {
+        managed_child.ReapDisposition.INCONCLUSIVE,
+        managed_child.ReapDisposition.NOT_OWN_CHILD,
+    }
+    assert sends == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signals are required")
+@pytest.mark.parametrize("signum", (signal.SIGINT, signal.SIGTERM))
+def test_signal_forwarding_reaches_the_child_group(
+    signum: int,
+    signalable_child: subprocess.Popen[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interrupt path sends directly to the queried child process group."""
+    observed: list[tuple[int, int]] = []
+
+    def record_killpg(process_group: int, forwarded: int) -> None:
+        observed.append((process_group, forwarded))
+
+    monkeypatch.setattr(managed_child.os, "killpg", record_killpg)
+
+    result = managed_child.signal_process_tree(signalable_child, signum)
+
+    assert result.process_group == os.getpgid(signalable_child.pid)
+    assert observed == [(result.process_group, signum)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signals are required")
+def test_handler_only_sends_and_main_flow_escalates(
+    signalable_child: subprocess.Popen[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forwarding has no waits; the caller-owned reap performs escalation."""
+    operations: list[str] = []
+
+    original_killpg = os.killpg
+
+    def record_killpg(process_group: int, signum: int) -> None:
+        operations.append(signal.Signals(signum).name)
+        if signum == signal.SIGKILL:
+            original_killpg(process_group, signum)
+
+    monkeypatch.setattr(managed_child.os, "killpg", record_killpg)
+    monkeypatch.setattr(managed_child, "PROCESS_TREE_EXIT_TIMEOUT_SECONDS", 0.01)
+
+    def refuse_wait(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("signal handler must not wait")
+
+    with monkeypatch.context() as handler_scope:
+        handler_scope.setattr(signalable_child, "wait", refuse_wait)
+        signal_result = managed_child.signal_process_tree(
+            signalable_child, signal.SIGTERM
+        )
+    assert operations == ["SIGTERM"]
+    assert managed_child.reap_process_tree(signalable_child, signal_result) is None
+    assert operations == ["SIGTERM", "SIGKILL"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_process_group_is_queried_not_assumed(
+    signalable_child: subprocess.Popen[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A queried group distinct from the pid is the group sent a signal."""
+    observed: list[tuple[int, int]] = []
+    queried_group = 987_654
+
+    monkeypatch.setattr(managed_child.os, "getpgid", lambda _pid: queried_group)
+    monkeypatch.setattr(
+        managed_child.os,
+        "killpg",
+        lambda group, signum: observed.append((group, signum)),
+    )
+
+    assert managed_child.signal_process_tree(signalable_child, signal.SIGTERM).process_group == queried_group
+    assert observed == [(queried_group, signal.SIGTERM)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_reap_uses_the_queried_group_not_the_child_pid(
+    signalable_child: subprocess.Popen[str],
+    group: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reap signals the group it was handed, not the child's own identity.
+
+    Substituting ``child.pid`` internally is invisible to any behavioural
+    assertion on this platform, because ``start_new_session`` makes the two
+    equal. Handing in a group the pid demonstrably is not, and insisting that is
+    what gets signalled, is the only way to falsify the clause.
+    """
+    sends: list[int] = []
+    sentinel_group = 987_654
+    assert group != sentinel_group
+    monkeypatch.setattr(
+        managed_child.os, "killpg", lambda target, _signum: sends.append(target)
+    )
+    signalable_child.send_signal(signal.SIGTERM)
+
+    managed_child.reap_normal_exit_process_tree(signalable_child, sentinel_group)
+
+    assert sends and set(sends) == {sentinel_group}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_permission_error_after_the_proof_is_success_without_escalation(
+    signalable_child: subprocess.Popen[str],
+    group: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EPERM reached after the ownership proof is success, with no escalation.
+
+    The group id came from ``os.getpgid`` on our own child and that child is
+    still unreaped, so the group is provably ours and EPERM means it holds no
+    signalable live member. The original expectation here was INCONCLUSIVE,
+    which execution disproved: the kernel answers EPERM for the ordinary
+    no-descendant case, so every clean gate run reported inconclusive.
+    """
+    sends: list[int] = []
+
+    def deny_killpg(_process_group: int, signum: int) -> None:
+        sends.append(signum)
+        raise PermissionError
+
+    monkeypatch.setattr(managed_child.os, "killpg", deny_killpg)
+    signalable_child.send_signal(signal.SIGTERM)
+
+    assert (
+        managed_child.reap_normal_exit_process_tree(signalable_child, group)
+        is managed_child.ReapDisposition.REAPED
+    )
+    assert sends == [signal.SIGTERM]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_a_real_childless_exit_is_reaped_with_nothing_mocked() -> None:
+    """The ordinary case, against the real kernel rather than a patched killpg.
+
+    This is the case the first implementation got wrong, and it slipped through
+    because every other disposition test patches ``os.killpg``. Nothing is
+    patched here on purpose: a fixture cannot testify about kernel behaviour.
+    """
+    child = managed_child.spawn_child(
+        (sys.executable, "-c", "raise SystemExit(0)"), dict(os.environ), Path.cwd()
+    )
+    child_group = managed_child.query_process_group(child)
+    assert child_group is not None
+
+    assert (
+        managed_child.reap_normal_exit_process_tree(child, child_group)
+        is managed_child.ReapDisposition.REAPED
+    )
+    assert child.returncode == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX waitid is required")
+def test_missing_nonreaping_wait_reports_unavailable_without_a_group_send(
+    signalable_child: subprocess.Popen[str],
+    group: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ownership proof means no normal-exit process-group signal."""
+    sends: list[tuple[int, int]] = []
+    monkeypatch.setattr(managed_child.os, "waitid", None)
+    monkeypatch.setattr(
+        managed_child.os,
+        "killpg",
+        lambda group, signum: sends.append((group, signum)),
+    )
+    signalable_child.send_signal(signal.SIGTERM)
+
+    assert (
+        managed_child.reap_normal_exit_process_tree(signalable_child, group)
+        is managed_child.ReapDisposition.UNAVAILABLE
+    )
+    assert sends == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_unqueryable_group_is_inconclusive_without_a_send(
+    signalable_child: subprocess.Popen[str],
+    group: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A group that could not be identified cannot be safely signalled.
+
+    The capture happens at spawn now, so an unidentifiable group arrives as
+    ``None`` rather than as a raising ``getpgid``. Verify the real capture path
+    also yields ``None`` when the query fails, so this is not merely asserting
+    that ``None`` is handled.
+    """
+    sends: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        managed_child.os,
+        "getpgid",
+        lambda _pid: (_ for _ in ()).throw(OSError("cannot query group")),
+    )
+    assert managed_child.query_process_group(signalable_child) is None
+    monkeypatch.setattr(
+        managed_child.os,
+        "killpg",
+        lambda group, signum: sends.append((group, signum)),
+    )
+    signalable_child.send_signal(signal.SIGTERM)
+
+    assert (
+        managed_child.reap_normal_exit_process_tree(signalable_child, None)
+        is managed_child.ReapDisposition.INCONCLUSIVE
+    )
+    assert sends == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX waitid is required")
+def test_an_empty_owned_group_is_a_silent_success(
+    signalable_child: subprocess.Popen[str],
+    group: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ProcessLookupError represents an already-empty group, not a failure."""
+    signalable_child.send_signal(signal.SIGTERM)
+    monkeypatch.setattr(
+        managed_child.os,
+        "killpg",
+        lambda _group, _signum: (_ for _ in ()).throw(ProcessLookupError),
+    )
+
+    assert (
+        managed_child.reap_normal_exit_process_tree(signalable_child, group)
+        is managed_child.ReapDisposition.REAPED
+    )
+
+
+def test_frontend_runtime_delegates_to_the_single_runner() -> None:
+    """A forwarding wrapper or copied group signal is not an implementation share."""
+    source = Path(frontend_runtime.__file__).read_text(encoding="utf-8")
+
+    assert frontend_runtime._run_child is managed_child.run_child
+    assert "os.killpg" not in source

--- a/tools/test_managed_child.py
+++ b/tools/test_managed_child.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from tools.repo import frontend_runtime, managed_child
+from tools.repo.managed_child import ReapDisposition
 
 
 @pytest.fixture
@@ -400,6 +401,41 @@ def test_an_empty_owned_group_is_a_silent_success(
         managed_child.reap_normal_exit_process_tree(signalable_child, group)
         is managed_child.ReapDisposition.REAPED
     )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups are required")
+def test_a_non_reaped_disposition_is_reported_by_the_runner(
+    managed_cwd: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A degraded reap must be SAID, not swallowed.
+
+    `run_child` discarded the disposition, so every disposition test in this file
+    asserted an enum the only caller threw away -- and the ordinary fast-exit path
+    produced INCONCLUSIVE with no reap and no word of it. AC13 requires the runner
+    to say so, so the report is what this asserts, not the enum.
+    """
+    monkeypatch.setattr(managed_child, "query_process_group", lambda _child: None)
+
+    code = managed_child.run_child(
+        (sys.executable, "-c", "raise SystemExit(4)"), dict(os.environ), managed_cwd
+    )
+
+    assert code == 4, "the child's verdict must survive a degraded reap"
+    captured = capsys.readouterr()
+    assert "normal-exit process-group reap did not complete" in captured.err
+    assert ReapDisposition.INCONCLUSIVE.value in captured.err
+
+
+def test_a_clean_reap_reports_nothing(
+    managed_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The healthy path stays silent, so the warning above means something."""
+    code = managed_child.run_child(
+        (sys.executable, "-c", "raise SystemExit(0)"), dict(os.environ), managed_cwd
+    )
+
+    assert code == 0
+    assert "reap did not complete" not in capsys.readouterr().err
 
 
 def test_frontend_runtime_delegates_to_the_single_runner() -> None:

--- a/tools/test_windows_lock_semantics.py
+++ b/tools/test_windows_lock_semantics.py
@@ -1,0 +1,180 @@
+"""Characterise byte-range advisory locking, so a lease can be designed on fact.
+
+This file exists to answer ONE question that cannot be answered on macOS or Linux:
+does `msvcrt.locking` — which locks a single byte at the CURRENT FILE POSITION —
+let a holder and a prober conflict when the holder locks after writing a payload?
+
+The cooperative worktree lease deferred out of spec/worktree-runtime-hygiene AC6
+uses "is this claim's lock still held?" as its liveness signal. On POSIX `flock`
+locks the whole open file description and position is irrelevant, so the question
+does not arise. On Windows it does, and getting it wrong is not a degradation: if a
+held lock is invisible to a prober, every liveness probe reads NOT_LIVE, a live
+peer's claim is reclaimed, and `clean --apply` deletes under a live mutator — the
+exact failure the lease exists to prevent.
+
+Scope of the claim: these cases measure `windows-latest` in GitHub Actions, which
+is the runner CI uses. They are not a statement about every Windows filesystem;
+network shares in particular may differ, and the POSIX cases here are a control,
+not the subject.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+WINDOWS = os.name == "nt"
+PAYLOAD = b'{"pid": 1234, "token": "abc"}'
+
+
+def _lock_one_byte_here(handle) -> None:
+    """Lock one byte at the handle's CURRENT position (Windows) or the file (POSIX)."""
+    if WINDOWS:
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _probe_is_blocked(path: Path, *, seek_to_zero: bool) -> bool:
+    """Report whether a second handle is refused the lock. Never holds one."""
+    with path.open("r+b") as probe:
+        if seek_to_zero:
+            probe.seek(0)
+        try:
+            _lock_one_byte_here(probe)
+        except OSError:
+            return True
+        # Release immediately: a probe must never retain a lock.
+        if WINDOWS:
+            import msvcrt
+
+            msvcrt.locking(probe.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+        return False
+
+
+@pytest.fixture
+def claim_file() -> Path:
+    """One fresh claim-shaped file per case, canonicalised once."""
+    root = Path(tempfile.mkdtemp(prefix="lock-semantics-")).resolve()
+    return root / "claim.lease"
+
+
+def test_locking_after_a_write_without_seeking_is_the_documented_hazard(
+    claim_file: Path,
+) -> None:
+    """MEASUREMENT, not a requirement: does write-then-lock hide the lock?
+
+    This is the shape the deferred implementation had. It asserts nothing about
+    which answer is correct — it records the answer so the design can stop
+    guessing. On POSIX the lock covers the open file description, so the probe is
+    blocked regardless of position and this reads True.
+    """
+    with claim_file.open("w+b") as holder:
+        holder.write(PAYLOAD)
+        holder.flush()
+        # deliberately NOT seeking: position is now len(PAYLOAD)
+        _lock_one_byte_here(holder)
+        blocked_at_zero = _probe_is_blocked(claim_file, seek_to_zero=True)
+
+    print(
+        f"\nMEASURED [{sys.platform} / os.name={os.name}] "
+        f"write-then-lock, probe at position 0 -> "
+        f"{'blocked (lock visible)' if blocked_at_zero else 'NOT blocked (LOCK INVISIBLE)'}"
+    )
+    if not WINDOWS:
+        assert blocked_at_zero, "POSIX control: flock must be position-independent"
+
+
+@pytest.mark.skipif(not WINDOWS, reason="the hazard is specific to msvcrt byte ranges")
+def test_windows_write_then_lock_hides_the_lock_from_a_probe(claim_file: Path) -> None:
+    """Pin the hazard explicitly on Windows so its removal is a visible change.
+
+    If this ever fails, `msvcrt.locking` stopped being position-relative and the
+    lease's Windows branch can be simplified — which is worth noticing, not
+    silently inheriting.
+    """
+    with claim_file.open("w+b") as holder:
+        holder.write(PAYLOAD)
+        holder.flush()
+        _lock_one_byte_here(holder)
+        assert _probe_is_blocked(claim_file, seek_to_zero=True) is False, (
+            "msvcrt.locking appears position-independent now; revisit the lease's "
+            "Windows branch, which exists only because it is not"
+        )
+
+
+def test_seeking_to_zero_in_both_paths_makes_a_held_lock_observable(
+    claim_file: Path,
+) -> None:
+    """THE INVARIANT ANY LOCK-BASED LIVENESS SCHEME NEEDS, on every platform.
+
+    Both sides lock byte zero, so holder and prober contend for the same range.
+    This is the candidate fix. If it fails on Windows, byte-range locking cannot
+    carry liveness there and the lease must report UNDETERMINABLE on that platform
+    rather than a wrong answer — failing safe toward refusing, never toward
+    deleting.
+    """
+    with claim_file.open("w+b") as holder:
+        holder.write(PAYLOAD)
+        holder.flush()
+        holder.seek(0)
+        _lock_one_byte_here(holder)
+
+        assert _probe_is_blocked(claim_file, seek_to_zero=True) is True, (
+            "a held claim lock was invisible to a prober even with both sides at "
+            "byte zero; byte-range locking cannot carry liveness on this platform"
+        )
+
+
+def test_a_dead_holder_releases_the_lock(claim_file: Path) -> None:
+    """The other half of the scheme: the OS must release on process death.
+
+    Reclaiming a crashed run's claim is the whole reason liveness is a lock rather
+    than a recorded process id, and this host reaps runs under memory pressure.
+    """
+    claim_file.write_bytes(PAYLOAD)
+    holder_source = (
+        "import os, sys\n"
+        f"path = {str(claim_file)!r}\n"
+        "handle = open(path, 'r+b')\n"
+        "handle.seek(0)\n"
+        "if os.name == 'nt':\n"
+        "    import msvcrt; msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)\n"
+        "else:\n"
+        "    import fcntl; fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "print('LOCKED', flush=True)\n"
+        "sys.stdin.read()\n"
+    )
+    holder = subprocess.Popen(
+        [sys.executable, "-c", holder_source],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "LOCKED", "holder failed to start"
+        assert _probe_is_blocked(claim_file, seek_to_zero=True) is True, (
+            "a live holder's lock was not observable"
+        )
+    finally:
+        holder.kill()
+        holder.wait()
+
+    assert _probe_is_blocked(claim_file, seek_to_zero=True) is False, (
+        "the OS did not release a killed holder's lock; a crashed run would wedge "
+        "the lease permanently"
+    )

--- a/web/src/test/site-base.test.ts
+++ b/web/src/test/site-base.test.ts
@@ -60,12 +60,21 @@ describe('warm-up contract', () => {
     expect(source).toMatch(/\}, *[0-9][0-9_]*\);/);
   });
 
+  it('stubs a known-valid port before importing, and restores after', () => {
+    // Deleting the stub failed nothing: the checks below match only the hook's
+    // shape, its import and its budget. `site-base.ts` throws at module load on an
+    // invalid ARR_PREVIEW_PORT, so an ambient value would replace eight readable
+    // per-case failures with one unreadable hook abort.
+    expect(source).toMatch(/beforeAll\([\s\S]*?vi\.stubEnv\('ARR_PREVIEW_PORT', '4321'\)/);
+    expect(source).toMatch(/beforeAll\([\s\S]*?vi\.unstubAllEnvs\(\)/);
+  });
+
   it('leaves every case on the default per-test budget', () => {
     // Any INDENTED `}, <number>);` is a case widening its own budget. The hook's
     // own budget sits at column 0, so requiring leading whitespace distinguishes
     // the two. An earlier version of this pattern demanded four spaces and would
     // have missed a real widening, since the cases close at two.
-    const widened = source.match(/^\s+\},\s*[0-9][0-9_]*\);\s*$/gm) ?? [];
+    const widened = source.match(/^[ \t]+\},[ \t]*[0-9][0-9_]*\);[ \t]*$/gm) ?? [];
     expect(widened).toEqual([]);
   });
 });

--- a/web/src/test/site-base.test.ts
+++ b/web/src/test/site-base.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 async function previewPort(value: string | undefined): Promise<number> {
   vi.resetModules();
@@ -10,9 +12,62 @@ async function previewPort(value: string | undefined): Promise<number> {
   return (await import('./e2e/site-base')).PREVIEW_PORT;
 }
 
+// Warm the module graph once, OUTSIDE any timed test body.
+//
+// The first `await import('./e2e/site-base')` pays the whole cold transform, and
+// under machine contention that has exceeded vitest's 5000 ms default inside the
+// first case -- a flake with nothing to do with what the case asserts. Measured
+// here: first case 1536 ms and 2247 ms across two runs, later cases 7-52 ms; an
+// instrumented probe put 1817.9 ms in the dynamic import and 0.1 ms in
+// `vi.resetModules()`, so the cost is the transform, not the reset. With this
+// hook the first case drops to 9 ms and every case runs 7-13 ms.
+//
+// The hook carries an explicit budget because vitest's default HOOK timeout is
+// 10000 ms and a loaded full-suite run measured this import at ~114 s -- warming
+// without a budget just relocates the same flake from the test to the hook. The
+// asymmetry is deliberate: widen the budget for the transform, whose cost really
+// does vary with load, and leave every assertion on the tight default, because
+// widening an assertion's budget is what hides the defect.
+//
+// A known-valid port is stubbed before importing: `site-base.ts` throws at module
+// load on an invalid `ARR_PREVIEW_PORT`, so an ambient value would turn eight
+// readable per-case failures into one unreadable hook abort.
+beforeAll(async () => {
+  vi.stubEnv('ARR_PREVIEW_PORT', '4321');
+  try {
+    await import('./e2e/site-base');
+  } finally {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  }
+}, 120_000);
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.resetModules();
+});
+
+describe('warm-up contract', () => {
+  // AC14 is checked MECHANICALLY, not by timing. A flake cannot be asserted
+  // against a clock: delete the hook and every case below still passes, just
+  // slowly enough to fail on a loaded runner. So the contract is structural --
+  // the hook exists, it carries an explicit budget, and no case widens its own.
+  const source = readFileSync(new URL(import.meta.url), 'utf8');
+
+  it('warms the module in a hook with an explicit budget', () => {
+    expect(source).toMatch(/beforeAll\(async \(\) => \{/);
+    expect(source).toMatch(/await import\('\.\/e2e\/site-base'\)/);
+    expect(source).toMatch(/\}, *[0-9][0-9_]*\);/);
+  });
+
+  it('leaves every case on the default per-test budget', () => {
+    // Any INDENTED `}, <number>);` is a case widening its own budget. The hook's
+    // own budget sits at column 0, so requiring leading whitespace distinguishes
+    // the two. An earlier version of this pattern demanded four spaces and would
+    // have missed a real widening, since the cases close at two.
+    const widened = source.match(/^\s+\},\s*[0-9][0-9_]*\);\s*$/gm) ?? [];
+    expect(widened).toEqual([]);
+  });
 });
 
 describe('PREVIEW_PORT', () => {

--- a/workspace.toml
+++ b/workspace.toml
@@ -502,6 +502,38 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # The cooperative worktree lease from spec/worktree-runtime-hygiene AC6. It was built
+  # to completion across five layers and then SPLIT OUT under review rather than landed:
+  # three independent reviewers found failure modes AC6 does not enumerate. The two that
+  # decide it needs its own spec rather than a patch:
+  #   - Windows `msvcrt.locking` locks one byte at the CURRENT FILE POSITION. The publish
+  #     path writes the payload then locks (position = payload length) while the probe
+  #     opens at 0 and locks byte 0, so the ranges never overlap, every probe reads
+  #     NOT_LIVE, and `clean --apply` can delete under a live mutator -- the exact failure
+  #     the lease exists to prevent. The `_port_coordination_lock` it replaced handled
+  #     this deliberately (wrote a NUL, seeked to 0); the refactor dropped that.
+  #   - The remedies applied under review each introduced a further defect: an age
+  #     backstop for the admission roles contradicts AC6's "undeterminable counts as
+  #     live", and widening `release-claim` to run-tickets created a path where a removed
+  #     ticket is never re-published, turning a queued run into a 90-minute wait ending in
+  #     a refusal.
+  # Also open: the memory clamp's divisor sits exactly on its calibration point and
+  # SC_PHYS_PAGES reports USABLE pages, so a nominal-32GiB Linux host clamps to 1; the
+  # decision lock's ~1s retry budget is the first thing to exhaust under the contention it
+  # exists to bound, and exhausting it degrades the limiter to a no-op; and the recursive
+  # $(MAKE) through a Python wrapper loses the jobserver, so `make -j` warns and drops to
+  # -j1. The work is preserved on branch eugenelim/worktree-hygience-c-lease-wip.
+  # De-risked before the re-spec: tools/test_windows_lock_semantics.py runs on a
+  # windows-latest job (build-check-windows.yml, lock-semantics-windows) that
+  # REPORTS rather than gates, because nothing depends on it yet. It measures
+  # whether a claim lock held after writing a payload is observable by a prober,
+  # and whether seeking both sides to byte zero makes it observable. Read that job's
+  # log before designing the Windows branch: if the seek-to-zero invariant fails
+  # there, byte-range locking cannot carry liveness on Windows and the lease must
+  # report UNDETERMINABLE on that platform -- failing safe toward refusing, never
+  # toward deleting. Wire the job into build-check-windows's `needs` in the same
+  # change that lands the lease, so the invariant is enforced once relied upon.
+  {slug = "worktree-cooperative-lease", source = "spec/worktree-runtime-hygiene AC6", summary = "Re-spec and land the cooperative worktree lease, admission queue and with-lease wrapper: fix the Windows byte-range claim lock, reconcile the admission-role reclaim policy with AC6, re-publish a lost waiter ticket, recalibrate the memory clamp against usable-page reporting, scale the decision-lock budget with the wait budget, and forward the make jobserver"},
   # RFC-0092 D7 deferred direction. The canonical MCP primitive stays transport-first so
   # a typed acquisition descriptor stays possible; fetch-on-run launchers are already
   # refused at the build boundary, so this is a permit-something RFC, not a restrict one.


### PR DESCRIPTION
Closes **AC11** and **AC12** of `spec/worktree-runtime-hygiene`. AC6's cooperative lease is **deferred, not abandoned** — see below.

## What problem is this solving?

Two documented residuals from earlier rounds, neither of which depended on the cooperative lease:

- **AC11** — `frontend_runtime._run_child` reaped the child's process group on its interrupt paths but not after a normal `wait()`, and the port lease was released as soon as the child returned. A gate command that backgrounds the preview server and exits zero therefore left a descendant holding the port, so a peer could lease a port still bound.
- **AC12** — `web/src/test/site-base.test.ts`'s first case paid the whole cold module transform inside vitest's 5000 ms default and timed out under machine contention, for a reason unrelated to what it asserts.

## How does it work?

**AC11.** One shared child runner in `tools/repo/managed_child.py`; `frontend_runtime` delegates by identity and no group-signalling call remains in it. Ownership is proved before any group signal — `os.waitid(WEXITED|WNOWAIT)` succeeds only for our own child — and the child is not reaped until after the final escalation, so the identity signalled cannot have been recycled. Any outcome other than a completed reap is reported rather than degrading silently.

Three design points were **disproved by execution after passing source review**:

| Measured | Consequence |
|---|---|
| `os.getpgid` on an unreaped zombie → `ProcessLookupError`, 15/15 | The group cannot be looked up after exit; it's captured at spawn (20/20, equal to the pid) and carried in |
| `killpg` on a zombie-only group → `EPERM` on macOS (12/12 sig 0, 8/8 SIGTERM, 6/6 re-measured); succeeds 4/4 with a live grandchild | A drain probe can't distinguish "empty but for my zombie" from "not my group", so the design omits it |
| `Popen.send_signal` calls `poll()`, which reaps | After that the proof correctly refuses — nothing may poll before the reap, and a test pins it |

**AC12.** A warm-up hook imports the subject once with an explicit budget. First case **1536–2247 ms → 9–11 ms**; a probe attributed 1817.9 ms to the dynamic import and 0.1 ms to `vi.resetModules()`. The hook needs its own budget because vitest's default *hook* timeout is 10000 ms and a loaded run measured that import at ~114 s. The contract is checked mechanically, because a timing assertion cannot be the contract for a flake.

**New: Windows lock semantics are measured, not inferred.** A `windows-latest` job (`lock-semantics-windows`) runs `tools/test_windows_lock_semantics.py`. It **reports rather than gates** — deliberately absent from `build-check-windows`'s `needs`, to be wired in by the change that lands the lease. `build-check-windows.yml` is out of scope for `lint-ci-parity`, so no disposition is needed and no released artifact moves.

## What did you not change that you considered?

- **AC6's cooperative lease.** Built to completion across five layers, then split out when three independent reviewers found failure modes the criterion does not enumerate. Decisive: `msvcrt.locking` locks one byte at the **current file position**, the publish path locks after writing a payload while the probe locks at position 0, so the ranges never overlap — on Windows every probe would read `NOT_LIVE`, a live peer's claim would be reclaimed, and `clean --apply` could delete under a live mutator. Registered in `workspace.toml [backlog].open` with the full diagnosis; preserved on `eugenelim/worktree-hygience-c-lease-wip`.
- **A downward-only memory clamp for concurrency**, and the `with-lease` wrapper, admission queue and Makefile wiring — all part of the deferred lease.
- **Reporting stray `__pycache__` under `packs/` from `scan`.** Nearly free, since `scan` already classifies it — but it means touching AC1's pinned JSON key set and `schema_version`.
- **The one pre-existing suite failure.** `test_marketplace_envelope_parity::test_resolved_layer_fails_loudly_when_the_package_is_unimportable` reproduces on clean `main`: a global non-editable `agentbundle` shadows the tree. AC8 is its diagnosis; a per-worktree venv is its fix and is queued separately.
- **`docs/CONVENTIONS.md`'s changelog obligations.** Governed work needing an RFC; a peer has RFC-0094 in flight.

## How do you know it works?

- `pytest tools/ tests/`: **1511 passed, 1 failed** — failure set identical to the pre-existing baseline.
- `lint-ruff`, `bandit`, `lint-nosec-form`, `lint-ci-parity` (118 targets corroborated), `test-lint-ci-parity` (104/104), `assert-sast-chain-reachable`, `test-pages-workflow`, `lint-spec-status` — all clean.
- **Mutation proofs, each verified green-before *and* red-after with a byte-identical restore.** Four review findings fixed before landing, and every one had been invisible in a green suite: `ReapDisposition` was never consumed by its only caller; the reap grace was documented as free but rests on a macOS-only measurement (cut 2.0s → 0.5s, comment now names the platform); AC12's env-stub clause failed nothing when deleted; and the widening detector's `\s+` spanned newlines, so a blank line would have reported a false widening — the false-positive case is verified to stay green, not just the true ones.

No changelog entry: `tools/repo/**` is exempt under the released-artifact trigger, `tools/repo/` sits in `check_release_impact.py`'s `NON_IMPACTING_PREFIXES`, and `b37055ad` is precedent.