### PR TITLE
sast: retire the semgrep transitive-CVE suppressions, their expiry having arrived

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,11 @@ sast-unleased:
 		packages/agentbundle/pyproject.toml
 	# No suppressions. This leg carried four `--ignore-vuln` flags for semgrep's
 	# mcp/click transitive pins until semgrep 1.174 shipped mcp==1.29.0 and
-	# click~=8.4.2, clearing them.
+	# click~=8.4.2, clearing them. The removed flags named CVE ids while
+	# pip-audit now reports the same three advisories under PYSEC ids; OSV
+	# records them as aliases, one to one -- CVE-2026-52870/PYSEC-2026-3481,
+	# CVE-2026-52869/PYSEC-2026-3482, CVE-2026-59950/PYSEC-2026-3483 -- so the
+	# suppressions retired are exactly the advisories measured as cleared.
 	# Note what this command does and does not see: pip-audit RESOLVES the
 	# requirements file, so it always audits the newest version the range allows
 	# and would read clean even at the old `semgrep>=1.166` floor. It says

--- a/Makefile
+++ b/Makefile
@@ -292,21 +292,19 @@ sast-unleased:
 	# input fails closed if the optional dependency declaration changes.
 	python3 tools/audit-requirements.py --optional-group lint \
 		packages/agentbundle/pyproject.toml
-	# semgrep>=1.166 hard-pins mcp==1.23.3 and click~=8.1.8, both carrying known CVEs
-	# (mcp: CVE-2026-52870, CVE-2026-52869, CVE-2026-59950; click: PYSEC-2026-2132).
-	# Attack surface is negligible: these packages are SAST-tooling transitive deps only,
-	# never present in shipped artifacts (which declare dependencies=[]); exploiting the
-	# mcp CVEs requires a Semgrep backend compromise + targeted CI attack; the click CVE
-	# requires controlling semgrep's CLI args (i.e. write access to this repo).
-	# Suppression is unblocked once semgrep ships mcp>=1.28.1 + click>=8.3.3 deps.
-	# Full diagnosis and unblock condition: workspace.toml [backlog].open, entry
-	# `semgrep-mcp-cve-allowlist` — the suppressions' only recorded expiry.
-	@echo "pip-audit -r tools/requirements-sast.txt (semgrep transitive-dep CVE allowlist applied)"
-	@pip-audit -r tools/requirements-sast.txt \
-		--ignore-vuln CVE-2026-52870 \
-		--ignore-vuln CVE-2026-52869 \
-		--ignore-vuln CVE-2026-59950 \
-		--ignore-vuln PYSEC-2026-2132
+	# No suppressions. This leg carried four `--ignore-vuln` flags for semgrep's
+	# mcp/click transitive pins until semgrep 1.174 shipped mcp==1.29.0 and
+	# click~=8.4.2, clearing them.
+	# Note what this command does and does not see: pip-audit RESOLVES the
+	# requirements file, so it always audits the newest version the range allows
+	# and would read clean even at the old `semgrep>=1.166` floor. It says
+	# nothing about the semgrep actually installed on this machine — that is what
+	# requirements-sast.txt's floor is for, and why the floor moved with this
+	# change rather than being left behind.
+	# A new suppression here needs a written diagnosis and a recorded unblock
+	# condition, the discipline that retired the last four.
+	@echo "pip-audit -r tools/requirements-sast.txt"
+	@pip-audit -r tools/requirements-sast.txt
 	# Both shipped packages declare dependencies=[]; their optional extras are
 	# the only third-party code either can pull, so audit those explicitly.
 	# Mirror packages/credbroker/pyproject.toml [crypto] and

--- a/docs/specs/stale-reference-corrections/spec.md
+++ b/docs/specs/stale-reference-corrections/spec.md
@@ -1,6 +1,12 @@
 # Spec: stale-reference-corrections
 
-- **Status:** Shipped
+- **Status:** Shipped (AC4's register anchor `semgrep-mcp-cve-allowlist` was
+  closed on 2026-08-25 when its recorded unblock condition arrived and the four
+  `--ignore-vuln` suppressions were removed from the `sast` target; the entry is
+  gone from `workspace.toml [backlog].open`, and the Makefile citation AC4
+  repointed went with the suppressions it annotated. Not a supersession — every
+  decision here stands, and AC4's repointing was correct for as long as the
+  suppressions existed.)
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Contract:** none — every change is a comment or a prose sentence. No

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -10,12 +10,14 @@ whose committed lockfiles ship into built output. This closes that half.
 **Why a wrapper rather than two `npm audit` lines in the Makefile.** `npm audit`
 has no per-advisory ignore. Its only lever is `--audit-level`, which is
 repo-wide: the escape hatch for one unfixable transitive advisory is to stop
-gating an entire severity band. The sibling `pip-audit` leg in `make sast`
-already runs with four live `--ignore-vuln` suppressions, each carrying a
-written diagnosis and an unblock condition — suppressions are the observed
-steady state of this control in this repo, not a hypothetical. So the escape
-hatch is built now, as an ID-keyed allowlist that forces a reason and an unblock
-condition into a reviewed diff, and it ships empty.
+gating an entire severity band. The sibling `pip-audit` leg in `make sast` ran
+for months with four live `--ignore-vuln` suppressions, each carrying a written
+diagnosis and an unblock condition, and they were removed only once that
+condition was met — so suppressions are the observed steady state of this
+control in this repo, not a hypothetical, and the written-expiry discipline is
+what retires them. So the escape hatch is built now, as an ID-keyed allowlist
+that forces a reason and an unblock condition into a reviewed diff, and it ships
+empty.
 
 **Why the verdict comes from the payload, never the exit code.** `npm audit`
 exits non-zero for *both* "found advisories" and "could not reach the registry".

--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -11,11 +11,11 @@ whose committed lockfiles ship into built output. This closes that half.
 has no per-advisory ignore. Its only lever is `--audit-level`, which is
 repo-wide: the escape hatch for one unfixable transitive advisory is to stop
 gating an entire severity band. The sibling `pip-audit` leg in `make sast` ran
-for months with four live `--ignore-vuln` suppressions, each carrying a written
-diagnosis and an unblock condition, and they were removed only once that
-condition was met — so suppressions are the observed steady state of this
-control in this repo, not a hypothetical, and the written-expiry discipline is
-what retires them. So the escape hatch is built now, as an ID-keyed allowlist
+from 2026-07-16 to 2026-08-25 with four live `--ignore-vuln` suppressions, each
+carrying a written diagnosis and an unblock condition, and they were removed
+only once that condition was met — so suppressions are the observed steady state
+of this control in this repo, not a hypothetical, and the written-expiry
+discipline is what retires them. So the escape hatch is built now, as an ID-keyed allowlist
 that forces a reason and an unblock condition into a reviewed diff, and it ships
 empty.
 

--- a/tools/requirements-sast.txt
+++ b/tools/requirements-sast.txt
@@ -9,4 +9,10 @@
 # `make sast`.
 bandit>=1.9,<2
 pip-audit>=2.10,<3
-semgrep>=1.166,<2
+# semgrep 1.174 is the release whose transitive pins (mcp==1.29.0, click~=8.4.2)
+# clear the SAST-toolchain CVEs that `make sast` suppressed until 2026-08-25.
+# The floor is load-bearing for the INSTALL, not for the audit: `pip-audit -r`
+# resolves the newest version the range allows either way, but pip leaves an
+# already-satisfying older semgrep in place, so a lower floor lets a contributor
+# keep running a toolchain carrying the very advisories the gate reports clean.
+semgrep>=1.174,<2

--- a/workspace.toml
+++ b/workspace.toml
@@ -2086,7 +2086,7 @@ open = [
   # exits 0 with empty errors under --strict today). Then close the whole-file
   # residue independently: compile each ratcheted target with ast.parse before
   # trusting its silence. Cheap and offline. Re-probe on a semgrep major bump
-  # (pinned semgrep>=1.166,<2).
+  # (pinned semgrep>=1.174,<2 since 2026-08-25; was >=1.166,<2 when this was written).
   {slug = "sast-semgrep-unparseable-target-reads-clean", summary = "A whole-file parse failure is reported as scanned with zero findings and no signal even under --strict, so a ratcheted script that stops parsing reads as clean; partial failures ARE gateable via --strict and are not yet gated", source = "spec/semgrep-selftest-batching security review"},
   # A single `# nosemgrep` comment on the offending line leaves the file in
   # paths.scanned with zero findings, zero errors and exit 0 -- indistinguishable

--- a/workspace.toml
+++ b/workspace.toml
@@ -1673,16 +1673,6 @@ open = [
   # Unblocks when: the sidecar schema is pinned (RFC-0048 Decision-7 spike lands).
   {slug = "sidecar-drift-hard-fail"},
 
-  # Monitoring. semgrep>=1.166 hard-pins mcp==1.23.3 and click~=8.1.8, both with
-  # published CVEs. These are transitive SAST-tooling deps only — never shipped to
-  # end users. The Makefile sast target carries --ignore-vuln flags to suppress them
-  # while upstream semgrep hasn't released an update. Low risk (requires attacker
-  # control of MCP protocol messages or CLI args inside an ephemeral CI runner).
-  # Fix: remove the --ignore-vuln flags from the Makefile sast target once semgrep
-  #   ships mcp>=1.28.1 and click>=8.3.3. Check via `pip show semgrep | grep Requires`.
-  # Unblocks when: semgrep releases with updated mcp + click transitive dep pins.
-  {slug = "semgrep-mcp-cve-allowlist"},
-
   # Unverified: walkthrough and projection checks pass, but four skills have not exercised
   # present, absent, sensitive, and brownfield detection through a live mock MCP tool.
   # Settle when a harness can register a stub MCP retrieval tool and record all four


### PR DESCRIPTION
## What does this change?

`make sast`'s pip-audit leg carried four `--ignore-vuln` flags suppressing CVEs in
semgrep's hard-pinned transitive dependencies. This removes them, raises the semgrep
floor to the release that clears the advisories, and deletes the backlog entry that
recorded the expiry.

## Why?

`[backlog].open`'s `semgrep-mcp-cve-allowlist` recorded the unblock condition exactly:
*"remove the --ignore-vuln flags from the Makefile sast target once semgrep ships
mcp>=1.28.1 and click>=8.3.3."* semgrep 1.174.0 declares `mcp==1.29.0` and
`click~=8.4.2`, against 1.166.0's `mcp==1.23.3` and `click~=8.1.8`. The condition is met.

Governed by ADR-0017 (the SAST/SCA gate). The ADR footer is on the second commit;
the first predates the review that asked for it.

## How do I verify it?

Four `pip-audit` runs — the first is the discriminating one:

| Input | Exit | Result |
|---|---|---|
| `semgrep==1.166.0` | **1** | mcp PYSEC-2026-3481/3482/3483, click PYSEC-2026-2132 |
| `semgrep==1.174.0` | 0 | No known vulnerabilities found |
| `semgrep>=1.166,<2` (the *old* range) | 0 | No known vulnerabilities found |
| the edited requirements file | 0 | No known vulnerabilities found |

Control 1 proves the suppressions were load-bearing rather than decorative, so this
is a real change of state and not a no-op.

- `make ci` — exit 0, banner `complete — every leg of this target was invoked, SAST/SCA included`
- `lint-spec-status.py --root .` — exit 0, `spec metadata clean`

**On the advisory ids.** The removed comment named CVE ids; pip-audit now reports
PYSEC ids. OSV records them as one-to-one aliases (`CVE-2026-52870`↔`PYSEC-2026-3481`,
`-52869`↔`-3482`, `-59950`↔`-3483`), so the suppressions retired are exactly the
advisories measured as cleared. The mapping is recorded in the Makefile.

## What did you not change that you considered?

- **The floor bump is not what makes the gate green, and the PR does not claim it is.**
  `pip-audit -r` resolves the newest version a range allows, so the old range also
  exits 0 (control 3). The floor is load-bearing for `pip install -r`: pip leaves an
  already-satisfying older semgrep in place, so a lower floor lets a contributor keep
  running a toolchain carrying the very advisories the gate reports clean. The machine
  this was developed on was in exactly that state — semgrep 1.166.0 installed,
  declaring `mcp==1.23.3`.
- **Two other restatements of the old floor are deliberately left alone.**
  `docs/specs/semgrep-selftest-batching/plan.md` records the pin in force when it was
  written (frozen history, correct as written); `tools/test_build_gate_chain.py` writes
  its own fixture requirements file rather than asserting anything about the real one.
  Only `workspace.toml`'s live register entry was corrected.
- **`docs/specs/pip-audit-batching/spec.md` is not annotated.** It names a different
  slug (`sast-semgrep-cve-allowlist-pointer-stale`) in a findings list, not a deferral
  anchor. Only `stale-reference-corrections/spec.md`, whose AC4 names this anchor
  directly, gets the `Status`-line pointer that `CONVENTIONS.md` § "The same carrier,
  for a pointer that is not a supersession" requires.
- **No new lint, no `--strict`, no nosemgrep work.** Those are separate open entries
  (`sast-semgrep-unparseable-target-reads-clean`, `sast-nosemgrep-has-no-form-lint`)
  and each needs its own decision.