### PR TITLE
ci(sast): cover the CI-tooling requirements manifests by construction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,11 @@ sast-unleased:
 	# `dependencies = []` on both, so they contribute no tree, and resolving them
 	# against the public index would couple a merge to a release that has not
 	# happened yet. Every skip is printed. See tools/audit-requirements.py.
-	python3 tools/audit-requirements.py tools/requirements.txt $$(find packs -name requirements.txt | sort)
+	python3 tools/audit-requirements.py $$(find packs -name requirements.txt | sort)
+	# Discover tools/requirements*.txt in the auditor so a new CI manifest is
+	# covered at once; requirements-sast.txt remains on its direct, suppression-
+	# bearing invocation below.
+	python3 tools/audit-requirements.py --tools-manifests
 	# Audit the PEP 517 backends that execute during package builds. Extract the
 	# declarations from pyproject.toml itself so the SCA input cannot drift.
 	python3 tools/audit-requirements.py --build-system \

--- a/tools/audit-requirements.py
+++ b/tools/audit-requirements.py
@@ -18,6 +18,7 @@ file whose remainder is empty says so rather than passing quietly.
 
 Usage:
     audit-requirements.py <requirements.txt> [<requirements.txt> ...]
+    audit-requirements.py --tools-manifests
     audit-requirements.py --optional-group <name> <pyproject.toml> [...]
 """
 
@@ -47,6 +48,12 @@ _PIP_AUDIT_TIMEOUT_S = 300
 # exit 0 without touching a tracked file.
 _SCRUBBED_ENV_PREFIXES = ("PIP_AUDIT_",)
 _SCRUBBED_ENV_NAMES = ("PIP_INDEX_URL", "PIP_EXTRA_INDEX_URL")
+
+# requirements-sast.txt has its own direct pip-audit invocation in Makefile,
+# where four accepted Semgrep transitive-dependency CVEs are suppressed. Do not
+# include it here: removing those suppressions or auditing the file twice would
+# respectively regress the accepted allowlist or duplicate SCA findings.
+_DIRECT_SAST_MANIFEST = "requirements-sast.txt"
 
 
 def _scrubbed_env() -> dict[str, str]:
@@ -78,6 +85,15 @@ def first_party_names(root: Path) -> set[str]:
                 names.add(_canonical(match.group(1)))
                 break
     return names
+
+
+def tools_requirements_manifests(tools_dir: Path) -> list[Path]:
+    """Return every tools requirements manifest except the direct SAST manifest."""
+    return [
+        path
+        for path in sorted(tools_dir.glob("requirements*.txt"))
+        if path.is_file() and not path.is_symlink() and path.name != _DIRECT_SAST_MANIFEST
+    ]
 
 
 # Option lines that pull in dependencies pip-audit would have to resolve. A
@@ -259,6 +275,19 @@ def main(argv: list[str]) -> int:
             print(f"audit-requirements: {exc}", file=sys.stderr)
             return 2
         return audit_lines("build-system-requirements", requirements, first_party)
+
+    if argv == ["--tools-manifests"]:
+        paths = tools_requirements_manifests(_REPO_ROOT / "tools")
+        if not paths:
+            print(
+                "audit-requirements: found no tools/requirements*.txt manifests",
+                file=sys.stderr,
+            )
+            return 2
+        failed = 0
+        for path in paths:
+            failed |= audit(path, first_party)
+        return 1 if failed else 0
 
     if argv[0] == "--optional-group":
         if len(argv) < 3:

--- a/tools/test-audit-requirements.py
+++ b/tools/test-audit-requirements.py
@@ -11,9 +11,11 @@ was removed.
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
@@ -45,6 +47,25 @@ def check(label: str, condition: bool, detail: str = "") -> None:
     else:
         FAILURES.append(f"{label}{': ' + detail if detail else ''}")
         print(f"  FAIL {label} {detail}")
+
+
+_MAKE_TARGET = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.\- ]*?\s*::?(?!=)")
+
+
+def sast_unleased_recipe_lines(makefile: str) -> list[str]:
+    """Return target recipe lines, retaining Make conditionals but not define bodies."""
+    lines = makefile.splitlines()
+    try:
+        start = lines.index("sast-unleased:")
+    except ValueError:
+        return []
+    recipe: list[str] = []
+    for line in lines[start + 1:]:
+        if line.startswith(("\t", " ")):
+            recipe.append(line)
+        elif line.startswith("define ") or _MAKE_TARGET.match(line.split("#", 1)[0]):
+            break
+    return recipe
 
 
 def main() -> int:
@@ -207,39 +228,39 @@ def main() -> int:
                     "AUDIT_SELFTEST_KEEP_ME"):
             _os.environ.pop(key, None)
 
-    # 12. THE AUDITED SET HAS A FLOOR.
-    #     Makefile's `$(find packs -name requirements.txt | sort)` has its exit
-    #     status swallowed by the pipeline, so a renamed, moved or deleted manifest
-    #     shrinks the audited input silently at exit 0 and nothing notices the gate
-    #     covers less than it did. Pin the shape AND the count.
+    # 12. THE PACKS AUDITED SET HAS A FLOOR.
+    #     A renamed, moved or deleted pack manifest must not silently shrink the
+    #     SCA input at exit 0. Pin the shape AND the count.
     repo_root = _HERE.parent
     makefile = (repo_root / "Makefile").read_text(encoding="utf-8")
-    # A recipe line, not the SAST_CONFIG assignment that also names the script:
-    # match on the invocation prefix so `SAST_CONFIG := … tools/audit-requirements.py …`
-    # cannot satisfy this case (it did, on the first attempt).
-    audit_invocation = next(
-        (
-            line for line in makefile.splitlines()
-            if line.lstrip("\t ").startswith("python3 tools/audit-requirements.py")
-            and "--build-system" not in line
-            and "--optional-group" not in line
+    makefile_lines = sast_unleased_recipe_lines(makefile)
+    check(
+        "the packs audit invocation is present",
+        any(
+            line.lstrip("\t ").startswith(
+                "python3 tools/audit-requirements.py "
+                "$$(find packs -name requirements.txt | sort)"
+            )
+            for line in makefile_lines
         ),
-        "",
     )
     check(
-        "the packs+tools audit invocation was located in the Makefile",
-        bool(audit_invocation),
-        "no `python3 tools/audit-requirements.py <manifests>` recipe line found",
+        "the tools-manifests audit invocation is present",
+        any(
+            line.lstrip("\t ").startswith(
+                "python3 tools/audit-requirements.py --tools-manifests"
+            )
+            for line in makefile_lines
+        ),
     )
     check(
-        "the Makefile still enumerates packs manifests by find",
-        "find packs -name requirements.txt" in audit_invocation,
-        audit_invocation.strip(),
-    )
-    check(
-        "the Makefile still audits tools/requirements.txt explicitly",
-        "tools/requirements.txt" in audit_invocation,
-        audit_invocation.strip(),
+        "the direct SAST audit matches the resolver exclusion",
+        any(
+            line.lstrip("\t ").startswith(
+                f"@pip-audit -r tools/{_MOD._DIRECT_SAST_MANIFEST}"
+            )
+            for line in makefile_lines
+        ),
     )
     pack_manifests = sorted(
         path.relative_to(repo_root).as_posix()
@@ -252,10 +273,10 @@ def main() -> int:
         f"raise _EXPECTED_PACK_MANIFESTS in the same commit; if one vanished, the "
         f"SCA input just shrank and that is the failure this case exists for.",
     )
-    #     A NEW tools/requirements*.txt must not silently join the unaudited set.
-    #     The three below are unaudited today and tracked as
-    #     `sast-requirements-not-audited` in workspace.toml [backlog].open; this
-    #     case pins the roster so a fourth is a deliberate decision.
+    # 13. THE TOOLS AUDITED SET IS CONSTRUCTED BY THE AUDITOR.
+    #     A new matching manifest joins the audit without a Makefile edit. The
+    #     direct SAST manifest remains excluded because its accepted-CVE
+    #     suppressions belong to its dedicated pip-audit invocation.
     tools_manifests = sorted(
         path.name for path in (repo_root / "tools").glob("requirements*.txt")
     )
@@ -263,8 +284,46 @@ def main() -> int:
         "the tools/ manifest roster is unchanged",
         tools_manifests == _EXPECTED_TOOLS_MANIFESTS,
         f"found {tools_manifests}, expected {_EXPECTED_TOOLS_MANIFESTS}. A new "
-        f"tools/requirements*.txt is unaudited until it is added to the Makefile "
-        f"invocation or dispositioned under sast-requirements-not-audited.",
+        f"tools/requirements*.txt is selected automatically by the auditor.",
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        tools_dir = Path(tmp)
+        for name in (
+            "requirements.txt",
+            "requirements-ci-security-locked.txt",
+            "requirements-evals-locked.txt",
+            "requirements-extra.txt",
+            "requirements-linked.txt",
+            "requirements-sast.txt",
+            "not-a-requirements.txt",
+        ):
+            (tools_dir / name).write_text("example>=1\n", encoding="utf-8")
+        resolved = [
+            path.name for path in _MOD.tools_requirements_manifests(tools_dir)
+        ]
+        with mock.patch.object(
+            Path,
+            "is_symlink",
+            lambda path: path.name == "requirements-linked.txt",
+        ):
+            resolved_without_symlink = [
+                path.name for path in _MOD.tools_requirements_manifests(tools_dir)
+            ]
+    check(
+        "tools resolver includes every matching manifest except direct SAST",
+        resolved == [
+            "requirements-ci-security-locked.txt",
+            "requirements-evals-locked.txt",
+            "requirements-extra.txt",
+            "requirements-linked.txt",
+            "requirements.txt",
+        ],
+        str(resolved),
+    )
+    check(
+        "tools resolver ignores symlink candidates",
+        "requirements-linked.txt" not in resolved_without_symlink,
+        str(resolved_without_symlink),
     )
 
     if FAILURES:

--- a/tools/test_okf_pre_pr.py
+++ b/tools/test_okf_pre_pr.py
@@ -33,6 +33,7 @@ def _load(name: str, path: Path):
 
 
 okf_check = _load("check_okf_managed_packs", REPO_ROOT / "tools" / "check-okf-managed-packs.py")
+audit_requirements = _load("audit_requirements", REPO_ROOT / "tools" / "audit-requirements.py")
 
 
 def _write_pack(root: Path, name: str, *, okf_path: str = "okf/demo") -> Path:
@@ -501,7 +502,11 @@ class OkfCheckGateTests(unittest.TestCase):
         self.assertIn("SAST_DIRS := tools packs packages tests", makefile)
         self.assertIn("tools/run-bandit-gate.py $(SAST_DIRS)", makefile)
         self.assertIn("$(SEMGREP_EXCLUDE) $(SAST_DIRS)", makefile)
-        self.assertIn("tools/audit-requirements.py tools/requirements.txt", makefile)
+        # test-audit-requirements.py owns the comment-rejecting invocation check.
+        resolved_tools_manifests = audit_requirements.tools_requirements_manifests(
+            REPO_ROOT / "tools"
+        )
+        self.assertIn(REPO_ROOT / "tools" / "requirements.txt", resolved_tools_manifests)
         self.assertIn("$$(find packs -name requirements.txt | sort)", makefile)
         self.assertIn("--optional-group lint", makefile)
         self.assertIn("packages/agentbundle/pyproject.toml", makefile)

--- a/workspace.toml
+++ b/workspace.toml
@@ -2705,19 +2705,6 @@ open = [
   # the unconditional step, keeping requirements-sast.txt as the canonical input
   # so nothing restates a pin. Needs a refresh procedure, hence its own PR.
   {slug = "sast-requirements-hash-locked", summary = "Generate and install a hash-locked tools/requirements-sast-locked.txt with --require-hashes, mirroring the ci-security locked file", source = "spec/build-check-coverage-gaps security review"},
-  # pip-audit covers tools/requirements.txt and every packs/*/requirements.txt
-  # (Makefile:235) and the PEP 517 build-system requirements (Makefile:238). It
-  # does NOT cover tools/requirements-sast.txt,
-  # tools/requirements-ci-security-locked.txt, or tools/requirements-evals-locked.txt
-  # -- the CI tooling itself has no SCA. The evals file was added here by
-  # spec/stale-reference-corrections: it is equally unaudited and fell outside every
-  # other entry, so nothing named it.
-  # Confirmed by reading the audit invocations, not inferred. Adjacent to
-  # npm-dependabot-wiring but a different ecosystem and a different file set.
-  # Fix: add the three CI-tooling requirements files to the audit-requirements.py
-  # invocation, or wire Dependabot for pip so the bumps arrive as PRs. Decide
-  # which, then do one -- doing both duplicates the noise.
-  {slug = "sast-requirements-not-audited", summary = "Give tools/requirements-sast.txt, requirements-ci-security-locked.txt, and requirements-evals-locked.txt SCA coverage -- pip-audit skips all three today", source = "spec/build-check-coverage-gaps security review"},
   # Semgrep's signal for a target it could not parse depends on HOW it failed.
   # A PARTIAL failure (unbalanced bracket, stray token) does surface as a
   # path-attributed PartialParsing entry in `errors`, and --strict escalates it


### PR DESCRIPTION
Closes the `sast-requirements-not-audited` backlog item, and corrects its premise.

## What the entry claimed, and what was actually true

> It does NOT cover tools/requirements-sast.txt, tools/requirements-ci-security-locked.txt, or tools/requirements-evals-locked.txt — the CI tooling itself has no SCA.

`tools/requirements-sast.txt` **has** been audited all along, by a direct `pip-audit -r` at `Makefile:279-284`. Only the two hash-locked manifests were genuinely uncovered.

## The change

`audit-requirements.py` gains `--tools-manifests`, which globs `tools/requirements*.txt` at runtime. `requirements-sast.txt` is excluded by a named constant recording why: it keeps its own direct invocation because that carries four `--ignore-vuln` suppressions for accepted semgrep transitive-dep CVEs, and auditing it twice would double-report.

The Makefile no longer enumerates individual manifests. A new `tools/requirements-*.txt` is therefore audited the moment it lands — the drift this entry describes is **prevented by construction** rather than detected after the fact.

The entry offered Dependabot-for-pip as an alternative and asked for one option, not both. Rejected: it needs a repository-settings action and routes findings into a separate PR stream instead of the gate that already reports every other SCA result.

## Why there is no Makefile-parsing guard

A guard was attempted and defeated three times, each fix calibrated to the previous defect and failing in its blind spot:

| attempt | defeated by |
|---|---|
| substring scan of one physical line | a `\` line continuation made it vacuous |
| tokenise the logical line | a trailing `# comment` — tokens still visible, coverage gone, gate **green** |
| `shlex` tokenising | an inert `define…endef` block supplied manifest names while the real recipe audited nothing |

Parsing a recipe's text cannot answer what the recipe executes. ~130 lines of that parsing are deleted.

What survives is the half that was always sound: a **bounded, comment-rejecting presence check** that both auditor invocations exist as recipe lines in `sast-unleased`. Locating an invocation that way is reliable — a commented line does not match, and the window is bounded to the target so a decoy elsewhere cannot satisfy it. Extracting an argument list from it was the unsound part.

That check is load-bearing: without it this change would have been a **net loss** against `main`, which did catch a commented-out invocation. Caught by comparing against the baseline rather than against the previous round.

## Verification

| check | result |
|---|---|
| `make sast` | exit 0; all four manifests audited **exactly once** — no gap, no double-audit |
| `python3 tools/test-audit-requirements.py` | `audit-requirements self-test: passed` |
| `python3 -m pytest tools/test_okf_pre_pr.py` | 18 passed |

**Mutation proofs** — all seven run by the supervisor, working tree verified byte-identical after each:

| mutation | expected | assertion that fires |
|---|---|---|
| `ifeq (1,1)` / `endif` around the audit lines | **stays green** | valid make must not redden the gate |
| comment out `--tools-manifests` | red | tools-manifests audit invocation is present |
| comment out the packs audit | red | packs audit invocation is present |
| symlink a `tools/requirements-*.txt` outside the tree | excluded | resolver ignores symlink candidates |
| rename the SAST manifest in the Makefile only | red | direct SAST audit matches the resolver exclusion |
| narrow the resolver glob | red | resolver includes every matching manifest except direct SAST |
| drop the SAST exclusion | red | same |

The first row is deliberate: an earlier revision reddened on a legal `ifeq` wrapper, and a guard that rejects correct edits is one the next person deletes.

## Test ownership

`test_okf_pre_pr.py` previously asserted the Makefile audits `tools/requirements.txt` (it carries the pyyaml the OKF compiler needs). That literal is gone, so it now calls the resolver directly and names `test-audit-requirements.py` as owner of the invocation-presence property. A first replacement was a plain substring search satisfied by a commented line; that was removed rather than left as a weak duplicate.

## Known pre-existing failure, not from this change

`make ci` fails only `tools/test_marketplace_envelope_parity.py::test_resolved_layer_fails_loudly_when_the_package_is_unimportable`. Verified identical on a clean detached `origin/main` worktree with none of these changes. It is the registered environmental issue `pre-existing-roster-catalogue-index-and-okf-release-metadata`, and is being fixed separately.

## Process

Authorised by the repository owner as a **direct-light** change under an explicit waiver of the work-loop's full-mode route. This touches a compliance/governance surface (SCA gate coverage), which normally routes to full mode with a durable spec, plan and two approval gates. Gates, mutation proofs and independent adversarial review still applied and are recorded above.

## Out of scope

`sast-requirements-hash-locked` is a separate entry whose own comment says "hence its own PR". It remains open and untouched; nothing here adds `--require-hashes` or modifies an install step.
