### PR TITLE
docs(rfc): RFC-0088 — re-scope the native-addon confinement bypass to flag-granting configurations

### DIFF
--- a/docs/rfc/0088-web-pilot-foundation.md
+++ b/docs/rfc/0088-web-pilot-foundation.md
@@ -3823,3 +3823,90 @@ that mechanism rather than record the channel as inherently uncontrollable.
   artifact is created. The five binding requirements stand exactly as the 2026-08-22 entry
   restated them, including the first-browser-digest-pin requirement, which remains **not
   measurable**.
+
+- **2026-08-23 — `rfc0088-native-addon-confinement-bypass` is re-scoped, not closed. A
+  disposition, not a measurement.** This is the second entry dated 2026-08-23. It relabels
+  one carried residual, which the preceding entry's closing line said it was not doing —
+  that line was accurate for the entry carrying it.
+
+  **This entry establishes a reading convention: per-entry "nothing else moves" clauses are
+  self-scoped to the entry that carries them.** It is established here rather than claimed
+  as settled practice, because nobody recorded it. One prior instance is consistent with it:
+  the 2026-08-22 *rulings-on-questions-1/5/6* entry closes with an unqualified "no residual
+  is relabelled", and the 2026-08-23 *deferrals* entry then relabelled
+  `rfc0088-signing-identity-update-survival` without superseding it — but a single silence is
+  equally readable as an omission, so it is offered as consistency rather than as proof.
+  Three such clauses already run in sequence before this one, which is why the convention is
+  worth stating.
+
+  This does not weaken the explicit-supersession rule this section states elsewhere. That
+  rule governs cross-entry *decisions* — a later ruling displacing an earlier one — whereas a
+  closing "nothing else moves" clause is a scope statement about its own entry's reach, and a
+  scope statement cannot bind acts it never contemplated.
+
+  **What is measured, and what is not.** Round 11 measured the *gate*: Node's permission
+  model refuses `process.dlopen` by **policy** when `--allow-addons` is absent
+  (`ERR_DLOPEN_DISABLED`) and lets it through to a non-policy failure when the flag is
+  granted (`ERR_DLOPEN_FAILED`), so "denied" cannot be satisfied by a file that merely fails
+  to load. What has never been measured is whether a genuinely compiled `.node` addon,
+  loaded through a granted gate, defeats the filesystem confinement round 10 established —
+  the correction-9 session-theft path, reading the live browser profile off disk. Measuring
+  it needs `node-gyp` and a C++ toolchain in the evidence tree.
+
+  **Why the question arose now.** "Deny `--allow-addons`" is one of the five binding
+  requirements, and the 2026-08-22 *binding-requirements* entry restates it as holding. In the pilot the flag is
+  therefore never granted, and the bypass has no gate to come through.
+
+  **The ruling: re-scope to configurations that grant the flag, and keep it carried.** The
+  slug's second unblock condition read "an approver rules that the pilot's unconditional
+  addon denial makes it moot **and re-scopes the slug accordingly**". Both conjuncts are
+  answered, and they are answered differently: the **moot half is rejected** — the pilot's
+  denial makes the bypass *unreachable*, which is not the same as *measured* — and the
+  **re-scope half is taken**.
+
+  **Where the unmeasured half is and is not already recorded, stated precisely because an
+  earlier draft of this entry overstated it.** The distinction is recorded in the evidence
+  layer in several places: § *Approver dispositions — 2026-08-18*'s round-11 layer calls it
+  "bounded, not closed", the
+  round-11 note and the round-11 spec's AC7 both name it, and this section's blocker item 5
+  states the argv half as "a bound, not an all-clear … which round 10 did not test". So the
+  register entry is **not** the only record of the distinction. What it is the only record
+  of is the distinction **as a live open item an approver must dispose of** — and that is
+  the reason to keep it rather than close it. Blocker item 5's *filesystem* half is the text
+  that would be left misleading by a closure: it reads "closed by composition … both
+  permission-model arms deny it", with no compiled-addon caveat attached.
+
+  **Two alternatives were put to the approver and declined.** Commissioning the toolchain
+  was declined. The same reason is on the record twice already, and neither instance was an
+  approver ruling: round 11 recorded it on 2026-08-18 as a *product* decision in its spec's
+  Assumptions ("stays an unmeasured named residual rather than adding node-gyp and a C++
+  toolchain … source: user confirmation"), and round 13 carried the reason forward on
+  2026-08-21. **This is the first approver ruling on it.** It adds
+  a dependency to measure a path the pilot forbids, and recording a new dependency would
+  ordinarily want a decision record, which the Boundaries forbid while this RFC is
+  `Experimental`. Closing outright was declined for the reason above.
+
+  **A mechanical fact that narrows what any of the three options could have meant.** The
+  slug is pinned by a `(deferred: …)` marker in a **frozen** predecessor spec, and the
+  deferral lint resolves markers against the open register only. So the entry cannot leave
+  `[backlog].open` under any disposition — closing it would have meant `closed_retained`
+  with a satisfaction summary, on the retained-frozen-anchor precedent this repository has
+  already settled for several slugs. The practical difference between closing and
+  re-scoping was therefore what the entry *says*, not whether it exists.
+
+  **What the approver gives up by taking this**, stated rather than discovered later: a
+  carried residual that no pilot work will close. Nothing in the pilot grants the flag, so
+  nothing in the pilot can measure the bypass.
+
+  **What moves, and what does not.** A third thing moves and it is deliberately not on the
+  register entry: **this entry records the per-entry self-scoping convention for the
+  amendment layer**, stated above. The other two are on the register entry and nowhere else —
+  its **scope**, now configurations that grant `--allow-addons`; and its
+  **unblock condition**, whose rejected moot-ness clause is replaced by "a configuration
+  outside the pilot needs the flag granted and commissions the measurement". The unblock
+  condition is part of a `carried` disposition's content, so its replacement is named here
+  rather than left to a diff. Nothing else: no blocker item closes, no other residual is
+  relabelled, no disposition is withdrawn, the status field does not move, no follow-on
+  artifact is created, and the five binding requirements are unchanged. The slug stays
+  `carried` in the round-13 disposition partition, so no slug-set comparison against the
+  pinned base moves.

--- a/workspace.toml
+++ b/workspace.toml
@@ -1193,16 +1193,20 @@ open = [
   # session-theft path). Measuring it needs node-gyp and a C++ toolchain in the
   # evidence tree, which is a new dependency and outside a pre-acceptance spike.
   # Node itself warns `--allow-addons` "could invalidate the permission model".
-  # STATUS CHANGE, needs an approver call: the second unblock condition below now appears
-  # MET. "Deny `--allow-addons`" is a binding requirement that round 11 measured as holding,
-  # and the 2026-08-22 entry restates all five requirements with that one still holding -- so
-  # in the pilot the flag is never granted and the bypass has no gate to come through. What
-  # survives is the bypass in any configuration that DOES grant the flag. Closing versus
-  # re-scoping this slug to that narrower case is a disposition, not a measurement, so it is
-  # carried unchanged until an approver takes it.
-  # Unblocks when: an approver accepts a C++ toolchain in the evidence tree so the bypass can
-  # be measured directly, OR an approver rules that the pilot's unconditional addon denial
-  # makes it moot and re-scopes the slug accordingly.
+  # RE-SCOPED by approver ruling 2026-08-23. SCOPE IS NOW: configurations that DO grant
+  # `--allow-addons`. NOT closed. The pilot never grants the flag ("deny `--allow-addons`"
+  # is a binding requirement measured as holding), so the bypass is unreachable there --
+  # unreachable is not measured.
+  # The full rationale and the two declined alternatives live in ONE place: the second
+  # 2026-08-23 entry in rfc/0088's amendment layer. Restating them
+  # here would give a load-bearing rationale two homes that drift at the first edit.
+  # ACCEPTED COST: a carried residual no pilot work will close, because nothing in the
+  # pilot grants the flag.
+  # Unblocks when: an approver accepts a C++ toolchain in the evidence tree so the bypass
+  # can be measured directly, OR a configuration outside the pilot needs the flag granted
+  # and commissions the measurement.
+  # (Replaces the previous second condition, whose "the pilot's denial makes it moot" half
+  # the ruling rejected while taking its re-scope half.)
   {slug = "rfc0088-native-addon-confinement-bypass", source = "spec/rfc0088-round11-binding-requirements AC7"},
   # Round 11 accepted, and no measured control closes, the exposure that any same-uid
   # process can attach to the browser's unconfined bind endpoint. The 2026-08-22 matrix


### PR DESCRIPTION
## What does this change?

Records an approver ruling on the carried register residual `rfc0088-native-addon-confinement-bypass`, which needed a **disposition rather than a measurement**: it is **re-scoped** to configurations that grant `--allow-addons`, not closed and not measured. One appended RFC amendment entry plus a comment-only `workspace.toml` edit.

## Why?

- Follows from: [RFC-0088](docs/rfc/0088-web-pilot-foundation.md) (Experimental) — the entry is appended to the amendment layer, which that RFC designates as the authoritative current contract.
- Source of the residual: `docs/specs/rfc0088-round11-binding-requirements/spec.md` AC7.

No spec accompanies this PR, and deliberately so: it records a decision, not a change in behaviour or evidence. RFC-0088's Boundaries forbid creating a follow-on artifact (including an ADR) while the RFC is `Experimental`, so the amendment layer is the only available home.

**The substance.** Round 11 measured the addon *gate* — Node refuses `process.dlopen` by policy without the flag (`ERR_DLOPEN_DISABLED`) and lets it reach a non-policy failure with it (`ERR_DLOPEN_FAILED`). What is unmeasured is whether a compiled `.node` addon loaded through a granted gate defeats round 10's filesystem confinement (the correction-9 session-theft path); measuring it needs `node-gyp` and a C++ toolchain.

Because "deny `--allow-addons`" is a binding requirement measured as holding, the pilot never grants the flag and the bypass is **unreachable** there. Unreachable is not the same as measured — which is the whole reason this is a re-scope rather than a closure.

## How do I verify it?

```bash
export RFC88_REPO=$PWD PYTHONDONTWRITEBYTECODE=1
python3 ~/.local/share/rfc0088-evidence/r13-decision-surface.py
python3 ~/.local/share/rfc0088-evidence/r13-decision-surface.py --self-test-follow-on-detector
python3 ~/.local/share/rfc0088-evidence/r13-decision-surface.py --self-test-follow-on-scoping
python3 ~/.local/share/rfc0088-evidence/r13-digest-coverage.py
python3 ~/.local/share/rfc0088-evidence/r13-spec-consistency.py
python3 ~/.local/share/rfc0088-evidence/r13-disposition-partition.py d59da746 \
  docs/rfc/0088-notes/round13-consolidated-evidence-digest.md
python3 .claude/skills/work-loop/scripts/lint-spec-status.py --root .
```

All seven pass. Two further checks worth reproducing:

**The frozen-body gate was positive-controlled, not merely observed green.** A hunk planted above the `## Amendments` anchor makes `r13-decision-surface.py` exit 1 and name the line; the tree then restores to an identical hash and the gate returns to 0.

**`workspace.toml` is comment-only, proven by parsing rather than by reading the diff:**

```bash
python3 -c "
import tomllib, subprocess
base = tomllib.loads(subprocess.run(['git','show','origin/main:workspace.toml'],
                                    capture_output=True,text=True).stdout)
print(base == tomllib.loads(open('workspace.toml').read()))"   # True
```

`SKIP_SAST=1 make build-check` was **not** run locally, and that is deliberate: three peer worktrees were mid-gate (`make ci`, `make build-check`, pytest) at loadavg ~99, and bootstrapping this worktree performs a global editable install that kills their in-flight runs. CI's required contexts cover it.

## What did you not change that you considered?

- **Closing the slug.** Declined: the pilot's denial makes the bypass unreachable, not measured, and blocker item 5's *filesystem* half reads "closed by composition" with no compiled-addon caveat — a closure would leave that misleading.
- **Commissioning a C++ toolchain to measure the bypass.** Declined: a new dependency to measure a path the pilot forbids, and recording a dependency would ordinarily want a decision record that the Boundaries forbid here.
- **Removing the entry from `[backlog].open`.** Not possible under any disposition: a frozen predecessor spec pins the slug with a `(deferred: …)` marker and `lint-spec-status.py` resolves markers against the open register only.
- **Round 15's reference-consumer measurement**, which is the other half of this session's work. Split out deliberately: it blocks on an attended human sign-in, and this repository squash-merges, so two PRs is the only way to get real revert granularity between a decision and an experiment.
- **Touching the digest's disposition block.** The slug stays `carried`, so no peer's slug-set comparison against the pinned base moves.

---

## Checklist

- [x] Tests pass locally — `lint-spec-status.py` (clean), `pytest tools/test_documentation_entry_links.py` (2 passed), six RFC-0088 governance gates
- [x] Lint and typecheck pass — docs-only change; `lint-spec-status` is the applicable linter
- [x] Self-review run via `adversarial-reviewer` — **two rounds**. Round 1 returned 1 blocker + 5 concerns + 2 nits; all closed, including a real factual error (I claimed the register was "the only place" the distinction is recorded — it is not) and a wrong citation of blocker item 5's argv half. Round 2 confirmed all eight closed and returned only wording-level findings, which this commit also applies. No security boundary crossed; no logic to review.
- [x] Spec and code agree — no code; the RFC entry and the register comment were verified consistent, with the rationale kept canonical in the entry only
- [x] Living docs match reality — no released artifact version bumped, so no changelog entry (`docs/CONVENTIONS.md` § 5b); no user-facing behaviour, structure, or roadmap item touched
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the self-scoping convention for per-entry "nothing else moves" clauses is now recorded in the amendment layer, where the next reader meets it
