### PR TITLE
ci: wire test-ci-security-workflow.py into the build-check gate chain

### DIFF
--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -455,6 +455,12 @@ def build_check(args: argparse.Namespace) -> int:
             "test-build-check-workflow",
             "tools", "test-build-check-workflow.py",
         ),
+        # ci-security.yml's security-posture assertion lives in the unfiltered
+        # chain because no other local gate reads that workflow.
+        _script_step(
+            "test-ci-security-workflow",
+            "tools", "test-ci-security-workflow.py",
+        ),
         # AC10: no CI path executes `build-check`'s `$(MAKE) sast` branch after
         # ADR-0086, so nothing else would notice it being deleted or made
         # unreachable. Skips cleanly where `make` is absent.

--- a/tools/test-build-check-workflow.py
+++ b/tools/test-build-check-workflow.py
@@ -4,11 +4,12 @@
 # STUB: AC13 — red stub materialised at PLAN per CONVENTIONS § Stub → EXECUTE
 handoff.
 
-Pure stdlib, matching `tools/test-build-check-windows-workflow.py`, the repo's only
-*wired* posture test. (`tools/test-ci-security-workflow.py` imports PyYAML and is
-invoked nowhere.) Staying stdlib is load-bearing: this runs inside the aggregator
-job that wears the sole required status check, and a test that can fail on a missing
-import is a test someone import-guards under pressure.
+Pure stdlib, matching `tools/test-build-check-windows-workflow.py`.
+(`tools/test-ci-security-workflow.py` is wired too, but imports PyYAML — tolerable
+there because it runs only as a `tools/repo/build_gate_chain.py` chain step, not
+inside the aggregator job.) Staying stdlib is load-bearing *here*: this runs inside
+the aggregator job that wears the sole required status check, and a test that can
+fail on a missing import is a test someone import-guards under pressure.
 
 ## Controls are matched as shell COMMAND WORDS, never as substrings
 

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -20,6 +20,15 @@ import sys
 
 import yaml
 
+# Windows cp1252 guard — this script prints non-ASCII verdict marks, and
+# `build_gate_chain.py`'s own guard covers only the parent process: `_script_step`
+# spawns children with the inherited environment and nothing forcing PYTHONUTF8.
+# A redirected or piped stdout on Windows falls back to the legacy ANSI code page,
+# where even the SUCCESS print raises UnicodeEncodeError and a passing check
+# returns non-zero. Same shape as `tools/test-test-all.py`.
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-security.yml"
 

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -859,6 +859,7 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-lint-ci-parity.py",
     "tools/test-build-check-windows-workflow.py",
     "tools/test-build-check-workflow.py",
+    "tools/test-ci-security-workflow.py",
     "tools/assert-sast-chain-reachable.py",
     "tools/lint-ci-parity.py",
     "tools/test-test-all.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -455,23 +455,29 @@ open = [
   # test, making the bypass need a second human. This repo has no CODEOWNERS today.
   # To close: decide between the two (or both) and apply.
   {slug = "ci-gate-parallelization-required-workflow-pinned-ref", source = "spec/ci-gate-parallelization AC3"},
-  # tools/test-ci-security-workflow.py asserts ci-security.yml's security posture
-  # (permissions, pull_request_target absence) — and is invoked by NOTHING. Found
-  # while looking for a precedent to model a new posture test on: only
-  # test-build-check-windows-workflow.py is genuinely wired (via
-  # tools/repo/build_gate_chain.py, and pinned in test_build_gate_chain.py's
-  # EXPECTED_SCRIPT_STEPS). A shipped AC in spec/secret-scanner-for-api-key-workflows
-  # claims that file gates ci-security.yml, so the claim is live and false. This is
-  # the repo's own "wire it explicitly or it never gates" failure, in a file whose
-  # whole job is to prevent it. To close: wire it into the gate chain (and update
-  # EXPECTED_SCRIPT_STEPS + its pinned count), or delete it and correct the AC.
-  # Second, smaller item, recorded so the next author does not copy the shape:
+  # Two defects shared this entry. The FIRST IS CLOSED (2026-08-26):
+  # tools/test-ci-security-workflow.py asserted ci-security.yml's security posture
+  # and was invoked by nothing, which also left a shipped AC in
+  # spec/secret-scanner-for-api-key-workflows live and false. It is now a step in
+  # tools/repo/build_gate_chain.py's build-check chain, pinned in
+  # test_build_gate_chain.py's EXPECTED_SCRIPT_STEPS — that list is the sole source
+  # of the step count, so there is no separate literal to keep in step.
+  # Recorded on the way past, because wiring it did not make its assertions
+  # trustworthy: unlike its chain neighbour test-build-check-workflow.py, which runs
+  # a mutation matrix on every invocation, that file has no --self-test and no
+  # fixture. Its eight assertions now BLOCK make build-check with no automated proof
+  # they can fail, so a silently-weakened one would pass. Building that harness was
+  # outside the wiring chore and needs an owner decision.
+  # The SECOND IS STILL OPEN. This is why the slug survives — docs/adr/0086 and
+  # spec/ci-gate-parallelization both cite it, and both are frozen:
   # ci-security.yml documents "cancel-in-progress gated to pull_request only —
   # push-to-main scans run to completion", and codeql.yml uses unconditional
   # cancel-in-progress on a push trigger. Both rest on a false belief — GitHub
   # allows one running plus one PENDING run per concurrency group regardless of
   # that flag, so a third queued run cancels the pending one. See AC12 of
   # spec/ci-gate-parallelization for the group expression that avoids it.
+  # To close: fix both workflows' concurrency-group expressions, and decide whether
+  # the posture test earns a mutation harness.
   {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions


### PR DESCRIPTION
## What does this change?

Adds `tools/test-ci-security-workflow.py` to the `make build-check` gate chain
in `tools/repo/build_gate_chain.py`, and to `EXPECTED_SCRIPT_STEPS` in
`tools/test_build_gate_chain.py` at the matching position. Seven added lines,
no behaviour change to any existing step.

## Why?

The file is a posture test for `.github/workflows/ci-security.yml`. It asserts
the security-load-bearing invariants of that workflow: `pull_request` + `push`
triggers with no `pull_request_target`, top-level `contents: read` with no
job-level escalation, `fetch-depth: 0` for the gitleaks history range, the
env-var (non-interpolating) shell pattern, `--redact` on the gitleaks step, and
`sha256sum` before every binary extraction.

Nothing executed it. Every one of those assertions was inert, and a shipped AC
in `spec/secret-scanner-for-api-key-workflows` claiming this file gates
`ci-security.yml` was live and false. This is the repo's own "wire it
explicitly or it never gates" failure, in a file whose whole job is to prevent
that.

- Closes backlog: `ci-security-posture-test-unwired` (`workspace.toml`
  `[backlog].open`, source `spec/ci-gate-parallelization` AC13)

No changelog entry: repository tooling under `tools/**` ships in no release
(`docs/CONVENTIONS.md` § 5b).

## How do I verify it?

```
python3 tools/test-ci-security-workflow.py       # EXIT=0
python3 -m pytest tools/test_build_gate_chain.py -q   # 28 passed, 16 subtests
python3 tools/test-lint-ci-parity.py             # EXIT=0
python3 tools/lint-ci-parity.py                  # EXIT=0
python3 tools/test-test-all.py                   # EXIT=0
```

Mutation proof that the new step is load-bearing rather than decorative: flip
`ci-security.yml`'s top-level `permissions.contents` from `read` to `write` and
the step exits 1 with

```
✖ ci-security.yml: top-level permissions must be {contents: read}, got {'contents': 'write'}
```

Restoring the file returns it to exit 0, with an empty `git diff --stat` on the
workflow.

## What did you not change that you considered?

- **The `cancel-in-progress` concurrency question** recorded in the same
  `workspace.toml` backlog comment — that `ci-security.yml` and `codeql.yml`
  both rest on a false belief about GitHub allowing one running plus one
  *pending* run per concurrency group. That is a separate defect in the
  workflows themselves, not in the wiring, and it stays in the backlog.
- **The assertions inside `test-ci-security-workflow.py`.** Wiring an existing
  test in and rewriting what it checks are different changes; bundling them
  would make the first unreviewable.
- **Adding it to `tools/test-all.py`'s `TESTS`.** That manifest is curated
  rather than exhaustive, and the test is now directly gated here.

---

## Checklist

- [x] Tests pass locally (see commands above)
- [x] Lint and typecheck pass (`tools/lint-ruff.py`, chain-internal)
- [x] Self-review run via `adversarial-reviewer`; blockers addressed
- [x] Spec and code agree — makes a shipped AC in
      `spec/secret-scanner-for-api-key-workflows` true rather than false
- [x] Living docs match reality — no changelog entry owed (`tools/**` ships in
      no release)
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured