### PR TITLE
test(tools): gate docs-site's @astrojs/markdown-remark version, and record the build-not-required gap

### DIFF
--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -35,8 +35,10 @@ npm run build --prefix docs-site
   `markdown.remarkPlugins`/`rehypePlugins` fail config validation when the
   package is unresolvable. The declaration turns root placement from luck into
   a requirement. Two duties come with it: keep the pin equal to `astro`'s exact
-  optional-peer version, and expect an astro major to arrive alone and need
-  both moved together.
+  optional-peer version — `tools/test_browser_gate_subset.py` refuses from
+  `gate-main` when the manifest, the lockfile and that peer disagree, or when
+  Starlight's declared range stops accepting the pin — and expect an astro major
+  to arrive alone and need both moved together.
 - `markdown.remarkPlugins` and `markdown.rehypePlugins` are deprecated — every
   docs build prints so. The migration is `markdown.processor: unified({...})`
   from `@astrojs/markdown-remark`; until it happens, an astro major can drop

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -319,6 +319,10 @@ PINNED_SITE_BUILD_PYTEST = (
     # pages.yml, which is not a required merge context; its construction test —
     # the spec allowlist, the matrix's route/width/theme contract, and the
     # DOCS_BASE agreement — runs HERE so the wiring is proven in a required one.
+    # That module has since become the home for the site manifests' other
+    # must-stay-in-relation pairs too, which are here for the same reason and not
+    # for a browser-gate one: the `@astrojs/markdown-remark` version that
+    # docs-site's manifest, its lockfile and astro's optional peer must agree on.
     "tools/test_browser_gate_subset.py"
 )
 PINNED_CONTRAST_CHECKER = "python3 tools/check-docs-contrast.py"

--- a/tools/test_browser_gate_subset.py
+++ b/tools/test_browser_gate_subset.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
-"""The browser gate's spec allowlist, checked against the filesystem.
+"""The browser gate's spec allowlist, plus the site files' must-stay-in-relation values.
 
 `site-browser-quality-gate` AC11: required CI must leave the tracked tree clean,
 and two of the e2e specs write PNGs into tracked `docs/specs/**/notes/screenshots/`.
+
+A further resident class — alongside the AC1/AC2 matrix contract, the
+unbound-helper-identifier check and the tap-target audit arithmetic below — is a
+value that tracked site files must keep in a fixed relation, where nothing else
+would notice them diverging: the `base` the docs config must derive from the
+marketing one, and the `@astrojs/markdown-remark` version that
+`docs-site/package.json`, the lockfile and astro's optional peer must agree on.
+They live here because this module runs from `gate-main`, a required context;
+`pages.yml` is not one, so a pin gate placed there could not block the merge that
+broke it.
 
 Scope is deliberately narrow. `pages.yml` posture — that the gate step exists by
 statement equality, is not advisory/conditional/redirected, runs after both builds
@@ -155,6 +165,167 @@ def test_the_docs_base_agrees_with_the_docs_site_config() -> None:
         f"docs-site base is {docs_base.group(1)!r} but site-base.ts derives "
         f"{expected!r} from the marketing base — update site-base.ts to read the "
         "docs config, or realign the two"
+    )
+
+
+MARKDOWN_REMARK = "@astrojs/markdown-remark"
+EXACT_VERSION = re.compile(r"\d+\.\d+\.\d+")
+CARET_RANGE = re.compile(r"\^(\d+)\.(\d+)\.(\d+)")
+
+
+def _docs_site_versions() -> dict[str, str | None]:
+    """Every recorded copy of the `@astrojs/markdown-remark` version, and astro's.
+
+    Missing values come back as ``None`` rather than raising. The drift shape this
+    guards has already occurred in the exact form of an ABSENT key — at #1036's
+    head 6990d3d7, `docs-site/package.json` declared no `@astrojs/markdown-remark`
+    at all — and a `KeyError` traceback would replace the remediation text the
+    assertions exist to deliver.
+
+    `@astrojs/mdx` is a fifth recorder and is deliberately absent: it requires
+    `@astrojs/markdown-remark` through its own `dependencies`, not a peer, so an
+    mdx divergence nests a private copy under `@astrojs/mdx/node_modules/` and
+    leaves the ROOT slot — the only placement `astro.config.ts` can import from —
+    untouched. Comparing it would fail on a difference that cannot break this
+    build. Do not add it back without re-deriving that argument.
+    """
+    site = REPO_ROOT / "docs-site"
+    manifest = json.loads((site / "package.json").read_text(encoding="utf-8"))
+    packages = json.loads((site / "package-lock.json").read_text(encoding="utf-8"))
+    packages = packages.get("packages", {})
+    deps = manifest.get("dependencies", {})
+    root = packages.get("", {}).get("dependencies", {})
+    astro = packages.get("node_modules/astro", {})
+    starlight = packages.get("node_modules/@astrojs/starlight", {})
+    return {
+        "manifest_pin": deps.get(MARKDOWN_REMARK),
+        "lock_root_pin": root.get(MARKDOWN_REMARK),
+        "installed": packages.get(f"node_modules/{MARKDOWN_REMARK}", {}).get("version"),
+        "astro_peer": astro.get("peerDependencies", {}).get(MARKDOWN_REMARK),
+        "manifest_astro": deps.get("astro"),
+        "installed_astro": astro.get("version"),
+        "starlight_peer": starlight.get("peerDependencies", {}).get(MARKDOWN_REMARK),
+        "starlight_version": starlight.get("version"),
+    }
+
+
+def test_the_markdown_remark_pin_equals_astros_optional_peer() -> None:
+    """One `@astrojs/markdown-remark` version, agreed by all four files recording it.
+
+    astro declares it an *optional* peer at an exact version, so npm neither
+    installs it nor complains when the two drift — but `astro.config.ts` needs it
+    resolvable at the root, and a mismatched copy is a resolution failure at build
+    time, not an install-time warning. The duty to move both together was prose in
+    `docs-site/AGENTS.md` that no gate read.
+
+    Read from the lockfile rather than `node_modules/astro/package.json`: this
+    module runs in `gate-main`, which installs no Node, and a check that skips
+    itself in the job most PRs actually run is not a check.
+
+    All four recorded copies are compared, not just the manifest against the peer.
+    `npm ci` would refuse a lockfile that disagrees with the manifest — but `npm
+    ci` runs in `build`, which is not a required context, and that is the same
+    argument that puts this test here rather than in `node_modules`. It cannot be
+    used to justify reading the lockfile and then to excuse trusting it.
+    """
+    v = _docs_site_versions()
+
+    # The two absences mean opposite things and need opposite first moves.
+    assert v["manifest_pin"] is not None, (
+        f"docs-site/package.json declares no `{MARKDOWN_REMARK}`. The declaration "
+        "is what makes root placement a requirement rather than a hoisting "
+        "accident (docs-site/AGENTS.md § Action-changing traps) — restore it, or "
+        "delete this test with a reason if the duty genuinely ended."
+    )
+    assert v["astro_peer"] is not None, (
+        f"astro {v['installed_astro']} no longer declares `{MARKDOWN_REMARK}` as a "
+        "peer. This is the arrival docs-site/AGENTS.md predicts, and it is NOT a "
+        "signal to delete this test: run `npm run build --prefix docs-site` and "
+        "check whether astro.config.ts's markdown configuration still validates "
+        "before concluding anything about the duty."
+    )
+
+    # Exact equality is the whole contract. A range on any of the three means the
+    # premise changed, and "make them equal" would be the wrong instruction.
+    for key, what in (
+        ("manifest_pin", "the markdown-remark pin"),
+        ("astro_peer", "astro's declared peer"),
+        ("manifest_astro", "the astro pin"),
+    ):
+        assert EXACT_VERSION.fullmatch(v[key] or ""), (
+            f"{what} is {v[key]!r}, not an exact version. This test asserts exact "
+            "equality because astro declared an exact optional peer; a range means "
+            "that premise no longer holds and the check needs re-deriving, not "
+            "loosening."
+        )
+
+    # The peer range is evidence about the pinned astro only if the lockfile still
+    # describes that astro.
+    assert v["installed_astro"] == v["manifest_astro"], (
+        f"docs-site/package.json pins astro {v['manifest_astro']!r} but the lockfile "
+        f"resolves {v['installed_astro']!r} — regenerate docs-site/package-lock.json"
+    )
+
+    agreed = {
+        "docs-site/package.json": v["manifest_pin"],
+        "package-lock.json root dependencies": v["lock_root_pin"],
+        "package-lock.json resolved version": v["installed"],
+        f"astro {v['installed_astro']} optional peer": v["astro_peer"],
+    }
+    assert len(set(agreed.values())) == 1, (
+        f"the four recorded `{MARKDOWN_REMARK}` versions disagree: "
+        + ", ".join(f"{where} = {ver!r}" for where, ver in agreed.items())
+        + " — they move together, or `astro build` fails to resolve the package "
+        "astro.config.ts imports"
+    )
+
+
+def test_starlight_also_accepts_the_markdown_remark_pin() -> None:
+    """astro is not the only optional-peer consumer; Starlight is the other.
+
+    Starlight declares a *range* where astro declares an exact version, so a
+    Starlight bump can move its floor while astro stays put — leaving the pin
+    equal to astro's peer, this site's other guard green, and Starlight's
+    requirement unsatisfied. Checking only astro would miss it.
+
+    Caret satisfaction is computed here rather than pulled from a semver library:
+    this module is stdlib-only by construction, it runs in a required job, and a
+    test that can fail on a missing import is one someone import-guards under
+    pressure. Any range shape other than a caret on a non-zero major fails loudly
+    instead of being approximated.
+    """
+    v = _docs_site_versions()
+    # Guard the early return: "Starlight is installed and stopped declaring the
+    # peer" is the only world that may pass vacuously. A missing Starlight entry,
+    # or a changed key shape, would otherwise retire this check silently.
+    assert v["starlight_version"] is not None, (
+        "docs-site/package-lock.json records no `node_modules/@astrojs/starlight` "
+        "— either Starlight is gone, in which case delete this test, or the "
+        "lockfile's key shape changed and this check is reading the wrong place."
+    )
+    spec = v["starlight_peer"]
+    if spec is None:
+        return  # Starlight stopped declaring it; astro's exact peer is the contract.
+
+    caret = CARET_RANGE.fullmatch(spec)
+    assert caret, (
+        f"Starlight {v['starlight_version']} declares `{MARKDOWN_REMARK}` as "
+        f"{spec!r}, which is not the `^X.Y.Z` shape this check understands — "
+        "re-derive the comparison rather than widening it to pass."
+    )
+    floor = tuple(int(g) for g in caret.groups())
+    assert floor[0] != 0, (
+        f"Starlight's range {spec!r} is a caret on major 0, where caret semantics "
+        "pin the minor instead of the major — re-derive this comparison."
+    )
+    pin = v["manifest_pin"] or ""
+    assert EXACT_VERSION.fullmatch(pin), f"the pin is {pin!r}, not an exact version"
+    got = tuple(int(part) for part in pin.split("."))
+    assert got[0] == floor[0] and got >= floor, (
+        f"docs-site pins `{MARKDOWN_REMARK}` {pin!r}, which does not satisfy "
+        f"Starlight {v['starlight_version']}'s declared range {spec!r} — a "
+        "Starlight bump moved the floor and the pin has to follow it too, not "
+        "only astro's exact peer"
     )
 
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -3136,6 +3136,65 @@ open = [
   # names public visibility as evidence only. An ADR after experimentation is
   # the right record for the execution boundary.
   { slug = "agentbundle-catalogue-test-command", source = "spec/pytest-resource-optimization (adopter gap)", summary = "Give catalogue adopters a canonical way to execute the tests they receive, discovering pack and conformance suites from the ADR-0071 layout while preserving one process per skill and keeping test dependencies development-only" },
+  # pages.yml's `build` job is where BOTH site builds, `npm run test:plugins
+  # --prefix docs-site`, web/'s rendered-output invariants and the browser gate
+  # (60 pinned matrix cases — see tools/test_browser_gate_subset.py's
+  # test_the_approved_matrix_is_exactly_sixty_cases; cited by symbol because a
+  # line number in that file has already gone stale once — plus
+  # quality-assertions.spec.ts) actually execute, and it is not a required check.
+  # Required contexts on main are the five from build-check.yml alone:
+  # `make build-check`, `gate-main`, `gate-sast`, `gate-export-boundary`,
+  # `gate-credbroker` (API read 2026-08-23, strict = true; unchanged from the
+  # 2026-08-18 read recorded under ci-gate-credbroker-branch-protection-widening).
+  #
+  # NOT THEORETICAL — measured on #1036. At head 6990d3d7 (2026-08-20) all five
+  # required checks were `success` and `build` was `failure`. That PR was
+  # mergeable green with the Pages deploy broken; only a human noticing the
+  # non-required red stopped it. `gh api repos/OWNER/REPO/commits/6990d3d7/
+  # check-runs` still shows the pair.
+  #
+  # WHY THE OBVIOUS FIX IS THE TRAP, and why this entry exists rather than a
+  # one-line instruction to the owner: pages.yml carries a `paths:` filter on
+  # `pull_request` — fourteen entries covering web/**, docs-site/**, guides/**,
+  # several tools/*.py and more; `.github/workflows/pages.yml`'s own
+  # `on.pull_request.paths` is the canonical set and the only place to read it.
+  # GitHub treats a required context that never reports as PERPETUALLY PENDING, not as
+  # passed. Ticking `build` in branch protection would therefore permanently wedge
+  # every PR touching none of those paths — most PRs in this repo. build-check.yml
+  # can carry required contexts precisely because it has NO paths filter; that is
+  # the property, not a coincidence.
+  #
+  # OPTION TO EVALUATE: a companion always-runs job in a filter-free workflow that
+  # reports the same `build` context and exits 0 when the filtered paths did not
+  # change. The job-level shape is ALREADY IN TREE and is the closest precedent:
+  # build-check.yml:913's aggregator carries `if: ${{ always() }}`, sits in a
+  # workflow with no `paths:` filter, and itself wears one of the five required
+  # contexts (`make build-check`); build-check-windows.yml:162 is the same shape.
+  # Read those before designing anything. The genuinely unprecedented part is
+  # narrower: whether two workflows may report ONE context name without either
+  # masking the other. Settle that first — it decides whether the companion can
+  # reuse the name `build` or must take a new one and be required instead.
+  # (Note the spelling when searching: `if: ${{ always() }}`, not `if: always()`.
+  # Grepping only the bare form finds pack-evals.yml:72 alone and reads as "no
+  # job-level precedent exists", which is how this entry first recorded it.)
+  #
+  # REJECTED, recorded so it is not re-proposed: moving the assertions into
+  # build-check.yml. pages.yml's own comments state that the required workflow
+  # deliberately carries no Node and must carry no paths filter; adding them makes
+  # every PR in the repo wait on two `npm ci` runs.
+  #
+  # THE BRANCH-PROTECTION WRITE IS THE OWNER'S, NOT AN AGENT'S, and it MUST NOT be
+  # done before the companion job exists and has reported once on main — a required
+  # check cannot precede the job that reports it, and the Settings UI only offers
+  # contexts seen on main recently (same constraint as
+  # ci-gate-credbroker-branch-protection-widening; read its FORBIDDEN block before
+  # touching the API instead). main uses CLASSIC branch protection — the repo's only
+  # ruleset is the separate "claude-plugins-dist publisher-only" branch rule — so
+  # the click-path is:
+  #   https://github.com/eugenelim/agent-ready-repo/settings/branches
+  #   -> Branch protection rules -> Edit on `main` -> Require status checks to pass
+  #   -> search `build` -> select -> Save changes
+  { slug = "pages-build-job-not-a-required-check", source = "CI observation 2026-08-23, PR #1036", summary = "pages.yml's `build` job carries both site builds, the plugin suite, the rendered-output invariants and the browser gate but is not a required status check, and its `paths:` filter means it cannot simply be ticked as one" },
 ]
 
 # Resolved repo-durable items. Kept rather than deleted so a reader who arrives


### PR DESCRIPTION
Two follow-ups from the astro 7.2 dependency bumps (#1036, #1037). Deliberately separate from the `docs-site` `markdown.processor` migration, which lands as its own PR — this repo squash-merges, so separate PRs are the only way to get separate revert units.

## What does this change?

**1. A gate for a duty that was only prose.** `docs-site/package.json` pins `@astrojs/markdown-remark` at the exact version astro declares as an *optional* peer. Because the peer is optional, npm neither installs it nor warns when the copies drift — but `docs-site/astro.config.ts` needs it resolvable at the root, so a mismatch surfaces as an `astro build` config-validation failure rather than an install-time warning. `docs-site/AGENTS.md` recorded the duty; nothing enforced it.

The test compares **all four** recorded copies — the manifest pin, the lockfile's root dependency, the lockfile's resolved version, and astro's peer — plus a separate check that Starlight's declared *range* (`^7.2.0`) still accepts the pin. Starlight is the second optional-peer consumer, and a Starlight bump can move its floor while astro stays put, leaving the pin equal to astro's peer and Starlight unsatisfied.

**2. A backlog entry** recording that `pages.yml`'s `build` job — both site builds, the docs plugin suite, the rendered-output invariants, the browser gate — is not a required status check.

## Why?

Two design decisions worth stating, because both have a cheaper wrong answer.

**It reads the lockfile, not `node_modules`.** A `skipIf(node_modules absent)` clause would be simpler and would fire only in the `build` job — which, per the second half of this PR, is not required. A skip is not a pass. `docs-site/package-lock.json` records the peer range under `packages["node_modules/astro"].peerDependencies`, so the assertion needs no install and runs in `gate-main`, which every PR runs.

**It compares four copies, not two.** `npm ci` would refuse a lockfile disagreeing with the manifest, but `npm ci` runs in `build`. That is the same argument that puts this test in a required job; it cannot also be used to excuse trusting the lockfile once read.

For the backlog entry: `build`'s non-required status is not theoretical. On #1036 at head `6990d3d7`, all five required checks reported success while `build` reported failure — that PR was mergeable green with the Pages deploy broken. The entry also records why *ticking `build` in branch protection is the wrong fix*: `pages.yml` carries a `paths:` filter on `pull_request`, and GitHub treats a required context that never reports as perpetually pending rather than passed, so it would wedge every PR touching none of those paths. The branch-protection write is left to the repo owner and sequenced after a companion job exists.

## How is it tested?

Eleven mutations, each checked non-no-op by digest before running, tree restored and verified clean after:

| Mutation | Result |
|---|---|
| markdown-remark pin bumped | red |
| astro pin bumped (lockfile goes stale) | red |
| astro's recorded peer moved | red |
| pin key **deleted** | red, with the crafted message — not a `KeyError` |
| lockfile root dependency moved | red |
| lockfile resolved version moved | red |
| pin loosened to `^7.2.2` | red, "the premise no longer holds" |
| astro pin loosened to `^7.2.2` | red, same |
| astro's peer key deleted | red, and explicitly *not* "delete this test" |
| Starlight floor raised to `^8.0.0` | red |
| Starlight peer removed | **green, deliberately** — astro's exact peer is then the whole contract |

The deleted-key case is not hypothetical: `git show 6990d3d7:docs-site/package.json` has no `@astrojs/markdown-remark` key at all, so the head that motivated this test would have produced a traceback instead of remediation text.

Gates: `make build-check` complete with the full SAST/SCA leg, `lint-ruff`, `lint-mypy`, both workflow posture self-tests (178 and 38 mutations), the AGENTS.md lint suite, and `make test`.

`make test` has one failure, and it is pre-existing and environmental — `tools/test_marketplace_envelope_parity.py::test_resolved_layer_fails_loudly_when_the_package_is_unimportable`, recorded at `workspace.toml:1118-1185` under slug `pre-existing-roster-catalogue-index-and-okf-release-metadata`. Cause confirmed independently: a **non-editable** `agentbundle` in pyenv site-packages shadows the worktree source, and the test resolves its constants in a child spawned with `-I`, which `pyproject.toml`'s `pythonpath` cannot reach. CI installs agentbundle editable, so it does not reproduce there.

## What did you not change that you considered?

- **A new test file wired into `build-check.yml`.** Correct taxonomy, but four coordinated edits — the workflow, `PINNED_SITE_BUILD_PYTEST`, the Makefile, the parity roster — two of them in the required-check workflow, for a four-line assertion. Placed it in `tools/test_browser_gate_subset.py` instead, which already hosts `test_the_docs_base_agrees_with_the_docs_site_config` for the same reason: a cross-file site invariant that needs a required job. The module docstring is amended so its narrow-scope claim stays true.
- **A fifth comparison against `@astrojs/mdx`.** It records the same version, and `docs-site/AGENTS.md` blames it for the original `astro build` exit 1 — but it requires the package through `dependencies`, not a peer, so a divergence nests a private copy and leaves the root slot untouched. Excluded, with the reason recorded in the helper's docstring so the next auditor does not re-derive it or add a wrong check.
- **Updating `.github/workflows/pages.yml:24-25`'s comment.** Its operative claim is why the path is *listed* — an edit disabling the gate must trigger a Pages run — which the pin gate does not affect. Editing it would pull the whole `build` job into a chore PR to fix a label.
- **Building the companion always-runs job.** Recorded, not built, per the request.
- **Semver via a library.** This module is stdlib-only by construction and runs in a required job; caret satisfaction is computed inline, and any range shape other than a caret on a non-zero major fails loudly rather than being approximated.

## Notes for the reviewer

Commit 2's `workspace.toml` write is a `work-intake` capture made at the owner's explicit request ("record item 3 through work-intake without building it"), routed through that skill — its router maps action `remember` to `backlog.open` with no processor. It is **not** direct-light bookkeeping, which `work-loop/SKILL.md:74` forbids; `docs/CONVENTIONS.md` § Intent-scoped completion authorizes exactly this on an explicit owner capture request. The one-PR packaging was also the owner's explicit choice. Recorded here because a reader would otherwise reconstruct it as a mode violation — an adversarial reviewer did, then withdrew it on checking the router.

Two findings in review came from my own errors worth naming: I recorded "no job-level `always()` precedent exists" from a grep for `if: always()` that missed `if: ${{ always() }}` on the required aggregator at `build-check.yml:913` — the exact pattern the entry recommends building. And I cited a line number computed before my own insertion moved the symbol 104 lines. Both are fixed, and the entry now names the spelling trap.