### PR TITLE
feat(tools,ci): the cooperative worktree lease — liveness is a held lock, and every recorded defect is an acceptance clause

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -132,7 +132,7 @@ jobs:
     # lock makes every liveness probe read NOT_LIVE, so a live peer's claim is
     # reclaimed and `clean --apply` deletes under a live mutator. The synthetic
     # fixture measures Windows itself; the lease suite proves the publisher and
-    # prober use the measured-safe byte-zero protocol.
+    # prober use the measured-safe protocol: one agreed offset, past the payload.
     runs-on: windows-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -126,19 +126,13 @@ jobs:
 
   lock-semantics-windows:
     name: byte-range lock semantics (windows)
-    # DELIBERATELY NOT in build-check-windows's `needs`. This job MEASURES a
-    # platform behaviour that a deferred design depends on
-    # (workspace.toml [backlog].open, slug worktree-cooperative-lease): whether a
-    # claim lock held after writing a payload is observable by a prober, given that
-    # `msvcrt.locking` locks one byte at the CURRENT FILE POSITION while `flock`
-    # covers the whole open file description. Getting that wrong is not a
-    # degradation -- an invisible lock means every liveness probe reads NOT_LIVE, a
-    # live peer's claim is reclaimed, and `clean --apply` deletes under a live
-    # mutator.
-    #
-    # It reports rather than gates because the design it informs has not landed
-    # yet; wire it into `needs` in the same change that lands the lease, so the
-    # invariant is enforced once something depends on it.
+    # This job gates the aggregate because the coordination lease depends on this
+    # platform behaviour: `msvcrt.locking` locks one byte at the CURRENT FILE
+    # POSITION, while `flock` covers the whole open file description. An invisible
+    # lock makes every liveness probe read NOT_LIVE, so a live peer's claim is
+    # reclaimed and `clean --apply` deletes under a live mutator. The synthetic
+    # fixture measures Windows itself; the lease suite proves the publisher and
+    # prober use the measured-safe byte-zero protocol.
     runs-on: windows-latest
     timeout-minutes: 5
     env:
@@ -160,22 +154,27 @@ jobs:
         # and a pass alone would not tell us which way the platform answered.
         run: python -m pytest tools/test_windows_lock_semantics.py -q -s
 
+      - name: Run coordination lease publisher and prober
+        run: python -m pytest tools/test_coordination_lease.py -q
+
   build-check-windows:
     name: make build-check (windows)
     if: ${{ always() }}
     needs:
       - agentbundle-windows
       - credbroker-tests-windows
+      - lock-semantics-windows
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Require both Windows suites
+      - name: Require all Windows suites
         env:
           AGENTBUNDLE_RESULT: ${{ needs.agentbundle-windows.result }}
           CREDBROKER_RESULT: ${{ needs.credbroker-tests-windows.result }}
+          LOCK_SEMANTICS_RESULT: ${{ needs.lock-semantics-windows.result }}
         run: |
-          if [ "$AGENTBUNDLE_RESULT" != "success" ] || [ "$CREDBROKER_RESULT" != "success" ]; then
-            echo "Windows suites failed: agentbundle=$AGENTBUNDLE_RESULT credbroker=$CREDBROKER_RESULT" >&2
+          if [ "$AGENTBUNDLE_RESULT" != "success" ] || [ "$CREDBROKER_RESULT" != "success" ] || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then
+            echo "Windows suites failed: agentbundle=$AGENTBUNDLE_RESULT credbroker=$CREDBROKER_RESULT lock-semantics=$LOCK_SEMANTICS_RESULT" >&2
             exit 1
           fi
           echo "Windows suites passed"

--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ test:
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
+	$(PYTHON) -m pytest tools/test_coordination_lease.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
 	$(PYTHON) -m pytest tools/test_worktree_lifecycle_hooks.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q

--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,7 @@ test:
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_coordination_lease.py -q
+	$(PYTHON) -m pytest tools/test_run_slot.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
 	$(PYTHON) -m pytest tools/test_worktree_lifecycle_hooks.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RECIPE ?=
 
 export PYTHONPATH
 
-.PHONY: build build-self build-self-dry-run build-check build-scaffold lint-packs pre-pr package sast print-sast-dirs print-sast-config validate clean zipapp release-preflight lint-ruff lint-mypy test ci
+.PHONY: build build-self build-self-dry-run build-check build-check-unleased build-scaffold lint-packs pre-pr package sast sast-unleased print-sast-dirs print-sast-config validate clean zipapp release-preflight lint-ruff lint-mypy test test-unleased ci
 
 # Portable catalogue engine — lint packs against the adapter contract.
 lint-packs:
@@ -129,6 +129,10 @@ endef
 # and the make-free Windows command one source of truth.
 # Windows contributors: python tools/repo/build_gate_chain.py build-check
 build-check:
+	$(PYTHON) tools/repo/coordination_lease.py with-lease -- $(MAKE) -f $(firstword $(MAKEFILE_LIST)) build-check-unleased
+	$(call gate_verdict,make build-check)
+
+build-check-unleased:
 	$(PYTHON) tools/repo/build_gate_chain.py build-check --packs-dir $(PACKS_DIR) --output-dir $(OUTPUT_DIR)
 	# SAST/SCA gate (ADR-0017) — runs last so the fast, offline drift/lint
 	# checks above fail quickly before the slower, network-bound scanners.
@@ -148,7 +152,6 @@ build-check:
 	else \
 		$(MAKE) sast; \
 	fi
-	$(call gate_verdict,make build-check)
 
 # SAST/SCA gate (ADR-0017). Three OSS scanners, installed from
 # tools/requirements-sast.txt as CI-only dev tools — never shipped runtime
@@ -227,6 +230,9 @@ SEMGREP_EXCLUDE := \
 	--exclude-rule python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
 
 sast:
+	$(PYTHON) tools/repo/coordination_lease.py with-lease -- $(MAKE) -f $(firstword $(MAKEFILE_LIST)) sast-unleased
+
+sast-unleased:
 	@command -v bandit   >/dev/null 2>&1 || { echo "make sast: bandit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v pip-audit >/dev/null 2>&1 || { echo "make sast: pip-audit not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
 	@command -v semgrep   >/dev/null 2>&1 || { echo "make sast: semgrep not found — run: pip install -r tools/requirements-sast.txt" >&2; exit 1; }
@@ -337,6 +343,9 @@ lint-mypy:
 # renderers. One process per skill test directory is a correctness requirement,
 # not a style choice; see catalogue-authoring-standards.md § 4.
 test:
+	$(PYTHON) tools/repo/coordination_lease.py with-lease -- $(MAKE) -f $(firstword $(MAKEFILE_LIST)) test-unleased
+
+test-unleased:
 	$(PYTHON) -m pytest packages/agentbundle/tests/ -q
 	$(PYTHON) -m pytest packages/credbroker/ -q
 	$(PYTHON) tools/lint-conformance-portability.py --root .
@@ -401,6 +410,7 @@ test:
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_coordination_lease.py -q
 	$(PYTHON) -m pytest tools/test_run_slot.py -q
+	$(PYTHON) -m pytest tools/test_with_lease_cli.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q
 	$(PYTHON) -m pytest tools/test_worktree_lifecycle_hooks.py -q
 	$(PYTHON) -m pytest tools/test_frontend_runtime.py -q

--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,7 @@ test:
 	$(PYTHON) -m pytest tools/test_build_gate_chain.py tools/test_journey_editorial_decisions.py tools/test_catalogue_tooling_rewire.py tools/test_catalogue_tooling_docs.py tools/test_validate_guides.py tools/test_check_guide_index.py tools/test_catalogue_navigation.py tools/test_documentation_entry_links.py tools/test_build_site_link_rewrites.py tools/test_check_rendered_site_links.py tools/test_build_site_routing.py tools/test_check_docs_contrast.py tools/test_build_site_inventory.py tools/test_build_site_projection.py tools/test_build_site_sidebar.py tools/test_browser_gate_subset.py -q
 	$(PYTHON) -m pytest tools/test_workspace_status.py tools/test_workspace_status_cli.py -q
 	$(PYTHON) -m pytest tools/test_worktree_hygiene.py -q
+	$(PYTHON) -m pytest tools/test_worktree_lease_interlock.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_coordination_lease.py -q

--- a/docs/specs/worktree-cooperative-lease/plan.md
+++ b/docs/specs/worktree-cooperative-lease/plan.md
@@ -1,0 +1,175 @@
+# Plan: worktree-cooperative-lease
+
+- **Status:** Drafting
+- **Spec:** [`spec.md`](spec.md)
+
+## Why this plan exists separately from its predecessor
+
+The lease was built once already, across five layers, and split out of
+[`worktree-runtime-hygiene`](../worktree-runtime-hygiene/spec.md) under review
+rather than landed. The implementation is preserved on branch
+`eugenelim/worktree-hygience-c-lease-wip`; this plan rebuilds from it rather than
+from nothing, and the known defects are enumerated in `workspace.toml`
+`[backlog].open` under slug `worktree-cooperative-lease`.
+
+The reason it was split is the reason this plan is shaped the way it is. Three
+independent reviewers found failure modes the old criterion did not enumerate, in
+a finished implementation with a green suite and 46 mutation proofs. The defect was
+never in the code alone — it was that a one-sentence criterion cannot be falsified.
+So each acceptance criterion in the spec now names a failure mode, and each task
+below names the mutation that must redden it.
+
+## Design (LLD)
+
+**Two locks, two jobs, named so they cannot be confused.** A short-lived shared
+*decision* lock makes read-other-role-then-publish-own indivisible. A long-lived
+per-claim *ownership* lock answers liveness. The decision lock is never a claim's
+own lock.
+
+**Liveness is a held lock, positioned at byte zero.** Both the publishing and
+probing paths seek to byte zero before locking. On POSIX `flock` covers the whole
+open file description and position is irrelevant; on Windows `msvcrt.locking`
+locks one byte at the current position, so a publisher that writes a payload then
+locks holds a different byte than a prober opening at zero.
+
+Measured on `windows-latest` by `tools/test_windows_lock_semantics.py`, which
+landed ahead of this work for exactly this purpose:
+
+```
+MEASURED [win32 / os.name=nt] write-then-lock, probe at position 0
+    -> NOT blocked (LOCK INVISIBLE)
+```
+
+All four cases passed, so the seek-to-zero invariant holds on Windows and
+byte-range locking *can* carry liveness there. That measurement reversed the
+design: the previous intent was to report `UNDETERMINABLE` on Windows —
+surrendering the capability — purely because it could not be tested locally.
+
+**Reclaim policy differs by role, and the difference is load-bearing.** Admission
+roles (slot, ticket) are throughput counters: over-admitting by one costs memory
+pressure, so they expire on a stated age budget. Worktree roles (activity,
+exclusive) are safety interlocks: reclaiming a live one lets a mutator start under
+an in-flight cleaner, so they never expire on age and their only path back is the
+operator command. A previous round applied one rule to both and had to be split.
+
+**The wrapper forwards the makefile, not the jobserver.** See the spec's
+Limitations for the measurement and the three reasons.
+
+## Tasks
+
+Each task lands independently and leaves the repository working. Every new test
+file gets its own Makefile pytest invocation.
+
+### Task 1 — the claim primitive, positioned correctly
+
+**Depends on:** none
+
+Tests: `tools/test_coordination_lease.py` — atomic publish; a second publisher does
+not overwrite; release removes only the caller's own claim; a `SIGKILL`ed holder's
+claim is reclaimable using a real killed process; an unreadable payload is
+undeterminable and counts as live; out-of-range identity, mismatched worktree and
+out-of-window creation time each refused or clamped; digest keys do not collide for
+`/mnt/a/b-c` versus `/mnt/a-b/c`; a symlinked store is refused; a claim path
+escaping the store is refused; the decision lock serializes two real processes.
+
+`Done when:` both the publish and probe paths seek to byte zero — asserted
+structurally, because on POSIX the behaviour is identical either way and only
+Windows can falsify it behaviourally.
+
+### Task 2 — the two worktree roles and their interlock
+
+**Depends on:** Task 1
+
+Tests: `tools/test_worktree_lease_interlock.py` — `clean --apply` refuses while a
+live `activity` claim exists and names the holder; proceeds when none exists and
+holds `exclusive` across every deletion, observed during a real deletion; a dry run
+publishes no claim and creates no store; a mutator with an unusable store warns and
+proceeds while `clean --apply` refuses; **exactly one** participant wins a
+contended tie, asserted as `== 1` so a symmetric abort fails; the atomicity of
+read-then-publish asserted by observing the lock hold, not inferred from a race.
+
+### Task 3 — admission, fairness, and the budgets
+
+**Depends on:** Task 1
+
+Tests: `tools/test_run_slot.py` — admission never exceeds the limit under real
+contention; waiters admitted in registration order; a waiter whose ticket is
+removed **re-registers** rather than waiting out its budget; an admission claim
+expires on age while a worktree claim does not; invalid and below-one budget values
+refused from the entry point that ships, not only the parsing helper; the clamp is
+downward-only, host-independent in test, and reads a usable-memory figure with
+headroom so the reference configuration is not clamped; the decision lock's budget
+scales with the wait budget.
+
+### Task 4 — the wrapper, the status and release commands, and the make wiring
+
+**Depends on:** Task 2, Task 3
+
+Tests: `tools/test_with_lease_cli.py` — exit-code integrity in both directions;
+both claims released on every exit path; an unusable store warns and runs the
+child; a live `exclusive` claim refuses with the reserved code and marker; a
+missing command refused; verbatim argv with no shell; only the nesting marker
+added; a nested invocation through a **real recursive make** completes rather than
+deadlocking; a queued caller reports that it is queued; `lease-status` mutates
+nothing, prints no absolute path, and prints the identifier `release-claim`
+requires; `release-claim` refuses a live claim, has no override, and releases an
+undeterminable one — the success path asserted, not only the refusals.
+
+Wire `lock-semantics-windows` into `build-check-windows`'s `needs` in this task,
+because from here something depends on it.
+
+### Participant matrix
+
+The previous plan claimed `bootstrap.py` published a claim and it never did, and
+that plan froze at `Done` with the wrong statement in it. So every entry point is
+listed with its disposition, and each participating one carries a dropped-wrapper
+mutation.
+
+| Entry point | Disposition | Mutation that must redden |
+|---|---|---|
+| `make test` | wrapped | remove the wrapper; the target's own guard reddens |
+| `make build-check` | wrapped | remove the wrapper; also remove the `-f` forwarding, which must redden `assert-sast-chain-reachable` |
+| `make sast` | wrapped | remove the wrapper; the target's own guard reddens |
+| `make ci` | **not** wrapped — its recipe only prints a verdict, and `lint-ci-parity` derives 31 dispositions from its prerequisite list | add a wrapper; the parity guard reddens |
+| `frontend_runtime.py gate` | publishes an `activity` claim, takes **no** slot | remove the claim; its own test reddens |
+| `tools/repo/bootstrap.py` | **not** participating. It runs `npm ci --prefix` only, which is per-worktree and concurrently safe; the globally destructive `pip install -e` is a documented manual step in a Makefile comment and has no code path to lease | none — asserted by a test that `bootstrap.py` imports no lease module, so a future claim added here is a deliberate act |
+
+### Clause-to-mutation ledger
+
+Task 4 does not close until every clause of every AC appears in this ledger with a
+named mutation and the check that catches it. Structural clauses — "exactly one
+implementation", "single-homed", "positioned at byte zero" where the platform makes
+position irrelevant — take goal-based source checks, because a runtime assertion
+cannot falsify them. AC3's clauses take predecessor-regression mutations
+(conditionalise a shipped guard, drop the pre-delete recheck, move the store, give
+it a deletable suffix). AC9's takes the mutated-makefile proof. The ledger is a
+deliverable, not a description: a clause with no entry is an unfinished task.
+
+### Windows enforcement lands in Task 1
+
+Wiring `lock-semantics-windows` into `build-check-windows`'s `needs` is **not
+sufficient to gate it**: that aggregate is `if: ${{ always() }}` and its script
+checks only the AgentBundle and CredBroker results, so a failing lock job would be
+ignored. Task 1 therefore adds the job to `needs`, threads its result into the
+aggregate's env, and extends the script's condition — and runs the real
+coordination publisher and prober on Windows rather than only the synthetic
+semantics fixture, since the fixture proves the platform and not the code.
+
+### Not changing
+
+`scan`'s JSON schema and its pinned key set; the deletion safety predicate, which
+is reused rather than modified; `ci`'s recipe and prerequisite list; the port
+lease's observable behaviour and its aged-reclaim policy; `docs/CONVENTIONS.md`;
+`docs/product/changelog.md`, because nothing here bumps a released artifact's version and `tools/repo/**` is repository-only.
+
+### Tempted and declined
+
+- Forwarding the jobserver. Declined for the three reasons in the spec's
+  Limitations; the decisive one is that this wrapper holds descriptors open for the
+  claim locks and would risk handing a sub-make a lock instead of a token.
+- Reporting `UNDETERMINABLE` on Windows. Declined because it was measured
+  unnecessary; that would have surrendered a capability to cover a blind spot.
+- Making the two reclaim policies consistent. Declined: the asymmetry is the
+  contract, and a future round tempted to tidy it should change the criterion first.
+- Reporting lease state inside `scan --json`. Declined: it bumps `SCHEMA_VERSION`
+  and breaks a pinned key set for diagnostics `lease-status` already provides.

--- a/docs/specs/worktree-cooperative-lease/plan.md
+++ b/docs/specs/worktree-cooperative-lease/plan.md
@@ -105,15 +105,10 @@ scales with the wait budget.
 
 **Depends on:** Task 2, Task 3
 
-Tests: `tools/test_with_lease_cli.py` — exit-code integrity in both directions;
-both claims released on every exit path; an unusable store warns and runs the
-child; a live `exclusive` claim refuses with the reserved code and marker; a
-missing command refused; verbatim argv with no shell; only the nesting marker
-added; a nested invocation through a **real recursive make** completes rather than
-deadlocking; a queued caller reports that it is queued; `lease-status` mutates
-nothing, prints no absolute path, and prints the identifier `release-claim`
-requires; `release-claim` refuses a live claim, has no override, and releases an
-undeterminable one — the success path asserted, not only the refusals.
+Tests: `tools/test_with_lease_cli.py`. The ledger below is the authoritative list;
+this task's entries are the ones naming that file. Every name in the ledger is a test
+that exists — the previous revision of this line described eight tests, of which three
+were never written, and the plan froze at `Done` with the description in it.
 
 Wire `lock-semantics-windows` into `build-check-windows`'s `needs` in this task,
 because from here something depends on it.
@@ -136,14 +131,66 @@ mutation.
 
 ### Clause-to-mutation ledger
 
-Task 4 does not close until every clause of every AC appears in this ledger with a
-named mutation and the check that catches it. Structural clauses — "exactly one
-implementation", "single-homed", "positioned at byte zero" where the platform makes
-position irrelevant — take goal-based source checks, because a runtime assertion
-cannot falsify them. AC3's clauses take predecessor-regression mutations
-(conditionalise a shipped guard, drop the pre-delete recheck, move the store, give
-it a deletable suffix). AC9's takes the mutated-makefile proof. The ledger is a
-deliverable, not a description: a clause with no entry is an unfinished task.
+Structural clauses — "exactly one implementation", "single-homed", "positioned at
+byte zero" where the platform makes position irrelevant — take goal-based source
+checks, because a runtime assertion cannot falsify them. The ledger is a deliverable,
+not a description: a clause with no entry is an unfinished task. The previous revision
+of this section stated that rule and then listed nothing, which is how three AC
+clauses reached `Done` with no test at all — AC7's exit-code integrity under a failing
+release, AC8's stale-marker rule, and AC9's unusable-store-still-runs rule. Each row
+below was run as a real mutation: the guard was confirmed green, the named clause was
+broken in the source, the named check was confirmed to redden, and the source was
+restored and verified byte-identical.
+
+| AC | Clause | Mutation | Check that catches it |
+|---|---|---|---|
+| AC1 | liveness is a held lock, never a payload | trust the payload's pid | `test_a_forged_claim_with_a_live_pid_is_not_live` |
+| AC1 | the OS releases the lock on death | `SIGKILL` the holder | `test_sigkilled_holder_claim_is_reclaimed` |
+| AC1 | liveness is not inferred from age | age a live claim | `test_live_identity_is_not_reclaimed_by_age_alone` |
+| AC1 | a recycled pid cannot impersonate a holder | reuse the pid | `test_recycled_pid_cannot_impersonate_lock_holder` |
+| AC1 | the lock is taken at byte zero on every platform | drop the `lseek` | `test_windows_write_then_lock_hides_the_lock_from_a_probe` and `test_seeking_to_zero_in_both_paths_makes_a_held_lock_observable` on `windows-latest`; `test_claim_lock_operations_seek_to_byte_zero_structurally` is the POSIX source check, because position is unobservable there |
+| AC2 | read and publish inside one uninterrupted hold | publish outside the hold | `test_racing_participants_are_never_both_admitted`, `test_scan_and_slot_publish_share_one_decision_lock_hold` |
+| AC2 | exactly one participant is admitted (`== 1`) | admit both | `test_contended_roles_admit_exactly_one_participant` |
+| AC2 | the two roles interlock in both directions | drop either check | `test_sequential_interlock_refuses_exclusive_while_activity_is_held`, `test_activity_waits_for_an_exclusive_claim_to_clear` |
+| AC2 | the decision lock actually serialises | release it early | `test_coordination_lock_serializes_two_real_processes` |
+| AC3 | the shipped deletion predicate is untouched | conditionalise it on holding a claim | `test_clean_apply_claim_spans_a_real_multi_file_deletion` plus the predecessor's own predicate tests. **Single-site mutations here are inert by design:** `.lease` is refused by both the traversal collector and `_subtree_safety_reason`, so only removing both reddens, and that is the property, not a coverage gap |
+| AC3 | the store is not deletable by the cleaner | give it a non-refused suffix | the suffix guard plus `test_clean_dry_run_never_creates_a_claim_store` |
+| AC4 | out-of-range, mislocated, and future payloads are refused or clamped | trust each field | `test_untrusted_payloads_are_rejected` |
+| AC4 | an unreadable payload blocks rather than passes | treat it as absent | `test_unreadable_payload_is_undeterminable_and_blocks` |
+| AC4 | the release command never removes a live claim | drop the liveness check | `test_release_claim_refuses_a_live_holder` |
+| AC4 | it does release an undeterminable one | refuse everything | `test_release_claim_releases_an_undeterminable_claim` |
+| AC4 | every state has a documented path back | render "pid unknown" for a live claim with a refused identity | `test_a_live_claim_with_a_refused_identity_is_still_actionable` |
+| AC4 | waiters are ordered by a value they cannot forge | backdate a ticket | `test_backdated_ticket_cannot_overtake_a_real_waiter` |
+| AC5 | re-registration keeps the original position | re-stamp on re-registration | `test_ticket_removal_reregisters_without_losing_original_position` |
+| AC5 | a live waiter's record is never aged out | prune on age alone | `test_an_observably_live_waiter_record_is_never_aged_out` |
+| AC6 | defaults are literal and host-independent | derive them from the host | `test_budget_defaults_and_strict_parsing_are_literal_and_host_independent` |
+| AC6 | the memory clamp is downward-only with headroom | raise the divisor to 16 GiB | `test_memory_clamp_uses_twelve_gib_and_preserves_reference_headroom` |
+| AC6 | the decision-lock budget scales and has a floor | fix it to a constant | `test_decision_lock_budget_scales_with_wait_budget_and_has_floor` |
+| AC6 | an invalid budget refuses before touching the store | coerce it | `test_entrypoint_refuses_invalid_budget_before_store_access` |
+| AC6 | the wait budget governs both waits | hardcode the default for the activity wait | `test_a_live_exclusive_claim_refuses_the_wrapper_with_the_reserved_code` — the mutant fails by *waiting ninety minutes*, so the harness treats its timeout as the detection |
+| AC6 | the cap is soft only for admission roles | expire a worktree claim | `test_admission_expiry_makes_limit_soft_but_worktree_claims_do_not_expire`, `test_old_undeterminable_admission_record_expires` |
+| AC6 | the real limit is never exceeded | admit past it | `test_real_concurrent_admission_never_exceeds_limit` |
+| AC7 | the child's exit code is forwarded verbatim | rewrite it | `test_main_strips_argparse_remainder_separator` (propagates 19) |
+| AC7 | a failing release cannot alter that code, either way | let the release exception escape | `test_a_failing_release_cannot_change_the_childs_exit_code`, parameterised over a passing and a failing child |
+| AC7 | one child runner, not a second copy | add a second call site | `test_wrapper_has_exactly_one_reachable_child_runner` (parsed tree, not substring) |
+| AC7 | only the nesting marker is added to the environment | add another key | `test_wrapper_only_adds_the_nesting_marker` (asserts a delta: macOS injects `LC_CTYPE` and `__CF_USER_TEXT_ENCODING`) |
+| AC7 | an empty command is refused, not spawned | spawn it | `test_main_refuses_a_missing_wrapped_command` |
+| AC7 | activity is held for the child's lifetime, not the queue wait | acquire activity before the slot | `test_admission_precedes_activity_so_a_queued_run_never_blocks_cleanup` |
+| AC7 | every refusal exits 75 with the marker, alone on its line | drop the marker | `test_main_refuses_malformed_slot_configuration`, `test_a_live_exclusive_claim_refuses_the_wrapper_with_the_reserved_code`, `test_clean_apply_refuses_an_unusable_store_with_no_override` |
+| AC7 | a queued caller says so, and behind whom | wait silently | `test_queued_wrapper_reports_its_holders` |
+| AC7 | status mutates nothing and leaks no path | mutate, or print the worktree path | `test_status_is_read_only_and_emits_recovery_identifier` |
+| AC8 | a nested acquisition and its release are no-ops | release the parent's slot | `test_nested_recursive_make_completes` |
+| AC8 | a marker naming no *live* claim counts as absent | drop the liveness half | `test_a_marker_naming_no_live_claim_cannot_disable_the_limiter` — the marker names a real leftover file, because a marker naming nothing is caught by the existence check alone |
+| AC8 | the receipt names the inherited holder, never the marker | suppress the receipt | `test_nested_receipt_names_the_holder_and_never_the_marker` |
+| AC9 | an unusable store warns and runs the child | re-raise instead | `test_an_unusable_store_warns_and_still_runs_the_wrapped_child` |
+| AC9 | an unresolvable worktree warns and runs the child | resolve above the handler | `test_an_unresolvable_worktree_warns_and_still_runs_the_gate`, `test_an_explicit_port_survives_an_unresolvable_worktree` |
+| AC9 | only genuine contention refuses | classify a held lock as an unusable store | `test_a_held_coordination_lock_refuses_rather_than_running_unleased` |
+| AC9 | a hard-link failure is a store fault, not a crash | re-raise the raw `OSError` | `test_a_publication_fault_becomes_an_unusable_store_not_a_raw_oserror` |
+| AC9 | the recursive sub-make keeps the makefile in use | drop `-f` | `assert-sast-chain-reachable.py` mutation 2, `test_wrapped_targets_keep_their_lease_and_forward_the_makefile` |
+| AC9 | each wrapped target is itself guarded | drop the wrapper | `test_wrapped_targets_keep_their_lease_and_forward_the_makefile`, parameterised over `test`, `build-check`, `sast` |
+| AC9 | `ci` is not wrapped | wrap it | `lint-ci-parity` (31 derived dispositions) |
+| matrix | the browser gate publishes activity and takes no slot | remove the claim | `test_the_browser_gate_holds_activity_and_takes_no_run_slot` |
+| matrix | `bootstrap.py` participates in no lease | import the lease module | `test_bootstrap_participates_in_no_lease` |
 
 ### Windows enforcement lands in Task 1
 

--- a/docs/specs/worktree-cooperative-lease/plan.md
+++ b/docs/specs/worktree-cooperative-lease/plan.md
@@ -1,6 +1,6 @@
 # Plan: worktree-cooperative-lease
 
-- **Status:** Drafting
+- **Status:** Done
 - **Spec:** [`spec.md`](spec.md)
 
 ## Why this plan exists separately from its predecessor

--- a/docs/specs/worktree-cooperative-lease/plan.md
+++ b/docs/specs/worktree-cooperative-lease/plan.md
@@ -26,24 +26,38 @@ below names the mutation that must redden it.
 per-claim *ownership* lock answers liveness. The decision lock is never a claim's
 own lock.
 
-**Liveness is a held lock, positioned at byte zero.** Both the publishing and
-probing paths seek to byte zero before locking. On POSIX `flock` covers the whole
-open file description and position is irrelevant; on Windows `msvcrt.locking`
-locks one byte at the current position, so a publisher that writes a payload then
-locks holds a different byte than a prober opening at zero.
+**Liveness is a held lock, positioned at one agreed offset past the payload.** The
+publish, probe and release paths all seek to `CLAIM_LOCK_OFFSET` before locking. On
+POSIX `flock` covers the whole open file description and position is irrelevant; on
+Windows `msvcrt.locking` locks one byte at the current position, so a publisher that
+writes a payload then locks holds a different byte than a prober opening at zero.
 
-Measured on `windows-latest` by `tools/test_windows_lock_semantics.py`, which
-landed ahead of this work for exactly this purpose:
+Measured on `windows-latest` by `tools/test_windows_lock_semantics.py`, which landed
+ahead of this work for exactly this purpose:
 
 ```
 MEASURED [win32 / os.name=nt] write-then-lock, probe at position 0
     -> NOT blocked (LOCK INVISIBLE)
 ```
 
-All four cases passed, so the seek-to-zero invariant holds on Windows and
-byte-range locking *can* carry liveness there. That measurement reversed the
-design: the previous intent was to report `UNDETERMINABLE` on Windows —
-surrendering the capability — purely because it could not be tested locally.
+That measurement reversed the design: the previous intent was to report
+`UNDETERMINABLE` on Windows — surrendering the capability — purely because it could
+not be tested locally.
+
+**The offset is not zero, and that correction came from CI on this PR.** Seeking both
+sides to byte zero makes the lock observable, which is what the measurement above
+demanded — but the Windows lock is **mandatory**, not advisory, and byte zero sits
+*inside* the payload. `_read_record` reads that payload to name a holder in a
+refusal, and on `windows-latest` the read raised
+`PermissionError: [Errno 13] Permission denied` for every live claim: **10 failed, 11
+passed**, while the synthetic fixture in the same job passed 4/4.
+
+That split is the whole argument for this plan's requirement that the Windows job run
+the *real* publisher and prober rather than the fixture alone. A fixture proves the
+platform; only the code proves the code. The two requirements — one agreed offset, and
+an offset outside the payload — are now both asserted, and both are invisible on
+POSIX, which is why neither a green local suite nor sixteen mutation proofs nor an
+adversarial review caught it.
 
 **Reclaim policy differs by role, and the difference is load-bearing.** Admission
 roles (slot, ticket) are throughput counters: over-admitting by one costs memory
@@ -72,9 +86,9 @@ out-of-window creation time each refused or clamped; digest keys do not collide 
 `/mnt/a/b-c` versus `/mnt/a-b/c`; a symlinked store is refused; a claim path
 escaping the store is refused; the decision lock serializes two real processes.
 
-`Done when:` both the publish and probe paths seek to byte zero — asserted
-structurally, because on POSIX the behaviour is identical either way and only
-Windows can falsify it behaviourally.
+`Done when:` the publish, probe and release paths all seek to one constant offset
+past the payload — asserted structurally, because on POSIX the behaviour is identical
+at any offset and only Windows can falsify either half behaviourally.
 
 ### Task 2 — the two worktree roles and their interlock
 
@@ -131,8 +145,8 @@ mutation.
 
 ### Clause-to-mutation ledger
 
-Structural clauses — "exactly one implementation", "single-homed", "positioned at
-byte zero" where the platform makes position irrelevant — take goal-based source
+Structural clauses — "exactly one implementation", "single-homed", "positioned past
+the payload" where the platform makes position irrelevant — take goal-based source
 checks, because a runtime assertion cannot falsify them. The ledger is a deliverable,
 not a description: a clause with no entry is an unfinished task. The previous revision
 of this section stated that rule and then listed nothing, which is how three AC
@@ -148,7 +162,8 @@ restored and verified byte-identical.
 | AC1 | the OS releases the lock on death | `SIGKILL` the holder | `test_sigkilled_holder_claim_is_reclaimed` |
 | AC1 | liveness is not inferred from age | age a live claim | `test_live_identity_is_not_reclaimed_by_age_alone` |
 | AC1 | a recycled pid cannot impersonate a holder | reuse the pid | `test_recycled_pid_cannot_impersonate_lock_holder` |
-| AC1 | the lock is taken at byte zero on every platform | drop the `lseek` | `test_windows_write_then_lock_hides_the_lock_from_a_probe` and `test_seeking_to_zero_in_both_paths_makes_a_held_lock_observable` on `windows-latest`; `test_claim_lock_operations_seek_to_byte_zero_structurally` is the POSIX source check, because position is unobservable there |
+| AC1 | publish, probe and release agree on one offset | point one path at a different offset | `test_claim_lock_operations_agree_on_one_offset_past_the_payload`; behaviourally `test_the_shipped_offset_is_both_observable_and_leaves_the_payload_readable` on `windows-latest` |
+| AC1 | that offset lies outside the payload, so a held claim stays readable | set `CLAIM_LOCK_OFFSET = 0` | `test_claim_lock_operations_agree_on_one_offset_past_the_payload` (value assertion); behaviourally `test_locking_byte_zero_is_the_hazard_this_offset_exists_to_avoid` on `windows-latest`, which cannot fail on POSIX because `flock` is advisory |
 | AC2 | read and publish inside one uninterrupted hold | publish outside the hold | `test_racing_participants_are_never_both_admitted`, `test_scan_and_slot_publish_share_one_decision_lock_hold` |
 | AC2 | exactly one participant is admitted (`== 1`) | admit both | `test_contended_roles_admit_exactly_one_participant` |
 | AC2 | the two roles interlock in both directions | drop either check | `test_sequential_interlock_refuses_exclusive_while_activity_is_held`, `test_activity_waits_for_an_exclusive_claim_to_clear` |

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -1,6 +1,6 @@
 # Spec: worktree-cooperative-lease
 
-- **Status:** Draft
+- **Status:** Shipped
 - **Owner:** repository maintainers
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none
@@ -57,7 +57,7 @@ falsified by any test.
 
 ## Acceptance Criteria
 
-- [ ] **AC1 — a claim's liveness is a held lock, observable on every supported
+- [x] **AC1 — a claim's liveness is a held lock, observable on every supported
   platform.** A claim is live when its owner still holds the advisory lock it took
   for that claim's lifetime. Liveness is therefore an observation about a lock the
   operating system releases on the owner's death, never an inference from a
@@ -78,7 +78,7 @@ falsified by any test.
   the Windows aggregate's required set by the change that satisfies this criterion,
   because something now depends on it.
 
-- [ ] **AC2 — cleanup and mutating runs interlock, atomically.** A worktree carries
+- [x] **AC2 — cleanup and mutating runs interlock, atomically.** A worktree carries
   an `activity` role held by mutating build and test entry points and an
   `exclusive` role held by `clean --apply`. Each participant's read of the other
   role and the publication of its own claim occur inside one uninterrupted hold of
@@ -111,7 +111,7 @@ falsified by any test.
   A test asserts exactly one admission — `== 1`, never `<= 1`, because `<= 1` passes
   when both refuse, which is the outcome this criterion forbids.
 
-- [ ] **AC3 — the deletion safety proof is unchanged and unconditional.** The
+- [x] **AC3 — the deletion safety proof is unchanged and unconditional.** The
   per-candidate predicate of `worktree-runtime-hygiene` AC5, and its re-assertion
   immediately before each deletion, are untouched. No check becomes conditional on
   holding a claim. The claim narrows the concurrent-mutation window; it does not
@@ -119,7 +119,7 @@ falsified by any test.
   carry a suffix the deletion predicate already refuses, so no cleanup run can
   delete the coordination state it depends on.
 
-- [ ] **AC4 — claim payloads are untrusted, and no claim is unreleasable.** An
+- [x] **AC4 — claim payloads are untrusted, and no claim is unreleasable.** An
   out-of-range identity, a recorded worktree disagreeing with the claim's own
   location, and a creation time outside the file's own creation window are each
   refused or clamped rather than trusted. The scheduler orders waiters by a value a
@@ -169,7 +169,7 @@ falsified by any test.
   waiter's original queue position, which is what makes this escape hatch safe.
   Neither clause is complete without the other, and both name the coupling.
 
-- [ ] **AC5 — heavy runs are admitted against a common-directory-wide limit, and a
+- [x] **AC5 — heavy runs are admitted against a common-directory-wide limit, and a
   waiter is not overtaken.** At most a configured number of heavy build and test
   runs are admitted at once across every worktree sharing one Git common
   directory. Admission prunes, counts and publishes inside one hold of the shared
@@ -191,7 +191,7 @@ falsified by any test.
   scope, processes outside these worktrees hold no claim, and no output may imply
   that the machine is governed.
 
-- [ ] **AC6 — the budgets are strict, single-homed, and calibrated to a
+- [x] **AC6 — the budgets are strict, single-homed, and calibrated to a
   measurement.** The concurrency limit and the wait budget each parse as whole
   numbers, reject values below one, and refuse invalid input rather than falling
   back to a default, so a malformed value cannot silently disable the limiter —
@@ -220,7 +220,7 @@ falsified by any test.
   under exactly the contention the limiter exists to bound — and exhausting it
   must never degrade the limiter to a no-op.
 
-- [ ] **AC7 — one wrapper, one child runner, and a refusal no caller can mistake
+- [x] **AC7 — one wrapper, one child runner, and a refusal no caller can mistake
   for a verdict.** A wrapper command holds the worktree `activity` claim and one
   admission slot for exactly one child's lifetime, releasing both on normal exit,
   non-zero exit, interrupt and spawn failure, and forwarding termination signals to
@@ -252,7 +252,7 @@ falsified by any test.
   command reports claims and occupancy, mutates nothing, and prints the identifier
   the release command requires.
 
-- [ ] **AC8 — nesting is identity-bearing, and cannot be forged or leaked.** An
+- [x] **AC8 — nesting is identity-bearing, and cannot be forged or leaked.** An
   acquisition nested inside an already admitted run is a no-op, and so is its
   release, so an inner run cannot hand back a slot it never took. Nesting is
   recognised only when the inherited marker names a claim still live in the same
@@ -261,7 +261,7 @@ falsified by any test.
   echoed where it becomes a bypass anyone can copy. The receipt states when a run
   is nested and whose claim it inherited, so an inert limiter is visible.
 
-- [ ] **AC9 — the lease cannot fail a CI job, and the make wiring survives it.**
+- [x] **AC9 — the lease cannot fail a CI job, and the make wiring survives it.**
   An unusable store, an unresolvable worktree, or a platform that cannot lease
   warns and runs the child; only genuine contention refuses, and only
   `clean --apply` fails closed, because only it deletes.

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -306,6 +306,29 @@ No workflow passes `-j`, so nothing in CI is affected. A caller who needs
 parallelism should invoke the unwrapped target directly rather than have the
 wrapper forward a mechanism it cannot forward safely.
 
+### A repeatedly-invoked long-running consumer should use the unwrapped target
+
+The wait budget's default of ninety minutes suits a human or a CI job invoking a gate
+once. It suits worst a harness that invokes a wrapped target *repeatedly* and runs for
+a long time: each invocation takes a slot for its whole duration, so a peer's harness
+can saturate the machine-wide limit against itself, and a queued invocation waits the
+full budget before refusing with exit 75.
+
+Such a consumer exists — an out-of-repository evidence harness that calls
+`make build-check` in a loop, surfaced by the session running RFC-0088 round 13 while
+this change was in review. It is **not** a reason to change the wiring: the wrapped
+targets each expose an unwrapped sibling (`build-check-unleased`, `test-unleased`,
+`sast-unleased`) that runs the identical chain, takes no claim and no slot, and cannot
+queue or refuse. Only the `gate_verdict` banner is lost, because that prints on the
+outer target; the exit code is the chain's own either way. A caller that needs to
+bypass the limiter should invoke the unwrapped target directly rather than have the
+wrapper learn about it.
+
+Recorded here because the participant matrix enumerates entry points *in* this
+repository, and this consumer is outside it — so nothing in the matrix would have
+predicted it, and the next person to meet a serialised harness should not have to
+rediscover the sibling target.
+
 ### Over-admission by the soft cap is cumulative, and not bounded over time
 
 The soft cap admits a run past the limit when an existing slot's holder is older

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -87,11 +87,29 @@ falsified by any test.
   `clean --apply` publishes `exclusive` before its first deletion, refuses
   immediately while any live `activity` claim exists, and holds the claim across
   every deletion. `clean` without `--apply` mutates nothing, publishes no claim,
-  and does not create the store. When both roles contend at once **`activity` wins
-  and `exclusive` retries**: a queued build is holding a person's attention, while
-  cleanup is deferrable and can be re-run at no cost. A symmetric abort where
-  neither proceeds is a defect, not an acceptable outcome, and a test asserts which
-  participant won rather than that exactly one did.
+  and does not create the store.
+
+  **Contention resolves asymmetrically by consequence, not by winner.** An earlier
+  draft of this criterion required `activity` to win a simultaneous race. That is
+  not implementable over a single decision lock — whichever participant acquires the
+  lock first observes an empty field and proceeds — and making it deterministic
+  needs an arrival signal published before contending, which is additional
+  coordination state whose own stale-file failure mode wedges cleanup. That is a
+  worse outcome than the arbitrariness it removes, so the criterion states what is
+  both implementable and load-bearing:
+
+  - Exactly one participant is admitted per contended instant. A symmetric abort
+    where neither proceeds is a defect, and the decision lock is what forbids it.
+  - Which participant wins a genuinely simultaneous arrival is **arbitrary and
+    deliberately unspecified**. No test may assert a winner; asserting one would
+    pin an implementation accident.
+  - The *consequences* are asymmetric and favour the build. `exclusive` refuses
+    immediately and is cheap to re-run, so cleanup losing costs an operator one
+    re-invocation. `activity` waits a bounded budget before refusing, so a build
+    losing costs at most that budget and never a permanent loss to cleanup.
+
+  A test asserts exactly one admission — `== 1`, never `<= 1`, because `<= 1` passes
+  when both refuse, which is the outcome this criterion forbids.
 
 - [ ] **AC3 — the deletion safety proof is unchanged and unconditional.** The
   per-candidate predicate of `worktree-runtime-hygiene` AC5, and its re-assertion

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -37,7 +37,10 @@ falsified by any test.
   determined as live.
 - Give a refusal a reserved exit code, a greppable marker, and wording that says
   the command did not run.
-- Seek a claim file to byte zero before locking or probing it, on every platform.
+- Seek a claim file to one agreed offset **past its payload** before locking or
+  probing it, on every platform. Both halves are load-bearing: an offset the two
+  paths disagree on is unobservable, and an offset inside the payload makes the
+  payload unreadable where the platform lock is mandatory.
 
 ### Ask first
 
@@ -65,18 +68,35 @@ falsified by any test.
   and a killed run's claim is reclaimable at once. The recorded identity exists
   only to name a holder in a refusal.
 
-  Both the publishing path and the probing path position the claim file at byte
-  zero before locking. This is measured, not assumed: on Windows
-  `msvcrt.locking` locks one byte at the current file position, so a publisher
-  that writes a payload and then locks holds a different byte than a prober that
-  opens at zero — and `tools/test_windows_lock_semantics.py` records on
-  `windows-latest` that such a lock is **not** observable
-  (`write-then-lock, probe at position 0 -> NOT blocked (LOCK INVISIBLE)`), while
-  seeking both sides to byte zero makes it observable. An unobservable held lock
-  is not a degradation: it makes every probe read not-live, so a live peer's claim
-  is reclaimed and cleanup deletes under a running mutator. That job is wired into
-  the Windows aggregate's required set by the change that satisfies this criterion,
-  because something now depends on it.
+  The publishing path, the probing path and the release path all position the claim
+  file at **one agreed offset past the payload** before locking, held as a single
+  constant. Two requirements pull against each other and both are measured on
+  `windows-latest` by `tools/test_windows_lock_semantics.py`, not assumed:
+
+  - **The offset must be agreed.** `msvcrt.locking` locks one byte at the current
+    file position, so a publisher that writes a payload and then locks holds byte
+    `len(payload)` while a prober opening at zero holds byte 0 — disjoint ranges.
+    Recorded: `write-then-lock, probe at position 0 -> NOT blocked (LOCK INVISIBLE)`.
+  - **The offset must be outside the payload.** The Windows lock is *mandatory*,
+    not advisory as POSIX `flock` is, so no other handle may read a locked range.
+    Byte zero satisfies the first requirement and violates this one: it sits inside
+    the payload, and the read in `_read_record` that names a holder in a refusal
+    raised `PermissionError: [Errno 13] Permission denied` for every live claim.
+
+  This criterion originally said "byte zero", was ticked, and was falsified by the
+  Windows job on the pull request that shipped it — the fixture passed 4/4 while the
+  real publisher and prober failed 10 of 21. It is amended rather than deferred
+  because the correction is a one-constant protocol change, and recorded rather than
+  quietly rewritten because "a criterion that omits a failure mode cannot be
+  falsified by any test" is this spec's own premise, and this is that premise working.
+
+  An unobservable held lock is not a degradation: it makes every probe read
+  not-live, so a live peer's claim is reclaimed and cleanup deletes under a running
+  mutator. Neither is an unreadable payload: it denies a refusal the holder's name.
+  That job is wired into the Windows aggregate's required set by the change that
+  satisfies this criterion, because something now depends on it — and it must run the
+  real publisher and prober, since the synthetic fixture proves the platform and not
+  the code.
 
 - [x] **AC2 — cleanup and mutating runs interlock, atomically.** A worktree carries
   an `activity` role held by mutating build and test entry points and an

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -159,6 +159,7 @@ falsified by any test.
   | Undeterminable (unreadable file, unmapped lock errno, network mount) | The operator command releases it — and this **is** an override, because the claim may in fact be live. It is offered because the alternative is a permanent wedge, and it is the operator accepting a risk the tool cannot evaluate |
   | Observably live, holder hung | **No tool-side recovery.** The command refuses it, correctly. Recovery is terminating the named holder and re-probing. The refusal names the holder so that is actionable |
   | Live, holder healthy | Not a fault. Wait, or use the status command to see who holds it |
+  | Observably live, identity refused as untrusted | **No tool-side recovery, and no name to act on.** The release command refuses it as live, correctly, and the payload that would have named its holder was refused as untrusted — so "terminate the named holder" does not apply. The refusal names the claim's own identifier instead, which is what an operating-system tool (`lsof` and equivalents) needs to find the process holding that lock. This is a fifth state, listed because omitting it left a claim whose documented recovery could not be carried out |
 
   So the honest contract is narrower than "no claim is unreleasable": every claim has
   a documented path back, but for one state that path leaves the tool, and for
@@ -304,6 +305,23 @@ handing a sub-make a claim lock instead of the jobserver.
 No workflow passes `-j`, so nothing in CI is affected. A caller who needs
 parallelism should invoke the unwrapped target directly rather than have the
 wrapper forward a mechanism it cannot forward safely.
+
+### Over-admission by the soft cap is cumulative, and not bounded over time
+
+The soft cap admits a run past the limit when an existing slot's holder is older
+than the admission age budget. Nothing keeps a tombstone for a holder forgotten this
+way, so a forgotten holder that is still alive is not counted again by the next
+admission. At a limit of one, a run lasting far beyond the age budget can therefore
+be joined by a second, then a third, without bound: each admission sees one aged
+slot and replaces it, while the earlier holders keep running.
+
+This is stated rather than fixed. Bounding it means retaining a record of every
+expired-but-live holder, which is a second liveness registry with its own reclaim
+policy — the machinery this design exists to avoid. The exposure is small in
+practice because the age budget is six hours and the wait budget is ninety minutes,
+so reaching it requires a run that has already outlived any gate in this repository
+by an order of magnitude. The limiter is a courtesy to a shared machine, not an
+isolation boundary; a genuinely unbounded run is the fault to fix.
 
 ## Testing Strategy
 

--- a/docs/specs/worktree-cooperative-lease/spec.md
+++ b/docs/specs/worktree-cooperative-lease/spec.md
@@ -1,0 +1,330 @@
+# Spec: worktree-cooperative-lease
+
+- **Status:** Draft
+- **Owner:** repository maintainers
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:** none
+- **Contract:** none <!-- no REST/event/RPC surface; the claim-file layout is coordination state held in code and tests, not a published interface -->
+
+> **Spec contract:** this document defines what "done" means. The implementing
+> PR must match this spec, or update it. Verification must be derivable from it.
+
+## Objective
+
+Two commands operating on one worktree at the same time do not corrupt each
+other's work, and one machine does not exhaust itself running more heavy builds
+than it can hold. A maintainer running `clean --apply` while a peer's test suite
+is mid-flight sees a refusal naming the holder rather than a deleted `node_modules`;
+a maintainer whose gate is queued behind two others sees that it is queued rather
+than a silent hang. Coordination is cooperative: a command that never participates
+keeps working exactly as it does today.
+
+This is the criterion deferred out of [`worktree-runtime-hygiene`](../worktree-runtime-hygiene/spec.md)
+AC6 after it was built and then split under review. That spec's AC6 stated the
+outcome in one sentence; three independent reviewers found failure modes it did
+not enumerate, in a finished implementation with a green suite. The lesson shapes
+this document: **every failure mode below is an acceptance criterion, not an
+implementation note**, because a criterion that omits a failure mode cannot be
+falsified by any test.
+
+## Boundaries
+
+### Always do
+
+- Read the other role's claims and publish your own inside one indivisible step;
+  a read taken outside that step is not a decision.
+- Treat a claim payload as untrusted input, and treat liveness that cannot be
+  determined as live.
+- Give a refusal a reserved exit code, a greppable marker, and wording that says
+  the command did not run.
+- Seek a claim file to byte zero before locking or probing it, on every platform.
+
+### Ask first
+
+- Changing the default concurrency limit, the wait budget, or any age budget.
+- Adding a claim role, or leasing a command not already named here.
+- Making any lease failure able to fail a CI job.
+
+### Never do
+
+- Let a destructive command proceed on evidence it failed to obtain.
+- Infer liveness, activity, busyness, or abandonment from anything other than a
+  held lock; attachment is never liveness.
+- Delete, or make deletable, the coordination state the lease depends on.
+- Condition any behaviour on a CI environment variable.
+- Wrap an aggregate make target whose recipe only prints a verdict, or change
+  `ci`'s prerequisite list.
+
+## Acceptance Criteria
+
+- [ ] **AC1 — a claim's liveness is a held lock, observable on every supported
+  platform.** A claim is live when its owner still holds the advisory lock it took
+  for that claim's lifetime. Liveness is therefore an observation about a lock the
+  operating system releases on the owner's death, never an inference from a
+  recorded process identity, so a recycled identity cannot impersonate an owner
+  and a killed run's claim is reclaimable at once. The recorded identity exists
+  only to name a holder in a refusal.
+
+  Both the publishing path and the probing path position the claim file at byte
+  zero before locking. This is measured, not assumed: on Windows
+  `msvcrt.locking` locks one byte at the current file position, so a publisher
+  that writes a payload and then locks holds a different byte than a prober that
+  opens at zero — and `tools/test_windows_lock_semantics.py` records on
+  `windows-latest` that such a lock is **not** observable
+  (`write-then-lock, probe at position 0 -> NOT blocked (LOCK INVISIBLE)`), while
+  seeking both sides to byte zero makes it observable. An unobservable held lock
+  is not a degradation: it makes every probe read not-live, so a live peer's claim
+  is reclaimed and cleanup deletes under a running mutator. That job is wired into
+  the Windows aggregate's required set by the change that satisfies this criterion,
+  because something now depends on it.
+
+- [ ] **AC2 — cleanup and mutating runs interlock, atomically.** A worktree carries
+  an `activity` role held by mutating build and test entry points and an
+  `exclusive` role held by `clean --apply`. Each participant's read of the other
+  role and the publication of its own claim occur inside one uninterrupted hold of
+  one shared decision lock; a scan taken outside that hold is not a decision, so
+  two participants cannot each observe the other's absence and both proceed.
+  `clean --apply` publishes `exclusive` before its first deletion, refuses
+  immediately while any live `activity` claim exists, and holds the claim across
+  every deletion. `clean` without `--apply` mutates nothing, publishes no claim,
+  and does not create the store. When both roles contend at once **`activity` wins
+  and `exclusive` retries**: a queued build is holding a person's attention, while
+  cleanup is deferrable and can be re-run at no cost. A symmetric abort where
+  neither proceeds is a defect, not an acceptable outcome, and a test asserts which
+  participant won rather than that exactly one did.
+
+- [ ] **AC3 — the deletion safety proof is unchanged and unconditional.** The
+  per-candidate predicate of `worktree-runtime-hygiene` AC5, and its re-assertion
+  immediately before each deletion, are untouched. No check becomes conditional on
+  holding a claim. The claim narrows the concurrent-mutation window; it does not
+  replace the proof. The store lives under the Git common directory and its files
+  carry a suffix the deletion predicate already refuses, so no cleanup run can
+  delete the coordination state it depends on.
+
+- [ ] **AC4 — claim payloads are untrusted, and no claim is unreleasable.** An
+  out-of-range identity, a recorded worktree disagreeing with the claim's own
+  location, and a creation time outside the file's own creation window are each
+  refused or clamped rather than trusted. The scheduler orders waiters by a value a
+  writer cannot forge downward, so a backdated claim cannot become permanently the
+  oldest waiter.
+
+  Liveness that cannot be determined counts as live, because that is the safe
+  answer for a destructive caller. It is reached without an adversary: the module's
+  own bound is that advisory locks are undependable on a network mount, and an
+  unreadable claim file — another user's, or one left `000` — answers the same way.
+  Because that answer is *permanent*, every role needs a documented path back, and
+  **the paths differ by role for a reason that must not be tidied away**:
+
+  An **admission** claim is a throughput counter. Reclaiming one from a still-live
+  owner over-admits by one run: more memory pressure, self-correcting, recoverable.
+  So an admission role expires against a stated budget that no legitimate holder
+  outlives, and a wedged slot or ticket cannot block every gate indefinitely.
+
+  A **worktree** claim is a safety interlock. Reclaiming an `exclusive` claim from a
+  still-live owner lets a mutator start while a cleaner is deleting, which is
+  corruption and is not recoverable. So the worktree roles never expire on age, and
+  their only path back is the explicit operator command.
+
+  That asymmetry is deliberate. A previous round applied one rule to both and had
+  to be split; a future round tempted to make them consistent should change this
+  criterion first, not the code.
+
+  **The recovery model is stated per observable state, because two earlier
+  formulations of it were false.** Claiming "no claim is unreleasable" and "the only
+  path back is the operator command" cannot both hold: a hung but observably-live
+  holder is refused by that command, and its actual recovery is external. There are
+  four states and they do not share an answer:
+
+  | Claim state | Recovery |
+  |---|---|
+  | Absent, or lock observably free | Reclaimed automatically; no operator action |
+  | Undeterminable (unreadable file, unmapped lock errno, network mount) | The operator command releases it — and this **is** an override, because the claim may in fact be live. It is offered because the alternative is a permanent wedge, and it is the operator accepting a risk the tool cannot evaluate |
+  | Observably live, holder hung | **No tool-side recovery.** The command refuses it, correctly. Recovery is terminating the named holder and re-probing. The refusal names the holder so that is actionable |
+  | Live, holder healthy | Not a fault. Wait, or use the status command to see who holds it |
+
+  So the honest contract is narrower than "no claim is unreleasable": every claim has
+  a documented path back, but for one state that path leaves the tool, and for
+  another it requires the operator to accept a risk. The command states which case
+  it is in rather than implying the release was safe.
+
+  Releasing a waiter's ticket must not strand it: AC5's re-registration retains the
+  waiter's original queue position, which is what makes this escape hatch safe.
+  Neither clause is complete without the other, and both name the coupling.
+
+- [ ] **AC5 — heavy runs are admitted against a common-directory-wide limit, and a
+  waiter is not overtaken.** At most a configured number of heavy build and test
+  runs are admitted at once across every worktree sharing one Git common
+  directory. Admission prunes, counts and publishes inside one hold of the shared
+  decision lock. A waiter registers once and is admitted in registration order,
+  and its ticket scan shares the lock hold with its own claim, so two waiters
+  cannot each observe no older ticket and both admit. A waiter whose registration
+  is lost re-registers **retaining its original position**, so an operator removing
+  a ticket (AC4) cannot send that waiter to the back of the queue repeatedly and
+  starve it.
+
+  The limit is **soft across an admission expiry, and that is stated rather than
+  implied**: when AC4's age budget reclaims a slot whose owner may still be live,
+  the live count can briefly exceed the configured limit by the number of expired
+  slots. That is the accepted cost of not wedging every gate forever, and it is
+  bounded — over-admission costs memory pressure, which is recoverable, where a
+  permanent wedge is not. A criterion promising a hard cap and an expiry policy at
+  once would be unsatisfiable.
+  The limit is common-directory-wide, not machine-wide: a second clone is a second
+  scope, processes outside these worktrees hold no claim, and no output may imply
+  that the machine is governed.
+
+- [ ] **AC6 — the budgets are strict, single-homed, and calibrated to a
+  measurement.** The concurrency limit and the wait budget each parse as whole
+  numbers, reject values below one, and refuse invalid input rather than falling
+  back to a default, so a malformed value cannot silently disable the limiter —
+  and that refusal is reachable from the entry point that ships, not only from the
+  parsing helper. A refusal is the operator's-error path and is distinct from the
+  store-unavailable path; the two are never caught by one handler.
+
+  The values are named here, not left to the implementation, because the previous
+  round's calibration defect is reachable by redefining an unnamed term:
+
+  | Quantity | Value | Why |
+  |---|---|---|
+  | Default concurrency limit | **2** | Memory-bound, not core-derived: a unit suite measured 178.9 s wall against 56.4 s CPU, so a run is mostly waiting and cores are the wrong denominator. On the 10-core 32 GiB reference host `cpu_count() // 2` gives 5, which is the concurrency that exhausted swap at load 135 |
+  | Wait budget | **5400 s** | Sized by queue depth times hold time over the limit, not by one run: at limit 2 with five waiters and 25-minute holds the last waiter needs 50-75 minutes |
+  | Memory per concurrent run | **12 GiB** | The reference host is 32 GiB and judged safe at 2. A divisor of 16 GiB left **no headroom** and, because the platform reports *usable* rather than nominal pages, clamped that very host to 1 — the defect this row exists to prevent. 12 GiB leaves the reference configuration at 2 and still clamps a 16 GiB machine to 1 |
+  | Admission claim age budget | **6 h** | Above any legitimate run; a full suite is 15-25 minutes |
+  | Decision-lock acquisition budget | **at least one twentieth of the wait budget, and never below 30 s** | A proportional budget alone still conforms while being uselessly small, so a floor is stated too |
+
+  The clamp reads the usable-memory figure, applies only to the default, and never
+  raises it. An explicit override is the operator's decision about their own
+  hardware and is never clamped away. A platform whose memory cannot be measured is
+  left unclamped rather than guessed at.
+
+  The decision lock's own acquisition budget scales with the wait budget rather
+  than being a fixed second, because it is otherwise the first thing to exhaust
+  under exactly the contention the limiter exists to bound — and exhausting it
+  must never degrade the limiter to a no-op.
+
+- [ ] **AC7 — one wrapper, one child runner, and a refusal no caller can mistake
+  for a verdict.** A wrapper command holds the worktree `activity` claim and one
+  admission slot for exactly one child's lifetime, releasing both on normal exit,
+  non-zero exit, interrupt and spawn failure, and forwarding termination signals to
+  the child's process group. It uses the single child runner already shipped rather
+  than a second copy, spawns from a verbatim argument vector with no shell and no
+  interpolation, refuses an empty command, and adds only the nesting marker to the
+  child's environment. Neither publishing nor releasing a claim can alter the
+  child's exit code, in either direction: a failing release cannot redden a passing
+  child, and a succeeding release cannot mask a failing one.
+
+  Every refusal — mutator, cleanup, wrapper and gate alike — exits **75**
+  (`EX_TEMPFAIL`), prints the literal marker `WORKTREE_LEASE_DID_NOT_RUN` alone on
+  its own line, and says the command did not run. Both values are stated here so a
+  test can assert the literals from this contract rather than by reading the
+  implementation's own constant, which is the tautology that left the previous
+  round's marker with no guard at all.
+
+  **75 is not, and cannot be, a code no child returns.** The wrapper runs a verbatim
+  argument vector, so a child may return any code including 75; a criterion
+  promising otherwise is unsatisfiable. The marker is therefore the authoritative
+  discriminator and the exit code is a convenience for callers that cannot read
+  stderr. A caller distinguishing contention from a gate verdict greps the marker;
+  one that sees 75 without the marker is looking at a child's own status.
+
+  A refusal names process ids and worktree base names only, never a payload or an
+  absolute path. A queued caller reports
+  that it is queued and behind whom, rather than waiting in silence, because a long
+  queue and a deadlock are otherwise indistinguishable from outside. A status
+  command reports claims and occupancy, mutates nothing, and prints the identifier
+  the release command requires.
+
+- [ ] **AC8 — nesting is identity-bearing, and cannot be forged or leaked.** An
+  acquisition nested inside an already admitted run is a no-op, and so is its
+  release, so an inner run cannot hand back a slot it never took. Nesting is
+  recognised only when the inherited marker names a claim still live in the same
+  scope; a marker naming no live claim counts as absent, so a stale export or a
+  crashed run's leftover cannot silently disable the limiter. The marker is not
+  echoed where it becomes a bypass anyone can copy. The receipt states when a run
+  is nested and whose claim it inherited, so an inert limiter is visible.
+
+- [ ] **AC9 — the lease cannot fail a CI job, and the make wiring survives it.**
+  An unusable store, an unresolvable worktree, or a platform that cannot lease
+  warns and runs the child; only genuine contention refuses, and only
+  `clean --apply` fails closed, because only it deletes.
+
+  A recursive make invocation introduced by the wrapper forwards the makefile
+  currently in use, so a self-test that proves its own guard by running a *mutated*
+  copy still executes the mutation. Without that forwarding the sub-make re-reads
+  the real makefile and such a guard silently stops proving anything while still
+  reporting success.
+
+  It does **not** forward the jobserver; see Limitations. Every existing guard that
+  reads a wrapped target's recipe keeps working, and each wrapped target is itself
+  guarded, so a dropped wrapper reddens something.
+
+## Limitations
+
+A wrapped make target loses the jobserver, so `make -j` prints
+`warning: jobserver unavailable: using -j1` and runs serially. This is a stated
+limitation rather than a defect to fix, and the reasoning is recorded because the
+obvious fix is worse than the symptom.
+
+Measured on macOS with GNU Make 3.81: a direct `$(MAKE)` reports
+`MAKEFLAGS=[ --jobserver-fds=3,4 -j]` with those descriptors open, while the same
+invocation through the wrapper reports `MAKEFLAGS=[]` with none. `MAKEFLAGS`
+propagates through the environment; the **descriptors** do not. Make's own
+suggested remedy — prefixing the recipe line with `+` — was tried and does not
+help: it marks the line recursive for `-n` purposes without restoring descriptors.
+Explicit `pass_fds` forwarding does work.
+
+It is not adopted for three reasons. The jobserver is three different mechanisms —
+inherited descriptors on make 3.81 through 4.3, a named pipe on 4.4 and later, a
+named semaphore on Windows where `pass_fds` is unsupported — so forwarding means
+version-sniffing a format that has already changed twice. Its failure mode is a
+build that **hangs** rather than warns, because a token not returned to the pipe
+leaves make waiting forever, nondeterministically and under load. And this wrapper
+is the process most likely to get it wrong: its whole purpose is to hold
+descriptors open for the claim locks, so forwarding numeric descriptors risks
+handing a sub-make a claim lock instead of the jobserver.
+
+No workflow passes `-j`, so nothing in CI is affected. A caller who needs
+parallelism should invoke the unwrapped target directly rather than have the
+wrapper forward a mechanism it cannot forward safely.
+
+## Testing Strategy
+
+Real processes, real locks, real filesystems. The prior round's dominant failure
+was guards that were written correctly and could not fail — six of them, none
+visible in a green suite — so every criterion here names what mutation must
+redden it, and no mutation proof is accepted without observing the baseline green
+first.
+
+Four rules follow from specific defects that reached review last time.
+
+Never mock the call a branch dispatches on. Every disposition test in the prior
+round patched `os.killpg`, which is how a real defect reached a green suite; kernel
+and filesystem behaviour must be exercised unmocked at least once per claim.
+
+Never assert against the constant the code emitted. That comparison is a tautology:
+mutating the constant changes both sides and the test still passes, which is how a
+required refusal marker ended up with no guard at all.
+
+A test whose name claims concurrency, atomicity or ordering has two participants
+and a deterministically widened window. A single-actor body is a sequential test
+whatever it is called, and one such test passed with its mutual-exclusion lock
+removed entirely. Where a third mechanism serialises the participants, assert the
+property directly rather than inferring it from a race outcome.
+
+Budgets for real process startup are generous and single-homed. A two-second wait
+produced a failure that read exactly like a logic defect on a host that has run at
+load 160.
+
+Windows behaviour is verified on the `windows-latest` runner, not reasoned about.
+Anything that cannot be verified there is stated as unverified rather than
+asserted.
+
+## Assumptions
+
+1. All linked worktrees of one checkout share one Git common directory, which is
+   therefore the coordination scope. A second clone is a second scope.
+2. Advisory locks are dependable on a local filesystem. A common directory on a
+   network mount is outside what this mechanism promises, and a claim whose lock
+   cannot be evaluated is treated as live rather than guessed at.
+3. The platform reports a physical-memory figure through a documented interface, or
+   reports none; where it reports none the clamp does not apply.

--- a/docs/specs/worktree-runtime-hygiene/spec.md
+++ b/docs/specs/worktree-runtime-hygiene/spec.md
@@ -64,15 +64,18 @@ state, and silently skipped tests unrelated to the actual space problem.
   `__pycache__` is a correctness cleanup because stale bytecode can violate CAT-V-014
   during a run.
 
-- [ ] **AC6 — round 2: concurrent operations are explicitly leased.** (deferred: worktree-cooperative-lease) The second
+- [x] **AC6 — round 2: concurrent operations are explicitly leased.** The second
   implementation task adds a caller-selected preview-port override and a gate wrapper
   that leases it without binding the shared default port. It also adds the cooperative
   worktree lease shared by cleanup and mutating build/test entry points; only that
   shared lease can close the remaining check-to-delete concurrency window completely.
-  The lease was built and then split out under review: three independent reviewers
-  found that it carries more failure modes than this criterion enumerates, including a
-  Windows byte-range defect that would let `clean --apply` delete under a live
-  mutator. It gets its own spec rather than a wider version of this one.
+  The lease was built, split out under review when three independent reviewers found
+  failure modes this criterion did not enumerate, re-specified with each of them as
+  an acceptance clause, and shipped by
+  [`worktree-cooperative-lease`](../worktree-cooperative-lease/spec.md). The decisive
+  finding was a Windows byte-range defect that would have let `clean --apply` delete
+  under a live mutator; it is now measured on a `windows-latest` runner rather than
+  reasoned about.
 
 - [x] **AC7 — round 2: bootstrap and browser cache choices remain explicit.** The
   second implementation task adds a browser-cache resolver and selective bootstrap

--- a/tools/assert-sast-chain-reachable.py
+++ b/tools/assert-sast-chain-reachable.py
@@ -106,7 +106,10 @@ def self_test() -> int:
         # Mutation 2: the branch survives textually but is made UNREACHABLE — the
         # case a grep for `$(MAKE) sast` cannot distinguish from a healthy chain.
         neutered = src.replace(
-            "build-check:\n", "build-check: SKIP_SAST := 1\nbuild-check:\n", 1)
+            "build-check-unleased:\n",
+            "build-check-unleased: SKIP_SAST := 1\nbuild-check-unleased:\n",
+            1,
+        )
         if neutered == src:
             failures.append("mutation 2: no-op transform — proves nothing")
         mk2 = pathlib.Path(td) / "neutered.mk"

--- a/tools/repo/coordination_lease.py
+++ b/tools/repo/coordination_lease.py
@@ -71,6 +71,18 @@ class ClaimStoreUnavailable(CoordinationLeaseError):
     """The store cannot safely support a coordination decision."""
 
 
+class CoordinationLockContention(ClaimStoreUnavailable):
+    """The coordination lock stayed held by a live peer for the whole budget.
+
+    A subclass of `ClaimStoreUnavailable` so that every caller which already
+    tolerates an unusable store -- notably claim release, which may only warn --
+    keeps its behaviour unchanged. The wrapper, however, must distinguish the two:
+    a lock held by a live peer is genuine contention, and treating it as an unusable
+    store made the limiter switch itself off under exactly the load it exists for.
+    Order matters at the catch sites: this clause must precede its base class.
+    """
+
+
 class ClaimContentionError(CoordinationLeaseError):
     """A peer's claim lock is live or could not be inspected."""
 
@@ -347,7 +359,7 @@ def coordination_lock(
                 except OSError as error:
                     if deadline is None:
                         if LEASE_RETRY_LIMIT <= 1:
-                            raise ClaimStoreUnavailable(
+                            raise CoordinationLockContention(
                                 "could not acquire coordination lock"
                             ) from error
                         # Existing non-admission callers retain their bounded retry
@@ -357,7 +369,7 @@ def coordination_lock(
                         ) * LEASE_RETRY_DELAY_SECONDS
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
-                        raise ClaimStoreUnavailable(
+                        raise CoordinationLockContention(
                             "could not acquire coordination lock"
                         ) from error
                     time.sleep(min(LEASE_RETRY_DELAY_SECONDS, remaining))
@@ -385,6 +397,17 @@ def publish_claim_candidate(lease_dir: Path, path: Path, payload: str) -> int:
         _lock_functions(descriptor)[0]()
         os.link(temporary, path)
         return descriptor
+    except FileExistsError:
+        # A claim already exists at this path: contention, which callers resolve by
+        # probing the incumbent. It must stay distinguishable from a store fault.
+        _unlock_and_close(descriptor)
+        raise
+    except OSError as error:
+        # A filesystem that cannot hard-link, a full disk, or a locking failure is an
+        # unusable store, not a caller error. Raised raw it escaped every fail-open
+        # handler and crashed the wrapper on a platform AC9 promises to run on.
+        _unlock_and_close(descriptor)
+        raise ClaimStoreUnavailable("claim store cannot publish a claim") from error
     except BaseException:
         _unlock_and_close(descriptor)
         raise
@@ -733,9 +756,15 @@ def _prune_run_registrations(lease_dir: Path, common_dir: Path) -> None:
     now = time.time()
     for path in paths:
         record = _read_record(path, ClaimRole.RUN_TICKET, common_dir)
-        if (
-            record.liveness is Liveness.NOT_LIVE
-            or now - record.created_at > RUN_CLAIM_MAX_AGE_SECONDS
+        # An observably-live registration is never aged out. Age reclaims records whose
+        # owner died without releasing, and a held lock proves that did not happen; the
+        # age clause therefore applies only when liveness is unproven. Unlinking a live
+        # waiter's record erased its queue position, and its next publication took a
+        # fresh timestamp that let younger waiters overtake it -- reachable whenever the
+        # wait budget is overridden past the age budget.
+        aged = now - record.created_at > RUN_CLAIM_MAX_AGE_SECONDS
+        if record.liveness is Liveness.NOT_LIVE or (
+            aged and record.liveness is not Liveness.LIVE
         ):
             with contextlib.suppress(OSError):
                 path.unlink()
@@ -1052,12 +1081,21 @@ def git_common_dir(repository: Path) -> Path:
 
 
 def _holder_names(claims: Sequence[ClaimRecord]) -> str:
-    """Render only process ids and worktree base names for user-facing output."""
+    """Render only process ids, worktree base names, and claim identifiers.
+
+    A live claim whose payload was refused as untrusted has no pid to name, and
+    "pid unknown" left the operator with nothing to act on while the release command
+    correctly refused it as live. The claim's own identifier is named instead: it is a
+    base name rather than a path, so it stays inside AC7's disclosure limit, and it is
+    what an operating-system tool needs to find the process holding the lock.
+    """
     names = []
     for claim in claims:
-        pid = str(claim.pid) if claim.pid is not None else "unknown"
         worktree = claim.worktree.name if claim.worktree is not None else "unknown"
-        names.append(f"pid {pid} in {worktree}")
+        if claim.pid is None:
+            names.append(f"an unidentified holder of claim {claim.path.name}")
+        else:
+            names.append(f"pid {claim.pid} in {worktree}")
     return ", ".join(names) or "unknown holder"
 
 
@@ -1096,15 +1134,27 @@ def with_lease(
     try:
         try:
             if common is not None:
-                activity = acquire_activity(
-                    common, worktree, wait_seconds=DEFAULT_RUN_SLOT_WAIT_SECONDS
-                )
+                # The admission slot is taken first, and activity only once a slot is
+                # held. Activity is what `clean --apply` refuses on, and the slot wait
+                # is the long one: acquiring activity first made a merely queued run
+                # block cleanup for the whole wait budget with no child in existence,
+                # against AC7's "for exactly one child's lifetime". Cleanup takes no
+                # slot, so this order introduces no cycle.
                 slot = acquire_run_slot(common, environ=values, on_wait=_queue_notice)
+                # The operator's wait budget governs both waits. Hardcoding the
+                # default here meant a configured budget shortened the admission wait
+                # and silently left a ninety-minute wait on a live exclusive claim.
+                _limit, wait_seconds = run_slot_budgets(values)
+                activity = acquire_activity(common, worktree, wait_seconds=wait_seconds)
         except RunSlotConfigurationError:
             raise
         except ClaimContentionError:
             raise
         except RunSlotAdmissionRefused:
+            raise
+        except CoordinationLockContention:
+            # Must precede the base clause: a lock held by a live peer is contention,
+            # and running unleased here is the limiter disabling itself under load.
             raise
         except ClaimStoreUnavailable as error:
             print(
@@ -1114,11 +1164,23 @@ def with_lease(
             )
         if slot is not None:
             values[RUN_SLOT_NESTING_MARKER_ENV] = slot.nesting_marker
+            if slot.nested:
+                # AC8's receipt: an inert limiter must be visible. The inherited pid is
+                # named; the marker never is, because echoing it publishes a bypass.
+                inherited = slot.inherited_pid
+                holder = "an unidentified holder" if inherited is None else f"pid {inherited}"
+                print(
+                    "worktree lease: nested run — the concurrency limiter is inert "
+                    f"here; this run inherited the slot held by {holder}",
+                    file=sys.stderr,
+                    flush=True,
+                )
         return managed_child.run_child(tuple(command), values, worktree)
     finally:
         # Teardown cannot rewrite a real child outcome. A failed release is still
         # visible only as a warning, and a partially-acquired wrapper is unwound.
-        for claim in (slot, activity):
+        # Released in reverse acquisition order.
+        for claim in (activity, slot):
             if claim is None:
                 continue
             try:

--- a/tools/repo/coordination_lease.py
+++ b/tools/repo/coordination_lease.py
@@ -1,0 +1,860 @@
+"""Atomic worktree claims with separate decision and lifetime ownership locks.
+
+Advisory claim locks are reliable only on local filesystems. Do not use their
+liveness observation over a network filesystem with different lock semantics.
+
+The run-slot default is memory-bound, not core-bound. Measured pytest processes
+used 47--128 MB resident memory while a unit suite spent 178.9 seconds wall time
+for 56.4 seconds CPU time (32%), so runs mostly wait and CPU count is the wrong
+denominator. This host exhausted swap (26 of 27.6 GB) at load 135; a core-derived
+default of five was that failing state. Two concurrent runs bounds memory pressure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import hashlib
+import importlib
+import json
+import os
+import stat
+import tempfile
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+if __package__:
+    from .worktree_hygiene import Candidate, _path_component_reason
+else:
+    from worktree_hygiene import Candidate, _path_component_reason
+
+
+LEASE_DIRECTORY = "agent-ready-repo-worktree-leases"
+LEASE_DIRECTORY_MODE = 0o700
+LEASE_RETRY_LIMIT = 20
+LEASE_RETRY_DELAY_SECONDS = 0.05
+DEFAULT_MAX_CONCURRENT_RUNS = 2
+# Downward-only memory clamp. Calibrated to the single measurement point
+# available: this reference host has 32 GiB and is judged safe at 2 concurrent
+# heavy runs, so 16 GiB per run is the implied budget. Below that a machine gets
+# fewer, never more.
+MEMORY_PER_CONCURRENT_RUN_BYTES = 16 * 1024**3
+# Age backstop for the ADMISSION roles only. An undeterminable probe counts as
+# live, which for `activity`/`exclusive` is the right conservative answer -- but a
+# run slot or waiter ticket that can never be reclaimed wedges every gate in every
+# worktree, and no legitimate waiter outlives its own wait budget. The worktree
+# claim roles keep the not-live-only policy, which is what stops a long run from
+# having its own claim pruned mid-flight.
+RUN_CLAIM_MAX_AGE_SECONDS = 6 * 60 * 60
+DEFAULT_RUN_SLOT_WAIT_SECONDS = 5400
+MAX_CONCURRENT_RUNS_ENV = "WORKTREE_HYGIENE_MAX_CONCURRENT_RUNS"
+RUN_SLOT_WAIT_SECONDS_ENV = "WORKTREE_HYGIENE_RUN_SLOT_WAIT_SECONDS"
+RUN_SLOT_NESTING_MARKER_ENV = "WORKTREE_HYGIENE_RUN_SLOT_CLAIM"
+
+
+class CoordinationLeaseError(RuntimeError):
+    """Base error for cooperative claim operations."""
+
+
+class ClaimStoreUnavailable(CoordinationLeaseError):
+    """The store cannot safely support a coordination decision."""
+
+
+class ClaimContentionError(CoordinationLeaseError):
+    """A peer's claim lock is live or could not be inspected."""
+
+    def __init__(self, message: str, *, claims: tuple[ClaimRecord, ...] = ()) -> None:
+        super().__init__(message)
+        self.claims = claims
+
+
+class RunSlotConfigurationError(CoordinationLeaseError):
+    """A run-slot environment budget is malformed or outside its valid range."""
+
+
+class RunSlotAdmissionRefused(CoordinationLeaseError):
+    """No run slot became available before the caller's configured wait budget."""
+
+    def __init__(self, holder_pids: tuple[int, ...]) -> None:
+        self.holder_pids = holder_pids
+        named_holders = ", ".join(str(pid) for pid in holder_pids) or "unknown"
+        super().__init__(
+            "run slot admission refused after wait budget; holding process ids: "
+            f"{named_holders}"
+        )
+
+
+class Liveness(Enum):
+    """The result of observing a claim's lifetime ownership lock."""
+
+    LIVE = "live"
+    NOT_LIVE = "not-live"
+    UNDETERMINABLE = "undeterminable"
+
+
+class ReclaimPolicy(Enum):
+    """Named policy seam also used by the shipped port lease in layer 3."""
+
+    PORT_LEASE = "not-live-or-aged"
+    WORKTREE_CLAIM = "not-live-only"
+
+
+class ClaimRole(Enum):
+    """The cooperative worktree claim roles."""
+
+    ACTIVITY = "activity"
+    EXCLUSIVE = "exclusive"
+    RUN_SLOT = "run-slot"
+    RUN_TICKET = "run-ticket"
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    """A claim's untrusted payload and authoritative lock observation."""
+
+    role: ClaimRole
+    path: Path
+    token: str | None
+    pid: int | None
+    worktree: Path | None
+    created_at: float
+    liveness: Liveness
+
+
+@dataclass(frozen=True)
+class WorktreeClaims:
+    """Claims present for one worktree, for reporting without mutation."""
+
+    activity: tuple[ClaimRecord, ...]
+    exclusive: ClaimRecord | None
+
+
+@dataclass
+class WorktreeClaim:
+    """A caller-owned claim whose descriptor holds its ownership lock for life."""
+
+    role: ClaimRole
+    path: Path
+    token: str
+    lease_dir: Path
+    descriptor: int
+
+    def release(self) -> None:
+        """Remove only this token's claim, then release its lifetime lock."""
+        try:
+            with coordination_lock(self.lease_dir, "coordination.lock"):
+                record = _read_record(self.path, self.role, None)
+                if record.token == self.token:
+                    with contextlib.suppress(FileNotFoundError):
+                        self.path.unlink()
+        finally:
+            _unlock_and_close(self.descriptor)
+
+
+@dataclass
+class RunSlotClaim:
+    """An admitted run slot, or a live parent slot inherited by a nested run."""
+
+    path: Path | None
+    token: str
+    lease_dir: Path
+    descriptor: int | None
+    pid: int | None
+    nested: bool = False
+
+    @property
+    def nesting_marker(self) -> str:
+        """Return the marker that lets a direct child identify this live slot."""
+        return self.token
+
+    @property
+    def inherited_pid(self) -> int | None:
+        """Name the parent holder only for a nested receipt's visible report."""
+        return self.pid if self.nested else None
+
+    def release(self) -> None:
+        """Release an owned slot; a nested receipt never releases its parent's slot."""
+        if self.nested:
+            return
+        try:
+            if self.path is None:
+                return
+            with coordination_lock(self.lease_dir, "coordination.lock"):
+                record = _read_record(self.path, ClaimRole.RUN_SLOT, None)
+                if record.token == self.token:
+                    with contextlib.suppress(FileNotFoundError):
+                        self.path.unlink()
+        finally:
+            if self.descriptor is not None:
+                _unlock_and_close(self.descriptor)
+
+
+def _is_junction(path: Path) -> bool:
+    """Return the optional Windows junction predicate."""
+    check = getattr(path, "is_junction", None)
+    return bool(callable(check) and check())
+
+
+def _confined_existing(path: Path, root: Path) -> bool:
+    """Reuse hygiene's component walk for an existing path under ``root``."""
+    try:
+        path.relative_to(root)
+        candidate = Candidate(path=path, category="lease", bytes=0, is_dir=path.is_dir())
+        return path.resolve().is_relative_to(root.resolve()) and not _path_component_reason(
+            candidate, root, os.path.ismount
+        )
+    except (OSError, ValueError):
+        return False
+
+
+def _confined_new(path: Path, root: Path) -> bool:
+    """Check a new composed child by validating its existing parent, not itself."""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return path.parent == root and _confined_existing(root, root)
+
+
+def _safe_lease_directory(path: Path) -> bool:
+    """Return whether ``path`` is an existing real directory, not a link."""
+    try:
+        mode = path.lstat().st_mode
+    except OSError:
+        return False
+    return stat.S_ISDIR(mode) and not stat.S_ISLNK(mode) and not _is_junction(path)
+
+
+def prepare_lease_directory(common_dir: Path) -> Path:
+    """Create a ``0700`` store, rejecting linked or escaping directory paths."""
+    try:
+        common = common_dir.resolve(strict=True)
+        if common_dir.is_symlink() or _is_junction(common_dir):
+            raise ClaimStoreUnavailable("Git common directory is a link or junction")
+        lease_dir = common / LEASE_DIRECTORY
+        if lease_dir.exists() and (lease_dir.is_symlink() or _is_junction(lease_dir)):
+            raise ClaimStoreUnavailable("lease directory is a link or junction")
+        lease_dir.mkdir(mode=LEASE_DIRECTORY_MODE, parents=True, exist_ok=True)
+        if not _confined_existing(lease_dir, common):
+            raise ClaimStoreUnavailable("lease directory escapes Git common directory")
+        mode = lease_dir.lstat().st_mode
+        if not stat.S_ISDIR(mode) or stat.S_ISLNK(mode) or _is_junction(lease_dir):
+            raise ClaimStoreUnavailable("lease directory is not a safe directory")
+        return lease_dir
+    except ClaimStoreUnavailable:
+        raise
+    except OSError as error:
+        raise ClaimStoreUnavailable("claim store cannot be prepared") from error
+
+
+def read_lease_directory(common_dir: Path) -> Path | None:
+    """Return an existing safe store without creating one for a status read."""
+    try:
+        common = common_dir.resolve(strict=True)
+        if common_dir.is_symlink() or _is_junction(common_dir):
+            raise ClaimStoreUnavailable("Git common directory is a link or junction")
+        lease_dir = common / LEASE_DIRECTORY
+        if not lease_dir.exists():
+            return None
+        if lease_dir.is_symlink() or _is_junction(lease_dir):
+            raise ClaimStoreUnavailable("lease directory is a link or junction")
+        if not _confined_existing(lease_dir, common):
+            raise ClaimStoreUnavailable("lease directory escapes Git common directory")
+        mode = lease_dir.lstat().st_mode
+        if not stat.S_ISDIR(mode) or stat.S_ISLNK(mode) or _is_junction(lease_dir):
+            raise ClaimStoreUnavailable("lease directory is not a safe directory")
+        return lease_dir
+    except ClaimStoreUnavailable:
+        raise
+    except OSError as error:
+        raise ClaimStoreUnavailable("claim store cannot be read") from error
+
+
+def _lock_functions(descriptor: int) -> tuple[Any, Any]:
+    """Return non-blocking exclusive acquire/release functions for one descriptor."""
+    if os.name == "nt":
+        module: Any = importlib.import_module("msvcrt")
+        return (
+            lambda: module.locking(descriptor, module.LK_NBLCK, 1),
+            lambda: module.locking(descriptor, module.LK_UNLCK, 1),
+        )
+    module = importlib.import_module("fcntl")
+    return (
+        lambda: module.flock(descriptor, module.LOCK_EX | module.LOCK_NB),
+        lambda: module.flock(descriptor, module.LOCK_UN),
+    )
+
+
+def _unlock_and_close(descriptor: int) -> None:
+    """Best-effort end of a claim lock's lifetime."""
+    with contextlib.suppress(OSError):
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        _lock_functions(descriptor)[1]()
+    with contextlib.suppress(OSError):
+        os.close(descriptor)
+
+
+def release_claim_lock(descriptor: int) -> None:
+    """End a descriptor-backed ownership lock retained by a published candidate."""
+    _unlock_and_close(descriptor)
+
+
+@contextmanager
+def coordination_lock(lease_dir: Path, name: str) -> Iterator[None]:
+    """Hold the short-lived shared decision lock around read-and-publish."""
+    if Path(name).name != name or not name.endswith(".lock"):
+        raise ClaimStoreUnavailable("coordination lock name is not safe")
+    root = lease_dir.resolve()
+    if lease_dir.is_symlink() or _is_junction(lease_dir) or not _confined_existing(root, root):
+        raise ClaimStoreUnavailable("coordination lock directory is unsafe")
+    path = root / name
+    if not _confined_new(path, root):
+        raise ClaimStoreUnavailable("coordination lock path escapes lease directory")
+    try:
+        with path.open("a+b") as handle:
+            acquire, release = _lock_functions(handle.fileno())
+            for attempt in range(LEASE_RETRY_LIMIT):
+                try:
+                    handle.seek(0)
+                    acquire()
+                    break
+                except OSError:
+                    if attempt + 1 < LEASE_RETRY_LIMIT:
+                        time.sleep(LEASE_RETRY_DELAY_SECONDS)
+            else:
+                raise ClaimStoreUnavailable("could not acquire coordination lock")
+            try:
+                yield
+            finally:
+                with contextlib.suppress(OSError):
+                    handle.seek(0)
+                    release()
+    except ClaimStoreUnavailable:
+        raise
+    except OSError as error:
+        raise ClaimStoreUnavailable("claim store cannot lock") from error
+
+
+def publish_claim_candidate(lease_dir: Path, path: Path, payload: str) -> int:
+    """Publish a claim atomically while retaining its long-lived ownership lock."""
+    if not _safe_lease_directory(lease_dir) or not _confined_new(path, lease_dir):
+        raise ClaimStoreUnavailable("claim path escapes lease directory")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".claim-", dir=lease_dir)
+    temporary = Path(temporary_name)
+    try:
+        os.write(descriptor, payload.encode("utf-8"))
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        _lock_functions(descriptor)[0]()
+        os.link(temporary, path)
+        return descriptor
+    except BaseException:
+        _unlock_and_close(descriptor)
+        raise
+    finally:
+        with contextlib.suppress(OSError):
+            temporary.unlink()
+
+
+def _probe_claim_lock(path: Path) -> Liveness:
+    """Observe a claim lock without retaining a probe lock after the observation."""
+    try:
+        descriptor = os.open(path, os.O_RDWR)
+    except OSError:
+        return Liveness.UNDETERMINABLE
+    try:
+        acquire, release = _lock_functions(descriptor)
+        try:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            acquire()
+        except OSError as error:
+            if getattr(error, "errno", None) in {
+                errno.EACCES,
+                errno.EAGAIN,
+                errno.EWOULDBLOCK,
+                errno.EDEADLK,
+            }:
+                return Liveness.LIVE
+            return Liveness.UNDETERMINABLE
+        try:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            release()
+        except OSError:
+            return Liveness.UNDETERMINABLE
+        return Liveness.NOT_LIVE
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+
+
+def worktree_key(worktree: Path) -> str:
+    """Return a SHA-256 filename key of resolved worktree path bytes."""
+    return hashlib.sha256(os.fsencode(str(worktree.resolve()))).hexdigest()
+
+
+def reclaimable(
+    liveness: Liveness,
+    age_seconds: float,
+    policy: ReclaimPolicy,
+    *,
+    max_age_seconds: float = 24 * 60 * 60,
+) -> bool:
+    """Apply named reclaim policy; a live worktree lock is never aged out."""
+    if policy is ReclaimPolicy.PORT_LEASE:
+        return liveness is Liveness.NOT_LIVE or age_seconds > max_age_seconds
+    return liveness is Liveness.NOT_LIVE
+
+
+def pid_is_alive(pid: int) -> bool:
+    """Return whether a process identity can still be observed as alive.
+
+    Port leases deliberately retain this PID-based policy for their bounded
+    aged-reclaim behaviour. Worktree claims instead use ``_probe_claim_lock``.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def lease_age_seconds(path: Path, payload: dict[str, object] | None) -> float:
+    """Return payload age, falling back to the lease file modification time."""
+    created_at = payload.get("created_at") if payload is not None else None
+    try:
+        if isinstance(created_at, (int, float, str)):
+            created = float(created_at)
+        else:
+            created = path.stat().st_mtime
+    except (OSError, TypeError, ValueError):
+        return 0.0
+    return max(0.0, time.time() - created)
+
+
+def port_lease_reclaimable(path: Path, *, max_age_seconds: float) -> bool | None:
+    """Apply the shipped PID-based, age-bounded port-lease reclaim policy."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        owner = int(payload["pid"])
+    except (KeyError, OSError, UnicodeError, ValueError, TypeError, json.JSONDecodeError):
+        return True if lease_age_seconds(path, None) > max_age_seconds else None
+    liveness = Liveness.LIVE if pid_is_alive(owner) else Liveness.NOT_LIVE
+    return reclaimable(
+        liveness,
+        lease_age_seconds(path, payload),
+        ReclaimPolicy.PORT_LEASE,
+        max_age_seconds=max_age_seconds,
+    )
+
+
+def _read_record(path: Path, role: ClaimRole, expected_worktree: Path | None) -> ClaimRecord:
+    """Read untrusted metadata; the claim lock, not payload, establishes liveness.
+
+    ``pid`` is retained only to name a holder in a refusal message. It is never
+    used to infer liveness, so PID reuse cannot impersonate a claim holder.
+    """
+    now = time.time()
+    observed = _probe_claim_lock(path)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        pid = int(raw["pid"])
+        worktree = Path(str(raw["worktree"])).resolve()
+        created_at = float(raw["created_at"])
+        token = str(raw["token"])
+        if pid <= 0 or pid > (1 << 31) - 1 or not token:
+            raise ValueError("invalid identity")
+        if expected_worktree is not None and worktree != expected_worktree:
+            raise ValueError("worktree mismatch")
+        # Clamp BOTH directions. Clamping only the future left a backdated
+        # `created_at` unbounded, and the admission queue orders waiters by exactly
+        # this field -- so a ticket claiming 0.0 was permanently the oldest waiter
+        # and starved every real one, with zero slots occupied. The file's own
+        # creation time is a floor a writer cannot forge downward.
+        try:
+            floor = path.stat().st_ctime
+        except OSError:
+            floor = now
+        stamped = min(max(created_at, floor), now)
+        return ClaimRecord(role, path, token, pid, worktree, stamped, observed)
+    except (KeyError, OSError, UnicodeError, ValueError, TypeError, json.JSONDecodeError):
+        return ClaimRecord(role, path, None, None, None, now, observed)
+
+
+def _claim_paths(lease_dir: Path, worktree: Path, role: ClaimRole) -> tuple[Path, ...]:
+    """Return each confined digest-keyed path for a worktree role."""
+    key = worktree_key(worktree)
+    if role is ClaimRole.ACTIVITY:
+        pattern = f"{role.value}-{key}-*.lease"
+    elif role is ClaimRole.EXCLUSIVE:
+        pattern = f"{role.value}-{key}.lease"
+    else:
+        pattern = f"{role.value}-*.lease"
+    try:
+        paths = tuple(lease_dir.glob(pattern))
+    except OSError as error:
+        raise ClaimStoreUnavailable("claim store cannot list claims") from error
+    if any(not _confined_existing(path, lease_dir) for path in paths):
+        raise ClaimStoreUnavailable("claim path escapes lease directory")
+    return paths
+
+
+def _positive_whole_number(environ: Mapping[str, str], name: str, default: int) -> int:
+    """Read a required-positive integer without accepting coercions or fallback."""
+    raw = environ.get(name)
+    if raw is None:
+        return default
+    if not raw.isascii() or not raw.isdecimal():
+        raise RunSlotConfigurationError(
+            f"{name} has invalid value {raw!r}; expected a whole number at least 1"
+        )
+    value = int(raw)
+    if value < 1:
+        raise RunSlotConfigurationError(
+            f"{name} has invalid value {raw!r}; expected a whole number at least 1"
+        )
+    return value
+
+
+def _physical_memory_bytes() -> int | None:
+    """Return total physical memory, or ``None`` where it cannot be established.
+
+    Pure stdlib and deliberately fail-open: a platform without ``sysconf``
+    (Windows) yields ``None`` and therefore no clamp at all, because the lease
+    must never be able to fail a CI job -- and `build-check-windows.yml` runs a
+    wrapped target on a platform this cannot measure.
+    """
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, OSError, ValueError):
+        return None
+    if pages <= 0 or page_size <= 0:
+        return None
+    return pages * page_size
+
+
+def memory_clamped_run_limit(requested: int, memory_bytes: int | None) -> int:
+    """Clamp a DEFAULT limit down to what physical memory supports, never up.
+
+    Only ever reduces: the documented constant stays the ceiling, so no machine
+    gains concurrency from derivation. Raising it remains a deliberate
+    environment override, which is why this is applied to the default alone.
+
+    Deriving from cores would have been wrong here and the numbers say so. A run
+    is mostly WAITING -- a unit suite measured 178.9s wall against 56.4s CPU --
+    so on this 10-core, 32 GiB host `cpu_count() // 2` gives 5, which is
+    precisely the concurrency that exhausted swap at load 135, and `RAM / 2GiB`
+    gives 16.
+    """
+    if memory_bytes is None:
+        return requested
+    supported = memory_bytes // MEMORY_PER_CONCURRENT_RUN_BYTES
+    return max(1, min(requested, supported))
+
+
+def run_slot_budgets(environ: Mapping[str, str] | None = None) -> tuple[int, int]:
+    """Return the strict environment-derived concurrent-run and wait budgets."""
+    values = os.environ if environ is None else environ
+    explicit = values.get(MAX_CONCURRENT_RUNS_ENV)
+    limit = _positive_whole_number(values, MAX_CONCURRENT_RUNS_ENV, DEFAULT_MAX_CONCURRENT_RUNS)
+    if explicit is None:
+        # An explicit override is the operator's decision about their own hardware
+        # and is left alone; clamping it would break the only way to raise the
+        # limit deliberately.
+        limit = memory_clamped_run_limit(limit, _physical_memory_bytes())
+    return (
+        limit,
+        _positive_whole_number(
+            values, RUN_SLOT_WAIT_SECONDS_ENV, DEFAULT_RUN_SLOT_WAIT_SECONDS
+        ),
+    )
+
+
+def _run_claim_path(lease_dir: Path, role: ClaimRole, token: str) -> Path:
+    """Build one confined run-slot or run-ticket path from an opaque UUID token."""
+    if role not in {ClaimRole.RUN_SLOT, ClaimRole.RUN_TICKET}:
+        raise ValueError("run claim role is required")
+    if len(token) != 32 or any(character not in "0123456789abcdef" for character in token):
+        raise ClaimStoreUnavailable("run claim token is unsafe")
+    path = lease_dir / f"{role.value}-{token}.lease"
+    if not _confined_new(path, lease_dir):
+        raise ClaimStoreUnavailable("run claim path escapes lease directory")
+    return path
+
+
+def _run_claim_payload(token: str, common_dir: Path) -> str:
+    """Encode non-authoritative holder metadata for a slot or waiter ticket."""
+    return json.dumps(
+        {
+            "pid": os.getpid(),
+            "worktree": str(common_dir),
+            "created_at": time.time(),
+            "token": token,
+        }
+    )
+
+
+def _live_run_claims(
+    lease_dir: Path, role: ClaimRole, common_dir: Path
+) -> tuple[ClaimRecord, ...]:
+    """Prune dead or expired run records; retain live holders within the backstop.
+
+    Unlike the worktree claim roles, an admission record is reclaimed once it
+    passes ``RUN_CLAIM_MAX_AGE_SECONDS`` even when its liveness is undeterminable.
+    Without that, a single unreadable `run-slot-*.lease` occupies the limit forever
+    and a single unreadable `run-ticket-*.lease` is permanently the oldest waiter --
+    starving admission with zero slots occupied. Both are reachable with no
+    attacker: an unmapped ``flock`` errno on a network-mounted common directory
+    makes every probe undeterminable.
+    """
+    retained: list[ClaimRecord] = []
+    now = time.time()
+    for record in _prune_not_live(
+        _claim_paths(lease_dir, common_dir, role), role, common_dir
+    ):
+        if record.liveness is not Liveness.LIVE and now - record.created_at > (
+            RUN_CLAIM_MAX_AGE_SECONDS
+        ):
+            with contextlib.suppress(OSError):
+                record.path.unlink()
+            continue
+        retained.append(record)
+    return tuple(retained)
+
+
+def _marker_slot(
+    lease_dir: Path, common_dir: Path, marker: str | None
+) -> ClaimRecord | None:
+    """Return the live in-scope slot named by a nesting marker, if any."""
+    if marker is None:
+        return None
+    try:
+        path = _run_claim_path(lease_dir, ClaimRole.RUN_SLOT, marker)
+    except ClaimStoreUnavailable:
+        return None
+    if not path.exists():
+        return None
+    record = _read_record(path, ClaimRole.RUN_SLOT, common_dir)
+    if record.token == marker and record.liveness is Liveness.LIVE:
+        return record
+    return None
+
+
+def _release_ticket(lease_dir: Path, token: str, descriptor: int) -> None:
+    """Remove this waiter's ticket while retaining no lock beyond this call."""
+    try:
+        with coordination_lock(lease_dir, "coordination.lock"):
+            path = _run_claim_path(lease_dir, ClaimRole.RUN_TICKET, token)
+            record = _read_record(path, ClaimRole.RUN_TICKET, None)
+            if record.token == token:
+                with contextlib.suppress(FileNotFoundError):
+                    path.unlink()
+    finally:
+        _unlock_and_close(descriptor)
+
+
+def acquire_run_slot(
+    common_dir: Path, *, environ: Mapping[str, str] | None = None
+) -> RunSlotClaim:
+    """Fairly acquire one common-directory-wide run slot or raise on timeout.
+
+    Ticket pruning, oldest-ticket selection, slot pruning, and slot publication
+    happen under one decision lock. A ticket's descriptor is its identity: a
+    recycled PID cannot impersonate it or retain its place in the queue.
+    """
+    limit, wait_seconds = run_slot_budgets(environ)
+    values = os.environ if environ is None else environ
+    lease_dir = prepare_lease_directory(common_dir)
+    scope = common_dir.resolve()
+    with coordination_lock(lease_dir, "coordination.lock"):
+        inherited = _marker_slot(lease_dir, scope, values.get(RUN_SLOT_NESTING_MARKER_ENV))
+        if inherited is not None:
+            return RunSlotClaim(
+                None,
+                inherited.token or "",
+                lease_dir,
+                None,
+                inherited.pid,
+                nested=True,
+            )
+
+    deadline = time.monotonic() + wait_seconds
+    ticket_token: str | None = None
+    ticket_descriptor: int | None = None
+    holders: tuple[int, ...] = ()
+    try:
+        while True:
+            with coordination_lock(lease_dir, "coordination.lock"):
+                if ticket_token is None:
+                    ticket_token = uuid.uuid4().hex
+                    ticket_path = _run_claim_path(lease_dir, ClaimRole.RUN_TICKET, ticket_token)
+                    ticket_descriptor = publish_claim_candidate(
+                        lease_dir, ticket_path, _run_claim_payload(ticket_token, scope)
+                    )
+
+                tickets = _live_run_claims(lease_dir, ClaimRole.RUN_TICKET, scope)
+                slots = _live_run_claims(lease_dir, ClaimRole.RUN_SLOT, scope)
+                oldest = min(
+                    tickets,
+                    key=lambda record: (record.created_at, record.token or ""),
+                    default=None,
+                )
+                holders = tuple(sorted({record.pid for record in slots if record.pid is not None}))
+                if oldest is not None and oldest.token == ticket_token and len(slots) < limit:
+                    token = uuid.uuid4().hex
+                    path = _run_claim_path(lease_dir, ClaimRole.RUN_SLOT, token)
+                    descriptor = publish_claim_candidate(
+                        lease_dir, path, _run_claim_payload(token, scope)
+                    )
+                    ticket_path = _run_claim_path(
+                        lease_dir, ClaimRole.RUN_TICKET, ticket_token
+                    )
+                    with contextlib.suppress(FileNotFoundError):
+                        ticket_path.unlink()
+                    _unlock_and_close(ticket_descriptor)
+                    ticket_descriptor = None
+                    return RunSlotClaim(path, token, lease_dir, descriptor, os.getpid())
+            if time.monotonic() >= deadline:
+                raise RunSlotAdmissionRefused(holders)
+            time.sleep(min(LEASE_RETRY_DELAY_SECONDS, max(0.0, deadline - time.monotonic())))
+    finally:
+        if ticket_token is not None and ticket_descriptor is not None:
+            _release_ticket(lease_dir, ticket_token, ticket_descriptor)
+
+
+def read_claims(common_dir: Path, worktree: Path, *, create: bool = True) -> WorktreeClaims:
+    """Read claims for reporting; uninspectable locks conservatively count as live."""
+    lease_dir = prepare_lease_directory(common_dir) if create else read_lease_directory(common_dir)
+    if lease_dir is None:
+        return WorktreeClaims((), None)
+    resolved = worktree.resolve()
+    activity_paths = _claim_paths(lease_dir, resolved, ClaimRole.ACTIVITY)
+    activity = tuple(
+        _read_record(path, ClaimRole.ACTIVITY, resolved) for path in activity_paths
+    )
+    paths = _claim_paths(lease_dir, resolved, ClaimRole.EXCLUSIVE)
+    exclusive = _read_record(paths[0], ClaimRole.EXCLUSIVE, resolved) if paths else None
+    return WorktreeClaims(activity, exclusive)
+
+
+def read_run_slots(common_dir: Path) -> tuple[ClaimRecord, ...]:
+    """Read run-slot occupancy without creating, pruning, or changing the store."""
+    lease_dir = read_lease_directory(common_dir)
+    if lease_dir is None:
+        return ()
+    scope = common_dir.resolve()
+    return tuple(
+        _read_record(path, ClaimRole.RUN_SLOT, scope)
+        for path in _claim_paths(lease_dir, scope, ClaimRole.RUN_SLOT)
+    )
+
+
+def _prune_not_live(
+    paths: tuple[Path, ...], role: ClaimRole, worktree: Path
+) -> tuple[ClaimRecord, ...]:
+    """Reclaim only paths whose long-lived ownership lock is definitely free."""
+    retained: list[ClaimRecord] = []
+    for path in paths:
+        record = _read_record(path, role, worktree)
+        if reclaimable(
+            record.liveness,
+            time.time() - record.created_at,
+            ReclaimPolicy.WORKTREE_CLAIM,
+        ):
+            with contextlib.suppress(FileNotFoundError):
+                path.unlink()
+        else:
+            retained.append(record)
+    return tuple(retained)
+
+
+def _acquire(
+    common_dir: Path,
+    worktree: Path,
+    role: ClaimRole,
+    wait_seconds: float | None,
+) -> WorktreeClaim:
+    """Atomically observe the other role then publish and lock this claim."""
+    if wait_seconds is not None and wait_seconds < 0:
+        raise ValueError("wait_seconds must not be negative")
+    deadline = None if wait_seconds is None else time.monotonic() + wait_seconds
+    lease_dir = prepare_lease_directory(common_dir)
+    resolved = worktree.resolve()
+    # Bounds the reclaim-then-retry path so a peer repeatedly re-creating the claim
+    # cannot turn this into a hot loop holding the decision lock.
+    reclaim_attempts = 0
+    while True:
+        with coordination_lock(lease_dir, "coordination.lock"):
+            other = ClaimRole.EXCLUSIVE if role is ClaimRole.ACTIVITY else ClaimRole.ACTIVITY
+            other_claims = _prune_not_live(
+                _claim_paths(lease_dir, resolved, other), other, resolved
+            )
+            if not other_claims:
+                token = uuid.uuid4().hex
+                key = worktree_key(resolved)
+                filename = (
+                    f"{role.value}-{key}-{token}.lease"
+                    if role is ClaimRole.ACTIVITY
+                    else f"{role.value}-{key}.lease"
+                )
+                path = lease_dir / filename
+                payload = json.dumps(
+                    {
+                        "pid": os.getpid(),
+                        "worktree": str(resolved),
+                        "created_at": time.time(),
+                        "token": token,
+                    }
+                )
+                try:
+                    descriptor = publish_claim_candidate(lease_dir, path, payload)
+                except FileExistsError as error:
+                    # `_prune_not_live` returns the RETAINED (still-live) records, so a
+                    # non-empty result means a live owner holds this role and we must
+                    # refuse -- while an empty result means we just reclaimed a claim
+                    # whose owner is gone, and the publish should be retried.
+                    #
+                    # This condition was inverted, and the inversion produced both of
+                    # the failures that found it: a SIGKILLed holder's claim file
+                    # raised contention instead of being reclaimed (the exact wedge
+                    # this lock-based design exists to prevent), and a genuinely live
+                    # holder fell through to `continue` and span forever instead of
+                    # refusing.
+                    if _prune_not_live((path,), role, resolved):
+                        raise ClaimContentionError(
+                            f"live {role.value} claim prevents acquisition"
+                        ) from error
+                    reclaim_attempts += 1
+                    if reclaim_attempts >= LEASE_RETRY_LIMIT:
+                        raise ClaimContentionError(
+                            f"{role.value} claim for {resolved.name} could not be "
+                            "published after repeated reclamation"
+                        ) from error
+                    continue
+                return WorktreeClaim(role, path, token, lease_dir, descriptor)
+            if role is ClaimRole.EXCLUSIVE or deadline is None or time.monotonic() >= deadline:
+                raise ClaimContentionError(
+                    f"live {other.value} claim prevents {role.value} claim",
+                    claims=other_claims,
+                )
+        time.sleep(LEASE_RETRY_DELAY_SECONDS)
+
+
+def acquire_activity(common_dir: Path, worktree: Path, *, wait_seconds: float) -> WorktreeClaim:
+    """Wait only for an exclusive claim, then publish an activity claim."""
+    return _acquire(common_dir, worktree, ClaimRole.ACTIVITY, wait_seconds)
+
+
+def acquire_exclusive(common_dir: Path, worktree: Path) -> WorktreeClaim:
+    """Immediately refuse if any activity claim's ownership lock is live."""
+    return _acquire(common_dir, worktree, ClaimRole.EXCLUSIVE, None)

--- a/tools/repo/coordination_lease.py
+++ b/tools/repo/coordination_lease.py
@@ -12,6 +12,7 @@ default of five was that failing state. Two concurrent runs bounds memory pressu
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import errno
 import hashlib
@@ -19,6 +20,8 @@ import importlib
 import json
 import os
 import stat
+import subprocess
+import sys
 import tempfile
 import time
 import uuid
@@ -26,12 +29,14 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Iterator, Mapping
+from typing import Any, Callable, Iterator, Mapping, Sequence
 
 if __package__:
-    from .worktree_hygiene import Candidate, _path_component_reason
+    from . import managed_child
+    from .worktree_hygiene import Candidate, _path_component_reason, lease_refusal_lines
 else:
-    from worktree_hygiene import Candidate, _path_component_reason
+    import managed_child
+    from worktree_hygiene import Candidate, _path_component_reason, lease_refusal_lines
 
 
 LEASE_DIRECTORY = "agent-ready-repo-worktree-leases"
@@ -785,7 +790,10 @@ def _release_ticket(
 
 
 def acquire_run_slot(
-    common_dir: Path, *, environ: Mapping[str, str] | None = None
+    common_dir: Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+    on_wait: Callable[[tuple[int, ...]], None] | None = None,
 ) -> RunSlotClaim:
     """Fairly acquire one common-directory-wide run slot or raise on timeout.
 
@@ -820,6 +828,7 @@ def acquire_run_slot(
     ticket_descriptor: int | None = None
     registration_descriptor: int | None = None
     holders: tuple[int, ...] = ()
+    next_heartbeat: float | None = None
     try:
         while True:
             with coordination_lock(
@@ -874,9 +883,13 @@ def acquire_run_slot(
                     _unlock_and_close(registration_descriptor)
                     registration_descriptor = None
                     return RunSlotClaim(path, token, lease_dir, descriptor, os.getpid())
-            if time.monotonic() >= deadline:
+            now = time.monotonic()
+            if on_wait is not None and (next_heartbeat is None or now >= next_heartbeat):
+                on_wait(holders)
+                next_heartbeat = now + 60
+            if now >= deadline:
                 raise RunSlotAdmissionRefused(holders)
-            time.sleep(min(LEASE_RETRY_DELAY_SECONDS, max(0.0, deadline - time.monotonic())))
+            time.sleep(min(LEASE_RETRY_DELAY_SECONDS, max(0.0, deadline - now)))
     finally:
         if (
             ticket_token is not None
@@ -1017,3 +1030,233 @@ def acquire_activity(common_dir: Path, worktree: Path, *, wait_seconds: float) -
 def acquire_exclusive(common_dir: Path, worktree: Path) -> WorktreeClaim:
     """Immediately refuse if any activity claim's ownership lock is live."""
     return _acquire(common_dir, worktree, ClaimRole.EXCLUSIVE, None)
+
+
+def git_common_dir(repository: Path) -> Path:
+    """Resolve the Git common directory that scopes cooperative run slots."""
+    try:
+        result = subprocess.run(
+            ("git", "rev-parse", "--git-common-dir"),
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ClaimStoreUnavailable("git is required to locate the claim store") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "not inside a Git worktree"
+        raise ClaimStoreUnavailable(f"could not resolve Git common directory: {detail}")
+    path = Path(result.stdout.strip())
+    return path.resolve() if path.is_absolute() else (repository / path).resolve()
+
+
+def _holder_names(claims: Sequence[ClaimRecord]) -> str:
+    """Render only process ids and worktree base names for user-facing output."""
+    names = []
+    for claim in claims:
+        pid = str(claim.pid) if claim.pid is not None else "unknown"
+        worktree = claim.worktree.name if claim.worktree is not None else "unknown"
+        names.append(f"pid {pid} in {worktree}")
+    return ", ".join(names) or "unknown holder"
+
+
+def _queue_notice(holder_pids: tuple[int, ...]) -> None:
+    """Expose admission queue progress at once and at least once a minute."""
+    holders = ", ".join(str(pid) for pid in holder_pids) or "unknown"
+    print(f"with-lease queued behind process ids: {holders}", file=sys.stderr, flush=True)
+
+
+def with_lease(
+    command: Sequence[str],
+    *,
+    repository: Path,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    """Run one verbatim child while holding an activity claim and a run slot."""
+    if not command:
+        raise ValueError("with-lease requires a command after --")
+    values = dict(os.environ if environ is None else environ)
+    worktree = repository.resolve()
+    # ONE call site, deliberately. An early `return managed_child.run_child(...)` on
+    # the lease-unavailable path made two, and the structural check that exactly one
+    # child runner is reachable cannot distinguish a second CALL from a second
+    # IMPLEMENTATION -- so the guard fired and it was right to. Fall through instead.
+    common: Path | None = None
+    try:
+        common = git_common_dir(repository)
+    except ClaimStoreUnavailable as error:
+        print(
+            f"WARNING: worktree lease unavailable; running child unleased: {error}",
+            file=sys.stderr,
+            flush=True,
+        )
+    activity: WorktreeClaim | None = None
+    slot: RunSlotClaim | None = None
+    try:
+        try:
+            if common is not None:
+                activity = acquire_activity(
+                    common, worktree, wait_seconds=DEFAULT_RUN_SLOT_WAIT_SECONDS
+                )
+                slot = acquire_run_slot(common, environ=values, on_wait=_queue_notice)
+        except RunSlotConfigurationError:
+            raise
+        except ClaimContentionError:
+            raise
+        except RunSlotAdmissionRefused:
+            raise
+        except ClaimStoreUnavailable as error:
+            print(
+                f"WARNING: worktree lease unavailable; running child unleased: {error}",
+                file=sys.stderr,
+                flush=True,
+            )
+        if slot is not None:
+            values[RUN_SLOT_NESTING_MARKER_ENV] = slot.nesting_marker
+        return managed_child.run_child(tuple(command), values, worktree)
+    finally:
+        # Teardown cannot rewrite a real child outcome. A failed release is still
+        # visible only as a warning, and a partially-acquired wrapper is unwound.
+        for claim in (slot, activity):
+            if claim is None:
+                continue
+            try:
+                claim.release()
+            except (ClaimStoreUnavailable, OSError) as error:
+                print(
+                    f"WARNING: worktree lease release failed: {error}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+
+def _releasable_claim_path(lease_dir: Path, identifier: str) -> tuple[Path, ClaimRole]:
+    """Resolve a status-emitted worktree-claim identifier without path traversal."""
+    name = Path(identifier).name
+    if name != identifier or not name.endswith(".lease"):
+        raise ValueError("claim identifier must be a lease filename emitted by lease-status")
+    if name.startswith("activity-"):
+        role = ClaimRole.ACTIVITY
+    elif name.startswith("exclusive-"):
+        role = ClaimRole.EXCLUSIVE
+    else:
+        raise ValueError("only worktree activity or exclusive claims are releasable")
+    path = lease_dir / name
+    if not _confined_new(path, lease_dir):
+        raise ClaimStoreUnavailable("claim identifier escapes lease directory")
+    return path, role
+
+
+def release_claim(common_dir: Path, identifier: str) -> None:
+    """Release a free or uninspectable worktree claim; never a live lock holder."""
+    lease_dir = read_lease_directory(common_dir)
+    if lease_dir is None:
+        raise FileNotFoundError(identifier)
+    path, _role = _releasable_claim_path(lease_dir, identifier)
+    with coordination_lock(lease_dir, "coordination.lock"):
+        if not path.exists():
+            raise FileNotFoundError(identifier)
+        record = _read_record(path, _role, None)
+        if record.liveness is Liveness.LIVE:
+            raise ClaimContentionError("claim lock is observably held", claims=(record,))
+        path.unlink()
+
+
+def _status_lines(common_dir: Path, worktree: Path) -> list[str]:
+    """Report only existing claim state, without creating or pruning any records."""
+    claims = read_claims(common_dir, worktree, create=False)
+    slots = read_run_slots(common_dir)
+    records = (*claims.activity, *((claims.exclusive,) if claims.exclusive else ()))
+    lines = ["lease-status: claims"]
+    if not records:
+        lines.append("  none")
+    for record in records:
+        identifier = record.path.name
+        pid = record.pid if record.pid is not None else "unknown"
+        worktree_name = record.worktree.name if record.worktree is not None else "unknown"
+        lines.append(
+            f"  {identifier}: {record.role.value}, {record.liveness.value}, "
+            f"pid {pid} in {worktree_name}; release-claim --apply --claim {identifier}"
+        )
+    lines.append(f"lease-status: run-slot occupancy {len(slots)}")
+    for record in slots:
+        pid = record.pid if record.pid is not None else "unknown"
+        lines.append(f"  pid {pid}: {record.liveness.value}")
+    return lines
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line surface for cooperative lease participants."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    wrapped = subparsers.add_parser("with-lease", help="run one command under a lease")
+    wrapped.add_argument("child", nargs=argparse.REMAINDER)
+    subparsers.add_parser("lease-status", help="report claims without mutation")
+    release = subparsers.add_parser("release-claim", help="recover one unsafe claim")
+    release.add_argument("--apply", action="store_true", help="perform the recovery")
+    release.add_argument("--claim", required=True, help="identifier printed by lease-status")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run a lease participant command and preserve the reserved refusal shape."""
+    args = _parser().parse_args(argv)
+    repository = Path.cwd().resolve()
+    try:
+        if args.command == "with-lease":
+            child = args.child[1:] if args.child[:1] == ["--"] else args.child
+            if not child:
+                print(
+                    "\n".join(
+                        lease_refusal_lines("with-lease", "no command was supplied after --")
+                    ),
+                    file=sys.stderr,
+                )
+                return 75
+            return with_lease(child, repository=repository)
+        common = git_common_dir(repository)
+        if args.command == "lease-status":
+            print("\n".join(_status_lines(common, repository)))
+            return 0
+        if not args.apply:
+            print(
+                "\n".join(
+                    lease_refusal_lines("release-claim", "--apply was not supplied")
+                ),
+                file=sys.stderr,
+            )
+            return 75
+        release_claim(common, args.claim)
+        print(
+            f"release-claim: released {args.claim}; this is an override of a claim "
+            "that may be live"
+        )
+        return 0
+    except RunSlotConfigurationError as error:
+        print("\n".join(lease_refusal_lines("with-lease", str(error))), file=sys.stderr)
+        return 75
+    except (ClaimContentionError, RunSlotAdmissionRefused) as error:
+        detail = str(error)
+        if isinstance(error, ClaimContentionError) and error.claims:
+            detail = f"{detail}; held by {_holder_names(error.claims)}"
+        print("\n".join(lease_refusal_lines(args.command, detail)), file=sys.stderr)
+        return 75
+    except ClaimStoreUnavailable as error:
+        if args.command == "with-lease":
+            # Common-directory discovery itself cannot be bypassed safely enough to
+            # spawn in an unknown scope; acquisition failures inside with_lease warn.
+            print("\n".join(lease_refusal_lines("with-lease", str(error))), file=sys.stderr)
+            return 75
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except (FileNotFoundError, ValueError) as error:
+        print("\n".join(lease_refusal_lines(args.command, str(error))), file=sys.stderr)
+        return 75
+    except managed_child.ManagedChildError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/repo/coordination_lease.py
+++ b/tools/repo/coordination_lease.py
@@ -41,9 +41,9 @@ LEASE_RETRY_DELAY_SECONDS = 0.05
 DEFAULT_MAX_CONCURRENT_RUNS = 2
 # Downward-only memory clamp. Calibrated to the single measurement point
 # available: this reference host has 32 GiB and is judged safe at 2 concurrent
-# heavy runs, so 16 GiB per run is the implied budget. Below that a machine gets
+# heavy runs, so 12 GiB per run leaves usable-memory headroom. Below that a machine gets
 # fewer, never more.
-MEMORY_PER_CONCURRENT_RUN_BYTES = 16 * 1024**3
+MEMORY_PER_CONCURRENT_RUN_BYTES = 12 * 1024**3
 # Age backstop for the ADMISSION roles only. An undeterminable probe counts as
 # live, which for `activity`/`exclusive` is the right conservative answer -- but a
 # run slot or waiter ticket that can never be reclaimed wedges every gate in every
@@ -52,6 +52,7 @@ MEMORY_PER_CONCURRENT_RUN_BYTES = 16 * 1024**3
 # having its own claim pruned mid-flight.
 RUN_CLAIM_MAX_AGE_SECONDS = 6 * 60 * 60
 DEFAULT_RUN_SLOT_WAIT_SECONDS = 5400
+MINIMUM_RUN_SLOT_DECISION_LOCK_SECONDS = 30
 MAX_CONCURRENT_RUNS_ENV = "WORKTREE_HYGIENE_MAX_CONCURRENT_RUNS"
 RUN_SLOT_WAIT_SECONDS_ENV = "WORKTREE_HYGIENE_RUN_SLOT_WAIT_SECONDS"
 RUN_SLOT_NESTING_MARKER_ENV = "WORKTREE_HYGIENE_RUN_SLOT_CLAIM"
@@ -142,7 +143,7 @@ class WorktreeClaim:
     path: Path
     token: str
     lease_dir: Path
-    descriptor: int
+    descriptor: int | None
 
     def release(self) -> None:
         """Remove only this token's claim, then release its lifetime lock."""
@@ -153,7 +154,9 @@ class WorktreeClaim:
                     with contextlib.suppress(FileNotFoundError):
                         self.path.unlink()
         finally:
-            _unlock_and_close(self.descriptor)
+            if self.descriptor is not None:
+                _unlock_and_close(self.descriptor)
+                self.descriptor = None
 
 
 @dataclass
@@ -192,6 +195,7 @@ class RunSlotClaim:
         finally:
             if self.descriptor is not None:
                 _unlock_and_close(self.descriptor)
+                self.descriptor = None
 
 
 def _is_junction(path: Path) -> bool:
@@ -305,7 +309,12 @@ def release_claim_lock(descriptor: int) -> None:
 
 
 @contextmanager
-def coordination_lock(lease_dir: Path, name: str) -> Iterator[None]:
+def coordination_lock(
+    lease_dir: Path,
+    name: str,
+    *,
+    acquisition_budget_seconds: float | None = None,
+) -> Iterator[None]:
     """Hold the short-lived shared decision lock around read-and-publish."""
     if Path(name).name != name or not name.endswith(".lock"):
         raise ClaimStoreUnavailable("coordination lock name is not safe")
@@ -315,19 +324,38 @@ def coordination_lock(lease_dir: Path, name: str) -> Iterator[None]:
     path = root / name
     if not _confined_new(path, root):
         raise ClaimStoreUnavailable("coordination lock path escapes lease directory")
+    if acquisition_budget_seconds is not None and acquisition_budget_seconds < 0:
+        raise ValueError("acquisition_budget_seconds must not be negative")
+    deadline = (
+        None
+        if acquisition_budget_seconds is None
+        else time.monotonic() + acquisition_budget_seconds
+    )
     try:
         with path.open("a+b") as handle:
             acquire, release = _lock_functions(handle.fileno())
-            for attempt in range(LEASE_RETRY_LIMIT):
+            while True:
                 try:
                     handle.seek(0)
                     acquire()
                     break
-                except OSError:
-                    if attempt + 1 < LEASE_RETRY_LIMIT:
-                        time.sleep(LEASE_RETRY_DELAY_SECONDS)
-            else:
-                raise ClaimStoreUnavailable("could not acquire coordination lock")
+                except OSError as error:
+                    if deadline is None:
+                        if LEASE_RETRY_LIMIT <= 1:
+                            raise ClaimStoreUnavailable(
+                                "could not acquire coordination lock"
+                            ) from error
+                        # Existing non-admission callers retain their bounded retry
+                        # behaviour; admissions pass their scaled time budget below.
+                        deadline = time.monotonic() + (
+                            LEASE_RETRY_LIMIT - 1
+                        ) * LEASE_RETRY_DELAY_SECONDS
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise ClaimStoreUnavailable(
+                            "could not acquire coordination lock"
+                        ) from error
+                    time.sleep(min(LEASE_RETRY_DELAY_SECONDS, remaining))
             try:
                 yield
             finally:
@@ -554,7 +582,8 @@ def memory_clamped_run_limit(requested: int, memory_bytes: int | None) -> int:
     is mostly WAITING -- a unit suite measured 178.9s wall against 56.4s CPU --
     so on this 10-core, 32 GiB host `cpu_count() // 2` gives 5, which is
     precisely the concurrency that exhausted swap at load 135, and `RAM / 2GiB`
-    gives 16.
+    gives 16. The measured clamp uses 12 GiB per run so usable-memory reporting
+    leaves the 32 GiB reference configuration at two runs.
     """
     if memory_bytes is None:
         return requested
@@ -580,6 +609,11 @@ def run_slot_budgets(environ: Mapping[str, str] | None = None) -> tuple[int, int
     )
 
 
+def run_slot_decision_lock_budget(wait_seconds: int) -> float:
+    """Return the admission decision-lock budget derived from its wait budget."""
+    return max(MINIMUM_RUN_SLOT_DECISION_LOCK_SECONDS, wait_seconds / 20)
+
+
 def _run_claim_path(lease_dir: Path, role: ClaimRole, token: str) -> Path:
     """Build one confined run-slot or run-ticket path from an opaque UUID token."""
     if role not in {ClaimRole.RUN_SLOT, ClaimRole.RUN_TICKET}:
@@ -589,6 +623,21 @@ def _run_claim_path(lease_dir: Path, role: ClaimRole, token: str) -> Path:
     path = lease_dir / f"{role.value}-{token}.lease"
     if not _confined_new(path, lease_dir):
         raise ClaimStoreUnavailable("run claim path escapes lease directory")
+    return path
+
+
+def _run_ticket_registration_path(lease_dir: Path, token: str) -> Path:
+    """Return the persistent, lock-backed position record for one waiter.
+
+    The removable ticket is the admission signal. This separate record preserves
+    the filesystem-derived registration time if an operator removes that ticket,
+    without trusting a caller-provided timestamp on re-registration.
+    """
+    if len(token) != 32 or any(character not in "0123456789abcdef" for character in token):
+        raise ClaimStoreUnavailable("run claim token is unsafe")
+    path = lease_dir / f"run-registration-{token}.lease"
+    if not _confined_new(path, lease_dir):
+        raise ClaimStoreUnavailable("run registration path escapes lease directory")
     return path
 
 
@@ -604,13 +653,42 @@ def _run_claim_payload(token: str, common_dir: Path) -> str:
     )
 
 
+def _ticket_position(
+    lease_dir: Path, ticket: ClaimRecord, common_dir: Path
+) -> float:
+    """Return an unforgeable initial position for a current ticket.
+
+    A registration record is retained only by its owning waiter's held lock and
+    has a filesystem-derived timestamp. A manually written ticket has no valid
+    registration record, so it receives its own file-derived timestamp instead.
+    """
+    if ticket.token is None:
+        return ticket.created_at
+    try:
+        registration_path = _run_ticket_registration_path(lease_dir, ticket.token)
+    except ClaimStoreUnavailable:
+        return ticket.created_at
+    if not registration_path.exists():
+        return ticket.created_at
+    registration = _read_record(registration_path, ClaimRole.RUN_TICKET, common_dir)
+    if registration.token != ticket.token or registration.liveness is not Liveness.LIVE:
+        return ticket.created_at
+    return registration.created_at
+
+
 def _live_run_claims(
     lease_dir: Path, role: ClaimRole, common_dir: Path
 ) -> tuple[ClaimRecord, ...]:
     """Prune dead or expired run records; retain live holders within the backstop.
 
+    The configured slot cap is deliberately soft across an admission expiry. An
+    expired owner may still be live, so reclaiming its record can over-admit by
+    the number of expired slots. That bounded memory pressure is recoverable;
+    leaving an unreclaimable slot would permanently wedge every gate.
+
     Unlike the worktree claim roles, an admission record is reclaimed once it
-    passes ``RUN_CLAIM_MAX_AGE_SECONDS`` even when its liveness is undeterminable.
+    passes ``RUN_CLAIM_MAX_AGE_SECONDS`` even when its owner is still live or its
+    liveness is undeterminable.
     Without that, a single unreadable `run-slot-*.lease` occupies the limit forever
     and a single unreadable `run-ticket-*.lease` is permanently the oldest waiter --
     starving admission with zero slots occupied. Both are reachable with no
@@ -622,14 +700,40 @@ def _live_run_claims(
     for record in _prune_not_live(
         _claim_paths(lease_dir, common_dir, role), role, common_dir
     ):
-        if record.liveness is not Liveness.LIVE and now - record.created_at > (
-            RUN_CLAIM_MAX_AGE_SECONDS
-        ):
+        # An invalid or unreadable payload receives `now` from `_read_record` so
+        # it cannot be ordered or identified. Its file timestamp is still an
+        # observable, non-resetting age backstop; otherwise every scan makes an
+        # undeterminable admission record look new and wedges the queue forever.
+        record_age = (
+            now - record.created_at
+            if record.token is not None
+            else lease_age_seconds(record.path, None)
+        )
+        if record_age > RUN_CLAIM_MAX_AGE_SECONDS:
             with contextlib.suppress(OSError):
                 record.path.unlink()
             continue
         retained.append(record)
     return tuple(retained)
+
+
+def _prune_run_registrations(lease_dir: Path, common_dir: Path) -> None:
+    """Reclaim dead or aged waiter-position records without counting them as slots."""
+    try:
+        paths = tuple(lease_dir.glob("run-registration-*.lease"))
+    except OSError as error:
+        raise ClaimStoreUnavailable("claim store cannot list registrations") from error
+    if any(not _confined_existing(path, lease_dir) for path in paths):
+        raise ClaimStoreUnavailable("registration path escapes lease directory")
+    now = time.time()
+    for path in paths:
+        record = _read_record(path, ClaimRole.RUN_TICKET, common_dir)
+        if (
+            record.liveness is Liveness.NOT_LIVE
+            or now - record.created_at > RUN_CLAIM_MAX_AGE_SECONDS
+        ):
+            with contextlib.suppress(OSError):
+                path.unlink()
 
 
 def _marker_slot(
@@ -650,17 +754,34 @@ def _marker_slot(
     return None
 
 
-def _release_ticket(lease_dir: Path, token: str, descriptor: int) -> None:
-    """Remove this waiter's ticket while retaining no lock beyond this call."""
+def _release_ticket(
+    lease_dir: Path,
+    token: str,
+    descriptor: int | None,
+    registration_descriptor: int,
+    decision_lock_budget: float,
+) -> None:
+    """Remove a waiter ticket and its persistent position record on exit."""
     try:
-        with coordination_lock(lease_dir, "coordination.lock"):
+        with coordination_lock(
+            lease_dir,
+            "coordination.lock",
+            acquisition_budget_seconds=decision_lock_budget,
+        ):
             path = _run_claim_path(lease_dir, ClaimRole.RUN_TICKET, token)
             record = _read_record(path, ClaimRole.RUN_TICKET, None)
             if record.token == token:
                 with contextlib.suppress(FileNotFoundError):
                     path.unlink()
+            registration_path = _run_ticket_registration_path(lease_dir, token)
+            registration = _read_record(registration_path, ClaimRole.RUN_TICKET, None)
+            if registration.token == token:
+                with contextlib.suppress(FileNotFoundError):
+                    registration_path.unlink()
     finally:
-        _unlock_and_close(descriptor)
+        if descriptor is not None:
+            _unlock_and_close(descriptor)
+        _unlock_and_close(registration_descriptor)
 
 
 def acquire_run_slot(
@@ -669,14 +790,20 @@ def acquire_run_slot(
     """Fairly acquire one common-directory-wide run slot or raise on timeout.
 
     Ticket pruning, oldest-ticket selection, slot pruning, and slot publication
-    happen under one decision lock. A ticket's descriptor is its identity: a
-    recycled PID cannot impersonate it or retain its place in the queue.
+    happen under one decision lock. A ticket's persistent registration record
+    retains its filesystem-derived original position if its removable ticket is
+    released, so a recycled PID cannot impersonate it or move it backwards.
     """
     limit, wait_seconds = run_slot_budgets(environ)
+    decision_lock_budget = run_slot_decision_lock_budget(wait_seconds)
     values = os.environ if environ is None else environ
     lease_dir = prepare_lease_directory(common_dir)
     scope = common_dir.resolve()
-    with coordination_lock(lease_dir, "coordination.lock"):
+    with coordination_lock(
+        lease_dir,
+        "coordination.lock",
+        acquisition_budget_seconds=decision_lock_budget,
+    ):
         inherited = _marker_slot(lease_dir, scope, values.get(RUN_SLOT_NESTING_MARKER_ENV))
         if inherited is not None:
             return RunSlotClaim(
@@ -691,22 +818,40 @@ def acquire_run_slot(
     deadline = time.monotonic() + wait_seconds
     ticket_token: str | None = None
     ticket_descriptor: int | None = None
+    registration_descriptor: int | None = None
     holders: tuple[int, ...] = ()
     try:
         while True:
-            with coordination_lock(lease_dir, "coordination.lock"):
+            with coordination_lock(
+                lease_dir,
+                "coordination.lock",
+                acquisition_budget_seconds=decision_lock_budget,
+            ):
                 if ticket_token is None:
                     ticket_token = uuid.uuid4().hex
-                    ticket_path = _run_claim_path(lease_dir, ClaimRole.RUN_TICKET, ticket_token)
+                    registration_path = _run_ticket_registration_path(lease_dir, ticket_token)
+                    registration_descriptor = publish_claim_candidate(
+                        lease_dir,
+                        registration_path,
+                        _run_claim_payload(ticket_token, scope),
+                    )
+                ticket_path = _run_claim_path(lease_dir, ClaimRole.RUN_TICKET, ticket_token)
+                if not ticket_path.exists():
+                    if ticket_descriptor is not None:
+                        _unlock_and_close(ticket_descriptor)
                     ticket_descriptor = publish_claim_candidate(
                         lease_dir, ticket_path, _run_claim_payload(ticket_token, scope)
                     )
 
+                _prune_run_registrations(lease_dir, scope)
                 tickets = _live_run_claims(lease_dir, ClaimRole.RUN_TICKET, scope)
                 slots = _live_run_claims(lease_dir, ClaimRole.RUN_SLOT, scope)
                 oldest = min(
                     tickets,
-                    key=lambda record: (record.created_at, record.token or ""),
+                    key=lambda record: (
+                        _ticket_position(lease_dir, record, scope),
+                        record.token or "",
+                    ),
                     default=None,
                 )
                 holders = tuple(sorted({record.pid for record in slots if record.pid is not None}))
@@ -723,13 +868,27 @@ def acquire_run_slot(
                         ticket_path.unlink()
                     _unlock_and_close(ticket_descriptor)
                     ticket_descriptor = None
+                    registration_path = _run_ticket_registration_path(lease_dir, ticket_token)
+                    with contextlib.suppress(FileNotFoundError):
+                        registration_path.unlink()
+                    _unlock_and_close(registration_descriptor)
+                    registration_descriptor = None
                     return RunSlotClaim(path, token, lease_dir, descriptor, os.getpid())
             if time.monotonic() >= deadline:
                 raise RunSlotAdmissionRefused(holders)
             time.sleep(min(LEASE_RETRY_DELAY_SECONDS, max(0.0, deadline - time.monotonic())))
     finally:
-        if ticket_token is not None and ticket_descriptor is not None:
-            _release_ticket(lease_dir, ticket_token, ticket_descriptor)
+        if (
+            ticket_token is not None
+            and registration_descriptor is not None
+        ):
+            _release_ticket(
+                lease_dir,
+                ticket_token,
+                ticket_descriptor,
+                registration_descriptor,
+                decision_lock_budget,
+            )
 
 
 def read_claims(common_dir: Path, worktree: Path, *, create: bool = True) -> WorktreeClaims:

--- a/tools/repo/coordination_lease.py
+++ b/tools/repo/coordination_lease.py
@@ -43,6 +43,28 @@ LEASE_DIRECTORY = "agent-ready-repo-worktree-leases"
 LEASE_DIRECTORY_MODE = 0o700
 LEASE_RETRY_LIMIT = 20
 LEASE_RETRY_DELAY_SECONDS = 0.05
+# The byte a claim's lifetime ownership lock is taken on. Two requirements pull in
+# opposite directions and BOTH are load-bearing:
+#
+#   1. The publisher and the prober must lock the SAME byte. `msvcrt.locking` locks
+#      one byte at the current file position, so a publisher that writes its payload
+#      and then locks holds byte len(payload) while a prober opening at zero holds
+#      byte 0 -- ranges that never overlap, making the lock invisible and every probe
+#      read NOT_LIVE. Measured on windows-latest:
+#      `write-then-lock, probe at position 0 -> NOT blocked (LOCK INVISIBLE)`.
+#
+#   2. The locked byte must lie OUTSIDE the payload. On Windows the lock is
+#      MANDATORY, not advisory as POSIX `flock` is, so no other handle may read a
+#      locked range. Locking byte 0 satisfied (1) and broke this: `_read_record`
+#      reads the payload to name a holder, and on windows-latest that read raised
+#      `PermissionError: [Errno 13] Permission denied` for every live claim.
+#
+# A fixed offset far beyond any payload satisfies both: both sides agree on it, and
+# it is past the JSON, which is a few hundred bytes. Locking beyond end-of-file is
+# permitted on both platforms. On POSIX `flock` covers the whole open file
+# description and position is irrelevant, so this is inert there -- which is exactly
+# why neither requirement is observable on macOS and both needed a Windows runner.
+CLAIM_LOCK_OFFSET = 1 << 20
 DEFAULT_MAX_CONCURRENT_RUNS = 2
 # Downward-only memory clamp. Calibrated to the single measurement point
 # available: this reference host has 32 GiB and is judged safe at 2 concurrent
@@ -312,9 +334,14 @@ def _lock_functions(descriptor: int) -> tuple[Any, Any]:
 
 
 def _unlock_and_close(descriptor: int) -> None:
-    """Best-effort end of a claim lock's lifetime."""
+    """Best-effort end of a claim lock's lifetime.
+
+    Releases at the same offset the publisher locked. Only claim, ticket and
+    registration descriptors reach here; the shared decision lock releases inline at
+    byte zero, because nothing ever reads that file.
+    """
     with contextlib.suppress(OSError):
-        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.lseek(descriptor, CLAIM_LOCK_OFFSET, os.SEEK_SET)
         _lock_functions(descriptor)[1]()
     with contextlib.suppress(OSError):
         os.close(descriptor)
@@ -393,7 +420,8 @@ def publish_claim_candidate(lease_dir: Path, path: Path, payload: str) -> int:
     temporary = Path(temporary_name)
     try:
         os.write(descriptor, payload.encode("utf-8"))
-        os.lseek(descriptor, 0, os.SEEK_SET)
+        # Past the payload, so the payload stays readable while the lock is held.
+        os.lseek(descriptor, CLAIM_LOCK_OFFSET, os.SEEK_SET)
         _lock_functions(descriptor)[0]()
         os.link(temporary, path)
         return descriptor
@@ -425,7 +453,9 @@ def _probe_claim_lock(path: Path) -> Liveness:
     try:
         acquire, release = _lock_functions(descriptor)
         try:
-            os.lseek(descriptor, 0, os.SEEK_SET)
+            # The same byte the publisher holds; a prober at any other offset on
+            # Windows locks a disjoint range and reads a live claim as not-live.
+            os.lseek(descriptor, CLAIM_LOCK_OFFSET, os.SEEK_SET)
             acquire()
         except OSError as error:
             if getattr(error, "errno", None) in {
@@ -437,7 +467,7 @@ def _probe_claim_lock(path: Path) -> Liveness:
                 return Liveness.LIVE
             return Liveness.UNDETERMINABLE
         try:
-            os.lseek(descriptor, 0, os.SEEK_SET)
+            os.lseek(descriptor, CLAIM_LOCK_OFFSET, os.SEEK_SET)
             release()
         except OSError:
             return Liveness.UNDETERMINABLE

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -38,8 +38,9 @@ from typing import Any, Callable, Iterator, Mapping, Sequence
 # namespace package, which is how tools/test_frontend_runtime.py:16 imports it.
 # Dropping either branch breaks one of those callers at collection time.
 if __package__:
-    from . import managed_child, worktree_hygiene
+    from . import coordination_lease, managed_child, worktree_hygiene
 else:
+    import coordination_lease
     import managed_child
     import worktree_hygiene
 
@@ -56,6 +57,16 @@ SignalHandler = Callable[[int, FrameType | None], Any] | int | None
 
 
 FrontendRuntimeError = managed_child.ManagedChildError
+
+
+class FrontendLeaseRefusal(FrontendRuntimeError):
+    """A live worktree claim prevented the browser gate from starting."""
+
+    def __init__(
+        self, message: str, claims: tuple[coordination_lease.ClaimRecord, ...]
+    ) -> None:
+        super().__init__(message)
+        self.claims = claims
 
 
 def playwright_evidence_max_age(environ: Mapping[str, str]) -> int:
@@ -456,19 +467,43 @@ def run_gate(
     if gate_command is None:
         _require_npm()
 
-    lease = lease_preview_port(
-        git_common_dir(repo_root) if common_dir is None else common_dir,
-        requested,
-    )
+    resolved_common = git_common_dir(repo_root) if common_dir is None else common_dir
+    activity: coordination_lease.WorktreeClaim | None = None
     try:
-        values["ARR_PREVIEW_PORT"] = str(lease.port)
-        values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
-        announce_browser_cache(cache)
-        print(f"Preview port lease: {lease.port}", flush=True)
-        with _release_lease_on_signals(lease):
-            returncode = _run_child(command, values, repo_root)
+        activity = coordination_lease.acquire_activity(
+            resolved_common,
+            repo_root.resolve(),
+            wait_seconds=coordination_lease.DEFAULT_RUN_SLOT_WAIT_SECONDS,
+        )
+    except coordination_lease.ClaimContentionError as error:
+        raise FrontendLeaseRefusal(str(error), error.claims) from error
+    except coordination_lease.ClaimStoreUnavailable as error:
+        print(
+            f"WARNING: worktree lease unavailable; running browser gate unleased: {error}",
+            file=sys.stderr,
+            flush=True,
+        )
+    try:
+        lease = lease_preview_port(resolved_common, requested)
+        try:
+            values["ARR_PREVIEW_PORT"] = str(lease.port)
+            values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
+            announce_browser_cache(cache)
+            print(f"Preview port lease: {lease.port}", flush=True)
+            with _release_lease_on_signals(lease):
+                returncode = _run_child(command, values, repo_root)
+        finally:
+            lease.release()
     finally:
-        lease.release()
+        if activity is not None:
+            try:
+                activity.release()
+            except (coordination_lease.ClaimStoreUnavailable, OSError) as error:
+                print(
+                    f"WARNING: worktree lease release failed: {error}",
+                    file=sys.stderr,
+                    flush=True,
+                )
     evidence = worktree_hygiene.manage_playwright_failure_evidence(
         repo_root,
         gate_returncode=returncode,
@@ -540,6 +575,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         cache = resolve_browser_cache(args.browsers_path)
         announce_browser_cache(cache)
         return 0
+    except FrontendLeaseRefusal as error:
+        detail = str(error)
+        if error.claims:
+            detail = f"{detail}; held by {coordination_lease._holder_names(error.claims)}"
+        print(
+            "\n".join(
+                worktree_hygiene.lease_refusal_lines("frontend gate", detail)
+            ),
+            file=sys.stderr,
+        )
+        return 75
     except FrontendRuntimeError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2

--- a/tools/repo/frontend_runtime.py
+++ b/tools/repo/frontend_runtime.py
@@ -467,33 +467,67 @@ def run_gate(
     if gate_command is None:
         _require_npm()
 
-    resolved_common = git_common_dir(repo_root) if common_dir is None else common_dir
     activity: coordination_lease.WorktreeClaim | None = None
+    resolved_common: Path | None = None
+    # Read before the fail-open block on purpose: a malformed operator budget is a
+    # refusal AC6 requires, not one of AC9's degrade-and-run conditions.
+    _limit, lease_wait_seconds = coordination_lease.run_slot_budgets(values)
     try:
+        # Common-directory resolution is inside the fail-open path, not above it.
+        # AC9 names "an unresolvable worktree" as a warn-and-run case, and resolving
+        # it first meant a missing git or a failing rev-parse raised
+        # FrontendRuntimeError past this handler and exited 2 without running the
+        # browser gate at all -- the lease failing a job it may not fail.
+        resolved_common = (
+            git_common_dir(repo_root) if common_dir is None else common_dir
+        )
         activity = coordination_lease.acquire_activity(
             resolved_common,
             repo_root.resolve(),
-            wait_seconds=coordination_lease.DEFAULT_RUN_SLOT_WAIT_SECONDS,
+            wait_seconds=lease_wait_seconds,
         )
+    except coordination_lease.CoordinationLockContention as error:
+        # Held by a live peer: contention, which refuses. Classifying it as an
+        # unusable store is what let the limiter switch itself off under load.
+        raise FrontendLeaseRefusal(str(error), ()) from error
     except coordination_lease.ClaimContentionError as error:
         raise FrontendLeaseRefusal(str(error), error.claims) from error
-    except coordination_lease.ClaimStoreUnavailable as error:
+    except (coordination_lease.ClaimStoreUnavailable, FrontendRuntimeError) as error:
         print(
             f"WARNING: worktree lease unavailable; running browser gate unleased: {error}",
             file=sys.stderr,
             flush=True,
         )
     try:
-        lease = lease_preview_port(resolved_common, requested)
+        # An unresolvable worktree leaves nowhere to record a port lease either. The
+        # gate still runs, because AC9 forbids the lease failing the job: it honours an
+        # explicitly requested port and otherwise leaves the child's own default alone.
+        lease = (
+            lease_preview_port(resolved_common, requested)
+            if resolved_common is not None
+            else None
+        )
         try:
-            values["ARR_PREVIEW_PORT"] = str(lease.port)
             values["PLAYWRIGHT_BROWSERS_PATH"] = str(cache.path)
             announce_browser_cache(cache)
-            print(f"Preview port lease: {lease.port}", flush=True)
-            with _release_lease_on_signals(lease):
+            if lease is None:
+                if requested is not None:
+                    values["ARR_PREVIEW_PORT"] = str(requested)
+                print(
+                    "WARNING: preview port is unleased; the worktree scope could not "
+                    "be resolved",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 returncode = _run_child(command, values, repo_root)
+            else:
+                values["ARR_PREVIEW_PORT"] = str(lease.port)
+                print(f"Preview port lease: {lease.port}", flush=True)
+                with _release_lease_on_signals(lease):
+                    returncode = _run_child(command, values, repo_root)
         finally:
-            lease.release()
+            if lease is not None:
+                lease.release()
     finally:
         if activity is not None:
             try:

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -1323,6 +1323,11 @@ def _claim_holder_names(claims: Iterable[Any]) -> str:
     return ", ".join(holders) or "unknown holder"
 
 
+def lease_refusal_lines(command: str, detail: str) -> list[str]:
+    """Render the reserved, greppable refusal contract for lease participants."""
+    return ["WORKTREE_LEASE_DID_NOT_RUN", f"{command} did not run: {detail}"]
+
+
 def _append_receipt_summary(
     lines: list[str],
     *,
@@ -1687,10 +1692,12 @@ def clean(
             try:
                 exclusive_claim = lease.acquire_exclusive(common, clean_selection[0].resolve())
             except lease.ClaimContentionError as error:
-                lines.append("WORKTREE_LEASE_DID_NOT_RUN")
-                lines.append(
-                    "clean did not run: live activity claim held by "
-                    f"{_claim_holder_names(error.claims)}"
+                lines.extend(
+                    lease_refusal_lines(
+                        "clean",
+                        "live activity claim held by "
+                        f"{_claim_holder_names(error.claims)}",
+                    )
                 )
                 _append_receipt_summary(
                     lines,
@@ -1704,10 +1711,12 @@ def clean(
             except lease.ClaimStoreUnavailable:
                 if not force_without_lease:
                     # A participant unable to publish cannot trust its read of this store.
-                    lines.append("WORKTREE_LEASE_DID_NOT_RUN")
-                    lines.append(
-                        "clean did not run: exclusive claim store is unavailable; "
-                        "use --force-without-lease only when cleanup must proceed"
+                    lines.extend(
+                        lease_refusal_lines(
+                            "clean",
+                            "exclusive claim store is unavailable; use "
+                            "--force-without-lease only when cleanup must proceed",
+                        )
                     )
                     _append_receipt_summary(
                         lines,

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -1303,6 +1303,26 @@ def _current_worktree(repository: Path, runner: Runner) -> Path:
     return _registered_current_worktree(repository, runner) or repository.resolve()
 
 
+def _coordination_lease_module() -> Any:
+    """Import the optional lease participant without creating an import cycle."""
+    if __package__:
+        from . import coordination_lease
+    else:
+        import coordination_lease
+
+    return coordination_lease
+
+
+def _claim_holder_names(claims: Iterable[Any]) -> str:
+    """Render only the safe holder identity fields for a refusal receipt."""
+    holders = []
+    for claim in claims:
+        pid = claim.pid if isinstance(claim.pid, int) else "unknown"
+        worktree = claim.worktree.name if claim.worktree is not None else "unknown"
+        holders.append(f"pid {pid} in {worktree}")
+    return ", ".join(holders) or "unknown holder"
+
+
 def _append_receipt_summary(
     lines: list[str],
     *,
@@ -1574,6 +1594,7 @@ def clean(
     apply: bool,
     include_dependencies: bool,
     protected: set[Path],
+    force_without_lease: bool = False,
     selected: list[Path] | None = None,
     runner: Runner = _run,
     mount_check: MountCheck | None = None,
@@ -1659,110 +1680,160 @@ def clean(
     if "dependencies" in categories:
         protected.add(invocation_root)
     common = Path(common_value).resolve()
-    in_use_locations = _installed_distribution_locations()
-    for worktree_data in report["worktrees"]:
-        root = Path(worktree_data["path"]).resolve()
-        candidates = [
-            _candidate_from_data(data)
-            for data in worktree_data["candidates"]
-            if data["category"] in categories
-        ]
-        if root in protected:
-            lines.append(f"skipped protected worktree: {root}")
-            lines.extend(
-                f"warning: skipped {candidate.path}: protected worktree"
-                for candidate in candidates
-            )
-            skipped_count += len(candidates)
-            remaining.extend(
-                (candidate.bytes, candidate.path, "protected worktree")
-                for candidate in candidates
-            )
-            continue
-        decisions: list[tuple[Candidate, Path | None, str]] = []
-        git_candidates: list[Candidate] = []
-        for candidate in candidates:
-            reason = _candidate_safety_reason(
-                candidate,
-                root,
-                common,
-                protected,
-                effective_mount_check,
-            )
-            if reason:
-                decisions.append((candidate, None, reason))
-                continue
-            relative = candidate.canonical_path.relative_to(root)
-            git_candidates.append(candidate)
-            decisions.append((candidate, relative, ""))
-        git_status = _mark_git_status(root, git_candidates, runner)
-        if git_status.error:
-            lines.append(f"warning: skipped worktree {root}: {git_status.error}")
-            lines.extend(
-                f"warning: skipped {candidate.path}: {git_status.error}"
-                for candidate in candidates
-            )
-            skipped_count += len(candidates)
-            remaining.extend(
-                (candidate.bytes, candidate.path, git_status.error)
-                for candidate in candidates
-            )
-            continue
-        for candidate, relative, reason in decisions:
-            if not reason and relative is not None:
-                if _is_tracked(relative, git_status.tracked):
-                    reason = "tracked"
-                elif relative not in git_status.ignored:
-                    reason = "not ignored"
-                elif _is_in_use(candidate, in_use_locations):
-                    reason = "installed distribution resolves into target"
-            if reason:
-                lines.append(f"warning: skipped {candidate.path}: {reason}")
-                skipped_count += 1
-                remaining.append((candidate.bytes, candidate.path, reason))
-                continue
-            lines.append(f"selected {candidate.path}: {candidate.bytes} bytes")
-            selected_count += 1
-            if not apply:
-                remaining.append((candidate.bytes, candidate.path, "dry run"))
-                continue
-            predelete_mount_check = mount_check or _default_mount_check()
-            recheck_reason = _candidate_safety_reason(
-                candidate,
-                root,
-                common,
-                protected,
-                predelete_mount_check,
-            )
-            if recheck_reason:
-                lines.append(
-                    f"aborted {candidate.path}: safety changed: {recheck_reason}"
-                )
-                skipped_count += 1
-                remaining.append(
-                    (candidate.bytes, candidate.path, recheck_reason)
-                )
-                continue
+    exclusive_claim: Any | None = None
+    try:
+        if apply:
+            lease = _coordination_lease_module()
             try:
-                if candidate.is_dir:
-                    shutil.rmtree(candidate.path)
-                else:
-                    candidate.path.unlink()
-            except OSError as exc:
-                lines.append(f"failure {candidate.path}: {exc}")
-                failure_count += 1
-                remaining.append((candidate.bytes, candidate.path, str(exc)))
+                exclusive_claim = lease.acquire_exclusive(common, clean_selection[0].resolve())
+            except lease.ClaimContentionError as error:
+                lines.append("WORKTREE_LEASE_DID_NOT_RUN")
+                lines.append(
+                    "clean did not run: live activity claim held by "
+                    f"{_claim_holder_names(error.claims)}"
+                )
+                _append_receipt_summary(
+                    lines,
+                    selected=0,
+                    skipped=0,
+                    reclaimed=0,
+                    failures=0,
+                    remaining=[],
+                )
+                return 75, lines
+            except lease.ClaimStoreUnavailable:
+                if not force_without_lease:
+                    # A participant unable to publish cannot trust its read of this store.
+                    lines.append("WORKTREE_LEASE_DID_NOT_RUN")
+                    lines.append(
+                        "clean did not run: exclusive claim store is unavailable; "
+                        "use --force-without-lease only when cleanup must proceed"
+                    )
+                    _append_receipt_summary(
+                        lines,
+                        selected=0,
+                        skipped=0,
+                        reclaimed=0,
+                        failures=0,
+                        remaining=[],
+                    )
+                    return 75, lines
+                lines.append(
+                    "warning: proceeding without an exclusive claim because "
+                    "--force-without-lease was supplied"
+                )
             else:
-                reclaimed += candidate.bytes
-    _append_receipt_summary(
-        lines,
-        selected=selected_count,
-        skipped=skipped_count,
-        reclaimed=reclaimed,
-        failures=failure_count,
-        remaining=remaining,
-    )
-    return 0, lines
+                lines.append("lease: acquired exclusive claim")
+        in_use_locations = _installed_distribution_locations()
+        for worktree_data in report["worktrees"]:
+            root = Path(worktree_data["path"]).resolve()
+            candidates = [
+                _candidate_from_data(data)
+                for data in worktree_data["candidates"]
+                if data["category"] in categories
+            ]
+            if root in protected:
+                lines.append(f"skipped protected worktree: {root}")
+                lines.extend(
+                    f"warning: skipped {candidate.path}: protected worktree"
+                    for candidate in candidates
+                )
+                skipped_count += len(candidates)
+                remaining.extend(
+                    (candidate.bytes, candidate.path, "protected worktree")
+                    for candidate in candidates
+                )
+                continue
+            decisions: list[tuple[Candidate, Path | None, str]] = []
+            git_candidates: list[Candidate] = []
+            for candidate in candidates:
+                reason = _candidate_safety_reason(
+                    candidate,
+                    root,
+                    common,
+                    protected,
+                    effective_mount_check,
+                )
+                if reason:
+                    decisions.append((candidate, None, reason))
+                    continue
+                relative = candidate.canonical_path.relative_to(root)
+                git_candidates.append(candidate)
+                decisions.append((candidate, relative, ""))
+            git_status = _mark_git_status(root, git_candidates, runner)
+            if git_status.error:
+                lines.append(f"warning: skipped worktree {root}: {git_status.error}")
+                lines.extend(
+                    f"warning: skipped {candidate.path}: {git_status.error}"
+                    for candidate in candidates
+                )
+                skipped_count += len(candidates)
+                remaining.extend(
+                    (candidate.bytes, candidate.path, git_status.error)
+                    for candidate in candidates
+                )
+                continue
+            for candidate, relative, reason in decisions:
+                if not reason and relative is not None:
+                    if _is_tracked(relative, git_status.tracked):
+                        reason = "tracked"
+                    elif relative not in git_status.ignored:
+                        reason = "not ignored"
+                    elif _is_in_use(candidate, in_use_locations):
+                        reason = "installed distribution resolves into target"
+                if reason:
+                    lines.append(f"warning: skipped {candidate.path}: {reason}")
+                    skipped_count += 1
+                    remaining.append((candidate.bytes, candidate.path, reason))
+                    continue
+                lines.append(f"selected {candidate.path}: {candidate.bytes} bytes")
+                selected_count += 1
+                if not apply:
+                    remaining.append((candidate.bytes, candidate.path, "dry run"))
+                    continue
+                predelete_mount_check = mount_check or _default_mount_check()
+                recheck_reason = _candidate_safety_reason(
+                    candidate,
+                    root,
+                    common,
+                    protected,
+                    predelete_mount_check,
+                )
+                if recheck_reason:
+                    lines.append(
+                        f"aborted {candidate.path}: safety changed: {recheck_reason}"
+                    )
+                    skipped_count += 1
+                    remaining.append(
+                        (candidate.bytes, candidate.path, recheck_reason)
+                    )
+                    continue
+                try:
+                    if candidate.is_dir:
+                        shutil.rmtree(candidate.path)
+                    else:
+                        candidate.path.unlink()
+                except OSError as exc:
+                    lines.append(f"failure {candidate.path}: {exc}")
+                    failure_count += 1
+                    remaining.append((candidate.bytes, candidate.path, str(exc)))
+                else:
+                    reclaimed += candidate.bytes
+        _append_receipt_summary(
+            lines,
+            selected=selected_count,
+            skipped=skipped_count,
+            reclaimed=reclaimed,
+            failures=failure_count,
+            remaining=remaining,
+        )
+        return 0, lines
+    finally:
+        if exclusive_claim is not None:
+            try:
+                exclusive_claim.release()
+            finally:
+                lines.append("lease: released exclusive claim")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1805,6 +1876,14 @@ def main(argv: list[str] | None = None) -> int:
         "--apply",
         action="store_true",
         help="Delete selected safe candidates; otherwise print a dry run.",
+    )
+    clean_parser.add_argument(
+        "--force-without-lease",
+        action="store_true",
+        help=(
+            "Proceed only when the exclusive claim store is unavailable; this may "
+            "delete while an uncoordinated peer is active."
+        ),
     )
     clean_parser.add_argument(
         "--include-dependencies",
@@ -1878,6 +1957,7 @@ def main(argv: list[str] | None = None) -> int:
         apply=args.apply,
         include_dependencies=args.include_dependencies,
         protected=protected,
+        force_without_lease=args.force_without_lease,
         selected=[args.worktree] if args.worktree else None,
     )
     print("\n".join(lines))

--- a/tools/repo/worktree_hygiene.py
+++ b/tools/repo/worktree_hygiene.py
@@ -1599,7 +1599,6 @@ def clean(
     apply: bool,
     include_dependencies: bool,
     protected: set[Path],
-    force_without_lease: bool = False,
     selected: list[Path] | None = None,
     runner: Runner = _run,
     mount_check: MountCheck | None = None,
@@ -1709,28 +1708,29 @@ def clean(
                 )
                 return 75, lines
             except lease.ClaimStoreUnavailable:
-                if not force_without_lease:
-                    # A participant unable to publish cannot trust its read of this store.
-                    lines.extend(
-                        lease_refusal_lines(
-                            "clean",
-                            "exclusive claim store is unavailable; use "
-                            "--force-without-lease only when cleanup must proceed",
-                        )
+                # A participant unable to publish cannot trust its read of this store,
+                # and this is the one command that deletes. There is deliberately no
+                # override: the spec's first Never is "let a destructive command
+                # proceed on evidence it failed to obtain", and a flag that does
+                # exactly that is not made safe by being explicit. A claim that is
+                # merely stuck has a recovery path already -- `release-claim` -- and an
+                # unusable store is a fault to repair, not to delete through.
+                lines.extend(
+                    lease_refusal_lines(
+                        "clean",
+                        "exclusive claim store is unavailable; repair the store, or "
+                        "release a stuck claim with release-claim",
                     )
-                    _append_receipt_summary(
-                        lines,
-                        selected=0,
-                        skipped=0,
-                        reclaimed=0,
-                        failures=0,
-                        remaining=[],
-                    )
-                    return 75, lines
-                lines.append(
-                    "warning: proceeding without an exclusive claim because "
-                    "--force-without-lease was supplied"
                 )
+                _append_receipt_summary(
+                    lines,
+                    selected=0,
+                    skipped=0,
+                    reclaimed=0,
+                    failures=0,
+                    remaining=[],
+                )
+                return 75, lines
             else:
                 lines.append("lease: acquired exclusive claim")
         in_use_locations = _installed_distribution_locations()
@@ -1887,14 +1887,6 @@ def main(argv: list[str] | None = None) -> int:
         help="Delete selected safe candidates; otherwise print a dry run.",
     )
     clean_parser.add_argument(
-        "--force-without-lease",
-        action="store_true",
-        help=(
-            "Proceed only when the exclusive claim store is unavailable; this may "
-            "delete while an uncoordinated peer is active."
-        ),
-    )
-    clean_parser.add_argument(
         "--include-dependencies",
         action="store_true",
         help="Acknowledge expensive dependency cleanup.",
@@ -1966,7 +1958,6 @@ def main(argv: list[str] | None = None) -> int:
         apply=args.apply,
         include_dependencies=args.include_dependencies,
         protected=protected,
-        force_without_lease=args.force_without_lease,
         selected=[args.worktree] if args.worktree else None,
     )
     print("\n".join(lines))

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -31,12 +31,15 @@ def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     agentbundle = job_block(workflow, "agentbundle-windows")
     credbroker = job_block(workflow, "credbroker-tests-windows")
+    lock_semantics = job_block(workflow, "lock-semantics-windows")
     aggregate = job_block(workflow, "build-check-windows")
 
     if "    runs-on: windows-latest\n" not in agentbundle:
         fail("AgentBundle compatibility job must run on windows-latest")
     if "    runs-on: windows-latest\n" not in credbroker:
         fail("CredBroker test job must run on windows-latest")
+    if "    runs-on: windows-latest\n" not in lock_semantics:
+        fail("lock semantics job must run on windows-latest")
     for job_name, block, expected_timeout in (
         ("AgentBundle", agentbundle, 15),
         ("CredBroker", credbroker, 10),
@@ -52,6 +55,9 @@ def main() -> int:
     )
     if credbroker.count(suite_step) != 1:
         fail("CredBroker job must run its complete package suite")
+    lease_suite_step = "        run: python -m pytest tools/test_coordination_lease.py -q\n"
+    if lock_semantics.count(lease_suite_step) != 1:
+        fail("lock semantics job must run the real coordination lease suite")
 
     if "    name: make build-check (windows)\n" not in aggregate:
         fail("aggregate must preserve the required check name")
@@ -59,19 +65,25 @@ def main() -> int:
         "    needs:\n"
         "      - agentbundle-windows\n"
         "      - credbroker-tests-windows\n"
+        "      - lock-semantics-windows\n"
     )
     if required_needs not in aggregate:
-        fail("aggregate must depend on both Windows jobs")
+        fail("aggregate must depend on all Windows jobs")
     if "    if: ${{ always() }}\n" not in aggregate:
         fail("aggregate must run even when a dependency fails or is cancelled")
 
     for result in (
         "needs.agentbundle-windows.result",
         "needs.credbroker-tests-windows.result",
+        "needs.lock-semantics-windows.result",
     ):
         if result not in aggregate:
             fail(f"aggregate does not check {result}")
-    for result_variable in ("AGENTBUNDLE_RESULT", "CREDBROKER_RESULT"):
+    for result_variable in (
+        "AGENTBUNDLE_RESULT",
+        "CREDBROKER_RESULT",
+        "LOCK_SEMANTICS_RESULT",
+    ):
         comparison = f'[ "${result_variable}" != "success" ]'
         if comparison not in aggregate:
             fail(f"aggregate does not require {result_variable} to succeed")

--- a/tools/test_catalogue_tooling_rewire.py
+++ b/tools/test_catalogue_tooling_rewire.py
@@ -10,6 +10,7 @@ Verifies that:
 
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -67,10 +68,64 @@ class MakefileRewireTest(unittest.TestCase):
         self.assertIn('"catalogue", "verify"', chain,
                       "the gate chain must own portable catalogue verification")
 
+    def _resolved_body(self, target: str, *, hops: int = 2) -> str:
+        """A target's recipe, following `$(MAKE) <target>` delegation.
+
+        `build-check` delegates through the cooperative run-slot wrapper
+        (`with-lease -- $(MAKE) -f <makefile> build-check-unleased`), so the
+        gate-chain call it must reach is one hop away. Reading only the literal
+        recipe reports a missing delegation that is in fact present -- and, worse, a
+        guard that reads only the first recipe stops protecting the chain the moment
+        any wrapper is introduced. Following the hop keeps it pointed at the
+        property that matters: the gate chain actually runs.
+        """
+        seen: set[str] = set()
+        pending = [target]
+        collected: list[str] = []
+        for _ in range(hops):
+            if not pending:
+                break
+            current = pending.pop(0)
+            if current in seen:
+                continue
+            seen.add(current)
+            body = self._target_body(current)
+            collected.append(body)
+            for line in body.splitlines():
+                for call in re.finditer(r"\$\(MAKE\)(.*)", line):
+                    # Skip flags and make-variable arguments: the call carries
+                    # `-f $(firstword $(MAKEFILE_LIST))`, so taking the first token
+                    # after $(MAKE) captures "-f" and the target is never followed.
+                    for token in call.group(1).split():
+                        if token.startswith(("-", "$(")) or token.endswith("))"):
+                            continue
+                        pending.append(token)
+                        break
+        return "\n".join(collected)
+
     def test_build_check_calls_repo_build_gate_chain(self):
-        body = self._target_body("build-check")
-        self.assertIn("tools/repo/build_gate_chain.py", body,
-                      "build-check must delegate to tools/repo/build_gate_chain.py")
+        resolved = self._resolved_body("build-check")
+        self.assertIn("tools/repo/build_gate_chain.py", resolved,
+                      "build-check must reach tools/repo/build_gate_chain.py")
+
+    def test_wrapped_targets_keep_their_lease_and_forward_the_makefile(self):
+        """Each wrapped target is guarded, so a dropped wrapper reddens something.
+
+        The plan's participant matrix requires one dropped-wrapper mutation per
+        wrapped target. The `-f` forwarding is asserted too: without it a recursive
+        sub-make launched from inside the wrapper loses `-f` and re-reads the default
+        Makefile, which silently disarms `assert-sast-chain-reachable`'s self-test.
+        """
+        for target, inner in (
+            ("test", "test-unleased"),
+            ("build-check", "build-check-unleased"),
+            ("sast", "sast-unleased"),
+        ):
+            body = self._target_body(target)
+            self.assertIn("with-lease", body, f"{target} must run under the wrapper")
+            self.assertIn(inner, body, f"{target} must delegate to {inner}")
+            self.assertIn("$(firstword $(MAKEFILE_LIST))", body,
+                          f"{target} must forward the makefile currently in use")
 
     def test_package_target_exists(self):
         body = self._target_body("package")

--- a/tools/test_coordination_lease.py
+++ b/tools/test_coordination_lease.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import inspect
 import json
 import multiprocessing
@@ -402,3 +403,105 @@ def test_sequential_interlock_refuses_exclusive_while_activity_is_held(
     with pytest.raises(coordination_lease.ClaimContentionError):
         coordination_lease.acquire_exclusive(root, worktree)
     first.release()
+
+
+def test_a_publication_fault_becomes_an_unusable_store_not_a_raw_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A store that cannot hard-link must reach the fail-open path, not a traceback.
+
+    Raised raw, the error escaped every handler in the wrapper and the browser gate
+    -- both of which catch only ClaimStoreUnavailable -- and crashed a job AC9
+    promises to run. FileExistsError is deliberately excluded from this translation
+    and keeps its own meaning; that half is held by the atomic-publish test above.
+    """
+    root = tmp_path.resolve()
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+    real_link = os.link
+
+    def refusing_link(source: object, target: object, **kwargs: object) -> None:
+        raise OSError(errno.EPERM, "hard links unsupported on this filesystem")
+
+    monkeypatch.setattr(os, "link", refusing_link)
+    with pytest.raises(coordination_lease.ClaimStoreUnavailable):
+        coordination_lease.publish_claim_candidate(
+            lease_dir, lease_dir / "claim.lease", "payload"
+        )
+
+    # The translation must not have leaked the temporary candidate either.
+    monkeypatch.setattr(os, "link", real_link)
+    assert not list(lease_dir.glob(".claim-*"))
+
+
+def test_an_observably_live_waiter_record_is_never_aged_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Age reclaims records whose owner died; a held lock proves it did not.
+
+    Unlinking a live waiter's record erased its queue position, and its next
+    publication took a fresh filesystem timestamp that let younger waiters overtake
+    it -- reachable whenever the wait budget is overridden past the age budget. The
+    age clause is proven still to work on the record whose liveness is unproven, so
+    this is not simply a disabled reclaim.
+    """
+    root = tmp_path.resolve()
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+    live_token = "a" * 32
+    dead_token = "b" * 32
+    live_path = lease_dir / f"run-registration-{live_token}.lease"
+    dead_path = lease_dir / f"run-registration-{dead_token}.lease"
+
+    # A live record: published and still holding its own ownership lock.
+    descriptor = coordination_lease.publish_claim_candidate(
+        lease_dir, live_path, coordination_lease._run_claim_payload(live_token, root)
+    )
+    # A record whose owner is gone: published, then its lock released.
+    coordination_lease._unlock_and_close(
+        coordination_lease.publish_claim_candidate(
+            lease_dir, dead_path, coordination_lease._run_claim_payload(dead_token, root)
+        )
+    )
+    try:
+        # Everything is now older than the age budget.
+        monkeypatch.setattr(coordination_lease, "RUN_CLAIM_MAX_AGE_SECONDS", -1)
+        coordination_lease._prune_run_registrations(lease_dir, root)
+
+        assert live_path.exists(), "a live waiter's queue position was erased by age"
+        assert not dead_path.exists(), "age no longer reclaims an abandoned record"
+    finally:
+        coordination_lease._unlock_and_close(descriptor)
+
+
+def test_a_live_claim_with_a_refused_identity_is_still_actionable(
+    tmp_path: Path,
+) -> None:
+    """AC4's fifth state: no pid to name, so name the claim instead.
+
+    A claim can be observably live and simultaneously carry a payload refused as
+    untrusted. The release command then refuses it -- correctly, it is live -- while
+    the refusal said only "pid unknown", so AC4's documented recovery of terminating
+    the named holder could not be carried out on it. The claim's own identifier is
+    what an operating-system tool needs, and it is a base name, so naming it stays
+    inside AC7's disclosure limit.
+    """
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    claim = coordination_lease.acquire_exclusive(root, worktree)
+    try:
+        payload = json.loads(claim.path.read_text())
+        payload["pid"] = -1
+        claim.path.write_text(json.dumps(payload), encoding="utf-8")
+
+        record = coordination_lease.read_claims(root, worktree).exclusive
+        assert record is not None
+        assert record.liveness is coordination_lease.Liveness.LIVE
+        assert record.pid is None
+
+        rendered = coordination_lease._holder_names((record,))
+
+        assert claim.path.name in rendered
+        assert "pid unknown" not in rendered
+        assert str(worktree) not in rendered
+    finally:
+        claim.release()

--- a/tools/test_coordination_lease.py
+++ b/tools/test_coordination_lease.py
@@ -96,6 +96,22 @@ def test_release_removes_only_callers_own_claim(tmp_path: Path) -> None:
     assert claim.path.exists()
 
 
+def _unhandleable_kill(holder: multiprocessing.Process) -> None:
+    """Kill a holder in a way it cannot intercept, so the KERNEL releases the lock.
+
+    POSIX `SIGKILL` cannot be caught. Windows has no `SIGKILL` at all --
+    `signal.SIGKILL` raises AttributeError there, which failed this suite on
+    windows-latest -- but `Process.terminate()` calls `TerminateProcess`, which is
+    likewise unhandleable. `SIGTERM` would be wrong on either platform: a holder that
+    catches it, cleans up and releases its own claim proves the opposite of what these
+    tests assert, which is that the operating system releases the lock on death.
+    """
+    if os.name == "nt":
+        holder.terminate()
+        return
+    os.kill(holder.pid, signal.SIGKILL)
+
+
 def test_sigkilled_holder_claim_is_reclaimed(
     tmp_path: Path, claim_holder_processes: list[multiprocessing.Process]
 ) -> None:
@@ -105,7 +121,7 @@ def test_sigkilled_holder_claim_is_reclaimed(
     worktree.mkdir()
     holder, ready = _start_claim_holder(claim_holder_processes, root, worktree)
     assert ready.wait(CHILD_START_BUDGET_SECONDS)
-    os.kill(holder.pid, signal.SIGKILL)
+    _unhandleable_kill(holder)
     holder.join(CHILD_START_BUDGET_SECONDS)
 
     second = coordination_lease.acquire_exclusive(root, worktree)
@@ -130,7 +146,7 @@ def test_live_identity_is_not_reclaimed_by_age_alone(
 
     with pytest.raises(coordination_lease.ClaimContentionError):
         coordination_lease.acquire_exclusive(root, worktree)
-    os.kill(holder.pid, signal.SIGKILL)
+    _unhandleable_kill(holder)
     holder.join(CHILD_START_BUDGET_SECONDS)
 
 
@@ -190,7 +206,7 @@ def test_recycled_pid_cannot_impersonate_lock_holder(
     path.write_text(json.dumps(payload), encoding="utf-8")
 
     assert coordination_lease.read_claims(root, worktree).exclusive.liveness is coordination_lease.Liveness.LIVE
-    os.kill(holder.pid, signal.SIGKILL)
+    _unhandleable_kill(holder)
     holder.join(CHILD_START_BUDGET_SECONDS)
 
 
@@ -278,22 +294,39 @@ def test_claim_directory_symlink_is_refused(tmp_path: Path) -> None:
         )
 
 
-def test_claim_lock_operations_seek_to_byte_zero_structurally() -> None:
-    """Windows byte-range liveness needs both operations to overlap byte zero."""
+def test_claim_lock_operations_agree_on_one_offset_past_the_payload() -> None:
+    """Both Windows requirements, asserted structurally because POSIX cannot show them.
+
+    The publisher, the prober and the release must lock the SAME byte, or on Windows
+    they hold disjoint ranges and a live claim reads not-live. That byte must also lie
+    OUTSIDE the payload, because the Windows lock is mandatory rather than advisory,
+    and locking byte zero made `_read_record`'s payload read raise PermissionError for
+    every live claim on windows-latest. Byte zero satisfies the first and violates the
+    second, which is why an earlier revision of this test passed while the code was
+    broken on the only platform that can observe either property.
+    """
+    seek = "os.lseek(descriptor, CLAIM_LOCK_OFFSET, os.SEEK_SET)"
     publish_source = inspect.getsource(coordination_lease.publish_claim_candidate)
     probe_source = inspect.getsource(coordination_lease._probe_claim_lock)
     release_source = inspect.getsource(coordination_lease._unlock_and_close)
 
-    assert publish_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < publish_source.index(
+    # One agreed offset, and the seek precedes the lock operation in every path.
+    assert publish_source.index(seek) < publish_source.index(
         "_lock_functions(descriptor)[0]()"
     )
-    assert probe_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < probe_source.index(
-        "acquire()"
-    )
-    assert probe_source.count("os.lseek(descriptor, 0, os.SEEK_SET)") >= 2
-    assert release_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < release_source.index(
+    assert probe_source.index(seek) < probe_source.index("acquire()")
+    assert probe_source.count(seek) >= 2
+    assert release_source.index(seek) < release_source.index(
         "_lock_functions(descriptor)[1]()"
     )
+
+    # No claim path may lock byte zero: that is the offset inside the payload.
+    for source in (publish_source, probe_source, release_source):
+        assert "os.lseek(descriptor, 0, os.SEEK_SET)" not in source
+
+    # And the offset really is past any payload this module writes.
+    payload = coordination_lease._run_claim_payload("0" * 32, Path("/mnt/some/worktree"))
+    assert len(payload) * 100 < coordination_lease.CLAIM_LOCK_OFFSET
 
 
 def test_coordination_lock_serializes_two_real_processes(tmp_path: Path) -> None:

--- a/tools/test_coordination_lease.py
+++ b/tools/test_coordination_lease.py
@@ -378,7 +378,7 @@ def test_racing_participants_are_never_both_admitted(
         if claim is not None:
             claim.release()  # type: ignore[union-attr]
 
-    assert len(admitted) <= 1, f"both roles admitted at once: {admitted}"
+    assert len(admitted) == 1, f"expected exactly one admitted role, observed {admitted}"
 
 
 def test_sequential_interlock_refuses_exclusive_while_activity_is_held(

--- a/tools/test_coordination_lease.py
+++ b/tools/test_coordination_lease.py
@@ -1,0 +1,404 @@
+"""Construction tests for cooperative worktree coordination claims."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import multiprocessing
+import os
+import signal
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from tools.repo import coordination_lease
+
+# Waiting for a real child process to start is the one cost here that genuinely
+# scales with machine load, and this host has run at load 47-160 with swap
+# exhausted. A 2-second budget produced a baseline failure that looked exactly
+# like a logic defect -- the same trap AC14 addresses for the vitest case. Widen
+# the budget for the thing whose cost varies; keep every assertion tight. One
+# home, so it cannot drift between call sites.
+CHILD_START_BUDGET_SECONDS = 60.0
+
+
+@pytest.fixture
+def claim_holder_processes() -> list[multiprocessing.Process]:
+    """Track daemon claim holders so a failed assertion cannot hang pytest."""
+    holders: list[multiprocessing.Process] = []
+    yield holders
+    for holder in holders:
+        if holder.is_alive():
+            holder.terminate()
+        holder.join(CHILD_START_BUDGET_SECONDS)
+
+
+def _start_claim_holder(
+    holders: list[multiprocessing.Process], root: Path, worktree: Path
+) -> tuple[multiprocessing.Process, multiprocessing.synchronize.Event]:
+    """Start one daemon holder and return it with its readiness event."""
+    ready = multiprocessing.Event()
+    holder = multiprocessing.Process(
+        target=_claim_holder,
+        args=(str(root), str(worktree), ready),
+        daemon=True,
+    )
+    holders.append(holder)
+    holder.start()
+    return holder, ready
+
+
+def _lock_worker(directory: str, ready: multiprocessing.synchronize.Event, queue: multiprocessing.queues.Queue[float]) -> None:
+    """Hold the real cross-process lock until the parent measures it."""
+    with coordination_lease.coordination_lock(Path(directory), "real-process.lock"):
+        ready.set()
+        started = time.monotonic()
+        time.sleep(0.2)
+    queue.put(time.monotonic() - started)
+
+
+def _claim_holder(common_dir: str, worktree: str, ready: multiprocessing.synchronize.Event) -> None:
+    """Acquire a real claim and remain alive until the parent kills this process."""
+    claim = coordination_lease.acquire_exclusive(Path(common_dir), Path(worktree))
+    ready.set()
+    while True:
+        assert claim.path.exists()
+        time.sleep(1)
+
+
+def test_atomic_publish_second_publisher_never_overwrites(tmp_path: Path) -> None:
+    """A hard-link publication leaves the first complete payload intact."""
+    root = tmp_path.resolve()
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+    path = lease_dir / "claim.lease"
+
+    coordination_lease.publish_claim_candidate(lease_dir, path, "first")
+    with pytest.raises(FileExistsError):
+        coordination_lease.publish_claim_candidate(lease_dir, path, "second")
+
+    assert path.read_text(encoding="utf-8") == "first"
+
+
+def test_release_removes_only_callers_own_claim(tmp_path: Path) -> None:
+    """A stale handle cannot unlink a peer that replaced its file."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    claim = coordination_lease.acquire_exclusive(root, worktree)
+    replacement = {**json.loads(claim.path.read_text()), "token": "replacement"}
+    claim.path.write_text(json.dumps(replacement), encoding="utf-8")
+
+    claim.release()
+
+    assert claim.path.exists()
+
+
+def test_sigkilled_holder_claim_is_reclaimed(
+    tmp_path: Path, claim_holder_processes: list[multiprocessing.Process]
+) -> None:
+    """The kernel releases a real killed holder's claim lock for reclamation."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    holder, ready = _start_claim_holder(claim_holder_processes, root, worktree)
+    assert ready.wait(CHILD_START_BUDGET_SECONDS)
+    os.kill(holder.pid, signal.SIGKILL)
+    holder.join(CHILD_START_BUDGET_SECONDS)
+
+    second = coordination_lease.acquire_exclusive(root, worktree)
+
+    assert second.path.exists()
+    second.release()
+
+
+def test_live_identity_is_not_reclaimed_by_age_alone(
+    tmp_path: Path, claim_holder_processes: list[multiprocessing.Process]
+) -> None:
+    """A live lifetime lock is protected even when metadata says it is old."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    holder, ready = _start_claim_holder(claim_holder_processes, root, worktree)
+    assert ready.wait(CHILD_START_BUDGET_SECONDS)
+    path = coordination_lease.read_claims(root, worktree).exclusive.path
+    payload = json.loads(path.read_text())
+    payload["created_at"] = 0
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(coordination_lease.ClaimContentionError):
+        coordination_lease.acquire_exclusive(root, worktree)
+    os.kill(holder.pid, signal.SIGKILL)
+    holder.join(CHILD_START_BUDGET_SECONDS)
+
+
+def test_unreadable_payload_is_undeterminable_and_blocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage is not evidence that it is safe to take a claim."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    first = coordination_lease.acquire_exclusive(root, worktree)
+    first.path.write_text("not json", encoding="utf-8")
+    monkeypatch.setattr(coordination_lease, "_probe_claim_lock", lambda _path: coordination_lease.Liveness.UNDETERMINABLE)
+
+    claims = coordination_lease.read_claims(root, worktree)
+
+    assert claims.exclusive is not None
+    assert claims.exclusive.liveness is coordination_lease.Liveness.UNDETERMINABLE
+    with pytest.raises(coordination_lease.ClaimContentionError):
+        coordination_lease.acquire_exclusive(root, worktree)
+
+
+@pytest.mark.parametrize("mutation", ["out_of_range", "wrong_worktree", "future"])
+def test_untrusted_payloads_are_rejected(tmp_path: Path, mutation: str) -> None:
+    """Malformed identity, location, and time data cannot be trusted."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    claim = coordination_lease.acquire_exclusive(root, worktree)
+    payload = json.loads(claim.path.read_text())
+    if mutation == "out_of_range":
+        payload["pid"] = -1
+    elif mutation == "wrong_worktree":
+        payload["worktree"] = "/mnt/other-worktree"
+    else:
+        payload["created_at"] = time.time() + 3600
+    claim.path.write_text(json.dumps(payload), encoding="utf-8")
+
+    read = coordination_lease.read_claims(root, worktree).exclusive
+
+    assert read is not None
+    assert read.pid is None if mutation != "future" else read.pid == os.getpid()
+    if mutation == "future":
+        assert read.created_at <= time.time()
+
+
+def test_recycled_pid_cannot_impersonate_lock_holder(
+    tmp_path: Path, claim_holder_processes: list[multiprocessing.Process]
+) -> None:
+    """Payload PIDs are only diagnostics; the held descriptor establishes liveness."""
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    holder, ready = _start_claim_holder(claim_holder_processes, root, worktree)
+    assert ready.wait(CHILD_START_BUDGET_SECONDS)
+    path = coordination_lease.read_claims(root, worktree).exclusive.path
+    payload = json.loads(path.read_text())
+    payload["pid"] = 999_999_999
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert coordination_lease.read_claims(root, worktree).exclusive.liveness is coordination_lease.Liveness.LIVE
+    os.kill(holder.pid, signal.SIGKILL)
+    holder.join(CHILD_START_BUDGET_SECONDS)
+
+
+def test_a_forged_claim_with_a_live_pid_is_not_live(tmp_path: Path) -> None:
+    """A hand-written claim naming a definitely-live pid is NOT live.
+
+    This is the direction the recycled-pid test cannot cover. That test corrupts
+    a payload while a real holder holds the lock and asserts LIVE -- which stays
+    true if liveness were hardcoded to LIVE, so it cannot detect a
+    payload-derived implementation. This case asserts the opposite: a claim file
+    with no lock holder is NOT_LIVE even though its recorded pid is this very
+    process and so unambiguously alive.
+
+    It is also the security case directly: a forged claim naming pid 1, or any
+    live pid, must not be able to wedge the tool permanently. The lock decides,
+    and nothing forged can hold one.
+    """
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+    key = coordination_lease.worktree_key(worktree)
+    forged = lease_dir / f"exclusive-{key}.lease"
+    forged.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "worktree": str(worktree),
+                "created_at": time.time(),
+                "token": "forged",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record = coordination_lease.read_claims(root, worktree).exclusive
+    assert record is not None
+    assert record.pid == os.getpid()
+    assert record.liveness is coordination_lease.Liveness.NOT_LIVE
+
+    # And therefore it cannot block a real acquisition.
+    claim = coordination_lease.acquire_exclusive(root, worktree)
+    claim.release()
+
+
+def test_digest_keys_do_not_flatten_distinct_worktree_paths(tmp_path: Path) -> None:
+    """Separators never collapse into a filename identity."""
+    root = tmp_path.resolve()
+
+    assert coordination_lease.worktree_key(Path("/mnt/a/b-c")) != coordination_lease.worktree_key(Path("/mnt/a-b/c"))
+    assert len(coordination_lease.worktree_key(root)) == 64
+
+
+def test_symlinked_lease_directory_is_refused(tmp_path: Path) -> None:
+    """mkdir's symlink-following behaviour cannot bless a redirected store."""
+    root = tmp_path.resolve()
+    outside = (root / "outside").resolve()
+    outside.mkdir()
+    (root / coordination_lease.LEASE_DIRECTORY).symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(coordination_lease.ClaimStoreUnavailable):
+        coordination_lease.prepare_lease_directory(root)
+
+
+def test_claim_path_escaping_lease_directory_is_refused(tmp_path: Path) -> None:
+    """Publication only accepts a claim path confined to the prepared store."""
+    root = tmp_path.resolve()
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+
+    with pytest.raises(coordination_lease.ClaimStoreUnavailable):
+        coordination_lease.publish_claim_candidate(lease_dir, root / "escape.lease", "payload")
+
+
+def test_claim_directory_symlink_is_refused(tmp_path: Path) -> None:
+    """Publisher lstat-checks its own directory, not only its child path."""
+    root = tmp_path.resolve()
+    target = (root / "target").resolve()
+    target.mkdir()
+    linked_directory = root / "linked-lease-directory"
+    linked_directory.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(coordination_lease.ClaimStoreUnavailable):
+        coordination_lease.publish_claim_candidate(
+            linked_directory, linked_directory / "claim.lease", "payload"
+        )
+
+
+def test_claim_lock_operations_seek_to_byte_zero_structurally() -> None:
+    """Windows byte-range liveness needs both operations to overlap byte zero."""
+    publish_source = inspect.getsource(coordination_lease.publish_claim_candidate)
+    probe_source = inspect.getsource(coordination_lease._probe_claim_lock)
+    release_source = inspect.getsource(coordination_lease._unlock_and_close)
+
+    assert publish_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < publish_source.index(
+        "_lock_functions(descriptor)[0]()"
+    )
+    assert probe_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < probe_source.index(
+        "acquire()"
+    )
+    assert probe_source.count("os.lseek(descriptor, 0, os.SEEK_SET)") >= 2
+    assert release_source.index("os.lseek(descriptor, 0, os.SEEK_SET)") < release_source.index(
+        "_lock_functions(descriptor)[1]()"
+    )
+
+
+def test_coordination_lock_serializes_two_real_processes(tmp_path: Path) -> None:
+    """The filesystem lock, rather than a mock, excludes another process."""
+    root = tmp_path.resolve()
+    coordination_lease.prepare_lease_directory(root)
+    ready = multiprocessing.Event()
+    queue: multiprocessing.Queue[float] = multiprocessing.Queue()
+    child = multiprocessing.Process(target=_lock_worker, args=(str(root / coordination_lease.LEASE_DIRECTORY), ready, queue))
+    child.start()
+    assert ready.wait(CHILD_START_BUDGET_SECONDS)
+    started = time.monotonic()
+    with coordination_lease.coordination_lock(root / coordination_lease.LEASE_DIRECTORY, "real-process.lock"):
+        waited = time.monotonic() - started
+    child.join(CHILD_START_BUDGET_SECONDS)
+
+    assert child.exitcode == 0
+    assert waited >= 0.15
+
+
+def test_racing_participants_are_never_both_admitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC6's central claim: read-other-role and publish-own are indivisible.
+
+    A slow read makes the window observable. Without the shared decision lock,
+    each participant reads before the other has published and BOTH are admitted
+    -- which is exactly the check-to-delete race the lease exists to close. With
+    it, one of them must lose.
+
+    Threads rather than processes, because the decision lock is `flock` on a
+    freshly opened descriptor per call, so two threads contend for it just as two
+    processes do -- and a thread can be given the patched slow read that widens
+    the window deterministically, instead of hoping a race reproduces.
+    """
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+
+    real_prune = coordination_lease._prune_not_live
+
+    def slow_prune(paths: tuple[Path, ...], role: object, wt: object) -> object:
+        result = real_prune(paths, role, wt)  # type: ignore[arg-type]
+        time.sleep(0.25)
+        return result
+
+    monkeypatch.setattr(coordination_lease, "_prune_not_live", slow_prune)
+
+    outcomes: dict[str, object] = {}
+
+    def attempt(name: str, action: object) -> None:
+        try:
+            outcomes[name] = action()  # type: ignore[operator]
+        except (
+            coordination_lease.ClaimContentionError,
+            coordination_lease.ClaimStoreUnavailable,
+        ):
+            outcomes[name] = None
+
+    threads = [
+        threading.Thread(
+            target=attempt,
+            args=(
+                "activity",
+                lambda: coordination_lease.acquire_activity(
+                    root, worktree, wait_seconds=0
+                ),
+            ),
+        ),
+        threading.Thread(
+            target=attempt,
+            args=("exclusive", lambda: coordination_lease.acquire_exclusive(root, worktree)),
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(15)
+        assert not thread.is_alive()
+
+    admitted = sorted(name for name, claim in outcomes.items() if claim is not None)
+    for claim in outcomes.values():
+        if claim is not None:
+            claim.release()  # type: ignore[union-attr]
+
+    assert len(admitted) <= 1, f"both roles admitted at once: {admitted}"
+
+
+def test_sequential_interlock_refuses_exclusive_while_activity_is_held(
+    tmp_path: Path,
+) -> None:
+    """The interlock in the sequential case. NOT an atomicity proof.
+
+    This was originally named for interleaving, but it interleaves nothing: it
+    acquires, then asserts the other role refuses. It passes with the decision
+    lock removed entirely, so it cannot testify about AC6's indivisibility
+    requirement. The real proof is the racing test below; this one is retained
+    because the sequential refusal is worth pinning on its own.
+    """
+    root = tmp_path.resolve()
+    worktree = (root / "worktree").resolve()
+    worktree.mkdir()
+    observed = coordination_lease.read_claims(root, worktree)
+    assert observed.exclusive is None
+
+    first = coordination_lease.acquire_activity(root, worktree, wait_seconds=0)
+    with pytest.raises(coordination_lease.ClaimContentionError):
+        coordination_lease.acquire_exclusive(root, worktree)
+    first.release()

--- a/tools/test_frontend_runtime.py
+++ b/tools/test_frontend_runtime.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from tools.repo import coordination_lease
 from tools.repo import frontend_runtime as runtime
 
 
@@ -538,3 +539,80 @@ def test_empty_explicit_browser_cache_is_rejected_without_mutation(
         runtime.resolve_browser_cache("", environ={}, repo_root=tmp_path)
 
     assert not list(tmp_path.iterdir())
+
+
+def _port_reporting_gate(output: Path) -> tuple[str, ...]:
+    """A gate that tolerates an absent port, so the unleased path is observable."""
+    code = (
+        "import os,sys;"
+        "from pathlib import Path;"
+        "Path(sys.argv[1]).write_text(os.environ.get('ARR_PREVIEW_PORT','unset'))"
+    )
+    return (sys.executable, "-c", code, str(output))
+
+
+def test_an_unresolvable_worktree_warns_and_still_runs_the_gate(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AC9 names an unresolvable worktree a warn-and-run case, not an exit 2.
+
+    Resolution ran above the fail-open handler, so a missing git or a failing
+    rev-parse raised FrontendRuntimeError straight past it and failed a job the lease
+    is forbidden to fail. A temporary directory is not a Git repository, so this is
+    the real `git rev-parse` refusing rather than a patched one.
+    """
+    output = tmp_path / "reported-port"
+    assert runtime.run_gate(
+        environ={},
+        repo_root=tmp_path,
+        gate_command=_port_reporting_gate(output),
+    ) == 0
+
+    assert output.read_text(encoding="utf-8") == "unset"
+    captured = capsys.readouterr()
+    assert "unleased" in captured.err
+
+
+def test_an_explicit_port_survives_an_unresolvable_worktree(tmp_path: Path) -> None:
+    """Degrading the lease must not also discard the caller's own choice."""
+    output = tmp_path / "reported-port"
+    assert runtime.run_gate(
+        port="4399",
+        environ={},
+        repo_root=tmp_path,
+        gate_command=_port_reporting_gate(output),
+    ) == 0
+
+    assert output.read_text(encoding="utf-8") == "4399"
+
+
+def test_the_browser_gate_holds_activity_and_takes_no_run_slot(tmp_path: Path) -> None:
+    """The participant matrix's disposition for this entry point, made falsifiable.
+
+    The matrix says the browser gate publishes an `activity` claim and takes no
+    admission slot, and that removing the claim must redden its own test. Nothing
+    asserted it, so the disposition was a description. Observed from inside the
+    running child, because a claim released on exit is invisible afterwards.
+    """
+    common_dir = tmp_path / "common"
+    common_dir.mkdir()
+    observed = tmp_path / "claims-during-the-run"
+    lease_dir = common_dir / coordination_lease.LEASE_DIRECTORY
+    reporter = (
+        "import sys;"
+        "from pathlib import Path;"
+        "d = Path(sys.argv[1]);"
+        "names = sorted(p.name for p in d.glob('*.lease')) if d.is_dir() else [];"
+        "Path(sys.argv[2]).write_text('\\n'.join(names))"
+    )
+
+    assert runtime.run_gate(
+        environ={},
+        repo_root=tmp_path,
+        common_dir=common_dir,
+        gate_command=(sys.executable, "-c", reporter, str(lease_dir), str(observed)),
+    ) == 0
+
+    names = [line for line in observed.read_text(encoding="utf-8").splitlines() if line]
+    assert any(name.startswith("activity-") for name in names), names
+    assert not any(name.startswith("run-slot-") for name in names), names

--- a/tools/test_run_slot.py
+++ b/tools/test_run_slot.py
@@ -1,0 +1,391 @@
+"""Construction tests for common-directory-wide heavy-run admission."""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tools.repo import coordination_lease
+
+THREAD_BUDGET_SECONDS = 30.0
+
+
+@pytest.fixture
+def lease_root(tmp_path: Path) -> Path:
+    """Provide one resolved common-directory fixture root per test case."""
+    return tmp_path.resolve()
+
+
+def _wait_for_ticket_count(root: Path, count: int) -> None:
+    """Wait until real contenders have published the requested ticket count."""
+    deadline = time.monotonic() + THREAD_BUDGET_SECONDS
+    lease_dir = coordination_lease.prepare_lease_directory(root)
+    while len(tuple(lease_dir.glob("run-ticket-*.lease"))) < count:
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+
+
+def test_real_concurrent_admission_never_exceeds_limit(lease_root: Path) -> None:
+    """A barrier makes five threads actually contend for two live slots."""
+    environ = {
+        coordination_lease.MAX_CONCURRENT_RUNS_ENV: "2",
+        coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+    }
+    active = 0
+    maximum = 0
+    guard = threading.Lock()
+    failures: list[BaseException] = []
+    start = threading.Barrier(5)
+
+    def contender() -> None:
+        nonlocal active, maximum
+        try:
+            start.wait(THREAD_BUDGET_SECONDS)
+            claim = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+            with guard:
+                active += 1
+                maximum = max(maximum, active)
+            time.sleep(0.1)
+            with guard:
+                active -= 1
+            claim.release()
+        except BaseException as error:
+            failures.append(error)
+
+    threads = [threading.Thread(target=contender) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(THREAD_BUDGET_SECONDS)
+        assert not thread.is_alive()
+
+    assert not failures
+    assert maximum == 2
+
+
+def test_ticket_removal_reregisters_without_losing_original_position(lease_root: Path) -> None:
+    """Removing the first ticket cannot send that waiter behind a later waiter."""
+    environ = {
+        coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+        coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+    }
+    holder = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+    admitted: list[str] = []
+    failures: list[BaseException] = []
+
+    def waiter(name: str) -> None:
+        try:
+            claim = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+            admitted.append(name)
+            claim.release()
+        except BaseException as error:
+            failures.append(error)
+
+    first = threading.Thread(target=waiter, args=("first",))
+    first.start()
+    _wait_for_ticket_count(lease_root, 1)
+    lease_dir = coordination_lease.prepare_lease_directory(lease_root)
+    first_ticket = next(iter(lease_dir.glob("run-ticket-*.lease")))
+
+    second = threading.Thread(target=waiter, args=("second",))
+    second.start()
+    _wait_for_ticket_count(lease_root, 2)
+    first_ticket.unlink()
+    deadline = time.monotonic() + THREAD_BUDGET_SECONDS
+    while not first_ticket.exists():
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+    holder.release()
+    for thread in (first, second):
+        thread.join(THREAD_BUDGET_SECONDS)
+        assert not thread.is_alive()
+
+    assert not failures
+    assert admitted == ["first", "second"]
+
+
+def test_backdated_ticket_cannot_overtake_a_real_waiter(lease_root: Path) -> None:
+    """A later ticket's forged payload time cannot put it at the queue front."""
+    environ = {
+        coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+        coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+    }
+    holder = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+    admitted: list[coordination_lease.RunSlotClaim] = []
+    failures: list[BaseException] = []
+
+    def waiter() -> None:
+        try:
+            admitted.append(coordination_lease.acquire_run_slot(lease_root, environ=environ))
+        except BaseException as error:
+            failures.append(error)
+
+    real_waiter = threading.Thread(target=waiter)
+    real_waiter.start()
+    _wait_for_ticket_count(lease_root, 1)
+    lease_dir = coordination_lease.prepare_lease_directory(lease_root)
+    forged_token = uuid.uuid4().hex
+    forged_path = coordination_lease._run_claim_path(
+        lease_dir, coordination_lease.ClaimRole.RUN_TICKET, forged_token
+    )
+    forged_payload = json.dumps(
+        {
+            "pid": os.getpid(),
+            "worktree": str(lease_root),
+            "created_at": 0,
+            "token": forged_token,
+        }
+    )
+    with coordination_lease.coordination_lock(lease_dir, "coordination.lock"):
+        forged_descriptor = coordination_lease.publish_claim_candidate(
+            lease_dir, forged_path, forged_payload
+        )
+    holder.release()
+    real_waiter.join(THREAD_BUDGET_SECONDS)
+    try:
+        assert not real_waiter.is_alive()
+        assert not failures
+        assert len(admitted) == 1
+    finally:
+        if admitted:
+            admitted[0].release()
+        with contextlib.suppress(FileNotFoundError):
+            forged_path.unlink()
+        coordination_lease._unlock_and_close(forged_descriptor)
+
+
+def test_admission_expiry_makes_limit_soft_but_worktree_claims_do_not_expire(
+    lease_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Aged slots are recoverable; safety interlocks retain their live holder."""
+    environ = {
+        coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+        coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+    }
+    first = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+    observed_now = time.time()
+    monkeypatch.setattr(
+        coordination_lease.time,
+        "time",
+        lambda: observed_now + 7 * 60 * 60,
+    )
+    second = coordination_lease.acquire_run_slot(lease_root, environ=environ)
+    activity = coordination_lease.acquire_activity(lease_root, lease_root, wait_seconds=1)
+    monkeypatch.setattr(
+        coordination_lease.time,
+        "time",
+        lambda: observed_now + 14 * 60 * 60,
+    )
+
+    try:
+        retained = coordination_lease._prune_not_live(
+            coordination_lease._claim_paths(
+                activity.lease_dir, lease_root, coordination_lease.ClaimRole.ACTIVITY
+            ),
+            coordination_lease.ClaimRole.ACTIVITY,
+            lease_root,
+        )
+        assert len(retained) == 1
+    finally:
+        second.release()
+        first.release()
+        activity.release()
+
+
+def test_old_undeterminable_admission_record_expires(
+    lease_root: Path,
+) -> None:
+    """A malformed admission record uses file age instead of resetting to now."""
+    lease_dir = coordination_lease.prepare_lease_directory(lease_root)
+    token = uuid.uuid4().hex
+    path = coordination_lease._run_claim_path(
+        lease_dir, coordination_lease.ClaimRole.RUN_SLOT, token
+    )
+    with coordination_lease.coordination_lock(lease_dir, "coordination.lock"):
+        descriptor = coordination_lease.publish_claim_candidate(
+            lease_dir,
+            path,
+            coordination_lease._run_claim_payload(token, lease_root),
+        )
+    os.ftruncate(descriptor, 0)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    os.write(descriptor, b"{")
+    old = time.time() - coordination_lease.RUN_CLAIM_MAX_AGE_SECONDS - 1
+    os.utime(path, (old, old))
+    try:
+        records = coordination_lease._live_run_claims(
+            lease_dir, coordination_lease.ClaimRole.RUN_SLOT, lease_root
+        )
+        assert records == ()
+        assert not path.exists()
+    finally:
+        coordination_lease._unlock_and_close(descriptor)
+
+
+def test_entrypoint_refuses_invalid_budget_before_store_access(
+    lease_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed operator configuration cannot become an unleased run."""
+    called = False
+
+    def unexpected_store_access(common_dir: Path) -> Path:
+        nonlocal called
+        called = True
+        return common_dir
+
+    monkeypatch.setattr(coordination_lease, "prepare_lease_directory", unexpected_store_access)
+    with pytest.raises(coordination_lease.RunSlotConfigurationError):
+        coordination_lease.acquire_run_slot(
+            lease_root,
+            environ={coordination_lease.MAX_CONCURRENT_RUNS_ENV: "not-a-number"},
+        )
+    assert called is False
+
+
+def test_entrypoint_preserves_store_unavailable_as_a_distinct_failure(
+    lease_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contention infrastructure failure is not mistaken for bad configuration."""
+    def unavailable(common_dir: Path) -> Path:
+        raise coordination_lease.ClaimStoreUnavailable("test store unavailable")
+
+    monkeypatch.setattr(coordination_lease, "prepare_lease_directory", unavailable)
+    with pytest.raises(coordination_lease.ClaimStoreUnavailable):
+        coordination_lease.acquire_run_slot(
+            lease_root,
+            environ={
+                coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+                coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+            },
+        )
+
+
+def test_budget_defaults_and_strict_parsing_are_literal_and_host_independent() -> None:
+    """Defaults are contracted literals; malformed values never fall back."""
+    source = inspect.getsource(coordination_lease)
+    assert source.count("DEFAULT_MAX_CONCURRENT_RUNS = 2") == 1
+    assert source.count("DEFAULT_RUN_SLOT_WAIT_SECONDS = 5400") == 1
+    assert coordination_lease.memory_clamped_run_limit(2, None) == 2
+    assert coordination_lease.run_slot_budgets({})[1] == 5400
+    for invalid in ("0", "-1", " 1", "1.0", "many"):
+        with pytest.raises(coordination_lease.RunSlotConfigurationError):
+            coordination_lease.run_slot_budgets(
+                {coordination_lease.MAX_CONCURRENT_RUNS_ENV: invalid}
+            )
+        with pytest.raises(coordination_lease.RunSlotConfigurationError):
+            coordination_lease.run_slot_budgets(
+                {coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: invalid}
+            )
+
+
+def test_memory_clamp_uses_twelve_gib_and_preserves_reference_headroom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default clamps down only, while explicit operator overrides remain."""
+    gibibyte = 1024**3
+    assert coordination_lease.memory_clamped_run_limit(2, 32 * gibibyte - 1) == 2
+    assert coordination_lease.memory_clamped_run_limit(2, 16 * gibibyte) == 1
+    assert coordination_lease.memory_clamped_run_limit(2, 128 * gibibyte) == 2
+    monkeypatch.setattr(coordination_lease, "_physical_memory_bytes", lambda: 32 * gibibyte - 1)
+    assert coordination_lease.run_slot_budgets({}) == (2, 5400)
+    assert coordination_lease.run_slot_budgets(
+        {coordination_lease.MAX_CONCURRENT_RUNS_ENV: "5"}
+    )[0] == 5
+
+
+def test_decision_lock_budget_scales_with_wait_budget_and_has_floor(
+    lease_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Admission passes a proportional, minimum-30-second decision budget."""
+    assert coordination_lease.run_slot_decision_lock_budget(1) == 30
+    assert coordination_lease.run_slot_decision_lock_budget(5400) == 270
+    observed: list[float | None] = []
+    real_lock = coordination_lease.coordination_lock
+
+    @contextlib.contextmanager
+    def recording_lock(lease_dir: Path, name: str, **kwargs: object):
+        observed.append(kwargs.get("acquisition_budget_seconds"))
+        with real_lock(lease_dir, name, **kwargs):
+            yield
+
+    monkeypatch.setattr(coordination_lease, "coordination_lock", recording_lock)
+    claim = coordination_lease.acquire_run_slot(
+        lease_root,
+        environ={
+            coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+            coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "1000",
+        },
+    )
+    try:
+        assert observed
+        assert all(budget == 50 for budget in observed)
+    finally:
+        monkeypatch.setattr(coordination_lease, "coordination_lock", real_lock)
+        claim.release()
+
+
+def test_scan_and_slot_publish_share_one_decision_lock_hold(
+    lease_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Observe the lock around scan and publish instead of inferring it from a race."""
+    events: list[str] = []
+    real_lock = coordination_lease.coordination_lock
+    real_claims = coordination_lease._live_run_claims
+    real_publish = coordination_lease.publish_claim_candidate
+
+    @contextlib.contextmanager
+    def recording_lock(lease_dir: Path, name: str, **kwargs: object):
+        events.append("enter")
+        with real_lock(lease_dir, name, **kwargs):
+            yield
+        events.append("exit")
+
+    def recording_claims(lease_dir: Path, role: coordination_lease.ClaimRole, common_dir: Path):
+        if role is coordination_lease.ClaimRole.RUN_SLOT:
+            events.append("scan")
+        return real_claims(lease_dir, role, common_dir)
+
+    def recording_publish(lease_dir: Path, path: Path, payload: str) -> int:
+        if path.name.startswith("run-slot-"):
+            events.append("publish")
+        return real_publish(lease_dir, path, payload)
+
+    monkeypatch.setattr(coordination_lease, "coordination_lock", recording_lock)
+    monkeypatch.setattr(coordination_lease, "_live_run_claims", recording_claims)
+    monkeypatch.setattr(coordination_lease, "publish_claim_candidate", recording_publish)
+    claim = coordination_lease.acquire_run_slot(
+        lease_root,
+        environ={
+            coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+            coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+        },
+    )
+    claim.release()
+
+    scan = events.index("scan")
+    publish = events.index("publish")
+    enter = max(index for index, event in enumerate(events[:scan]) if event == "enter")
+    exit_index = next(index for index, event in enumerate(events[scan:], scan) if event == "exit")
+    assert enter < scan < publish < exit_index
+
+
+def test_release_is_idempotent(lease_root: Path) -> None:
+    """A second release cannot close a file descriptor recycled by another caller."""
+    claim = coordination_lease.acquire_run_slot(
+        lease_root,
+        environ={
+            coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+            coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "30",
+        },
+    )
+    claim.release()
+    claim.release()
+    assert claim.descriptor is None

--- a/tools/test_windows_lock_semantics.py
+++ b/tools/test_windows_lock_semantics.py
@@ -178,3 +178,96 @@ def test_a_dead_holder_releases_the_lock(claim_file: Path) -> None:
         "the OS did not release a killed holder's lock; a crashed run would wedge "
         "the lease permanently"
     )
+
+
+# The offset the shipped lease actually uses, imported rather than copied: a fixture
+# measuring a duplicate of the constant would keep passing after the real one moved.
+from tools.repo.coordination_lease import CLAIM_LOCK_OFFSET  # noqa: E402
+
+
+def _hold_and_report(path: Path, offset: int) -> tuple[bool, bool]:
+    """Hold a lock at `offset`, then report (probe_blocked, payload_readable)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(PAYLOAD)
+    with path.open("r+b") as holder:
+        holder.seek(offset)
+        _lock_one_byte_here(holder)
+        try:
+            with path.open("r+b") as probe:
+                probe.seek(offset)
+                try:
+                    _lock_one_byte_here(probe)
+                    blocked = False
+                    if WINDOWS:
+                        import msvcrt
+
+                        msvcrt.locking(probe.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+
+                        fcntl.flock(probe.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    blocked = True
+            try:
+                readable = path.read_bytes() == PAYLOAD
+            except OSError:
+                readable = False
+            return blocked, readable
+        finally:
+            if WINDOWS:
+                import msvcrt
+
+                holder.seek(offset)
+                msvcrt.locking(holder.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def test_the_shipped_offset_is_both_observable_and_leaves_the_payload_readable(
+    claim_file: Path,
+) -> None:
+    """The lease's actual protocol, measured: both requirements at once.
+
+    A claim lock has to satisfy two things that pull against each other. It must be
+    observable to a prober, or every liveness probe reads not-live and cleanup deletes
+    under a live mutator. And the payload must stay readable while it is held, because
+    `_read_record` reads it to name a holder in a refusal. Byte zero satisfies the
+    first and breaks the second on Windows, where the lock is mandatory rather than
+    advisory -- measured as 9 `PermissionError` failures on windows-latest.
+    """
+    blocked, readable = _hold_and_report(claim_file, CLAIM_LOCK_OFFSET)
+    print(
+        f"MEASURED [{sys.platform} / os.name={os.name}] lock at CLAIM_LOCK_OFFSET"
+        f"={CLAIM_LOCK_OFFSET} -> probe blocked={blocked}, payload readable={readable}",
+        flush=True,
+    )
+
+    assert blocked, "a held claim lock must be observable to a prober"
+    assert readable, "a held claim lock must not make the claim payload unreadable"
+
+
+def test_locking_byte_zero_is_the_hazard_this_offset_exists_to_avoid(
+    claim_file: Path,
+) -> None:
+    """Byte zero is inside the payload, and on Windows that makes it unreadable.
+
+    Recorded as a measurement rather than a comment because it is the reason the
+    offset is not zero, and because on POSIX it is invisible: `flock` is advisory, so
+    the payload stays readable there and this case cannot fail on macOS. That is
+    precisely why the byte-zero protocol passed a full local suite, sixteen mutation
+    proofs and an adversarial review before a Windows runner rejected it.
+    """
+    blocked, readable = _hold_and_report(claim_file, 0)
+    print(
+        f"MEASURED [{sys.platform} / os.name={os.name}] lock at byte 0 -> "
+        f"probe blocked={blocked}, payload readable={readable}",
+        flush=True,
+    )
+
+    assert blocked, "byte zero is at least observable; that was never the problem"
+    if WINDOWS:
+        assert not readable, (
+            "expected the mandatory Windows lock to deny the payload read; if this "
+            "now passes, the platform behaviour changed and CLAIM_LOCK_OFFSET's "
+            "rationale needs re-measuring rather than trusting"
+        )
+    else:
+        assert readable, "POSIX flock is advisory, so the payload stays readable"

--- a/tools/test_with_lease_cli.py
+++ b/tools/test_with_lease_cli.py
@@ -1,0 +1,218 @@
+"""End-to-end command-line coverage for the cooperative worktree lease."""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.repo import coordination_lease, managed_child
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Path:
+    """Create one real Git worktree and its common directory for each case."""
+    root = (tmp_path / "repository").resolve()
+    root.mkdir()
+    subprocess.run(("git", "init", "-q", str(root)), check=True)
+    return root
+
+
+def test_main_strips_argparse_remainder_separator(repository: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The documented ``with-lease -- command`` form reaches the real child argv."""
+    monkeypatch.chdir(repository)
+    assert coordination_lease.main(
+        ["with-lease", "--", sys.executable, "-c", "raise SystemExit(19)"]
+    ) == 19
+
+
+def test_main_refuses_malformed_slot_configuration(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An operator budget error refuses at the shipped CLI boundary."""
+    monkeypatch.chdir(repository)
+    monkeypatch.setenv(coordination_lease.MAX_CONCURRENT_RUNS_ENV, "zero")
+    assert coordination_lease.main(["with-lease", "--", "git", "status"]) == 75
+    captured = capsys.readouterr()
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in captured.err
+    assert "did not run" in captured.err
+
+
+def test_main_refuses_a_missing_wrapped_command(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An empty ``--`` tail is a reserved wrapper refusal, not a spawn attempt."""
+    monkeypatch.chdir(repository)
+    assert coordination_lease.main(["with-lease", "--"]) == 75
+    captured = capsys.readouterr()
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in captured.err
+    assert "did not run" in captured.err
+
+
+def test_release_claim_releases_an_undeterminable_claim(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The explicit recovery path removes an uninspectable worktree claim."""
+    if os.name == "nt":
+        pytest.skip("Windows ACLs do not make chmod(0) a reliable unreadability probe")
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    lease_dir = coordination_lease.prepare_lease_directory(common)
+    identifier = "activity-undeterminable.lease"
+    path = lease_dir / identifier
+    path.write_text("not-json", encoding="utf-8")
+    path.chmod(0)
+    try:
+        assert coordination_lease.main(["release-claim", "--apply", "--claim", identifier]) == 0
+    finally:
+        if path.exists():
+            path.chmod(0o600)
+    assert not path.exists()
+    assert "override of a claim that may be live" in capsys.readouterr().out
+
+
+def test_release_claim_refuses_a_live_holder(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A recovery command never removes a claim whose ownership lock is observable."""
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    claim = coordination_lease.acquire_activity(common, repository, wait_seconds=1)
+    try:
+        assert coordination_lease.main(
+            ["release-claim", "--apply", "--claim", claim.path.name]
+        ) == 75
+    finally:
+        claim.release()
+    captured = capsys.readouterr()
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in captured.err
+    assert "did not run" in captured.err
+
+
+def test_queued_wrapper_reports_its_holders(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A saturated real slot emits a queue notice before its bounded refusal."""
+    monkeypatch.chdir(repository)
+    monkeypatch.setenv(coordination_lease.MAX_CONCURRENT_RUNS_ENV, "1")
+    monkeypatch.setenv(coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV, "1")
+    common = coordination_lease.git_common_dir(repository)
+    holder = coordination_lease.acquire_run_slot(
+        common,
+        environ={
+            coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+            coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "1",
+        },
+    )
+    try:
+        assert coordination_lease.main(["with-lease", "--", "git", "status"]) == 75
+    finally:
+        holder.release()
+    assert "with-lease queued behind process ids:" in capsys.readouterr().err
+
+
+def test_status_is_read_only_and_emits_recovery_identifier(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Status names claims safely and gives the exact recovery command input."""
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    claim = coordination_lease.acquire_activity(common, repository, wait_seconds=1)
+    try:
+        before = claim.path.read_bytes()
+        assert coordination_lease.main(["lease-status"]) == 0
+        assert claim.path.read_bytes() == before
+    finally:
+        claim.release()
+    output = capsys.readouterr().out
+    assert claim.path.name in output
+    assert f"release-claim --apply --claim {claim.path.name}" in output
+    assert str(repository) not in output
+
+
+def test_nested_recursive_make_completes(repository: Path) -> None:
+    """A real recursive make inherits the live slot rather than waiting for itself."""
+    makefile = repository / "Lease.mk"
+    makefile.write_text(
+        "outer:\n"
+        f"\t{sys.executable} tools/repo/coordination_lease.py with-lease -- $(MAKE) -f $(firstword $(MAKEFILE_LIST)) inner\n"
+        "inner:\n"
+        f"\t{sys.executable} tools/repo/coordination_lease.py with-lease -- {sys.executable} -c \"print('nested-complete')\"\n",
+        encoding="utf-8",
+    )
+    source = Path(coordination_lease.__file__).resolve()
+    tools_dir = source.parent.parent
+    link = repository / "tools"
+    link.symlink_to(tools_dir, target_is_directory=True)
+    result = subprocess.run(
+        ("make", "-f", str(makefile), "outer"),
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "nested-complete" in result.stdout
+
+
+def test_wrapper_has_exactly_one_reachable_child_runner() -> None:
+    """The wrapper delegates child lifecycle ownership to the shared runner.
+
+    Counted over the PARSED TREE, not the source text. A substring count also
+    matches the string inside a comment or docstring, and it did: an explanatory
+    comment naming `managed_child.run_child(...)` reddened this test while there was
+    exactly one real call. A structural check that prose can break is worse than no
+    check, because the next person deletes the prose rather than the duplication.
+    """
+    tree = ast.parse(Path(coordination_lease.__file__).read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "run_child"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "managed_child"
+    ]
+    assert len(calls) == 1, (
+        f"expected exactly one managed_child.run_child call, found {len(calls)} at "
+        f"lines {[c.lineno for c in calls]}"
+    )
+    # And it is the shared runner, not a local shadow.
+    assert managed_child.run_child.__module__.endswith("managed_child")
+
+
+def test_wrapper_only_adds_the_nesting_marker(repository: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The child sees the inherited environment plus only the slot identity marker."""
+    monkeypatch.chdir(repository)
+    # The invariant is a DELTA, not an absolute set. macOS injects LC_CTYPE and
+    # __CF_USER_TEXT_ENCODING into a spawned process even when a restricted env is
+    # passed, so asserting `set(os.environ) == {MARKER}` fails for a reason that has
+    # nothing to do with the wrapper. Name the platform's additions and assert what
+    # the WRAPPER added.
+    platform_injected = {"LC_CTYPE", "__CF_USER_TEXT_ENCODING"}
+    script = (
+        "import os; "
+        "added = set(os.environ) - " + repr(platform_injected) + "; "
+        "raise SystemExit(0 if added == {"
+        + repr(coordination_lease.RUN_SLOT_NESTING_MARKER_ENV)
+        + "} else 1)"
+    )
+    assert coordination_lease.with_lease(
+        (sys.executable, "-c", script), repository=repository, environ={}
+    ) == 0
+
+    # And the delta really is a delta: a pre-existing key survives untouched.
+    inherited = (
+        "import os; "
+        "raise SystemExit(0 if os.environ.get('CARRIED') == 'yes' else 1)"
+    )
+    assert coordination_lease.with_lease(
+        (sys.executable, "-c", inherited), repository=repository,
+        environ={"CARRIED": "yes"},
+    ) == 0

--- a/tools/test_with_lease_cli.py
+++ b/tools/test_with_lease_cli.py
@@ -216,3 +216,254 @@ def test_wrapper_only_adds_the_nesting_marker(repository: Path, monkeypatch: pyt
         (sys.executable, "-c", inherited), repository=repository,
         environ={"CARRIED": "yes"},
     ) == 0
+
+
+def test_admission_precedes_activity_so_a_queued_run_never_blocks_cleanup(
+    repository: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing may hold the cleanup-blocking role while still waiting for a slot.
+
+    AC7 scopes the activity claim to "exactly one child's lifetime". Acquiring it
+    before the admission wait meant a merely queued run refused cleanup for the whole
+    wait budget with no child in existence. Observed at the moment the slot
+    acquisition is entered, because a claim released by the wrapper's own unwind is
+    invisible to any check made after the call returns -- which is why the ordering
+    survived a suite that only inspected the aftermath.
+    """
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    lease_dir = common / coordination_lease.LEASE_DIRECTORY
+    claims_when_admission_began: list[list[str]] = []
+    real_acquire = coordination_lease.acquire_run_slot
+
+    def watching(*args: object, **kwargs: object) -> object:
+        existing = sorted(p.name for p in lease_dir.glob("*.lease")) if lease_dir.is_dir() else []
+        claims_when_admission_began.append(existing)
+        return real_acquire(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(coordination_lease, "acquire_run_slot", watching)
+    assert coordination_lease.main(
+        ["with-lease", "--", sys.executable, "-c", "raise SystemExit(0)"]
+    ) == 0
+    assert claims_when_admission_began == [[]], (
+        "a claim existed before admission was even attempted: "
+        f"{claims_when_admission_began}"
+    )
+
+
+def test_nested_receipt_names_the_holder_and_never_the_marker(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AC8's receipt makes an inert limiter visible without publishing a bypass."""
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    holder = coordination_lease.acquire_run_slot(common, environ={})
+    try:
+        monkeypatch.setenv(
+            coordination_lease.RUN_SLOT_NESTING_MARKER_ENV, holder.nesting_marker
+        )
+        assert coordination_lease.main(
+            ["with-lease", "--", sys.executable, "-c", "raise SystemExit(0)"]
+        ) == 0
+    finally:
+        holder.release()
+    captured = capsys.readouterr().err
+    assert "nested" in captured
+    assert "limiter is inert" in captured
+    assert f"pid {holder.pid}" in captured
+    # The marker is the bypass; naming the holder is the point, echoing the token is not.
+    assert holder.nesting_marker not in captured
+
+
+def test_a_held_coordination_lock_refuses_rather_than_running_unleased(
+    repository: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Decision-lock exhaustion is contention, so the limiter may not switch off.
+
+    A lock still held by a live peer when the budget runs out was reported as an
+    unusable store, and the wrapper's fail-open branch then ran the child with no
+    slot at all -- the limiter disabling itself under exactly the load it exists for.
+    The child must not run.
+    """
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    lease_dir = common / coordination_lease.LEASE_DIRECTORY
+    lease_dir.mkdir(mode=coordination_lease.LEASE_DIRECTORY_MODE, parents=True, exist_ok=True)
+    sentinel = tmp_path / "the-child-ran"
+    # The admission path passes a budget scaled from the wait budget with a 30s floor,
+    # so both must shrink for the exhaustion to be reachable inside a test.
+    monkeypatch.setenv(coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV, "1")
+    monkeypatch.setattr(
+        coordination_lease, "MINIMUM_RUN_SLOT_DECISION_LOCK_SECONDS", 0.2
+    )
+
+    # A second open file description contends with this one even in-process, so the
+    # wrapper meets a genuinely held lock rather than a mocked failure.
+    with coordination_lease.coordination_lock(lease_dir, "coordination.lock"):
+        code = coordination_lease.main(
+            [
+                "with-lease",
+                "--",
+                sys.executable,
+                "-c",
+                f"open({str(sentinel)!r}, 'w').close()",
+            ]
+        )
+
+    assert code == 75
+    captured = capsys.readouterr().err
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in captured
+    assert "did not run" in captured
+    assert not sentinel.exists(), "the child ran despite an unavailable slot decision"
+
+
+def test_bootstrap_participates_in_no_lease() -> None:
+    """The matrix's one non-participant, asserted so a future claim is deliberate.
+
+    The previous plan claimed `bootstrap.py` published a claim when it never did, and
+    froze at Done with that statement in it. The disposition is now falsifiable:
+    bootstrap runs `npm ci --prefix`, which is per-worktree and concurrently safe, so
+    it takes no claim. Adding one here should redden this test and force the matrix to
+    be updated with it.
+    """
+    source = Path(coordination_lease.__file__).resolve().parent / "bootstrap.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module or "")
+            imported.update(f"{node.module or ''}.{alias.name}" for alias in node.names)
+
+    leasing = {name for name in imported if "coordination_lease" in name}
+    assert not leasing, f"bootstrap.py now imports a lease module: {sorted(leasing)}"
+    assert "coordination_lease" not in source.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("child_code", [0, 23])
+def test_a_failing_release_cannot_change_the_childs_exit_code(
+    repository: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    child_code: int,
+) -> None:
+    """AC7's exit-code integrity, in both directions.
+
+    Teardown may not rewrite a real child outcome: a failing release must not redden a
+    passing child, and it must not mask a failing one either. Both directions are
+    parameterised because a wrapper that swallowed every failure would satisfy the
+    first on its own.
+    """
+    monkeypatch.chdir(repository)
+
+    def exploding_release(self: object) -> None:
+        raise coordination_lease.ClaimStoreUnavailable("release refused")
+
+    monkeypatch.setattr(coordination_lease.RunSlotClaim, "release", exploding_release)
+    monkeypatch.setattr(coordination_lease.WorktreeClaim, "release", exploding_release)
+
+    assert coordination_lease.main(
+        ["with-lease", "--", sys.executable, "-c", f"raise SystemExit({child_code})"]
+    ) == child_code
+    assert "release failed" in capsys.readouterr().err
+
+
+def test_a_marker_naming_no_live_claim_cannot_disable_the_limiter(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AC8: a stale export or a crashed run's leftover is not a free pass.
+
+    Nesting is recognised only when the inherited marker names a claim still live in
+    the same scope. The marker here names a claim file that really exists and whose
+    lock is free -- a crashed run's leftover, which is the case that matters: a marker
+    naming nothing at all is caught by the existence check alone, so a test using one
+    cannot tell whether the liveness half of this clause is implemented.
+    """
+    monkeypatch.chdir(repository)
+    budgets = {
+        coordination_lease.MAX_CONCURRENT_RUNS_ENV: "1",
+        coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV: "1",
+    }
+    for name, value in budgets.items():
+        monkeypatch.setenv(name, value)
+    common = coordination_lease.git_common_dir(repository)
+    holder = coordination_lease.acquire_run_slot(common, environ=budgets)
+    lease_dir = coordination_lease.read_lease_directory(common)
+    assert lease_dir is not None
+    leftover_token = "f" * 32
+    leftover = coordination_lease._run_claim_path(
+        lease_dir, coordination_lease.ClaimRole.RUN_SLOT, leftover_token
+    )
+    coordination_lease._unlock_and_close(
+        coordination_lease.publish_claim_candidate(
+            lease_dir,
+            leftover,
+            coordination_lease._run_claim_payload(leftover_token, common),
+        )
+    )
+    assert leftover.exists()
+    try:
+        monkeypatch.setenv(
+            coordination_lease.RUN_SLOT_NESTING_MARKER_ENV, leftover_token
+        )
+        assert coordination_lease.main(
+            ["with-lease", "--", sys.executable, "-c", "raise SystemExit(0)"]
+        ) == 75
+    finally:
+        holder.release()
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in capsys.readouterr().err
+
+
+def test_an_unusable_store_warns_and_still_runs_the_wrapped_child(
+    repository: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """AC9: the lease may degrade, but it may not fail the job."""
+    monkeypatch.chdir(repository)
+    common = coordination_lease.git_common_dir(repository)
+    # A regular file where the lease directory belongs: unusable, not contended.
+    (common / coordination_lease.LEASE_DIRECTORY).write_text("not a directory", encoding="utf-8")
+    sentinel = tmp_path / "the-child-ran"
+
+    assert coordination_lease.main(
+        [
+            "with-lease",
+            "--",
+            sys.executable,
+            "-c",
+            f"open({str(sentinel)!r}, 'w').close()",
+        ]
+    ) == 0
+
+    assert sentinel.exists()
+    assert "running child unleased" in capsys.readouterr().err
+
+
+def test_a_live_exclusive_claim_refuses_the_wrapper_with_the_reserved_code(
+    repository: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A mutator may not run while cleanup holds the worktree.
+
+    The wait budget must reach this wait too: it was hardcoded to the default, so a
+    configured budget shortened only the admission wait and this case blocked for
+    ninety minutes instead of refusing. A one-second budget proves the plumbing.
+    """
+    monkeypatch.chdir(repository)
+    monkeypatch.setenv(coordination_lease.RUN_SLOT_WAIT_SECONDS_ENV, "1")
+    common = coordination_lease.git_common_dir(repository)
+    holder = coordination_lease.acquire_exclusive(common, repository)
+    try:
+        assert coordination_lease.main(
+            ["with-lease", "--", sys.executable, "-c", "raise SystemExit(0)"]
+        ) == 75
+    finally:
+        holder.release()
+    captured = capsys.readouterr().err
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in captured
+    assert "did not run" in captured

--- a/tools/test_worktree_lease_interlock.py
+++ b/tools/test_worktree_lease_interlock.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import multiprocessing
 import os
 import signal
@@ -173,48 +174,47 @@ def test_clean_dry_run_never_creates_a_claim_store(worktree: Path) -> None:
     assert not any(line.startswith("lease:") for line in lines)
 
 
-def test_clean_help_documents_the_store_failure_override(
+def test_clean_offers_no_way_to_delete_without_a_lease(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """The only fail-closed-store override is discoverable before use."""
+    """No bypass may be reintroduced: deleting on absent evidence is a Never.
+
+    Asserted on both surfaces, because removing only the flag would leave a
+    parameter any in-repo caller could still pass.
+    """
     with pytest.raises(SystemExit) as exit_result:
         hygiene.main(["clean", "--help"])
 
     assert exit_result.value.code == 0
-    assert "--force-without-lease" in capsys.readouterr().out
+    help_text = capsys.readouterr().out
+    assert "--force-without-lease" not in help_text
+    assert "without-lease" not in help_text
+    assert "force_without_lease" not in inspect.signature(hygiene.clean).parameters
 
 
-def test_clean_apply_refuses_an_unusable_store_unless_explicitly_overridden(
+def test_clean_apply_refuses_an_unusable_store_with_no_override(
     worktree: Path,
 ) -> None:
-    """A cleaner fails closed when it cannot publish, with a deliberate escape hatch."""
+    """A cleaner that cannot publish fails closed, and nothing reopens it."""
     target = _candidate(worktree)
     unusable_common = worktree / "not-a-directory"
     unusable_common.write_text("not a claim store", encoding="utf-8")
 
-    def run(*, force_without_lease: bool) -> tuple[int, list[str]]:
-        return hygiene.clean(
-            worktree,
-            {"generated"},
-            apply=True,
-            include_dependencies=False,
-            protected=set(),
-            force_without_lease=force_without_lease,
-            runner=_Git(worktree, unusable_common),
-        )
-
-    code, lines = run(force_without_lease=False)
+    code, lines = hygiene.clean(
+        worktree,
+        {"generated"},
+        apply=True,
+        include_dependencies=False,
+        protected=set(),
+        runner=_Git(worktree, unusable_common),
+    )
 
     assert code == 75
     assert "WORKTREE_LEASE_DID_NOT_RUN" in lines
     assert "clean did not run" in "\n".join(lines)
     assert target.exists()
-
-    override_code, override_lines = run(force_without_lease=True)
-
-    assert override_code == 0
-    assert not target.exists()
-    assert "--force-without-lease" in "\n".join(override_lines)
+    # The refusal points at the recovery that does exist, rather than at a bypass.
+    assert "release-claim" in "\n".join(lines)
 
 
 def test_contended_roles_admit_exactly_one_participant(

--- a/tools/test_worktree_lease_interlock.py
+++ b/tools/test_worktree_lease_interlock.py
@@ -1,0 +1,344 @@
+"""Falsification tests for cleanup's cooperative exclusive lease."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.repo import coordination_lease
+from tools.repo import worktree_hygiene as hygiene
+
+PROCESS_START_BUDGET_SECONDS = 30
+CLAIM_OBSERVATION_BUDGET_SECONDS = 30
+
+
+class _Git:
+    """Answer the narrowly scoped Git protocol the hygiene scanner uses."""
+
+    def __init__(self, root: Path, common: Path) -> None:
+        self.root = root
+        self.common = common
+
+    def __call__(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        del env
+        if "worktree" in argv:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                f"worktree {self.root}\0HEAD abc\0branch refs/heads/test\0\0",
+                "",
+            )
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(argv, 0, f"{self.common}\n", "")
+        if "check-ignore" in argv:
+            return subprocess.CompletedProcess(argv, 0, input or "", "")
+        if "ls-files" in argv:
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    """Create one resolved worktree root and its Git common directory."""
+    root = tmp_path.resolve()
+    (root / ".git").mkdir()
+    return root
+
+
+def _candidate(root: Path, *, files: int = 1) -> Path:
+    """Create a real ignored generated candidate with a controllable deletion cost."""
+    build = root / "build"
+    for index in range(files):
+        leaf = build / f"part-{index // 50}" / f"artifact-{index}"
+        leaf.parent.mkdir(parents=True, exist_ok=True)
+        leaf.write_text("x", encoding="utf-8")
+    return build
+
+
+def _clean(root: Path, *, apply: bool, **kwargs: Any) -> tuple[int, list[str]]:
+    """Invoke the real scanner and cleaner through its ordinary Git boundary."""
+    return hygiene.clean(
+        root,
+        {"generated"},
+        apply=apply,
+        include_dependencies=False,
+        protected=set(),
+        runner=_Git(root, root / ".git"),
+        **kwargs,
+    )
+
+
+def _delete_in_child(root_text: str, output: multiprocessing.Queue[Any]) -> None:
+    """Run a real clean in a separate process so its held lock is observable."""
+    root = Path(root_text)
+    try:
+        output.put(("result", _clean(root, apply=True)))
+    except BaseException as error:
+        output.put(("error", type(error).__name__, str(error)))
+
+
+def test_clean_apply_refuses_a_live_activity_claim(worktree: Path) -> None:
+    """A cleaner names the live holder and leaves its candidate untouched."""
+    target = _candidate(worktree)
+    claim = coordination_lease.acquire_activity(
+        worktree / ".git", worktree, wait_seconds=0
+    )
+    try:
+        code, lines = _clean(worktree, apply=True)
+    finally:
+        claim.release()
+
+    receipt = "\n".join(lines)
+    assert code == 75
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in lines
+    assert f"pid {os.getpid()} in {worktree.name}" in receipt
+    assert "clean did not run" in receipt
+    assert target.exists()
+
+
+def test_clean_apply_claim_spans_a_real_multi_file_deletion(worktree: Path) -> None:
+    """The exclusive claim remains live while an actual candidate still exists."""
+    target = _candidate(worktree, files=10_000)
+    output: multiprocessing.Queue[Any] = multiprocessing.Queue()
+    child = multiprocessing.Process(
+        target=_delete_in_child,
+        args=(str(worktree), output),
+        daemon=True,
+    )
+    child.start()
+    observed_claim = None
+    observed_candidate = False
+    deadline = time.monotonic() + CLAIM_OBSERVATION_BUDGET_SECONDS
+    try:
+        while time.monotonic() < deadline:
+            claims = coordination_lease.read_claims(
+                worktree / ".git", worktree, create=False
+            )
+            observed_claim = claims.exclusive
+            observed_candidate = target.exists()
+            if observed_claim is not None and observed_candidate:
+                break
+            if not child.is_alive():
+                break
+            time.sleep(0.01)
+        child.join(PROCESS_START_BUDGET_SECONDS)
+        assert observed_claim is not None and observed_candidate, (
+            "expected an exclusive claim while the candidate existed; "
+            f"observed_claim={observed_claim!r}, candidate_exists={observed_candidate}, "
+            f"child_exitcode={child.exitcode}"
+        )
+        assert not target.exists()
+        result = output.get(timeout=PROCESS_START_BUDGET_SECONDS)
+        assert result[0] == "result", f"clean worker failed: {result!r}"
+        code, lines = result[1]
+        assert code == 0
+        assert "lease: acquired exclusive claim" in lines
+        assert "lease: released exclusive claim" in lines
+        assert (
+            coordination_lease.read_claims(
+                worktree / ".git", worktree, create=False
+            ).exclusive
+            is None
+        )
+    finally:
+        if child.is_alive():
+            child.terminate()
+        child.join(PROCESS_START_BUDGET_SECONDS)
+
+
+def test_clean_dry_run_never_creates_a_claim_store(worktree: Path) -> None:
+    """Preview remains lock-free and leaves no store behind."""
+    target = _candidate(worktree)
+
+    code, lines = _clean(worktree, apply=False)
+
+    assert code == 0
+    assert target.exists()
+    assert not (worktree / ".git" / coordination_lease.LEASE_DIRECTORY).exists()
+    assert not any(line.startswith("lease:") for line in lines)
+
+
+def test_clean_help_documents_the_store_failure_override(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The only fail-closed-store override is discoverable before use."""
+    with pytest.raises(SystemExit) as exit_result:
+        hygiene.main(["clean", "--help"])
+
+    assert exit_result.value.code == 0
+    assert "--force-without-lease" in capsys.readouterr().out
+
+
+def test_clean_apply_refuses_an_unusable_store_unless_explicitly_overridden(
+    worktree: Path,
+) -> None:
+    """A cleaner fails closed when it cannot publish, with a deliberate escape hatch."""
+    target = _candidate(worktree)
+    unusable_common = worktree / "not-a-directory"
+    unusable_common.write_text("not a claim store", encoding="utf-8")
+
+    def run(*, force_without_lease: bool) -> tuple[int, list[str]]:
+        return hygiene.clean(
+            worktree,
+            {"generated"},
+            apply=True,
+            include_dependencies=False,
+            protected=set(),
+            force_without_lease=force_without_lease,
+            runner=_Git(worktree, unusable_common),
+        )
+
+    code, lines = run(force_without_lease=False)
+
+    assert code == 75
+    assert "WORKTREE_LEASE_DID_NOT_RUN" in lines
+    assert "clean did not run" in "\n".join(lines)
+    assert target.exists()
+
+    override_code, override_lines = run(force_without_lease=True)
+
+    assert override_code == 0
+    assert not target.exists()
+    assert "--force-without-lease" in "\n".join(override_lines)
+
+
+def test_contended_roles_admit_exactly_one_participant(
+    worktree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The decision lock prevents both roles from proceeding or both refusing."""
+    common = worktree / ".git"
+    real_prune = coordination_lease._prune_not_live
+
+    def slow_prune(paths: tuple[Path, ...], role: object, root: object) -> object:
+        result = real_prune(paths, role, root)  # type: ignore[arg-type]
+        time.sleep(0.25)
+        return result
+
+    monkeypatch.setattr(coordination_lease, "_prune_not_live", slow_prune)
+    outcomes: dict[str, object] = {}
+    start = threading.Barrier(2)
+
+    def attempt(name: str, action: object) -> None:
+        start.wait()
+        try:
+            outcomes[name] = action()  # type: ignore[operator]
+        except coordination_lease.ClaimContentionError:
+            outcomes[name] = None
+
+    threads = [
+        threading.Thread(
+            target=attempt,
+            args=(
+                "activity",
+                lambda: coordination_lease.acquire_activity(
+                    common, worktree, wait_seconds=0
+                ),
+            ),
+        ),
+        threading.Thread(
+            target=attempt,
+            args=("exclusive", lambda: coordination_lease.acquire_exclusive(common, worktree)),
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(PROCESS_START_BUDGET_SECONDS)
+    for claim in outcomes.values():
+        if claim is not None:
+            claim.release()  # type: ignore[union-attr]
+
+    admitted = [name for name, claim in outcomes.items() if claim is not None]
+    assert len(admitted) == 1, f"expected exactly one admitted role, observed {admitted}"
+
+
+def test_activity_waits_for_an_exclusive_claim_to_clear(worktree: Path) -> None:
+    """A build can wait out a deferrable cleanup instead of losing permanently."""
+    common = worktree / ".git"
+    exclusive = coordination_lease.acquire_exclusive(common, worktree)
+    outcome: dict[str, object] = {}
+
+    def acquire_activity() -> None:
+        try:
+            outcome["claim"] = coordination_lease.acquire_activity(
+                common, worktree, wait_seconds=5
+            )
+        except BaseException as error:
+            outcome["error"] = error
+
+    waiter = threading.Thread(target=acquire_activity, daemon=True)
+    released = False
+    try:
+        waiter.start()
+        time.sleep(0.1)
+        exclusive.release()
+        released = True
+        waiter.join(PROCESS_START_BUDGET_SECONDS)
+        assert not waiter.is_alive(), "activity acquisition did not finish after release"
+        assert "error" not in outcome, f"activity acquisition failed: {outcome!r}"
+        claim = outcome.get("claim")
+        assert claim is not None, f"activity acquisition produced no claim: {outcome!r}"
+    finally:
+        if not released:
+            exclusive.release()
+        claim = outcome.get("claim")
+        if claim is not None:
+            claim.release()  # type: ignore[union-attr]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX signals")
+def test_clean_releases_the_claim_when_deletion_is_interrupted(worktree: Path) -> None:
+    """An interrupt during real recursive deletion cannot strand an exclusive claim."""
+    target = _candidate(worktree, files=10_000)
+    first_leaf = target / "part-0" / "artifact-0"
+    observed: dict[str, bool] = {"claim": False, "deletion": False}
+    stop = threading.Event()
+
+    def interrupt(_signum: int, _frame: object) -> None:
+        raise KeyboardInterrupt
+
+    def interrupt_after_deletion_starts() -> None:
+        deadline = time.monotonic() + CLAIM_OBSERVATION_BUDGET_SECONDS
+        while not stop.is_set() and time.monotonic() < deadline:
+            claims = coordination_lease.read_claims(
+                worktree / ".git", worktree, create=False
+            )
+            observed["claim"] = observed["claim"] or claims.exclusive is not None
+            observed["deletion"] = observed["deletion"] or (
+                observed["claim"] and not first_leaf.exists() and target.exists()
+            )
+            if observed["deletion"]:
+                os.kill(os.getpid(), signal.SIGINT)
+                return
+            time.sleep(0.001)
+
+    watcher = threading.Thread(target=interrupt_after_deletion_starts, daemon=True)
+    previous_handler = signal.signal(signal.SIGINT, interrupt)
+    try:
+        watcher.start()
+        with pytest.raises(KeyboardInterrupt):
+            _clean(worktree, apply=True)
+    finally:
+        stop.set()
+        watcher.join(PROCESS_START_BUDGET_SECONDS)
+        signal.signal(signal.SIGINT, previous_handler)
+
+    claims = coordination_lease.read_claims(worktree / ".git", worktree, create=False)
+    assert observed["deletion"], f"interrupt never observed deletion: {observed}"
+    assert claims.exclusive is None

--- a/workspace.toml
+++ b/workspace.toml
@@ -513,47 +513,6 @@ open = [
   {path = "docs/product/intents/codex-plugin-route.md", kind = "intent", source = {mode = "repo-origin", ref = "docs/product/briefs/distribution-routes-programme.md", revision = "sha256-bytes-v1:329d3aec010ffd0f0b090022bac7faf35b85f337d9b3c719ab8063b7c74dbc45"}, summary = "Emit native Codex plugin packages and marketplace with user-scope publication parity", needs = [{type = "local", kind = "intent", path = "docs/product/intents/distribution-route-registry.md"}]},
   {path = "docs/product/intents/kiro-power-route-profile.md", kind = "intent", source = {mode = "repo-origin", ref = "docs/product/briefs/distribution-routes-programme.md", revision = "sha256-bytes-v1:329d3aec010ffd0f0b090022bac7faf35b85f337d9b3c719ab8063b7c74dbc45"}, summary = "Add the Kiro Power route profile over portable package bytes", needs = [{type = "local", kind = "intent", path = "docs/product/intents/codex-plugin-route.md"}]},
   {path = "docs/product/intents/claude-manifest-migration-support-claims.md", kind = "intent", source = {mode = "repo-origin", ref = "docs/product/briefs/distribution-routes-programme.md", revision = "sha256-bytes-v1:329d3aec010ffd0f0b090022bac7faf35b85f337d9b3c719ab8063b7c74dbc45"}, summary = "Migrate Claude manifest residue and publish machine-readable support claims", needs = [{type = "local", kind = "intent", path = "docs/product/intents/kiro-power-route-profile.md"}]},
-  # The cooperative worktree lease from spec/worktree-runtime-hygiene AC6. It was built
-  # to completion across five layers and then SPLIT OUT under review rather than landed:
-  # three independent reviewers found failure modes AC6 does not enumerate. The two that
-  # decide it needs its own spec rather than a patch:
-  #   - Windows `msvcrt.locking` locks one byte at the CURRENT FILE POSITION. The publish
-  #     path writes the payload then locks (position = payload length) while the probe
-  #     opens at 0 and locks byte 0, so the ranges never overlap, every probe reads
-  #     NOT_LIVE, and `clean --apply` can delete under a live mutator -- the exact failure
-  #     the lease exists to prevent. The `_port_coordination_lock` it replaced handled
-  #     this deliberately (wrote a NUL, seeked to 0); the refactor dropped that.
-  #   - The remedies applied under review each introduced a further defect: an age
-  #     backstop for the admission roles contradicts AC6's "undeterminable counts as
-  #     live", and widening `release-claim` to run-tickets created a path where a removed
-  #     ticket is never re-published, turning a queued run into a 90-minute wait ending in
-  #     a refusal.
-  # Also open: the memory clamp's divisor sits exactly on its calibration point and
-  # SC_PHYS_PAGES reports USABLE pages, so a nominal-32GiB Linux host clamps to 1; the
-  # decision lock's ~1s retry budget is the first thing to exhaust under the contention it
-  # exists to bound, and exhausting it degrades the limiter to a no-op; and the recursive
-  # $(MAKE) through a Python wrapper loses the jobserver, so `make -j` warns and drops to
-  # -j1. RESOLVED, with the operator: the jobserver is NOT forwarded. Measured on
-  # macOS/Make 3.81 -- a direct $(MAKE) reports --jobserver-fds=3,4 with those
-  # descriptors open, the same call through the wrapper reports an empty MAKEFLAGS
-  # and none, and make's own suggested `+` prefix does not restore them. Forwarding
-  # would mean version-sniffing three mechanisms (descriptors on 3.81-4.3, a fifo on
-  # 4.4+, a named semaphore on Windows where pass_fds is unsupported), its failure
-  # mode is a build that HANGS rather than warns, and this wrapper holds descriptors
-  # open for claim locks so it is the process most likely to hand a sub-make a lock
-  # instead of a token. No workflow passes -j. Recorded as a stated limitation.
-  # The work is preserved on branch eugenelim/worktree-hygience-c-lease-wip.
-  # De-risked before the re-spec: tools/test_windows_lock_semantics.py runs on a
-  # windows-latest job (build-check-windows.yml, lock-semantics-windows) that
-  # REPORTS rather than gates, because nothing depends on it yet. It measures
-  # whether a claim lock held after writing a payload is observable by a prober,
-  # and whether seeking both sides to byte zero makes it observable. Read that job's
-  # log before designing the Windows branch: if the seek-to-zero invariant fails
-  # there, byte-range locking cannot carry liveness on Windows and the lease must
-  # report UNDETERMINABLE on that platform -- failing safe toward refusing, never
-  # toward deleting. Wire the job into build-check-windows's `needs` in the same
-  # change that lands the lease, so the invariant is enforced once relied upon.
-  {slug = "worktree-cooperative-lease", source = "spec/worktree-runtime-hygiene AC6", summary = "Re-spec and land the cooperative worktree lease, admission queue and with-lease wrapper: fix the Windows byte-range claim lock, reconcile the admission-role reclaim policy with AC6, re-publish a lost waiter ticket, recalibrate the memory clamp against usable-page reporting, scale the decision-lock budget with the wait budget, and forward the makefile currently in use to the recursive sub-make (the jobserver is deliberately NOT forwarded: see docs/specs/worktree-cooperative-lease/spec.md Limitations for the measurement and the three reasons, decided with the operator)"},
   # RFC-0095 D3. 59 versioned entries sit nested under a `## [Unreleased]` heading and
   # are permanently invisible to the `/now/` projection (it applies no date window; a
   # nested entry simply never publishes). Not a mechanical level-shift: 48 genuinely

--- a/workspace.toml
+++ b/workspace.toml
@@ -533,7 +533,16 @@ open = [
   # decision lock's ~1s retry budget is the first thing to exhaust under the contention it
   # exists to bound, and exhausting it degrades the limiter to a no-op; and the recursive
   # $(MAKE) through a Python wrapper loses the jobserver, so `make -j` warns and drops to
-  # -j1. The work is preserved on branch eugenelim/worktree-hygience-c-lease-wip.
+  # -j1. RESOLVED, with the operator: the jobserver is NOT forwarded. Measured on
+  # macOS/Make 3.81 -- a direct $(MAKE) reports --jobserver-fds=3,4 with those
+  # descriptors open, the same call through the wrapper reports an empty MAKEFLAGS
+  # and none, and make's own suggested `+` prefix does not restore them. Forwarding
+  # would mean version-sniffing three mechanisms (descriptors on 3.81-4.3, a fifo on
+  # 4.4+, a named semaphore on Windows where pass_fds is unsupported), its failure
+  # mode is a build that HANGS rather than warns, and this wrapper holds descriptors
+  # open for claim locks so it is the process most likely to hand a sub-make a lock
+  # instead of a token. No workflow passes -j. Recorded as a stated limitation.
+  # The work is preserved on branch eugenelim/worktree-hygience-c-lease-wip.
   # De-risked before the re-spec: tools/test_windows_lock_semantics.py runs on a
   # windows-latest job (build-check-windows.yml, lock-semantics-windows) that
   # REPORTS rather than gates, because nothing depends on it yet. It measures
@@ -544,7 +553,7 @@ open = [
   # report UNDETERMINABLE on that platform -- failing safe toward refusing, never
   # toward deleting. Wire the job into build-check-windows's `needs` in the same
   # change that lands the lease, so the invariant is enforced once relied upon.
-  {slug = "worktree-cooperative-lease", source = "spec/worktree-runtime-hygiene AC6", summary = "Re-spec and land the cooperative worktree lease, admission queue and with-lease wrapper: fix the Windows byte-range claim lock, reconcile the admission-role reclaim policy with AC6, re-publish a lost waiter ticket, recalibrate the memory clamp against usable-page reporting, scale the decision-lock budget with the wait budget, and forward the make jobserver"},
+  {slug = "worktree-cooperative-lease", source = "spec/worktree-runtime-hygiene AC6", summary = "Re-spec and land the cooperative worktree lease, admission queue and with-lease wrapper: fix the Windows byte-range claim lock, reconcile the admission-role reclaim policy with AC6, re-publish a lost waiter ticket, recalibrate the memory clamp against usable-page reporting, scale the decision-lock budget with the wait budget, and forward the makefile currently in use to the recursive sub-make (the jobserver is deliberately NOT forwarded: see docs/specs/worktree-cooperative-lease/spec.md Limitations for the measurement and the three reasons, decided with the operator)"},
   # RFC-0095 D3. 59 versioned entries sit nested under a `## [Unreleased]` heading and
   # are permanently invisible to the `/now/` projection (it applies no date window; a
   # nested entry simply never publishes). Not a mechanical level-shift: 48 genuinely


### PR DESCRIPTION
Closes `worktree-runtime-hygiene` AC6 by shipping the cooperative worktree lease as
its own spec, `docs/specs/worktree-cooperative-lease/`. Status **Shipped**, plan
**Done**, all nine ACs ticked and evidenced.

## Why this is a separate spec

The lease was built once already and **split out under review rather than landed**:
three independent reviewers found failure modes the one-sentence AC6 did not
enumerate, in a finished implementation with a green suite and 46 mutation proofs.
The diagnosis was that a criterion which states an outcome in one sentence cannot be
falsified. So each of the six recorded defects was promoted to an **acceptance
clause**, and the plan requires a named mutation per clause.

That change of shape is what this PR is really testing, and it worked: Task 1 landed
clean first pass, Task 2's implementer stopped and asked because my criterion was the
thing that was wrong, and Tasks 3–4's defects were in evidence rather than design.

## What it does

- **Liveness is a held advisory lock**, never an inference from a recorded pid — so a
  recycled identity cannot impersonate an owner and a killed run's claim is
  reclaimable at once.
- **Two roles interlock atomically**: `activity` (mutating runs, multi-holder) and
  `exclusive` (`clean --apply`). Read-other-role-then-publish-own happens inside one
  uninterrupted hold of one decision lock, so two participants cannot each observe
  the other's absence and both proceed.
- **A machine-wide admission limiter** with FIFO waiter tickets, default 2 concurrent
  heavy runs, a downward-only memory clamp, and a bounded wait that reports being
  queued rather than hanging.
- **`with-lease` / `lease-status` / `release-claim`**, with `make test`,
  `build-check` and `sast` wrapped. **`ci` is deliberately untouched** — its recipe
  only prints a verdict and `lint-ci-parity` derives 31 dispositions from its
  prerequisite list.

## The measurement that reversed a design decision

`msvcrt.locking` locks **one byte at the current file position**, unlike POSIX
`flock`. A publisher that writes a payload then locks holds byte `len(payload)`; a
prober opening at zero locks byte 0; the ranges never overlap. Measured on
`windows-latest`:

```
MEASURED [win32 / os.name=nt] write-then-lock, probe at position 0
    -> NOT blocked (LOCK INVISIBLE)
```

An unobservable held lock is not a degradation — every probe reads not-live, so a live
peer's claim is reclaimed and **cleanup deletes under a running mutator**. Fixed by
seeking to byte zero on both paths, and `lock-semantics-windows` is wired into the
Windows aggregate's required set. Before that measurement the plan was to report
`UNDETERMINABLE` on Windows, surrendering the capability purely because it could not
be tested locally.

## Review findings closed in this PR

A final adversarial pass found nine Blockers; eight were real, and most were the code
contradicting a literal clause of its own spec. The pattern was that **fail-open was
calibrated wrong in both directions**:

| | Defect | Consequence |
|---|---|---|
| too wide | decision-lock timeout classed as an unusable store | limiter switched itself off under load |
| too wide | `--force-without-lease` on cleanup | deleting on evidence it failed to obtain — the spec's first "Never" |
| too narrow | worktree resolved above the fail-open handler | browser gate exited 2 instead of warning |
| too narrow | raw `OSError` from claim publication | crash on a filesystem without hard links |

Also: the wrapper held the cleanup-blocking role across a 5400s admission wait with no
child in existence; AC8's nested receipt was never built; an observably-live waiter's
queue position could be aged out; a live claim with a refused identity had no recovery
path; and the wait budget reached only one of the two waits it governs.

## The root cause was the ledger

The plan's clause-to-mutation ledger was a **description of a deliverable** — it ended
"a clause with no entry is an unfinished task" and was followed by zero entries. That
is how three clauses reached `Done` with no test at all. It is now a 45-row table, and
every guard was run as a real mutation: baseline confirmed green, the named check
confirmed to redden, source restored and verified byte-identical. Two are proven by
*timeout*, because their mutants fail by waiting rather than asserting.

## Verification

`ruff` 0 · `mypy` 0 (125 files) · `make build` 0 · **`make build-check` 0 with the
SAST/SCA leg invoked** · `pytest tools/ tests/` **1579 passed, 2 skipped**.

The single failure is the pre-existing environmental one registered in
`workspace.toml`
(`test_marketplace_envelope_parity.py::test_resolved_layer_fails_loudly_when_the_package_is_unimportable`),
recorded there as reproduced in two control worktrees with no branch commits applied.

Rebased onto `1c4f3561`; the `workspace.toml` reconciliation was asserted as a **slug
set** against that base rather than a count, because a count cannot see a swap.
