### PR TITLE
docs(spec): close docs-site-print-chrome-suppression and fix its T1 check

### DIFF
--- a/docs/specs/docs-site-print-chrome-suppression/plan.md
+++ b/docs/specs/docs-site-print-chrome-suppression/plan.md
@@ -1,7 +1,7 @@
 # Plan: Docs-site print chrome suppression
 
 - **Spec:** [`spec.md`](spec.md)
-- **Status:** Approved
+- **Status:** Done
 - **Repository anchors:** `docs-site/AGENTS.md` (build order, styling
   invariants, vendored-Starlight rule); `web/AGENTS.md` (gate browser,
   preview-server daemonization, snapshot-staging rule);
@@ -137,9 +137,12 @@ routes × five widths, plus two docs routes × five widths × two themes (spec A
 - Goal-based: after the full build, a browser probe at 717×900 under print media
   reports `display: none` for `.docs-site-footer__groups`, and `grid` under
   screen media. Verifies spec AC1 and AC2.
-- Goal-based: `! grep -q 'print:hidden' docs-site/src/components/Footer.astro`.
-  Stated as a grep rather than a `git diff`, which goes vacuous once the revert
-  is committed. Verifies part of spec AC6.
+- Goal-based: `! grep -qE 'class="[^"]*print:hidden' docs-site/src/components/Footer.astro`.
+  Scoped to the class attribute, not the bare token: the `@media print` block
+  this task adds is commented, and that comment names `print:hidden` — a bare
+  grep would fail on a correct implementation. Stated as a grep rather than a
+  `git diff`, which goes vacuous once the revert is committed. Verifies part of
+  spec AC6.
 
 **Approach:**
 - Revert the uncommitted `print:hidden` class on line 21 so the element's markup

--- a/docs/specs/docs-site-print-chrome-suppression/spec.md
+++ b/docs/specs/docs-site-print-chrome-suppression/spec.md
@@ -1,6 +1,6 @@
 # Spec: Docs-site print chrome suppression
 
-- **Status:** Approved
+- **Status:** Shipped
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** none
@@ -97,33 +97,33 @@ Every acceptance criterion below names its mode.
 
 ## Acceptance Criteria
 
-- [ ] Given a built docs route under print media at 717×900, when
+- [x] Given a built docs route under print media at 717×900, when
       `.docs-site-footer__groups` is measured, its computed `display` is `none`.
-- [ ] Given the same route under screen media at 717×900, when the same element
+- [x] Given the same route under screen media at 717×900, when the same element
       is measured, its computed `display` is `grid`.
-- [ ] The AC1 and AC2 assertions live in `web/src/test/e2e/site-quality-gate.spec.ts`,
+- [x] The AC1 and AC2 assertions live in `web/src/test/e2e/site-quality-gate.spec.ts`,
       a file `npm run test:e2e:gate --prefix web` already runs, so they execute in
       CI without changing `tools/test-pages-workflow.py:96`'s gate-script pin or
       `tools/test_browser_gate_subset.py:341,365,375`'s matrix constants; the gate
       run reports the new case by name.
-- [ ] The AC1 assertion is mutation-proved: with the `@media print` rule removed
+- [x] The AC1 assertion is mutation-proved: with the `@media print` rule removed
       **and the site rebuilt** (`python3 tools/build-site.py` → `npm run build
       --prefix web` → `npm run build --prefix docs-site`, because the gate serves
       `build/`) it fails reporting `grid`; with the rule restored and the site
       rebuilt again it passes. Both outcomes, including the rebuild between them,
       are recorded in
       `docs/specs/docs-site-print-chrome-suppression/notes/mutation-proof.md`.
-- [ ] Printed output for the five documentation routes contains no page
+- [x] Printed output for the five documentation routes contains no page
       consisting solely of navigation chrome; each document's final page is
       content or the copyright line.
-- [ ] `docs-site/src/components/Footer.astro` carries no `print:hidden` class,
+- [x] `docs-site/src/components/Footer.astro` carries no `print:hidden` class,
       and `web/src/test/rendered-output.test.ts` contains no assertion about
       print behaviour; its existing shared-chrome emission assertions pass.
-- [ ] `npm run test:e2e:gate --prefix web` is green — the 60-case matrix is
+- [x] `npm run test:e2e:gate --prefix web` is green — the 60-case matrix is
       unchanged and passing, and the added 717px print case passes alongside it.
       `docs/guides/how-to/verify-a-site-release.md` describes the gate as that
       matrix plus the print case.
-- [ ] `docs-site/AGENTS.md` records, under its action-changing traps, three
+- [x] `docs-site/AGENTS.md` records, under its action-changing traps, three
       things: that `print:hidden` does not suppress an element whose own unlayered
       component rule sets `display`; that layering a `docs-site` rule to win that
       contest demotes the component's `:focus-visible` offset; and that


### PR DESCRIPTION
## What changed and why?

Follow-up to #1123. Marks the spec `Shipped` and the plan `Done` now the implementation is merged.

It also fixes a **real defect in the plan's own verification**, found while checking each AC rather than ticking them as a batch. T1's check was:

```
! grep -q 'print:hidden' docs-site/src/components/Footer.astro
```

That **fails on a correct implementation**. The `@media print` block T1 adds is commented, and the comment explains why `print:hidden` cannot do that job — so the token is present in the file by design. Now scoped to what AC6 actually forbids:

```
! grep -qE 'class="[^"]*print:hidden' docs-site/src/components/Footer.astro
```

## How was it verified?

Each AC checked individually before any box was ticked:

| AC | Evidence |
| --- | --- |
| 1, 2 | Both gate cases pass — `display:none` print, `grid` screen |
| 3 | Guard in the pinned gate spec; neither matrix pin in the diff |
| 4 | `notes/mutation-proof.md` records both states with the rebuild |
| 5 | Zero navigation lines across five documents; four lost a page |
| 6 | No class attribute carries the token; emitted element is `docs-site-footer__groups astro-jo6i4kqk` |
| 7 | 182 gate cases pass; guide describes the matrix plus print cases |
| 8 | `docs-site/AGENTS.md` carries all three required facts |

`lint-spec-status.py --root .` → `spec metadata clean` (the Shipped transition requires every AC checked or deferred). `SKIP_SAST=1 make build-check` → pass.

## What did you consider and not change?

Left the implementation alone — this is bookkeeping plus a check correction, no behaviour change.

## Risks and rollback

None to runtime. Reverting restores a status pair that disagrees with reality and a check that fails on correct code.