### PR TITLE
fix(tools): align iac-terraform sidebar label and guard the retired research pack id

### DIFF
--- a/site.toml
+++ b/site.toml
@@ -124,7 +124,7 @@ label = "Cross-cutting"
 
 [[guide_groups]]
 dir = "iac-terraform"
-label = "IaC (Terraform)"
+label = "Terraform and OpenTofu"
 
 [[guide_groups]]
 dir = "catalogue-curation"

--- a/tools/lint-plugin-route-docs.py
+++ b/tools/lint-plugin-route-docs.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Assert no doc offers the Claude-plugin route for a pack that cannot use it.
+"""Assert install-route documentation does not make false catalogue claims.
 
 Per-site `(path, pattern, expected)` rather than one repo-wide grep, because the
-sites do not share a pattern — `README.md` writes `claude plugin install`,
-several guides write `/plugin install`, and two files name the dist-tree path
-`<output>/claude-plugins/core/…`. A single `! grep -q 'claude plugin install'`
-would pass green on most of them.
+plugin-route sites do not share a pattern — `README.md` writes `claude plugin
+install`, several guides write `/plugin install`, and two files name the
+dist-tree path `<output>/claude-plugins/core/…`. A single `! grep -q 'claude
+plugin install'` would pass green on most of them. The retired-pack guard is
+the exception: it scans every guide because the false install claim could be
+introduced anywhere in the adopter-facing tree.
 
 Each entry also asserts its file **exists**, so a rename is not a silent pass —
 the failure mode of every absence-only check.
@@ -20,6 +22,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -47,6 +50,18 @@ def _offers(pack: str) -> list[str]:
 
 
 _NO_REPO_ONLY_OFFER = [pat for p in REPO_ONLY for pat in _offers(p)]
+
+# `research` was renamed to `desk-research`. Keep command detection separate
+# from pack-argument detection: `--pack` may appear after the catalogue URI,
+# while the legacy positional spelling appeared immediately after `install`.
+# The explicit bounds treat hyphens as part of an id, unlike ``\b``.
+_INSTALL_COMMAND_RE = re.compile(r"\bagentbundle\s+install\b")
+_RETIRED_PACK_FLAG_RE = re.compile(
+    r"--pack(?:\s+|=)(?<![A-Za-z0-9_-])research(?![A-Za-z0-9_-])"
+)
+_RETIRED_LEGACY_PACK_RE = re.compile(
+    r"\bagentbundle\s+install\s+(?<![A-Za-z0-9_-])research(?![A-Za-z0-9_-])"
+)
 
 SITES: list[tuple[str, list[str], list[str]]] = [
     # (path, forbidden substrings, required substrings)
@@ -83,6 +98,33 @@ SITES: list[tuple[str, list[str], list[str]]] = [
 ]
 
 
+def _offers_retired_research_install(line: str) -> bool:
+    """Return whether one line offers either retired ``research`` install form."""
+
+    return bool(_INSTALL_COMMAND_RE.search(line)) and bool(
+        _RETIRED_PACK_FLAG_RE.search(line) or _RETIRED_LEGACY_PACK_RE.search(line)
+    )
+
+
+def _retired_guide_install_failures(root: Path) -> list[str]:
+    """Return guide diagnostics for the retired ``research`` pack install form."""
+
+    guides_root = root / "guides"
+    if not guides_root.is_dir():
+        return []
+
+    failures: list[str] = []
+    for path in sorted(guides_root.rglob("*.md")):
+        body = path.read_text(encoding="utf-8", errors="replace")
+        for line_number, line in enumerate(body.splitlines(), start=1):
+            if _offers_retired_research_install(line):
+                failures.append(
+                    f"{GATE}: {path.relative_to(root)}:{line_number} offers retired "
+                    "pack id `research`; use `desk-research`"
+                )
+    return failures
+
+
 def check(root: Path) -> list[str]:
     failures: list[str] = []
     for rel, forbidden, required in SITES:
@@ -106,6 +148,7 @@ def check(root: Path) -> list[str]:
                     f"{GATE}: {rel} is missing {pat!r} — the scope precondition "
                     f"is stated once and referenced; this reference is gone"
                 )
+    failures.extend(_retired_guide_install_failures(root))
     return failures
 
 

--- a/tools/test-lint-plugin-route-docs.py
+++ b/tools/test-lint-plugin-route-docs.py
@@ -112,6 +112,38 @@ def main() -> int:
                len(out) == len(lint.SITES) and len(out) > 0,
                f"got {len(out)} of {len(lint.SITES)}")
 
+    # The positional legacy fixture is copied from research-pack/spec.md:190;
+    # the uninstall line is copied from m3-desk-research-rename/plan.md:303.
+    # The nested case proves recursive guides/ discovery, not just matching.
+    install_cases = [
+        ("agentbundle install --pack research", True, "retired-install.md"),
+        ("agentbundle install research --scope user", True, "retired-install.md"),
+        ("agentbundle install ./my-catalogue --pack research", True, "retired-install.md"),
+        ("agentbundle install <catalogue-uri> --pack research", True, "retired-install.md"),
+        ("agentbundle install --pack=research", True, "retired-install.md"),
+        ("agentbundle install --pack research --scope user", True, "nested/retired.md"),
+        ("agentbundle install --pack research-tools", False, "current-install.md"),
+        ("agentbundle install --pack desk-research", False, "current-install.md"),
+        ("agentbundle install desk-research", False, "current-install.md"),
+        ("agentbundle install --pack=desk-research", False, "current-install.md"),
+        ("agentbundle uninstall research --adapter <adapter>", False, "uninstall.md"),
+        ("This research guide explains the method.", False, "prose.md"),
+        ("agentbundle install --pack core", False, "current-install.md"),
+    ]
+    for line, should_fire, relative_path in install_cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "guides" / relative_path
+            path.parent.mkdir(parents=True)
+            path.write_text(f"{line}\n", encoding="utf-8")
+            out = lint.check(root)
+            fired = any("retired pack id `research`" in message for message in out)
+            _check(
+                f"retired install guard: {line!r}",
+                fired is should_fire,
+                f"expected fire={should_fire}, got fire={fired}; output={out}",
+            )
+
     if FAILURES:
         print(f"test-lint-plugin-route-docs: FAIL ({len(FAILURES)})", file=sys.stderr)
         return 1

--- a/tools/test_build_site_projection.py
+++ b/tools/test_build_site_projection.py
@@ -206,7 +206,7 @@ def test_iac_arc_orders_1_2_3():
         for e in tomllib.load((REPO_ROOT / "guide-nav-baseline.toml").open("rb"))["entry"]
     }
     out = build_site.project_guide_sidebar(records, groups, baseline)
-    arc = _slugs(_group(out, "IaC (Terraform)"))
+    arc = _slugs(_group(out, "Terraform and OpenTofu"))
     assert arc[:4] == [
         "guides/iac-terraform",
         "guides/iac-terraform/explanation/infrastructure-in-the-release-loop",

--- a/tools/test_build_site_sidebar.py
+++ b/tools/test_build_site_sidebar.py
@@ -178,7 +178,7 @@ def test_no_sibling_label_collision_anywhere_in_the_real_tree():
 def test_every_guides_directory_is_declared_in_site_toml():
     """AC8. An undeclared directory silently takes the title-cased fallback and
     is appended last — `iac-terraform` would read "Iac Terraform" rather than
-    its curated "IaC (Terraform)"."""
+    its curated "Terraform and OpenTofu"."""
     dirs = {p.name for p in (REPO_ROOT / "guides").iterdir() if p.is_dir()}
     with (REPO_ROOT / "site.toml").open("rb") as f:
         declared = {g["dir"] for g in tomllib.load(f).get("guide_groups", [])}
@@ -400,7 +400,7 @@ def test_no_projected_sidebar_label_is_a_retired_string():
 
     Scope is exactly what `_pairs(_guides_group())` yields — the slug-bearing
     items inside the `Guides` super-group. Group labels carry no slug and are not
-    covered here; `IaC (Terraform)` is a group label and is deliberately retained
+    covered here; `Terraform and OpenTofu` is a group label and is deliberately retained
     (see `notes/render-review.md`).
     """
     offenders = {slug: label for slug, label in _pairs(_guides_group())


### PR DESCRIPTION
Two mechanical items from `[backlog].open`, grouped because both are one-line alignments between a projected surface and its source of truth.

## `iac-terraform-group-label-alignment`

> Align the iac-terraform sidebar GROUP label with its retitled index page

`guides/iac-terraform/README.md` was retitled to `Terraform and OpenTofu guides`; `site.toml` still declared `IaC (Terraform)`.

The label is now `Terraform and OpenTofu` — the index title in the form every other `guide_groups` entry uses. All 27 sibling labels are bare title-case noun phrases with no `guides` suffix (`Desk Research`, `Credential Brokers`, `Cross-cutting`), and the super-group is already `Guides`, so the verbatim page title would have been the odd one out.

**No sidebar reordering.** `project_guide_sidebar` builds `declared` from `guide_groups` and emits in `site.toml` declaration order (`tools/build-site.py:850,864`); only undeclared extras are label-sorted. The coupling recorded in `guide-sidebar-label-order-coupling` does not fire here. `guide-nav-baseline.toml` has no `iac-terraform` entry.

## `desk-research-install-name-drift`

> no lint carries a retired-id negative fixture, so nothing stops `install research` being reintroduced into guides/ tomorrow. Fix: extend the owning docs/parity lint with a negative fixture asserting the retired `research` pack id does not appear in guides/.

Extends `lint-plugin-route-docs` — the gate that already exists to stop docs making false pack-install claims. `lint-site-scope-parity` only compares web metadata to `pack.toml`, `lint-guide-titles` compares frontmatter to H1, and `lint-guides-no-repo-only-refs` covers governance citations; none owns this class.

The guard matches the **pack-id argument**, not argument order, because `agentbundle install` takes the catalogue URI positionally and the real guides put it before `--pack` (`guides/_shared/reference/agentbundle.md:27,111`). Bounds are explicit lookarounds, not `\b`, because `\b` treats the `h`/`-` junction in `research-tools` as a boundary.

13 behaviour rows are pinned as fixtures, plus a nested-path fixture proving the scan is recursive:

| line | verdict |
|---|---|
| `agentbundle install --pack research` | fires |
| `agentbundle install research --scope user` | fires |
| `agentbundle install ./my-catalogue --pack research` | fires |
| `agentbundle install <catalogue-uri> --pack research` | fires |
| `agentbundle install --pack=research` | fires |
| `agentbundle install --pack research-tools` | quiet |
| `agentbundle install --pack desk-research` | quiet |
| `agentbundle uninstall research --adapter <adapter>` | quiet |
| `This research guide explains the method.` | quiet |

`uninstall` is deliberately excluded: it accurately describes migrating away from an already-installed retired pack.

## Verification

Both scripts are wired into the required gate: `tools/repo/build_gate_chain.py:367,373` → `Makefile:140` `make build-check` → `.github/workflows/build-check.yml:148`.

**Mutation proofs** (each run by the supervisor; each turns exactly its own assertion red, then restored, with the working tree verified byte-identical afterwards):

| mutation | result |
|---|---|
| `site.toml` label reverted to `IaC (Terraform)` | `test_iac_arc_orders_1_2_3` fails, `StopIteration` |
| `--pack` arm removed from the predicate | 5 fire-cases die; positional case stays green |
| legacy positional arm removed | exactly 1 failure, the positional case |
| trailing complete-token bound dropped | `research-tools` flips to firing |
| `rglob` → `glob` | the nested-path fixture dies |

An independent review session rejected the first implementation for missing the URI-before-`--pack` form and false-firing on `research-tools`; both findings were reproduced against the real tree before being fixed, and the behaviour table above is the result.