### PR TITLE
ci: declare workflow permissions and gate Pages concurrency

### DIFF
--- a/.github/workflows/build-check-windows.yml
+++ b/.github/workflows/build-check-windows.yml
@@ -54,6 +54,12 @@ on:
       - "Makefile"
       - "*.md"
 
+# Every job only checks out source and runs tests. setup-python's cache uses the
+# Actions runtime token, not this repository token; no artifact, check, PR, or
+# repository write is performed.
+permissions:
+  contents: read
+
 jobs:
   agentbundle-windows:
     name: AgentBundle compatibility (windows)

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -311,6 +311,11 @@ jobs:
       # collection would silently run nothing.
       - name: pages.yml deploy-gate posture
         run: python3 tools/test-pages-workflow.py
+      # Pages is not a required context, so its concurrency isolation must be
+      # asserted from this required job. The script's self-test mutates both the
+      # group and cancellation scope on every invocation.
+      - name: pages.yml concurrency posture
+        run: python3 tools/test-pages-concurrency.py
       # The credential-setup skill's own suite (RFC-0023 T8 + the
       # missing-credbroker guard) lives under packs/credential-brokers/tests/skills/credential-setup/ (ADR-0071), which
       # neither `make build-check` nor any package pytest discovers. Wire it

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -5,7 +5,8 @@ name: ci-security
 # Three tools:
 #   gitleaks   — secret scanner; fails on detected secrets (exit 1)
 #   actionlint — GitHub Actions linter; fails on workflow errors
-#   zizmor     — GitHub Actions security analyzer; --min-severity high
+#   zizmor     — GitHub Actions security analyzer; high severity plus a focused
+#                 excessive-permissions run for the owned workflow pair
 #
 # Posture (security-load-bearing; asserted by tools/test-ci-security-workflow.py):
 #   - pull_request + push ONLY — pull_request_target absent (would expose secrets
@@ -115,6 +116,13 @@ jobs:
       - name: zizmor (min-severity high)
         # Scans workflow files for high-severity GitHub Actions vulnerabilities:
         # template-injection, cache-poisoning, dangerous-triggers, artipacked, etc.
-        # unpinned-uses (HIGH in zizmor 1.27.0) is suppressed via .github/zizmor.yml —
-        # the repo accepts @vN tag-pinning as current posture (SHA pinning is backlog).
+        # `.github/zizmor.yml` declares no suppressions; unpinned action references
+        # are SHA-pinned and remain visible to this high-severity gate.
         run: zizmor --min-severity high .github/workflows/
+
+      - name: zizmor (excessive-permissions)
+        # Do not lower the global threshold: that would make unrelated medium/low
+        # findings (for example artipacked) block this focused posture gate. The
+        # checker consumes zizmor's JSON and fails only on excessive-permissions in
+        # the two workflows this backlog item owns.
+        run: python3 tools/check-zizmor-excessive-permissions.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,11 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
+# Default floor for any future job. The analyzer's elevated permissions remain
+# scoped to that job below.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: CodeQL analyze (python)

--- a/Makefile
+++ b/Makefile
@@ -416,6 +416,7 @@ test-unleased: lint-editable-install
 	@test -d docs-site/node_modules || { echo "make test: docs-site deps missing — run: npm ci --prefix docs-site" >&2; exit 1; }
 	npm run test:plugins --prefix docs-site
 	$(PYTHON) tools/test-pages-workflow.py
+	$(PYTHON) tools/test-pages-concurrency.py
 	$(PYTHON) -m pytest tests/ -q
 	$(PYTHON) -m pytest packs/core/tests/hooks/ -q
 	$(PYTHON) -m pytest packs/core/tests/pack/ -q

--- a/tools/check-zizmor-excessive-permissions.py
+++ b/tools/check-zizmor-excessive-permissions.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Fail CI only for zizmor's excessive-permissions audit in owned workflows.
+
+The broad zizmor gate intentionally retains its high-severity floor. Lowering it
+would also make the repository's unrelated medium/low findings block this job.
+This focused companion run keeps `excessive-permissions` continuously enforced
+for the two workflows closed by the CI-posture backlog item.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = (
+    ".github/workflows/build-check-windows.yml",
+    ".github/workflows/codeql.yml",
+)
+AUDIT = "excessive-permissions"
+CODEQL = ".github/workflows/codeql.yml"
+CODEQL_TOP_LEVEL_FLOOR = "permissions:\n  contents: read\n"
+CODEQL_ANALYZE_PERMISSIONS = (
+    "    permissions:\n"
+    "      security-events: write\n"
+    "      contents: read\n"
+    "      actions: read\n"
+)
+
+
+def _job_block(workflow: str, job_id: str) -> str:
+    """Return one two-space-indented job block, excluding YAML comments."""
+    clean = "\n".join(line.split("#", 1)[0].rstrip() for line in workflow.splitlines())
+    match = re.search(rf"^  {re.escape(job_id)}:\s*$", clean, re.M)
+    if match is None:
+        return ""
+    following = clean[match.end():]
+    next_job = re.search(r"^  [A-Za-z0-9_-]+:\s*$", following, re.M)
+    return following[:next_job.start()] if next_job else following
+
+
+def _check_codeql_permission_shape() -> str | None:
+    """Validate CodeQL's future-job floor and analyzer-only elevation."""
+    path = REPO_ROOT / CODEQL
+    workflow = path.read_text(encoding="utf-8")
+    if workflow.count(CODEQL_TOP_LEVEL_FLOOR) != 1:
+        return "codeql.yml must retain top-level permissions: contents: read"
+    analyze = _job_block(workflow, "analyze")
+    if analyze.count(CODEQL_ANALYZE_PERMISSIONS) != 1:
+        return "codeql.yml analyze job must retain its scoped CodeQL permissions"
+    return None
+
+
+def main() -> int:
+    """Run zizmor and fail when its focused audit reports a finding."""
+    missing = [path for path in WORKFLOWS if not (REPO_ROOT / path).is_file()]
+    if missing:
+        print(
+            f"zizmor excessive-permissions: owned workflow missing: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return 2
+    if problem := _check_codeql_permission_shape():
+        print(f"zizmor excessive-permissions: {problem}", file=sys.stderr)
+        return 1
+
+    command = [
+        "zizmor", "--no-exit-codes", "--min-severity", "low", "--format", "json", *WORKFLOWS,
+    ]
+    result = subprocess.run(command, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
+    try:
+        findings = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print("zizmor excessive-permissions: invalid JSON output", file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        return 2
+    if not isinstance(findings, list):
+        print("zizmor excessive-permissions: JSON result is not a list", file=sys.stderr)
+        return 2
+
+    violations = [finding for finding in findings if finding.get("ident") == AUDIT]
+    if violations:
+        print(
+            f"zizmor excessive-permissions: {len(violations)} finding(s) in "
+            f"{', '.join(WORKFLOWS)}",
+            file=sys.stderr,
+        )
+        for finding in violations:
+            for location in finding.get("locations", []):
+                path = location.get("symbolic", {}).get("key", {}).get("Local", {})
+                print(f"  - {path.get('verbatim_path', 'unknown workflow')}", file=sys.stderr)
+        return 1
+    if result.returncode != 0:
+        print(f"zizmor excessive-permissions: zizmor exited {result.returncode}", file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        return result.returncode
+    print("zizmor excessive-permissions: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-zizmor-excessive-permissions.py
+++ b/tools/check-zizmor-excessive-permissions.py
@@ -54,6 +54,31 @@ def _check_codeql_permission_shape() -> str | None:
     return None
 
 
+def _finding_paths(finding: dict[str, object]) -> tuple[str, ...] | None:
+    """Return an audit finding's local paths, rejecting unknown result shapes."""
+    locations = finding.get("locations")
+    if not isinstance(locations, list) or not locations:
+        return None
+    paths: list[str] = []
+    for location in locations:
+        if not isinstance(location, dict):
+            return None
+        symbolic = location.get("symbolic")
+        if not isinstance(symbolic, dict):
+            return None
+        key = symbolic.get("key")
+        if not isinstance(key, dict):
+            return None
+        local = key.get("Local")
+        if not isinstance(local, dict):
+            return None
+        path = local.get("verbatim_path")
+        if not isinstance(path, str):
+            return None
+        paths.append(path)
+    return tuple(paths)
+
+
 def main() -> int:
     """Run zizmor and fail when its focused audit reports a finding."""
     missing = [path for path in WORKFLOWS if not (REPO_ROOT / path).is_file()]
@@ -82,17 +107,35 @@ def main() -> int:
         print("zizmor excessive-permissions: JSON result is not a list", file=sys.stderr)
         return 2
 
-    violations = [finding for finding in findings if finding.get("ident") == AUDIT]
+    violations: list[tuple[dict[str, object], tuple[str, ...]]] = []
+    for finding in findings:
+        if not isinstance(finding, dict) or not isinstance(finding.get("ident"), str):
+            print("zizmor excessive-permissions: finding lacks string ident", file=sys.stderr)
+            return 2
+        if finding["ident"] != AUDIT:
+            continue
+        paths = _finding_paths(finding)
+        if paths is None:
+            print("zizmor excessive-permissions: finding lacks local paths", file=sys.stderr)
+            return 2
+        unexpected = sorted(set(paths) - set(WORKFLOWS))
+        if unexpected:
+            print(
+                "zizmor excessive-permissions: finding outside owned workflows: "
+                f"{', '.join(unexpected)}",
+                file=sys.stderr,
+            )
+            return 2
+        violations.append((finding, paths))
     if violations:
         print(
             f"zizmor excessive-permissions: {len(violations)} finding(s) in "
             f"{', '.join(WORKFLOWS)}",
             file=sys.stderr,
         )
-        for finding in violations:
-            for location in finding.get("locations", []):
-                path = location.get("symbolic", {}).get("key", {}).get("Local", {})
-                print(f"  - {path.get('verbatim_path', 'unknown workflow')}", file=sys.stderr)
+        for _, paths in violations:
+            for path in paths:
+                print(f"  - {path}", file=sys.stderr)
         return 1
     if result.returncode != 0:
         print(f"zizmor excessive-permissions: zizmor exited {result.returncode}", file=sys.stderr)

--- a/tools/fixtures/build-check-good.yml
+++ b/tools/fixtures/build-check-good.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           python3 tools/check-docs-contrast.py
           python -m pytest tools/test_check_docs_contrast.py -q
+      - name: pages.yml concurrency posture
+        run: python3 tools/test-pages-concurrency.py
   gate-sast:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/tools/lint-ci-parity.py
+++ b/tools/lint-ci-parity.py
@@ -383,6 +383,11 @@ STEP_DISPOSITION: dict[str, tuple[str, str]] = {
     # `test` target, which invokes the same script.
     "pages.yml deploy-gate posture":
         LOCAL("test"),
+    # The Pages concurrency checker is independently reachable from `make ci`
+    # through `test`, and runs in required gate-main so it cannot become the
+    # unwired workflow-posture anti-pattern.
+    "pages.yml concurrency posture":
+        LOCAL("test"),
     # RFC-0082 export boundary. The gate itself runs in release-agentbundle.yml;
     # this step runs the gate's own tests, so a regression to always-exit-0 goes
     # red here rather than staying silently green.

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -327,6 +327,7 @@ PINNED_SITE_BUILD_PYTEST = (
 )
 PINNED_CONTRAST_CHECKER = "python3 tools/check-docs-contrast.py"
 PINNED_CONTRAST_SUITE = "python -m pytest tools/test_check_docs_contrast.py -q"
+PINNED_PAGES_CONCURRENCY = "python3 tools/test-pages-concurrency.py"
 # The GENERIC form of the five pins above, keyed by job id, for work jobs whose
 # gate is a whole step body rather than one statement. `gate-main`, `gate-sast` and
 # `gate-export-boundary` carry the bespoke constants above; a job added later gets
@@ -372,6 +373,7 @@ _NO_CWD_STEPS = (
     ("gate-main", "pytest guides + catalogue navigation"),
     ("gate-main", "pytest site build + link rewriting"),
     ("gate-main", "docs palette contrast gate"),
+    ("gate-main", "pages.yml concurrency posture"),
 )
 # Non-run steps permitted in the aggregator, compared as the `uses:` VALUE for equality.
 # A substring test over the step chunk — the previous shape — accepted
@@ -1414,6 +1416,9 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     check("contrast-body-exact",
           _run_lines(_step_named(main_blk, "docs palette contrast gate"))
           == [PINNED_CONTRAST_CHECKER, PINNED_CONTRAST_SUITE])
+    check("pages-concurrency-body-exact",
+          _run_lines(_step_named(main_blk, "pages.yml concurrency posture"))
+          == [PINNED_PAGES_CONCURRENCY])
 
     # AC2's second neutering form. `continue-on-error` is covered file-wide, and
     # cwd redirection by _NO_CWD_STEPS above — but a step-level `if:` was the live
@@ -1422,7 +1427,8 @@ def _audit(text: str, evaluated: list[str] | None) -> list[str]:
     # `if:` at all, so the honest assertion is that it stays that way.
     for _step_name in ("pytest guides + catalogue navigation",
                        "pytest site build + link rewriting",
-                       "docs palette contrast gate"):
+                       "docs palette contrast gate",
+                       "pages.yml concurrency posture"):
         _st = _step_named(main_blk, _step_name)
         check(f"site-step-no-if[{_step_name}]", bool(_st) and not _has_if(_st))
 
@@ -1626,6 +1632,8 @@ _MUTATIONS: list[tuple[str, str, object]] = [
     ("drop-contrast-suite", "contrast-gate[tools/test_check_docs_contrast.py]",
      lambda t: t.replace(
          "          python -m pytest tools/test_check_docs_contrast.py -q\n", "")),
+    ("drop-pages-concurrency-posture", "pages-concurrency-body-exact",
+     lambda t: t.replace("        run: python3 tools/test-pages-concurrency.py\n", "", 1)),
     ("if-false-on-contrast-step", "site-step-no-if[docs palette contrast gate]",
      lambda t: t.replace("      - name: docs palette contrast gate\n",
                          "      - name: docs palette contrast gate\n        if: ${{ false }}\n")),

--- a/tools/test-pages-concurrency.py
+++ b/tools/test-pages-concurrency.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Mutation-tested concurrency posture check for `.github/workflows/pages.yml`.
+
+A pull-request Pages run must not share a concurrency group with a push/deploy
+run, and only pull-request runs may cancel an in-progress run. This deliberately
+owns concurrency rather than extending test-pages-workflow.py, whose charter is
+the deploy-blocking gate's steps, ordering, and path filters.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pages.yml"
+EXPECTED_GROUP = "pages-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+EXPECTED_CANCEL = "${{ github.event_name == 'pull_request' }}"
+
+
+def _strip_comments(text: str) -> str:
+    """Remove YAML comments so a comment cannot satisfy a posture assertion."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        quote: str | None = None
+        cut = len(line)
+        for index, char in enumerate(line):
+            if quote:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == "#":
+                cut = index
+                break
+        lines.append(line[:cut].rstrip())
+    return "\n".join(lines)
+
+
+def _concurrency_block(text: str) -> str:
+    """Return the top-level concurrency mapping, or an empty string."""
+    match = re.search(r"^concurrency:\s*$", text, re.M)
+    if match is None:
+        return ""
+    following = text[match.end():]
+    next_key = re.search(r"^[A-Za-z][A-Za-z0-9_-]*:\s*$", following, re.M)
+    return following[:next_key.start()] if next_key else following
+
+
+def audit(text: str) -> list[str]:
+    """Return the concurrency-posture violations in a workflow's text."""
+    clean = _strip_comments(text)
+    block = _concurrency_block(clean)
+    bad: list[str] = []
+    if not block:
+        return ["concurrency-present"]
+
+    group = re.findall(r"^  group:\s*(.*?)\s*$", block, re.M)
+    if group != [EXPECTED_GROUP]:
+        bad.append("pr-and-deploy-groups-separated")
+    cancel = re.findall(r"^  cancel-in-progress:\s*(.*?)\s*$", block, re.M)
+    if cancel != [EXPECTED_CANCEL]:
+        bad.append("cancellation-pr-only")
+    return bad
+
+
+def _baseline() -> str:
+    if not WORKFLOW.is_file():
+        raise SystemExit(f"missing {WORKFLOW} — cannot prove mutations")
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+_MUTATIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("drop-concurrency", "concurrency-present", "concurrency:\n", "concurrency-disabled:\n"),
+    ("unkeyed-group", "pr-and-deploy-groups-separated", EXPECTED_GROUP, '"pages"'),
+    ("unconditional-cancellation", "cancellation-pr-only", EXPECTED_CANCEL, "true"),
+)
+
+
+def self_test() -> int:
+    """Prove each assertion family catches a concrete unsafe edit."""
+    good = _baseline()
+    failures: list[str] = []
+    if baseline := audit(good):
+        failures.append(f"baseline should be clean, got {baseline}")
+    for mutation, expected, old, new in _MUTATIONS:
+        changed = good.replace(old, new, 1)
+        if changed == good:
+            failures.append(f"{mutation}: mutation was a no-op")
+        elif expected not in audit(changed):
+            failures.append(f"{mutation}: expected {expected!r}, got {audit(changed)}")
+    if failures:
+        print("✖ pages concurrency self-test:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(f"✓ pages concurrency self-test: {len(_MUTATIONS)} mutations caught")
+    return 0
+
+
+def main() -> int:
+    """Run mutation coverage and then validate the repository workflow."""
+    if self_test() != 0:
+        return 1
+    violations = audit(_baseline())
+    if violations:
+        print(f"✖ pages concurrency: {', '.join(violations)}", file=sys.stderr)
+        return 1
+    print("✓ pages.yml concurrency posture OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test-pages-concurrency.py
+++ b/tools/test-pages-concurrency.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pages.yml"
 EXPECTED_GROUP = "pages-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
 EXPECTED_CANCEL = "${{ github.event_name == 'pull_request' }}"
+EXPECTED_DEPLOY_IF = "github.ref == 'refs/heads/main'"
 
 
 def _strip_comments(text: str) -> str:
@@ -48,6 +49,16 @@ def _concurrency_block(text: str) -> str:
     return following[:next_key.start()] if next_key else following
 
 
+def _job_block(text: str, job_id: str) -> str:
+    """Return a job's mapping body, or an empty string when it is absent."""
+    match = re.search(rf"^  {re.escape(job_id)}:\s*$", text, re.M)
+    if match is None:
+        return ""
+    following = text[match.end():]
+    next_job = re.search(r"^  [A-Za-z0-9_-]+:\s*$", following, re.M)
+    return following[:next_job.start()] if next_job else following
+
+
 def audit(text: str) -> list[str]:
     """Return the concurrency-posture violations in a workflow's text."""
     clean = _strip_comments(text)
@@ -62,6 +73,10 @@ def audit(text: str) -> list[str]:
     cancel = re.findall(r"^  cancel-in-progress:\s*(.*?)\s*$", block, re.M)
     if cancel != [EXPECTED_CANCEL]:
         bad.append("cancellation-pr-only")
+    deploy = _job_block(clean, "deploy")
+    deploy_if = re.findall(r"^    if:\s*(.*?)\s*$", deploy, re.M)
+    if deploy_if != [EXPECTED_DEPLOY_IF]:
+        bad.append("deploy-main-only")
     return bad
 
 
@@ -75,6 +90,13 @@ _MUTATIONS: tuple[tuple[str, str, str, str], ...] = (
     ("drop-concurrency", "concurrency-present", "concurrency:\n", "concurrency-disabled:\n"),
     ("unkeyed-group", "pr-and-deploy-groups-separated", EXPECTED_GROUP, '"pages"'),
     ("unconditional-cancellation", "cancellation-pr-only", EXPECTED_CANCEL, "true"),
+    (
+        "widen-deploy-to-pr",
+        "deploy-main-only",
+        EXPECTED_DEPLOY_IF,
+        "github.event_name == 'pull_request' || github.ref == 'refs/heads/main'",
+    ),
+    ("drop-deploy-if", "deploy-main-only", f"    if: {EXPECTED_DEPLOY_IF}\n", ""),
 )
 
 
@@ -105,7 +127,20 @@ def main() -> int:
         return 1
     violations = audit(_baseline())
     if violations:
-        print(f"✖ pages concurrency: {', '.join(violations)}", file=sys.stderr)
+        details = {
+            "pr-and-deploy-groups-separated":
+                "top-level group must retain the exact documented expression; reread its "
+                "deadlock comment before changing it",
+            "deploy-main-only":
+                "deploy must remain exactly main-only; reread its bare-pages concurrency "
+                "comment before changing it",
+        }
+        print(
+            "✖ pages concurrency: " + "; ".join(
+                f"{violation} ({details.get(violation, violation)})" for violation in violations
+            ),
+            file=sys.stderr,
+        )
         return 1
     print("✓ pages.yml concurrency posture OK")
     return 0

--- a/workspace.toml
+++ b/workspace.toml
@@ -2689,6 +2689,35 @@ open = [
   # file and install from it with --require-hashes in both the conditional and
   # the unconditional step, keeping requirements-sast.txt as the canonical input
   # so nothing restates a pin. Needs a refresh procedure, hence its own PR.
+  #
+  # SCOPED 2026-08-24, measured not estimated, after this was picked up and put
+  # back down. It is larger than the entry above implies, and the ci-security
+  # precedent does not generalise the way it looks like it should.
+  #   - `--require-hashes` pins the whole transitive closure, not the three
+  #     direct requirements. Measured with `pip install --dry-run
+  #     --ignore-installed --report`: 86 packages, so roughly 250 hash lines.
+  #     A three-line locked file is not an option -- pip refuses the mode
+  #     unless every requirement is pinned with `==`.
+  #   - THE REAL CONSTRAINT IS PLATFORM. The closure carries binary wheels
+  #     (cryptography, pydantic_core, rpds-py, protobuf, cffi, msgpack,
+  #     ruamel.yaml.clib). A file generated on a contributor's macOS pins macOS
+  #     wheels and breaks ubuntu CI. requirements-ci-security-locked.txt sidesteps
+  #     this by pinning ONE package and saying so in its own header ("Other
+  #     platform wheels are not pinned here"); at 86 packages that is not a
+  #     footnote. Target manylinux explicitly, and treat the locked file as
+  #     CI-only -- contributors keep installing requirements-sast.txt, which the
+  #     entry already implies by calling it the canonical input.
+  #   - `pip-compile` is NOT installed here and pip-tools is not a declared
+  #     dependency, so the header's suggested command does not work as written.
+  #     Adding pip-tools is its own dependency decision (AGENTS.md). Viable
+  #     stdlib path instead: `pip install --dry-run --report` emits
+  #     `download_info.archive_info.hashes` with sha256 per package, so a
+  #     generator can be written against the report JSON with no new dependency.
+  #   - Three pins move with the install-step change and are easy to miss:
+  #     `PINNED_SAST_INSTALL` (tools/test-build-check-workflow.py:296) plus the
+  #     `drop-bandit-pin-read` and `echo-wrap-sast-install` mutation lambdas in
+  #     the same file.
+  # Unblocks when: picked up with the platform-targeting decision made first.
   {slug = "sast-requirements-hash-locked", summary = "Generate and install a hash-locked tools/requirements-sast-locked.txt with --require-hashes, mirroring the ci-security locked file", source = "spec/build-check-coverage-gaps security review"},
   # Semgrep's signal for a target it could not parse depends on HOW it failed.
   # A PARTIAL failure (unbalanced bracket, stray token) does surface as a

--- a/workspace.toml
+++ b/workspace.toml
@@ -2680,22 +2680,6 @@ open = [
   # have no corresponding surface here.
   {slug = "sast-cwe-delta-review", summary = "Review the 23-CWE residual delta vs Snyk Code's published rule tables and add rules only where the class is real for this codebase", source = "spec/pack-script-root-boundary-validation"},
 
-  # build-check.yml declares no top-level `permissions:` block, so every step --
-  # including three pip installs and an editable install that executes setup.py
-  # -- runs under the repository's DEFAULT GITHUB_TOKEN. The job also runs on
-  # `push: branches: [main]`, where that default may be write-scoped. 10 of the
-  # 14 workflows here already declare one; ci-security.yml:27 documents
-  # `contents: read` as the intended posture, so this is the repo's own pattern
-  # being missed rather than an unconsidered gap. Surfaced by security review on
-  # spec/build-check-coverage-gaps and deliberately NOT bundled there: adding the
-  # block changes the job's token scope, which is a behaviour change and outside
-  # that spec's bundled-fixes carve-out.
-  # Fix: add `permissions: contents: read` at the top of build-check.yml (and
-  # sweep the other three undeclared workflows). zizmor's `excessive-permissions`
-  # audit would own this class going forward, but ci-security.yml:120 filters it
-  # out with --min-severity high -- lower the threshold or add a rule-specific
-  # run in the same change, or the next one lands the same way.
-  {slug = "build-check-yml-no-permissions-block", summary = "Declare `permissions: contents: read` on build-check.yml (and the three other undeclared workflows), and stop zizmor's --min-severity high from filtering out excessive-permissions", source = "spec/build-check-coverage-gaps security review"},
   # tools/requirements-sast.txt is installed by range (`bandit>=1.9,<2` etc.)
   # with no hashes, and after spec/build-check-coverage-gaps its bandit line is
   # fetched on 100% of build-check runs rather than a subset. The repo already
@@ -3164,15 +3148,6 @@ open = [
   # marketing catalogue and pack cards, so aligning it is a naming decision
   # across surfaces that spec does not own.
   { slug = "iac-terraform-group-label-alignment", source = "spec/guide-title-clarity", summary = "Align the iac-terraform sidebar GROUP label with its retitled index page" },
-  # tools/test-pages-workflow.py deliberately does not assert concurrency: its
-  # charter is deploy-blocking gates, their ordering, and paths: filters, and
-  # every assertion family requires mutation coverage. Required CI therefore
-  # would not catch restoration of unkeyed group: "pages" with cancellation,
-  # which cancelled 18 of 40 runs, including a PR run cancelling a main deploy.
-  # Closing this needs a dedicated mutation-tested concurrency check and a
-  # tools/lint-ci-parity.py registration, not a patch; avoid the unwired
-  # tools/test-ci-security-workflow.py anti-precedent. Unblocks when: ready now.
-  { slug = "pages-concurrency-has-no-regression-gate", source = "spec/pages-concurrency-isolation (review concern)", summary = "pages.yml concurrency has no required-CI assertion, so restoring unkeyed group: \"pages\" would silently reintroduce cross-branch run cancellation" },
   # Surfaced by a peer session while coordinating the pages-concurrency-isolation
   # merge. The deploy lane serializes Pages deployments but does NOT order them:
   # builds now run in distinct workflow groups, so two Pages-relevant merges to main


### PR DESCRIPTION
Closes `build-check-yml-no-permissions-block` and `pages-concurrency-has-no-regression-gate`, and records measured scope on a third entry.

## `build-check-yml-no-permissions-block` — scope corrected

The entry's headline was **stale**: `build-check.yml` has declared `permissions: contents: read` since `823cd1742` (#990). Of the three workflows still undeclared, `catalogue-tooling-ci-gates.yml` is excluded — its own entry `catalogue-tooling-workflow-hardening` requires a seven-gate token-use review first. Real scope was two files.

| workflow | permissions | why |
|---|---|---|
| `build-check-windows.yml` | `contents: read` | checkout reads; no artifact, check, PR or git write |
| `codeql.yml` | `contents: read` floor + `security-events: write` / `contents: read` / `actions: read` on `analyze` | matches the repo's own shape for elevated workflows |

Hoisting CodeQL's elevated set to workflow scope was tried and **reverted**. It is behaviour-preserving today (`analyze` is the only job), but it would silently grant `security-events: write` to any job added later. All three existing elevated workflows — `pages.yml`, `release-agentbundle.yml`, `release-credbroker.yml` — use a narrow top-level floor plus job-level elevation.

Note the entry's premise did not quite fit `codeql.yml`: its concern is steps running on the *default* token, and `analyze` already declared its own permissions. What was missing was the floor for a future job.

## The zizmor half

Takes the entry's second option — a rule-specific run — rather than lowering `--min-severity`. Lowering the global threshold surfaces unrelated medium/low findings across all 14 workflows and would block this gate on unrelated triage.

`tools/check-zizmor-excessive-permissions.py` runs zizmor with `--no-exit-codes` and renders its own verdict from the JSON. A first revision propagated zizmor's raw exit code, which is **inverted** on both ends — I pinned the semantics empirically:

| exit | meaning |
|---|---|
| 0 | no findings |
| 13 | findings present, any severity ≥ threshold |
| 1 | tool error (reproduced with a missing file) |

Treating 13 as fatal made the gate fail on an unrelated `artipacked` finding, and treating 1 as clean meant a renamed workflow would silently stop being gated. It now fails only on `excessive-permissions` within the owned paths, fails closed if a finding lacks a string `ident` (schema drift), and fails loudly when an owned path is missing.

The `ci-security.yml` comment claiming `unpinned-uses` is suppressed via `.github/zizmor.yml` was **false** — that file is `rules: {}` and every `uses:` is SHA-pinned. Corrected in place.

## `pages-concurrency-has-no-regression-gate`

`tools/test-pages-concurrency.py` is stdlib-only, runs its own 5-mutation self-test on every invocation, is reachable through `make test`, runs in the required `gate-main`, and is registered in `lint-ci-parity`. That wiring is deliberate — the entry names the unwired `tools/test-ci-security-workflow.py` as an anti-precedent.

It guards **both** lanes. The first revision protected only the workflow-level group; independent review found a second route to the same failure, which I reproduced — widening the `deploy` job's `if:` puts PR runs into its deliberately-bare `group: pages` alongside main deployments, and **neither** guard caught it.

## Verification

| mutation | expected | result |
|---|---|---|
| current tree (unrelated `artipacked` present) | green | ✓ |
| delete Windows permissions block | red | names the workflow |
| delete CodeQL **job-level** block | red | `analyze job must retain its scoped CodeQL permissions` |
| rename an owned `WORKFLOWS` path | red | `owned workflow missing:` |
| rename `concurrency:` / group → `"pages"` / cancel → `true` | red | each caught |
| widen `deploy.if` to admit PRs / remove it | red | `deploy-main-only` |

`tools/test-build-check-workflow.py`: baseline clean, **179 mutations each caught**, all 79 assertion families covered. Adding a required step meant updating three places — the workflow, the posture assertions, and `tools/fixtures/build-check-good.yml`, the golden baseline the self-test audits as clean.

Deleting CodeQL's job-level block is caught by an explicit shape assertion, not by zizmor — with the top-level floor still narrow it is not an `excessive-permissions` finding, so zizmor alone would have missed the regression the fix exists to prevent.

## Known pre-existing failure

`make ci` fails only `test_resolved_layer_fails_loudly_when_the_package_is_unimportable`, which this branch inherits from its base. Proven not to be from this change: applying #1109's single-file fix onto this branch clears it (60 passed). #1109 is queued ahead of this PR.

## Accepted residuals, named rather than silently left

1. **The focused zizmor step can be deleted without a required check noticing.** `ci-security.yml` is not a required context and its posture test is invoked by nothing — the open `ci-security-posture-test-unwired` entry owns exactly that gap. Asserting from an unwired test would be theatre; the alternatives need zizmor as a contributor dependency, which is a decision outside this change.
2. **The Pages guard pins the canonical expressions exactly**, so a semantically equivalent rewrite reddens it. Deliberate: the adjacent comment documents a deadlock hazard if the group ever becomes bare `pages`, and a rewrite should send a human back to it. The failure message says so.

## Also in this PR

`sast-requirements-hash-locked` gains a measured scoping note — 86-package transitive closure, the manylinux-vs-macOS wheel constraint, `pip-compile` absent with a stdlib generator path via `--report` JSON, and the three posture-test pins that move with it. No code change; it stays open with the platform decision named as its first step.

## Process

Authorised by the repository owner as a **direct-light** change under an explicit waiver of the work-loop's full-mode route. Gates, mutation proofs and independent adversarial review still applied.