### PR TITLE
chore(workspace): move shipped shaping-intake-handoff out of the ini-002 queue

### DIFF
--- a/workspace.toml
+++ b/workspace.toml
@@ -254,9 +254,9 @@ shipped = [
   {path = "docs/specs/site-shared-chrome/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/product/briefs/tech-site-completion.md", revision = "7da8b07571e44fe5d6052f0efca7952484e173c8", parent = "docs/product/briefs/tech-site-completion.md"}, summary = "Share destination architecture while retaining renderer-local chrome", needs = []},
   {path = "docs/specs/local-ci-orchestration/spec.md", kind = "spec", source = {mode = "repo-origin"}, summary = "Remove duplicate local CI orchestration and resolve Make's default Python once", needs = []},
   {path = "docs/specs/architecture-decision-surface-portability/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/rfc/0096-portable-delivery-artifact-lifecycle.md", revision = "d5e68b6969bf601d06479a8ac14613bc9693d8fc"}, summary = "Resolve design, current architecture, and decision-record destinations without changing their methods", needs = []},
+  {path = "docs/specs/shaping-intake-handoff/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/rfc/0096-portable-delivery-artifact-lifecycle.md", revision = "f7660b00820dc06cf7f4618e0b6479d135e5c726"}, summary = "Reuse optional shaping and external work through portable core intake routing", needs = []},
 ]
 queue   = [
-  {path = "docs/specs/shaping-intake-handoff/spec.md", kind = "spec", source = {mode = "repo-origin", ref = "docs/rfc/0096-portable-delivery-artifact-lifecycle.md", revision = "f7660b00820dc06cf7f4618e0b6479d135e5c726"}, summary = "Reuse optional shaping and external work through portable core intake routing", needs = []},
   # Work-loop runtime: one transition, one Python process. `loop-engine.py
   # transition` shelled out to `loop-cohort.py` and `check-spec-status.py` for
   # its read-only guards, so a single transition started up to three extra


### PR DESCRIPTION
## What

`docs/specs/shaping-intake-handoff/spec.md` reads `Status: Shipped` while its
workspace entry sat in `[ini-002 work].queue`. `workspace-status` reported it as a
Type 2 stale-queue finding, and the queue carried a false record.

Applied through the sanctioned repair surface — `workspace-status repair-plan`
then `repair-apply --yes` — which preserves the complete structured entry and
performs a comment-preserving atomic write. The entry moved verbatim; no field
was rewritten. Diff is one line moved, one line removed.

## What this deliberately does not do

Three Type 2 findings remain. `repair-plan` classifies each as manual, and I left
all three alone:

| Finding | Why manual |
| --- | --- |
| `review-finding-adjudication` in `[ini-002 work].active` | active-list findings are never automated |
| `distribution-route-contract` in `[ini-002 work].active` | same |
| `semantic-surface-resolver` in ini-008's queue | inactive initiative (`type2-queue-canonical-blocked`) |

Moving a Shipped entry can silently promote a stale spec to dispatchable —
`[backlog].open`'s `ini-008-anchor-staleness-check` records exactly that failure
end to end. The ready-set delta has to be measured by hand before any of the three
moves. That is not this change.

## Verification

- `make ci` — exit 0, terminal banner `complete — every leg of this target was invoked, SAST/SCA included` (run pre-rebase; re-running post-rebase)
- `pytest tests/roster/test_workspace_status_projection.py` — 22 passed, 12 subtests passed
- `lint-spec-status.py --root .` — exit 0, `spec metadata clean` (warn-only findings are pre-existing)
- `workspace-status status` after the write: the `shaping-intake-handoff` Type 2 finding is gone; canonical ready set unchanged (still empty), so nothing was promoted to dispatchable.