### PR TITLE
docs(rfc): RFC-0088 round 14 — the bar becomes a contract, and its precondition fails

### DIFF
--- a/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
+++ b/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
@@ -221,7 +221,7 @@ Declared explicitly, because filenames cannot express it.
 | Twelfth | The round-12 note |
 | Thirteenth | This digest, and the round-13 amendment entry |
 
-Round fourteen is deliberately absent from this roster. The roster's one home is the coverage checker's declared tuple, and round fourteen has a dated note of its own, so set one already carries it; adding a row here would give the round two homes.
+Round fourteen is deliberately absent from this roster. The roster is a projection of the coverage checker's declared tuple, which stops at the thirteenth and which round fourteen did not extend; set one carries the round through its own dated note. Having a dated note is not itself the reason — the tenth through thirteenth each have one and a roster row both.
 
 ---
 

--- a/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
+++ b/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
@@ -187,6 +187,16 @@ reader can see what moved rather than trusting that something did.
 rounds seven, eight and nine, and carries the archive digest the RFC's amendment
 entry cites. This is the archive the later rounds' apparatus continues to build.
 
+**`spikes/2026-08-21-destination-token-landing.md`** — Asked where a real
+destination's issued token actually lands, and whether the response that issues it is
+marked `no-store`. Measured against two pinned containers of deliberately opposite
+render and authentication shape, each driven through a real browser login: the
+issuing response carries no cache directive at all, and the destination's own frontend
+writes the token into a page-readable web-storage key from which it reaches browser
+user-data on disk. Changed open question 5 from an accommodation with an untested
+precondition into one whose precondition no consumer can establish, and supplied the
+measured fixture pair that the amended open-question-3 bar names.
+
 ---
 
 ## Set two — the rounds roster

--- a/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
+++ b/docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
@@ -190,10 +190,12 @@ entry cites. This is the archive the later rounds' apparatus continues to build.
 **`spikes/2026-08-21-destination-token-landing.md`** — Asked where a real
 destination's issued token actually lands, and whether the response that issues it is
 marked `no-store`. Measured against two pinned containers of deliberately opposite
-render and authentication shape, each driven through a real browser login: the
-issuing response carries no cache directive at all, and the destination's own frontend
-writes the token into a page-readable web-storage key from which it reaches browser
-user-data on disk. Changed open question 5 from an accommodation with an untested
+render and authentication shape, each driven through a real browser login: on the half
+that issues a token, that response carries no cache directive at all, and the
+destination's own frontend writes the token into a page-readable web-storage key from
+which it reaches browser user-data on disk. The contrast half issues no token and its
+cookie arrives on a `private`-marked response, so it neither supports the precondition
+nor refutes it. Changed open question 5 from an accommodation with an untested
 precondition into one whose precondition no consumer can establish, and supplied the
 measured fixture pair that the amended open-question-3 bar names.
 
@@ -218,6 +220,8 @@ Declared explicitly, because filenames cannot express it.
 | Eleventh | The round-11 note |
 | Twelfth | The round-12 note |
 | Thirteenth | This digest, and the round-13 amendment entry |
+
+Round fourteen is deliberately absent from this roster. The roster's one home is the coverage checker's declared tuple, and round fourteen has a dated note of its own, so set one already carries it; adding a row here would give the round two homes.
 
 ---
 

--- a/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
@@ -242,13 +242,29 @@ sits between them and is unmeasured.
   origin is an ambient default, and none is persisted.
 - The reference-consumer probe is operator-run and has no results artifact. Its record
   is the table above, which is why the date and the status codes are in it.
-- **The decision-surface gate is red for a reason unrelated to this round, and stays
-  red.** Its follow-on-artifact check scopes "added" to paths added since a pinned base
-  commit, so an ADR merged by any team after that base trips it — one did, and the gate
-  now fails on a clean checkout of the default branch with no RFC-0088 work present.
-  Verified in a detached worktree rather than inferred. Round 14 does not rescope another
-  round's control; the condition is carried as `rfc0088-decision-surface-base-scoping`,
-  and the next round cannot get a green decision surface until it is fixed.
+- **The decision-surface gate's added-paths check was rescoped, because it had stopped
+  being usable.** It scoped "added" to paths added since a pinned base commit, which was
+  written to mean "paths this round created" but reads as "paths anyone created since".
+  An ADR merged by another team tripped it, and it failed on a clean checkout of the
+  default branch with no RFC-0088 work present — verified in a detached worktree, not
+  inferred. The two checks in that script need different bases and were sharing one: the
+  frozen-body check compares RFC text, where a pinned hash is right and a moving ref
+  would fabricate phantom hunks, while this one asks what the round created, which is the
+  merge-base with the upstream default branch. Upstream movement makes the second
+  *more* accurate, not less. A fallback to the pinned base remains for a checkout with no
+  upstream ref, and it says so in the output rather than silently restoring the defect.
+  A new self-test drives the production scan against a synthetic repository carrying the
+  exact history that broke it — a peer ADR on the default branch and a round branch that
+  created nothing — and asserts three things: the peer's artifact is excluded, the same
+  tree read against the pinned base still shows it (so the clean result is not a detector
+  matching nothing), and an artifact the round really did create is still caught. It runs
+  in the gate chain rather than on request.
+- **A different apparatus control is red, pre-existing, and not fixed here.**
+  `r12-fact-negative-tests.py` reports MISSED and NOT-RESTORED privacy cases, and fails
+  with *more* cases against a clean checkout of the default branch than against this
+  round's branch, so it is environment- or state-dependent rather than caused by a round.
+  Carried as `rfc0088-r12-fact-negative-tests-red`. The full gate chain cannot be green
+  until it is diagnosed; the individually-run controls this round depends on are.
 - The privacy bound on the results artifact is stated as a prohibition — no origin, no
   credential, no fixture identity, no value read out of a storage entry or a cookie —
   rather than as an allowlist of recorded field classes. An allowlist was tried and was

--- a/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
@@ -21,6 +21,12 @@ Driven through a real browser login against a pinned container, the token-issuin
 response carries **no cache directive at all** — not `no-store`, not `private`, no
 `Pragma`. The precondition is not weakened; it is absent.
 
+The claim is scoped to the half that issues a token, because only one half does. The
+contrast half's credential arrives as a cookie on a response marked
+`max-age=0, private, must-revalidate, no-transform`. That is a cache directive, and it
+is neither evidence for the precondition nor against it — the accommodation the
+precondition belongs to cannot apply there at all.
+
 ### The token is at rest by the destination's own storage choice
 
 The sharper observation, and the reason this is a finding rather than a missing header.
@@ -39,9 +45,18 @@ but that its precondition is not something any consumer can establish.
 
 The server-rendered half of the pair issues an `HttpOnly` session cookie. Page script
 cannot read it — `document.cookie` exposes no name at all — so a page-resident replay
-consumer cannot capture the credential in the first place. Neither destination
-therefore *satisfies* the accommodation's condition, but they fail it in opposite
-directions, which is why one destination could not have established either result.
+consumer cannot capture the credential in the first place.
+
+**The session is proven authenticated before that claim is made**, and the arm did not
+originally do this. Every cookie the row inspects is set by the login *page*, so the
+assertion passed byte-identically against a session that never logged in; a reviewer
+found it. A declared row now navigates to a path that requires the session and asserts
+it returns 200 without redirecting to login and without a password field. Its mutation
+re-runs the probe in a context that never authenticated, and the row flips.
+
+Neither destination therefore *satisfies* the accommodation's condition, but they fail
+it in opposite directions, which is why one destination could not have established
+either result.
 
 ### The leading candidate was excluded on measurement, not on preference
 
@@ -51,9 +66,15 @@ a JWT at a session endpoint, with `Authorization: Bearer` on subsequent API requ
 Its storage location was unverified, which is what this round set out to measure.
 
 It never reached measurement. Its API server refuses to start without a cluster API,
-exiting fatal on a missing configuration. Standing it up would mean shipping a control
-plane as the CI fixture, not a pinned container, and the decision that the fixture *is*
-a container is precisely what excluded it. Recorded because a documentation-confirmed
+exiting fatal within a second of launch on `invalid configuration: no configuration has
+been provided, try setting KUBERNETES_MASTER environment variable`. The quoted line is
+a generic Kubernetes client error, and it is what makes the elimination re-derivable
+by anyone who runs that server entrypoint bare.
+
+Standing it up would mean shipping a control plane as the CI fixture, not a pinned
+container, and the decision that the fixture *is* a container is precisely what excluded
+it. The image is not named here because it is not the fixture, and the vendor-name
+boundary admits only what a fixture requires. Recorded because a documentation-confirmed
 auth shape is worth nothing if the thing cannot be started the way the fixture contract
 requires — and because that is only visible by trying.
 
@@ -62,10 +83,14 @@ requires — and because that is only visible by trying.
 Two pinned containers of deliberately opposite render and authentication shape. Both
 are reached over loopback; neither origin is persisted into the results artifact.
 
-| Half | Image | Render shape | Credential shape |
+| Half | Image, pinned by digest | Render shape | Credential shape |
 | --- | --- | --- | --- |
-| SPA | `vikunja/vikunja:0.24.6` | Login form absent from the initial HTML; the password field exists only after script runs | JWT in the login response body, written to a page-readable web-storage key |
-| Server-rendered | `gitea/gitea:1.22.6` | Login form present in the initial HTML, with a `<form>` element and a password input | `HttpOnly` session cookie, unreadable from page script |
+| SPA | `vikunja/vikunja:0.24.6`<br>`@sha256:ed1f3ed467fecec0b57e9de7bc6607f8bbcbb23ffced6a81f5dfefc794cdbe3b` | Login form absent from the initial HTML; the password field exists only after script runs | JWT in the login response body, written to a page-readable web-storage key |
+| Server-rendered | `gitea/gitea:1.22.6`<br>`@sha256:538658de667c5d098a274f2f63aa6ec891d88f670cdd5282cf27221ba747dda4` | Login form present in the initial HTML, with a `<form>` element and a password input | `HttpOnly` session cookie, unreadable from page script |
+
+The digest is the pin AD-4 requires; the tag is recorded beside it only so a reader can
+tell which release it is. Pulling either still contacts a registry on a cold cache —
+that is a named, allowlisted egress rather than an absence of one.
 
 The contrast is measured rather than assumed: the SPA half's login document arrives
 without a `<form>` element or a password input and acquires both under script, while
@@ -93,7 +118,16 @@ which a skipping harness reports as a control that did not fail.
 Every declared row carries a mutation that changes the row's outcome, and the harness
 asserts the flipped value rather than merely that the mutant ran. The unmutated
 baseline is recorded immediately before the harness runs, so both directions are
-observed rather than one being inferred.
+observed rather than one being inferred, and the harness's own summary is kept beside
+the results artifact so the coverage claim has a durable record rather than a
+self-reported field.
+
+**One row carries two cases**, because one case per row is not the unit that matters
+when a row is a conjunction. The contrast row's first mutation flips it through the
+empty-store conjunct alone and leaves the `HttpOnly` conjunct — the one the RFC's
+contrast claim actually rests on — asserted by nobody. A second case anchored on the
+cookie mapping covers it. A row with several load-bearing conjuncts needs a case per
+conjunct.
 
 Two rows are **declared failing**, and the declaration is the finding rather than a
 tolerance: the row asserting the issuing response is `no-store`, and the row asserting
@@ -105,31 +139,63 @@ and a row that cannot pass is not evidence.
 The at-rest scan plants a labelled decoy in the profile and requires it to be
 recovered. Without a recovered plant, "token not found" is indistinguishable from a
 scanner that cannot read those buffers at all, so an absence result there establishes
-nothing. A privacy row asserts over the **serialized artifact bytes** that no encoded
-form of either the issued token or the fixture credential appears in it, rather than
-trusting the code that built the artifact to have been careful.
+nothing.
+
+**The privacy control is a write gate, not only a row.** A row asserts that no encoded
+form of the issued token, the fixture credential, either destination origin or the
+fixture user name appears in the artifact — origins included because a navigation
+timeout embeds the URL in the error text, and that text reaches the failure record. The
+scan runs twice, and the split is what makes the claim true rather than nearly true:
+the row's own result is part of the artifact, so a single pass over the final bytes
+cannot produce the row it must contain. Pass one yields the row; pass two scans the
+exact bytes about to be written and **refuses the write** on a hit, emitting a
+counts-only refusal record instead. An earlier form scanned a prefix and then wrote the
+file regardless — a detected leak would still have landed on disk. The mutation plants
+a registered sentinel rather than the live credential, because a mutant that proves the
+row can fail by writing a real credential to disk has committed the exposure the row
+exists to prevent.
+
+**Cleanup is symlink-safe, and a surviving profile is fatal.** Chromium plants
+`SingletonLock` and its siblings as symlinks in every profile root and removes them only
+on a clean exit; the confined remover refuses any tree containing a symlink, by design.
+Handing it a browser profile directly therefore throws on any unclean exit, and what is
+left behind is the profile holding the live token. Proven rather than reasoned: with a
+`SingletonLock` planted, the remover throws `refuse symlink` and the token-bearing file
+survives. Symlinks are now unlinked first with a mechanism that cannot follow one, a
+profile that survives cleanup is a fatal outcome rather than a field, and signal
+handlers cover the interrupt path, since a `finally` block does not run on a kill.
 
 ## Reference consumer, and what it is not
 
-The documented reference consumer is a fantasy-football league surface an adopter runs
+The documented reference consumer is a consumer-facing hosted service an adopter runs
 against their own account, read-only, and it **never runs in CI** — the repository does
 not contact a third party's servers. It is a recorded observation with provenance, not
 an acceptance criterion. An acceptance criterion that cannot fire is worse than an
 honest observation, which is why one is not written.
 
-Its unauthenticated surface was probed read-only to establish where the session is
-actually required. Public classic leagues are readable by identifier with no
-credential, and the league object returned by that endpoint carries its own privacy
-field, so the distinction is visible in the response rather than having to be assumed.
-A separate manager-scoped endpoint refuses an unauthenticated request outright.
+The service is described by shape rather than named, and the same applies to its
+endpoint vocabulary. A provider's API terminology identifies it as surely as its name
+does, and the observation below also records that the operator holds an account there —
+so naming it by either route would put an account relationship into a permanent record.
+Nothing below depends on which provider it is.
 
-**Residual, named rather than glossed:** whether a *private* mini-league's standings
-endpoint specifically requires the session is **not established here**. Confirming it
-needs one private league identifier, which only the operator holds, and the alternative
-— probing identifiers until a private one is found — is enumeration against a third
-party and was not run. What is established is that the public case is genuinely open
-and that manager-scoped surfaces are genuinely gated; the private-league case sits
-between them and is unmeasured.
+**Probe, 2026-08-21, unauthenticated and read-only, four requests.** The observation is
+about which surfaces need the session:
+
+| Surface | Observed |
+| --- | --- |
+| Bulk reference data | `200`, served without a credential |
+| A collection readable by identifier, marked public in its own response | `200`, served without a credential; the response carries the privacy marking itself, so the distinction need not be assumed |
+| Caller-identity endpoint | `200`, with an empty unauthenticated body rather than a refusal |
+| An account-scoped endpoint | `403`, `"Authentication credentials were not provided."` |
+
+**Residual, named rather than glossed:** whether the *private* variant of the
+readable-by-identifier collection requires the session is **not established here**.
+Confirming it needs one private identifier, which only the operator holds, and the
+alternative — probing identifiers until a private one is found — is enumeration against
+a third party and was not run. What is established is that the public variant is
+genuinely open and that account-scoped surfaces are genuinely gated; the private variant
+sits between them and is unmeasured.
 
 ## Limits
 
@@ -145,3 +211,5 @@ between them and is unmeasured.
 - The arm needs both containers running and is therefore not part of the unconditional
   gate chain. It is invoked explicitly with the destinations supplied as inputs; no
   origin is an ambient default, and none is persisted.
+- The reference-consumer probe is operator-run and has no results artifact. Its record
+  is the table above, which is why the date and the status codes are in it.

--- a/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
@@ -242,6 +242,13 @@ sits between them and is unmeasured.
   origin is an ambient default, and none is persisted.
 - The reference-consumer probe is operator-run and has no results artifact. Its record
   is the table above, which is why the date and the status codes are in it.
+- **The decision-surface gate is red for a reason unrelated to this round, and stays
+  red.** Its follow-on-artifact check scopes "added" to paths added since a pinned base
+  commit, so an ADR merged by any team after that base trips it — one did, and the gate
+  now fails on a clean checkout of the default branch with no RFC-0088 work present.
+  Verified in a detached worktree rather than inferred. Round 14 does not rescope another
+  round's control; the condition is carried as `rfc0088-decision-surface-base-scoping`,
+  and the next round cannot get a green decision surface until it is fixed.
 - The privacy bound on the results artifact is stated as a prohibition — no origin, no
   credential, no fixture identity, no value read out of a storage entry or a cookie —
   rather than as an allowlist of recorded field classes. An allowlist was tried and was

--- a/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
@@ -1,0 +1,147 @@
+# RFC-0088 round 14 — destination token landing and the fixture pair
+
+**Status:** complete measurements; open question 3's bar is amended in the RFC's
+amendment layer, and question 5 stays outstanding with a new finding against it.
+
+This round exists to answer two questions the earlier rounds could not, because both
+are properties of a **destination** and every prior arm measured a synthetic issuer
+this project controls. Where the token lands, and whether the response that issues it
+is marked `no-store`.
+
+## Findings
+
+### The `no-store` precondition is absent at a real destination
+
+Round 12 established the page-resident replay accommodation **conditionally**: it held
+when the issuing response was marked `no-store`, and the otherwise identical
+default-cache arm found the live token at rest in browser user-data. The condition was
+never tested against anything but the synthetic issuer that supplied it.
+
+Driven through a real browser login against a pinned container, the token-issuing
+response carries **no cache directive at all** — not `no-store`, not `private`, no
+`Pragma`. The precondition is not weakened; it is absent.
+
+### The token is at rest by the destination's own storage choice
+
+The sharper observation, and the reason this is a finding rather than a missing header.
+The destination's frontend writes the issued token into a **page-readable web-storage
+key**, and a scan of the closed browser profile recovers the live token from the
+storage log on disk. That path does not run through the response cache, so a
+destination that *did* send `no-store` would leave the token at rest here anyway.
+
+Keeping the token page-resident does not prevent this. A consumer sets neither the
+destination's cache-control nor where the destination's own frontend stores its token,
+so question 5's recommended accommodation is conditional on behaviour outside the
+boundary this RFC governs. That is the finding: not that the accommodation is wrong,
+but that its precondition is not something any consumer can establish.
+
+### The contrast half shows the accommodation is inapplicable, not unsafe, elsewhere
+
+The server-rendered half of the pair issues an `HttpOnly` session cookie. Page script
+cannot read it — `document.cookie` exposes no name at all — so a page-resident replay
+consumer cannot capture the credential in the first place. Neither destination
+therefore *satisfies* the accommodation's condition, but they fail it in opposite
+directions, which is why one destination could not have established either result.
+
+### The leading candidate was excluded on measurement, not on preference
+
+The candidate going in was an operator-internal delivery tool whose documentation
+confirms exactly the shape open question 5 names: username and password exchanged for
+a JWT at a session endpoint, with `Authorization: Bearer` on subsequent API requests.
+Its storage location was unverified, which is what this round set out to measure.
+
+It never reached measurement. Its API server refuses to start without a cluster API,
+exiting fatal on a missing configuration. Standing it up would mean shipping a control
+plane as the CI fixture, not a pinned container, and the decision that the fixture *is*
+a container is precisely what excluded it. Recorded because a documentation-confirmed
+auth shape is worth nothing if the thing cannot be started the way the fixture contract
+requires — and because that is only visible by trying.
+
+## The fixture pair
+
+Two pinned containers of deliberately opposite render and authentication shape. Both
+are reached over loopback; neither origin is persisted into the results artifact.
+
+| Half | Image | Render shape | Credential shape |
+| --- | --- | --- | --- |
+| SPA | `vikunja/vikunja:0.24.6` | Login form absent from the initial HTML; the password field exists only after script runs | JWT in the login response body, written to a page-readable web-storage key |
+| Server-rendered | `gitea/gitea:1.22.6` | Login form present in the initial HTML, with a `<form>` element and a password input | `HttpOnly` session cookie, unreadable from page script |
+
+The contrast is measured rather than assumed: the SPA half's login document arrives
+without a `<form>` element or a password input and acquires both under script, while
+the server-rendered half's arrives with each already present. That difference is the
+whole point of requiring two fixtures — an adapter contract exercised only against a
+server-rendered destination never has to solve "the form is not in the document yet",
+and one exercised only against an SPA never has to carry a CSRF token out of the
+delivered HTML.
+
+Fixture credentials are synthetic placeholders created against the container at run
+time. Nothing is recorded from a live account, and no fixture credential is written to
+the repository or to the results artifact.
+
+## Apparatus
+
+The arm follows the round-12 page-resident driver's construction: a declared row
+inventory checked against what the run actually emitted, an in-region uniqueness
+assertion for every mutation anchor, and a mutation harness that **throws on a stale
+anchor rather than skipping it**. That assertion fired twice while this arm was being
+built — once on an anchor that occurred twice in the region, once on an anchor left
+over from an earlier draft that occurred zero times. The second is the case that
+matters: a zero-occurrence anchor produces an unmutated mutant whose row never flips,
+which a skipping harness reports as a control that did not fail.
+
+Every declared row carries a mutation that changes the row's outcome, and the harness
+asserts the flipped value rather than merely that the mutant ran. The unmutated
+baseline is recorded immediately before the harness runs, so both directions are
+observed rather than one being inferred.
+
+Two rows are **declared failing**, and the declaration is the finding rather than a
+tolerance: the row asserting the issuing response is `no-store`, and the row asserting
+the live token is absent from browser user-data at rest. Both mutate *toward passing*,
+which is the direction that matters for a row whose recorded outcome is a finding — the
+risk is not that such a row fails spuriously, it is that it could never have passed,
+and a row that cannot pass is not evidence.
+
+The at-rest scan plants a labelled decoy in the profile and requires it to be
+recovered. Without a recovered plant, "token not found" is indistinguishable from a
+scanner that cannot read those buffers at all, so an absence result there establishes
+nothing. A privacy row asserts over the **serialized artifact bytes** that no encoded
+form of either the issued token or the fixture credential appears in it, rather than
+trusting the code that built the artifact to have been careful.
+
+## Reference consumer, and what it is not
+
+The documented reference consumer is a fantasy-football league surface an adopter runs
+against their own account, read-only, and it **never runs in CI** — the repository does
+not contact a third party's servers. It is a recorded observation with provenance, not
+an acceptance criterion. An acceptance criterion that cannot fire is worse than an
+honest observation, which is why one is not written.
+
+Its unauthenticated surface was probed read-only to establish where the session is
+actually required. Public classic leagues are readable by identifier with no
+credential, and the league object returned by that endpoint carries its own privacy
+field, so the distinction is visible in the response rather than having to be assumed.
+A separate manager-scoped endpoint refuses an unauthenticated request outright.
+
+**Residual, named rather than glossed:** whether a *private* mini-league's standings
+endpoint specifically requires the session is **not established here**. Confirming it
+needs one private league identifier, which only the operator holds, and the alternative
+— probing identifiers until a private one is found — is enumeration against a third
+party and was not run. What is established is that the public case is genuinely open
+and that manager-scoped surfaces are genuinely gated; the private-league case sits
+between them and is unmeasured.
+
+## Limits
+
+- Two destinations do not establish a population. They establish that the
+  accommodation's precondition is not universal, which is what the conditional result
+  needed testing against.
+- The at-rest result holds only for buffers where the planted decoy was recovered.
+  Buffers without one are absence-unverifiable and contribute no absence claim.
+- This note is not registered in the figure-verifier document corpus, so its figures
+  are carried by the results artifact rather than by claim accounting. Registering it
+  would bring the note under the claim-accounting requirement, which this round did not
+  commission.
+- The arm needs both containers running and is therefore not part of the unconditional
+  gate chain. It is invoked explicitly with the destinations supplied as inputs; no
+  origin is an ambient default, and none is persisted.

--- a/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
+++ b/docs/rfc/0088-notes/spikes/2026-08-21-destination-token-landing.md
@@ -149,11 +149,25 @@ scan runs twice, and the split is what makes the claim true rather than nearly t
 the row's own result is part of the artifact, so a single pass over the final bytes
 cannot produce the row it must contain. Pass one yields the row; pass two scans the
 exact bytes about to be written and **refuses the write** on a hit, emitting a
-counts-only refusal record instead. An earlier form scanned a prefix and then wrote the
-file regardless — a detected leak would still have landed on disk. The mutation plants
-a registered sentinel rather than the live credential, because a mutant that proves the
-row can fail by writing a real credential to disk has committed the exposure the row
-exists to prevent.
+refusal record instead — and the refusal is scanned too, because "this record cannot
+leak" is the kind of claim that stops being true the moment someone adds a field to it.
+An earlier form scanned a prefix and then wrote the file regardless; a detected leak
+would still have landed on disk.
+
+The redactor is built from the **same encoded forms** the detector uses, and it was not
+always. Measured while under review: a plain `page.goto: … at http://<origin>/login` was
+redacted, while the percent-encoded form of the same origin walked straight past a
+raw-substring redactor and was caught only by the write gate. Safe either way, but the
+outcome differed — a redacted line in one case, a refused run in the other — which is a
+redactor disagreeing with its own detector. They now share one definition.
+
+The mutation plants the **live token**, and the write gate is what makes that safe. An
+earlier form planted a synthetic sentinel to avoid writing a credential anywhere, but
+the sentinel is detected through the origin and user terms, so the credential detector
+itself was exercised by nothing: removing it left every case and the no-op still
+passing. That is a control that cannot fail. With the write gate refusing, the planted
+token reaches no file, so the stronger plant costs nothing — and the harness now asserts
+*which* term produced the refusal, not merely that something did.
 
 **Cleanup is symlink-safe, and a surviving profile is fatal.** Chromium plants
 `SingletonLock` and its siblings as symlinks in every profile root and removes them only
@@ -162,8 +176,24 @@ Handing it a browser profile directly therefore throws on any unclean exit, and 
 left behind is the profile holding the live token. Proven rather than reasoned: with a
 `SingletonLock` planted, the remover throws `refuse symlink` and the token-bearing file
 survives. Symlinks are now unlinked first with a mechanism that cannot follow one, a
-profile that survives cleanup is a fatal outcome rather than a field, and signal
-handlers cover the interrupt path, since a `finally` block does not run on a kill.
+forced removal backs that up so a fatal outcome means "could not be removed by any
+means" rather than "the confined path declined", a root that survives every path is
+fatal rather than a field, and signal handlers cover the interrupt path with the same
+verification, since a `finally` block does not run on a kill.
+
+**Confinement is established before anything is unlinked**, and the first version of
+this fix had that backwards. Reproduced: with a sibling directory outside the root
+holding a symlink, the removal unlinked it and only *then* threw `refuse path outside
+root` — a bypass of the blessed helper wearing the shape of a use of it. Both sides are
+now real-pathed before the check, which also caught a second defect on the first run
+after: comparing a real-pathed root against an unresolved target refuses its own
+legitimate caller on a platform where the temporary directory is itself a symlink.
+
+The sibling round-12 arms call the confined remover on browser profiles without this
+pre-unlink, and are **not** exposed by it: their runner sets the temporary directory
+inside the tree it cleans, and its own cleanup unlinks symlinks before the confined
+removal. The exposure is specific to a driver invoked **bare**, with no runner beneath
+it, which is how this arm runs.
 
 ## Reference consumer, and what it is not
 
@@ -174,9 +204,8 @@ an acceptance criterion. An acceptance criterion that cannot fire is worse than 
 honest observation, which is why one is not written.
 
 The service is described by shape rather than named, and the same applies to its
-endpoint vocabulary. A provider's API terminology identifies it as surely as its name
-does, and the observation below also records that the operator holds an account there —
-so naming it by either route would put an account relationship into a permanent record.
+endpoint vocabulary: a provider's API terminology identifies it as surely as its name
+does, so de-naming that left the vocabulary in place would not have de-named anything.
 Nothing below depends on which provider it is.
 
 **Probe, 2026-08-21, unauthenticated and read-only, four requests.** The observation is
@@ -213,3 +242,7 @@ sits between them and is unmeasured.
   origin is an ambient default, and none is persisted.
 - The reference-consumer probe is operator-run and has no results artifact. Its record
   is the table above, which is why the date and the status codes are in it.
+- The privacy bound on the results artifact is stated as a prohibition — no origin, no
+  credential, no fixture identity, no value read out of a storage entry or a cookie —
+  rather than as an allowlist of recorded field classes. An allowlist was tried and was
+  incomplete the first time it was checked against the artifact it described.

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -968,7 +968,7 @@ bottom will meet all of these as live text; every one is superseded here:
 | "Live adapters reject loopback, private, link-local, multicast, and metadata destinations after DNS resolution and on every redirect/connection" | *Website-adapter artifact and runtime contract* | *Network corrections in force* — an invariant, not a capability of the route API |
 | Node permissions listed among the safety rails | *Native Playwright and trusted-code posture* | Correction 7 — one coarse `net` permission gates the transport too |
 | "S1, S2, S3, S4, and S5 remain open Experimental gates" | *Experimental run ledger — 2026-08-15* | The current-state table above; that sentence is dated commentary, not a live status |
-| The three *Open questions* | *Open questions* | Q1 is now blocker item 1; Q2 was answered by S2 (plain self-contained ESM, no bundler); Q3 remains open and is unchanged |
+| The three *Open questions* | *Open questions* | Q1 is now blocker item 1; Q2 was answered by S2 (plain self-contained ESM, no bundler); Q3's bar is amended by the 2026-08-21 entry below and the question stays open |
 
 The `Experimental run ledger — 2026-08-15` and the `Experiment / validation`
 tables are the **first** run's record. Where they and this section disagree,
@@ -3349,9 +3349,9 @@ that mechanism rather than record the channel as inherently uncontrollable.
     asking.
   - S5's own two providers were the synthetic fixtures `example-provider-a` and
     `example-provider-b`. They demonstrated the pack/grant vertical mechanism and were
-    never independent consumers. They did not satisfy the two-consumer bar and do not
-    satisfy the one-consumer bar; recording that closes the reading in which the
-    original bar was already met.
+    never independent consumers, so the reading in which the original bar was already
+    met does not survive either. Under the amended bar they are not consumers at all —
+    they are the wrong kind of object, which is the point.
   - `web-automation` is not even an existing pack category — the RFC's own D8 resolves
     discovery through `integrations` plus a namespaced conformance marker, so there is
     no category a consumer could already be sitting in unnoticed.
@@ -3369,8 +3369,10 @@ that mechanism rather than record the channel as inherently uncontrollable.
   acceptance and lowering it explicitly. Neither is taken. The bar is re-denominated:
   acceptance no longer waits on independent adopters appearing, which nothing in the
   pilot's control could cause, nor on a single consumer being built inside a boundary
-  that forbids publishing it. It waits on a **destination adapter contract holding
-  against two fixtures**, which is work this project can schedule and CI can assert.
+  that forbids publishing it. It waits on the bar as blockquoted above — which is work
+  this project can schedule, and whose contract half CI can assert. The blockquote is
+  the canonical statement of the bar; this paragraph does not restate it, because a bar
+  written twice is a bar that disagrees with itself at the first edit.
 
   Two things follow that the approver is accepting by taking this ruling. The fixtures
   are the foundation's own, and that is deliberate rather than a concession: they are
@@ -3383,7 +3385,7 @@ that mechanism rather than record the channel as inherently uncontrollable.
 
   **The fixture pair is measured, not proposed.** Both halves are pinned containers,
   and the pair was selected by standing them up and observing them rather than from
-  documentation. The named candidate going in was an operator-internal delivery tool
+  documentation. The leading candidate going in was an operator-internal delivery tool
   whose documentation confirms the exact shape this question wants — username and
   password exchanged for a JWT at a session endpoint, `Authorization: Bearer` on API
   requests. It was rejected on measurement: its server refuses to start without a
@@ -3429,7 +3431,7 @@ that mechanism rather than record the channel as inherently uncontrollable.
   section is already the authoritative current contract, so it is where a decision
   taken before acceptance belongs. Each one graduates to an ADR when the RFC is
   Accepted and implementation is separately authorised — the follow-on list already
-  reserves a slot for the first of them. RFC-0088 remains `Experimental`; open
+  reserves an ADR slot that AD-3 graduates into. RFC-0088 remains `Experimental`; open
   questions 1, 2, 5 and 6 remain outstanding; no blocker item closes.
 
   **AD-1 — authentication is an optional layer, not a precondition of page driving.**
@@ -3449,13 +3451,30 @@ that mechanism rather than record the channel as inherently uncontrollable.
   destination's state, and no aggregate health signal may collapse it into a
   session-wide verdict.
 
-  **AD-3 — credentials resolve through the broker, and never cross a process boundary
-  to a model.** Credential resolution is `credbroker`'s, in its declared order, and a
-  resolved secret is never placed in a prompt, a tool argument, a transcript, or any
-  other value an LLM process can read. Nor is one committed. This has been true in
-  practice; what it did not have was a stated reason, which is that the credential
+  **AD-3 — credentials resolve through the broker, and no model-reachable process may
+  hold or obtain one.** Credential resolution is `credbroker`'s, in its declared order.
+  The boundary is stated as a **property, not a list of channels**: no LLM-reachable
+  process may hold, or be able to obtain, a resolved or destination-issued credential.
+  Nor is one committed. The reason it did not have before is that the credential
   boundary and the model boundary are different boundaries, and a design that lets them
   coincide has no way to say which one failed.
+
+  It is written as a property because this round's own measurement is a channel a list
+  would have missed. A prompt, a tool argument and a transcript are the obvious three;
+  the token this round found lands in **browser user-data on disk**, inside a profile
+  directory the agent process owns, and question 5's accommodation puts the same token
+  in a **DOM the agent reads**. An agent with an ordinary file-read or page-evaluate
+  tool obtains the credential without using any of the obvious three. Two derived
+  obligations follow for the build, and they are consequences of this decision rather
+  than criteria this round claims to have met: a browser user-data directory is a
+  credential-bearing artifact with a declared lifetime, and a page-resident token is
+  out of reach of every model-facing tool.
+
+  **Scope.** AD-3 governs production packs, adapters and CLI surfaces. The
+  out-of-repository evidence apparatus is outside it and reads its fixture credential
+  straight from the environment — deliberately, because it is not a credential the
+  broker mediates and not one any adopter holds, and routing a synthetic fixture secret
+  through the broker would exercise none of the boundary AD-3 is about.
 
   **AD-4 — a pinned container is the CI fixture, and it is load-bearing.** The fixture
   is not a convenience stand-in for a real destination. It is the *only* destination
@@ -3467,7 +3486,11 @@ that mechanism rather than record the channel as inherently uncontrollable.
   may be used however convenient. And the fixture must be a *container* — an image
   pinned by digest that CI can start — rather than a hosted demo instance, because a
   hosted instance is a third party the repository would be contacting on every run.
-  That clause did real work this round: it is what excluded the leading candidate.
+  What that does not remove is the registry: a digest-pinned pull still contacts one on
+  a cold cache, so the registry is a **named, allowlisted egress**, not an absence of
+  egress, and the difference between it and a demo instance is that a digest pin makes
+  what comes back immutable. That clause did real work this round: it is what excluded
+  the leading candidate.
 
   **Scope residual, carried from the withdrawn narrowing.** An earlier proposal would
   have narrowed `web-pilot`'s scope to destinations offering no token mechanism at all.
@@ -3490,8 +3513,11 @@ that mechanism rather than record the channel as inherently uncontrollable.
   Two pinned containers were stood up and driven through a real browser login, chosen
   for opposite render and authentication shape. Measured, not read from documentation:
 
-  - The token-issuing response carries **no cache directive at all** — not `no-store`,
-    not `private`, nothing. The precondition round 12 identified is simply absent.
+  - **On the token-issuing half** — the only half that issues a token — that response
+    carries **no cache directive at all**: not `no-store`, not `private`, nothing. The
+    precondition round 12 identified is simply absent. The contrast half issues no
+    token; its credential arrives as a cookie on a response marked `private`, which is
+    a different thing and is not evidence for or against the precondition.
   - The issued token is written by the destination's own frontend into a
     **page-readable web-storage key**, from which it reaches browser user-data on disk.
 

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3311,3 +3311,88 @@ that mechanism rather than record the channel as inherently uncontrollable.
   authorised. Conversion was available to it because no frozen spec pins it with a
   deferral marker; a pinned slug cannot be removed from the register and is carried
   instead.
+
+- **2026-08-21 — approver rulings on open questions 3 and 4.** Two rulings, taken
+  after the round-13 decision surface was assembled and superseding what that section
+  records for these two questions. Nothing else changes: RFC-0088 remains
+  `Experimental`, open questions 1, 2, 5 and 6 remain outstanding, no blocker item
+  closes, and no follow-on artifact is created.
+
+  **Open question 3 — ruled. The bar is one independent consumer, not two.** The
+  recommended default in the open-question text required S5 to prove *two* independent
+  software-delivery provider consumers before acceptance. The approver lowers that to
+  **one**. This is a policy judgement about the charter's "used often enough" test, not
+  a measurement, and it is recorded here as the ruling the question asked for.
+
+  **What satisfies the lowered bar: nothing yet, and that is the finding.** The
+  satisfying consumer has to be one that drives **web page automation** — this RFC's
+  subject is a browser session, page-resident credentials, service-worker policy and
+  realm boundaries. Searched rather than assumed, and no such consumer exists in this
+  repository, built or planned:
+
+  - Nothing under `packs/` references `web-pilot`, `auth: browser-session`, or the
+    `provider-v1` conformance marker.
+  - The three packs that touch a browser at all do so for **credential capture**, not
+    page automation: the `atlassian` pack's `setup_sso.py`, and `credential-brokers`'
+    `_sso.py` and `sso-broker.py`. That is SSO-cookie auth governed by
+    [RFC-0035](0035-sso-cookie-auth-for-atlassian-pack.md), a different concern with a
+    different boundary, and counting it here would answer a question this RFC is not
+    asking.
+  - S5's own two providers were the synthetic fixtures `example-provider-a` and
+    `example-provider-b`. They demonstrated the pack/grant vertical mechanism and were
+    never independent consumers. They did not satisfy the two-consumer bar and do not
+    satisfy the one-consumer bar; recording that closes the reading in which the
+    original bar was already met.
+  - `web-automation` is not even an existing pack category — the RFC's own D8 resolves
+    discovery through `integrations` plus a namespaced conformance marker, so there is
+    no category a consumer could already be sitting in unnoticed.
+
+  So question 3 splits in two, and only the first half is ruled. **The bar is ruled at
+  one consumer.** **Satisfaction is outstanding**, and what satisfies it is a
+  page-automation consumer that has to be *built* — the example candidate the
+  foundation exists to serve.
+
+  **Consequence for acceptance, and it is not "question 3 is done".** The round-13
+  section presented question 3 as the choice between accepting a bar that blocks
+  acceptance and lowering it explicitly. This is the explicit lowering, and it changes
+  the *shape* of the blocker rather than removing it: acceptance no longer waits on two
+  independent adopters appearing, which nothing in the pilot's control could cause. It
+  waits on **one page-automation consumer being built**, which is work this project can
+  schedule. A bar that could only be met by other people's adoption becomes a bar met
+  by an artifact — and unlike the original, it is reachable.
+
+  Two things follow that the approver is accepting by taking this ruling. The consumer
+  cannot be the foundation's own fixtures, or the bar means nothing. And building it is
+  gated behind the same two doors as every other follow-on artifact: the RFC being
+  Accepted, and implementation being separately authorised. So question 3 stops being
+  the *first* blocker and becomes a consequence of the others.
+
+  **Open question 4 — the contradicted candidate is re-drafted, and the re-draft is
+  the ruling asked for.** The original candidate folded worker policy into the
+  destination constraint decision C established, so that one policy would decide both
+  where a session may talk and whether a worker may run there. Measurement contradicted
+  it: registration blocking is destination-scopable **only by partitioning destinations
+  into separate browser contexts**, and scoping within one shared session was not
+  demonstrated. A session-wide switch therefore still forces the choice between losing
+  a surface and losing the control, and the candidate as drafted did not remove that.
+
+  The amended requirement, superseding the session-wide reading of D / item 6:
+
+  > Worker policy is decided by the **destination group**, not by the session. A
+  > destination group is the unit at which decision C already constrains egress, and it
+  > is realised as a **separate browser context**. One policy per group decides both
+  > where that group may talk and whether a worker may run there. The session-wide
+  > reading of item 6 is withdrawn.
+
+  What the approver is accepting by adopting it, stated rather than discovered later: a
+  deployment needing opposite worker policies for two destinations must run them in
+  **separate contexts**, so those destinations do not share session state and each
+  group carries its own sign-in. That cost is real and unmeasured — it is the subject
+  of the carried `rfc0088-destination-group-split-cost` register slug, which remains
+  carried because measuring it needs an attended interactive sign-in per group that has
+  not been commissioned. Adopting the re-draft does not close that slug; it is why the
+  slug exists.
+
+  Question 4's status therefore moves from outstanding-with-a-contradicted-candidate to
+  **ruled**, with the per-group cost carried as a named residual rather than absorbed
+  silently.

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3318,14 +3318,23 @@ that mechanism rather than record the channel as inherently uncontrollable.
   `Experimental`, open questions 1, 2, 5 and 6 remain outstanding, no blocker item
   closes, and no follow-on artifact is created.
 
-  **Open question 3 — ruled. The bar is one independent consumer, not two.** The
+  **Open question 3 — ruled. The bar is amended: it is a contract, not a count.** The
   recommended default in the open-question text required S5 to prove *two* independent
-  software-delivery provider consumers before acceptance. The approver lowers that to
-  **one**. This is a policy judgement about the charter's "used often enough" test, not
-  a measurement, and it is recorded here as the ruling the question asked for.
+  software-delivery provider consumers before acceptance. That default is withdrawn
+  whole. It is replaced by, and this paragraph is question 3's ruling in full — no
+  count-based reading of the bar survives it:
 
-  **What satisfies the lowered bar: nothing yet, and that is the finding.** The
-  satisfying consumer has to be one that drives **web page automation** — this RFC's
+  > The bar is a **destination adapter contract**, exercised by **two independent
+  > fixtures of differing render and authentication shape**, plus **one documented
+  > reference consumer** an adopter runs against their own account. The original bar
+  > assumed the pack could ship its consumers; its legitimate destinations are
+  > predominantly operator-internal surfaces no pack can carry, so a shipped-consumer
+  > count measures what the pack is permitted to bundle rather than whether the
+  > foundation works. The contract is asserted in CI; the reference consumer is a
+  > recorded observation.
+
+  **Why a count was the wrong instrument, and the evidence for it is the search.** The
+  satisfying consumer would have had to drive **web page automation** — this RFC's
   subject is a browser session, page-resident credentials, service-worker policy and
   realm boundaries. Searched rather than assumed, and no such consumer exists in this
   repository, built or planned:
@@ -3347,25 +3356,41 @@ that mechanism rather than record the channel as inherently uncontrollable.
     discovery through `integrations` plus a namespaced conformance marker, so there is
     no category a consumer could already be sitting in unnoticed.
 
-  So question 3 splits in two, and only the first half is ruled. **The bar is ruled at
-  one consumer.** **Satisfaction is outstanding**, and what satisfies it is a
-  page-automation consumer that has to be *built* — the example candidate the
-  foundation exists to serve.
+  That list is not an argument for lowering the count. It is the evidence that a count
+  is measuring the wrong thing. Every entry on it is absent for the same reason: the
+  destinations this foundation exists to reach are operator-internal, so a consumer of
+  it is something an adopter builds inside their own boundary and never publishes here.
+  A bar denominated in shipped consumers reads that as failure indefinitely, however
+  well the foundation works, because the pack is not permitted to bundle the consumers
+  that would satisfy it.
 
   **Consequence for acceptance, and it is not "question 3 is done".** The round-13
   section presented question 3 as the choice between accepting a bar that blocks
-  acceptance and lowering it explicitly. This is the explicit lowering, and it changes
-  the *shape* of the blocker rather than removing it: acceptance no longer waits on two
-  independent adopters appearing, which nothing in the pilot's control could cause. It
-  waits on **one page-automation consumer being built**, which is work this project can
-  schedule. A bar that could only be met by other people's adoption becomes a bar met
-  by an artifact — and unlike the original, it is reachable.
+  acceptance and lowering it explicitly. Neither is taken. The bar is re-denominated:
+  acceptance no longer waits on independent adopters appearing, which nothing in the
+  pilot's control could cause, nor on a single consumer being built inside a boundary
+  that forbids publishing it. It waits on a **destination adapter contract holding
+  against two fixtures**, which is work this project can schedule and CI can assert.
 
-  Two things follow that the approver is accepting by taking this ruling. The consumer
-  cannot be the foundation's own fixtures, or the bar means nothing. And building it is
-  gated behind the same two doors as every other follow-on artifact: the RFC being
-  Accepted, and implementation being separately authorised. So question 3 stops being
-  the *first* blocker and becomes a consequence of the others.
+  Two things follow that the approver is accepting by taking this ruling. The fixtures
+  are the foundation's own, and that is deliberate rather than a concession: they are
+  the only destinations whose credentials the repository may hold, so they are the only
+  place the full login-to-frontend-API path can be mechanically asserted at all. What
+  they cannot supply is evidence that anyone wants this, and the reference consumer is
+  what carries that — as an observation with provenance, never as an acceptance
+  criterion. An acceptance criterion that cannot fire in CI is worse than an honest
+  observation, so it is not written as one.
+
+  **The fixture pair is measured, not proposed.** Both halves are pinned containers,
+  and the pair was selected by standing them up and observing them rather than from
+  documentation. The named candidate going in was an operator-internal delivery tool
+  whose documentation confirms the exact shape this question wants — username and
+  password exchanged for a JWT at a session endpoint, `Authorization: Bearer` on API
+  requests. It was rejected on measurement: its server refuses to start without a
+  cluster API, so it is not a pinned container but a control plane, and the ruling that
+  the fixture is a container is the thing that excluded it. The pair that replaced it,
+  and the at-rest finding that came out of measuring it, are recorded in
+  [the destination token-landing note](0088-notes/spikes/2026-08-21-destination-token-landing.md).
 
   **Open question 4 — the contradicted candidate is re-drafted, and the re-draft is
   the ruling asked for.** The original candidate folded worker policy into the
@@ -3396,3 +3421,94 @@ that mechanism rather than record the channel as inherently uncontrollable.
   Question 4's status therefore moves from outstanding-with-a-contradicted-candidate to
   **ruled**, with the per-group cost carried as a named residual rather than absorbed
   silently.
+
+- **2026-08-21 — four architectural decisions, one scope residual, and the round-14
+  destination measurement.** These are decision records, and they are recorded *here*
+  rather than under `docs/adr/` deliberately: the Boundaries forbid creating a
+  follow-on artifact while this RFC is `Experimental`, and an ADR file is one. This
+  section is already the authoritative current contract, so it is where a decision
+  taken before acceptance belongs. Each one graduates to an ADR when the RFC is
+  Accepted and implementation is separately authorised — the follow-on list already
+  reserves a slot for the first of them. RFC-0088 remains `Experimental`; open
+  questions 1, 2, 5 and 6 remain outstanding; no blocker item closes.
+
+  **AD-1 — authentication is an optional layer, not a precondition of page driving.**
+  The foundation ships page driving without any authentication mechanism. Sign-in and
+  the human handoff are a layer composed *onto* it, and a deployment that never
+  authenticates is a supported configuration rather than a degraded one. The
+  consequence the approver accepts: the credential-free core and the live-session layer
+  are separately buildable and separately testable, and the core's tests may not depend
+  on a credential existing. That split is what keeps CI meaningful — see AD-4.
+
+  **AD-2 — per-destination degradation is first-class.** Any single destination may go
+  dark — unreachable, contract-changed, or policy-refused — without failing the pack or
+  the session that reaches its other destinations. This adds nothing new; it states the
+  degradation semantics that decision C's destination-scoped egress constraint and
+  question 4's per-group worker policy already imply, so that a reader does not have to
+  derive them. The consequence: a destination's failure is reported as that
+  destination's state, and no aggregate health signal may collapse it into a
+  session-wide verdict.
+
+  **AD-3 — credentials resolve through the broker, and never cross a process boundary
+  to a model.** Credential resolution is `credbroker`'s, in its declared order, and a
+  resolved secret is never placed in a prompt, a tool argument, a transcript, or any
+  other value an LLM process can read. Nor is one committed. This has been true in
+  practice; what it did not have was a stated reason, which is that the credential
+  boundary and the model boundary are different boundaries, and a design that lets them
+  coincide has no way to say which one failed.
+
+  **AD-4 — a pinned container is the CI fixture, and it is load-bearing.** The fixture
+  is not a convenience stand-in for a real destination. It is the *only* destination
+  whose credentials this repository may own, and therefore the only place the full
+  login → token → frontend-API path can be asserted mechanically rather than described.
+  Two consequences the approver accepts by taking it. Fixtures are **synthetic**, never
+  recorded from a live account: a captured response would put third-party content and
+  personal data in the repository, and both are prohibited, so no recorded transcript
+  may be used however convenient. And the fixture must be a *container* — an image
+  pinned by digest that CI can start — rather than a hosted demo instance, because a
+  hosted instance is a third party the repository would be contacting on every run.
+  That clause did real work this round: it is what excluded the leading candidate.
+
+  **Scope residual, carried from the withdrawn narrowing.** An earlier proposal would
+  have narrowed `web-pilot`'s scope to destinations offering no token mechanism at all.
+  That proposal is **withdrawn** — token unavailability is org-by-org and commonly
+  reflects process friction or IT maturity rather than a deliberate posture, so the
+  narrowing would have excluded the ordinary case while claiming to exclude an
+  exceptional one. One narrow constraint survives it, and it is the whole residual: the
+  pack must not be positioned as a substitute for a credential an operator *explicitly
+  refused* to a user who asked for it. That is a constraint on how the pack is
+  described and offered, not on which destinations it may technically reach.
+
+  **The round-14 destination measurement, and it is a finding against question 5.**
+  Question 5's recommended accommodation keeps a captured bearer token **page-resident**
+  so the broker never holds it. Round 12 established that accommodation against a
+  synthetic issuer, and established it *conditionally*: it held when the issuing
+  response was marked `no-store`, and the otherwise identical default-cache arm left
+  the live token at rest in browser user-data. Round 14 put that condition to a real
+  destination for the first time, and the condition does not hold.
+
+  Two pinned containers were stood up and driven through a real browser login, chosen
+  for opposite render and authentication shape. Measured, not read from documentation:
+
+  - The token-issuing response carries **no cache directive at all** — not `no-store`,
+    not `private`, nothing. The precondition round 12 identified is simply absent.
+  - The issued token is written by the destination's own frontend into a
+    **page-readable web-storage key**, from which it reaches browser user-data on disk.
+
+  The second observation is the sharper one, and it is why this is a finding rather
+  than a missing header. Even a destination that *did* send `no-store` would leave the
+  live token at rest here, because the exposure comes from the destination's storage
+  choice rather than from the response cache. Keeping the token page-resident does not
+  prevent it. **No consumer can fix either.** A consumer does not set the destination's
+  cache-control and does not choose where the destination's frontend stores its own
+  token, so question 5's recommended accommodation is conditional on behaviour that
+  sits entirely outside the boundary this RFC governs.
+
+  The contrast half of the pair shows the condition is not universal in the other
+  direction either: its credential is an `HttpOnly` cookie that page script cannot read
+  at all, so a page-resident replay consumer cannot capture it — the accommodation is
+  not *unsafe* there, it is *inapplicable*. Question 5 therefore stays **outstanding**,
+  and what it now needs is not a better accommodation but a decision about which
+  destination behaviours the pack will refuse to accommodate. Apparatus, row inventory,
+  mutation controls and the at-rest scan are recorded in
+  [the destination token-landing note](0088-notes/spikes/2026-08-21-destination-token-landing.md).

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3451,11 +3451,15 @@ that mechanism rather than record the channel as inherently uncontrollable.
   destination's state, and no aggregate health signal may collapse it into a
   session-wide verdict.
 
-  **AD-3 — credentials resolve through the broker, and no model-reachable process may
-  hold or obtain one.** Credential resolution is `credbroker`'s, in its declared order.
-  The boundary is stated as a **property, not a list of channels**: no LLM-reachable
-  process may hold, or be able to obtain, a resolved or destination-issued credential.
-  Nor is one committed. The reason it did not have before is that the credential
+  **AD-3 — credentials resolve through the broker, and no model-facing tool can reach
+  one.** Credential resolution is `credbroker`'s, in its declared order. The boundary is
+  stated as a **property, not a list of channels**, and the property is about *reach*
+  rather than about *possession*: no credential — resolved or destination-issued — is
+  reachable by a model-facing tool, and any credential a process does hold carries a
+  declared lifetime. Possession by some process is unavoidable; a browser holds a
+  session in order to be a browser. Reachability is the thing a design controls, and
+  writing the property as "no process may hold one" would forbid the architecture AD-1
+  and AD-4 are building. Nor is a credential committed. The reason it did not have before is that the credential
   boundary and the model boundary are different boundaries, and a design that lets them
   coincide has no way to say which one failed.
 
@@ -3467,8 +3471,9 @@ that mechanism rather than record the channel as inherently uncontrollable.
   tool obtains the credential without using any of the obvious three. Two derived
   obligations follow for the build, and they are consequences of this decision rather
   than criteria this round claims to have met: a browser user-data directory is a
-  credential-bearing artifact with a declared lifetime, and a page-resident token is
-  out of reach of every model-facing tool.
+  credential-bearing artifact whose lifetime is declared and enforced, and a
+  page-resident token is out of reach of every model-facing tool. Both are statements
+  about reach and lifetime, which is why the headline is written that way.
 
   **Scope.** AD-3 governs production packs, adapters and CLI surfaces. The
   out-of-repository evidence apparatus is outside it and reads its fixture credential

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
@@ -1,11 +1,11 @@
 # Plan: rfc0088-round14-destination-adapter-contract
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Approved
+- **Status:** Done
 
 ## Approach
 
-Six tasks in dependency order, delivered as one review unit. The ordering is forced by
+Seven tasks in dependency order, delivered as one review unit. The ordering is forced by
 a single fact: **the fixture pair cannot be specified before it is measured.** T1 and T2
 are candidate elimination and measurement; everything the spec says about the pair is
 downstream of what they observed. Writing the RFC amendment first would have meant
@@ -63,6 +63,28 @@ row inventory. Record the raw observation before designing the assertions around
 designing assertions first is how a measurement gets calibrated to the answer it
 expected.
 
+**Outcome:** pair selected. The SPA half's login document arrives with no `<form>` and
+no password input and acquires both under script; the contrast half's arrives with each
+already present. The token-issuing response carries no cache directive, and the token
+reaches browser user-data at rest through the destination's own web-storage write.
+
+### T2a — Probe the reference consumer's unauthenticated surface
+
+**Depends on:** none
+**Verification mode:** goal-based check
+**Tests:** no stub (goal-based). *Done when:* the note records the probe date, each
+surface probed, and the status code observed for each.
+
+**Approach:** a handful of unauthenticated read-only requests against documented public
+endpoints, to establish which surfaces need the session. This is the round's only
+third-party contact and it sits under the spec's **Ask first** tier: it is operator-run,
+outside the repository's execution path, and never enters CI. Probing identifiers until
+a private one is found is refused rather than asked about — that is enumeration against
+a third party.
+
+**Outcome:** the public variant is open, an account-scoped surface is gated, and the
+private variant is recorded as unmeasured with the one input that would close it.
+
 ### T3 — Build the measurement arm
 
 **Depends on:** T2
@@ -79,7 +101,12 @@ and the baseline results before the first mutation run: a harness killed mid-run
 the mutant in place, and an untracked file does not show up in `git status`.
 
 Two rows are declared failing and mutate *toward passing*. A privacy row asserts over
-the serialized artifact bytes rather than over the code that built them.
+the serialized artifact bytes rather than over the code that built them, in two passes,
+with the second gating the write.
+
+**Outcome:** eleven rows, twelve mutation cases — one row is a conjunction and carries a
+case per load-bearing conjunct. Baseline and harness both clean, no stale mutants, and
+the harness summary persisted beside the results artifact.
 
 ### T4 — Amend open question 3 and record the decision records
 
@@ -94,6 +121,9 @@ second one, so the RFC never carries two answers. Leave question 4's ruling unto
 Append the decision records as a new same-level amendment bullet, which also bounds the
 preceding section correctly for the decision-surface reader.
 
+**Outcome:** done, and a stale row in the Current Experimental state table that this
+round contradicted outright was corrected in the same pass.
+
 ### T5 — Write the note and its digest entry
 
 **Depends on:** T3, T4
@@ -105,6 +135,10 @@ new note enumerated and covered by exactly one entry above its substance floor.
 apparatus figures out of both the entry and the note's headline claims; the figure
 boundary module is the authority, not judgement about what reads like a headline.
 
+**Outcome:** done. The note describes the reference consumer by shape rather than by
+name — a provider's API vocabulary identifies it as surely as its name does, and the
+note also records an operator account relationship.
+
 ### T6 — Register the spec and run the gate chain
 
 **Depends on:** T5
@@ -112,6 +146,10 @@ boundary module is the authority, not judgement about what reads like a headline
 **Tests:** no stub (goal-based). *Done when:* the spec has a workspace entry, the
 governance controls pass, and the repository gate chain reports no new failure against
 its pre-round state.
+
+**Outcome:** registered in `["ini-002".work].shipped`; governance controls, inherited
+apparatus controls, the privacy sweep, `lint-spec-status`, the documentation-entry link
+tests and `SKIP_SAST=1 make build-check` all clean.
 
 ## Rollout and recovery
 
@@ -123,9 +161,11 @@ affects no other harness, since it extends no shared verifier and shares no corp
 
 ## Risks
 
-- **The fixture pair drifts.** Both halves are pinned by tag today. A digest pin is the
-  stronger form and belongs with the build that consumes them, not with this round,
-  which only selects them.
+- **The fixture pair drifts.** Closed: both halves are pinned by image digest in the
+  note, which is what AD-4 requires and what makes a re-run comparable. The tag is kept
+  beside the digest for readability only. What remains open is the registry the pull
+  contacts on a cold cache; AD-4 names it as an allowlisted egress rather than pretending
+  a pinned container has none.
 - **The measurement generalises further than it should.** Two destinations establish
   that the accommodation's precondition is not universal; they do not establish a
   population. The note and the amendment both say so.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
@@ -75,6 +75,10 @@ reaches browser user-data at rest through the destination's own web-storage writ
 **Tests:** no stub (goal-based). *Done when:* the note records the probe date, each
 surface probed, and the status code observed for each.
 
+**Authorisation:** pre-authorised by the RFC approver, who commissioned this probe by
+name as one of the round's three named checks. Recorded here because an Ask-first tier
+whose only instance ran with no recorded ask is a tier that permits everything.
+
 **Approach:** a handful of unauthenticated read-only requests against documented public
 endpoints, to establish which surfaces need the session. This is the round's only
 third-party contact and it sits under the spec's **Ask first** tier: it is operator-run,
@@ -126,7 +130,7 @@ round contradicted outright was corrected in the same pass.
 
 ### T5 — Write the note and its digest entry
 
-**Depends on:** T3, T4
+**Depends on:** T2a, T3, T4
 **Verification mode:** goal-based check
 **Tests:** no stub (goal-based). *Done when:* `r13-digest-coverage.py` passes with the
 new note enumerated and covered by exactly one entry above its substance floor.
@@ -136,8 +140,8 @@ apparatus figures out of both the entry and the note's headline claims; the figu
 boundary module is the authority, not judgement about what reads like a headline.
 
 **Outcome:** done. The note describes the reference consumer by shape rather than by
-name — a provider's API vocabulary identifies it as surely as its name does, and the
-note also records an operator account relationship.
+name, endpoint vocabulary included — a provider's API terminology identifies it as
+surely as its name does.
 
 ### T6 — Register the spec and run the gate chain
 

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/plan.md
@@ -1,0 +1,134 @@
+# Plan: rfc0088-round14-destination-adapter-contract
+
+- **Spec:** [`spec.md`](spec.md)
+- **Status:** Approved
+
+## Approach
+
+Six tasks in dependency order, delivered as one review unit. The ordering is forced by
+a single fact: **the fixture pair cannot be specified before it is measured.** T1 and T2
+are candidate elimination and measurement; everything the spec says about the pair is
+downstream of what they observed. Writing the RFC amendment first would have meant
+naming a candidate that does not start.
+
+Row counts, closure tallies and residual counts are deliberately absent from this
+Approach. Their canonical homes are `workspace.toml [backlog].open` and the digest's
+disposition block; restating them here would drift at the first edit to either.
+
+The round's shape differs from round 13's. Round 13 was mostly *disposition* over
+existing evidence. Round 14 is one measurement plus one governance amendment, and the
+measurement exists to make the amendment honest rather than the other way round.
+
+## Constraints
+
+- No new repository dependency, no compile step, no production interface change.
+- No real credential, live account, or captured response anywhere in the repository or
+  in a results artifact.
+- No third-party contact from the repository. The reference-consumer probe is an
+  operator-run, read-only observation outside the repository's execution path.
+- Every RFC hunk below the `## Amendments` anchor. The body is frozen.
+- No file matching a follow-on-artifact shape is created.
+- The evidence apparatus stays out of tree at its existing location. Nothing about it is
+  recreated.
+
+## Tasks
+
+### T1 — Eliminate or confirm the leading candidate
+
+**Depends on:** none
+**Verification mode:** goal-based check
+**Tests:** no stub (goal-based). *Done when:* the candidate's server has been started
+in a container and its outcome recorded — either it serves a login surface, or it
+refuses and the refusal is the recorded reason for elimination.
+
+**Approach:** pull the image, invoke the API server with no cluster configuration, and
+read what it does. A documentation-confirmed authentication shape is worth nothing if
+the component cannot start the way the fixture contract requires, and that is only
+visible by trying.
+
+**Outcome:** eliminated. The server exits fatal on a missing cluster configuration, so
+it would be a control plane rather than a pinned container.
+
+### T2 — Stand up the fixture pair and measure token landing and cache-control
+
+**Depends on:** T1
+**Verification mode:** visual / manual QA, then goal-based
+**Tests:** no stub (manual QA first). *Done when:* both containers serve a login
+surface, a real browser login succeeds against each, and the login document's render
+shape, the issuing response's cache directive, the token's storage location, and the
+closed profile's at-rest contents are each observed rather than inferred.
+
+**Approach:** exploratory probe first, to learn the shapes without committing them to a
+row inventory. Record the raw observation before designing the assertions around it —
+designing assertions first is how a measurement gets calibrated to the answer it
+expected.
+
+### T3 — Build the measurement arm
+
+**Depends on:** T2
+**Verification mode:** TDD-shaped via the mutation harness
+**Tests:** the mutation harness is the test. Each declared row has a case asserting the
+row's *flipped* outcome under mutation; the no-op case asserts a clean run reports
+clean. Red state: a row with no case, or a case whose anchor is not unique within the
+mutable region, throws.
+
+**Approach:** follow the round-12 page-resident driver's construction — declared row
+inventory checked against emitted rows, mutable region below an explicit marker, anchor
+uniqueness asserted over the region the replacement actually uses. Back up the driver
+and the baseline results before the first mutation run: a harness killed mid-run leaves
+the mutant in place, and an untracked file does not show up in `git status`.
+
+Two rows are declared failing and mutate *toward passing*. A privacy row asserts over
+the serialized artifact bytes rather than over the code that built them.
+
+### T4 — Amend open question 3 and record the decision records
+
+**Depends on:** T2
+**Verification mode:** goal-based check
+**Tests:** no stub (goal-based). *Done when:* `r13-decision-surface.py` reports one
+record per open question with every hunk inside the evidence layer, and
+`r13-digest-coverage.py` reports no prohibited apparatus figure in the round-13 section.
+
+**Approach:** rewrite the superseded question-3 ruling in place rather than appending a
+second one, so the RFC never carries two answers. Leave question 4's ruling untouched.
+Append the decision records as a new same-level amendment bullet, which also bounds the
+preceding section correctly for the decision-surface reader.
+
+### T5 — Write the note and its digest entry
+
+**Depends on:** T3, T4
+**Verification mode:** goal-based check
+**Tests:** no stub (goal-based). *Done when:* `r13-digest-coverage.py` passes with the
+new note enumerated and covered by exactly one entry above its substance floor.
+
+**Approach:** append the digest entry rather than inserting it. Keep prohibited
+apparatus figures out of both the entry and the note's headline claims; the figure
+boundary module is the authority, not judgement about what reads like a headline.
+
+### T6 — Register the spec and run the gate chain
+
+**Depends on:** T5
+**Verification mode:** goal-based check
+**Tests:** no stub (goal-based). *Done when:* the spec has a workspace entry, the
+governance controls pass, and the repository gate chain reports no new failure against
+its pre-round state.
+
+## Rollout and recovery
+
+Single branch, single review unit, squash-merged. Recovery is `git revert` of one
+commit range: nothing in this round is consumed by another artifact at build time, and
+the evidence apparatus is out of tree, so reverting the repository side leaves no
+dangling reference. The apparatus arm is additive — removing it disables one arm and
+affects no other harness, since it extends no shared verifier and shares no corpus.
+
+## Risks
+
+- **The fixture pair drifts.** Both halves are pinned by tag today. A digest pin is the
+  stronger form and belongs with the build that consumes them, not with this round,
+  which only selects them.
+- **The measurement generalises further than it should.** Two destinations establish
+  that the accommodation's precondition is not universal; they do not establish a
+  population. The note and the amendment both say so.
+- **The note is unregistered in the figure-verifier corpus**, so its figures are carried
+  by the results artifact rather than by claim accounting. Stated as a limit in the note
+  rather than silently accepted.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -176,10 +176,17 @@ is implied that did not happen.
   enumeration was performed against a third party, and the provider is described by
   shape rather than named — including its endpoint vocabulary, because a provider's API
   terminology identifies it as surely as its name does.
-- [x] **AC12 — The round's governance controls stay green.** The digest covers the new
-  note with exactly one entry; the decision surface still carries one record per open
-  question; every RFC hunk sits below the `## Amendments` anchor; the follow-on-absence
-  detector reports nothing created.
+- [x] **AC12 — The round's governance controls hold, with one pre-existing failure
+  named rather than absorbed.** The digest covers the new note with exactly one entry;
+  the decision surface carries one record per open question; every RFC hunk sits below
+  the `## Amendments` anchor; the follow-on-absence detector's self-test passes and this
+  round created nothing matching a follow-on shape. The decision-surface gate itself is
+  **red for a reason this round did not cause**: its added-paths check is scoped to a
+  pinned base commit, so an ADR merged by another team after that base trips it. Verified
+  by running the gate against a clean checkout of the default branch, where it fails
+  identically with no RFC-0088 work present. Carried as
+  `rfc0088-decision-surface-base-scoping`; rescoping another round's control is that
+  round's decision, not this one's.
 - [x] **AC13 — The round's verdict remains NOT FINAL with its carried residuals
   unchanged.** No residual is relabelled, and no disposition moves. This round adds
   evidence and amends one bar; it does not shorten the tail.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -52,20 +52,43 @@ is implied that did not happen.
 
 ## Boundaries
 
-- **No follow-on artifact.** RFC-0088 is `Experimental`, so no ADR file, no `Spec 1/2/3`
-  and no `auth: browser-session` convention artifact is created. The four decision
+### Always do
+
+- Put every RFC hunk **below** the `## Amendments` anchor; the body above it is frozen.
+- Pin each fixture by image digest, and record the digest where a reader can re-derive
+  the measurement from it.
+- Record a residual that cannot be measured as a residual, naming the one input that
+  would close it — never as a weaker claim that can be met.
+- Re-run the inherited apparatus controls after touching anything shared, and the
+  privacy sweep with its detector self-test, so a clean result is not a vacuous one.
+
+### Ask first
+
+- **Probing any third-party surface**, even read-only and unauthenticated. The
+  reference-consumer probe in T2a is the only one this round performs; it is
+  operator-run, outside the repository's execution path, and bounded to a handful of
+  requests against documented public endpoints. Enumerating identifiers to find a
+  private one is refused outright, not asked about.
+- Registering a new note in the figure-verifier document corpus, which brings it under
+  claim accounting and changes what later rounds must maintain.
+- Adding any repository dependency, toolchain, or compile step.
+
+### Never do
+
+- **Create a follow-on artifact.** RFC-0088 is `Experimental`, so no ADR file, no
+  `Spec 1/2/3` and no `auth: browser-session` convention artifact. The four decision
   records live in the RFC's amendment layer, which the RFC already designates as the
   authoritative current contract, and graduate to ADRs on acceptance.
-- **No production interface changes.** No pack, no adapter, no CLI surface.
-- **No third-party contact from the repository.** Fixtures are pinned containers reached
-  over loopback. The reference consumer never runs in CI.
-- **No captured fixtures.** Every fixture is synthetic and created against the container
-  at run time. A recorded response would place third-party content and personal data in
-  the repository.
-- **No credential, personal identifier, or destination origin** in the repository or in
-  any results artifact. Generic placeholders only.
-- **No terms-of-service or case-law reasoning** in any repository artifact. The
-  amendment layer receives architectural statements only.
+- Change a production interface — no pack, no adapter, no CLI surface.
+- Create any path by which the repository or CI contacts a third party. Fixtures are
+  pinned containers reached over loopback; the reference consumer never runs in CI.
+- Capture a fixture from a live account. Every fixture is synthetic and created against
+  the container at run time; a recorded response would place third-party content and
+  personal data in the repository.
+- Put a credential, personal identifier, account relationship, or destination origin in
+  the repository or in any results artifact. Generic placeholders only.
+- Put terms-of-service or case-law reasoning in any repository artifact. The amendment
+  layer receives architectural statements only.
 
 ## Acceptance criteria
 
@@ -85,44 +108,62 @@ is implied that did not happen.
   boundary to a model; a pinned container as the load-bearing CI fixture. Plus the
   withdrawn scope narrowing's one surviving constraint. Each states what the approver
   accepts by taking it.
-- [x] **AC4 — The credential-free core and the live-session layer are separable, and
-  the fixture pair can tell them apart.** This is structural, not conventional: the
-  server-rendered half's credential is unreadable by page script, so a page-resident
-  consumer cannot operate against it *at all*, while page driving against it is
-  unaffected. A pair that could not distinguish the two layers would let a build
-  conflate them and still pass.
+- [x] **AC4 — The fixture pair discriminates the credential-free core from the
+  live-session layer, and a declared row fails if it does not.** This is structural, not
+  conventional, and it is checked rather than argued: `R14-SR-TOKEN-NOT-PAGE-READABLE`
+  asserts that the contrast half's credential is unreadable from page script — no
+  JS-visible cookie, no web-storage entry — on a session `R14-SR-AUTHENTICATED-SESSION`
+  has separately proven is authenticated. A page-resident consumer therefore cannot
+  operate against that half at all, which is what makes the live-session layer separable
+  from page driving rather than a precondition of it. Both rows carry mutations, and the
+  contrast row carries a second case aimed at the `HttpOnly` conjunct specifically, so
+  the property the criterion rests on is not the one conjunct nobody tests.
 - [x] **AC5 — The fixture pair is selected on measurement, and the rejection is
   recorded with its reason.** Both halves are pinned container images. Their render
   shapes are observed from the login document as delivered — one arrives without a
   `<form>` element or password input and acquires both under script; the other arrives
-  with each already present. The leading candidate's elimination (its server refuses to
-  start without a cluster API, so it is a control plane and not a pinned container) is
-  recorded as a measurement, not a preference.
+  with each already present. Both are pinned by image digest, recorded in the note. The
+  leading candidate's elimination is recorded as a measurement rather than a preference,
+  and is re-derivable: the note quotes the fatal startup line its server emits with no
+  cluster configuration, which is what makes it a control plane and not a container.
 - [x] **AC6 — The token-landing and cache-control observations are recorded as a
-  finding against open question 5, and question 5 stays outstanding.** The issuing
-  response carries no cache directive; the destination's own frontend writes the token
-  to a page-readable web-storage key from which it reaches browser user-data at rest.
+  finding against open question 5, and question 5 stays outstanding.** On the half that
+  issues a token, that response carries no cache directive; the destination's own
+  frontend writes the token to a page-readable web-storage key from which it reaches
+  browser user-data at rest. The claim is scoped to that half in every place it appears,
+  because the contrast half issues no token and its cookie arrives `private`-marked.
   The record states plainly that no consumer controls either, so the accommodation's
   precondition sits outside the boundary this RFC governs.
 - [x] **AC7 — The measurement arm carries a declared row inventory, in-region anchor
   uniqueness, and a mutation harness that fails on a stale anchor rather than
   skipping.** Every declared row has a mutation that changes that row's outcome, the
   harness asserts the flipped value, and the unmutated baseline is recorded immediately
-  before the harness runs so both directions are observed.
+  before the harness runs so both directions are observed. The harness's own summary is
+  persisted beside the results artifact, because the artifact's `coverage` block is
+  derived from the row inventory and would report clean whether the harness ran or not.
+  A row that is a conjunction carries a case per load-bearing conjunct, not one per row.
 - [x] **AC8 — Declared-failing rows mutate toward passing.** For a row whose recorded
   outcome is a finding, the risk is not a spurious failure but a row that could never
   have passed. Both declared-failing rows are mutated in the passing direction.
 - [x] **AC9 — Absence claims are decoy-verified.** The at-rest scan plants a labelled
   decoy and requires its recovery; a buffer with no recovered plant is recorded
   absence-unverifiable and supports no absence claim.
-- [x] **AC10 — No credential reaches the results artifact, asserted over serialized
-  bytes.** The privacy row scans the serialized artifact for every encoded form of the
-  issued token and the fixture credential, rather than trusting the construction code.
+- [x] **AC10 — No credential, origin or fixture identity reaches the results artifact,
+  and a detected leak blocks the write.** Two passes, because the row's own result is
+  part of the artifact and a single pass over the final bytes cannot produce the row it
+  must contain. Pass one yields the row; pass two scans the exact bytes about to be
+  written and refuses the write on a hit, emitting a counts-only refusal instead. The
+  needle set covers the issued token, the fixture credential, both destination origins
+  and the fixture user name — origins included because a navigation timeout embeds the
+  URL in the error text and that text reaches the failure record.
 - [x] **AC11 — The reference consumer is an observation with provenance, never an
   acceptance criterion.** Its unauthenticated surface is probed read-only; the
-  public-by-identifier case and the gated manager-scoped case are both recorded, and the
-  private-league case is named as unmeasured with the one input that would close it. No
-  identifier enumeration was performed against a third party.
+  probe date, the four surfaces and their observed status codes are recorded in a table
+  in the note, so the observation can be re-run rather than taken on trust. The private
+  variant is named as unmeasured with the one input that would close it. No identifier
+  enumeration was performed against a third party, and the provider is described by
+  shape rather than named — its API vocabulary identifies it as surely as its name, and
+  the observation also records that the operator holds an account there.
 - [x] **AC12 — The round's governance controls stay green.** The digest covers the new
   note with exactly one entry; the decision surface still carries one record per open
   question; every RFC hunk sits below the `## Amendments` anchor; the follow-on-absence
@@ -136,11 +177,18 @@ is implied that did not happen.
 Goal-based checks and one measurement arm; no production code changes, so no unit
 surface.
 
-- **Governance controls** — `r13-digest-coverage.py`, `r13-decision-surface.py` (and its
-  follow-on-detector self-test), and `r13-spec-consistency.py` are run against the
-  working tree. These are the checks that would catch a frozen-body edit, a missing or
-  duplicated digest entry, a prohibited apparatus figure, and a created follow-on
-  artifact.
+- **Governance controls** — `r13-digest-coverage.py` and `r13-decision-surface.py` (with
+  its follow-on-detector self-test) are run against the working tree. These are the
+  checks that would catch a frozen-body edit, a missing or duplicated digest entry, a
+  prohibited apparatus figure, and a created follow-on artifact.
+  `r13-spec-consistency.py` is deliberately **not** listed: it hard-codes round 13's spec
+  directory, so running it here exercises nothing of round 14's, and reporting its green
+  result as this round's evidence would be a skip dressed as a pass. It is still run, as
+  a regression check that round 14 did not disturb round 13.
+- **Inherited apparatus controls** — the archive self-tests and the privacy sweep with
+  its detector self-test, because extending a shared tree has previously disabled a
+  second harness silently. The detector self-test is what stops a clean sweep from being
+  a vacuous one.
 - **Measurement arm** — the driver is run unmutated to record the baseline, then run
   under its own mutation harness. A row that does not flip, or an anchor that is not
   unique within the mutable region, fails the harness loudly.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -176,17 +176,22 @@ is implied that did not happen.
   enumeration was performed against a third party, and the provider is described by
   shape rather than named — including its endpoint vocabulary, because a provider's API
   terminology identifies it as surely as its name does.
-- [x] **AC12 — The round's governance controls hold, with one pre-existing failure
-  named rather than absorbed.** The digest covers the new note with exactly one entry;
-  the decision surface carries one record per open question; every RFC hunk sits below
-  the `## Amendments` anchor; the follow-on-absence detector's self-test passes and this
-  round created nothing matching a follow-on shape. The decision-surface gate itself is
-  **red for a reason this round did not cause**: its added-paths check is scoped to a
-  pinned base commit, so an ADR merged by another team after that base trips it. Verified
-  by running the gate against a clean checkout of the default branch, where it fails
-  identically with no RFC-0088 work present. Carried as
-  `rfc0088-decision-surface-base-scoping`; rescoping another round's control is that
-  round's decision, not this one's.
+- [x] **AC12 — The round's governance controls are green, and the one that was not is
+  fixed rather than carried.** The digest covers the new note with exactly one entry; the
+  decision surface carries one record per open question; every RFC hunk sits below the
+  `## Amendments` anchor; the follow-on-absence detector's self-test passes and this
+  round created nothing matching a follow-on shape.
+  The decision-surface gate's added-paths check was **rescoped** from a pinned base to
+  the merge-base with the upstream default branch, because against a pinned base it
+  answered "what has anyone created since" and had gone red on a clean default branch
+  through another team's ADR. Narrowed, not disabled: a planted ADR in this tree is still
+  caught, and a new self-test asserts the peer case is excluded, the pinned-base read
+  still shows it, and a round-created artifact is caught. It runs in the gate chain.
+- [x] **AC12b — A pre-existing apparatus failure is named rather than absorbed.**
+  `r12-fact-negative-tests.py` is red, fails with more cases against a clean checkout of
+  the default branch than against this branch, and references nothing this round edited.
+  Carried as `rfc0088-r12-fact-negative-tests-red`. This round does not claim a green
+  full gate chain; it claims the individually-run controls it depends on.
 - [x] **AC13 — The round's verdict remains NOT FINAL with its carried residuals
   unchanged.** No residual is relabelled, and no disposition moves. This round adds
   evidence and amends one bar; it does not shorten the tail.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -1,0 +1,159 @@
+# Spec: rfc0088-round14-destination-adapter-contract
+
+- **Status:** Shipped
+- **Owner:** eugenelim
+- **Plan:** [`plan.md`](plan.md)
+- **Constrained by:**
+  - [RFC-0088](../../rfc/0088-web-pilot-foundation.md) — Experimental. This spec amends
+    open question 3's bar in the amendment layer, records four decision records and one
+    scope residual there, and adds one measurement arm. It moves no status field,
+    closes no blocker item, and creates no follow-on artifact.
+  - [RFC-0093](../../rfc/0093-intent-scoped-completion.md) — the accepted intent is the
+    whole round; it is delivered as one review unit in one session.
+- **Contract:** none for production interfaces. This spec produces an RFC
+  amendment-layer entry, one evidence note, one digest entry, and changes only the
+  existing out-of-repository evidence apparatus named in the plan.
+- **Shape:** service
+
+## Objective
+
+Round 14 answers the one question that blocked open question 3 from being ruled
+usefully: **what should the bar actually measure?** The recommended default counted
+shipped consumers. That count is unsatisfiable in principle, not merely unsatisfied —
+`web-pilot`'s legitimate destinations are predominantly operator-internal surfaces no
+pack may bundle, so the count measures what the pack is *permitted to ship* rather than
+whether the foundation works.
+
+The bar is therefore re-denominated as a **destination adapter contract**, exercised by
+two independent fixtures of differing render and authentication shape, plus one
+documented reference consumer an adopter runs against their own account. The contract
+is asserted in CI; the reference consumer is a recorded observation.
+
+Two things follow that this round has to *establish* rather than assert.
+
+**The fixture pair has to be measured, not proposed.** A bar naming two fixtures of
+differing shape is empty until two such containers are known to exist, to start, and to
+differ in the way claimed. This round stands them up and observes them.
+
+**The measurement that selects them also tests open question 5.** Round 12 established
+the page-resident replay accommodation *conditionally* — it held only when the issuing
+response was marked `no-store` — against a synthetic issuer this project controls. The
+condition is a property of a destination, so it had never been tested against one. This
+round tests it, and it does not hold.
+
+### Sequencing, recorded rather than backfilled
+
+The measurement was taken **before** this spec was written. That ordering is deliberate
+and is not presented as anything else: the fixture pair could not be specified until it
+was known which candidates start as a single pinned container, and the leading
+candidate was eliminated only by trying to run it. This spec describes the intended
+final state and the already-observed repository reality; no implementation chronology
+is implied that did not happen.
+
+## Boundaries
+
+- **No follow-on artifact.** RFC-0088 is `Experimental`, so no ADR file, no `Spec 1/2/3`
+  and no `auth: browser-session` convention artifact is created. The four decision
+  records live in the RFC's amendment layer, which the RFC already designates as the
+  authoritative current contract, and graduate to ADRs on acceptance.
+- **No production interface changes.** No pack, no adapter, no CLI surface.
+- **No third-party contact from the repository.** Fixtures are pinned containers reached
+  over loopback. The reference consumer never runs in CI.
+- **No captured fixtures.** Every fixture is synthetic and created against the container
+  at run time. A recorded response would place third-party content and personal data in
+  the repository.
+- **No credential, personal identifier, or destination origin** in the repository or in
+  any results artifact. Generic placeholders only.
+- **No terms-of-service or case-law reasoning** in any repository artifact. The
+  amendment layer receives architectural statements only.
+
+## Acceptance criteria
+
+- [x] **AC1 — Open question 3's bar is amended in one place, and no earlier reading of
+  it survives.** The amendment layer states the bar as a destination adapter contract
+  exercised by two independent fixtures of differing render and authentication shape
+  plus one documented reference consumer, and closes with "The contract is asserted in
+  CI; the reference consumer is a recorded observation." The superseded count-based
+  ruling is **rewritten, not appended to**, so the RFC carries exactly one answer to
+  question 3.
+- [x] **AC2 — Open question 4's ruling is untouched.** The per-destination-group worker
+  policy re-draft and its carried `rfc0088-destination-group-split-cost` residual are
+  unchanged by this round.
+- [x] **AC3 — Four decision records and one scope residual are recorded as
+  architecture.** Authentication as an optional layer; per-destination degradation as
+  first-class; credential resolution through the broker and never across a process
+  boundary to a model; a pinned container as the load-bearing CI fixture. Plus the
+  withdrawn scope narrowing's one surviving constraint. Each states what the approver
+  accepts by taking it.
+- [x] **AC4 — The credential-free core and the live-session layer are separable, and
+  the fixture pair can tell them apart.** This is structural, not conventional: the
+  server-rendered half's credential is unreadable by page script, so a page-resident
+  consumer cannot operate against it *at all*, while page driving against it is
+  unaffected. A pair that could not distinguish the two layers would let a build
+  conflate them and still pass.
+- [x] **AC5 — The fixture pair is selected on measurement, and the rejection is
+  recorded with its reason.** Both halves are pinned container images. Their render
+  shapes are observed from the login document as delivered — one arrives without a
+  `<form>` element or password input and acquires both under script; the other arrives
+  with each already present. The leading candidate's elimination (its server refuses to
+  start without a cluster API, so it is a control plane and not a pinned container) is
+  recorded as a measurement, not a preference.
+- [x] **AC6 — The token-landing and cache-control observations are recorded as a
+  finding against open question 5, and question 5 stays outstanding.** The issuing
+  response carries no cache directive; the destination's own frontend writes the token
+  to a page-readable web-storage key from which it reaches browser user-data at rest.
+  The record states plainly that no consumer controls either, so the accommodation's
+  precondition sits outside the boundary this RFC governs.
+- [x] **AC7 — The measurement arm carries a declared row inventory, in-region anchor
+  uniqueness, and a mutation harness that fails on a stale anchor rather than
+  skipping.** Every declared row has a mutation that changes that row's outcome, the
+  harness asserts the flipped value, and the unmutated baseline is recorded immediately
+  before the harness runs so both directions are observed.
+- [x] **AC8 — Declared-failing rows mutate toward passing.** For a row whose recorded
+  outcome is a finding, the risk is not a spurious failure but a row that could never
+  have passed. Both declared-failing rows are mutated in the passing direction.
+- [x] **AC9 — Absence claims are decoy-verified.** The at-rest scan plants a labelled
+  decoy and requires its recovery; a buffer with no recovered plant is recorded
+  absence-unverifiable and supports no absence claim.
+- [x] **AC10 — No credential reaches the results artifact, asserted over serialized
+  bytes.** The privacy row scans the serialized artifact for every encoded form of the
+  issued token and the fixture credential, rather than trusting the construction code.
+- [x] **AC11 — The reference consumer is an observation with provenance, never an
+  acceptance criterion.** Its unauthenticated surface is probed read-only; the
+  public-by-identifier case and the gated manager-scoped case are both recorded, and the
+  private-league case is named as unmeasured with the one input that would close it. No
+  identifier enumeration was performed against a third party.
+- [x] **AC12 — The round's governance controls stay green.** The digest covers the new
+  note with exactly one entry; the decision surface still carries one record per open
+  question; every RFC hunk sits below the `## Amendments` anchor; the follow-on-absence
+  detector reports nothing created.
+- [x] **AC13 — The round's verdict remains NOT FINAL with its carried residuals
+  unchanged.** No residual is relabelled, and no disposition moves. This round adds
+  evidence and amends one bar; it does not shorten the tail.
+
+## Testing strategy
+
+Goal-based checks and one measurement arm; no production code changes, so no unit
+surface.
+
+- **Governance controls** — `r13-digest-coverage.py`, `r13-decision-surface.py` (and its
+  follow-on-detector self-test), and `r13-spec-consistency.py` are run against the
+  working tree. These are the checks that would catch a frozen-body edit, a missing or
+  duplicated digest entry, a prohibited apparatus figure, and a created follow-on
+  artifact.
+- **Measurement arm** — the driver is run unmutated to record the baseline, then run
+  under its own mutation harness. A row that does not flip, or an anchor that is not
+  unique within the mutable region, fails the harness loudly.
+- **Repository gates** — `SKIP_SAST=1 make build-check`, the documentation-entry link
+  tests, and the site link check, via the round's existing gate chain.
+
+## Non-goals
+
+- Building the adapter contract the amended bar names. That is implementation, gated
+  behind RFC acceptance and separate authorisation.
+- Closing open question 5. This round supplies a finding against its recommended
+  accommodation; deciding which destination behaviours the pack will refuse to
+  accommodate is a ruling, not a measurement.
+- Registering the new note in the figure-verifier document corpus. Doing so brings it
+  under claim accounting, which this round did not commission; the note states the
+  limitation.

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -24,10 +24,11 @@ shipped consumers. That count is unsatisfiable in principle, not merely unsatisf
 pack may bundle, so the count measures what the pack is *permitted to ship* rather than
 whether the foundation works.
 
-The bar is therefore re-denominated as a **destination adapter contract**, exercised by
-two independent fixtures of differing render and authentication shape, plus one
-documented reference consumer an adopter runs against their own account. The contract
-is asserted in CI; the reference consumer is a recorded observation.
+The bar is therefore re-denominated. Its canonical statement is the blockquote in
+RFC-0088's amendment layer, and this spec deliberately does not restate it — the same
+entry declares that a bar written twice is a bar that disagrees with itself at the first
+edit, and a spec that copies it would be the second copy. AC1 quotes its closing
+sentence, which is an assertion about the text rather than a second home for the bar.
 
 Two things follow that this round has to *establish* rather than assert.
 
@@ -80,8 +81,10 @@ is implied that did not happen.
   records live in the RFC's amendment layer, which the RFC already designates as the
   authoritative current contract, and graduate to ADRs on acceptance.
 - Change a production interface — no pack, no adapter, no CLI surface.
-- Create any path by which the repository or CI contacts a third party. Fixtures are
-  pinned containers reached over loopback; the reference consumer never runs in CI.
+- Create any path by which the repository or CI contacts a third party **beyond the
+  one allowlisted egress AD-4 names**. Fixtures are reached over loopback once pulled;
+  the digest-pinned registry pull is that egress, and calling it an absence of egress
+  would be the claim AD-4 explicitly withdraws. The reference consumer never runs in CI.
 - Capture a fixture from a live account. Every fixture is synthetic and created against
   the container at run time; a recorded response would place third-party content and
   personal data in the repository.
@@ -156,14 +159,23 @@ is implied that did not happen.
   needle set covers the issued token, the fixture credential, both destination origins
   and the fixture user name — origins included because a navigation timeout embeds the
   URL in the error text and that text reaches the failure record.
+- [x] **AC12a — No browser user-data directory survives any exit path, and a survivor
+  is fatal.** The temporary profile holds the live token, so its removal is the round's
+  highest-consequence control and is asserted rather than described: `R14-PROFILE-REMOVAL`
+  fails if either profile remains, symlinks are unlinked before the confined removal (a
+  browser that exits uncleanly leaves `SingletonLock` behind, and the confined remover
+  refuses a symlink-bearing tree by design), a forced removal backs that up, a root that
+  survives every path is a fatal outcome rather than a field, and signal handlers cover
+  the interrupt path because `finally` does not run on a kill. Confinement is established
+  before anything is unlinked, so the blessed helper is used rather than bypassed.
 - [x] **AC11 — The reference consumer is an observation with provenance, never an
   acceptance criterion.** Its unauthenticated surface is probed read-only; the
   probe date, the four surfaces and their observed status codes are recorded in a table
   in the note, so the observation can be re-run rather than taken on trust. The private
   variant is named as unmeasured with the one input that would close it. No identifier
   enumeration was performed against a third party, and the provider is described by
-  shape rather than named — its API vocabulary identifies it as surely as its name, and
-  the observation also records that the operator holds an account there.
+  shape rather than named — including its endpoint vocabulary, because a provider's API
+  terminology identifies it as surely as its name does.
 - [x] **AC12 — The round's governance controls stay green.** The digest covers the new
   note with exactly one entry; the decision surface still carries one record per open
   question; every RFC hunk sits below the `## Amendments` anchor; the follow-on-absence

--- a/workspace.toml
+++ b/workspace.toml
@@ -150,6 +150,7 @@ active  = [
 ]
 shipped = [
   {path = "docs/specs/rfc0088-round12-consumer-shaped-residuals/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Measure RFC-0088 open questions 4-6", needs = []},
+  {path = "docs/specs/rfc0088-round14-destination-adapter-contract/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Amend RFC-0088 open question 3 to a destination adapter contract and measure the fixture pair", needs = []},
   # P5 · Adopt — independent slices constrained by adopter-persona evidence.
   {path = "docs/specs/m6-astro-work-index/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Give PMs a static read-only view of canonical workspace status", needs = []},
   {path = "docs/specs/m6-enterprise-rollout-playbook/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Guide champions through pilot, wave, and organization-wide adoption", needs = []},

--- a/workspace.toml
+++ b/workspace.toml
@@ -1173,16 +1173,15 @@ open = [
   # keyed HMAC; across chains it remains operator-trusted, so this is bounded, not
   # closed.
   {slug = "rfc0088-privacy-term-identity-anchor", source = "round-12 security review"},
-  # RFC-0088 round-14 pre-flight, not caused by round 14. r13-decision-surface.py
-  # scopes its follow-on-artifact check to paths added since a PINNED base commit,
-  # so any ADR merged by any team after that base trips it. PR #1086's
-  # docs/adr/0093-okf-reference-corpora-... does, and the gate now fails on a
-  # CLEAN checkout of origin/main with no RFC-0088 work present -- verified in a
-  # detached worktree. Round 14 does not fix it: rescoping another round's
-  # control is its own decision. The next round cannot get a green decision
-  # surface until "added" is scoped to the round's own commits rather than to
-  # everything since the base.
-  {slug = "rfc0088-decision-surface-base-scoping", source = "pre-flight/2026-08-22"},
+  # RFC-0088 round-14 pre-flight, not caused by round 14 and NOT fixed by it.
+  # r12-fact-negative-tests.py reports MISSED and NOT-RESTORED privacy cases.
+  # Verified pre-existing: against a clean detached checkout of origin/main, with
+  # no RFC-0088 work in the tree, it fails with MORE cases than against the round
+  # branch (privacy empty, privacy count-minus-one, absolute-tree-root member),
+  # so it is environment- or state-dependent rather than caused by any round. It
+  # references neither file round 14 edited. It is in the r9-gates.sh chain, so
+  # the full chain cannot be green until it is diagnosed.
+  {slug = "rfc0088-r12-fact-negative-tests-red", source = "pre-flight/2026-08-22"},
   # Closed 2026-08-21. Root AGENTS.md § "Commands you'll need" now names
   # `make bootstrap-sites`, the sanctioned target that installs BOTH npm trees
   # (tools/repo/bootstrap.py profile_commands("sites")). Two corrections the entry

--- a/workspace.toml
+++ b/workspace.toml
@@ -1173,6 +1173,16 @@ open = [
   # keyed HMAC; across chains it remains operator-trusted, so this is bounded, not
   # closed.
   {slug = "rfc0088-privacy-term-identity-anchor", source = "round-12 security review"},
+  # RFC-0088 round-14 pre-flight, not caused by round 14. r13-decision-surface.py
+  # scopes its follow-on-artifact check to paths added since a PINNED base commit,
+  # so any ADR merged by any team after that base trips it. PR #1086's
+  # docs/adr/0093-okf-reference-corpora-... does, and the gate now fails on a
+  # CLEAN checkout of origin/main with no RFC-0088 work present -- verified in a
+  # detached worktree. Round 14 does not fix it: rescoping another round's
+  # control is its own decision. The next round cannot get a green decision
+  # surface until "added" is scoped to the round's own commits rather than to
+  # everything since the base.
+  {slug = "rfc0088-decision-surface-base-scoping", source = "pre-flight/2026-08-22"},
   # Closed 2026-08-21. Root AGENTS.md § "Commands you'll need" now names
   # `make bootstrap-sites`, the sanctioned target that installs BOTH npm trees
   # (tools/repo/bootstrap.py profile_commands("sites")). Two corrections the entry


### PR DESCRIPTION
## What does this change?

Amends RFC-0088 open question 3: the "used often enough" bar stops being a count of
shipped consumers and becomes a destination adapter contract exercised by two fixtures.
Adds four architectural decision records, one scope residual, and a measurement note that
puts open question 5's recommended accommodation to a real destination for the first time
— where its precondition turns out to be absent.

## Why?

- Implements: `docs/specs/rfc0088-round14-destination-adapter-contract/spec.md`
- Amends: [RFC-0088](docs/rfc/0088-web-pilot-foundation.md), amendment layer only

The previous bar was **unsatisfiable in principle**, not merely unsatisfied. `web-pilot`'s
legitimate destinations are predominantly operator-internal surfaces no pack may bundle,
so a shipped-consumer count measures what the pack is *permitted to ship* rather than
whether the foundation works — and would have read as failure indefinitely however well
the foundation worked. The held commit in this branch had lowered the count from two to
one; this rewrites that ruling rather than appending to it, so the RFC carries exactly
one answer to question 3.

The four decision records are recorded in the RFC's amendment layer rather than under
`docs/adr/`, deliberately: RFC-0088's Boundaries forbid creating a follow-on artifact
while it is Experimental, and an ADR file is one. Each graduates on acceptance.

**Finding against question 5.** Round 12 established the page-resident replay
accommodation only *conditionally* — it held when the issuing response was marked
`no-store` — against a synthetic issuer this project controls. Measured against a pinned
container: the token-issuing response carries no cache directive at all, and the
destination's own frontend writes the token into a page-readable web-storage key from
which it reaches browser user-data at rest. That second path does not run through the
response cache, so even a `no-store` destination would leave the token at rest. No
consumer sets either. Question 5 stays outstanding, with a finding that changes what
there is to decide.

## How do I verify it?

Repository gates, all green on this branch:

```bash
PYTHONDONTWRITEBYTECODE=1 SKIP_SAST=1 make build-check
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .
python3 -m pytest tools/test_documentation_entry_links.py -q
```

RFC-0088 governance controls (evidence apparatus is out of tree by design, at
`~/.local/share/rfc0088-evidence`; run from the repository root with `RFC88_REPO=$PWD`):

```bash
r13-digest-coverage.py            # new note covered by exactly one entry, no prohibited figure
r13-decision-surface.py           # one record per open question; every hunk below the anchor
r13-decision-surface.py --self-test-follow-on-detector
r13-decision-surface.py --self-test-follow-on-scoping
r13-spec-consistency.py           # repo root only — it resolves a relative path
```

The measurement arm carries eleven declared rows and twelve mutation cases; every row's
mutation flips that row, two declared-failing rows mutate *toward* passing, and the
harness summary is digest-bound to the driver and run-id-bound to the baseline.

## What did you not change that you considered?

- **The full gate chain was not run.** No `promote`, no end-to-end `r9-gates.sh`. Round 13
  did both. Individually-run controls are named above; "the chain is green" is *not*
  claimed.
- **`r12-fact-negative-tests.py` is red and is not fixed here.** Verified pre-existing: it
  fails with more cases against a clean checkout of `main` than against this branch, and
  references nothing this round touched. Nothing in CI, the Makefile or `tools/` runs the
  apparatus, so it does not gate this PR. Carried as `rfc0088-r12-fact-negative-tests-red`.
- **Round 14's evidence is not a promoted archive member**, so nothing checks its figures.
  By this apparatus's own standard an unregistered note is checked by nothing. Named as a
  limit in the note rather than quietly accepted.
- **Question 5 is not ruled.** This round supplies a finding; deciding which destination
  behaviours the pack will refuse to accommodate is a ruling, not a measurement.
- **The private-league residual is left unmeasured.** Closing it needs one private league
  identifier only the operator holds; the alternative — probing identifiers until a
  private one is found — is enumeration against a third party and was not run.
- **The excluded candidate is not named.** It is not the fixture, so the vendor-name
  boundary does not admit it. The note quotes its fatal startup line instead, which is a
  generic Kubernetes client error and makes the elimination re-derivable.
- **The verdict is unchanged: NOT FINAL**, with its carried residuals neither closed nor
  relabelled. This round adds evidence and amends one bar; it does not shorten the tail.
