### PR TITLE
docs(rfc): RFC-0088 — restate the two binding requirements that did not hold as written

### DIFF
--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3680,3 +3680,87 @@ that mechanism rather than record the channel as inherently uncontrollable.
   its cache-directive construction requirement for the page-resident candidate. Blocker
   item 1's matrix half is settled here; its sandbox-measurement residual is not. No other
   blocker item closes, no residual is relabelled, and no disposition is withdrawn.
+
+- **2026-08-22 — the two binding requirements that did not hold as written are restated,
+  and both now hold.** Round 11 measured the four measurable binding requirements and
+  found two holding and two not holding *as written*. Neither failure was a measurement
+  failure: in both cases the round found what closes the requirement and the requirement's
+  wording had not caught up. The approver restates both. **No disposition is withdrawn**,
+  the RFC remains `Experimental`, no blocker item closes, and no follow-on artifact is
+  created.
+
+  **D / item 3 — "one consumer per connection" holds, because the residue boundary is
+  redrawn.** Round 11 found the requirement covers two of the three surviving residue
+  classes: a foreign init script and origin-scoped storage do not cross an unshared
+  connection, while a committed download does — it is a filesystem artifact rather than a
+  browser-connection one, and clearing it would need job-root partitioning, a different
+  control from the one item 3 binds.
+
+  The approver rules that **a downloaded artifact has crossed to the user and is no longer
+  the pack's residue to clear**. A download is a deliberate delivery into the user's own
+  filesystem, requested through the session; treating it as connection residue would make
+  the pack responsible for a file the user asked for and may already be using. The residue
+  boundary ends where the artifact leaves the browser connection.
+
+  With that boundary, item 3's surviving classes are the two the requirement already
+  covers, and **the requirement holds as written**. Job-root partitioning is not required
+  and is not deferred — it is not needed for this boundary.
+
+  What the approver accepts, and it is a transfer rather than a closure: a downloaded
+  artifact **persists after the session ends, outside anything the pack tears down**, and
+  it may carry destination content. The pack must not imply otherwise. The approval surface
+  already has to state that every consumer sharing a connection inherits the connection
+  residue; it must **additionally** state that downloaded artifacts are the user's, are not
+  cleared on teardown, and outlive the session. Disclosure is the whole of what replaces
+  the control here, and saying so is the point.
+
+  **D / item 6 — "service workers disabled" is restated as a per-group composed control,
+  and the tension it carried is dissolved structurally rather than measured away.** Round
+  11 found the requirement under-specified: `serviceWorkers: 'block'` is a *context*
+  option, so it refuses new registrations but does not reach a worker already persisted in
+  a profile — a restored profile reported a controller at document start and emitted
+  traffic identically under `block` and under `allow`. Composing the block with a purge of
+  the profile's service-worker storage **does** close it: controller `false`, zero packets,
+  zero registrations. Round 13's blast-radius arm measured the purge itself — the worker
+  store is removed, an inventory of what was removed is recorded, an unknown store label is
+  refused rather than guessed, and a symlink-bearing tree is refused rather than escaped.
+
+  The requirement as restated, superseding the 2026-08-18 wording:
+
+  > Worker policy is decided **per destination group**, the unit question 4's ruling
+  > established, and a group is realised as a separate browser context. For a group whose
+  > policy is *no workers*, the control is **`serviceWorkers: 'block'` composed with a
+  > purge of that profile's persisted service-worker storage** — the block clause alone
+  > does not reach an already-registered worker, and the requirement is not met by it.
+  > Within a group, **the weakest member sets the policy**: if any destination in the group
+  > requires a worker, the group runs with workers permitted, because one context cannot
+  > both block and permit. Groups are drawn by **which destinations genuinely must share a
+  > sign-in**, not by product or vendor.
+
+  **Why the tension is gone.** The 2026-08-18 requirement carried a live one: some
+  authentication and SSO flows depend on service workers, and the pilot exists to hand an
+  interactively-authenticated session to an agent, so a session-wide disable could break
+  the very use case the control protects. That was an inference, and the RFC flagged it as
+  one. It does not survive the per-group unit: a worker-dependent destination goes in its
+  own group with workers permitted, and every other group keeps full item-6 protection.
+  The choice between losing a surface and losing the control was an artefact of the
+  session-wide reading, and question 4 withdrew that reading. Round 12 separately observed
+  post-authentication re-attach surviving worker suppression with zero registrations under
+  both policies, bounded to one destination, one device and one point in time.
+
+  **Two residuals survive this restatement and are named rather than absorbed.** Whether a
+  group can be split without costing an additional interactive sign-in is **unmeasured** —
+  that is the carried `rfc0088-destination-group-split-cost` slug, and it decides whether
+  drawing fine groups is cheap or expensive, which is what makes item-6 protection
+  practical or theoretical. And whether the purge clause scopes **below** the profile
+  remains open: an earlier measurement claiming it cannot was withdrawn by its author
+  pending re-measurement. The restated requirement deliberately **does not depend on that
+  answer** — the block clause alone forces the group unit, so purge scope changes how
+  finely the control can be applied, not whether the requirement is met.
+
+  **Where the five binding requirements now stand.** Composing the OS profile with the Node
+  permission model holds. Denying `--allow-addons` holds. One consumer per connection holds,
+  on the redrawn boundary above. Worker policy holds, as restated above. The fifth — that
+  the first browser-digest pin be established from an independently verified channel and
+  that channel recorded — remains **not measurable**: it is a process requirement, and no
+  experiment closes trust-on-first-use. It is unchanged by this entry.

--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3764,3 +3764,62 @@ that mechanism rather than record the channel as inherently uncontrollable.
   the first browser-digest pin be established from an independently verified channel and
   that channel recorded — remains **not measurable**: it is a process requirement, and no
   experiment closes trust-on-first-use. It is unchanged by this entry.
+
+- **2026-08-23 — two deferrals that unblock the Experimental exit, and neither is a
+  measurement.** Both were taken because the thing being waited on could not be produced
+  inside the Experimental phase — one for a structural reason, one for a temporal one.
+  Recording them as deferrals rather than closures, because neither underlying obligation
+  goes away.
+
+  **Question 3's contract clause is deferred OUT of this RFC.** The amended bar reads "a
+  destination adapter contract, exercised by two independent fixtures … The contract is
+  asserted in CI." Building that contract is *implementation*, and the Boundaries forbid
+  creating a follow-on artifact while this RFC is `Experimental` — so the bar required
+  something acceptance has to precede. **That is a circularity, not a high bar**, and it
+  would have held the RFC open indefinitely with no experiment able to resolve it.
+
+  The approver rules that **the contract clause is not an Experimental-phase experiment**.
+  It is post-acceptance implementation work, and its home already exists: the follow-on
+  list's **Spec 1**, whose scope covers the synthetic foundation/provider vertical and its
+  authorization-order fixtures. No new artifact is created here — the clause moves to a
+  slot the follow-on list already reserves.
+
+  What the bar therefore asks of the Experimental exit, and this is the whole of it: **two
+  independent fixtures of differing render and authentication shape** — measured in round
+  14 and recorded in [the destination token-landing note](0088-notes/spikes/2026-08-21-destination-token-landing.md)
+  — and **one documented reference consumer** an adopter runs against their own account,
+  as a recorded observation.
+
+  **What is given up, stated rather than discovered later.** At acceptance, nothing will
+  have asserted the full login → token → frontend-API path **mechanically in CI**. Round
+  14 measured that path by hand against two pinned containers; a CI contract that re-asserts
+  it on every change does not exist and will not before acceptance. The exit therefore rests
+  on measurement plus observation rather than on a standing gate. That is a genuine
+  reduction in what "clears the bar" means, and it is accepted deliberately in exchange for
+  an exit that is reachable at all.
+
+  **`rfc0088-signing-identity-update-survival` is deferred, and downgraded from acceptance
+  blocker to a post-acceptance observation.** Question 6 ruled signing identity as the
+  provenance anchor for system channels, and the 2026-08-22 matrix admits the macOS system
+  channel — so on 2026-08-22 this slug was correctly recorded as an acceptance blocker.
+
+  It is deferred now for a reason that is temporal rather than evidential: closing it needs
+  **two dated observations of the same system browser across a real vendor update**, and no
+  amount of work brings the second one forward. Holding acceptance for it means holding it
+  for an event outside anyone's control. **An earlier draft demoted this slug on a factual
+  error** — a bundled-only reading of the matrix that the approver corrected. This deferral
+  is not that: both channels remain admitted, signing identity remains live in the pilot,
+  and the deferral is a deliberate disposition rather than a consequence of a mistake. The
+  distinction is recorded because the two look identical in a diff and are not.
+
+  **It observes rather than gates.** The first dated observation is taken during pilot
+  operation and recorded; when a real update occurs, the second observation is carried by
+  an **RFC update**, not by re-opening the Experimental phase. The register entry stays
+  carried, with its unblock condition unchanged — what changes is that acceptance no longer
+  waits on it.
+
+  **Nothing else is deferred by this entry.** No blocker item closes, no other residual is
+  relabelled, no disposition is withdrawn, the status field does not move, and no follow-on
+  artifact is created. The five binding requirements stand exactly as the 2026-08-22 entry
+  restated them, including the first-browser-digest-pin requirement, which remains **not
+  measurable**.

--- a/workspace.toml
+++ b/workspace.toml
@@ -48,14 +48,25 @@ backlog = [
   # Shape: how should a broker accommodate a consumer that must replay a scoped API
   # token? The RFC's credential posture assumes the session stays in the browser;
   # a realistic consumer intercepts a scoped token and replays it. RFC open
-  # question 5 carries the recommended candidate (keep the token page-resident);
-  # round 12 measures whether that candidate works. This item shapes what the
-  # broker CONTRACT should say once it does.
+  # question 5 carried the recommended candidate (keep the token page-resident). ANSWERED:
+  # round 12 showed it holds only when the issuing response is `no-store`, and round 14
+  # measured a real destination that sends no cache directive AND persists the token to
+  # page-readable storage, so the token reaches disk regardless. Question 5 was RULED on
+  # 2026-08-22 -- the pattern is supported and the exposure is DECLARED per destination.
+  # What remains for this shaping item is narrower than when it was written: not whether to
+  # accommodate replay, but what the declaration looks like in the broker contract. The
+  # obligation is already carried into Spec 1's contract list, so this item shapes the
+  # wording, not the decision.
   {slug = "rfc0088-token-replay-consumer-contract", type = "shape"},
-  # Shape: destination-scoped constraint as a single axis. Decision C constrains
-  # egress by destination; measurement shows worker policy needs the same scoping
-  # because real surfaces have opposite needs. Should destination become the one
-  # place a session's per-destination policy lives (egress + worker + more)?
+  # Shape: destination-scoped constraint as a single axis. Decision C constrains egress by
+  # destination; worker policy needed the same scoping because real surfaces have opposite
+  # needs. PARTLY ANSWERED: question 4 was ruled on 2026-08-21 -- worker policy is decided by
+  # destination GROUP, realised as a separate browser context, and the session-wide reading is
+  # withdrawn. So the axis exists, but its unit is the group, not the destination, because
+  # contexts isolate sessions and destinations sharing a sign-in must share a context.
+  # What this item still shapes: whether egress and worker policy should collapse onto that one
+  # group axis together, and what else belongs on it. Note the two constraints do not obviously
+  # share a unit -- egress can scope per destination, worker policy cannot.
   {slug = "rfc0088-destination-scoped-policy-axis", type = "shape"},
   # Signal items — hand-authored by strategist; ongoing, non-graduating
   {slug = "ai-native-regulatory-watch", type = "signal"},
@@ -1182,44 +1193,59 @@ open = [
   # session-theft path). Measuring it needs node-gyp and a C++ toolchain in the
   # evidence tree, which is a new dependency and outside a pre-acceptance spike.
   # Node itself warns `--allow-addons` "could invalidate the permission model".
-  # Unblocks when: an approver accepts a toolchain in the evidence tree, or the
-  # pilot commits to denying addons unconditionally so the bypass is moot.
+  # STATUS CHANGE, needs an approver call: the second unblock condition below now appears
+  # MET. "Deny `--allow-addons`" is a binding requirement that round 11 measured as holding,
+  # and the 2026-08-22 entry restates all five requirements with that one still holding -- so
+  # in the pilot the flag is never granted and the bypass has no gate to come through. What
+  # survives is the bypass in any configuration that DOES grant the flag. Closing versus
+  # re-scoping this slug to that narrower case is a disposition, not a measurement, so it is
+  # carried unchanged until an approver takes it.
+  # Unblocks when: an approver accepts a C++ toolchain in the evidence tree so the bypass can
+  # be measured directly, OR an approver rules that the pilot's unconditional addon denial
+  # makes it moot and re-scopes the slug accordingly.
   {slug = "rfc0088-native-addon-confinement-bypass", source = "spec/rfc0088-round11-binding-requirements AC7"},
-  # Round 11 accepted, and no measured control closes, the exposure that any
-  # same-uid process can attach to the browser's unconfined bind endpoint. Round 13
-  # may measure whether a second OS user closes it once authorised. On this platform an unprivileged
-  # process cannot execute as another uid; the available switching mechanisms require
-  # administrator authority, which the current Ask-first boundary forbids. Unblocks
-  # when: an approver authorises a runnable second-uid mechanism or a suitable
+  # Round 11 accepted, and no measured control closes, the exposure that any same-uid
+  # process can attach to the browser's unconfined bind endpoint. The 2026-08-22 matrix
+  # inherits it as an accepted pilot exposure. On this platform an unprivileged process
+  # cannot execute as another uid, and every available switching mechanism requires
+  # administrator authority, which the Ask-first boundary forbids. Round 13 corrected the
+  # claim's WIDTH in the evidence layer as new evidence requiring re-ruling -- documentation,
+  # not measurement -- so the slug is carried rather than closed.
+  # Unblocks when: an approver authorises a runnable second-uid mechanism, or a suitable
   # non-administrative execution boundary exists.
-  # Unblocks when: an authorised second-uid mechanism or a non-administrative
-  # execution boundary exists. Round 13 corrected the claim's WIDTH in the evidence
-  # layer as new evidence requiring re-ruling, which is documentation rather than
-  # measurement, so the slug is carried rather than closed.
   {slug = "rfc0088-same-uid-attach-exposure", source = "rfc/0088 disposition B"},
-  # Round 12 amended item 6's accepted risk from per-destination to per-GROUP,
-  # derived from the BLOCK clause alone: blocking scopes only per context, contexts
-  # isolate sessions, so destinations sharing a sign-in share one worker policy and
-  # the weakest member sets it. The purge half is WITHDRAWN pending re-measurement
-  # and the amendment does not rest on it. What is NOT
-  # measured is whether a group can be split without costing an additional
-  # interactive sign-in -- spike A showed profile-bound re-attach works and spike E
-  # showed a fresh profile needs a real sign-in, which suggests one sign-in per
-  # group. That figure decides whether splitting is cheap or expensive.
-  # Unblocks when: a spike measures the per-group sign-in cost.
+  # Item 6's accepted risk is per-GROUP, derived from the BLOCK clause alone: blocking
+  # scopes only per context, contexts isolate sessions, so destinations sharing a sign-in
+  # share one worker policy and the weakest member sets it. The 2026-08-22 restatement of
+  # the item-6 binding requirement rests on that unit and NOT on purge scope, deliberately.
+  # Round 13's blast-radius arm measured the purge mechanics -- store removed, removals
+  # inventoried, unknown label refused, symlink tree refused. Whether purge scopes BELOW
+  # the profile is still open, an earlier claim having been withdrawn by its author.
+  # THIS SLUG IS THE ONE THAT DECIDES WHETHER ITEM-6 PROTECTION IS PRACTICAL. Drawing fine
+  # groups is how a worker-dependent destination stops forcing workers on everything sharing
+  # its session; if each extra group costs an interactive sign-in, fine grouping is
+  # theoretical. Spike A showed profile-bound re-attach works and spike E showed a fresh
+  # profile needs a real sign-in, which suggests one sign-in per group -- suggests, not measures.
+  # Unblocks when: a spike measures the per-group interactive sign-in cost.
   {slug = "rfc0088-destination-group-split-cost", source = "rfc/0088 item 6 per-group amendment"},
-  # Open question 6 recommends signing identity as the browser-provenance anchor.
-  # Round 12 AC5 measures present-run verification and tamper discrimination; it
-  # cannot observe the deferred update-survival property. Unblocks when: the same
-  # system browser can be read before and after a real update in a second dated
-  # observation.
+  # Open question 6 was RULED on 2026-08-22: signing identity is the provenance anchor for
+  # system channels. The same day's matrix admits the macOS system channel, so this is an
+  # ACCEPTANCE BLOCKER rather than a later-admission precondition -- an earlier draft demoted
+  # it on a bundled-only reading that the approver corrected. Round 12 AC5 measured present-run
+  # verification and tamper discrimination; neither can observe update survival, and one
+  # installation cannot observe an update at all.
+  # Unblocks when: the same system browser is read before and after a real update, as a second
+  # dated observation.
   {slug = "rfc0088-signing-identity-update-survival", source = "spec/rfc0088-round12-consumer-shaped-residuals AC5"},
-  # AC6 remains deferred only for its four unimplemented mutations: missing expected row,
-  # token encodings, browser-store decoy, and staged-member decoy search. Unblocks when:
-  # each named mutation is implemented and run in the gate chain.
+  # SATISFIED -- do not plan work against this. Round 13 closed mutation coverage by class.
+  # The entry is retained ONLY because a frozen spec pins the slug with a deferral marker and
+  # a pinned slug cannot be removed from the register; the lint resolves the marker here.
+  # Nothing unblocks it, because nothing is blocked. Remove only if that marker is ever
+  # unpinned.
   {slug = "rfc0088-round12-mutation-coverage", summary = "Satisfied by RFC-0088 round 13 (mutation coverage closed by class); retained as the frozen deferred-reference lint anchor", source = "spec/rfc0088-round12-consumer-shaped-residuals AC6"},
-  # AC4 requires a T6 staged-member decoy search; no promoted-state implementation exists.
-  # Unblocks when: promotion searches a published decoy in staged members and restores them.
+  # SATISFIED -- do not plan work against this. Round 13 implemented the staged-member decoy
+  # search, positive control first. Retained ONLY as the frozen deferred-reference lint anchor,
+  # exactly as the mutation-coverage slug above. Nothing unblocks it, because nothing is blocked.
   {slug = "rfc0088-staged-member-decoy-search", summary = "Satisfied by RFC-0088 round 13 (staged-member decoy search implemented, positive control first); retained as the frozen deferred-reference lint anchor", source = "spec/rfc0088-round12-consumer-shaped-residuals AC4"},
   # Unblocks when: cross-round term identity is anchored by something other than
   # operator trust. Round 13 closed same-file identity WITHIN a gate chain via a


### PR DESCRIPTION
## What does this change?

Restates the two RFC-0088 binding requirements that round 11 found "did not hold **as
written**", so that both now hold, and reconciles the `workspace.toml` register to the
result. Two files, documentation and register comments only.

## Why?

- Amends: [RFC-0088](docs/rfc/0088-web-pilot-foundation.md), below the `## Amendments` anchor
- Follows: the 2026-08-22 rulings and matrix (#1092)

Neither failure was a *measurement* failure. In both cases round 11 found what closes the
requirement, and the requirement's wording hadn't caught up.

**Item 3 — the residue boundary is redrawn.** The requirement covered two of three
surviving residue classes; a committed download crossed an unshared connection because it
is a filesystem artifact rather than a browser-connection one. The approver rules that a
downloaded artifact **has crossed to the user** — a deliberate delivery into the user's own
filesystem, requested through the session. On that boundary the requirement holds as
written, and job-root partitioning is neither required nor deferred.

This is a **transfer, not a closure**: the artifact persists after the session, outside
anything the pack tears down, and may carry destination content. The approval surface must
say downloads are the user's and are not cleared on teardown. Disclosure is the whole of
what replaces the control.

**Item 6 — restated as a per-group composed control.** `serviceWorkers: 'block'` is a
*context* option: it refuses new registrations but does not reach an already-persisted
worker. Block **composed with** a purge of the profile's worker storage closes it —
controller `false`, zero packets, zero registrations — and round 13's blast-radius arm
measured the purge itself.

The requirement now reads per **destination group** (question 4's unit, realised as a
separate browser context), with the weakest member setting the group's policy and groups
drawn by which destinations must genuinely share a sign-in.

**Its live tension is dissolved structurally, not measured away.** The old wording risked
breaking the very use case it protected, since some SSO flows depend on workers. Under the
per-group unit a worker-dependent destination goes in its own group and every other group
keeps full protection. The dilemma was an artefact of the session-wide reading question 4
withdrew.

## How do I verify it?

```bash
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .
python3 -m pytest tools/test_documentation_entry_links.py -q
python3 -c "import tomllib,pathlib; tomllib.loads(pathlib.Path('workspace.toml').read_text())"
```

The register change is **comment-only** — 175 slugs before and after, identical set, zero
symmetric difference — so a peer verifying slug sets against a base sees no delta:

```bash
git show HEAD~1:workspace.toml > /tmp/base.toml   # compare slug sets
```

RFC-0088 governance controls, all green (apparatus out of tree, `RFC88_REPO=$PWD` from the
repo root): `r13-decision-surface.py` plus both self-tests, `r13-digest-coverage.py`,
`r13-spec-consistency.py`, `r13-disposition-partition.py`.

`make build-check` is still running locally; this machine has been exceeding a ten-minute
wall clock under sustained load. CI on clean runners is the authority for this diff.

## What did you not change that you considered?

- **No disposition is withdrawn and no blocker item is declared closed.** Both requirements
  are restated, not waived.
- **`rfc0088-native-addon-confinement-bypass` is carried unchanged**, with a flagged status
  change rather than a silent one: its second unblock condition — the pilot denying addons
  unconditionally — now appears met, since that denial is a binding requirement measured as
  holding. Closing or re-scoping is a disposition, not a measurement, so it waits for an
  approver.
- **`rfc0088-destination-group-split-cost` stays carried.** It is the slug that decides
  whether item-6 protection is practical rather than theoretical, and the entry now says so
  instead of burying it.
- **Purge scope below the profile is left open.** The restated requirement deliberately does
  not depend on it, because the block clause alone forces the group unit.
- **The fifth binding requirement is untouched** — the first browser-digest pin from an
  independently verified channel remains *not measurable*, a process requirement no
  experiment closes.
- **Status stays `Experimental`.** Question 3's amended bar is still ruled-but-unmet.
