### PR TITLE
fix(tools): lint-pack-descriptions must not pass over an empty scan

### DIFF
--- a/tools/lint-pack-descriptions.py
+++ b/tools/lint-pack-descriptions.py
@@ -33,8 +33,23 @@ lints run only on this repository's own `make build-check`, which is the correct
 blast radius for a style rule. Pack discoverability is unaffected either way:
 that is carried by the separate `[pack].keywords` and `[pack].categories`.
 
-Pure-stdlib, `--root` flagged, exit 0=pass / 1=violation — matching the other
-`tools/` lints.
+Pure-stdlib, `--root` flagged, exit 0=pass / 1=violation / 2=scanned nothing.
+
+**Why exit 2 exists.** This lint used to print its pass line whenever
+`<root>/packs` was absent, so a `--root` aimed at the wrong tree reported
+"no pack description has run away" over zero examined manifests — a run that
+checked nothing reading identically to a run that checked everything. Both real
+invocations (`tools/repo/build_gate_chain.py`, `build-check.yml`) pass a correct
+root, so no green run was ever false; it was a latent hole, and it is now
+closed rather than left for the first person to pass a wrong `--root`.
+
+The repository had already settled this question twice before this lint caught
+up: `tools/lint-adapter-layer-boundary.py` refuses with "this must not pass
+vacuously", and `tools/audit-npm.py` treats zero discovered inputs as an error.
+Note the two disagree on the code — the former returns 1, the latter 2. This
+lint follows `tools/lint-pack-maintainer-emails.py`, its direct sibling and the
+lint that was modelled on this file, in using 2, so that "scanned nothing" stays
+distinguishable from "found violations".
 
 Usage:
     python3 tools/lint-pack-descriptions.py [--root .]
@@ -100,7 +115,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    violations = find_violations(Path(args.root) / "packs")
+    packs_dir = Path(args.root) / "packs"
+    # Fail closed before reporting anything: see the module docstring. A pass
+    # line printed over zero scanned manifests is the defect, not the absence.
+    # `find_violations` stays a pure function returning []; the decision lives
+    # here, where the operator's unmet intent -- "lint this root" -- is visible.
+    if not packs_dir.is_dir() or not any(packs_dir.glob("*/pack.toml")):
+        print(
+            f"lint-pack-descriptions: no pack.toml found under {packs_dir} "
+            "— scanned nothing, so this is not a pass. Check --root.",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations = find_violations(packs_dir)
     for violation in violations:
         print(violation, file=sys.stderr)
     if violations:

--- a/tools/lint-pack-maintainer-emails.py
+++ b/tools/lint-pack-maintainer-emails.py
@@ -34,18 +34,19 @@ only over this repository's own ``packs/`` tree through ``make build-check``.
 Pure-stdlib, ``--root`` flagged, exit 0=pass / 1=violation / **2=scanned
 nothing**.
 
-**Why exit 2 exists, and why this diverges from its sibling.**
-``lint-pack-descriptions.py`` returns "clean" when ``packs/`` is absent, so a
-wrong ``--root`` prints a pass line for a run that examined zero files. That is
-survivable for a drift backstop on display copy. It is not survivable for a
-privacy control on a release path: a run that gated nothing would read
-identically to a run that gated everything, which is the failure this
-repository has already been bitten by elsewhere (see ``[backlog].open``
-``curation-guard-silent-base-skip``, a false green reproduced three times in
-one session). So finding no ``pack.toml`` at all is an error here, not a pass.
-``find_violations`` stays a pure function returning ``[]``; the fail-closed
-decision lives in ``main``, where the operator's intent — "lint this root" — is
-what went unmet.
+**Why exit 2 exists.** A run that gated nothing must not read identically to a
+run that gated everything — the failure this repository has been bitten by
+elsewhere (see ``[backlog].open`` ``curation-guard-silent-base-skip``, a false
+green reproduced three times in one session). So finding no ``pack.toml`` at
+all is an error here, not a pass. ``find_violations`` stays a pure function
+returning ``[]``; the fail-closed decision lives in ``main``, where the
+operator's intent — "lint this root" — is what went unmet.
+
+This originally read as a deliberate divergence from
+``lint-pack-descriptions.py``, which then printed a pass line over an empty
+scan. That is no longer true: the same guard was added there on 2026-08-25, so
+the two agree and the sentence is kept only to stop the divergence being
+reintroduced as a "consistency" fix in the wrong direction.
 
 Usage:
     python3 tools/lint-pack-maintainer-emails.py [--root .]

--- a/tools/test-lint-pack-descriptions.py
+++ b/tools/test-lint-pack-descriptions.py
@@ -76,8 +76,25 @@ def test_directory_without_pack_toml_is_skipped() -> None:
 
 
 def test_missing_packs_dir_is_not_a_crash() -> None:
+    """`find_violations` stays pure; the fail-closed decision lives in main."""
     with tempfile.TemporaryDirectory() as tmp:
         assert lint.find_violations(Path(tmp) / "nope") == []
+
+
+def test_scanning_nothing_is_an_error_not_a_pass() -> None:
+    """A run that examined zero manifests must not print the pass line.
+
+    Without this the lint reported "no pack description has run away" for a
+    `--root` aimed at the wrong tree, so a run that checked nothing read
+    identically to one that checked everything.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        # packs/ absent entirely
+        assert lint.main(["--root", tmp]) == 2
+    with tempfile.TemporaryDirectory() as tmp:
+        # packs/ present but carrying no pack.toml
+        (Path(tmp) / "packs" / "not-a-pack").mkdir(parents=True)
+        assert lint.main(["--root", tmp]) == 2
 
 
 def test_backstop_is_not_the_target_vocab_cap() -> None:

--- a/workspace.toml
+++ b/workspace.toml
@@ -694,25 +694,6 @@ open = [
   # Deferred rather than bundled: closing it needs a repository-settings action and a
   # live canary run, neither of which is a code change this PR could carry.
   {slug = "publish-control-evidence-freshness-unbounded", summary = "Publish-control evidence has no freshness bound and the live-branch negative test was never run; a settings-side ruleset removal leaves every gate green", source = "spec/marketplace-generator-single-source (review concern 4)"},
-  # Found while writing tools/lint-pack-maintainer-emails.py against it as the
-  # model, 2026-08-25. lint-pack-descriptions.py's find_violations returns []
-  # when `<root>/packs` is not a directory (:69), and main() then prints
-  # "no pack description has run away" and exits 0 -- so `--root` pointed at the
-  # wrong tree reports a pass over zero scanned manifests. Same shape as
-  # curation-guard-silent-base-skip: a run that gated nothing reads identically
-  # to a run that gated everything.
-  # Bounded today: the only invocations are build_gate_chain.py and
-  # build-check.yml, both of which pass a correct root, so no green run in CI or
-  # in `make build-check` is currently false. This is a latent hole, not a live
-  # one, which is why it is recorded rather than fixed in the PR that found it.
-  # The new maintainer-email lint deliberately does NOT share the behaviour: it
-  # exits 2 when it finds no pack.toml. Deciding whether the descriptions lint
-  # should match is a change to a shipped gate's failure mode, so it wants its
-  # own criterion rather than a ride-along.
-  # Fix: give lint-pack-descriptions.py the same fail-closed check, or record
-  # why a drift backstop is allowed to differ from a privacy control.
-  # Unblocks when: picked up -- no dependency.
-  {slug = "lint-pack-descriptions-passes-on-empty-scan", summary = "lint-pack-descriptions.py exits 0 with a pass line when `<root>/packs` is absent, so a wrong --root reports clean over zero scanned manifests", source = "spec-less maintainer-email lint (discovered while modelling on it)"},
   # The parity gate's two layers bound static bindings and the resolved value at
   # import time. Neither bounds a rebind that happens AFTER import -- a function
   # mutating the module global while the build runs. The dynamic-rebinding refusal


### PR DESCRIPTION
## What does this change?

`tools/lint-pack-descriptions.py` now exits 2 when it finds no `pack.toml` under
`<root>/packs`, instead of printing "no pack description has run away" and exiting 0.
Closes `lint-pack-descriptions-passes-on-empty-scan`.

## Why?

A `--root` aimed at the wrong tree reported clean over zero examined manifests — a run
that checked nothing reading identically to one that checked everything.

The backlog entry left a decision open ("give it the same fail-closed check, **or**
record why a drift backstop is allowed to differ") and said it "wants its own criterion
rather than a ride-along". Three measurements retire that hedge:

1. **It is inert where it matters.** Both invocations pass a correct root, and
   `build_gate_chain.py:601` explicitly changes to the resolved repository root before
   invoking scripts. No CI or `make build-check` result moves. Only a human with a wrong
   `--root` sees a difference, and there exit 2 beats a false pass.
2. **The repository had already decided, twice.** `lint-adapter-layer-boundary.py:341`
   refuses with *"this must not pass vacuously"*; `audit-npm.py` errors on zero
   discovered inputs. The open branch was an unnoticed answer, not a live question.
3. **The class is one file.** All four `tools/` lints with a
   `if not <dir>.is_dir(): return []` shape, run against an empty root:

   | Lint | Empty root |
   |---|---|
   | `lint-pack-descriptions.py` | **exit 0** — the only false clean |
   | `lint-plugin-route-docs.py` | exit 1 |
   | `lint-adapter-layer-boundary.py` | exit 1 |
   | `lint-generated-path-ownership.py` | exit 1 |

   The other three early-return from per-item helpers where absent legitimately means
   empty, not from a scan-root guard. This is not the first of a sweep.

## How do I verify it?

| Check | Result |
|---|---|
| `lint --root .` | 0 |
| `lint --root <empty dir>` | **2** (was 0 with a pass line) |
| both self-tests | 0 |
| both lints on an empty root | 2 each — they now agree |
| `make lint-ruff` | 0 |
| `make ci` | 0, `complete — every leg … SAST/SCA included` |

**Mutation:** delete the guard → the new self-test case fails, *and* the original defect
reproduces verbatim (exit 0, "no pack description has run away", over an empty scan).
Mutant removed by edit, not `git checkout`.

## What did you not change that you considered?

- **Exit 2, not 1.** `lint-adapter-layer-boundary.py` uses 1 for the same condition,
  while `audit-npm.py` and this lint's direct sibling use 2. I took 2 so "scanned
  nothing" stays distinguishable from "found violations". That inconsistency is
  pre-existing; it is now named in the docstring rather than papered over, and no
  consumer distinguishes the codes today.
- **No spec amendment.** `pack-description-quality/spec.md` is frozen and pins that
  "both exit codes are exercised" and that the backstop "exits clean across `packs/`" —
  both still true; a third condition is additive. No `(deferred:)` marker or frozen
  prose anchors the deleted slug, so no `Status`-line annotation is owed.
- **The other three lints are untouched.** They already fail on an empty root.
- **The sibling's docstring was restated, not deleted.** It cited this lint's old
  behaviour as a deliberate divergence, which became false. Keeping the paragraph stops
  the divergence being reintroduced later as a "consistency" fix in the wrong direction.