### PR TITLE
test(sast): reject nosemgrep suppressions in the argv-boundary ratchet's targets

### DIFF
--- a/tools/test-semgrep-argv-boundary.py
+++ b/tools/test-semgrep-argv-boundary.py
@@ -32,8 +32,17 @@ the boundary is validated — see the rule's own header, which is emphatic that 
 is a tripwire for the obvious regression, not a proof of correctness.
 
 Run: python3 tools/test-semgrep-argv-boundary.py
-Exit 0 = all pass; exit non-zero = at least one failure. Skips (exit 0) when
-semgrep is not installed, matching `make sast`'s optional-tool posture.
+Exit 0 = all pass; exit non-zero = at least one failure.
+
+**What skips without semgrep, and what does not.** The SCAN skips (exit 0) when
+semgrep is not installed, matching `make sast`'s optional-tool posture. The
+integrity preconditions do NOT: the rule must exist, its `paths.include` must
+parse, every target it names must be on disk, and no target may carry a
+suppression comment. Those are text reads needing no semgrep, and each one is a
+condition under which a later green scan would be meaningless — so they run
+first and can return non-zero on a machine with no semgrep at all. Do not move
+them below the availability guard to restore a uniform skip; that would make a
+control that did not run indistinguishable from one that passed.
 """
 
 from __future__ import annotations
@@ -68,6 +77,14 @@ FIXTURES = REPO_ROOT / "tools" / "semgrep" / "fixtures" / "argv-path-boundary"
 # The rule under test, parsed once. `--config` names a FILE, so a finding's
 # check_id is `<file-stem>.<rule-id>`; RULE_ID is the bare id used to filter.
 RULE_ID = "argv-path-without-boundary-validator"
+# Matches semgrep's suppression pragma in a `#` comment, both spellings.
+# Scoped to `#` deliberately: every path this rule ratchets is Python (see the
+# rule's paths.include), so `//` and `<!-- -->` forms cannot occur in this target
+# set. That is a property of the target set, NOT general coverage — a non-Python
+# target added to paths.include would need this widened. Whether a
+# repository-wide form-lint should span comment syntaxes is the open half of the
+# `sast-nosemgrep-has-no-form-lint` backlog entry, which records the one live
+# `//` instance in the tree.
 NOSEMGREP_COMMENT = re.compile(r"#.*\bnosem(?:grep)?\b")
 
 

--- a/tools/test-semgrep-argv-boundary.py
+++ b/tools/test-semgrep-argv-boundary.py
@@ -39,6 +39,7 @@ semgrep is not installed, matching `make sast`'s optional-tool posture.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -67,6 +68,7 @@ FIXTURES = REPO_ROOT / "tools" / "semgrep" / "fixtures" / "argv-path-boundary"
 # The rule under test, parsed once. `--config` names a FILE, so a finding's
 # check_id is `<file-stem>.<rule-id>`; RULE_ID is the bare id used to filter.
 RULE_ID = "argv-path-without-boundary-validator"
+NOSEMGREP_COMMENT = re.compile(r"#.*\bnosem(?:grep)?\b")
 
 
 def ratcheted_scope() -> tuple[list[Path], list[str]]:
@@ -347,10 +349,27 @@ def test_ratcheted_scripts_silent(
             ok(name)
 
 
+def test_targets_have_no_nosemgrep_comments(targets: list[Path]) -> None:
+    """Reject suppression comments before semgrep's optional-tool guard.
+
+    This is a pure text check over the scan targets already on disk, so it must
+    remain before the ``semgrep`` availability guard in ``main``. Putting it
+    below that guard would silently skip the control on machines without
+    semgrep—the same indistinguishable-from-clean failure this check prevents.
+    """
+    name = "no scan target contains a nosemgrep/nosem comment"
+    suppressions: list[str] = []
+    for target in targets:
+        for line_number, line in enumerate(target.read_text(encoding="utf-8").splitlines(), 1):
+            if NOSEMGREP_COMMENT.search(line):
+                suppressions.append(f"{_key(target)}:{line_number}")
+    if suppressions:
+        fail(name, f"suppression comment found at: {', '.join(suppressions)}")
+    else:
+        ok(name)
+
+
 def main() -> int:
-    if shutil.which("semgrep") is None:
-        print("skip: semgrep not on PATH (install: pip install -r tools/requirements-sast.txt)")
-        return 0
     if not RULE.is_file():
         print(f"FAIL: rule not found at {RULE}", file=sys.stderr)
         return 1
@@ -361,22 +380,30 @@ def main() -> int:
     # points at the rule when the file is simply gone.
     ratcheted, _globs = ratcheted_scope()
 
-    missing = [p for p in (FIXTURES / "positive.py", FIXTURES / "negative.py") if not p.is_file()]
+    targets = [FIXTURES / "positive.py", FIXTURES / "negative.py", *ratcheted]
+    missing = [target for target in targets if not target.is_file()]
     for path in missing:
-        fail(f"{path.name} fixture is present", f"fixture not found at {path} — path drifted?")
+        fail(f"{path.name} scan target is present", f"target not found at {path} — path drifted?")
     if missing:
         print(f"\n{ran - len(failures)}/{ran} passed")
         print("Failed:", ", ".join(failures), file=sys.stderr)
         return 1
 
-    targets = [FIXTURES / "positive.py", FIXTURES / "negative.py", *ratcheted]
-    present = [t for t in targets if t.is_file()]
+    test_targets_have_no_nosemgrep_comments(targets)
+    if failures:
+        print(f"\n{ran - len(failures)}/{ran} passed")
+        print("Failed:", ", ".join(failures), file=sys.stderr)
+        return 1
 
-    unwired = unwired_fixtures(present)
+    if shutil.which("semgrep") is None:
+        print("skip: semgrep not on PATH (install: pip install -r tools/requirements-sast.txt)")
+        return 0
+
+    unwired = unwired_fixtures(targets)
     if unwired:
         fail("every fixture is wired into the scan", f"never scanned: {unwired}")
 
-    findings = scan_all(present)
+    findings = scan_all(targets)
 
     test_positive_fixture_fires(findings)
     test_negative_fixture_silent(findings)

--- a/workspace.toml
+++ b/workspace.toml
@@ -2097,17 +2097,23 @@ open = [
   # trusting its silence. Cheap and offline. Re-probe on a semgrep major bump
   # (pinned semgrep>=1.174,<2 since 2026-08-25; was >=1.166,<2 when this was written).
   {slug = "sast-semgrep-unparseable-target-reads-clean", summary = "A whole-file parse failure is reported as scanned with zero findings and no signal even under --strict, so a ratcheted script that stops parsing reads as clean; partial failures ARE gateable via --strict and are not yet gated", source = "spec/semgrep-selftest-batching security review"},
-  # A single `# nosemgrep` comment on the offending line leaves the file in
-  # paths.scanned with zero findings, zero errors and exit 0 -- indistinguishable
-  # from clean, so both the ratchet self-test and make sast's main scan go green.
-  # ADR-0084 built tools/lint-nosec-form.py plus a stderr gate for bandit's
-  # equivalent pragma; there is no nosemgrep counterpart anywhere in the repo, so
-  # the ratchet's five files can be suppressed by one uncommented, unreasoned,
-  # ungated line.
-  # Fix: assert in tools/test-semgrep-argv-boundary.py that none of its targets
-  # contains a nosemgrep/nosem comment, and/or extend the ADR-0084 form-lint to
-  # nosemgrep with a mandatory rule id and reason.
-  {slug = "sast-nosemgrep-has-no-form-lint", summary = "A bare # nosemgrep silently neuters the semgrep ratchet with no signal, and unlike bandit's # nosec it has no form-lint requiring a rule id and reason", source = "spec/semgrep-selftest-batching security review"},
+  # NARROWED 2026-08-25: tools/test-semgrep-argv-boundary.py now rejects
+  # nosemgrep/nosem comments in every target it scans, before its optional
+  # semgrep-availability skip. That closes the ratchet-specific suppression gap.
+  # Remaining: ADR-0084 has no nosemgrep counterpart, so no repository-wide
+  # form-lint requires a suppression rule id and reason.
+  # The one live instance, measured 2026-08-25, is the whole current population
+  # and is what a form-lint would have to accept or reject:
+  # packs/converters/.apm/skills/render-proof/scripts/render-proof.js:327 carries
+  # `// nosemgrep: typescript.react.security.audit.react-dangerouslysetinnerhtml
+  # .react-dangerouslysetinnerhtml`. It names a rule id but gives no reason, so
+  # it would pass an id-only rule and fail an id-and-reason one -- which is
+  # precisely the decision this entry is now reduced to. Note it is a `//`
+  # comment in JS, not `#`, so a form-lint modelled on lint-nosec-form.py's
+  # Python-comment assumption would not see it at all.
+  # Fix: decide whether to extend the ADR-0084 form-lint to nosemgrep with a
+  # mandatory rule id and reason, and in which comment syntaxes.
+  {slug = "sast-nosemgrep-has-no-form-lint", summary = "No repository-wide nosemgrep form-lint requires a suppression rule id and reason", source = "spec/semgrep-selftest-batching security review"},
   # lint-nosec-form.py's unknown-id check degrades silently when bandit's
   # registry is unreachable: id_checker() catches Exception and returns None,
   # and main() then appends " (bandit absent: IDs not resolved)" to an EXIT-0


### PR DESCRIPTION
## What does this change?

`tools/test-semgrep-argv-boundary.py` now fails if any target it scans carries a
`nosemgrep` / `nosem` suppression comment. The check runs **before** the script's
optional-semgrep skip.

## Why?

A single `# nosemgrep` on an offending line leaves a file in semgrep's `paths.scanned`
with zero findings, zero errors and exit 0 — indistinguishable from clean — so the
ratchet self-test and `make sast` both go green over a neutered scan. ADR-0084 built
`tools/lint-nosec-form.py` for bandit's `# nosec`; there is no nosemgrep counterpart.
Recorded as `sast-nosemgrep-has-no-form-lint`.

**Placement is the load-bearing part.** `main()` opened with

```python
if shutil.which("semgrep") is None: print("skip: ..."); return 0
```

so anything below it is silently skipped wherever semgrep is absent. A suppression
check that quietly does not run reads identically to one that passed — the exact
disease it exists to catch. It needs no semgrep, so it runs first, with a comment
saying why it must stay there.

## How do I verify it?

| Scenario | Result |
|---|---|
| semgrep present | 8/8 passed, exit 0 |
| semgrep genuinely absent | `ok [no scan target contains a nosemgrep/nosem comment]`, then `skip: semgrep not on PATH`, exit 0 |
| **mutation** (`# nosemgrep` appended to the positive fixture), semgrep present | **FAIL** `positive.py:25`, exit 1 |
| **mutation**, semgrep absent | **FAIL** `positive.py:25`, exit 1 |

The absent-semgrep mutation arm is the decisive one: it proves the control cannot be
hidden behind the optional-tool skip. Fixture restored from a byte-exact copy, not
`git checkout`; `git diff` on it is empty.

`make ci` exit 0 with the complete banner; `lint-ruff` exit 0.

> Testing the no-semgrep path needs the **real** interpreter, not the pyenv shim — the
> shim re-adds pyenv to `PATH`, so `shutil.which("semgrep")` still resolves and the
> scenario silently does not happen.

## What did you not change that you considered?

- **Only half the recorded fix ships, so the backlog entry is narrowed, not deleted.**
  The other half — whether ADR-0084's form-lint should grow a nosemgrep arm requiring a
  rule id and reason — is a shipped-lint contract decision. The narrowed entry now
  carries the tree's single live instance (`render-proof.js:327`: a `//` comment naming
  a rule id with no reason), so the remaining decision has its actual population
  attached instead of being re-measured later.
- **The regex matches `#` comments only.** Every path this rule ratchets is Python, so
  `//` and `<!-- -->` cannot occur in this target set. That is a property of the target
  set, not general coverage, and the code now says so rather than letting a reader
  overread it.
- **The missing-target guard widened from the two fixtures to all targets.** Previously
  a vanished ratcheted script silently shrank the scanned set; now it fails. This does
  make the absent-semgrep path fail-closed for drift where it previously returned 0 —
  deliberate, and the docstring's skip contract was corrected to match.
- **No repository-wide suppression policy.** `make sast`'s main scan is far broader than
  this ratchet, and this PR does not claim to cover it.