### PR TITLE
fix(tools,repo): stop build_gate_chain leaking packages/agentbundle onto sys.path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,6 +441,7 @@ test-unleased: lint-editable-install
 	$(PYTHON) -m pytest tools/test_worktree_lease_interlock.py -q
 	$(PYTHON) -m pytest tools/test_worktree_import_resolution.py -q
 	$(PYTHON) -m pytest tools/test_editable_install_guard.py -q
+	$(PYTHON) -m pytest tools/test_import_time_path_leaks.py -q
 	$(PYTHON) -m pytest tools/test_managed_child.py -q
 	$(PYTHON) -m pytest tools/test_coordination_lease.py -q
 	$(PYTHON) -m pytest tools/test_branch_added_paths.py -q

--- a/docs/adr/0094-no-per-worktree-virtualenv-source-imports-instead.md
+++ b/docs/adr/0094-no-per-worktree-virtualenv-source-imports-instead.md
@@ -154,7 +154,7 @@ the shared environment — the write that caused the original hazard.
 
 ## References
 
-- `tools/repo/build_gate_chain.py:60-72` — records that both packages are
+- `tools/repo/build_gate_chain.py:70-82` — records that both packages are
   importable from source, so neither needs `pip install -e`.
 - `tools/repo/worktree_hygiene.py:862-870`, `:1161`, `:1736` — the in-use guard
   that resolves distributions from the interpreter running the cleaner.

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -36,9 +36,19 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 # tools/repo/ → tools/ → repo root
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-# Make packages/agentbundle importable in-process (for any future in-process use).
+# Used to build a child's PYTHONPATH (`_agentbundle_env`), never inserted on this
+# process's sys.path. Doing that at import time made a combined
+# `pytest tools/ tests/` run order-dependent: two collected test modules import
+# this one, `tools/` is walked before `tests/`, so the insert landed before any
+# test ran and the first `import agentbundle` cached the worktree copy in
+# sys.modules for the whole session. Tests that failed on their own passed in that
+# combined run. (Not `make test`, which never puts the two trees in one process —
+# Makefile:394 runs `tests/` alone, in its own invocation. There the exported
+# PYTHONPATH on Makefile:11 is what resolves these packages.) pyproject.toml's
+# [tool.pytest.ini_options] pythonpath is the declared way to put them on
+# sys.path; tools/test_import_time_path_leaks.py fails if an import-time insert
+# comes back.
 _AGENTBUNDLE_PATH = str(REPO_ROOT / "packages" / "agentbundle")
-sys.path.insert(0, _AGENTBUNDLE_PATH)
 
 # A chain step: a human label plus a zero-arg thunk returning an exit code.
 Step = tuple[str, Callable[[], int]]

--- a/tools/test_import_time_path_leaks.py
+++ b/tools/test_import_time_path_leaks.py
@@ -1,0 +1,367 @@
+"""Construction test: collecting this repository's suite must not add a packaged
+source tree to `sys.path`.
+
+**The defect this exists to prevent.** `tools/repo/build_gate_chain.py` used to
+run `sys.path.insert(0, <repo>/packages/agentbundle)` at module scope, for an
+in-process use it never had. Two collected test modules import it
+(`tools/test_build_gate_chain.py`, `tools/catalogue/tests/test_verify_host_checks.py`),
+pytest imports every collected module before running any test, and `tools/` is
+walked before `tests/` — so the insert landed before the first test ran. The
+first `import agentbundle` after it then cached the WORKTREE copy in
+`sys.modules`, and every later test in that process saw it.
+
+The consequence is the dangerous direction: two roster tests FAILED when run on
+their own and PASSED inside a combined `pytest tools/ tests/` run, at the same
+commit. A suite whose result depends on file order cannot be trusted, and the
+accident is invisible — nothing in either roster test mentions `sys.path`.
+
+Be precise about which invocation was affected, because it is easy to get
+wrong. `make test` never puts `tools/` and `tests/` in one process — `Makefile:394`
+runs `tests/` alone and the `tools/` modules run in separate invocations — so
+this module was never imported in the session that ran the roster tests there. What makes
+`make test` green is the PYTHONPATH exported on `Makefile:11`. The leak masked a
+combined `pytest tools/ tests/`, which is how the failure was originally
+measured.
+
+**Why growth, and why a count.** `pyproject.toml` declares
+`[tool.pytest.ini_options] pythonpath`, so `packages/agentbundle` and
+`packages/credbroker` are on `sys.path` from the start of every session — by
+design, and that is the *declared* pin. Presence therefore proves nothing. What
+the accident produced was an EXTRA occurrence: `list.insert` does not
+de-duplicate, so an import-time insert of an already-present directory takes the
+entry's count from one to two. So this compares the count of `packages/*`
+entries per collector, before against after, and any increase is a leak.
+
+**Why the session is collected as-configured.** An earlier draft ran the child
+with the declared `pythonpath` reduced to `"."`, so that any `packages/*` entry
+at all was evidence. That is a stronger detector and the wrong trade: `Makefile`
+tells contributors not to install `agentbundle` or `credbroker`, so on the
+documented developer setup those imports would fail at COLLECTION and the guard
+would redden for a reason that has nothing to do with a leak. Collecting under
+`pyproject.toml` alone cannot fail that way.
+
+**The second invariant, which does not depend on counting.** A count catches an
+added occurrence, but not a *reorder*: `sys.path.remove(p)` followed by
+`sys.path.append(p)` — the "tidy my path" idiom — leaves every count identical
+while demoting the worktree copy below `site-packages`, flipping resolution
+exactly as the original defect did. Nor does a count see a shadowing directory
+outside `packages/`. So the probe also records where the finder actually
+resolves `agentbundle` and `credbroker`, at session start and again when
+collection ends, and requires the two to agree. That is the property the counts
+are a proxy for, asserted directly.
+
+**Why measured rather than linted.** A static scan for `sys.path.insert` is an
+enumeration, and enumerations leak: the mutation can be indirect, conditional,
+computed, or three imports deep. Two greps in the original investigation pointed
+at the wrong file for exactly that reason —
+`tools/test_marketplace_envelope_parity.py:186` matches a `sys.path.insert` that
+lives inside a raw string of *child* source and never runs in the parent. So
+this collects the real suite in a child interpreter and reads the real
+`sys.path`, attributing any growth to the collector that caused it.
+
+**What it does not prove, stated plainly.**
+
+- A *conditional* insert (`if p not in sys.path: sys.path.insert(...)`) of an
+  already-declared path adds no occurrence and moves no resolution, so neither
+  invariant reports it. It is not the defect above while the declared pin
+  stands — but it would become one if that `pythonpath` declaration were dropped.
+- Coverage starts at `pytest_sessionstart`. The `pythonpath` entries are applied
+  before that, during `Config._preparse`, as is anything a rootdir `conftest.py`
+  does — there is none today. Such a mutation would land in the baseline and in
+  the session-start resolution, and be invisible to both checks.
+- Only `agentbundle` and `credbroker` are watched for resolution, and only
+  `<repo>/packages/*` entries are counted. A third package shadowed by an
+  import-time mutation is not covered.
+- `sys.path` and the finder are not the only channels. A module could assign
+  into `sys.modules` directly, or install a `sys.meta_path` finder that answers
+  identically at both sample points. Neither is observed here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Collected in a child interpreter, because the property under test is a
+#: property of a whole pytest session and this process is already inside one.
+#: No `-o` overrides: the child must resolve `pyproject.toml` exactly as
+#: `make test` does, so that a leak is the only thing that can move the counts.
+_COLLECT_CHILD = r"""
+import importlib.util
+import json
+import pathlib
+import sys
+from collections import Counter
+
+import pytest
+
+ROOT = pathlib.Path(sys.argv[1]).resolve()
+PACKAGES = ROOT / "packages"
+WATCHED = ("agentbundle", "credbroker")
+
+
+def _packaged_counts():
+    counts = Counter()
+    for entry in sys.path:
+        if not entry:
+            continue
+        try:
+            resolved = pathlib.Path(entry).resolve()
+        except OSError:
+            continue
+        if resolved == PACKAGES or PACKAGES in resolved.parents:
+            counts[str(resolved)] += 1
+    return counts
+
+
+def _resolutions():
+    # Where the finder says each watched package lives, right now. `find_spec`
+    # on a top-level name imports nothing; once something HAS imported it, the
+    # spec comes from sys.modules — which is exactly what later tests get.
+    origins = {}
+    for name in WATCHED:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ValueError):
+            origins[name] = "<unresolvable>"
+            continue
+        origins[name] = str(getattr(spec, "origin", None)) if spec else "<missing>"
+    return origins
+
+
+class Probe:
+    def __init__(self):
+        self.before = {}
+        self.baseline = Counter()
+        self.leaks = []
+        self.errors = []
+        self.seen = []
+        self.collected = 0
+        self.final = Counter()
+        self.resolved_at_start = {}
+        self.resolved_at_end = {}
+
+    def pytest_sessionstart(self, session):
+        # NOT __init__: the `pythonpath` ini option is applied during
+        # `Config._preparse`, which runs after this object is constructed and
+        # before this hook. Snapshotting any earlier baselines an empty sys.path
+        # and makes every later count look like growth.
+        self.baseline = _packaged_counts()
+        self.resolved_at_start = _resolutions()
+
+    def pytest_collectstart(self, collector):
+        self.before[collector.nodeid] = _packaged_counts()
+
+    def pytest_collectreport(self, report):
+        self.seen.append(report.nodeid)
+        if report.failed:
+            self.errors.append(report.nodeid)
+        before = self.before.pop(report.nodeid, None)
+        if before is None:
+            return
+        after = _packaged_counts()
+        # Union of keys, so a REMOVAL is attributed too — `sys.path.remove` is a
+        # resolution change as surely as an insert is.
+        moved = {
+            p: [before.get(p, 0), after.get(p, 0)]
+            for p in set(before) | set(after)
+            if before.get(p, 0) != after.get(p, 0)
+        }
+        if not moved:
+            return
+        # pytest emits a directory's collectreport AFTER its children, so an
+        # ancestor re-reports a descendant's change. Keep the leaf: drop this
+        # entry only when an already-recorded DESCENDANT reported the identical
+        # movement. Matching on the movement alone would also swallow a second,
+        # genuine leak that happened to show the same before/after numbers.
+        if any(
+            leak["moved"] == moved
+            and leak["nodeid"].startswith(report.nodeid + "/")
+            for leak in self.leaks
+        ):
+            return
+        self.leaks.append({"nodeid": report.nodeid, "moved": moved})
+
+    def pytest_collection_finish(self, session):
+        self.collected = len(session.items)
+        self.final = _packaged_counts()
+        self.resolved_at_end = _resolutions()
+
+
+probe = Probe()
+code = pytest.main(
+    ["--collect-only", "-q", "-p", "no:cacheprovider",
+     "--continue-on-collection-errors", "tools", "tests"],
+    plugins=[probe],
+)
+sys.stdout.write(
+    "\nPROBE_JSON "
+    + json.dumps({
+        "leaks": probe.leaks,
+        "errors": probe.errors,
+        "seen": probe.seen,
+        "collected": probe.collected,
+        "baseline": dict(probe.baseline),
+        "final": dict(probe.final),
+        "resolved_at_start": probe.resolved_at_start,
+        "resolved_at_end": probe.resolved_at_end,
+        "code": int(code),
+    })
+    + "\n"
+)
+"""
+
+#: Generous floor, not a pinned inventory: the suite collected 1623 items when
+#: this was written, and an exact count would redden on any legitimate add or
+#: remove. This only has to be high enough that a collection that fell over
+#: early cannot pass vacuously. The named carriers below are the real
+#: anti-vacuity check; this floor is the backstop for everything else.
+MINIMUM_COLLECTED = 1200
+
+#: The two collected modules that import `tools/repo/build_gate_chain.py`, and so
+#: the two that carried the original leak into the session. If neither is in the
+#: collected set, this guard is watching a session that cannot exhibit the defect
+#: it was built for, and a green result means nothing.
+CARRIER_MODULES = (
+    "tools/test_build_gate_chain.py",
+    "tools/catalogue/tests/test_verify_host_checks.py",
+)
+
+
+def _collect_in_child() -> dict:
+    """Run a collect-only pytest session in a child and return its probe report."""
+    env = os.environ.copy()
+    # `make` exports PYTHONPATH with both package directories on it (Makefile:11).
+    # Inheriting it would put `packages/agentbundle` on the child's sys.path a
+    # second time before pytest starts. That is harmless for a movement
+    # comparison, but it would mean this guard measured one configuration under
+    # `make` and a different one under a bare `pytest`. Dropping it makes both
+    # invocations measure pyproject.toml alone.
+    env.pop("PYTHONPATH", None)
+    # `-n auto` would move every import into xdist workers, where none of the
+    # probe's hooks observe it.
+    env.pop("PYTEST_ADDOPTS", None)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    completed = subprocess.run(
+        [sys.executable, "-B", "-c", _COLLECT_CHILD, str(REPO_ROOT)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+        # Collection measures ~4s; the headroom is for a loaded machine, not for
+        # a wedged child, which should report rather than stall `make test`.
+        timeout=300,
+        check=False,
+    )
+    marker = "\nPROBE_JSON "
+    if marker not in completed.stdout:
+        raise AssertionError(
+            "the collect-only child produced no probe report "
+            f"(rc={completed.returncode}):\n"
+            f"--- stdout tail ---\n{completed.stdout[-4000:]}\n"
+            f"--- stderr tail ---\n{completed.stderr[-4000:]}"
+        )
+    return json.loads(completed.stdout.rsplit(marker, 1)[1].splitlines()[0])
+
+
+class ImportTimePathLeakTest(unittest.TestCase):
+    """One collected session, four assertions — the control must be able to fail."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.report = _collect_in_child()
+
+    def _child_context(self) -> str:
+        return f" (child rc={self.report['code']}, {self.report['collected']} items collected)"
+
+    def test_collection_reaches_the_modules_that_carried_the_leak(self) -> None:
+        """A collection that fell over early would pass the leak check vacuously."""
+        self.assertEqual(
+            self.report["errors"],
+            [],
+            "collection errors mean the leak check never reached those modules, "
+            "so a clean result below would prove nothing" + self._child_context(),
+        )
+        seen = set(self.report["seen"])
+        self.assertEqual(
+            [m for m in CARRIER_MODULES if m not in seen],
+            [],
+            "the modules that import build_gate_chain were not collected, so this "
+            "session cannot exhibit the defect this guard exists to catch"
+            + self._child_context(),
+        )
+        self.assertGreaterEqual(
+            int(self.report["collected"]),
+            MINIMUM_COLLECTED,
+            "far fewer items collected than this suite has — the probe did not "
+            "run the session it claims to have run" + self._child_context(),
+        )
+
+    def test_the_declared_pin_is_what_puts_packages_on_sys_path(self) -> None:
+        """Without a baseline entry, a movement comparison could never move."""
+        self.assertTrue(
+            self.report["baseline"],
+            "no packages/* entry was on the child's sys.path before collection: "
+            "pyproject.toml's [tool.pytest.ini_options] pythonpath is how this "
+            "suite resolves agentbundle and credbroker, and without it this "
+            "guard is comparing against nothing" + self._child_context(),
+        )
+        # Deliberately no "each entry appears exactly once" assertion. An editable
+        # install pointing at THIS worktree is a supported state (see the
+        # `Unblocks when` line on the register entry this guard closes), and in
+        # setuptools' `compat` editable mode that writes a raw-path .pth, which
+        # would make a baseline count of 2 legitimate.
+
+    def test_no_collector_moves_a_packaged_source_tree_on_sys_path(self) -> None:
+        """Attributed form: names the leaf collector, so the fix has an address."""
+        leaks = self.report["leaks"]
+        detail = "\n".join(
+            f"  {leak['nodeid']} took {path} from {counts[0]} to {counts[1]}"
+            for leak in leaks
+            for path, counts in leak["moved"].items()
+        )
+        self.assertEqual(
+            leaks,
+            [],
+            "importing these collectors changed the packaged source trees on "
+            "sys.path. That silently changes which copy of agentbundle or "
+            "credbroker every later test in the session imports, and makes the "
+            "result depend on file order:\n" + detail + "\n"
+            "Fix: put the path on a child's PYTHONPATH where it is actually "
+            "needed (see build_gate_chain._agentbundle_env) instead of mutating "
+            "this process's sys.path. pyproject.toml's "
+            "[tool.pytest.ini_options] pythonpath is the declared pin for the suite.",
+        )
+        # Backstop for a movement no collect hook was open for — a plugin, or an
+        # import that outlived the collector that triggered it.
+        self.assertEqual(
+            self.report["final"],
+            self.report["baseline"],
+            "the packages/* entries on sys.path differ from the baseline, but no "
+            "collector was credited with changing them" + self._child_context(),
+        )
+
+    def test_collection_does_not_move_where_the_packages_resolve(self) -> None:
+        """The property the counts are a proxy for, asserted directly.
+
+        Catches a reorder (`remove` then `append`), which keeps every count equal
+        while demoting the worktree copy below site-packages, and a shadowing
+        directory outside `packages/` that a count would never see.
+        """
+        self.assertEqual(
+            self.report["resolved_at_end"],
+            self.report["resolved_at_start"],
+            "collecting the suite changed where agentbundle or credbroker "
+            "resolves. Every test collected after the change imports a different "
+            "copy from the ones collected before it" + self._child_context(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workspace.toml
+++ b/workspace.toml
@@ -1128,13 +1128,39 @@ open = [
   #     under tests/roster/ returns nothing), so putting the worktree on sys.path
   #     is exactly the fix. Verified independent of the untracked *.egg-info: both
   #     still pass with it removed.
-  #     Kept named here because their whole-suite behaviour is ORDER-DEPENDENT:
+  #     Kept named here because their whole-suite behaviour WAS ORDER-DEPENDENT:
   #     under `pytest tools/ tests/` they passed even BEFORE this change, while
-  #     failing in isolation at the same commit. Some earlier test in that run
-  #     leaves the worktree on sys.path; the exact source was not identified, and
-  #     it is a pre-existing property of the suite, not of this change. The
-  #     consequence worth keeping: a green `make test` can mask a resolution
-  #     failure that `pytest <file>` exposes.
+  #     failing in isolation at the same commit. The consequence worth keeping:
+  #     a green combined run could mask a resolution failure that `pytest <file>`
+  #     exposes. Note the frame: `make test` is not that run — Makefile:394
+  #     collects `tests/` alone and the tools modules run in separate
+  #     invocations, so the two trees never share a process there, and
+  #     Makefile:11's exported PYTHONPATH is what resolves these packages
+  #     under make.
+  #
+  #     2026-08-22, later the same day: the source, recorded above as not
+  #     identified, has now been identified and removed. It was
+  #     `tools/repo/build_gate_chain.py`, whose module scope ran
+  #     `sys.path.insert(0, <repo>/packages/agentbundle)` for an in-process use
+  #     it never had. Two collected modules import it
+  #     (tools/test_build_gate_chain.py and
+  #     tools/catalogue/tests/test_verify_host_checks.py), pytest imports every
+  #     collected module before running any test, and `tools/` is walked before
+  #     `tests/` — so the insert landed first and the next `import agentbundle`
+  #     cached the worktree copy in sys.modules for the session. Bisected, not
+  #     inferred: prepending that one `tools/catalogue/tests` file to the two
+  #     roster files flips them 2-failed to 21-passed under `-o pythonpath=`.
+  #     The insert is deleted; the real (subprocess) need was already served by
+  #     `build_gate_chain._agentbundle_env`. tools/test_import_time_path_leaks.py
+  #     collects the suite in a child under the declared pyproject.toml
+  #     configuration and fails, naming the leaf collector, when a packages/*
+  #     entry's occurrence count moves during collection, or when the finder
+  #     resolves agentbundle or credbroker somewhere different at the end of
+  #     collection than at session start. It does NOT run with the pin removed:
+  #     the Makefile tells contributors not to install either package, so that
+  #     frame would redden at collection on the documented setup. So the
+  #     order-dependence is closed on its own terms, not only masked by the
+  #     pythonpath declaration.
   #   - test_resolved_layer_fails_loudly_when_the_package_is_unimportable still
   #     FAILS, and is now understood to be structurally out of reach of that
   #     remedy: it resolves its constants in a child spawned with `-I`


### PR DESCRIPTION
## What does this change?

Deletes a module-level `sys.path.insert(0, <repo>/packages/agentbundle)` from
`tools/repo/build_gate_chain.py` that made a combined `pytest tools/ tests/` run
order-dependent, and adds a construction test that fails if any collected module
mutates packaged-source resolution again.

## Why?

Two roster tests **failed when run on their own and passed inside a combined
run, at the same commit** — the alarming direction. `workspace.toml`'s
`pre-existing-roster-catalogue-index-and-okf-release-metadata` entry recorded
that order-dependence and said *"the exact source was not identified."* This
identifies it, removes it, and updates the entry.

- Follows from: PR #1091 / `docs/specs/repo-tests-worktree-source/`, which
  shipped the declared `[tool.pytest.ini_options] pythonpath` pin. That pin
  makes the leak's *effect* invisible; it does not remove the leak. This does.
- No new spec: one bounded fix to one dead statement, plus its guard.

### The culprit, by bisect

`tools/repo/build_gate_chain.py:41` inserted `packages/agentbundle` at
`sys.path[0]` at import time, for an in-process use the module never had — it
imports only stdlib, does no dynamic import, and a child process never inherits
`sys.path`. Every real use goes through `_agentbundle_env()`, which builds a
child's `PYTHONPATH` and is untouched.

Two collected modules import it (`tools/test_build_gate_chain.py`,
`tools/catalogue/tests/test_verify_host_checks.py`). pytest imports every
collected module before running any test, and `tools/` is walked before
`tests/` — so the insert landed first and the next `import agentbundle` cached
the worktree copy in `sys.modules` for the session.

Prepending only that one `tools/catalogue/tests` file to the two roster files
flips them from `2 failed, 4 passed` to `21 passed` under `-o pythonpath=`.
The grep-obvious candidate, `tools/test_marketplace_envelope_parity.py:186`,
does **not** — that `sys.path.insert` lives inside a raw string of *child*
source and never runs in the parent.

**One correction to the framing in the register entry, now fixed there too:**
this never affected `make test`. `Makefile:394` collects `tests/` in its own
invocation, so the two trees never share a process and this module is never
imported in the session that runs the roster tests. `make test` is green because
of the `PYTHONPATH` exported on `Makefile:11`. The leak masked a combined
`pytest tools/ tests/`.

## How do I verify it?

```bash
# The guard, in both invocation frames:
pytest tools/test_import_time_path_leaks.py -q                       # 4 passed
PYTHONPATH=packages/agentbundle:packages/credbroker pytest tools/test_import_time_path_leaks.py -q

# It discriminates — restore the insert at build_gate_chain.py:41 and re-run:
#   FAILED ...::test_no_collector_moves_a_packaged_source_tree_on_sys_path
#   tools/catalogue/tests/test_verify_host_checks.py took .../packages/agentbundle from 1 to 2
# ...and a reorder (remove+append), which leaves every count equal, fails the
# other assertion instead:
#   FAILED ...::test_collection_does_not_move_where_the_packages_resolve

# The changed artifact, exercised end-to-end in the bare frame the insert lived in:
env -u PYTHONPATH python3 tools/repo/build_gate_chain.py build-check      # exit 0

pytest tools/ tests/ -q     # see failure set below
```

**Full-suite failure set, compared as a set:** unchanged.
`2 failed, 1612 passed, 8 skipped, 101 subtests passed`. Both failures are
registered pre-existing in `workspace.toml [backlog].open` and neither is in the
diff — `test_ledger_has_complete_terminal_classifications`
(`guide-blockquote-ledger-has-no-regenerator`, fails on clean `origin/main`) and
`test_resolved_layer_fails_loudly_when_the_package_is_unimportable`. Both roster
tests pass alone **and** in the full run.

### Why the guard is shaped this way

It collects the real suite in a child with **no `-o` overrides**, so the child
resolves `pyproject.toml` exactly as a bare `pytest` does, and asserts two
things:

1. **No collector changes the occurrence count** of a `packages/*` entry. A
   count, not a presence check: the declared `pythonpath` already puts those
   directories on `sys.path`, and `list.insert` does not de-duplicate, so an
   import-time insert takes an entry from one to two.
2. **Collection does not move where the finder resolves** `agentbundle` or
   `credbroker` — the property the counts are a proxy for, asserted directly.
   This catches a reorder that a count cannot see.

An earlier draft ran the child with the pin reduced to `"."`, so any
`packages/*` entry was evidence. That is a stronger detector and the wrong
trade: the `Makefile` tells contributors **not** to install `agentbundle` or
`credbroker`, so on the documented developer setup it would redden at
*collection* for a reason that has nothing to do with a leak.

It is measured rather than linted because a static scan for `sys.path.insert` is
an enumeration, and that enumeration is exactly what pointed two greps at the
wrong file.

## What did you not change that you considered?

- **The two roster tests.** They are right, and #1091's `pythonpath` is already
  the declared, order-independent pin for the whole suite. Pinning worktree
  source a second time inside the tests would be drift, and it would have
  papered over the landmine rather than removing it.
- **`test_resolved_layer_fails_loudly_when_the_package_is_unimportable`.**
  Judged **not** the same root cause. Its `-I` child finds no `__init__.py` in
  the fixture tree, so PEP 420 treats it as a namespace portion and the regular
  package in `site-packages` answers instead. No in-process change reaches it.
  Its register disposition and unblockers are left alone.
- **Removing any test name from the register entry.** `docs/specs/repo-tests-worktree-source/spec.md`
  AC2 forbids it; all three names are retained. Only the cause is re-described,
  which that AC explicitly permits.
- **A repo-wide AST lint for module-level `sys.path` mutation.** Enumerations
  leak, and it would need to import 76 `tools/` modules.
- **Anything in `site-packages`.** No `pip install`, `-e`, or uninstall.

Residual worth naming: `docs/adr/0094`'s citation is a *line range*, so it drifts
whenever `build_gate_chain.py` changes above it. Retargeted here (`:60-72` →
`:70-82`) as a meaning-preserving mechanical rewrite under
`docs/CONVENTIONS.md:167-174`; the class of drift remains.

---

## Checklist

- [x] Tests pass locally (`pytest tools/ tests/ -q`; `make lint-ruff`; `make lint-mypy`)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy` — 125 source files clean)
- [x] Self-review run via `adversarial-reviewer` — two passes plus a Blocker
      re-review, ending `No Blockers`. Its Blocker (the register entry described
      a superseded detector) and eleven concerns/nits are applied; one rejection
      was reversed after it showed me the `CONVENTIONS.md:167-174` carve-out I
      had missed. No security boundary crossed — this *removes* a path-shadowing
      insert. `quality-engineer` not run: `AGENTS.md` declares no external
      quality gate, so light mode drops that pass.
- [x] Spec and code agree — `docs/specs/repo-tests-worktree-source/spec.md` AC2
      governs the `workspace.toml` edit and is honoured
- [x] Living docs match reality — `workspace.toml` register entry re-described;
      no changelog entry (repository tooling ships in no release, per
      `docs/CONVENTIONS.md` § 5b); no user-facing behaviour, config, or
      interface change
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured
