### PR TITLE
ci(pages): one setup-node for both npm projects

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,14 +76,27 @@ jobs:
       # ── Astro marketing site FIRST (RFC-0061) ───────────────────────────
       # `astro build` cleans its outDir (build/) on every run, so it must run
       # BEFORE the `docs-site/` Starlight build writes into build/docs/.
+      # One setup-node for both npm projects. The job installed `web/` and
+      # `docs-site/` from two separate setup-node steps pinned to the same
+      # node-version; the second only re-keyed the npm cache. BOTH lock files
+      # must stay listed — nothing in `tools/test-pages-workflow.py` asserts the
+      # cache paths, so dropping one degrades silently into an uncached install.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "24"
           cache: npm
-          cache-dependency-path: web/package-lock.json
+          cache-dependency-path: |
+            web/package-lock.json
+            docs-site/package-lock.json
 
       - name: Install web dependencies
         run: npm ci --prefix web
+
+      # Hoisted here from beside the docs build below, so both installs sit
+      # under the one setup-node. `tools/test-pages-workflow.py` pins this step
+      # NAME as the ordering anchor for the plugin suite — do not rename it.
+      - name: Install docs-site dependencies
+        run: npm ci --prefix docs-site
 
       # Provisioned HERE, beside the deps install, rather than beside the gate that
       # uses it. `--with-deps` pulls an apt layer, and that is the step's common
@@ -127,14 +140,7 @@ jobs:
       # ── Starlight reference docs SECOND — writes into build/docs/ ──────────
       # Build order is load-bearing: web/ Astro build (above) cleans build/
       # on every run, so it MUST run before docs-site/ writes into build/docs/.
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
-        with:
-          node-version: "24"
-          cache: npm
-          cache-dependency-path: docs-site/package-lock.json
-
-      - name: Install docs-site dependencies
-        run: npm ci --prefix docs-site
+      # The deps for this half are installed up top, beside the web install.
 
       # spec/docs-site-build-contract-hardening AC7. The rehype plugin's focused
       # suite, after the docs deps install (it imports the plugin's declared runtime


### PR DESCRIPTION
## What does this change?

The Pages `build` job ran `actions/setup-node` twice — once above the `web/`
install and again 50 lines down above the `docs-site/` install, both pinned to
`node-version: "24"`. This collapses them into a single step whose
`cache-dependency-path` lists both lock files, and hoists `Install docs-site
dependencies` up beside the web install so both npm projects are provisioned
under the one setup.

## Why?

The second invocation configured nothing new. Its only effect was to re-key the
npm cache onto `docs-site/package-lock.json` — a whole redundant toolchain setup
to carry one cache key.

No spec, ADR or RFC: this is a self-contained cleanup of duplicated CI plumbing,
not a behaviour change. No changelog entry — RFC-0095 D1 exempts repository
tooling that ships in no release, and names CI workflows explicitly.

## How do I verify it?

Behaviour held is a structural claim, so I checked it structurally rather than
reading the text diff. Parsing both sides and diffing the parsed step lists:

|  | `main` | this PR |
| --- | --- | --- |
| steps in `build` | 20 | 19 |
| `setup-node` steps | 2 | 1 |
| `node-version` | 24 | 24 |
| lock files cached | `web/…`, `docs-site/…` | both, one key |

Exactly one step removed and one relocated, with an **identical named-step set**.
That matters because `tools/test-pages-workflow.py` computes its ordering families
with `names.index(...)`, so a rename would read as absent.

```sh
python3 tools/test-pages-workflow.py        # 38 mutations caught, 23 families — posture OK
python3 tools/test-build-check-workflow.py  # 178 mutations, 78 families — posture OK
python3 tools/lint-ci-parity.py             # 78 steps dispositioned
python3 tools/lint-site-scope-parity.py     # ok
python3 tools/check-site-plugin-offers.py --build-dir build   # 14 packs offered
python3 -m pytest -q tools/test_check_rendered_site_links.py \
                     tools/test_browser_gate_subset.py \
                     tools/test_build_site_routing.py         # 114 passed
```

The deploy-gate ordering the guard pins is unchanged: `Install docs-site
dependencies` still precedes `Plugin unit tests`, and both still precede
`Upload Pages artifact`.

`tools/test_build_site_routing.py` needs a current site build — on a stale
`build/` its anchor test fails with an unrelated anchor-order diff. Run
`python3 tools/build-site.py && npm run build --prefix web && npm run build
--prefix docs-site` first.

## What did you not change that you considered?

**Separate cache keys.** One key now hashes both lock files, so a `web/` lock
bump invalidates the `docs-site/` entry too. I kept the consolidation anyway:
that is the normal shape for a multi-project job, the two locks move together
often enough that separate keys were not earning a duplicated toolchain setup,
and the cost is one extra `npm ci` on a subset of pushes. Stated here rather
than left for a reviewer to find.

**The install's position relative to the docs build.** `Install docs-site
dependencies` could have stayed put with only the cache path consolidated.
Hoisting it groups both installs under the one setup and makes the job's
provisioning phase contiguous; the ordering constraint the guard enforces is
"before `Plugin unit tests`", which hoisting cannot violate.

**Adding a cache-path assertion to the guard.** Nothing in
`tools/test-pages-workflow.py` asserts `cache-dependency-path`, so silently
dropping a lock file degrades to an uncached install with no gate firing. That
is a pre-existing gap and widening the guard is not this PR's job — but since
the consolidation erases the structural hint that `docs-site/` needs its own
path, I left the fact in a comment on the step, plus a do-not-rename note on
the ordering anchor.

**`node-version` unification.** Already identical on both steps, so there was
nothing to reconcile — worth stating because if they had differed, collapsing
them would have been a behaviour change rather than a cleanup.