### PR TITLE
test(web): schedule browser-gate tests instead of files

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -15,7 +15,11 @@ used by this site. Do not edit generated inputs by hand.
   subpath deployment.
 - Keep pack `docsUrl` and `journeyUrl` populated when those materials exist.
 - Use the e2e gate command, not the unrestricted browser suite, for deploy checks.
-- Launch with `channel="chrome"`: no `ms-playwright` browser binaries are installed.
+- Gate browser: the Playwright-managed Chromium `playwright.config.ts` declares; never
+  substitute `channel="chrome"`, which is not the engine the deploy is judged on.
+- A missing browser is routine, not a finding — `tools/repo/frontend_runtime.py browsers`
+  reports the resolved cache, `install-browsers` provisions it. Never record install
+  state here: it is machine-local and inverts without warning.
 - Full Playwright runs rewrite tracked snapshots; stage files explicitly, never `git add -A`.
 - Check `allowScripts` against install-script entries by eye when the lockfile moves.
 - Define the viewport meta tag once in `src/components/layout/SiteLayout.astro`; never duplicate it.

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -14,7 +14,18 @@ import {
 // qualification; this is where that starts.
 export default defineConfig({
   testDir: './src/test/e2e',
-  fullyParallel: false,
+  // Schedule TESTS, not files. Under `false` this capped workers at 2 by the
+  // FILE count, not the machine — the gate has two specs, 139 cases and 39, so
+  // one worker ground the 139 serially while the other idled. On CI (4 vCPU,
+  // Playwright's default 50% of cores) the worker count stays 2 either way; the
+  // gain is the removed imbalance, dropping the critical path to about 89.
+  //
+  // Safe because the specs share no state: no `beforeAll`/`afterEach`, every
+  // test takes its own `{ page }` fixture and so a fresh context, the 139 cases
+  // come from nested loops over route x width x theme, and the preview server
+  // serves read-only output. Raising `workers` is a SEPARATE change: 4 Chromium
+  // on 4 vCPU contend and `retries` is unset, so contention fails a deploy.
+  fullyParallel: true,
   timeout: 30000,
   use: {
     baseURL: PREVIEW_ORIGIN,


### PR DESCRIPTION
## What does this change?

Flips `fullyParallel` to `true` in `web/playwright.config.ts` so the deterministic
browser gate schedules **tests** rather than **files**, and replaces a `web/AGENTS.md`
bullet that asserted one workstation's browser-install state with the invariant plus
the resolver that reports it.

## Why?

The gate is 62% of the pages `build` job (216s of 348s). It is not slow — it is
single-cored. `fullyParallel: false` serializes tests within a file and parallelizes
only across files, and the gate has exactly two spec files:

| spec | tests | under `false`, on 2 workers |
| --- | --- | --- |
| `site-quality-gate.spec.ts` | 139 | one worker, serially — the whole run |
| `quality-assertions.spec.ts` | 39 | other worker, then **idle** |

So the worker count was capped by the **file count, not the machine**. The proof: on a
**10-core** machine, unmodified, Playwright still reports `Running 178 tests using 2
workers`. Flipping the flag takes it to 5.

The setting had no recorded rationale. "Deterministic" in
`spec/site-browser-quality-gate` names which specs the gate *selects* — it excludes the
screenshot-writers that dirty tracked paths — not the execution order, so nothing in the
spec required serial scheduling.

## How do I verify it?

**Parallel-safety, established by reading and then confirmed by running.** Neither spec
has a `beforeAll`/`afterAll`/`beforeEach`/`afterEach` hook; every test takes its own
`{ page }` fixture and therefore a fresh browser context; the 139 cases are generated by
nested loops over route x width x theme; the only mutable binding in either file is
function-local; the preview server serves read-only built output. The full suite passing
under parallel scheduling **is** the test for a hidden inter-test dependency.

```sh
npm run test:e2e:gate --prefix web     # 178 passed, every run
python3 tools/test-pages-workflow.py   # posture OK
python3 tools/lint-ci-parity.py        # 78 steps dispositioned
python3 -m pytest -q tools/test_playwright_evidence_lifecycle.py \
  tools/test_browser_gate_subset.py tools/test_lint_agents_md_*.py   # 51 passed
```

`tools/test_playwright_evidence_lifecycle.py` is the one that matters here: it reads this
config and pins `trace: 'retain-on-failure'` and `screenshot: 'only-on-failure'`. Both
untouched.

**On timing — read the CI run, not my local numbers.** Locally: 4.7m at 2 workers;
1.9m **and 3.0m** across two runs at 5, all 178 green every time. That spread is real
(machine load ranged 29-70 during measurement), so the local figure is directional only
and **not** a ratio.

The CI effect is smaller and is *not* the local ratio: the runner has 4 vCPU and
Playwright defaults to 50% of cores, so **CI stays at 2 workers either way**. The gain
there is only the removed imbalance — critical path drops from 139 serial tests to about
89, so roughly 216s -> 120-140s. **That is derived arithmetic, not a measurement.** This
PR's own run settles it, since `web/**` is in the pages `paths:` filter.

## What did you not change that you considered?

**`workers`.** Reaching 4 workers on a 4-vCPU runner puts four Chromium instances on four
cores, and with `retries` unset a contention timeout fails a *deploy*. Landing both
concurrency changes together would also make any resulting flake unattributable. If it is
wanted, it belongs in its own PR after this one's CI number is known.

**Sharding across runners** (`--shard`). Real added parallelism, but it costs runner
minutes, needs a merge-reports step, and changes the check surface — disproportionate when
the imbalance fix is one line.

**Trimming the 60-case matrix.** That reduces coverage and needs a spec amendment plus a
guard update. Wrong lever while free parallelism is on the table.

**Putting the flag in the npm script.** Not possible: `tools/test-pages-workflow.py:599`
pins `scripts['test:e2e:gate']` byte-exactly, so `--workers=N` appended there reddens the
required `gate-main` job. Concurrency has to be configured in the config file.

**Flipping the `web/AGENTS.md` claim instead of removing it.** The bullet said to use
`channel="chrome"` because "no `ms-playwright` browser binaries are installed" — false
here, since the cache holds `chromium-1234` and the gate runs against it with no override.
But asserting the opposite is no more durable: that cache is shared and evictable, and has
been observed deleted three times in one session, once mid-run, surfacing as 58 of 152
tests failing in 0-1ms and reading exactly like a code regression. So the bullet now names
the invariant and the resolver (`tools/repo/frontend_runtime.py browsers`, backed by
`resolve_browser_cache`) rather than any machine's state. The old advice was also actively
harmful independent of staleness: a system browser is not the engine the deploy is judged
on, so it makes a local pass and a CI failure look like the same run.