### PR TITLE
docs(governance): accept and adopt RFC-0095 — changelog entry obligation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,9 @@ paragraph why this PR doesn't need one.
 - [ ] Self-review run via the relevant reviewer subagent (`adversarial-reviewer` always; `security-reviewer` if security boundary crossed; `quality-engineer` for non-trivial logic / new test surface) — or in-code review for spec-less changes; blockers addressed
 - [ ] Spec and code agree (or spec was updated in this PR)
 - [ ] Living docs match reality:
-  - [ ] `docs/product/changelog.md` updated for any user-visible behavior change
+  - [ ] `docs/product/changelog.md` updated if this bumps a released artifact's
+        version — a pack or a published package (repository tooling that ships in
+        no release needs no entry; see `docs/CONVENTIONS.md` § 5b)
   - [ ] `guides/` updated if user-facing behavior, config, or interfaces changed (right Diátaxis bucket — see [`guides/README.md`](../guides/README.md))
   - [ ] `docs/architecture/` updated if code structure changed materially
   - [ ] `docs/product/roadmap.md` updated if this completes a roadmap item

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -655,8 +655,17 @@ right now?"
   commitments. Reviewed quarterly. Items that haven't moved in two
   consecutive reviews are a drift signal.
 - `changelog.md` — user-visible changes by release, in
-  [Keep a Changelog](https://keepachangelog.com/) format. Updated in the
-  same PR as any user-visible behavior change.
+  [Keep a Changelog](https://keepachangelog.com/) format. One section per
+  release, naming every artifact that release covers:
+  `## [<artifact>][<version>] — YYYY-MM-DD`, where `<artifact>` is a pack or a
+  published package. An entry is required in the same PR that bumps a released
+  artifact's version — you know the version at write time because you are
+  setting it. Repository tooling that ships in no release needs no entry. The
+  heading level is load-bearing: a section carrying a version and a date is
+  released, so it sits at that top level directly beneath `[Unreleased]`, never
+  nested inside it. A published package also keeps its own `CHANGELOG.md`
+  beside its source — `packages/<name>/CHANGELOG.md` in this layout — for
+  readers who get the package and not the repository.
 - `briefs/<slug>.md` (optional) — a received, externally-authored
   multi-feature product brief and its auto-rolled-up coverage map. Created by
   the `receive-brief` skill; one file per brief. See the brief altitude under
@@ -885,8 +894,10 @@ show no remaining references and green tests for bounded dead-code or
 unused-import removal. Tier 3 is hand-made: same-area, same-concern, visibly
 smaller mechanical work. Tier 1 and Tier 2 require their command or evidence.
 
-CI must be green. Specs must match implementation. Public-interface changes
-must be noted in `CHANGELOG.md`.
+CI must be green. Specs must match implementation. A released-artifact version
+bump carries its changelog entry (see *`docs/product/` — for maintainers*); if
+the repository publishes packages separately, each also updates its own
+`CHANGELOG.md`.
 
 ---
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -5,9 +5,18 @@ All notable user-visible changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> Maintenance: this file is updated in the same PR that introduces the
-> change. CI will warn (configurable: block) when a PR touches code that
-> changes user-visible behavior but does not touch this file.
+> Maintenance: see [`CONVENTIONS.md` § 5b](../CONVENTIONS.md) for *when* an
+> entry is owed. This header covers *how* this file is written.
+>
+> **A released section is free-standing, directly beneath `[Unreleased]`.**
+> Write `## [<artifact>][<version>] — YYYY-MM-DD` at the top level, newest
+> first. `[Unreleased]` holds only work that has no version yet: its own
+> `### Added` / `### Changed` / `### Fixed` sections, never a versioned entry
+> nested inside it. The level is load-bearing rather than cosmetic — a
+> versioned entry nested under `[Unreleased]` is invisible to the `/now/`
+> projection permanently, not until some later release step, because nothing
+> ever moves it out. Writing it at the right level is the whole of the
+> obligation.
 >
 > Entries can be drafted from conventional commits: `git log --oneline`
 > filtered to `feat:` and `fix:` since the last tag is a starting point,
@@ -15,14 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [Common Changelog guidance](https://common-changelog.org/) — the audience
 > is humans who use the software, not humans who wrote it.
 >
-> **Highlights (optional, feeds the public `/now/` page).** A release entry may
-> carry one `Highlights` subsection, one heading level below that entry. Its
-> bullets are the outcome-led, user-facing sentences that publish at `/now/`;
-> everything else in the entry stays technical. Three rules govern them:
+> **Highlights (feeds the public `/now/` page).** A release entry carries one
+> `Highlights` subsection, one heading level below that entry, when the release
+> changes what a consumer can do. Its bullets are the outcome-led, user-facing
+> sentences that publish at `/now/`; everything else in the entry stays
+> technical. Judge by the nature of the change, not the semver level: a patch
+> that changes an adopter's obligations earns one, a minor that only moves code
+> does not. A release that changes nothing a consumer acts on carries none — but
+> *none* is a verdict to record with its reason, not a step to skip. For a pack
+> release the decision is part of the release pipeline in
+> `packs/AGENTS.local.md`; nothing downstream makes it, because the projection is
+> a pure parser and no model runs in the build. Three rules govern them:
 >
-> - **Released only.** An entry beneath `[Unreleased]` never publishes, even
->   when it has a date and a `Highlights` block. Move the entry out of
->   `[Unreleased]` at release time and it publishes then — nothing else to do.
+> - **Released only.** An entry nested beneath `[Unreleased]` never publishes,
+>   even when it has a date and a `Highlights` block — see the free-standing
+>   rule above, which is why that case should not arise.
 > - **Reviewed like code.** Write them in the same PR as the implementation,
 >   grounded in that diff and its verification evidence. Ordinary PR review is
 >   the only approval gate; there is no separate editorial process. Drafting
@@ -31,9 +47,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > - **Outcome, not activity.** Describe what someone can now do. Never plans,
 >   queue state, commits, pull requests, or what the team is working on.
 >
-> A released entry with no `Highlights` is perfectly normal — it stays in this
-> changelog and is simply absent from `/now/`.
+> A released entry with no `Highlights` stays in this changelog and is simply
+> absent from `/now/`.
 
+## [core][2.10.4] — 2026-08-20
+
+### Highlights
+
+- **The changelog rule now says who "user-visible" means, so you can tell
+  whether your change needs an entry.** An entry is required when a pull
+  request bumps a released artifact's version — a pack or a published package
+  — and repository tooling that ships in no release needs none. The old wording
+  asked for an entry on "any user-visible behavior change", which read as
+  covering maintainer-only tooling and offered no heading to write it under.
+
+### Changed
+
+- **`CONVENTIONS.md` states one changelog trigger, and the section shape now
+  carries its heading level.** The `docs/product/` layout entry for
+  `changelog.md` gives the shape (`## [<artifact>][<version>] — YYYY-MM-DD`),
+  the released-artifact trigger, the exemption for repository tooling, and the
+  per-package path. The `##` is load-bearing, not cosmetic — see the fix below.
+  Adopted from RFC-0095 D1 and D3.
+- **The two overlapping changelog obligations became two rules scoped by file.**
+  The pull-request checklist previously required public-interface changes to be
+  "noted in `CHANGELOG.md`" — a path that resolves per-package, not at the
+  repository root, and the only reference anywhere in `CONVENTIONS.md` to the
+  per-package changelog tier. It now reads as a released-artifact reminder that
+  also names the published-package duty, phrased so it still holds for a
+  repository that *is* one published package. Adopted from RFC-0095 D2.
+- **The shipped changelog template and the pull-request template now state the
+  same trigger as `CONVENTIONS.md`.** The template's maintenance header asked
+  for an entry when a PR "bumps `pack.toml`" — packs only, with no published
+  packages and no exemption — and the pull-request checklist still carried the
+  old "any user-visible behavior change" wording verbatim. Three documents, three
+  triggers. Adopted from RFC-0095 D1.
+
+- **Deciding whether a pack release earns a `/now/` highlight is now a step in
+  the release pipeline, not something to remember.** `Highlights` is the only
+  content that reaches the public `/now/` page, and by contract no model runs in
+  CI or site generation — so if nobody writes the block while authoring, the
+  release is simply never mentioned publicly. Nothing prompted for it, and 1 of
+  144 entries had one. The pack release pipeline now obliges the call on every
+  pack release: read the diff, answer whether a consumer can now do something
+  new, and either draft the bullets or record the *none* verdict with its reason
+  where a reviewer will see it. The test is the nature of the change, not the
+  semver level. Adopted from RFC-0095 D4.
+
+### Fixed
+
+- **The changelog no longer claims a CI gate that does not exist.** Its
+  maintenance header stated that CI "will warn (configurable: block)" when a
+  pull request changed user-visible behaviour without touching the file. No
+  workflow has ever implemented that. The sentence is removed rather than
+  implemented: `tools/repo/check_release_impact.py` remains the only mechanical
+  check in this area, and it deliberately treats `tools/repo/` and `packs/` as
+  non-impacting. Adopted from RFC-0095 D5.
+- **A release entry nested under `[Unreleased]` can never reach the public
+  `/now/` page, and a new test now stops that happening.** 59 entries carrying
+  real versions and dates are nested there, and the `/now/` projection excludes
+  them by structure — permanently, because it applies no date window and nothing
+  moves an entry out later. A released section is written free-standing at `##`,
+  directly in the released part of the file; `[Unreleased]` holds only work with
+  no version yet. `test_no_new_release_is_nested_under_unreleased` ratchets the
+  count so a new nested release fails the roster suite instead of silently going
+  unpublished. Promoting the existing 59 is separate, registered work — 48
+  genuinely-unreleased bare sections are interleaved with them across three
+  `[Unreleased]` regions, so it needs per-section attribution rather than a
+  level-shift. Adopted from RFC-0095 D3.
 
 ## [Unreleased]
 

--- a/docs/rfc/0095-changelog-entry-obligation.md
+++ b/docs/rfc/0095-changelog-entry-obligation.md
@@ -1,0 +1,403 @@
+# RFC-0095: Changelog entry obligation and the release publication path
+
+- **Status:** Accepted
+- **Author:** eugenelim
+- **Approver:** @eugenelim
+- **Date opened:** 2026-08-20
+- **Date closed:** 2026-08-20
+- **Decision weight:** standard
+- **Related:** RFC-0090 (change sizing — the written-but-nonbinding diagnosis this
+  RFC reuses); `docs/CONVENTIONS.md`; `packs/core/seeds/docs/CONVENTIONS.md`;
+  `docs/product/changelog.md`; `packs/core/seeds/docs/product/changelog.md`;
+  `.github/pull_request_template.md`; `tools/repo/check_release_impact.py`;
+  `docs/specs/site-now-surface/spec.md`
+
+## Reviewer brief
+
+| Item | Summary |
+| --- | --- |
+| Decision | An entry is owed when a PR bumps a released artifact's version — not when a maintainer can see a difference; and a section carrying a version and a date is released, so it is written free-standing, never nested under `[Unreleased]`. |
+| Recommended outcome | Accept. Align the conventions to wording this repository already ships to adopters, and delete one asserted CI gate that does not exist. |
+| Change if accepted | Edit the core conventions seed and regenerate its projection; align the seed changelog and the PR template to the same trigger; correct the live changelog's maintenance header; give the pack release pipeline the `Highlights` decision; add a ratchet test enforcing D3; release core 2.10.4. |
+| Affected surface | `docs/CONVENTIONS.md` (generated projection) and its canonical seed; `packs/core/seeds/docs/product/changelog.md` (ships to adopters); `.github/pull_request_template.md` (repo-only); `docs/product/changelog.md` (live file, not a projection); `tests/roster/test_workspace_status_projection.py` (a widened correspondence check plus a new D3 ratchet); the generated `web/src/lib/now-highlights.generated.json`; `workspace.toml` (one backlog entry); `packs/AGENTS.local.md` (maintainer-only, unexported — the pack release pipeline); core's four version sites. |
+| Stakes | Reversible. Wording, one deletion, and one new test; no new script, workflow, or CI gate. |
+| Review focus | Whether the released-artifact test is the right trigger; whether the per-package tier deserves its own sentence; and whether the D3 ratchet is the right enforcement given the migration is deferred. |
+| Not in scope | Building the CI gate the changelog currently claims; retro-adding entries to past PRs; promoting the 59 already-nested entries (registered follow-on); any other `CONVENTIONS.md` section. |
+
+## The ask
+
+**Accept the released-artifact test as the single trigger for a changelog entry,
+and stop nesting released entries inside `[Unreleased]`.** Five decisions
+follow. None adds a script, workflow, or CI gate; one adds a test.
+
+Why now: the repository's own conventions carry the vague form of a rule that
+the copy it *ships to adopters* already states more precisely. A peer session
+correctly flagged a missing changelog entry for PR #1068 by reading the
+conventions literally — the reading was sound and the conclusion was wrong,
+which means the text is wrong. Separately, the public `/now/` page has been
+showing a single four-day-stale release, and the cause is measurable.
+
+| ID | Question | Recommendation | Why | Decide by | Reviewer action |
+| --- | --- | --- | --- | --- | --- |
+| D1 | What triggers a changelog entry? | An entry is required in the PR that bumps a released artifact's version — a pack, or a published package. Repository tooling that ships in no release is exempt. | Mechanically checkable, satisfied by all 144 existing entries, and close to the seed's own wording. "User-visible" never says visible to whom. | RFC acceptance | Approve the trigger and the exemption. |
+| D2 | One obligation or two? | Two, split by file rather than by scoping phrase: every released artifact gets an entry in `docs/product/changelog.md`; a published package *additionally* updates its own `CHANGELOG.md`. | The second tier is real — 10 of the last 10 package-changelog commits also touched the aggregate — and `CONVENTIONS.md` referenced it in exactly one place, ambiguously. | RFC acceptance | Approve two precisely-scoped rules replacing two overlapping ones. |
+| D3 | Does a released entry belong under `[Unreleased]`? | No. A section carrying a version *and* a date is released by definition and is written free-standing at `##`. `[Unreleased]` holds only work with no version yet. | 59 entries are currently nested there and can never publish. This is less work per PR, not more. | RFC acceptance | Approve the structural rule and its ratchet; the one-time promotion is follow-on. |
+| D4 | Is a `Highlights` block obliged, and who decides? | Obliged when the release changes what a consumer can do — judged by nature, not by semver level. The decision belongs to the pack release pipeline in `packs/AGENTS.local.md`, which now requires it on every pack release; a recorded *none* with its reason is a valid answer. | `Highlights` is the only content source for `/now/`, no model runs in the build, and nothing prompted for one — so 1 of 144 entries has one. An obligation with no owner is the failure this RFC diagnoses. | RFC acceptance | Approve the obligation, its owner, and the recorded-*none* escape hatch. |
+| D5 | Should the changelog keep asserting a CI gate? | No. Delete the sentence. Do not build the gate. | No such gate exists in `.github/workflows/`. A document asserting absent CI behaviour teaches readers to distrust it, and building it would impose per-PR ceremony nobody asked for. | Settled before drafting | Confirm deletion over implementation. |
+
+## Problem & goals
+
+Four findings sit in three documents. They share one shape: an obligation is
+written down, nothing binds it, and readers either over-comply or ignore it.
+RFC-0090 named this pattern in the same document while sizing changes — "the
+exact written-but-nonbinding failure this RFC diagnoses" (RFC-0090, D2). This is
+the same disease in four more corners.
+
+**1. "User-visible" never says visible to whom.** `docs/CONVENTIONS.md` required
+`changelog.md` to be "Updated in the same PR as any user-visible behavior
+change." Read literally, that binds far more than intended. PR #1068 added four
+CLI subcommands to `tools/repo/worktree_hygiene.py` and bumped its `scan --json`
+`SCHEMA_VERSION` from 1 to 2; anyone running `make worktree-doctor` sees
+different output, so a peer flagged the missing entry. The reading was correct.
+The operative rule — visible to a *consumer of a release*, not to a maintainer
+running repository tooling — was never stated. Worse, a literal reader has no
+heading to write under, and is pushed toward inventing a `[repo]` or `[tools]`
+section that has never existed on the shipped history.
+
+**2. A second obligation, scoped differently, naming a bare path.** The same
+document also said "Public-interface changes must be noted in `CHANGELOG.md`."
+There is no root `CHANGELOG.md`. The path is not meaningless, though: it
+resolves per-package, at `packages/agentbundle/CHANGELOG.md` (1,743 lines) and
+`packages/credbroker/CHANGELOG.md` (143 lines). That tier is real and
+consistently maintained, and this sentence was the *only* reference to it
+anywhere in `CONVENTIONS.md`. So the defect is not a typo to correct but two
+overlapping rules with two scoping phrases, one of which under-specifies a
+genuine second obligation.
+
+**3. The changelog asserted a CI gate that does not exist.** Its header claimed
+"CI will warn (configurable: block) when a PR touches code that changes
+user-visible behavior but does not touch this file." No workflow implements
+this. `pages.yml` references the file only as a path trigger and for
+release-anchor correspondence. The nearest mechanism,
+`tools/repo/check_release_impact.py`, fires only when a release-impacting path
+changes and then accepts an entry **or** a version bump **or** a no-release
+declaration — and `tools/repo/` is on its explicit `NON_IMPACTING_PREFIXES`
+list, as is `packs/`.
+
+**4. Released entries are nested where they can never publish.** This surfaced
+while verifying the above and is the most consequential finding. The `/now/`
+machinery is sound — running `project_now_highlights` against the live file
+returns a correct projection. The failure is authoring, in two compounding
+layers:
+
+- **59 versioned entries are nested under a `## [Unreleased]` heading.** Each
+  carries a real version and a real date, and their versions are already live in
+  `pack.toml` — `[core][2.10.2]` among them. The projection excludes them by
+  enclosing structure. Critically, this is a **permanent** loss, not a dated
+  one: `docs/specs/site-now-surface/spec.md` is explicit that "the projection
+  applies no date window at all", and `launch_window` in `tools/build-site.py`
+  is called only from tests, never by the generator. So a nested entry does not
+  age out of `/now/` — it never appears, and nothing will ever move it out. The
+  changelog's own header described a promotion step ("Move the entry out of
+  `[Unreleased]` at release time") that no one performs and no gate checks.
+- **`Highlights` is carried by 1 of 144 entries** (0.7%). It is the projection's
+  only content source, so `/now/` currently renders exactly one release —
+  `[governance-extras][0.9.7]`, dated 2026-08-16 — and has done since.
+
+The "two heading eras" that make this file hazardous to append to are not a
+historical accident: they *are* this finding. 85 entries are free-standing `##`
+and publishable; 59 are nested and are not. The seed prescribes the
+free-standing form and always has, so this is drift in the self-hosted copy
+rather than an open question about which form is right.
+
+**Goals.** State one trigger for an entry, in one place, that a contributor can
+apply without judgement and a reviewer can check. Keep the wording correct for
+adopters as well as for this repository, since the seed ships. Make D3 bind
+mechanically rather than adding a fifth unenforced rule.
+
+**Non-goals.** Building the promised CI gate (D5 rejects it deliberately, not
+for lack of time). Requiring narrative prose on every patch release. Revisiting
+the `/now/` projection's contract, which is `spec/site-now-surface`'s decision
+and is working as specified. Changing `check_release_impact.py`, which is
+correct for what it guards.
+
+## Proposal
+
+### D1 — the released-artifact test
+
+`docs/CONVENTIONS.md` § 5b replaces the "any user-visible behavior change"
+clause with the released-artifact test. An entry is owed when the PR bumps a
+released artifact's version; the artifact set is *every pack* plus the two
+published packages. Repository tooling that ships in no release — `tools/`, CI
+workflows, the `Makefile` — is exempt, and the exemption is stated rather than
+left to inference.
+
+`contracts` is a pack (`packs/contracts/` exists and has shipped a
+`## [contracts]` entry), so the non-pack members of the artifact set are
+`agentbundle` and `credbroker` and no others.
+
+Two existing headings release several artifacts at once — `[core][2.7.4] and
+[architect][0.14.5]`, and `[atlassian][0.8.4], [linear][0.2.3],
+[github][0.1.4]` — and `tools/build-site.py`'s parser handles that form
+deliberately. The wording is therefore "one section per release, naming every
+artifact that release covers", not one section per artifact.
+
+The same trigger is written into `.github/pull_request_template.md`, which
+carried the old "any user-visible behavior change" phrasing verbatim. Leaving it
+would have reproduced PR #1068's misfire from the highest-traffic surface in the
+repository while `CONVENTIONS.md` said something else.
+
+### D2 — two tiers, split by file
+
+The § 5b bullet owns the aggregate obligation, the section shape *including its
+heading level*, and the per-package path. The PR-hygiene sentence keeps a short,
+actionable reminder, cross-references § 5b, and states the package duty
+conditionally so it reads correctly for an adopter whose repository *is* a single
+published package:
+
+> CI must be green. Specs must match implementation. A released-artifact version
+> bump carries its changelog entry (see *`docs/product/` — for maintainers*); if
+> the repository publishes packages separately, each also updates its own
+> `CHANGELOG.md`.
+
+### D3 — released sections are free-standing, and a ratchet enforces it
+
+§ 5b and both changelog headers state the rule with the heading level made
+explicit — `## [<artifact>][<version>] — YYYY-MM-DD` — because the level is the
+whole defect. An earlier draft of this RFC stated the shape *without* the `##`
+marker, which would have shipped adopters the corrected instruction minus the
+one token that matters.
+
+D3 is not left as prose. `tests/roster/test_workspace_status_projection.py` gains
+`test_no_new_release_is_nested_under_unreleased`, a **ratchet** pinned at the
+current 59. A new release written as `### [artifact][version]` under
+`[Unreleased]` takes the count to 60 and fails, with a message naming the fix.
+The count may only ever decrease. Both directions were mutation-checked: adding
+a nested release fails it, rewriting this RFC's own entry as nested fails it, and
+the unmodified tree passes.
+
+The neighbouring correspondence check (`_product_release_heading_version`)
+deliberately accepts either heading level. A `##`-only match cannot work yet
+because some artifacts' *current* release is itself nested — `agentbundle`
+0.38.5 is, so a strict match reads a stale free-standing 0.30.1. Version
+correspondence and D3 compliance are therefore checked by two assertions rather
+than conflated into one.
+
+**The one-time promotion of the 59 nested entries is deliberately follow-on
+work, not part of this PR**, and is registered in `workspace.toml
+[backlog].open` as `changelog-promote-marooned-entries` with `source = "rfc/0095
+D3"`. It was scoped as a Tier 1 reproducible sweep under RFC-0090's bundled-fix
+rule and then measured, and it does not qualify. `[Unreleased]` holds two
+different things, interleaved: versioned entries that are nested, and bare
+`### Added` / `### Fixed` / `### Changed` / `### Removed` sections that are
+genuinely unreleased and correctly placed. There are **48** of the latter,
+spread across **three** separate `## [Unreleased]` regions (12, 5 and 31). They
+sit at the same heading level as the entries, so a uniform level-shift would
+graft them onto whichever versioned entry precedes them — a bare `### Fixed`
+describing `agentbundle pack evals run` sits directly below the
+`[atlassian][0.9.0]` entry, and promoting mechanically would republish an
+agentbundle fix under atlassian's heading.
+
+Separating the two needs per-section judgement about which artifact each
+orphaned block belongs to, and re-ordering rather than re-levelling. That is a
+data migration with its own verification burden, in a 4,500-line file. It gets
+its own change, where a botched promotion cannot take the wording decisions down
+with it. That work also restores Keep a Changelog ordering, with `[Unreleased]`
+first; until it lands, this release's entry sits above `[Unreleased]` so that it
+is the newest `core` heading the correspondence check finds.
+
+### D4 — `Highlights` obligation
+
+An entry carries a `Highlights` subsection when the release changes what a
+consumer can do. The test is the *nature* of the change, not its semver level: a
+patch that changes an adopter's obligations earns one, and a minor that only
+moves code does not. An earlier draft of this decision said "an internal,
+mechanical, or patch release carries none", which conflated those two axes and
+would have told the next author to skip a consumer-facing patch.
+
+**The decision has an owner, because an unowned obligation is this RFC's own
+diagnosis.** `packs/AGENTS.local.md` — the maintainer-only instruction surface
+that any agent editing under `packs/` reads, and which already owned the pack
+release pipeline — gains the step. On every pack release the agent reads the
+diff and its verification evidence, answers whether a consumer of the pack can
+now do something new, and either drafts the outcome-led bullets or records the
+*none* verdict and its reason in the PR's *What did you not change that you
+considered?* answer. A silent omission is no longer an available outcome.
+
+That placement is deliberate on two counts. It does not touch `work-loop`:
+pack-release concerns do not belong in core's generic repository-change loop,
+which ships to adopters who release no packs. And `packs/AGENTS.local.md` is
+maintainer-only and unexported, so this mechanism carries no adopter-facing
+contract change and no pack version bump.
+
+The decision stays at authoring time, never in the build.
+`docs/specs/site-now-surface/spec.md` is Shipped with a checked criterion that
+"no model or nondeterministic editorial operation runs in CI, release
+automation, or site generation", and the adjacent criterion explicitly permits
+"AI-assisted drafting from the implementation diff and verification evidence"
+under ordinary PR review. So the agent that wrote the diff decides — which is
+also the only party that knows — and `/now/` stays a pure function of the file's
+bytes.
+
+### D5 — delete the asserted gate
+
+The sentence is deleted from `docs/product/changelog.md`. Nothing replaces it.
+`check_release_impact.py` remains the only mechanical enforcement of release
+impact, and the header no longer describes CI behaviour at all.
+
+### Where this lands
+
+The false sentence existed **only** in this repository's live
+`docs/product/changelog.md` — zero occurrences in the seed at
+`packs/core/seeds/docs/product/changelog.md`, which is a 65-line starter template
+and a different file with a different hash. So D5 needs no seed edit and has no
+adopter impact.
+
+D1, D2 and D3 are the opposite: `docs/CONVENTIONS.md` is a generated projection,
+byte-identical to its seed. The seed is edited and the projection regenerated; a
+direct edit to the projection would be reverted by the next `make build-self`.
+The seed changelog's own maintenance header is corrected in the same pass,
+because its trigger disagreed with § 5b — it said "bumps `pack.toml`", covering
+packs only, with no published packages and no exemption clause. Shipping two
+adopter-facing documents with two different triggers is the defect this RFC
+exists to remove.
+
+Because the seed ships to adopters, D1–D3 are an adopter-facing contract change,
+which under D1's own rule obliges a `[core]` entry and a version bump. Core is
+`2.10.3` on `main` (RFC-0094 released it), so this takes **2.10.4** across all
+four places that hold it: `packs/core/pack.toml`,
+`packs/core/.claude-plugin/plugin.json`, and two assertions in
+`tests/roster/test_security_checklists_okf_projection.py`. The fix is
+self-obligating, which is a useful proof that the rule works.
+
+## Options considered
+
+Only D1 and D2 had genuinely contested option spaces; D3, D4 and D5 each had a
+dominant answer recorded in the table above.
+
+**D1 — axis: what scope of change obliges an entry.**
+
+| Option | Trade-off |
+| --- | --- |
+| Do nothing — keep "any user-visible behavior change" | Zero cost, but it has already misfired once, over-binds on a literal read, and leaves a literal reader with no heading to write under. |
+| **Released-artifact test (recommended)** | Mechanically checkable; satisfied by all 144 existing entries. Cost: says nothing about a maintainer-visible change, which is the intent. |
+| "Consumer-visible behaviour" prose test | Narrower than before, but still a judgement call with no check and no stated exemption — it restates the ambiguity in better words. |
+
+**D2 — axis: how many rules survive.**
+
+| Option | Trade-off |
+| --- | --- |
+| Keep both, fix the path to `docs/product/changelog.md` | Cheapest edit, but leaves two rules with two scoping phrases — the defect itself. |
+| Delete the clause as a duplicate | Smallest surface, but erases the only written reference to the per-package tier, which 10 of 10 recent package commits observe. Rejected once the tier was confirmed real. |
+| **Two tiers, split by file (recommended)** | Two sentences to keep in sync, but each states one thing about one file, and the actionable reminder stays in the PR checklist where it is what people forget. |
+
+## Risks & what would make this wrong
+
+**The released-artifact test could under-bind.** A change that alters
+maintainer-facing tooling behaviour now provably needs no entry. That is the
+intent, and `git log` remains the record for tooling changes — but if this
+repository later ships `tools/` to anyone, the test silently stops matching the
+artifact set. The mitigation is that the trigger is phrased against *released
+artifacts* rather than against a path list, so it follows the artifact set
+rather than needing an edit.
+
+**D4 still rests on a judgement, and now names who makes it.** "Changes what a
+consumer can do" is not mechanically decidable, so the pipeline step obliges the
+call and its recording rather than guaranteeing the answer. If the judgement
+drifts permissive, `/now/` fills with internal noise; if it drifts strict, the
+page stays near-empty. What changed is that a *silent* omission is no longer
+available: a *none* verdict has to be written down with its reason, which makes
+the drift visible in review instead of invisible in an empty page. There is
+deliberately no gate, for the same reason D5 declines to build one — and a gate
+is impossible here anyway without a model in CI, which a Shipped spec forbids.
+
+This RFC's own release is the first exercise of that step, and it is a fair test
+because the release is *only* prose: core 2.10.4 ships two edits, to § 5b and to
+the shipped changelog template's maintenance header. Running the question against
+the diff — can a consumer of the pack now do something they could not? — the
+answer is yes: an adopter now has a decidable rule for when an entry is owed,
+where before they had "any user-visible behavior change" and no heading to write
+under. Core's product *is* its prose, so a prose change is a product change. A
+reviewer who reads that as noise should say so, because it sets the precedent.
+
+**The trigger touches four shipped documents.** § 5b, the seed changelog header,
+the live changelog header and the PR template all speak to it. This RFC reduces
+that to one statement of *when* an entry is owed (§ 5b) plus file-format rules
+elsewhere, and the live header now cross-references § 5b rather than restating
+the trigger. The seed changelog necessarily repeats the shape, so that pair must
+move together.
+
+**D3 leaves 59 entries unpublished until the migration lands.** Accepting the
+rule does not refill `/now/`. That is a deliberate trade: the promotion needs
+semantic judgement rather than a level-shift, and shipping it half-verified
+alongside a wording change would risk republishing entries under the wrong
+artifact. The ratchet stops the backlog growing in the meantime, and the
+follow-on is registered rather than assumed.
+
+**What would make D3 wrong:** if `[Unreleased]` were genuinely being used as a
+staging area — entries written at merge time and promoted in a later release
+commit — then the rule pre-empts a real workflow. The evidence says otherwise:
+the nested entries carry final versions and dates, their versions are already
+live in `pack.toml`, and no promotion commit exists in the file's history.
+
+## Evidence & prior art
+
+- `packs/core/seeds/docs/product/changelog.md` — supplies the section *shape*
+  (`## [pack-name][version] — YYYY-MM-DD`, free-standing) and the write-time
+  rationale ("You know the version at write time because you are setting it"),
+  which D1 adopts. Its *trigger* was narrower than D1's — a `pack.toml` bump,
+  with no published packages and no exemption — so D1's artifact set and
+  exemption are new here, not merely restated. The seed carries no
+  `[Unreleased]` section at all, so it gives adopters nothing to drift from.
+- `docs/product/changelog.md` — 144 dated release entries; every
+  heading names a pack or one of `agentbundle`/`credbroker`. 85 free-standing,
+  59 nested under `[Unreleased]`. 1 carries `Highlights`.
+- `docs/specs/site-now-surface/spec.md` — "The projection applies no date window
+  at all… A reader expecting a seven-day filter in the projection will not find
+  one, and should not add one." `NOW_WINDOW_DAYS`/`launch_window` in
+  `tools/build-site.py` are referenced only by `tools/test_build_site_routing.py`,
+  and `web/src/pages/now/index.astro` renders the projection unfiltered. A nested
+  entry therefore never publishes, rather than ageing out.
+- `b37055ad` (3,789 insertions, the same worktree-hygiene tool), `fe26b042`
+  (tools + docs-site) and `f9ddf0f6`/PR #1068 (`SCHEMA_VERSION` 1→2, four new
+  subcommands) each shipped maintainer-visible tooling change with **no**
+  changelog entry. Precedent is unambiguous.
+- No `[repo]` or `[tools]` heading has ever existed on the shipped history. Three
+  `[repo]` sections were authored once, in `a66a8878d`, which is not an ancestor
+  of `HEAD` and is contained by no branch — the heading was tried and never
+  landed.
+- `tools/repo/check_release_impact.py` — `tools/repo/` and `packs/` are both on
+  `NON_IMPACTING_PREFIXES`; the gate accepts an entry **or** a version bump **or**
+  a no-release declaration, and its docstring describes its trigger paths as "a
+  public interface change", the same phrase as the defective sentence.
+- `.github/workflows/` — no workflow implements the asserted user-visible-behaviour
+  gate.
+- RFC-0090, D2 — the "written-but-nonbinding" framing this RFC reuses.
+- `4c1a776e` (RFC-0091) — precedent for landing an RFC, the conventions edit, the
+  seed edit and version bumps in a single accepted commit.
+
+## Open questions
+
+None. All five decisions are recommended and settled; D5 was settled before
+drafting.
+
+## Follow-on artifacts
+
+- **Convention edit (this PR).** `packs/core/seeds/docs/CONVENTIONS.md` § 5b and
+  the PR-hygiene sentence, with `docs/CONVENTIONS.md` regenerated; the seed
+  changelog header aligned to the same trigger; `.github/pull_request_template.md`
+  updated.
+- **Changelog correction (this PR).** Delete the asserted CI gate, replace the
+  restated trigger with a cross-reference, and state the free-standing rule.
+- **Enforcement (this PR).** The D3 ratchet in
+  `tests/roster/test_workspace_status_projection.py`, and the D4 `Highlights`
+  decision step in `packs/AGENTS.local.md`'s release pipeline.
+- **Migration (follow-on, registered).** `changelog-promote-marooned-entries` in
+  `workspace.toml [backlog].open` — promote the 59 nested entries, separate them
+  from the 48 interleaved bare sections across three `[Unreleased]` regions,
+  lower the ratchet baseline as they land, and restore `[Unreleased]`-first
+  ordering.
+- **Release (this PR).** Core `2.10.4` across its four version sites, with the
+  self-obligating `[core]` entry.
+- No ADR: this records a conventions wording decision, not an architectural one.
+- No spec: no new behaviour, script, or workflow is introduced.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -96,6 +96,7 @@
 | [0094](0094-direct-light-execution-without-durable-planning-artifacts.md) | Direct-light execution without durable planning artifacts | Accepted | 2026-08-20 | 2026-08-20 |
 | [0092](0092-first-class-distribution-routes.md) | First-class distribution routes — portable Agent Plugins, native Claude/Codex packages, and Kiro Powers from one pack model | Accepted | 2026-08-19 | 2026-08-20 |
 | [0093](0093-intent-scoped-completion.md) | Intent-scoped completion | Accepted | 2026-08-19 | 2026-08-20 |
+| [0095](0095-changelog-entry-obligation.md) | Changelog entry obligation and the release publication path | Accepted | 2026-08-20 | 2026-08-20 |
 
 ## Adding a new RFC
 

--- a/packs/AGENTS.local.md
+++ b/packs/AGENTS.local.md
@@ -27,7 +27,19 @@ For a non-engine change, the trailer accepts `n/a — <reason>`; never invent an
 
 1. Bump matching pack and plugin versions; see [Version bump rule](AGENTS.md#version-bump-rule).
 2. Run `FORCE=1 make build-self` to regenerate `marketplace.json`.
-3. Add the pack release entry to `docs/product/changelog.md`.
+3. Add the pack release entry to `docs/product/changelog.md`, free-standing at
+   `##` — never nested under `[Unreleased]`, where it could never publish.
+4. Decide the entry's `Highlights` disposition in the same step; do not leave it
+   to a human to remember. Read the release diff and its verification evidence
+   and answer one question: **does this change what a consumer of the pack can
+   do?** If yes, draft the outcome-led bullets under a `### Highlights`
+   subsection — those are what publish at `/now/`. If no, record that verdict
+   and its reason in the PR's *What did you not change that you considered?*
+   answer, so a reviewer sees a decision rather than an omission. Nothing
+   downstream will make this call for you: the `/now/` projection is a pure
+   parser over the file's bytes, and by contract no model runs in CI, release
+   automation, or site generation. An unwritten `Highlights` block is a release
+   the public page never mentions.
 
 Design against projected adopter state, not this checkout's internal corpus. Forks
 own their own publishing mechanism.

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.10.3"
+version = "2.10.4"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -655,8 +655,17 @@ right now?"
   commitments. Reviewed quarterly. Items that haven't moved in two
   consecutive reviews are a drift signal.
 - `changelog.md` — user-visible changes by release, in
-  [Keep a Changelog](https://keepachangelog.com/) format. Updated in the
-  same PR as any user-visible behavior change.
+  [Keep a Changelog](https://keepachangelog.com/) format. One section per
+  release, naming every artifact that release covers:
+  `## [<artifact>][<version>] — YYYY-MM-DD`, where `<artifact>` is a pack or a
+  published package. An entry is required in the same PR that bumps a released
+  artifact's version — you know the version at write time because you are
+  setting it. Repository tooling that ships in no release needs no entry. The
+  heading level is load-bearing: a section carrying a version and a date is
+  released, so it sits at that top level directly beneath `[Unreleased]`, never
+  nested inside it. A published package also keeps its own `CHANGELOG.md`
+  beside its source — `packages/<name>/CHANGELOG.md` in this layout — for
+  readers who get the package and not the repository.
 - `briefs/<slug>.md` (optional) — a received, externally-authored
   multi-feature product brief and its auto-rolled-up coverage map. Created by
   the `receive-brief` skill; one file per brief. See the brief altitude under
@@ -885,8 +894,10 @@ show no remaining references and green tests for bounded dead-code or
 unused-import removal. Tier 3 is hand-made: same-area, same-concern, visibly
 smaller mechanical work. Tier 1 and Tier 2 require their command or evidence.
 
-CI must be green. Specs must match implementation. Public-interface changes
-must be noted in `CHANGELOG.md`.
+CI must be green. Specs must match implementation. A released-artifact version
+bump carries its changelog entry (see *`docs/product/` — for maintainers*); if
+the repository publishes packages separately, each also updates its own
+`CHANGELOG.md`.
 
 ---
 

--- a/packs/core/seeds/docs/product/changelog.md
+++ b/packs/core/seeds/docs/product/changelog.md
@@ -5,10 +5,13 @@ All notable user-visible changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> Maintenance: add a `## [pack-name][version] — YYYY-MM-DD` section in the same
-> PR that bumps `pack.toml`. You know the version at write time because you are
-> setting it. A PR that bumps two packs adds two sections. Keep this file
-> newest-first. Rewrite entries for users, not contributors — see the
+> Maintenance: add a `## [<artifact>][<version>] — YYYY-MM-DD` section in the
+> same PR that bumps a released artifact's version — a pack or a published
+> package. You know the version at write time because you are setting it. A PR
+> that releases two artifacts adds two sections. The heading level is
+> load-bearing: a section with a version and a date is released, so it sits at
+> this top level directly beneath `[Unreleased]`, never nested inside it. Keep
+> this file newest-first. Rewrite entries for users, not contributors — see the
 > [Common Changelog guidance](https://common-changelog.org/).
 
 ## [core][1.0.0] — 2026-07-31

--- a/tests/roster/test_security_checklists_okf_projection.py
+++ b/tests/roster/test_security_checklists_okf_projection.py
@@ -103,8 +103,8 @@ def test_core_version_and_okf_declaration_are_synchronized() -> None:
         (PACK_ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
 
-    assert pack["pack"]["version"] == "2.10.3"
-    assert plugin["version"] == "2.10.3"
+    assert pack["pack"]["version"] == "2.10.4"
+    assert plugin["version"] == "2.10.4"
     assert pack["pack"]["metadata"]["okf"]["profile"] == "agentbundle-okf/v1"
     bundle = pack["pack"]["metadata"]["okf"]["bundles"][0]
     assert bundle["id"] == "security-checklists"

--- a/tests/roster/test_workspace_status_projection.py
+++ b/tests/roster/test_workspace_status_projection.py
@@ -115,9 +115,68 @@ def _sha256_file(path: Path) -> str:
 
 
 def _product_release_heading_version(text: str, name: str) -> str:
-    match = re.search(rf"^### \[{re.escape(name)}\]\[([^\]]+)\]", text, re.MULTILINE)
+    # Version correspondence only. Either heading level is accepted because the
+    # 59 pre-RFC-0095 nested entries include some artifacts' CURRENT release
+    # (agentbundle 0.38.5 among them), so a `##`-only match would read a stale
+    # free-standing heading. RFC-0095 D3 is enforced by the ratchet in
+    # `test_no_new_release_is_nested_under_unreleased`, not here.
+    match = re.search(
+        rf"^#{{2,3}} \[{re.escape(name)}\]\[([^\]]+)\]", text, re.MULTILINE
+    )
     assert match, f"missing {name} changelog heading"
     return match.group(1)
+
+
+# RFC-0095 D3 baseline. 59 versioned entries were nested under a `## [Unreleased]`
+# heading when D3 was accepted; every one is invisible to the `/now/` projection
+# permanently, because nothing ever moves an entry out. Their promotion needs
+# per-section artifact attribution (48 genuinely-unreleased bare sections are
+# interleaved across three `[Unreleased]` regions) and is tracked in
+# `workspace.toml [backlog].open` as `changelog-promote-marooned-entries`.
+#
+# This is a RATCHET, not a floor: it may only ever go DOWN. It is the mechanical
+# enforcement of D3 — the correspondence check in
+# `_product_release_heading_version` deliberately accepts either level.
+_MAROONED_RELEASE_BASELINE = 59
+
+
+def _nested_release_entries(text: str) -> list[str]:
+    """Versioned changelog entries nested under an `[Unreleased]` heading."""
+    nested: list[str] = []
+    unreleased_level: int | None = None
+    for line in text.splitlines():
+        heading = re.match(r"^(#{1,6})\s+(.*)", line)
+        if not heading:
+            continue
+        level, title = len(heading.group(1)), heading.group(2)
+        if unreleased_level is not None and level <= unreleased_level:
+            unreleased_level = None
+        if re.search(r"unreleased", title, re.IGNORECASE) and not re.match(
+            r"\[[a-z0-9-]+\]\[", title
+        ):
+            unreleased_level = level
+            continue
+        if unreleased_level is not None and re.match(
+            r"^\[.*\]\[.*\].*\d{4}-\d{2}-\d{2}", title
+        ):
+            nested.append(title)
+    return nested
+
+
+def test_no_new_release_is_nested_under_unreleased() -> None:
+    """RFC-0095 D3: a released section is free-standing, never nested.
+
+    Ratchet — this count may only decrease. A new release written as
+    `### [artifact][version]` under `[Unreleased]` increments it and fails here.
+    """
+    changelog = (REPO_ROOT / "docs/product/changelog.md").read_text(encoding="utf-8")
+    nested = _nested_release_entries(changelog)
+    assert len(nested) <= _MAROONED_RELEASE_BASELINE, (
+        f"{len(nested)} versioned entries are nested under `[Unreleased]`, above the "
+        f"RFC-0095 D3 baseline of {_MAROONED_RELEASE_BASELINE}. A release carries a "
+        f"version and a date, so it is written free-standing at `##` — nested entries "
+        f"never publish to `/now/`. Newest nested entries: {nested[:3]}"
+    )
 
 
 def test_t3_work_loop_step0_requires_canonical_preflight() -> None:

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -4,6 +4,32 @@
     {
       "packages": [
         {
+          "name": "core",
+          "version": "2.10.4"
+        }
+      ],
+      "date": "2026-08-20",
+      "heading": "[core][2.10.4] — 2026-08-20",
+      "changelogAnchor": "core2104--2026-08-20",
+      "highlights": [
+        {
+          "source": "**The changelog rule now says who \"user-visible\" means, so you can tell whether your change needs an entry.** An entry is required when a pull request bumps a released artifact's version — a pack or a published package — and repository tooling that ships in no release needs none. The old wording asked for an entry on \"any user-visible behavior change\", which read as covering maintainer-only tooling and offered no heading to write it under.",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "The changelog rule now says who \"user-visible\" means, so you can tell whether your change needs an entry."
+            },
+            {
+              "type": "text",
+              "value": " An entry is required when a pull request bumps a released artifact's version — a pack or a published package — and repository tooling that ships in no release needs none. The old wording asked for an entry on \"any user-visible behavior change\", which read as covering maintainer-only tooling and offered no heading to write it under."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "packages": [
+        {
           "name": "governance-extras",
           "version": "0.9.7"
         }

--- a/workspace.toml
+++ b/workspace.toml
@@ -534,6 +534,16 @@ open = [
   # toward deleting. Wire the job into build-check-windows's `needs` in the same
   # change that lands the lease, so the invariant is enforced once relied upon.
   {slug = "worktree-cooperative-lease", source = "spec/worktree-runtime-hygiene AC6", summary = "Re-spec and land the cooperative worktree lease, admission queue and with-lease wrapper: fix the Windows byte-range claim lock, reconcile the admission-role reclaim policy with AC6, re-publish a lost waiter ticket, recalibrate the memory clamp against usable-page reporting, scale the decision-lock budget with the wait budget, and forward the make jobserver"},
+  # RFC-0095 D3. 59 versioned entries sit nested under a `## [Unreleased]` heading and
+  # are permanently invisible to the `/now/` projection (it applies no date window; a
+  # nested entry simply never publishes). Not a mechanical level-shift: 48 genuinely
+  # unreleased bare `### Added`/`### Fixed` sections are interleaved across three
+  # `[Unreleased]` regions (12 / 5 / 31), and at least one — an `agentbundle pack evals
+  # run` fix directly below `[atlassian][0.9.0]` — would be republished under the wrong
+  # artifact by a uniform promotion. Needs per-section attribution. The ratchet in
+  # `tests/roster/test_workspace_status_projection.py` stops the count growing meanwhile,
+  # and should be lowered as entries are promoted.
+  {slug = "changelog-promote-marooned-entries", source = "rfc/0095 D3", summary = "Promote the 59 versioned changelog entries nested under [Unreleased] to free-standing `##` sections so they publish to /now/, separating them from the 48 interleaved genuinely-unreleased bare sections across three [Unreleased] regions; lower _MAROONED_RELEASE_BASELINE as they land, and restore Keep a Changelog ordering with [Unreleased] first"},
   # RFC-0092 D7 deferred direction. The canonical MCP primitive stays transport-first so
   # a typed acquisition descriptor stays possible; fetch-on-run launchers are already
   # refused at the build boundary, so this is a permit-something RFC, not a restrict one.


### PR DESCRIPTION
## What and why

`docs/CONVENTIONS.md` required a changelog entry "in the same PR as any user-visible behavior change" without ever saying **visible to whom**. Read literally it binds maintainer-only tooling: PR #1068 bumped `worktree_hygiene.py`'s `scan --json` `SCHEMA_VERSION` and added four subcommands, and a peer flagged a missing entry under that wording. The reading was sound, so the text was wrong.

The copy this repo *ships to adopters* already stated the rule more precisely, so this is drift in the self-hosted projection rather than a new policy.

## Decisions (RFC-0095)

| | |
|---|---|
| D1 | An entry is owed when a PR bumps a **released artifact's** version — a pack or a published package. Repository tooling that ships in no release is exempt, stated rather than inferred. |
| D2 | Two obligations split by **file**, not by scoping phrase: the aggregate `docs/product/changelog.md`, plus a published package's own `CHANGELOG.md`. That tier was real but referenced in exactly one ambiguous place; it now has its path. |
| D3 | A section carrying a version **and** a date is released, so it is written free-standing at `##`, never nested under `[Unreleased]`. |
| D4 | `Highlights` is obliged when a release changes what a consumer can do — judged by nature, not semver level — and the pack release pipeline owns the decision. |
| D5 | Delete the header's claim that CI warns/blocks on a missing entry. No workflow implements it; building it would impose unasked per-PR ceremony. |

## Neither D3 nor D4 ships as prose

**D3 has a ratchet.** 59 versioned entries are nested under `[Unreleased]` and can never publish to `/now/` — *permanently*, because the projection applies no date window and nothing moves an entry out later. `test_no_new_release_is_nested_under_unreleased` pins that count; a new nested release fails the roster suite. Mutation-checked both directions, and it already caught a real regression when main added one mid-review.

**D4 has an owner.** `Highlights` is the only content reaching `/now/`, and by contract no model runs in CI or site generation — so an unwritten block means a release the public page never mentions. Nothing prompted for one, hence 1 of 144 entries. The decision now sits in the pack release pipeline in `packs/AGENTS.local.md`: the maintainer-only surface any agent editing under `packs/` already reads. That keeps pack-release concerns out of core's generic `work-loop` and out of adopter artifacts, and it stays at authoring time — `docs/specs/site-now-surface/spec.md` (Shipped) forbids a model in CI/release/site generation and explicitly permits AI-assisted drafting from the diff under ordinary PR review.

## Not in scope

Promoting the 59 nested entries. It is **not** a mechanical level-shift: 48 genuinely-unreleased bare sections are interleaved across three `[Unreleased]` regions, and a uniform promotion would republish an `agentbundle pack evals run` fix under `[atlassian][0.9.0]`'s heading. Registered as `changelog-promote-marooned-entries` (`source = "rfc/0095 D3"`).

Also excluded: building the CI gate D5 deletes; retro-adding entries to past PRs; any other `CONVENTIONS.md` section.

## Self-obligating

The seed ships to adopters, so this is an adopter-facing contract change and owes its own entry under the rule it writes — core `2.10.3` → `2.10.4` across all four version sites, with a `[core]` entry. The PR template and the seed changelog carried two further variants of the old trigger and are aligned, so the repo no longer ships three different answers.

## Verification

- `tests/roster/` 533 passed · core pack suites 12/12 · `make build` rc=0
- `make build-check` rc=0 **with the SAST/SCA leg invoked** (no `SKIP_SAST`)
- `lint-ruff`, `lint-mypy`, `lint-spec-status`, `lint-traceability` all rc=0
- Seed and projection byte-identical (`3a96ea44`); seed edits confirmed present in both

## What did you not change that you considered?

- **The 59 nested entries** — registered follow-on; needs per-section artifact attribution, not a level-shift.
- **A CI gate for changelog entries** — D5 rejects it deliberately. `check_release_impact.py` stays the only mechanical release check.
- **`CONVENTIONS.md` § deferral-token wording** — a peer asked whether it reads as offering the backlog and the PR answer as alternatives. Re-read it; it scopes the backlog to in-scope deferrals and routes out-of-scope discoveries to the PR answer. Correct as written, and outside this RFC's scope.
- **`Highlights` on this entry** — kept, and this is D4's first exercise. Running D4's own question against the diff: core 2.10.4 ships only prose, but an adopter now has a decidable rule for when an entry is owed where before they had "any user-visible behavior change" and no heading to write under. Core's product *is* its prose, so this is a product change. Flagging it explicitly because it sets the precedent.