### PR TITLE
build(deps): machine-check the npm allowScripts install-script invariant

### DIFF
--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -25,7 +25,7 @@ npm run build --prefix docs-site
 - The repository, not Starlight, checks rendered internal links after both builds.
 - Styling changes must preserve no horizontal scroll at 375 px, usable focus in
   both themes, and reduced-motion behavior.
-- Run `tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
+- Run `python3 tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
   `allowScripts` entry or repin the dependency so it dedupes to a reviewed version.
 - `astro.config.ts` imports `@astrojs/markdown-remark` directly — it builds the
   site's Markdown processor with `unified({...})` and passes it as

--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -25,7 +25,8 @@ npm run build --prefix docs-site
 - The repository, not Starlight, checks rendered internal links after both builds.
 - Styling changes must preserve no horizontal scroll at 375 px, usable focus in
   both themes, and reduced-motion behavior.
-- Check `allowScripts` against install-script entries by eye when the lockfile moves.
+- Run `tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
+  `allowScripts` entry or repin the dependency so it dedupes to a reviewed version.
 - `astro.config.ts` imports `@astrojs/markdown-remark` directly — it builds the
   site's Markdown processor with `unified({...})` and passes it as
   `markdown.processor`. Astro and Starlight both carry the package as an

--- a/docs/specs/agents-md-lost-obligations/spec.md
+++ b/docs/specs/agents-md-lost-obligations/spec.md
@@ -1,6 +1,6 @@
 # Spec: AGENTS.md lost obligations
 
-- **Status:** Shipped (AC13's register anchor `npm-allowscripts-enforcement` was closed by [`npm-allowscripts-enforcement`](../npm-sca-gate/spec.md), which replaced the manual `allowScripts` review duty in both `AGENTS.md` files with the machine check that AC13 recorded as deferred; AC13's compensating-control rationale is therefore historical. Not a supersession — every decision here stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (AC13's register anchor `npm-allowscripts-enforcement` is now resolved in `workspace.toml [backlog].closed`; `tools/lint-npm-allow-scripts.py` replaced the manual `allowScripts` review duty in both `AGENTS.md` files, so AC13's compensating-control rationale is historical. Not a supersession — every decision here stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [ADR-0088](../../adr/0088-risk-triggers-have-a-single-documented-home.md)

--- a/docs/specs/agents-md-lost-obligations/spec.md
+++ b/docs/specs/agents-md-lost-obligations/spec.md
@@ -1,6 +1,6 @@
 # Spec: AGENTS.md lost obligations
 
-- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (AC13's register anchor `npm-allowscripts-enforcement` was closed by [`npm-allowscripts-enforcement`](../npm-sca-gate/spec.md), which replaced the manual `allowScripts` review duty in both `AGENTS.md` files with the machine check that AC13 recorded as deferred; AC13's compensating-control rationale is therefore historical. Not a supersession — every decision here stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** [ADR-0088](../../adr/0088-risk-triggers-have-a-single-documented-home.md)

--- a/docs/specs/npm-sca-gate/spec.md
+++ b/docs/specs/npm-sca-gate/spec.md
@@ -1,6 +1,6 @@
 # Spec: npm-sca-gate
 
-- **Status:** Shipped <!-- Draft | Approved | Implementing | Shipped | Archived -->
+- **Status:** Shipped (AC5's deferral anchor `npm-allowscripts-enforcement` is now closed in `workspace.toml [backlog].closed` — web's `playwright/fsevents@2.3.2` divergence was repinned away and `tools/lint-npm-allow-scripts.py` machine-checks the invariant; the "deferred" and "pre-existing and untouched" wording below is accurate as of ship time only. Not a supersession — every decision here stands) <!-- Draft | Approved | Implementing | Shipped | Archived -->
 - **Owner:** eugenelim
 - **Plan:** [`plan.md`](plan.md)
 - **Constrained by:** ADR-0017, ADR-0083

--- a/tools/lint-npm-allow-scripts.py
+++ b/tools/lint-npm-allow-scripts.py
@@ -19,6 +19,14 @@ function from a hyphenated executable rather than an importable helper module;
 mirroring the small walk keeps both standalone tools conventional and avoids
 dynamic execution of one gate from another.
 
+The binding limit is not that prune, though — it is ``.gitignore``, which
+ignores ``package-lock.json`` tree-wide and negates exactly ``web/`` and
+``docs-site/``. So in a clean checkout the discovered set is pinned at those
+two, and a third npm project cannot enter it without a new negation. The walk
+never consults git, so the reverse also holds locally: an in-place skill install
+under a non-dot ``packs/**`` path leaves an untracked lockfile that IS
+discovered, and it exits 2 for want of an ``allowScripts`` key in its manifest.
+
 Usage:
     lint-npm-allow-scripts.py [--root DIR]
 

--- a/tools/lint-npm-allow-scripts.py
+++ b/tools/lint-npm-allow-scripts.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Check npm install-script entries against each project's ``allowScripts``.
+
+An install script is arbitrary code executed during dependency installation.
+Every ``packages`` entry in a committed ``package-lock.json`` whose
+``hasInstallScript`` flag is true must therefore have an exact ``name@version``
+key in the sibling ``package.json`` ``allowScripts`` map. The reverse direction
+is also enforced: a stale allowlist key is a standing permission for a package
+that is not present, so its later return at another version could escape fresh
+review.
+
+Lockfiles are discovered rather than hardcoded, so a third npm project cannot
+appear without this gate noticing. Discovery mirrors ``tools/audit-npm.py``:
+walk from the repository root, prune ``node_modules`` and dot-directories, skip
+symlinked directories for loop safety, and sort the result for stable output.
+That script exposes the discovery function from a hyphenated executable rather
+than an importable helper module; mirroring the small walk keeps both standalone
+tools conventional and avoids dynamic execution of one gate from another.
+
+Usage:
+    lint-npm-allow-scripts.py [--root DIR]
+
+Exit codes deliberately preserve three outcomes, as ``tools/audit-npm.py`` and
+``tools/test-all.py`` do. A policy violation and a check that never actually ran
+are different facts; conflating them lets an unavailable or malformed input look
+like an ordinary finding and obscures that the repository was never checked.
+
+  0  every discovered project's install-script set exactly matches allowScripts.
+  1  at least one install-script entry is unallowlisted, or an allowScripts key
+     is stale.
+  2  the checker could not run: no lockfile was discovered; required JSON was
+     unreadable or unparseable; a lockfile had no usable ``packages`` map; or a
+     sibling package.json had no usable ``allowScripts`` map.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_LOCKFILE_NAME = "package-lock.json"
+_PRUNED_DIR_NAMES = frozenset({"node_modules"})
+
+
+class CheckError(Exception):
+    """The checker could not establish a verdict and must exit 2."""
+
+
+@dataclass(frozen=True)
+class ProjectVerdict:
+    """One npm project's exact set comparison."""
+
+    lockfile: Path
+    install_scripts: set[str]
+    allow_scripts: set[str]
+
+    @property
+    def unallowlisted(self) -> set[str]:
+        """Install-script packages that have not been reviewed and permitted."""
+        return self.install_scripts - self.allow_scripts
+
+    @property
+    def stale(self) -> set[str]:
+        """Standing permissions with no matching install-script package."""
+        return self.allow_scripts - self.install_scripts
+
+
+def discover_lockfiles(root: Path) -> list[Path]:
+    """Return every project package-lock under *root*, sorted for stable output."""
+    found: list[Path] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError as exc:
+            # Match audit-npm's fail-visible discovery idiom: partial walk
+            # failures are never silent, while the total-empty guard below
+            # still refuses a vacuous green result.
+            print(
+                f"lint-npm-allow-scripts: warning: cannot read {current}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        for entry in entries:
+            if entry.is_dir():
+                if (
+                    entry.is_symlink()
+                    or entry.name in _PRUNED_DIR_NAMES
+                    or entry.name.startswith(".")
+                ):
+                    continue
+                stack.append(entry)
+            elif entry.name == _LOCKFILE_NAME:
+                found.append(entry)
+    return sorted(found)
+
+
+def _load_json(path: Path) -> object:
+    """Read one UTF-8 JSON file, converting all input failures to exit-2 errors."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CheckError(f"cannot read valid JSON from {path}: {exc}") from exc
+
+
+def _install_script_key(lockfile: Path, package_path: str, entry: object) -> str | None:
+    """Return ``name@version`` for one install-script package, else ``None``."""
+    if not isinstance(entry, dict):
+        raise CheckError(
+            f"{lockfile}: packages entry {package_path!r} is not a JSON object"
+        )
+    if entry.get("hasInstallScript") is not True:
+        return None
+
+    marker = "node_modules/"
+    if marker not in package_path:
+        raise CheckError(
+            f"{lockfile}: install-script entry {package_path!r} has no "
+            f"{marker!r} segment from which to derive its package name"
+        )
+    name = package_path.rsplit(marker, 1)[1]
+    version = entry.get("version")
+    if not name or not isinstance(version, str) or not version:
+        raise CheckError(
+            f"{lockfile}: install-script entry {package_path!r} has no usable version"
+        )
+    return f"{name}@{version}"
+
+
+def check_project(lockfile: Path) -> ProjectVerdict:
+    """Load and compare one lockfile and its sibling package manifest."""
+    lock_data = _load_json(lockfile)
+    if not isinstance(lock_data, dict) or "packages" not in lock_data:
+        raise CheckError(f"{lockfile}: lockfile has no `packages` key")
+    packages = lock_data["packages"]
+    if not isinstance(packages, dict):
+        raise CheckError(f"{lockfile}: `packages` must be a JSON object")
+
+    install_scripts: set[str] = set()
+    for package_path, entry in packages.items():
+        key = _install_script_key(lockfile, package_path, entry)
+        if key is not None:
+            install_scripts.add(key)
+
+    package_json = lockfile.with_name("package.json")
+    package_data = _load_json(package_json)
+    if not isinstance(package_data, dict) or "allowScripts" not in package_data:
+        raise CheckError(f"{package_json}: package.json has no `allowScripts` key")
+    allow_scripts = package_data["allowScripts"]
+    if not isinstance(allow_scripts, dict):
+        raise CheckError(f"{package_json}: `allowScripts` must be a JSON object")
+
+    return ProjectVerdict(
+        lockfile=lockfile,
+        install_scripts=install_scripts,
+        allow_scripts=set(allow_scripts),
+    )
+
+
+def _relative(path: Path, root: Path) -> str:
+    """Render a stable POSIX-style path for diagnostics on every platform."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _validated_root(candidate: Path | None) -> Path:
+    """Resolve ``--root`` and reject unusable values without a traceback."""
+    raw = candidate if candidate is not None else _REPO_ROOT
+    try:
+        root = raw.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise SystemExit(
+            f"lint-npm-allow-scripts: --root is not a usable path: {raw!r} ({exc})"
+        ) from exc
+    if not root.exists():
+        raise SystemExit(f"lint-npm-allow-scripts: --root does not exist: {root}")
+    if not root.is_dir():
+        raise SystemExit(f"lint-npm-allow-scripts: --root is not a directory: {root}")
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args(argv)
+    root = _validated_root(args.root)
+
+    lockfiles = discover_lockfiles(root)
+    if not lockfiles:
+        print(
+            f"lint-npm-allow-scripts: no {_LOCKFILE_NAME} discovered under {root}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        verdicts = [check_project(lockfile) for lockfile in lockfiles]
+    except CheckError as exc:
+        print(f"lint-npm-allow-scripts: could not run: {exc}", file=sys.stderr)
+        return 2
+
+    failed = False
+    for verdict in verdicts:
+        display = _relative(verdict.lockfile, root)
+        for key in sorted(verdict.unallowlisted):
+            failed = True
+            print(
+                f"lint-npm-allow-scripts: {display}: unallowlisted install-script "
+                f"entry {key}",
+                file=sys.stderr,
+            )
+        for key in sorted(verdict.stale):
+            failed = True
+            print(
+                f"lint-npm-allow-scripts: {display}: stale allowScripts entry {key}",
+                file=sys.stderr,
+            )
+        if not verdict.unallowlisted and not verdict.stale:
+            checked = ", ".join(sorted(verdict.install_scripts)) or "none"
+            print(
+                f"lint-npm-allow-scripts: {display}: ok — install-script entries "
+                f"match allowScripts ({checked})"
+            )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint-npm-allow-scripts.py
+++ b/tools/lint-npm-allow-scripts.py
@@ -87,9 +87,20 @@ def discover_lockfiles(root: Path) -> list[Path]:
             # checked, so it is a could-not-run result rather than a warning.
             raise CheckError(f"cannot read directory {current}: {exc}") from exc
         for entry in entries:
-            if entry.is_dir():
+            # Classifying a child stats it, and that is a SECOND way the walk can
+            # fail: a directory at mode 0o400 lists fine but is not traversable,
+            # so `iterdir()` above succeeds and `is_dir()` here raises EACCES.
+            # Leaving it uncaught exited 1 -- the code reserved for policy
+            # violations -- with a traceback, which is the misclassification this
+            # function's could-not-run contract exists to prevent.
+            try:
+                is_dir = entry.is_dir()
+                is_symlink = entry.is_symlink()
+            except OSError as exc:
+                raise CheckError(f"cannot inspect {entry}: {exc}") from exc
+            if is_dir:
                 if (
-                    entry.is_symlink()
+                    is_symlink
                     or entry.name in _PRUNED_DIR_NAMES
                     or entry.name.startswith(".")
                 ):
@@ -119,7 +130,18 @@ def _install_script_key(
         raise CheckError(
             f"{lockfile}: packages entry {package_path!r} is not a JSON object"
         )
-    if entry.get("hasInstallScript") is not True:
+    # Symmetry with the allowScripts value check below: a non-boolean there is a
+    # could-not-run fact rather than a silent grant, so a non-boolean HERE must
+    # not be a silent "no install script" either. This is the fail-open
+    # direction -- it is the field npm's arborist reads to decide whether to run
+    # the script -- so an unrecognised shape has to stop the gate, not pass it.
+    has_install_script = entry.get("hasInstallScript")
+    if has_install_script is not None and not isinstance(has_install_script, bool):
+        raise CheckError(
+            f"{lockfile}: packages entry {package_path!r} has a non-boolean "
+            f"hasInstallScript ({has_install_script!r}); refusing to guess"
+        )
+    if has_install_script is not True:
         return None
 
     if package_path == "":

--- a/tools/lint-npm-allow-scripts.py
+++ b/tools/lint-npm-allow-scripts.py
@@ -9,13 +9,15 @@ is also enforced: a stale allowlist key is a standing permission for a package
 that is not present, so its later return at another version could escape fresh
 review.
 
-Lockfiles are discovered rather than hardcoded, so a third npm project cannot
-appear without this gate noticing. Discovery mirrors ``tools/audit-npm.py``:
-walk from the repository root, prune ``node_modules`` and dot-directories, skip
-symlinked directories for loop safety, and sort the result for stable output.
-That script exposes the discovery function from a hyphenated executable rather
-than an importable helper module; mirroring the small walk keeps both standalone
-tools conventional and avoids dynamic execution of one gate from another.
+Lockfiles are discovered rather than hardcoded across ordinary, non-hidden
+repository directories. Discovery mirrors ``tools/audit-npm.py``: walk from the
+repository root, prune ``node_modules`` and dot-directories, skip symlinked
+directories for loop safety, and sort the result for stable output. Lockfiles
+below dot paths are therefore outside this gate's discovery scope, including
+projects below ``packs/converters/.apm/``. That script exposes the discovery
+function from a hyphenated executable rather than an importable helper module;
+mirroring the small walk keeps both standalone tools conventional and avoids
+dynamic execution of one gate from another.
 
 Usage:
     lint-npm-allow-scripts.py [--root DIR]
@@ -28,9 +30,9 @@ like an ordinary finding and obscures that the repository was never checked.
   0  every discovered project's install-script set exactly matches allowScripts.
   1  at least one install-script entry is unallowlisted, or an allowScripts key
      is stale.
-  2  the checker could not run: no lockfile was discovered; required JSON was
-     unreadable or unparseable; a lockfile had no usable ``packages`` map; or a
-     sibling package.json had no usable ``allowScripts`` map.
+  2  the checker could not run: the root or discovery walk was unusable; no
+     lockfile was discovered; required JSON was unreadable or unparseable; or a
+     required ``packages`` or ``allowScripts`` map was unusable.
 """
 
 from __future__ import annotations
@@ -81,14 +83,9 @@ def discover_lockfiles(root: Path) -> list[Path]:
         try:
             entries = list(current.iterdir())
         except OSError as exc:
-            # Match audit-npm's fail-visible discovery idiom: partial walk
-            # failures are never silent, while the total-empty guard below
-            # still refuses a vacuous green result.
-            print(
-                f"lint-npm-allow-scripts: warning: cannot read {current}: {exc}",
-                file=sys.stderr,
-            )
-            continue
+            # A partial walk cannot establish that every in-scope lockfile was
+            # checked, so it is a could-not-run result rather than a warning.
+            raise CheckError(f"cannot read directory {current}: {exc}") from exc
         for entry in entries:
             if entry.is_dir():
                 if (
@@ -111,7 +108,12 @@ def _load_json(path: Path) -> object:
         raise CheckError(f"cannot read valid JSON from {path}: {exc}") from exc
 
 
-def _install_script_key(lockfile: Path, package_path: str, entry: object) -> str | None:
+def _install_script_key(
+    lockfile: Path,
+    package_path: str,
+    entry: object,
+    manifest: dict[str, object],
+) -> str | None:
     """Return ``name@version`` for one install-script package, else ``None``."""
     if not isinstance(entry, dict):
         raise CheckError(
@@ -120,17 +122,34 @@ def _install_script_key(lockfile: Path, package_path: str, entry: object) -> str
     if entry.get("hasInstallScript") is not True:
         return None
 
-    marker = "node_modules/"
-    if marker not in package_path:
-        raise CheckError(
-            f"{lockfile}: install-script entry {package_path!r} has no "
-            f"{marker!r} segment from which to derive its package name"
+    if package_path == "":
+        name = manifest.get("name")
+        version = manifest.get("version")
+    else:
+        marker = "node_modules/"
+        if marker not in package_path:
+            raise CheckError(
+                f"{lockfile}: install-script entry {package_path!r} has no "
+                f"{marker!r} segment from which to derive its package name"
+            )
+        entry_name = entry.get("name")
+        # npm aliases land in a differently named directory. The allowlist key
+        # must name the package whose code executes, not where npm placed it.
+        name = (
+            entry_name
+            if isinstance(entry_name, str) and entry_name
+            else package_path.rsplit(marker, 1)[1]
         )
-    name = package_path.rsplit(marker, 1)[1]
-    version = entry.get("version")
-    if not name or not isinstance(version, str) or not version:
+        version = entry.get("version")
+    if (
+        not isinstance(name, str)
+        or not name
+        or not isinstance(version, str)
+        or not version
+    ):
         raise CheckError(
-            f"{lockfile}: install-script entry {package_path!r} has no usable version"
+            f"{lockfile}: install-script entry {package_path!r} has no usable "
+            "name and version"
         )
     return f"{name}@{version}"
 
@@ -144,12 +163,6 @@ def check_project(lockfile: Path) -> ProjectVerdict:
     if not isinstance(packages, dict):
         raise CheckError(f"{lockfile}: `packages` must be a JSON object")
 
-    install_scripts: set[str] = set()
-    for package_path, entry in packages.items():
-        key = _install_script_key(lockfile, package_path, entry)
-        if key is not None:
-            install_scripts.add(key)
-
     package_json = lockfile.with_name("package.json")
     package_data = _load_json(package_json)
     if not isinstance(package_data, dict) or "allowScripts" not in package_data:
@@ -157,11 +170,24 @@ def check_project(lockfile: Path) -> ProjectVerdict:
     allow_scripts = package_data["allowScripts"]
     if not isinstance(allow_scripts, dict):
         raise CheckError(f"{package_json}: `allowScripts` must be a JSON object")
+    for key, permitted in allow_scripts.items():
+        if not isinstance(permitted, bool):
+            raise CheckError(
+                f"{package_json}: allowScripts entry {key!r} must be boolean"
+            )
+
+    install_scripts: set[str] = set()
+    for package_path, entry in packages.items():
+        key = _install_script_key(lockfile, package_path, entry, package_data)
+        if key is not None:
+            install_scripts.add(key)
 
     return ProjectVerdict(
         lockfile=lockfile,
         install_scripts=install_scripts,
-        allow_scripts=set(allow_scripts),
+        allow_scripts={
+            key for key, permitted in allow_scripts.items() if permitted is True
+        },
     )
 
 
@@ -173,19 +199,29 @@ def _relative(path: Path, root: Path) -> str:
         return path.as_posix()
 
 
-def _validated_root(candidate: Path | None) -> Path:
+def _validated_root(candidate: Path | None) -> Path | None:
     """Resolve ``--root`` and reject unusable values without a traceback."""
     raw = candidate if candidate is not None else _REPO_ROOT
     try:
         root = raw.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
-        raise SystemExit(
-            f"lint-npm-allow-scripts: --root is not a usable path: {raw!r} ({exc})"
-        ) from exc
+        print(
+            f"lint-npm-allow-scripts: --root is not a usable path: {raw!r} ({exc})",
+            file=sys.stderr,
+        )
+        return None
     if not root.exists():
-        raise SystemExit(f"lint-npm-allow-scripts: --root does not exist: {root}")
+        print(
+            f"lint-npm-allow-scripts: --root does not exist: {root}",
+            file=sys.stderr,
+        )
+        return None
     if not root.is_dir():
-        raise SystemExit(f"lint-npm-allow-scripts: --root is not a directory: {root}")
+        print(
+            f"lint-npm-allow-scripts: --root is not a directory: {root}",
+            file=sys.stderr,
+        )
+        return None
     return root
 
 
@@ -194,8 +230,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=None)
     args = parser.parse_args(argv)
     root = _validated_root(args.root)
+    if root is None:
+        return 2
 
-    lockfiles = discover_lockfiles(root)
+    try:
+        lockfiles = discover_lockfiles(root)
+    except CheckError as exc:
+        print(f"lint-npm-allow-scripts: could not run: {exc}", file=sys.stderr)
+        return 2
     if not lockfiles:
         print(
             f"lint-npm-allow-scripts: no {_LOCKFILE_NAME} discovered under {root}",

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -414,6 +414,18 @@ def build_check(args: argparse.Namespace) -> int:
             "lint-pack-maintainer-emails",
             "tools", "lint-pack-maintainer-emails.py",
         ),
+        # npm install scripts execute dependency code during installation, so
+        # keep this supply-chain permission check in the unfiltered policy
+        # chain. Its mutation self-test runs first: a broken detector would
+        # otherwise report green on the clean repository it is meant to guard.
+        _script_step(
+            "test-lint-npm-allow-scripts",
+            "tools", "test-lint-npm-allow-scripts.py",
+        ),
+        _script_step(
+            "lint-npm-allow-scripts",
+            "tools", "lint-npm-allow-scripts.py",
+        ),
         # The bandit suppression-comment form (ADR-0084). bandit.yaml's header
         # is the canonical statement of the rule and of why this runs here
         # rather than in `make sast`. Correction (ADR-0086 / AC14): it DOES need a

--- a/tools/test-lint-npm-allow-scripts.py
+++ b/tools/test-lint-npm-allow-scripts.py
@@ -50,7 +50,7 @@ def write_project(
     *,
     project: str = "site",
     packages: dict[str, object] | None = None,
-    allow_scripts: dict[str, bool] | None = None,
+    allow_scripts: dict[str, object] | None = None,
 ) -> Path:
     """Write one minimal npm project and return its directory."""
     project_dir = root / project
@@ -70,6 +70,7 @@ def write_project(
     }
     package = {
         "name": project,
+        "version": "1.0.0",
         "private": True,
         "allowScripts": allow_scripts
         if allow_scripts is not None
@@ -126,7 +127,11 @@ def main() -> int:
             allow_scripts={},
         )
         proc = run(root)
-        check("unallowlisted install script exits 1", proc.returncode == 1, combined(proc))
+        check(
+            "unallowlisted install script exits 1",
+            proc.returncode == 1,
+            combined(proc),
+        )
         check(
             "unallowlisted diagnostic names the offender",
             "fsevents@2.3.3" in combined(proc),
@@ -166,9 +171,16 @@ def main() -> int:
             allow_scripts={"b@4.5.6": True},
         )
         proc = run(root)
-        check("nested dependency uses the last node_modules segment", proc.returncode == 0,
-              combined(proc))
-        check("nested verdict names b@4.5.6", "b@4.5.6" in combined(proc), combined(proc))
+        check(
+            "nested dependency uses the last node_modules segment",
+            proc.returncode == 0,
+            combined(proc),
+        )
+        check(
+            "nested verdict names b@4.5.6",
+            "b@4.5.6" in combined(proc),
+            combined(proc),
+        )
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -195,6 +207,57 @@ def main() -> int:
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
+    root = fixture_root("npm-allow-alias-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {"name": "site", "version": "1.0.0"},
+                "node_modules/myfse": {
+                    "name": "fsevents",
+                    "version": "2.3.3",
+                    "hasInstallScript": True,
+                },
+            },
+            allow_scripts={"fsevents@2.3.3": True},
+        )
+        proc = run(root)
+        check("npm alias uses the entry name", proc.returncode == 0, combined(proc))
+        check(
+            "npm alias verdict names fsevents@2.3.3",
+            "fsevents@2.3.3" in proc.stdout and "myfse@2.3.3" not in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-root-script-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {
+                    "name": "lockfile-name-is-not-authoritative",
+                    "version": "9.9.9",
+                    "hasInstallScript": True,
+                }
+            },
+            allow_scripts={"site@1.0.0": True},
+        )
+        proc = run(root)
+        check(
+            "project install script exits 0 when allowed",
+            proc.returncode == 0,
+            combined(proc),
+        )
+        check(
+            "project install script uses manifest identity",
+            "site@1.0.0" in proc.stdout,
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
     root = fixture_root("npm-allow-no-lock-")
     try:
         proc = run(root)
@@ -202,20 +265,76 @@ def main() -> int:
 
         missing = root / "no-such-root"
         proc = run(missing)
-        check("nonexistent --root exits nonzero", proc.returncode != 0, combined(proc))
-        check("nonexistent --root names the path", missing.name in combined(proc),
-              combined(proc))
-        check("nonexistent --root has no traceback", "Traceback" not in combined(proc),
-              combined(proc))
+        check("nonexistent --root exits 2", proc.returncode == 2, combined(proc))
+        check(
+            "nonexistent --root names the path",
+            missing.name in combined(proc),
+            combined(proc),
+        )
+        check(
+            "nonexistent --root has no traceback",
+            "Traceback" not in combined(proc),
+            combined(proc),
+        )
 
         not_a_directory = root / "not-a-directory"
         not_a_directory.write_text("fixture", encoding="utf-8")
         proc = run(not_a_directory)
-        check("file-valued --root exits nonzero", proc.returncode != 0, combined(proc))
-        check("file-valued --root names the path", not_a_directory.name in combined(proc),
-              combined(proc))
-        check("file-valued --root has no traceback", "Traceback" not in combined(proc),
-              combined(proc))
+        check("file-valued --root exits 2", proc.returncode == 2, combined(proc))
+        check(
+            "file-valued --root names the path",
+            not_a_directory.name in combined(proc),
+            combined(proc),
+        )
+        check(
+            "file-valued --root has no traceback",
+            "Traceback" not in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-false-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {"name": "site", "version": "1.0.0"},
+                "node_modules/evil": {
+                    "version": "1.0.0",
+                    "hasInstallScript": True,
+                },
+            },
+            allow_scripts={"evil@1.0.0": False},
+        )
+        proc = run(root)
+        check(
+            "false allowScripts value exits 1",
+            proc.returncode == 1,
+            combined(proc),
+        )
+        check(
+            "false allowScripts value does not permit the package",
+            "unallowlisted install-script entry evil@1.0.0" in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-non-boolean-")
+    try:
+        write_project(root, allow_scripts={"esbuild@0.28.1": "yes"})
+        proc = run(root)
+        check(
+            "non-boolean allowScripts value exits 2",
+            proc.returncode == 2,
+            combined(proc),
+        )
+        check(
+            "non-boolean allowScripts diagnostic names the key",
+            "esbuild@0.28.1" in combined(proc),
+            combined(proc),
+        )
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -242,8 +361,11 @@ def main() -> int:
         project = write_project(root)
         (project / "package.json").unlink()
         proc = run(root)
-        check("missing sibling package.json exits 2", proc.returncode == 2,
-              combined(proc))
+        check(
+            "missing sibling package.json exits 2",
+            proc.returncode == 2,
+            combined(proc),
+        )
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -267,8 +389,11 @@ def main() -> int:
             newline="\n",
         )
         proc = run(root)
-        check("package.json without allowScripts exits 2", proc.returncode == 2,
-              combined(proc))
+        check(
+            "package.json without allowScripts exits 2",
+            proc.returncode == 2,
+            combined(proc),
+        )
     finally:
         shutil.rmtree(root, ignore_errors=True)
 
@@ -277,11 +402,33 @@ def main() -> int:
         write_project(root)
         ignored = root / "node_modules" / "dependency"
         hidden = root / ".cache" / "fixture"
-        write_project(ignored, packages={}, allow_scripts={})
-        write_project(hidden, packages={}, allow_scripts={})
+        violating_packages = {
+            "": {"name": "pruned", "version": "1.0.0"},
+            "node_modules/evil": {
+                "version": "1.0.0",
+                "hasInstallScript": True,
+            },
+        }
+        ignored_project = write_project(
+            ignored, packages=violating_packages, allow_scripts={}
+        )
+        hidden_project = write_project(
+            hidden, packages=violating_packages, allow_scripts={}
+        )
         proc = run(root)
-        check("node_modules and dot-directories are pruned", proc.returncode == 0,
-              combined(proc))
+        check(
+            "node_modules and dot-directories are pruned",
+            proc.returncode == 0,
+            combined(proc),
+        )
+        check(
+            "pruned project paths are absent from stdout",
+            all(
+                project.relative_to(root).as_posix() not in proc.stdout
+                for project in (ignored_project, hidden_project)
+            ),
+            combined(proc),
+        )
     finally:
         shutil.rmtree(root, ignore_errors=True)
 

--- a/tools/test-lint-npm-allow-scripts.py
+++ b/tools/test-lint-npm-allow-scripts.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Self-test for ``tools/lint-npm-allow-scripts.py``.
+
+Runs the real checker through subprocess against synthetic repositories, then
+against the real repository. Exit 0 means every case passed; exit 1 means at
+least one assertion failed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "tools" / "lint-npm-allow-scripts.py"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    """Record one assertion without aborting the remaining mutation cases."""
+    if condition:
+        print(f"  ok   {name}")
+        return
+    FAILURES.append(f"{name}: {detail}" if detail else name)
+    print(f"  FAIL {name}: {detail}")
+
+
+def run(root: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke the checker exactly as the build chain does, with a fixture root."""
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def write_project(
+    root: Path,
+    *,
+    project: str = "site",
+    packages: dict[str, object] | None = None,
+    allow_scripts: dict[str, bool] | None = None,
+) -> Path:
+    """Write one minimal npm project and return its directory."""
+    project_dir = root / project
+    project_dir.mkdir(parents=True, exist_ok=True)
+    lock = {
+        "name": project,
+        "lockfileVersion": 3,
+        "packages": packages
+        if packages is not None
+        else {
+            "": {"name": project, "version": "1.0.0"},
+            "node_modules/esbuild": {
+                "version": "0.28.1",
+                "hasInstallScript": True,
+            },
+        },
+    }
+    package = {
+        "name": project,
+        "private": True,
+        "allowScripts": allow_scripts
+        if allow_scripts is not None
+        else {"esbuild@0.28.1": True},
+    }
+    (project_dir / "package-lock.json").write_text(
+        json.dumps(lock), encoding="utf-8", newline="\n"
+    )
+    (project_dir / "package.json").write_text(
+        json.dumps(package), encoding="utf-8", newline="\n"
+    )
+    return project_dir
+
+
+def fixture_root(prefix: str) -> Path:
+    """Create a fixture root whose cleanup cannot mask successful assertions."""
+    return Path(tempfile.mkdtemp(prefix=prefix))
+
+
+def combined(proc: subprocess.CompletedProcess[str]) -> str:
+    """Return both streams for concise diagnostic assertions."""
+    return f"{proc.stdout}\n{proc.stderr}"
+
+
+def main() -> int:
+    print("test-lint-npm-allow-scripts:")
+
+    root = fixture_root("npm-allow-clean-")
+    try:
+        write_project(root)
+        proc = run(root)
+        check("clean fixture exits 0", proc.returncode == 0, combined(proc))
+        check(
+            "clean verdict names the checked lockfile",
+            "site/package-lock.json" in combined(proc),
+            combined(proc),
+        )
+    finally:
+        # This environment may deny os.rmdir during TemporaryDirectory cleanup.
+        # Best-effort cleanup must not turn already-passed assertions into errors.
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-unallowlisted-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {"name": "site", "version": "1.0.0"},
+                "node_modules/fsevents": {
+                    "version": "2.3.3",
+                    "hasInstallScript": True,
+                },
+            },
+            allow_scripts={},
+        )
+        proc = run(root)
+        check("unallowlisted install script exits 1", proc.returncode == 1, combined(proc))
+        check(
+            "unallowlisted diagnostic names the offender",
+            "fsevents@2.3.3" in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-stale-")
+    try:
+        write_project(
+            root,
+            packages={"": {"name": "site", "version": "1.0.0"}},
+            allow_scripts={"fsevents@2.3.3": True},
+        )
+        proc = run(root)
+        check("stale allowScripts entry exits 1", proc.returncode == 1, combined(proc))
+        check(
+            "stale diagnostic names the permission",
+            "fsevents@2.3.3" in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-nested-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {"name": "site", "version": "1.0.0"},
+                "node_modules/a/node_modules/b": {
+                    "version": "4.5.6",
+                    "hasInstallScript": True,
+                },
+            },
+            allow_scripts={"b@4.5.6": True},
+        )
+        proc = run(root)
+        check("nested dependency uses the last node_modules segment", proc.returncode == 0,
+              combined(proc))
+        check("nested verdict names b@4.5.6", "b@4.5.6" in combined(proc), combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-scoped-")
+    try:
+        write_project(
+            root,
+            packages={
+                "": {"name": "site", "version": "1.0.0"},
+                "node_modules/@scope/pkg": {
+                    "version": "7.8.9",
+                    "hasInstallScript": True,
+                },
+            },
+            allow_scripts={"@scope/pkg@7.8.9": True},
+        )
+        proc = run(root)
+        check("scoped package name is preserved", proc.returncode == 0, combined(proc))
+        check(
+            "scoped verdict names @scope/pkg@7.8.9",
+            "@scope/pkg@7.8.9" in combined(proc),
+            combined(proc),
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-no-lock-")
+    try:
+        proc = run(root)
+        check("no discovered lockfile exits 2", proc.returncode == 2, combined(proc))
+
+        missing = root / "no-such-root"
+        proc = run(missing)
+        check("nonexistent --root exits nonzero", proc.returncode != 0, combined(proc))
+        check("nonexistent --root names the path", missing.name in combined(proc),
+              combined(proc))
+        check("nonexistent --root has no traceback", "Traceback" not in combined(proc),
+              combined(proc))
+
+        not_a_directory = root / "not-a-directory"
+        not_a_directory.write_text("fixture", encoding="utf-8")
+        proc = run(not_a_directory)
+        check("file-valued --root exits nonzero", proc.returncode != 0, combined(proc))
+        check("file-valued --root names the path", not_a_directory.name in combined(proc),
+              combined(proc))
+        check("file-valued --root has no traceback", "Traceback" not in combined(proc),
+              combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-invalid-utf8-")
+    try:
+        project = write_project(root)
+        (project / "package-lock.json").write_bytes(b"\xff\xfe")
+        proc = run(root)
+        check("unreadable JSON exits 2", proc.returncode == 2, combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-bad-package-json-")
+    try:
+        project = write_project(root)
+        (project / "package.json").write_text("{not-json", encoding="utf-8")
+        proc = run(root)
+        check("unparseable package.json exits 2", proc.returncode == 2, combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-missing-package-json-")
+    try:
+        project = write_project(root)
+        (project / "package.json").unlink()
+        proc = run(root)
+        check("missing sibling package.json exits 2", proc.returncode == 2,
+              combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-no-packages-")
+    try:
+        project = write_project(root)
+        (project / "package-lock.json").write_text(
+            json.dumps({"lockfileVersion": 3}), encoding="utf-8", newline="\n"
+        )
+        proc = run(root)
+        check("lockfile without packages exits 2", proc.returncode == 2, combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-no-allow-scripts-")
+    try:
+        project = write_project(root)
+        (project / "package.json").write_text(
+            json.dumps({"name": "site", "private": True}),
+            encoding="utf-8",
+            newline="\n",
+        )
+        proc = run(root)
+        check("package.json without allowScripts exits 2", proc.returncode == 2,
+              combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    root = fixture_root("npm-allow-pruning-")
+    try:
+        write_project(root)
+        ignored = root / "node_modules" / "dependency"
+        hidden = root / ".cache" / "fixture"
+        write_project(ignored, packages={}, allow_scripts={})
+        write_project(hidden, packages={}, allow_scripts={})
+        proc = run(root)
+        check("node_modules and dot-directories are pruned", proc.returncode == 0,
+              combined(proc))
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+    proc = run(ROOT)
+    check("real repository exits 0", proc.returncode == 0, combined(proc))
+    check(
+        "real repository covers web and docs-site",
+        "web/package-lock.json" in proc.stdout
+        and "docs-site/package-lock.json" in proc.stdout,
+        combined(proc),
+    )
+
+    if FAILURES:
+        for failure in FAILURES:
+            print(f"FAIL {failure}", file=sys.stderr)
+        print(
+            f"test-lint-npm-allow-scripts: FAIL ({len(FAILURES)} assertion(s))",
+            file=sys.stderr,
+        )
+        return 1
+    print("test-lint-npm-allow-scripts: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test-lint-npm-allow-scripts.py
+++ b/tools/test-lint-npm-allow-scripts.py
@@ -422,9 +422,13 @@ def main() -> int:
             combined(proc),
         )
         check(
-            "pruned project paths are absent from stdout",
+            # Against COMBINED output, not stdout: the planted projects are
+            # deliberately violating, and a violation prints to STDERR. Checking
+            # stdout alone was true whether or not pruning happened, so this
+            # assertion was inert against the very mutant it exists to catch.
+            "pruned project paths are absent from all output",
             all(
-                project.relative_to(root).as_posix() not in proc.stdout
+                project.relative_to(root).as_posix() not in combined(proc)
                 for project in (ignored_project, hidden_project)
             ),
             combined(proc),

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -854,6 +854,8 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/lint-pack-descriptions.py",
     "tools/test-lint-pack-maintainer-emails.py",
     "tools/lint-pack-maintainer-emails.py",
+    "tools/test-lint-npm-allow-scripts.py",
+    "tools/lint-npm-allow-scripts.py",
     "tools/test-lint-nosec-form.py",
     "tools/lint-nosec-form.py",
     "tools/test-lint-ci-parity.py",

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -21,7 +21,7 @@ used by this site. Do not edit generated inputs by hand.
   reports the resolved cache, `install-browsers` provisions it. Never record install
   state here: it is machine-local and inverts without warning.
 - Full Playwright runs rewrite tracked snapshots; stage files explicitly, never `git add -A`.
-- Run `tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
+- Run `python3 tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
   `allowScripts` entry or repin the dependency so it dedupes to a reviewed version.
 - Keep `web/package.json`'s `fsevents@2.3.3` override: Playwright pins 2.3.2 exactly;
   the override collapses its nested copy so the `allowScripts` gate can be enforced.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -21,7 +21,10 @@ used by this site. Do not edit generated inputs by hand.
   reports the resolved cache, `install-browsers` provisions it. Never record install
   state here: it is machine-local and inverts without warning.
 - Full Playwright runs rewrite tracked snapshots; stage files explicitly, never `git add -A`.
-- Check `allowScripts` against install-script entries by eye when the lockfile moves.
+- Run `tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
+  `allowScripts` entry or repin the dependency so it dedupes to a reviewed version.
+- Keep `web/package.json`'s `fsevents@2.3.3` override: Playwright pins 2.3.2 exactly;
+  the override collapses its nested copy so the `allowScripts` gate can be enforced.
 - Under an agent, `astro dev` and `astro preview` fork a detached server and
   return at once with JSON output. The corollary is the reason this gets closed
   as "works for me": a human running the identical command in the identical

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4284,21 +4284,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,9 @@
     "@fontsource/jetbrains-mono": "5.3.0",
     "astro": "7.2.2"
   },
+  "overrides": {
+    "fsevents": "2.3.3"
+  },
   "allowScripts": {
     "esbuild@0.28.1": true,
     "fsevents@2.3.3": true

--- a/workspace.toml
+++ b/workspace.toml
@@ -1132,10 +1132,6 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
-  # Unblocks when: web's fsevents@2.3.2 divergence is dispositioned (add to
-  # allowScripts, or repin so it dedupes to 2.3.3).
-  {slug = "npm-allowscripts-enforcement", summary = "Make the documented allowScripts install-script invariant machine-checked for both npm projects, after dispositioning web's pre-existing playwright/fsevents@2.3.2 divergence", source = "spec/npm-sca-gate"},
-
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -1132,6 +1132,21 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
+  # Both npm gates decide "the walk could not complete" and neither has a
+  # regression test for it. lint-npm-allow-scripts.py now raises CheckError and
+  # exits 2 on an iterdir failure AND on a per-child stat failure (a dir at mode
+  # 0o400 lists but does not traverse) — the second path shipped broken and was
+  # caught by review, not by a test, because no fixture plants an unreadable
+  # directory. Its sibling tools/audit-npm.py still warns-and-continues on the
+  # same error, which is the "never actually ran, reported as clean" outcome its
+  # own three-outcome exit contract exists to prevent.
+  # Fix: plant chmod 0o000 and chmod 0o400 fixtures in
+  #   tools/test-lint-npm-allow-scripts.py asserting exit 2 with no traceback
+  #   (skip under root and on Windows), and give audit-npm.py the same
+  #   could-not-run treatment.
+  # Unblocks when: picked up — no dependency.
+  {slug = "npm-gate-walk-failure-untested", source = "spec-less allowScripts gate (adversarial review round 2)", summary = "Neither npm gate has a regression test for a partial directory walk, and audit-npm.py still treats one as a clean result"},
+
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -1828,6 +1828,8 @@ closed = [
   {slug = "security-checklists-okf-router-regression", summary = "Closed by restoring the hand-authored router and moving OKF projection to a sibling skill", source = "RFC-0087 OKF pilot regression"},
 
   {slug = "selftest-mutates-tracked-makefile", summary = "Closed for tracked-file mutation; lint-performance-p0 moved plants to fixtures, while selftest-untracked-plant-window owns the residual untracked-file risk", source = "spec/npm-sca-gate (unrelated find)"},
+
+  {slug = "npm-allowscripts-enforcement", source = "spec/npm-sca-gate", summary = "Closed by repinning web's fsevents to 2.3.3 through a package.json overrides entry -- playwright pins 2.3.2 exactly, so npm install alone could never dedupe it -- and adding tools/lint-npm-allow-scripts.py, which compares each project's lockfile install-script set against its allowScripts map in both directions"},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this change?

Repins `web/package-lock.json` so `fsevents` resolves to 2.3.3 everywhere, then
adds `tools/lint-npm-allow-scripts.py` — a checker that compares each npm
project's lockfile install-script entries against its `package.json`
`allowScripts` map — and wires it into the `make build-check` chain with its
self-test.

## Why?

Both `web/AGENTS.md` and `docs-site/AGENTS.md` carried the rule *"check
`allowScripts` against install-script entries by eye when the lockfile moves."*
Nothing checked it. An install script is arbitrary code executed during
dependency installation, so "by eye" is the whole control.

ADR-0083 recorded why the gate was not built: `web/`'s lockfile carried
`playwright/node_modules/fsevents@2.3.2` outside its `allowScripts` keys, so the
check would have landed CI red on arrival. That divergence is dispositioned here.

- Closes backlog: `npm-allowscripts-enforcement` (`workspace.toml`
  `[backlog].open`, source `spec/npm-sca-gate`)

**Why an `overrides` entry and not just `npm install`.** `playwright@1.62.1`
pins `fsevents` to `"2.3.2"` *exactly* — not a range — and 1.62.1 is the latest
published version, so a plain reinstall re-creates the nested copy every time.
An `overrides` entry is the only mechanism that collapses it. 2.3.3 is already
what the rest of the tree resolves to.

No changelog entry: `tools/**` and site manifests ship in no release
(`docs/CONVENTIONS.md` § 5b).

## How do I verify it?

```
python3 tools/lint-npm-allow-scripts.py        # EXIT=0
python3 tools/test-lint-npm-allow-scripts.py   # EXIT=0, 25+ checks
python3 -m pytest tools/test_build_gate_chain.py -q   # 40 passed, 28 subtests
python3 tools/lint-ci-parity.py                # EXIT=0
python3 tools/test-test-all.py                 # EXIT=0
python3 tools/lint-ruff.py                     # EXIT=0
```

The lockfile diff is a **pure 15-line deletion** — the nested
`playwright/node_modules/fsevents@2.3.2` entry and nothing else. `npm ci` was
then verified to reproduce that tree: no nested `playwright/node_modules`, root
`fsevents` at 2.3.3, lockfile unchanged.

Two proofs that the gate is load-bearing rather than decorative:

1. **The self-test discriminates.** Replacing the unallowlisted-set computation
   with `set()` — a gate that fails open — turns `test-lint-npm-allow-scripts.py`
   red (exit 1). Restoring it returns exit 0, with no mutant residue.
2. **Against the live tree.** Removing `fsevents@2.3.3` from `web/package.json`'s
   `allowScripts` gives exit 1 naming the entry; restoring gives a
   byte-identical `package.json` (same SHA-256) and exit 0.

## What did you not change that you considered?

- **`docs-site/` manifests.** Already clean — its only install-script entries
  are `esbuild@0.28.1` and `fsevents@2.3.3`, exactly matching its `allowScripts`.
  It serves as the checker's positive control rather than needing a fix.
- **ADR-0083's "deliberately not built here" bullet**, and
  `docs/specs/npm-sca-gate/spec.md`'s records of the divergence and the
  deferral. All three are frozen documents whose bodies take a Status-line
  pointer only under the supersession rule; their now-historical prose is
  accepted residue.
- **An allowlist-expiry mechanism** — that is the separate open slug
  `npm-allowlist-expiry-enforcement`, and its unblock condition (the allowlist
  gaining its first entry) is still unmet.
- **Dependabot wiring and JavaScript SAST** — different controls, separate
  open slugs.
- **A better diagnostic when a root manifest has no `version`.** npm permits a
  private `package.json` without one; the checker then reports the *lockfile*
  and an empty package path when the missing field is actually in
  `package.json`. Exit-2 classification is correct, so this is diagnostic
  quality only, and unreachable in this repo — both manifests carry a version.
- **Keying npm-workspaces member entries.** A `"packages/w1"` entry has no
  `node_modules/` segment, so it exits 2 with no route to green even though it
  carries the same `name`/`version` the alias fix now trusts. It fails loudly
  rather than mis-keying, so it is not a security hole, and neither site
  declares a `workspaces` key. Deferred rather than speculatively generalised.
- **A regression test for the partial-walk path**, and the same could-not-run
  treatment for the sibling `tools/audit-npm.py`. Registered as
  `npm-gate-walk-failure-untested` — that missing test is why the per-child
  stat path shipped broken and was caught by review instead.

---

## Checklist

- [x] Tests pass locally (see commands above)
- [x] Lint and typecheck pass (`tools/lint-ruff.py`)
- [x] Self-review run via `adversarial-reviewer`; blockers addressed
- [x] Spec and code agree
- [x] Living docs match reality — both `AGENTS.md` files now name the gate
      instead of prescribing manual inspection
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured
