### PR TITLE
feat(tools): lint that published pack maintainer emails stay non-identifying

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -701,6 +701,8 @@ jobs:
         run: |
           python3 tools/test-lint-pack-descriptions.py
           python3 tools/lint-pack-descriptions.py
+          python3 tools/test-lint-pack-maintainer-emails.py
+          python3 tools/lint-pack-maintainer-emails.py
 
   gate-sast:
     name: gate-sast

--- a/tools/lint-pack-maintainer-emails.py
+++ b/tools/lint-pack-maintainer-emails.py
@@ -96,13 +96,20 @@ def _split_address(email: str) -> tuple[str, str] | None:
 
 
 def _is_allowed_address(email: str) -> bool:
-    """Return whether *email* is on a reviewed host or is a reviewed address."""
-    if email.strip().lower() in ALLOWED_EMAILS:
-        return True
+    """Return whether *email* is on a reviewed host or is a reviewed address.
+
+    Structural parsing runs before EITHER allowlist, deliberately. Consulting
+    ``ALLOWED_EMAILS`` first would let a malformed entry -- one carrying two
+    ``@`` signs or internal whitespace -- clear the very check that exists to
+    refuse malformed addresses, reintroducing the round-1 defect through the
+    escape hatch instead of through the rule.
+    """
     parts = _split_address(email)
     if parts is None:
         return False
-    _local, host = parts
+    local, host = parts
+    if f"{local}@{host}" in ALLOWED_EMAILS:
+        return True
     return host in ALLOWED_HOSTS
 
 

--- a/tools/lint-pack-maintainer-emails.py
+++ b/tools/lint-pack-maintainer-emails.py
@@ -4,13 +4,27 @@
 ``agentbundle`` copies ``[[pack.maintainers]].email`` into published
 marketplace manifests. That makes a personal maintainer address in a source
 ``pack.toml`` a release-path privacy concern, rather than merely repository
-metadata. This lint permits no-reply addresses, plus reviewed exceptions in
-``ALLOWED_EMAILS``.
+metadata. This lint permits addresses on a reviewed host set
+(``ALLOWED_HOSTS``), plus whole-address exceptions in ``ALLOWED_EMAILS``.
 
 It deliberately does not try to decide whether an address is personal. That
 judgment is undecidable from an email string: a role mailbox can look personal,
-and a personal mailbox can look like a role. The explicit allowlist is the
+and a personal mailbox can look like a role. The explicit allowlists are the
 reviewed human decision for the cases a mechanical rule cannot classify.
+
+**Why a host allowlist and not a no-reply pattern.** The first draft accepted
+any address whose host contained a ``.noreply.`` label, or whose local part was
+``noreply``. Review broke it in three ways, and the bypasses were the point of
+the control rather than edge cases:
+``alice.smith@alice-smith.noreply.example.test`` is personally identifying and
+matched the host pattern; ``noreply@alice-smith.example.test`` put the person in
+the host instead; and ``noreply@alice-smith@example.test`` -- not a valid
+address at all -- passed because splitting on the first ``@`` left the local
+part reading ``noreply``. A pattern over an attacker- or author-chosen string
+cannot be made safe by adding more pattern. An allowlist can: the set of hosts
+this repository publishes from is small, known, and changes in a reviewed diff.
+Structural parsing (``_split_address``) runs first, and anything it cannot
+resolve to exactly one ordinary ``local@host`` is refused rather than cleared.
 
 **Why this lives in ``tools/`` and not in the ``agentbundle`` package.** The
 published package validates adopter catalogues; imposing this repository's
@@ -44,20 +58,52 @@ import sys
 import tomllib
 from pathlib import Path
 
-# Each exception must carry a reason in this reviewed diff. Keeping this empty
-# until one is needed prevents a role address from becoming an unexamined rule.
+# Hosts whose addresses cannot identify a person no matter the local part.
+# This is an allowlist, not a pattern, and that is the point -- see the module
+# docstring's § "Why a host allowlist and not a no-reply pattern". Adding a host
+# is a reviewed diff; state the reason beside it.
+ALLOWED_HOSTS: frozenset[str] = frozenset(
+    {
+        # GitHub's per-user no-reply host. The local part is a GitHub account id,
+        # which is already public, and the address does not deliver mail.
+        "users.noreply.github.com",
+    }
+)
+
+# Whole addresses admitted by review, for the cases a host rule cannot classify
+# -- typically a role mailbox on a real delivering domain. Each entry must carry
+# a reason in this reviewed diff. Empty until one is genuinely needed.
 ALLOWED_EMAILS: frozenset[str] = frozenset()
 
 
-def _is_no_reply_address(email: str) -> bool:
-    """Return whether *email* uses one of the repository's no-reply forms."""
-    local, separator, host = email.strip().lower().partition("@")
-    if not separator or not host:
-        return False
-    if local in {"noreply", "no-reply"}:
+def _split_address(email: str) -> tuple[str, str] | None:
+    """Return ``(local, host)`` for a structurally single, ordinary address.
+
+    Returns ``None`` for anything this lint refuses to reason about: an address
+    with no ``@`` or more than one, an empty side, or internal whitespace. Those
+    are not classified as no-reply by default -- an address the lint cannot
+    parse is an address it cannot clear.
+    """
+    candidate = email.strip().lower()
+    if candidate.count("@") != 1:
+        return None
+    local, _, host = candidate.partition("@")
+    if not local or not host:
+        return None
+    if any(character.isspace() for character in candidate):
+        return None
+    return local, host
+
+
+def _is_allowed_address(email: str) -> bool:
+    """Return whether *email* is on a reviewed host or is a reviewed address."""
+    if email.strip().lower() in ALLOWED_EMAILS:
         return True
-    prefix, marker, domain = host.partition(".noreply.")
-    return bool(prefix and marker and domain)
+    parts = _split_address(email)
+    if parts is None:
+        return False
+    _local, host = parts
+    return host in ALLOWED_HOSTS
 
 
 def find_violations(packs_dir: Path) -> list[str]:
@@ -87,16 +133,14 @@ def find_violations(packs_dir: Path) -> list[str]:
             email = maintainer.get("email")
             if not isinstance(email, str):
                 continue
-            normalised = email.strip().lower()
-            if normalised in ALLOWED_EMAILS or _is_no_reply_address(normalised):
+            if _is_allowed_address(email):
                 continue
             violations.append(
                 f"lint-pack-maintainer-emails: {pack_dir.name}: "
-                f"[[pack.maintainers]].email {email!r} is neither a no-reply "
-                "address nor an explicit reviewed allowlist entry. Use a "
-                "noreply/no-reply local part or a *.noreply.<domain> host; for "
-                "a role mailbox, add the exact address to ALLOWED_EMAILS with "
-                "its reason."
+                f"[[pack.maintainers]].email {email!r} is not on a reviewed "
+                "host and is not a reviewed address. Publish from one of "
+                f"{sorted(ALLOWED_HOSTS)}, or add the host to ALLOWED_HOSTS "
+                "(or the exact address to ALLOWED_EMAILS) with its reason."
             )
     return violations
 
@@ -131,8 +175,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     print(
-        "lint-pack-maintainer-emails: all maintainer emails are no-reply or "
-        "reviewed."
+        "lint-pack-maintainer-emails: every maintainer email is on a reviewed "
+        "host or is a reviewed address."
     )
     return 0
 

--- a/tools/lint-pack-maintainer-emails.py
+++ b/tools/lint-pack-maintainer-emails.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Repo-policy lint: keep published pack maintainer addresses non-identifying.
+
+``agentbundle`` copies ``[[pack.maintainers]].email`` into published
+marketplace manifests. That makes a personal maintainer address in a source
+``pack.toml`` a release-path privacy concern, rather than merely repository
+metadata. This lint permits no-reply addresses, plus reviewed exceptions in
+``ALLOWED_EMAILS``.
+
+It deliberately does not try to decide whether an address is personal. That
+judgment is undecidable from an email string: a role mailbox can look personal,
+and a personal mailbox can look like a role. The explicit allowlist is the
+reviewed human decision for the cases a mechanical rule cannot classify.
+
+**Why this lives in ``tools/`` and not in the ``agentbundle`` package.** The
+published package validates adopter catalogues; imposing this repository's
+privacy policy there would turn it into an adopter build break. This lint runs
+only over this repository's own ``packs/`` tree through ``make build-check``.
+
+Pure-stdlib, ``--root`` flagged, exit 0=pass / 1=violation / **2=scanned
+nothing**.
+
+**Why exit 2 exists, and why this diverges from its sibling.**
+``lint-pack-descriptions.py`` returns "clean" when ``packs/`` is absent, so a
+wrong ``--root`` prints a pass line for a run that examined zero files. That is
+survivable for a drift backstop on display copy. It is not survivable for a
+privacy control on a release path: a run that gated nothing would read
+identically to a run that gated everything, which is the failure this
+repository has already been bitten by elsewhere (see ``[backlog].open``
+``curation-guard-silent-base-skip``, a false green reproduced three times in
+one session). So finding no ``pack.toml`` at all is an error here, not a pass.
+``find_violations`` stays a pure function returning ``[]``; the fail-closed
+decision lives in ``main``, where the operator's intent — "lint this root" — is
+what went unmet.
+
+Usage:
+    python3 tools/lint-pack-maintainer-emails.py [--root .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+# Each exception must carry a reason in this reviewed diff. Keeping this empty
+# until one is needed prevents a role address from becoming an unexamined rule.
+ALLOWED_EMAILS: frozenset[str] = frozenset()
+
+
+def _is_no_reply_address(email: str) -> bool:
+    """Return whether *email* uses one of the repository's no-reply forms."""
+    local, separator, host = email.strip().lower().partition("@")
+    if not separator or not host:
+        return False
+    if local in {"noreply", "no-reply"}:
+        return True
+    prefix, marker, domain = host.partition(".noreply.")
+    return bool(prefix and marker and domain)
+
+
+def find_violations(packs_dir: Path) -> list[str]:
+    """Return one message per maintainer email outside the allowed forms.
+
+    Missing maintainer data and malformed manifests are left to schema
+    validation. This is only the address-class control, so duplicating those
+    failures would make its output noisier without adding coverage.
+    """
+    violations: list[str] = []
+    if not packs_dir.is_dir():
+        return violations
+    for pack_dir in sorted(packs_dir.iterdir()):
+        manifest = pack_dir / "pack.toml"
+        if not manifest.is_file():
+            continue
+        try:
+            parsed = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError, UnicodeDecodeError):
+            continue
+        maintainers = parsed.get("pack", {}).get("maintainers")
+        if not isinstance(maintainers, list):
+            continue
+        for maintainer in maintainers:
+            if not isinstance(maintainer, dict):
+                continue
+            email = maintainer.get("email")
+            if not isinstance(email, str):
+                continue
+            normalised = email.strip().lower()
+            if normalised in ALLOWED_EMAILS or _is_no_reply_address(normalised):
+                continue
+            violations.append(
+                f"lint-pack-maintainer-emails: {pack_dir.name}: "
+                f"[[pack.maintainers]].email {email!r} is neither a no-reply "
+                "address nor an explicit reviewed allowlist entry. Use a "
+                "noreply/no-reply local part or a *.noreply.<domain> host; for "
+                "a role mailbox, add the exact address to ALLOWED_EMAILS with "
+                "its reason."
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the policy lint and return its process exit status."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", default=".", help="repository root to lint (default: .)"
+    )
+    args = parser.parse_args(argv)
+
+    packs_dir = Path(args.root) / "packs"
+    # Fail closed before reporting anything: see the module docstring. A pass
+    # line printed over zero scanned manifests is the defect, not the absence.
+    if not packs_dir.is_dir() or not any(packs_dir.glob("*/pack.toml")):
+        print(
+            f"lint-pack-maintainer-emails: no pack.toml found under {packs_dir} "
+            "— scanned nothing, so this is not a pass. Check --root.",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations = find_violations(packs_dir)
+    for violation in violations:
+        print(violation, file=sys.stderr)
+    if violations:
+        print(
+            f"lint-pack-maintainer-emails: {len(violations)} maintainer email(s) "
+            "outside the repository privacy policy.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "lint-pack-maintainer-emails: all maintainer emails are no-reply or "
+        "reviewed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -402,6 +402,16 @@ def build_check(args: argparse.Namespace) -> int:
             "lint-pack-descriptions",
             "tools", "lint-pack-descriptions.py",
         ),
+        # Published marketplace manifests carry these values verbatim, so
+        # protect maintainers from an identifying address reaching that route.
+        _script_step(
+            "test-lint-pack-maintainer-emails",
+            "tools", "test-lint-pack-maintainer-emails.py",
+        ),
+        _script_step(
+            "lint-pack-maintainer-emails",
+            "tools", "lint-pack-maintainer-emails.py",
+        ),
         # The bandit suppression-comment form (ADR-0084). bandit.yaml's header
         # is the canonical statement of the rule and of why this runs here
         # rather than in `make sast`. Correction (ADR-0086 / AC14): it DOES need a

--- a/tools/test-lint-pack-maintainer-emails.py
+++ b/tools/test-lint-pack-maintainer-emails.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Self-test for ``lint-pack-maintainer-emails.py``.
+
+Matches the ``tools/test-lint-*.py`` convention: pure stdlib, no pytest, prints
+a pass line and exits 0, or raises on the first failure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_spec = importlib.util.spec_from_file_location(
+    "lint_pack_maintainer_emails", _HERE / "lint-pack-maintainer-emails.py"
+)
+assert _spec and _spec.loader
+lint = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint)
+
+
+def _pack(packs: Path, name: str, email: str | None) -> None:
+    pack = packs / name
+    pack.mkdir(parents=True)
+    body = f'[pack]\nname = "{name}"\nversion = "0.0.1"\n'
+    if email is not None:
+        body += "\n[[pack.maintainers]]\nname = \"Maintainer\"\n"
+        body += f"email = {json.dumps(email)}\n"
+    (pack / "pack.toml").write_text(body, encoding="utf-8", newline="\n")
+
+
+def test_non_no_reply_address_is_flagged() -> None:
+    """The control must fail on a fixture, never by changing a real pack."""
+    with tempfile.TemporaryDirectory() as tmp:
+        packs = Path(tmp) / "packs"
+        _pack(packs, "leaky", "person@example.test")
+        violations = lint.find_violations(packs)
+    assert len(violations) == 1, violations
+    assert "leaky" in violations[0]
+    assert "person@example.test" in violations[0]
+
+
+def test_no_reply_forms_pass() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        packs = Path(tmp) / "packs"
+        _pack(packs, "local", "noreply@example.test")
+        _pack(packs, "hyphenated", "no-reply@example.test")
+        _pack(packs, "host", "account@users.noreply.example.test")
+        assert lint.find_violations(packs) == []
+
+
+def test_allowlisted_address_passes() -> None:
+    address = "release-team@example.test"
+    original = lint.ALLOWED_EMAILS
+    lint.ALLOWED_EMAILS = frozenset({address})
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = Path(tmp) / "packs"
+            _pack(packs, "role", address)
+            assert lint.find_violations(packs) == []
+    finally:
+        lint.ALLOWED_EMAILS = original
+
+
+def test_absent_email_is_ignored() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        packs = Path(tmp) / "packs"
+        _pack(packs, "unowned", None)
+        assert lint.find_violations(packs) == []
+
+
+def test_malformed_pack_toml_is_not_a_crash() -> None:
+    """Schema validation owns that defect; this lint must not double-report."""
+    with tempfile.TemporaryDirectory() as tmp:
+        packs = Path(tmp) / "packs"
+        pack = packs / "broken"
+        pack.mkdir(parents=True)
+        (pack / "pack.toml").write_text("not toml [[[", encoding="utf-8")
+        assert lint.find_violations(packs) == []
+
+
+def test_directory_without_pack_toml_is_skipped() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        packs = Path(tmp) / "packs"
+        (packs / "not-a-pack").mkdir(parents=True)
+        assert lint.find_violations(packs) == []
+
+
+def test_missing_packs_dir_is_not_a_crash() -> None:
+    """`find_violations` stays pure; the fail-closed decision lives in main."""
+    with tempfile.TemporaryDirectory() as tmp:
+        assert lint.find_violations(Path(tmp) / "nope") == []
+
+
+def test_scanning_nothing_is_an_error_not_a_pass() -> None:
+    """A run that examined zero manifests must not read as clean.
+
+    This is the case that makes the control real. Without it a wrong --root
+    prints a pass line over an empty scan, which is indistinguishable from a
+    genuinely clean catalogue.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        # packs/ absent entirely
+        assert lint.main(["--root", tmp]) == 2
+    with tempfile.TemporaryDirectory() as tmp:
+        # packs/ present but carrying no pack.toml
+        (Path(tmp) / "packs" / "not-a-pack").mkdir(parents=True)
+        assert lint.main(["--root", tmp]) == 2
+
+
+def test_real_packs_are_clean() -> None:
+    """The in-tree catalogue must satisfy its own lint."""
+    packs = _HERE.parent / "packs"
+    if packs.is_dir():
+        assert lint.find_violations(packs) == [], lint.find_violations(packs)
+
+
+def test_exit_codes() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _pack(root / "packs", "leaky", "person@example.test")
+        assert lint.main(["--root", str(root)]) == 1
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _pack(root / "packs", "quiet", "noreply@example.test")
+        assert lint.main(["--root", str(root)]) == 0
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print("test-lint-pack-maintainer-emails: all cases passed.")
+    sys.exit(0)

--- a/tools/test-lint-pack-maintainer-emails.py
+++ b/tools/test-lint-pack-maintainer-emails.py
@@ -43,13 +43,46 @@ def test_non_no_reply_address_is_flagged() -> None:
     assert "person@example.test" in violations[0]
 
 
-def test_no_reply_forms_pass() -> None:
+def test_reviewed_host_passes() -> None:
+    """The one host this repository actually publishes from."""
     with tempfile.TemporaryDirectory() as tmp:
         packs = Path(tmp) / "packs"
-        _pack(packs, "local", "noreply@example.test")
-        _pack(packs, "hyphenated", "no-reply@example.test")
-        _pack(packs, "host", "account@users.noreply.example.test")
+        _pack(packs, "ok", "12345+someone@users.noreply.github.com")
         assert lint.find_violations(packs) == []
+
+
+def test_the_three_review_bypasses_are_rejected() -> None:
+    """Regression cases from the round-1 review of this lint.
+
+    The first draft matched a `.noreply.` pattern rather than a reviewed host
+    set. Each address below defeated it. They are pinned here because a future
+    "simplification" back to a pattern would reopen all three at once.
+    """
+    cases = [
+        # Identifying local part AND identifying host, but the host carried a
+        # `.noreply.` label, so the pattern cleared it.
+        "alice.smith@alice-smith.noreply.example.test",
+        # Person moved into the host; the `noreply` local part cleared it.
+        "noreply@alice-smith.example.test",
+        # Not a valid address at all. Splitting on the FIRST `@` left the local
+        # part reading `noreply`, so it was cleared.
+        "noreply@alice-smith@example.test",
+    ]
+    for address in cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = Path(tmp) / "packs"
+            _pack(packs, "bypass", address)
+            violations = lint.find_violations(packs)
+        assert len(violations) == 1, f"{address!r} was cleared: {violations}"
+
+
+def test_structurally_unparseable_addresses_are_refused_not_cleared() -> None:
+    """An address the lint cannot resolve must fail, never default to allowed."""
+    for address in ("no-at-sign", "@host.test", "local@", "a b@users.noreply.github.com"):
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = Path(tmp) / "packs"
+            _pack(packs, "weird", address)
+            assert len(lint.find_violations(packs)) == 1, address
 
 
 def test_allowlisted_address_passes() -> None:
@@ -125,7 +158,7 @@ def test_exit_codes() -> None:
         assert lint.main(["--root", str(root)]) == 1
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        _pack(root / "packs", "quiet", "noreply@example.test")
+        _pack(root / "packs", "quiet", "12345+someone@users.noreply.github.com")
         assert lint.main(["--root", str(root)]) == 0
 
 

--- a/tools/test-lint-pack-maintainer-emails.py
+++ b/tools/test-lint-pack-maintainer-emails.py
@@ -98,6 +98,25 @@ def test_allowlisted_address_passes() -> None:
         lint.ALLOWED_EMAILS = original
 
 
+def test_a_malformed_allowlist_entry_does_not_bypass_the_parser() -> None:
+    """The escape hatch must not reopen the defect the rule closed.
+
+    Round-2 review finding: `ALLOWED_EMAILS` was consulted before
+    `_split_address`, so a malformed entry would clear the structural check
+    that exists to refuse malformed addresses.
+    """
+    address = "role@a@example.test"
+    original = lint.ALLOWED_EMAILS
+    lint.ALLOWED_EMAILS = frozenset({address})
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            packs = Path(tmp) / "packs"
+            _pack(packs, "malformed-exception", address)
+            assert len(lint.find_violations(packs)) == 1
+    finally:
+        lint.ALLOWED_EMAILS = original
+
+
 def test_absent_email_is_ignored() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         packs = Path(tmp) / "packs"

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -502,6 +502,8 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-check-site-plugin-offers.py",
     "tools/test-lint-pack-descriptions.py",
     "tools/lint-pack-descriptions.py",
+    "tools/test-lint-pack-maintainer-emails.py",
+    "tools/lint-pack-maintainer-emails.py",
     "tools/test-lint-nosec-form.py",
     "tools/lint-nosec-form.py",
     "tools/test-lint-ci-parity.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -694,16 +694,25 @@ open = [
   # Deferred rather than bundled: closing it needs a repository-settings action and a
   # live canary run, neither of which is a code change this PR could carry.
   {slug = "publish-control-evidence-freshness-unbounded", summary = "Publish-control evidence has no freshness bound and the live-branch negative test was never run; a settings-side ruleset removal leaves every gate green", source = "spec/marketplace-generator-single-source (review concern 4)"},
-  # build/main.py:265-275 copies [[pack.maintainers]].email verbatim into the
-  # published marketplace manifest. Every in-repo pack currently uses a
-  # @users.noreply.github.com address by discipline alone; no lint enforces it, so
-  # an adopter or a future pack can leak a real address through a shipped code
-  # path. LINDDUN identifiability; residual is nil today.
-  # Fix: lint that maintainer emails are role or noreply addresses.
-  # Unblocks when: any privacy-surface pass touches the pack manifest.
-  # Deferred rather than bundled: residual is nil today (every address is a noreply
-  # one), and a new lint is its own surface with its own false-positive question.
-  {slug = "marketplace-maintainer-email-unlinted", summary = "Pack maintainer emails reach the published manifest with no address-class lint", source = "spec/marketplace-generator-single-source (review nit 7)"},
+  # Found while writing tools/lint-pack-maintainer-emails.py against it as the
+  # model, 2026-08-25. lint-pack-descriptions.py's find_violations returns []
+  # when `<root>/packs` is not a directory (:69), and main() then prints
+  # "no pack description has run away" and exits 0 -- so `--root` pointed at the
+  # wrong tree reports a pass over zero scanned manifests. Same shape as
+  # curation-guard-silent-base-skip: a run that gated nothing reads identically
+  # to a run that gated everything.
+  # Bounded today: the only invocations are build_gate_chain.py and
+  # build-check.yml, both of which pass a correct root, so no green run in CI or
+  # in `make build-check` is currently false. This is a latent hole, not a live
+  # one, which is why it is recorded rather than fixed in the PR that found it.
+  # The new maintainer-email lint deliberately does NOT share the behaviour: it
+  # exits 2 when it finds no pack.toml. Deciding whether the descriptions lint
+  # should match is a change to a shipped gate's failure mode, so it wants its
+  # own criterion rather than a ride-along.
+  # Fix: give lint-pack-descriptions.py the same fail-closed check, or record
+  # why a drift backstop is allowed to differ from a privacy control.
+  # Unblocks when: picked up -- no dependency.
+  {slug = "lint-pack-descriptions-passes-on-empty-scan", summary = "lint-pack-descriptions.py exits 0 with a pass line when `<root>/packs` is absent, so a wrong --root reports clean over zero scanned manifests", source = "spec-less maintainer-email lint (discovered while modelling on it)"},
   # The parity gate's two layers bound static bindings and the resolved value at
   # import time. Neither bounds a rebind that happens AFTER import -- a function
   # mutating the module global while the build runs. The dynamic-rebinding refusal


### PR DESCRIPTION
## What does this change?

Adds `tools/lint-pack-maintainer-emails.py` and its self-test, wired into the
build-check gate chain. A `[[pack.maintainers]].email` now passes only if it is on a
reviewed host or is a reviewed whole address. Closes `marketplace-maintainer-email-unlinted`.

## Why?

`agentbundle`'s build copies `[[pack.maintainers]].email` verbatim into the published
marketplace manifest (`build/main.py:268`), so a personal address in a source `pack.toml`
is a release-path privacy concern, not repository metadata. All 22 in-repo packs use
`@users.noreply.github.com` by discipline alone; nothing enforced it. LINDDUN
identifiability.

**Why `tools/` and not the engine.** `tools/lint-pack-descriptions.py`'s own § "Why this
lives in `tools/`…" argument applies verbatim: the published package validates *adopter*
catalogues, so this repository's privacy policy there becomes a third party's build
break. Independently, `packages/agentbundle/**` is a protected tree needing an
`Engine-Change-RFC:` trailer, which this neither has nor should need.

## How do I verify it?

The control is proven able to fail, which is the only thing that makes it a control:

| Check | Result |
|---|---|
| `lint --root .` | 0 |
| self-test | 0 |
| fixture with `a.person@example.com` | **1** |
| `lint --root /tmp` (nothing to scan) | **2** |
| `make lint-ruff` | 0 |
| `tools/test_build_gate_chain.py` | 25 passed, 4 subtests |
| `tools/lint-ci-parity.py` | 0, 79 steps dispositioned |
| `make ci` | 0, `complete — every leg … SAST/SCA included` |

**Three mutation proofs**, each restored by edit rather than checkout:

1. `_is_allowed_address` → `return True` → self-test fails.
2. Restore the round-1 `.noreply.` pattern rule → self-test fails on the pinned
   regression cases. This is the one worth keeping: it proves a later
   "simplification" back to a pattern cannot silently reopen the hole.
3. Restore the allowlist-before-parse order → self-test fails on the malformed-entry case.

## What did you not change that you considered?

- **The first draft's rule was broken by review and replaced.** It accepted any
  `.noreply.` host pattern. Three addresses defeated it —
  `alice.smith@alice-smith.noreply.example.test` (identifying on both sides),
  `noreply@alice-smith.example.test` (person in the host), and
  `noreply@alice-smith@example.test` (**not a valid address**; splitting on the first
  `@` left the local part reading `noreply`). A pattern over an author-chosen string
  can't be made safe with more pattern. All three are pinned as regression cases.
- **The lint fails closed on an empty scan (exit 2), diverging from the sibling it is
  modelled on.** `lint-pack-descriptions.py` prints a pass line when `packs/` is absent.
  Survivable for a drift backstop; not for a privacy control, where a run that gated
  nothing reads identically to one that gated everything. `tools/audit-npm.py:458` sets
  the same precedent.
- **That sibling's identical hole is recorded, not fixed.** New backlog entry
  `lint-pack-descriptions-passes-on-empty-scan`. It is latent rather than live — both
  its invocations pass a correct root — and changing a shipped gate's failure mode wants
  its own criterion, not a ride-along from the PR that noticed it.
- **`ALLOWED_EMAILS` ships empty and `ALLOWED_HOSTS` holds exactly one host.** No
  speculative role addresses. Adding either is a reviewed diff with a stated reason.
- **No attempt to detect "is this personal".** Undecidable from the string; the
  allowlists are where that judgment belongs.

ADR: docs/adr/0017-adopt-bandit-pip-audit-semgrep-sast-gate.md