### PR TITLE
test(parity): build the unimportable-package fixture as a regular package

### DIFF
--- a/tools/test_marketplace_envelope_parity.py
+++ b/tools/test_marketplace_envelope_parity.py
@@ -1261,9 +1261,17 @@ def test_resolved_layer_refuses_a_str_subclass(tmp_path: Path) -> None:
 
 
 def test_resolved_layer_fails_loudly_when_the_package_is_unimportable(tmp_path: Path) -> None:
-    """A layer that cannot read must fail, never degrade to a skip."""
-    root = tmp_path / "empty"
-    (root / BUILD_MAIN).parent.mkdir(parents=True)
+    """A layer that cannot read must fail, never degrade to a skip.
+
+    Built through `_package_fixture` rather than by planting a lone `main.py`, so the
+    fixture is a REGULAR package. A hand-built tree with no `__init__.py` is a PEP 420
+    namespace package, and a namespace package loses to a regular one on `sys.path`
+    regardless of order — so on any machine with `agentbundle` installed in
+    site-packages the child resolved THAT copy and raised the provenance refusal
+    instead of the import failure this case is about. The assertion then failed on the
+    message, and the whole case only passed where the package happened to be absent.
+    """
+    root = _package_fixture(tmp_path)
     (root / BUILD_MAIN).write_text("", encoding="utf-8")
     with pytest.raises(ParityError, match="child failed"):
         resolve_build_main_constants(root)


### PR DESCRIPTION
Fixes `test_resolved_layer_fails_loudly_when_the_package_is_unimportable`, which failed on any machine with `agentbundle` pip-installed — i.e. every machine that has run `pip install agentbundle` rather than working purely from the worktree.

## Root cause: PEP 420 precedence, not the environment

The case planted a lone `main.py` with no `__init__.py`, making its temp tree a **namespace package**. A namespace package loses to a **regular** package on `sys.path` regardless of order, so the child interpreter resolved `agentbundle.build.main` from site-packages instead of the fixture and raised the provenance refusal:

```
ParityError: provenance mismatch: the finder resolved agentbundle.build.main to
'…/site-packages/agentbundle/build/main.py', expected '…/empty/packages/agentbundle/…'
```

The case asserts `match="child failed"`, so it failed on the message.

Measured both directions:

| fixture shape | `agentbundle.build.main` resolves to |
|---|---|
| no `__init__.py` (before) | site-packages — fixture loses |
| real package tree (after) | the temp tree — fixture wins |

Every sibling case in this module already builds its tree with `_package_fixture()`, which `copytree`s the real `packages/agentbundle` and therefore carries both `__init__.py` files. This case was the only one hand-rolling its tree. It now uses the same helper and truncates `main.py`, preserving the exact mechanism under test: module present, constants absent, child exits non-zero.

## Verification

| check | result |
|---|---|
| the failing case | passes |
| `tools/test_marketplace_envelope_parity.py` | 60 passed |
| `make ci` | **exit 0** — first fully clean run in this worktree |

**Mutation proofs**, run by the supervisor, tree verified byte-identical after each:

| mutation | result |
|---|---|
| revert to the hand-built namespace-package tree | fails again — confirms this is the fix, not a coincidence |
| leave `main.py` intact so the child succeeds | caught — the case still tests something real, not a tautology |

## This corrects a recorded diagnosis

The `pre-existing-roster-catalogue-index-and-okf-release-metadata` backlog entry attributes this failure to pytest's `pythonpath` not reaching an `-I` child. That is true of `pythonpath` in general but is not the cause here — the child never relied on it, inserting the package root into `sys.path` explicitly (`tools/test_marketplace_envelope_parity.py:225`). The commit message records the correction so the next reader is not sent down that path. The entry itself is left alone: it covers two other tests whose status this change does not alter.

## Process

Authorised by the repository owner as a **direct-light** change under an explicit waiver of the work-loop's full-mode route. Gates, mutation proofs and independent review still apply.