### PR TITLE
feat(tools): scope "what did this change add" to the branch, not to a pinned base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,7 @@ test-unleased:
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_coordination_lease.py -q
+	$(PYTHON) -m pytest tools/test_branch_added_paths.py -q
 	$(PYTHON) -m pytest tools/test_run_slot.py -q
 	$(PYTHON) -m pytest tools/test_with_lease_cli.py -q
 	$(PYTHON) -m pytest tools/test_playwright_evidence_lifecycle.py -q

--- a/tools/repo/branch_added_paths.py
+++ b/tools/repo/branch_added_paths.py
@@ -1,0 +1,85 @@
+"""Which paths did *this branch* add?
+
+A check that asks "did this change create a forbidden artifact" needs the set of paths
+the branch added. The obvious implementation — diff against a commit hash pinned when the
+work started — answers a different question: "what has *anyone* added since that commit".
+The two agree only until someone else merges.
+
+They stopped agreeing in `agent-ready-repo`. An RFC-0088 control pinned its base and used
+that base for two different checks. One compares the text of a single governed document,
+where pinning is right: only that RFC's own rounds touch the file, and a moving ref would
+fabricate phantom hunks. The other asked what the round created. When an unrelated pull
+request merged an ADR, the second check reported that ADR as the round's own work, and
+failed on a clean checkout of the default branch with no round work in the tree at all.
+It would have stayed red for every later round.
+
+The branch's own additions are the paths added since its **merge-base with the upstream
+default branch**. Unlike the pinned-document case, upstream movement makes this *more*
+accurate rather than less: unrebased, the merge-base stays at the divergence point;
+rebased, it follows to the new tip. Either way the answer is the branch's own additions.
+
+Nothing here knows about RFC-0088, ADRs, or any particular forbidden shape. Callers
+supply the shapes; this module supplies the scope.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+#: Refs tried, in order, when resolving the upstream default branch.
+DEFAULT_UPSTREAM_REFS: tuple[str, ...] = ("origin/main", "origin/HEAD")
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=False
+    )
+
+
+def upstream_merge_base(
+    repo: Path,
+    fallback: str | None = None,
+    upstream_refs: tuple[str, ...] = DEFAULT_UPSTREAM_REFS,
+) -> tuple[str, str]:
+    """Resolve the base for "what did this branch add", with a named provenance.
+
+    Returns ``(base, how)``. ``how`` is a short human-readable description of where the
+    base came from, and callers are expected to print it: a fallback that silently
+    reinstated a pinned base would restore the defect on exactly the checkouts least able
+    to notice it.
+
+    Raises ``RuntimeError`` when no ref resolves and no ``fallback`` is supplied, rather
+    than returning a base that means something other than what the caller asked for.
+    """
+    for ref in upstream_refs:
+        if not ref:
+            continue
+        probe = _git(repo, "merge-base", "HEAD", ref)
+        if probe.returncode == 0 and probe.stdout.strip():
+            return probe.stdout.strip(), f"merge-base with {ref}"
+    if fallback is None:
+        raise RuntimeError(
+            "no upstream ref resolved and no fallback supplied, so the branch's own "
+            f"additions cannot be scoped (tried: {', '.join(r for r in upstream_refs if r)})"
+        )
+    return fallback, f"fallback base {fallback} (NO UPSTREAM REF RESOLVED)"
+
+
+def added_paths(repo: Path, base: str) -> list[str]:
+    """Repository-relative paths added between ``base`` and the **working tree**.
+
+    Working tree rather than ``base..HEAD``: comparing commits alone misses a
+    staged-but-uncommitted file entirely, which is how a decoy artifact once sat in a tree
+    that a control reported clean. Untracked paths are collected separately because
+    ``git diff`` does not see them at all.
+
+    Raises ``RuntimeError`` on a git failure instead of returning an empty list — an
+    absence check whose scan silently returned nothing would pass for the worst reason.
+    """
+    added = _git(repo, "diff", "--name-only", "--diff-filter=A", base)
+    untracked = _git(repo, "ls-files", "--others", "--exclude-standard")
+    if added.returncode != 0 or untracked.returncode != 0:
+        detail = f"{added.stderr.strip()} {untracked.stderr.strip()}".strip()
+        raise RuntimeError(f"cannot list paths added against {base}: {detail}")
+    return sorted({p for p in (added.stdout + untracked.stdout).split() if p})

--- a/tools/test_branch_added_paths.py
+++ b/tools/test_branch_added_paths.py
@@ -1,0 +1,146 @@
+"""Tests for `tools/repo/branch_added_paths.py`.
+
+Every case builds a real git repository. The defect these guard against is entirely about
+what git reports for a given base, so a mocked git would test the mock — the thing being
+claimed is kernel-and-git behaviour, and a fixture cannot testify about it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.repo.branch_added_paths import (  # noqa: E402
+    added_paths,
+    upstream_merge_base,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    done = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False
+    )
+    assert done.returncode == 0, f"git {' '.join(args)} failed: {done.stderr}"
+    return done.stdout
+
+
+def _commit(repo: Path, relative: str, body: str, message: str) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "--quiet", "-m", message)
+
+
+@pytest.fixture
+def peer_merge_repo(tmp_path: Path) -> tuple[Path, Path, str]:
+    """A branch that added nothing, and an upstream that gained a file after the base.
+
+    This is the exact history that broke the original control: work starts, a base is
+    pinned, someone else merges, and the branch is then asked what it created.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "--quiet", "--initial-branch=main")
+    _git(origin, "config", "user.email", "fixture@example.invalid")
+    _git(origin, "config", "user.name", "fixture")
+    _commit(origin, "README.md", "base\n", "base")
+    pinned = _git(origin, "rev-parse", "HEAD").strip()
+
+    # The peer's merge, landing on the default branch after the pinned base.
+    _commit(origin, "docs/adr/0093-a-peer-decision.md", "peer\n", "peer adr")
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", "--quiet", str(origin), str(work))
+    _git(work, "config", "user.email", "fixture@example.invalid")
+    _git(work, "config", "user.name", "fixture")
+    _git(work, "checkout", "--quiet", "-b", "round-branch")
+    _commit(work, "docs/specs/example-round/spec.md", "round\n", "round work")
+    return origin, work, pinned
+
+
+def test_peer_addition_is_not_attributed_to_this_branch(peer_merge_repo) -> None:
+    _origin, work, pinned = peer_merge_repo
+    base, how = upstream_merge_base(work, fallback=pinned)
+    assert "merge-base" in how
+    assert "docs/adr/0093-a-peer-decision.md" not in added_paths(work, base)
+
+
+def test_pinned_base_does_attribute_it_so_the_clean_result_is_not_vacuous(
+    peer_merge_repo,
+) -> None:
+    """The negative control.
+
+    Without this, the assertion above is satisfied just as well by a scan that returns
+    nothing at all. Reading the same tree against the pinned base must still surface the
+    peer's file, which is what makes its absence under the correct base meaningful.
+    """
+    _origin, work, pinned = peer_merge_repo
+    assert "docs/adr/0093-a-peer-decision.md" in added_paths(work, pinned)
+
+
+def test_this_branch_own_addition_is_still_caught(peer_merge_repo) -> None:
+    """The positive control: narrowing the scope must not disable the scan."""
+    _origin, work, pinned = peer_merge_repo
+    _commit(work, "docs/adr/0094-a-round-decision.md", "round\n", "round adr")
+    base, _how = upstream_merge_base(work, fallback=pinned)
+    assert "docs/adr/0094-a-round-decision.md" in added_paths(work, base)
+
+
+def test_uncommitted_and_untracked_additions_are_seen(peer_merge_repo) -> None:
+    """`base..HEAD` misses both; a decoy once sat in a tree reported clean."""
+    _origin, work, pinned = peer_merge_repo
+    (work / "docs" / "adr").mkdir(parents=True, exist_ok=True)
+    (work / "docs" / "adr" / "0095-staged.md").write_text("staged\n")
+    _git(work, "add", "docs/adr/0095-staged.md")
+    (work / "docs" / "adr" / "0096-untracked.md").write_text("untracked\n")
+
+    base, _how = upstream_merge_base(work, fallback=pinned)
+    found = added_paths(work, base)
+    assert "docs/adr/0095-staged.md" in found
+    assert "docs/adr/0096-untracked.md" in found
+
+
+def test_fallback_is_named_rather_than_silent(tmp_path: Path) -> None:
+    """A silent fallback would reinstate the defect where nobody would look."""
+    solo = tmp_path / "solo"
+    solo.mkdir()
+    _git(solo, "init", "--quiet", "--initial-branch=main")
+    _git(solo, "config", "user.email", "fixture@example.invalid")
+    _git(solo, "config", "user.name", "fixture")
+    _commit(solo, "README.md", "base\n", "base")
+    head = _git(solo, "rev-parse", "HEAD").strip()
+
+    base, how = upstream_merge_base(solo, fallback=head)
+    assert base == head
+    assert "NO UPSTREAM REF RESOLVED" in how
+
+
+def test_missing_upstream_without_a_fallback_refuses(tmp_path: Path) -> None:
+    solo = tmp_path / "solo"
+    solo.mkdir()
+    _git(solo, "init", "--quiet", "--initial-branch=main")
+    _git(solo, "config", "user.email", "fixture@example.invalid")
+    _git(solo, "config", "user.name", "fixture")
+    _commit(solo, "README.md", "base\n", "base")
+
+    with pytest.raises(RuntimeError, match="no upstream ref resolved"):
+        upstream_merge_base(solo)
+
+
+def test_a_git_failure_raises_rather_than_reporting_nothing_added(tmp_path: Path) -> None:
+    """An absence scan that swallows an error passes for the worst possible reason."""
+    solo = tmp_path / "solo"
+    solo.mkdir()
+    _git(solo, "init", "--quiet", "--initial-branch=main")
+    _git(solo, "config", "user.email", "fixture@example.invalid")
+    _git(solo, "config", "user.name", "fixture")
+    _commit(solo, "README.md", "base\n", "base")
+
+    with pytest.raises(RuntimeError, match="cannot list paths added"):
+        added_paths(solo, "0000000000000000000000000000000000000000")


### PR DESCRIPTION
## What does this change?

Adds `tools/repo/branch_added_paths.py`: the paths *this branch* added, scoped to the
merge-base with the upstream default branch rather than to a pinned commit hash. Seven
tests against real git repositories, and one Makefile line so they run in `make test`.

## Why?

A check asking "did this change create a forbidden artifact" needs the branch's own
additions. Diffing against a hash pinned when the work started answers "what has *anyone*
added since" — the two agree only until someone else merges.

They stopped agreeing. An RFC-0088 control pinned one base and used it for two different
checks: one compares the text of a single governed document (pinning is right there — only
that RFC's rounds touch the file, and a moving ref would fabricate phantom hunks), the
other asked what the round created. When an unrelated PR merged an ADR, that second check
reported the ADR as the round's own work and **failed on a clean checkout of `main` with
no round work in the tree at all**. It would have stayed red for every later round.

Upstream movement makes the merge-base *more* accurate, not less: unrebased it stays at
the divergence point, rebased it follows to the new tip.

## How do I verify it?

```bash
python3 -m pytest tools/test_branch_added_paths.py -q     # 7 passed
PYTHONDONTWRITEBYTECODE=1 SKIP_SAST=1 make build-check
```

Proven able to fail — revert the resolver to the pinned base and the peer-attribution test
goes red:

```bash
# delete the `for ref in upstream_refs:` loop body in upstream_merge_base
python3 -m pytest tools/test_branch_added_paths.py -q     # 1 failed, 6 passed
```

Three of the seven tests are one assertion plus its two controls: the peer's file is not
attributed to the branch; reading the same tree against the pinned base **still surfaces
it**, so the clean result is not a scan returning nothing; and a file the branch really
did add is still caught, so narrowing has not disabled the scan.

## What did you not change that you considered?

- **Not wired as a CI gate.** Nothing in CI, the Makefile or `tools/` has ever run the
  RFC-0088 control this came from — `main` does not go red today when an ADR merges, and
  this PR does not create that exposure either. Turning one RFC's internal boundary into a
  repository-wide gate is a separate decision with its own blast radius. The *tests* run in
  CI; the *check* does not gate anyone's PR.
- **The module knows nothing about RFC-0088, ADRs, or any forbidden shape.** Callers supply
  the shapes; this supplies the scope. Making it RFC-aware would have tied a generic
  primitive to one caller.
- **The out-of-tree consumer keeps a local fallback** for checkouts predating this module,
  rather than hard-failing. It imports this copy when present, so the primitive has one
  home instead of two.
- **Two refusals kept rather than softened**: no upstream ref and no explicit fallback
  raises rather than guessing, and a git failure raises rather than reporting nothing
  added.
