### PR TITLE
docs(repo): document make bootstrap-sites as the one-time site setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ recovery, and completion. Commit conventions live in
 ## Commands you'll need
 
 ```bash
+make bootstrap-sites   # one-time npm deps for make test and site-link-check
 python3 -m pytest packages/<pkg>/tests/ -q
 make lint-ruff
 make build-self

--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,8 @@ ci: build-check pre-pr lint-ruff lint-mypy test
 	$(call gate_verdict,make ci)
 
 # ── Site publishing ──────────────────────────────────────────────────────────
-# Requires: npm ci --prefix docs-site (one-time setup)
+# Requires: make bootstrap-sites (one-time setup) — site-build builds web/ first,
+# so the web tree is needed here too, not only docs-site.
 # Build order is load-bearing: web/ build cleans build/; docs-site/ build
 # writes into build/docs/. These targets are the valid LOCAL full-generation
 # sequence — one build-site.py pass, then both builds. CI is NOT identical; see

--- a/workspace.toml
+++ b/workspace.toml
@@ -1203,15 +1203,15 @@ open = [
   # keyed HMAC; across chains it remains operator-trusted, so this is bounded, not
   # closed.
   {slug = "rfc0088-privacy-term-identity-anchor", source = "round-12 security review"},
-  # AGENTS.md § "Commands you'll need" lists only `npm ci --prefix docs-site` as the
-  # one-time site setup, but `make site-link-check` runs `npm run build --prefix web`
-  # FIRST. Without `npm ci --prefix web` the gate dies with `sh: astro: command not
-  # found`, which reads as a broken gate rather than missing setup. Found in RFC-0088
-  # round 11, where it was almost recorded as a pre-existing failure. Not fixed in
-  # that PR: the round's own scope boundary is evidence-only, and root AGENTS.md is
-  # not a sibling of docs/rfc so it falls outside the bundled-fixes carve-out.
-  # Unblocks when: any PR that legitimately touches root AGENTS.md adds the command.
-  {slug = "agents-md-missing-web-npm-ci", source = "spec/rfc0088-round11-binding-requirements drift"},
+  # Closed 2026-08-21. Root AGENTS.md § "Commands you'll need" now names
+  # `make bootstrap-sites`, the sanctioned target that installs BOTH npm trees
+  # (tools/repo/bootstrap.py profile_commands("sites")). Two corrections the entry
+  # text got wrong, recorded so a reader arriving from a stale reference is not
+  # misled: AGENTS.md listed NEITHER npm command, not "only docs-site"; and the
+  # Makefile's own § Site publishing header carried the same one-sided claim, which
+  # was corrected in the same change. `make test` needs the docs-site tree only;
+  # `site-build` / `site-link-check` need both. No `(deferred: …)` marker anchored
+  # this slug, so removing the entry reds no lint-spec-status invariant.
   # `lint-spec-status.py`'s four `git` calls (:307, :316, :325, :427) have no
   # `timeout=`. Unreachable from the guard call path — proved by an AST reachability
   # assertion in test_loop_concurrency.py — so bounding them is not a mechanical


### PR DESCRIPTION
## What does this change?

Root `AGENTS.md` § "Commands you'll need" now names `make bootstrap-sites`, the
one-time npm setup two gates depend on. The Makefile's § Site publishing header,
which carried the same claim in a one-sided form, is corrected to match.

## Why?

Closes the `[backlog].open` entry `agents-md-missing-web-npm-ci`. No spec: this is
a bounded documentation correction with no behaviour change, run under work-loop
**direct-light** (no risk trigger fires — no new dependency, no interface change,
no security boundary, no destructive operation).

Two gates hard-fail without that setup, and both failures read as broken gates
rather than missing setup:

- `make test` exits 1 at `Makefile:350` with a message naming
  `npm ci --prefix docs-site`.
- `site-link-check` depends on `site-build` (`Makefile:457`), which runs
  `npm run build --prefix web` **first**, so a missing web tree dies with
  `sh: astro: command not found`.

`make bootstrap-sites` is documented rather than the two raw `npm ci` commands
because that target already exists and expands to exactly them
(`tools/repo/bootstrap.py` `profile_commands("sites")`). Naming it keeps one
statement of the fact instead of adding a third copy.

**The backlog entry's own text was stale on two points**, both corrected in the
disposition note that replaces it:

1. It claimed AGENTS.md "lists only `npm ci --prefix docs-site`". It listed
   **neither** command.
2. It did not mention that `Makefile:444` carried the same one-sided claim
   (`# Requires: npm ci --prefix docs-site`) for a section whose `site-build`
   builds `web/` first. Fixing only the AGENTS.md copy would have made the
   repository self-contradictory.

No `(deferred: agents-md-missing-web-npm-ci)` marker anchors the slug anywhere
(`git grep`, with a working positive control on other `deferred:` markers), so
removing the entry reds no `lint-spec-status` invariant (iv).

No changelog entry: RFC-0095 D2 scopes that obligation to released artifacts, and
this bumps no pack or package version.

## How do I verify it?

```bash
python3 tools/lint-agents-md.py          # exit 0 — root AGENTS.md 90 lines, cap 120
make pre-pr                              # exit 0 — includes "agents-md hygiene"
make build-check                          # exit 0 — full run, SAST/SCA included
make -n bootstrap-sites                  # confirms the documented target resolves
```

`make build-check` was run **without** `SKIP_SAST`: `Makefile` is a member of
`SAST_CONFIG` (`Makefile:198`), so the skip would not have been defensible once
this diff touched it. Terminal banner read
`make build-check: complete — every leg of this target was invoked, SAST/SCA included.`

`workspace.toml` re-parsed with `tomllib` after the edit and after rebasing onto
#1081: 187 `[backlog].open` entries, this slug absent, the six intents #1081 added
intact.

## What did you not change that you considered?

- **The two raw `npm ci` lines** the first draft added. Replaced with the single
  `make bootstrap-sites` line after verifying that target already expands to them.
  Three lines duplicating an existing target is the drift this entry is about.
- **`docs-site/AGENTS.md`, `web/AGENTS.md`, `CONTRIBUTING.md`,
  `docs/guides/how-to/verify-a-site-release.md`.** Each lists build commands and
  no install command. Incomplete, but not self-contradictory — scoped instructions
  inherit the corrected root guidance. Left out to keep this diff to the reported
  defect.
- **A gate asserting that documented commands resolve to real make targets.** That
  would have caught this class, and would catch the next one. It is a new lint with
  its own false-positive question, so it is unrequested hardening here.
- **Attributing per-tree need in the comment.** An earlier wording said the deps
  were "needed by `make test`"; review caught that `make test` needs the docs-site
  tree only. The shipped wording names both consumers without mis-attributing
  either.

---

## Checklist

- [x] Tests pass locally (`make build-check`, full, SAST included)
- [x] Lint and typecheck pass (`python3 tools/lint-agents-md.py`, `make pre-pr`)
- [x] Self-review run via an independent reviewer (fresh Codex session, told not to
      edit): 0 Blockers, 2 Concerns, **both applied** — the mis-attributed comment
      and the un-fixed Makefile copy. Both are in this diff.
- [x] Spec and code agree — no spec (direct-light; justified above)
- [x] Living docs match reality — `docs/product/changelog.md` deliberately not
      touched (no released artifact; RFC-0095 D2)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the corrected fact now has one home in `AGENTS.md`, and
      the Makefile comment points at it rather than restating it
