### PR TITLE
feat(core): require an explicit opt-out when a spec has no Acceptance-Criteria section

### DIFF
--- a/.agents/skills/new-spec/assets/spec.md
+++ b/.agents/skills/new-spec/assets/spec.md
@@ -8,6 +8,7 @@
 - **Discovery:** <!-- optional: the upstream discovery artifact this spec descended from (a decision brief / intent produced by an upstream discovery process), named by its stable id; the discovery-side sibling of Brief: (the spec→discovery up-edge a traceability check walks). Omit, or "none", for a spec authored without an upstream discovery. -->
 - **Contract:** <!-- contracts/<type>/<name> this spec defines or touches (see new-spec step 4b / CONVENTIONS § 4 Contracts), or "none" for a non-API feature. A contract surface is not just a synchronous REST API — an event interface or a backend-for-frontend (BFF) boundary is a contract too; name it here and author it under contracts/<type>/. -->
 - **Shape:** <!-- optional: ui | service | data | integration | mixed — selects which `## Design (LLD)` sub-sections scaffold in plan.md (e.g. ui pulls in component decomposition + state & control flow; service pulls in interfaces & contracts + data & schema + resilience — the plan template carries the authoritative map). Omit, or "mixed", when the feature spans several or you're unsure; the plan then scaffolds the full set and you prune. Stack-neutral: it names the *kind* of work, never a framework. -->
+<!-- If this spec intentionally has no criteria, remove the section below and add `- **Acceptance Criteria:** none — <one-line reason>` to the metadata header. -->
 
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.

--- a/.agents/skills/work-loop/evals/evals.json
+++ b/.agents/skills/work-loop/evals/evals.json
@@ -14,6 +14,17 @@
       ]
     },
     {
+      "id": "spec-missing-ac-section-explicit-opt-out",
+      "prompt": "The finish-time spec lint reports invariant (vi) because a spec has no `## Acceptance Criteria` section. When is that legal, and what exact metadata is required?",
+      "expected_output": "A missing Acceptance-Criteria section is legal only when the spec intentionally has no criteria and carries `- **Acceptance Criteria:** none — <one-line reason>` in its metadata header. The reason is required: bare `none` is a hard violation. A real section and the opt-out together are also a hard contradiction.",
+      "assertions": [
+        "Response gives the exact `- **Acceptance Criteria:** none — <one-line reason>` marker",
+        "Response requires a non-empty one-line reason",
+        "Response says missing section without the marker is a hard violation",
+        "Response says a real section plus the marker is a hard contradiction"
+      ]
+    },
+    {
       "id": "phase1-sequential-wave-routing",
       "prompt": "You are running the work-loop in code mode (Phase 1). The schedule has 3 waves. Wave 0 is complete. What is the correct next action to advance to wave 1 and begin implementing it?",
       "expected_output": "Fire `loop-engine transition <spec-dir> wave-passed --wave-index 0` to advance the engine state (the engine guard validates the wave is complete), then `loop-cohort wave advance <spec-dir> --from-index 0 --expect-run-id $run_id` to advance the cohort wave pointer. Do NOT use `worktree`, `dispatch-decision`, or `auto-parallel`.",

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -15,7 +15,7 @@ gate are the two invocation surfaces. (An earlier design shipped this as a
 standalone linter; it now ships as a skill script so it projects to adopters
 too.)
 
-It checks five invariants over `docs/specs/*/spec.md`, measured against the
+It checks six invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the
 header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
 
@@ -48,6 +48,13 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         mirrors invariant (iii)). No-ops where the spec names no contract
         (non-API features: empty / "none" / the template placeholder) or no
         `contracts/` tree exists — the common case in repos with no API surface.
+  (vi)  Acceptance-Criteria section presence (diff-triggered) — a new spec, or
+        a spec whose Acceptance-Criteria section was present at the base ref
+        and is missing now, must carry the
+        `- **Acceptance Criteria:** none — <reason>` opt-out header. Specs whose
+        section was already absent at the base ref are grandfathered. If no
+        base ref resolves, the invariant is skipped with a warning. HARD when
+        it runs; malformed or contradictory markers are always HARD.
 
 Exit codes: 0 = clean (warnings allowed), 1 = one or more HARD violations.
 Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
@@ -59,6 +66,7 @@ import argparse
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
@@ -112,6 +120,46 @@ _XSPEC_FORMATS = (".yaml", ".yml", ".json")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
+# The section-presence invariant and the criterion collector must share this
+# matcher: accepting a spelling that the collector cannot read recreates the
+# vacuous pass invariant (vi) exists to close.
+_AC_SECTION_HEADING_RE = re.compile(
+    r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
+)
+# Explicit opt-out for a spec that intentionally has no AC section. The reason
+# group is optional so the parser can distinguish a missing marker (None) from
+# a present but reasonless marker (an empty string).
+_AC_OPT_OUT_HEADER_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
+)
+# Case-insensitive candidate used only to produce a precise diagnostic when an
+# author intended the opt-out but missed its exact casing or separator syntax.
+_AC_OPT_OUT_NEAR_MISS_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+)
+_PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
+
+
+def _unfenced_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield source lines outside CommonMark fenced code regions."""
+    fence_char: str | None = None
+    fence_len = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        marker = stripped[:1]
+        if marker in ("`", "~"):
+            run = len(stripped) - len(stripped.lstrip(marker))
+            info = stripped[run:].strip()
+            if fence_char is None:
+                if run >= 3:
+                    fence_char, fence_len = marker, run
+                    continue
+            elif marker == fence_char and run >= fence_len and not info:
+                fence_char = None
+                fence_len = 0
+                continue
+        if fence_char is None:
+            yield lineno, line
 
 
 def extract_status_token(raw: str) -> str:
@@ -337,6 +385,63 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
     return []
 
 
+def acceptance_criteria_opt_out(spec_text: str) -> tuple[int, str] | None:
+    """Return ``(lineno, reason)`` for the Acceptance-Criteria opt-out.
+
+    ``None`` means the marker is absent; an empty reason means the marker is
+    present but reasonless. Only metadata-preamble fields count, and HTML
+    comments are removed while preserving line numbers.
+    """
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        match = _AC_OPT_OUT_HEADER_RE.match(line)
+        if match:
+            return lineno, (match.group(1) or "").strip()
+    return None
+
+
+def acceptance_criteria_opt_out_near_miss(
+    spec_text: str,
+) -> tuple[int, str] | None:
+    """Return a precise error for an unparsable opt-out-shaped preamble line."""
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        if _AC_OPT_OUT_HEADER_RE.match(line):
+            continue
+        match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
+        if match is None:
+            continue
+        if not line.startswith("- **Acceptance Criteria:**"):
+            return lineno, "field name must use exact casing `Acceptance Criteria`"
+        value = match.group(1).strip()
+        if value.lower().startswith("none") and not value.startswith("none"):
+            return lineno, "marker value must use exact lowercase casing `none`"
+        if re.match(r"^none[ \t]+-[ \t]*", value):
+            return lineno, (
+                "separator must be an em dash (U+2014), not an ASCII hyphen"
+            )
+        return lineno, (
+            "marker must exactly match "
+            "`- **Acceptance Criteria:** none — <one-line reason>`"
+        )
+    return None
+
+
+def acceptance_criteria_section_present(spec_text: str) -> bool:
+    """Return whether the criterion collector's section heading is present."""
+    return any(
+        _AC_SECTION_HEADING_RE.match(line) for _, line in _unfenced_lines(spec_text)
+    )
+
+
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
     `## Acceptance Criteria` section.
@@ -351,15 +456,20 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     A vacuous pass is the worst failure mode a gate has: it is indistinguishable
     from a real one at the call site.
     """
-    lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
-    for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
+    opened_level = 0
+    for lineno, line in _unfenced_lines(spec_text):
+        if _AC_SECTION_HEADING_RE.match(line):
             in_ac = True
+            stripped = line.lstrip()
+            opened_level = len(stripped) - len(stripped.lstrip("#"))
             continue
-        if in_ac and re.match(r"^##\s+", line):
-            break
+        if in_ac and _SECTION_HEADING_RE.match(line):
+            stripped = line.lstrip()
+            heading_level = len(stripped) - len(stripped.lstrip("#"))
+            if heading_level <= opened_level:
+                break
         if in_ac and (_AC_OPEN_RE.match(line) or _AC_DONE_RE.match(line)):
             out.append((lineno, line))
     return out
@@ -515,6 +625,10 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             "invariant (ii): no base ref resolvable — ship-transition AC check "
             "skipped (shallow clone / detached HEAD)"
         )
+        warn.append(
+            "invariant (vi): no base ref resolvable — Acceptance-Criteria "
+            "section-presence check skipped (shallow clone / detached HEAD)"
+        )
 
     specs_dir = root / "docs" / "specs"
     for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
@@ -522,6 +636,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         text = _read(spec_path)
         if text is None:
             continue
+        base_text = (
+            base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
+            if base_resolvable
+            else None
+        )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -544,6 +663,47 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 f"(warn-only)"
             )
 
+        # (vi) diff-triggered Acceptance-Criteria section presence. Existing
+        # sectionless specs are grandfathered, but any marker an author writes
+        # remains subject to the marker-shape invariants.
+        has_ac_section = acceptance_criteria_section_present(text)
+        ac_opt_out = acceptance_criteria_opt_out(text)
+        ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
+        if ac_opt_out_near_miss is not None:
+            lineno, problem = ac_opt_out_near_miss
+            hard.append(
+                f"{rel}:{lineno}: invariant (vi) — malformed Acceptance "
+                f"Criteria opt-out: {problem}"
+            )
+        if ac_opt_out is not None:
+            lineno, reason = ac_opt_out
+            if not reason or _PLACEHOLDER_REASON_RE.fullmatch(reason):
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — Acceptance Criteria "
+                    "opt-out requires a non-placeholder one-line reason "
+                    "after `none —`"
+                )
+            if has_ac_section:
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — spec has both an "
+                    "Acceptance-Criteria section and an opt-out header"
+                )
+        if (
+            not has_ac_section
+            and ac_opt_out is None
+            and ac_opt_out_near_miss is None
+            and base_resolvable
+            and (
+                base_text is None
+                or acceptance_criteria_section_present(base_text)
+            )
+        ):
+            hard.append(
+                f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
+                "section and no `- **Acceptance Criteria:** none — <reason>` "
+                "opt-out header"
+            )
+
         # (iv) deferral anchors resolve
         for lineno, anchor in deferred_anchors(text):
             if anchor not in anchors:
@@ -554,7 +714,6 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
 
         # (ii) ACs at the ship transition (diff-triggered)
         if base_resolvable and token == "Shipped":
-            base_text = base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -63,6 +63,7 @@ Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
 from __future__ import annotations
 
 import argparse
+import bisect
 import re
 import subprocess
 import sys
@@ -152,16 +153,125 @@ _AC_HEADING_NEAR_MISS_RE = re.compile(
 # invariant (vi) exists to close. Over-reading is the safe direction here;
 # under-reading is how a gate goes quiet.
 _AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
+
+
+def _code_span_ranges(line: str) -> list[tuple[int, int]]:
+    """Inline code spans on one line, by a linear scan over backtick runs.
+
+    A run of N backticks opens; the next run of exactly N closes. Deliberately
+    not a regex: the obvious ``(`+)(?:(?!\1).)*?\1`` backtracks cubically on a
+    long backtick run -- measured, a 12 KB backtick line took 106 s, against a
+    file-size cap that admits 8 MB of untrusted repository content.
+    """
+    runs: list[tuple[int, int]] = []
+    index, length = 0, len(line)
+    while index < length:
+        if line[index] == "`":
+            end = index
+            while end < length and line[end] == "`":
+                end += 1
+            runs.append((index, end - index))
+            index = end
+        else:
+            index += 1
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(runs):
+        open_at, open_len = runs[cursor]
+        probe = cursor + 1
+        while probe < len(runs) and runs[probe][1] != open_len:
+            probe += 1
+        if probe < len(runs):
+            spans.append((open_at, runs[probe][0] + runs[probe][1]))
+            cursor = probe + 1
+        else:
+            cursor += 1
+    return spans
+
+
+def commented_out_ac_heading(spec_text: str) -> tuple[int, str] | None:
+    """Return an Acceptance-Criteria heading that is inside an HTML comment.
+
+    Only when the spec has NO heading outside one -- a commented-out draft
+    beside a live section is the author's business.
+
+    This is a DETECTOR, not a change to what the readers read. The readers
+    deliberately keep their current notions: `acceptance_criteria_opt_out`
+    strips comments because 245 of 407 specs carry template comments in the
+    preamble, while the body readers do not because no spec needs it. Making
+    the body readers comment-aware is the change that failed four review
+    rounds. Turning the one dangerous shape into a hard error instead makes
+    their disagreement unreachable in a passing state, which is the same
+    guarantee for a fraction of the machinery.
+
+    An opener inside an inline code span does not open a comment. That is not
+    hypothetical: `docs/specs/digital-experience-contract/spec.md` writes
+    ``<!-- Required:`` and a matching closer in backticks 23 lines apart, and a
+    code-span-blind reader pairs those two *mentions* into a false span over
+    that spec's real heading and all 17 of its criteria.
+    """
+    lines = spec_text.splitlines()
+    headings = {n for n, line in _unfenced_lines(spec_text)
+                if _AC_COLLECTOR_HEADING_RE.match(line)}
+    if not headings:
+        return None
+
+    offsets: list[int] = []
+    position = 0
+    for raw in spec_text.splitlines(keepends=True):
+        offsets.append(position)
+        position += len(raw)
+
+    masked: set[int] = set()
+    for index, line in enumerate(lines):
+        for span_start, span_end in _code_span_ranges(line):
+            masked.update(range(offsets[index] + span_start,
+                                offsets[index] + span_end))
+
+    commented: set[int] = set()
+    cursor = 0
+    while True:
+        opener = spec_text.find("<!--", cursor)
+        if opener < 0:
+            break
+        if opener in masked:
+            cursor = opener + 4
+            continue
+        closer = spec_text.find("-->", opener + 4)
+        if closer < 0:
+            break  # an unterminated opener is literal text, not a comment
+        first = bisect.bisect_right(offsets, opener)
+        last = bisect.bisect_right(offsets, closer + 2)
+        commented.update(n for n in headings if first <= n <= last)
+        cursor = closer + 3
+
+    # Only when EVERY heading is commented out. A commented draft beside a live
+    # section is the author's business, not a defect.
+    if commented and commented == headings:
+        lineno = min(commented)
+        return lineno, lines[lineno - 1].strip()
+    return None
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
+
+
 _AC_OPT_OUT_HEADER_RE = re.compile(
     r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
 )
 # Case-insensitive candidate used only to produce a precise diagnostic when an
 # author intended the opt-out but missed its exact casing or separator syntax.
+# Deliberately WIDER than `_AC_OPT_OUT_HEADER_RE`, which stays exact. This one
+# only decides "did the author try to write an opt-out", so it must recognise
+# the attempt however it was spelled -- otherwise a visibly attempted marker
+# escapes both readers and the spec passes clean with a malformed opt-out on the
+# page. Measured before this widened: four of five plausible shapes escaped --
+# an indented marker, a `*` bullet, a colon outside the bold, and a double space
+# after the bullet. Widening what we DIAGNOSE is not widening what we ACCEPT.
 _AC_OPT_OUT_NEAR_MISS_RE = re.compile(
-    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+    r"^(?P<indent> {0,3})(?P<bullet>[-*+])(?P<gap>[ \t]+)"
+    r"\*\*Acceptance[ \t]+Criteria(?:\*\*[ \t]*:|:\*\*)(?P<value>.*)$",
+    re.IGNORECASE,
 )
 _PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
 
@@ -445,9 +555,28 @@ def acceptance_criteria_opt_out_near_miss(
         match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
         if match is None:
             continue
+        value = match.group("value").strip()
+        # Claim only a `none`-variant value. Prose in this field is not an
+        # attempted opt-out, and claiming it would hard-fail a spec that has a
+        # perfectly good Acceptance-Criteria section.
+        if not re.match(r"^none\b", value, re.IGNORECASE):
+            continue
+        if match.group("indent"):
+            return lineno, "marker must start at column 0, not indented"
+        if match.group("bullet") != "-":
+            return lineno, (
+                f"marker must use a `-` bullet, not "
+                f"`{match.group('bullet')}`"
+            )
+        if match.group("gap") != " ":
+            return lineno, "marker must have exactly one space after the `-`"
         if not line.startswith("- **Acceptance Criteria:**"):
+            if line.startswith("- **Acceptance Criteria**:"):
+                return lineno, (
+                    "the colon belongs inside the bold: "
+                    "`**Acceptance Criteria:**`, not `**Acceptance Criteria**:`"
+                )
             return lineno, "field name must use exact casing `Acceptance Criteria`"
-        value = match.group(1).strip()
         if value.lower().startswith("none") and not value.startswith("none"):
             return lineno, "marker value must use exact lowercase casing `none`"
         if re.match(r"^none[ \t]+-[ \t]*", value):
@@ -518,6 +647,27 @@ def resolve_default_base_ref(root: Path) -> str | None:
         capture_output=True, text=True, check=False,
     )
     return "origin/main" if r.returncode == 0 else None
+
+
+def base_ref_resolves(root: Path, base_ref: str) -> bool:
+    """Whether *base_ref* names a real commit in *root*.
+
+    An explicit `--base-ref` was taken on trust. When it did not resolve,
+    `base_spec_text` returned None for EVERY spec, which the diff-triggered
+    invariants read as "this spec is new" -- so a typo'd or unfetched ref
+    red-lined an entire clean corpus, telling each author to add an opt-out
+    marker for a section that was there all along. The module docstring
+    promises the opposite: an unresolvable base ref skips with a warning.
+    """
+    try:
+        probe = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
+             f"{base_ref}^{{commit}}"],
+            capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        return False  # git absent: no base ref is resolvable
+    return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
@@ -646,6 +796,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     anchors = backlog_open_slugs(workspace_path) if workspace_path is not None else set()
 
     base_resolvable = base_ref is not None
+    if base_resolvable and not base_ref_resolves(root, base_ref):
+        # Verified, not assumed. Falls into the same warn-and-skip path as a
+        # missing ref rather than reporting every spec as new.
+        warn.append(
+            f"base ref {base_ref!r} does not resolve to a commit — "
+            f"diff-triggered invariants (ii) and (vi) skipped"
+        )
+        base_resolvable = False
     if not base_resolvable:
         warn.append(
             "invariant (ii): no base ref resolvable — ship-transition AC check "
@@ -661,6 +819,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         rel = spec_path.relative_to(root).as_posix()
         text = _read(spec_path)
         if text is None:
+            # Never silent. `_read` returns None for an unreadable file or one
+            # over the size cap, and skipping quietly reports that spec as
+            # clean -- a vacuous pass over an entire file, which is the failure
+            # mode every invariant here exists to prevent.
+            warn.append(
+                f"{rel}: could not be read (unreadable, or over the size cap); "
+                f"no invariant was checked against it"
+            )
             continue
         base_text = (
             base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
@@ -693,6 +859,20 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        # A commented-out Acceptance-Criteria section is a hard error, not a
+        # section. The body readers still read raw text, so without this the
+        # heading would count and its criteria would be harvested -- (vi)
+        # satisfied and (ii) checking text the author disabled.
+        commented_ac = commented_out_ac_heading(text)
+        if commented_ac is not None:
+            _lineno, _line = commented_ac
+            hard.append(
+                f"{rel}:{_lineno}: invariant (vi) — the Acceptance-Criteria "
+                f"section is inside an HTML comment ({_line!r}); uncomment it, "
+                f"or add `- **Acceptance Criteria:** none — <reason>` if the "
+                f"spec genuinely has no criteria"
+            )
+
         ac_heading_near_miss = None
         if not has_ac_section:
             # Warn rather than accept or ignore: an adopter whose spec reads

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -123,9 +123,35 @@ _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
 # The section-presence invariant and the criterion collector must share this
 # matcher: accepting a spelling that the collector cannot read recreates the
 # vacuous pass invariant (vi) exists to close.
-_AC_SECTION_HEADING_RE = re.compile(
+#
+# EXACT on purpose. This was case-insensitive and accepted `###` and up to three
+# leading spaces, which is how six specs drifted to `## Acceptance criteria`
+# despite the new-spec template emitting the canonical form all along: a
+# hand-written variant passed silently, so nothing corrected it. One supported
+# shape, read exactly, is what stops the residue reappearing.
+_AC_SECTION_HEADING_RE = re.compile(r"^## Acceptance Criteria\b")
+# A heading differing only in case, level, or indentation. Not accepted --
+# accepting it IS the drift path -- but not silent either: it earns a warning
+# naming the exact form. Silence would un-gate an adopter's spec without telling
+# anyone, which is the failure this invariant exists to prevent.
+_AC_HEADING_NEAR_MISS_RE = re.compile(
     r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
 )
+# What the CRITERION COLLECTOR matches. Deliberately looser than
+# `_AC_SECTION_HEADING_RE`, and the direction is the whole point.
+#
+# Invariant (vi) -- "is there a section?" -- uses the EXACT matcher, so the
+# canonical heading is enforced and drift cannot reseed. The collector uses this
+# one, so invariant (ii) never stops reading criteria it can plainly see.
+#
+# Measured before this split existed: an adopter shipping a spec with an unmet
+# criterion under `## Acceptance criteria` went from
+# `invariant (ii) — AC is unchecked and not deferred` (exit 1) to a warning and
+# exit 0. Making the collector strict did not break their build; it silently
+# stopped catching a real violation, which is worse -- and is the vacuous pass
+# invariant (vi) exists to close. Over-reading is the safe direction here;
+# under-reading is how a gate goes quiet.
+_AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
@@ -460,7 +486,7 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     in_ac = False
     opened_level = 0
     for lineno, line in _unfenced_lines(spec_text):
-        if _AC_SECTION_HEADING_RE.match(line):
+        if _AC_COLLECTOR_HEADING_RE.match(line):
             in_ac = True
             stripped = line.lstrip()
             opened_level = len(stripped) - len(stripped.lstrip("#"))
@@ -667,6 +693,21 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        ac_heading_near_miss = None
+        if not has_ac_section:
+            # Warn rather than accept or ignore: an adopter whose spec reads
+            # `## Acceptance criteria` is told the exact form instead of
+            # silently losing its criteria to invariant (ii).
+            for _lineno, _line in enumerate(text.splitlines(), start=1):
+                if _AC_HEADING_NEAR_MISS_RE.match(_line):
+                    ac_heading_near_miss = (_lineno, _line.strip())
+                    warn.append(
+                        f"{rel}:{_lineno}: Acceptance-Criteria heading should be "
+                        f"exactly `## Acceptance Criteria` (found "
+                        f"{_line.strip()!r}); its criteria are still checked, "
+                        f"but the section does not satisfy invariant (vi)"
+                    )
+                    break
         ac_opt_out = acceptance_criteria_opt_out(text)
         ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
         if ac_opt_out_near_miss is not None:
@@ -699,6 +740,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
         ):
             hard.append(
+                f"{rel}:{ac_heading_near_miss[0]}: invariant (vi) — "
+                f"Acceptance-Criteria heading must be exactly "
+                f"`## Acceptance Criteria` (found {ac_heading_near_miss[1]!r}); "
+                f"fix the heading — do NOT add a `none` opt-out to a spec that "
+                f"has criteria"
+                if ac_heading_near_miss is not None else
                 f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
                 "section and no `- **Acceptance Criteria:** none — <reason>` "
                 "opt-out header"

--- a/.claude/skills/new-spec/assets/spec.md
+++ b/.claude/skills/new-spec/assets/spec.md
@@ -8,6 +8,7 @@
 - **Discovery:** <!-- optional: the upstream discovery artifact this spec descended from (a decision brief / intent produced by an upstream discovery process), named by its stable id; the discovery-side sibling of Brief: (the spec→discovery up-edge a traceability check walks). Omit, or "none", for a spec authored without an upstream discovery. -->
 - **Contract:** <!-- contracts/<type>/<name> this spec defines or touches (see new-spec step 4b / CONVENTIONS § 4 Contracts), or "none" for a non-API feature. A contract surface is not just a synchronous REST API — an event interface or a backend-for-frontend (BFF) boundary is a contract too; name it here and author it under contracts/<type>/. -->
 - **Shape:** <!-- optional: ui | service | data | integration | mixed — selects which `## Design (LLD)` sub-sections scaffold in plan.md (e.g. ui pulls in component decomposition + state & control flow; service pulls in interfaces & contracts + data & schema + resilience — the plan template carries the authoritative map). Omit, or "mixed", when the feature spans several or you're unsure; the plan then scaffolds the full set and you prune. Stack-neutral: it names the *kind* of work, never a framework. -->
+<!-- If this spec intentionally has no criteria, remove the section below and add `- **Acceptance Criteria:** none — <one-line reason>` to the metadata header. -->
 
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.

--- a/.claude/skills/work-loop/evals/evals.json
+++ b/.claude/skills/work-loop/evals/evals.json
@@ -14,6 +14,17 @@
       ]
     },
     {
+      "id": "spec-missing-ac-section-explicit-opt-out",
+      "prompt": "The finish-time spec lint reports invariant (vi) because a spec has no `## Acceptance Criteria` section. When is that legal, and what exact metadata is required?",
+      "expected_output": "A missing Acceptance-Criteria section is legal only when the spec intentionally has no criteria and carries `- **Acceptance Criteria:** none — <one-line reason>` in its metadata header. The reason is required: bare `none` is a hard violation. A real section and the opt-out together are also a hard contradiction.",
+      "assertions": [
+        "Response gives the exact `- **Acceptance Criteria:** none — <one-line reason>` marker",
+        "Response requires a non-empty one-line reason",
+        "Response says missing section without the marker is a hard violation",
+        "Response says a real section plus the marker is a hard contradiction"
+      ]
+    },
+    {
       "id": "phase1-sequential-wave-routing",
       "prompt": "You are running the work-loop in code mode (Phase 1). The schedule has 3 waves. Wave 0 is complete. What is the correct next action to advance to wave 1 and begin implementing it?",
       "expected_output": "Fire `loop-engine transition <spec-dir> wave-passed --wave-index 0` to advance the engine state (the engine guard validates the wave is complete), then `loop-cohort wave advance <spec-dir> --from-index 0 --expect-run-id $run_id` to advance the cohort wave pointer. Do NOT use `worktree`, `dispatch-decision`, or `auto-parallel`.",

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -15,7 +15,7 @@ gate are the two invocation surfaces. (An earlier design shipped this as a
 standalone linter; it now ships as a skill script so it projects to adopters
 too.)
 
-It checks five invariants over `docs/specs/*/spec.md`, measured against the
+It checks six invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the
 header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
 
@@ -48,6 +48,13 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         mirrors invariant (iii)). No-ops where the spec names no contract
         (non-API features: empty / "none" / the template placeholder) or no
         `contracts/` tree exists — the common case in repos with no API surface.
+  (vi)  Acceptance-Criteria section presence (diff-triggered) — a new spec, or
+        a spec whose Acceptance-Criteria section was present at the base ref
+        and is missing now, must carry the
+        `- **Acceptance Criteria:** none — <reason>` opt-out header. Specs whose
+        section was already absent at the base ref are grandfathered. If no
+        base ref resolves, the invariant is skipped with a warning. HARD when
+        it runs; malformed or contradictory markers are always HARD.
 
 Exit codes: 0 = clean (warnings allowed), 1 = one or more HARD violations.
 Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
@@ -59,6 +66,7 @@ import argparse
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
@@ -112,6 +120,46 @@ _XSPEC_FORMATS = (".yaml", ".yml", ".json")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
+# The section-presence invariant and the criterion collector must share this
+# matcher: accepting a spelling that the collector cannot read recreates the
+# vacuous pass invariant (vi) exists to close.
+_AC_SECTION_HEADING_RE = re.compile(
+    r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
+)
+# Explicit opt-out for a spec that intentionally has no AC section. The reason
+# group is optional so the parser can distinguish a missing marker (None) from
+# a present but reasonless marker (an empty string).
+_AC_OPT_OUT_HEADER_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
+)
+# Case-insensitive candidate used only to produce a precise diagnostic when an
+# author intended the opt-out but missed its exact casing or separator syntax.
+_AC_OPT_OUT_NEAR_MISS_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+)
+_PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
+
+
+def _unfenced_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield source lines outside CommonMark fenced code regions."""
+    fence_char: str | None = None
+    fence_len = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        marker = stripped[:1]
+        if marker in ("`", "~"):
+            run = len(stripped) - len(stripped.lstrip(marker))
+            info = stripped[run:].strip()
+            if fence_char is None:
+                if run >= 3:
+                    fence_char, fence_len = marker, run
+                    continue
+            elif marker == fence_char and run >= fence_len and not info:
+                fence_char = None
+                fence_len = 0
+                continue
+        if fence_char is None:
+            yield lineno, line
 
 
 def extract_status_token(raw: str) -> str:
@@ -337,6 +385,63 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
     return []
 
 
+def acceptance_criteria_opt_out(spec_text: str) -> tuple[int, str] | None:
+    """Return ``(lineno, reason)`` for the Acceptance-Criteria opt-out.
+
+    ``None`` means the marker is absent; an empty reason means the marker is
+    present but reasonless. Only metadata-preamble fields count, and HTML
+    comments are removed while preserving line numbers.
+    """
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        match = _AC_OPT_OUT_HEADER_RE.match(line)
+        if match:
+            return lineno, (match.group(1) or "").strip()
+    return None
+
+
+def acceptance_criteria_opt_out_near_miss(
+    spec_text: str,
+) -> tuple[int, str] | None:
+    """Return a precise error for an unparsable opt-out-shaped preamble line."""
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        if _AC_OPT_OUT_HEADER_RE.match(line):
+            continue
+        match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
+        if match is None:
+            continue
+        if not line.startswith("- **Acceptance Criteria:**"):
+            return lineno, "field name must use exact casing `Acceptance Criteria`"
+        value = match.group(1).strip()
+        if value.lower().startswith("none") and not value.startswith("none"):
+            return lineno, "marker value must use exact lowercase casing `none`"
+        if re.match(r"^none[ \t]+-[ \t]*", value):
+            return lineno, (
+                "separator must be an em dash (U+2014), not an ASCII hyphen"
+            )
+        return lineno, (
+            "marker must exactly match "
+            "`- **Acceptance Criteria:** none — <one-line reason>`"
+        )
+    return None
+
+
+def acceptance_criteria_section_present(spec_text: str) -> bool:
+    """Return whether the criterion collector's section heading is present."""
+    return any(
+        _AC_SECTION_HEADING_RE.match(line) for _, line in _unfenced_lines(spec_text)
+    )
+
+
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
     `## Acceptance Criteria` section.
@@ -351,15 +456,20 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     A vacuous pass is the worst failure mode a gate has: it is indistinguishable
     from a real one at the call site.
     """
-    lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
-    for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
+    opened_level = 0
+    for lineno, line in _unfenced_lines(spec_text):
+        if _AC_SECTION_HEADING_RE.match(line):
             in_ac = True
+            stripped = line.lstrip()
+            opened_level = len(stripped) - len(stripped.lstrip("#"))
             continue
-        if in_ac and re.match(r"^##\s+", line):
-            break
+        if in_ac and _SECTION_HEADING_RE.match(line):
+            stripped = line.lstrip()
+            heading_level = len(stripped) - len(stripped.lstrip("#"))
+            if heading_level <= opened_level:
+                break
         if in_ac and (_AC_OPEN_RE.match(line) or _AC_DONE_RE.match(line)):
             out.append((lineno, line))
     return out
@@ -515,6 +625,10 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             "invariant (ii): no base ref resolvable — ship-transition AC check "
             "skipped (shallow clone / detached HEAD)"
         )
+        warn.append(
+            "invariant (vi): no base ref resolvable — Acceptance-Criteria "
+            "section-presence check skipped (shallow clone / detached HEAD)"
+        )
 
     specs_dir = root / "docs" / "specs"
     for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
@@ -522,6 +636,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         text = _read(spec_path)
         if text is None:
             continue
+        base_text = (
+            base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
+            if base_resolvable
+            else None
+        )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -544,6 +663,47 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 f"(warn-only)"
             )
 
+        # (vi) diff-triggered Acceptance-Criteria section presence. Existing
+        # sectionless specs are grandfathered, but any marker an author writes
+        # remains subject to the marker-shape invariants.
+        has_ac_section = acceptance_criteria_section_present(text)
+        ac_opt_out = acceptance_criteria_opt_out(text)
+        ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
+        if ac_opt_out_near_miss is not None:
+            lineno, problem = ac_opt_out_near_miss
+            hard.append(
+                f"{rel}:{lineno}: invariant (vi) — malformed Acceptance "
+                f"Criteria opt-out: {problem}"
+            )
+        if ac_opt_out is not None:
+            lineno, reason = ac_opt_out
+            if not reason or _PLACEHOLDER_REASON_RE.fullmatch(reason):
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — Acceptance Criteria "
+                    "opt-out requires a non-placeholder one-line reason "
+                    "after `none —`"
+                )
+            if has_ac_section:
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — spec has both an "
+                    "Acceptance-Criteria section and an opt-out header"
+                )
+        if (
+            not has_ac_section
+            and ac_opt_out is None
+            and ac_opt_out_near_miss is None
+            and base_resolvable
+            and (
+                base_text is None
+                or acceptance_criteria_section_present(base_text)
+            )
+        ):
+            hard.append(
+                f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
+                "section and no `- **Acceptance Criteria:** none — <reason>` "
+                "opt-out header"
+            )
+
         # (iv) deferral anchors resolve
         for lineno, anchor in deferred_anchors(text):
             if anchor not in anchors:
@@ -554,7 +714,6 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
 
         # (ii) ACs at the ship transition (diff-triggered)
         if base_resolvable and token == "Shipped":
-            base_text = base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -63,6 +63,7 @@ Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
 from __future__ import annotations
 
 import argparse
+import bisect
 import re
 import subprocess
 import sys
@@ -152,16 +153,125 @@ _AC_HEADING_NEAR_MISS_RE = re.compile(
 # invariant (vi) exists to close. Over-reading is the safe direction here;
 # under-reading is how a gate goes quiet.
 _AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
+
+
+def _code_span_ranges(line: str) -> list[tuple[int, int]]:
+    """Inline code spans on one line, by a linear scan over backtick runs.
+
+    A run of N backticks opens; the next run of exactly N closes. Deliberately
+    not a regex: the obvious ``(`+)(?:(?!\1).)*?\1`` backtracks cubically on a
+    long backtick run -- measured, a 12 KB backtick line took 106 s, against a
+    file-size cap that admits 8 MB of untrusted repository content.
+    """
+    runs: list[tuple[int, int]] = []
+    index, length = 0, len(line)
+    while index < length:
+        if line[index] == "`":
+            end = index
+            while end < length and line[end] == "`":
+                end += 1
+            runs.append((index, end - index))
+            index = end
+        else:
+            index += 1
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(runs):
+        open_at, open_len = runs[cursor]
+        probe = cursor + 1
+        while probe < len(runs) and runs[probe][1] != open_len:
+            probe += 1
+        if probe < len(runs):
+            spans.append((open_at, runs[probe][0] + runs[probe][1]))
+            cursor = probe + 1
+        else:
+            cursor += 1
+    return spans
+
+
+def commented_out_ac_heading(spec_text: str) -> tuple[int, str] | None:
+    """Return an Acceptance-Criteria heading that is inside an HTML comment.
+
+    Only when the spec has NO heading outside one -- a commented-out draft
+    beside a live section is the author's business.
+
+    This is a DETECTOR, not a change to what the readers read. The readers
+    deliberately keep their current notions: `acceptance_criteria_opt_out`
+    strips comments because 245 of 407 specs carry template comments in the
+    preamble, while the body readers do not because no spec needs it. Making
+    the body readers comment-aware is the change that failed four review
+    rounds. Turning the one dangerous shape into a hard error instead makes
+    their disagreement unreachable in a passing state, which is the same
+    guarantee for a fraction of the machinery.
+
+    An opener inside an inline code span does not open a comment. That is not
+    hypothetical: `docs/specs/digital-experience-contract/spec.md` writes
+    ``<!-- Required:`` and a matching closer in backticks 23 lines apart, and a
+    code-span-blind reader pairs those two *mentions* into a false span over
+    that spec's real heading and all 17 of its criteria.
+    """
+    lines = spec_text.splitlines()
+    headings = {n for n, line in _unfenced_lines(spec_text)
+                if _AC_COLLECTOR_HEADING_RE.match(line)}
+    if not headings:
+        return None
+
+    offsets: list[int] = []
+    position = 0
+    for raw in spec_text.splitlines(keepends=True):
+        offsets.append(position)
+        position += len(raw)
+
+    masked: set[int] = set()
+    for index, line in enumerate(lines):
+        for span_start, span_end in _code_span_ranges(line):
+            masked.update(range(offsets[index] + span_start,
+                                offsets[index] + span_end))
+
+    commented: set[int] = set()
+    cursor = 0
+    while True:
+        opener = spec_text.find("<!--", cursor)
+        if opener < 0:
+            break
+        if opener in masked:
+            cursor = opener + 4
+            continue
+        closer = spec_text.find("-->", opener + 4)
+        if closer < 0:
+            break  # an unterminated opener is literal text, not a comment
+        first = bisect.bisect_right(offsets, opener)
+        last = bisect.bisect_right(offsets, closer + 2)
+        commented.update(n for n in headings if first <= n <= last)
+        cursor = closer + 3
+
+    # Only when EVERY heading is commented out. A commented draft beside a live
+    # section is the author's business, not a defect.
+    if commented and commented == headings:
+        lineno = min(commented)
+        return lineno, lines[lineno - 1].strip()
+    return None
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
+
+
 _AC_OPT_OUT_HEADER_RE = re.compile(
     r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
 )
 # Case-insensitive candidate used only to produce a precise diagnostic when an
 # author intended the opt-out but missed its exact casing or separator syntax.
+# Deliberately WIDER than `_AC_OPT_OUT_HEADER_RE`, which stays exact. This one
+# only decides "did the author try to write an opt-out", so it must recognise
+# the attempt however it was spelled -- otherwise a visibly attempted marker
+# escapes both readers and the spec passes clean with a malformed opt-out on the
+# page. Measured before this widened: four of five plausible shapes escaped --
+# an indented marker, a `*` bullet, a colon outside the bold, and a double space
+# after the bullet. Widening what we DIAGNOSE is not widening what we ACCEPT.
 _AC_OPT_OUT_NEAR_MISS_RE = re.compile(
-    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+    r"^(?P<indent> {0,3})(?P<bullet>[-*+])(?P<gap>[ \t]+)"
+    r"\*\*Acceptance[ \t]+Criteria(?:\*\*[ \t]*:|:\*\*)(?P<value>.*)$",
+    re.IGNORECASE,
 )
 _PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
 
@@ -445,9 +555,28 @@ def acceptance_criteria_opt_out_near_miss(
         match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
         if match is None:
             continue
+        value = match.group("value").strip()
+        # Claim only a `none`-variant value. Prose in this field is not an
+        # attempted opt-out, and claiming it would hard-fail a spec that has a
+        # perfectly good Acceptance-Criteria section.
+        if not re.match(r"^none\b", value, re.IGNORECASE):
+            continue
+        if match.group("indent"):
+            return lineno, "marker must start at column 0, not indented"
+        if match.group("bullet") != "-":
+            return lineno, (
+                f"marker must use a `-` bullet, not "
+                f"`{match.group('bullet')}`"
+            )
+        if match.group("gap") != " ":
+            return lineno, "marker must have exactly one space after the `-`"
         if not line.startswith("- **Acceptance Criteria:**"):
+            if line.startswith("- **Acceptance Criteria**:"):
+                return lineno, (
+                    "the colon belongs inside the bold: "
+                    "`**Acceptance Criteria:**`, not `**Acceptance Criteria**:`"
+                )
             return lineno, "field name must use exact casing `Acceptance Criteria`"
-        value = match.group(1).strip()
         if value.lower().startswith("none") and not value.startswith("none"):
             return lineno, "marker value must use exact lowercase casing `none`"
         if re.match(r"^none[ \t]+-[ \t]*", value):
@@ -518,6 +647,27 @@ def resolve_default_base_ref(root: Path) -> str | None:
         capture_output=True, text=True, check=False,
     )
     return "origin/main" if r.returncode == 0 else None
+
+
+def base_ref_resolves(root: Path, base_ref: str) -> bool:
+    """Whether *base_ref* names a real commit in *root*.
+
+    An explicit `--base-ref` was taken on trust. When it did not resolve,
+    `base_spec_text` returned None for EVERY spec, which the diff-triggered
+    invariants read as "this spec is new" -- so a typo'd or unfetched ref
+    red-lined an entire clean corpus, telling each author to add an opt-out
+    marker for a section that was there all along. The module docstring
+    promises the opposite: an unresolvable base ref skips with a warning.
+    """
+    try:
+        probe = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
+             f"{base_ref}^{{commit}}"],
+            capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        return False  # git absent: no base ref is resolvable
+    return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
@@ -646,6 +796,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     anchors = backlog_open_slugs(workspace_path) if workspace_path is not None else set()
 
     base_resolvable = base_ref is not None
+    if base_resolvable and not base_ref_resolves(root, base_ref):
+        # Verified, not assumed. Falls into the same warn-and-skip path as a
+        # missing ref rather than reporting every spec as new.
+        warn.append(
+            f"base ref {base_ref!r} does not resolve to a commit — "
+            f"diff-triggered invariants (ii) and (vi) skipped"
+        )
+        base_resolvable = False
     if not base_resolvable:
         warn.append(
             "invariant (ii): no base ref resolvable — ship-transition AC check "
@@ -661,6 +819,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         rel = spec_path.relative_to(root).as_posix()
         text = _read(spec_path)
         if text is None:
+            # Never silent. `_read` returns None for an unreadable file or one
+            # over the size cap, and skipping quietly reports that spec as
+            # clean -- a vacuous pass over an entire file, which is the failure
+            # mode every invariant here exists to prevent.
+            warn.append(
+                f"{rel}: could not be read (unreadable, or over the size cap); "
+                f"no invariant was checked against it"
+            )
             continue
         base_text = (
             base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
@@ -693,6 +859,20 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        # A commented-out Acceptance-Criteria section is a hard error, not a
+        # section. The body readers still read raw text, so without this the
+        # heading would count and its criteria would be harvested -- (vi)
+        # satisfied and (ii) checking text the author disabled.
+        commented_ac = commented_out_ac_heading(text)
+        if commented_ac is not None:
+            _lineno, _line = commented_ac
+            hard.append(
+                f"{rel}:{_lineno}: invariant (vi) — the Acceptance-Criteria "
+                f"section is inside an HTML comment ({_line!r}); uncomment it, "
+                f"or add `- **Acceptance Criteria:** none — <reason>` if the "
+                f"spec genuinely has no criteria"
+            )
+
         ac_heading_near_miss = None
         if not has_ac_section:
             # Warn rather than accept or ignore: an adopter whose spec reads

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -123,9 +123,35 @@ _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
 # The section-presence invariant and the criterion collector must share this
 # matcher: accepting a spelling that the collector cannot read recreates the
 # vacuous pass invariant (vi) exists to close.
-_AC_SECTION_HEADING_RE = re.compile(
+#
+# EXACT on purpose. This was case-insensitive and accepted `###` and up to three
+# leading spaces, which is how six specs drifted to `## Acceptance criteria`
+# despite the new-spec template emitting the canonical form all along: a
+# hand-written variant passed silently, so nothing corrected it. One supported
+# shape, read exactly, is what stops the residue reappearing.
+_AC_SECTION_HEADING_RE = re.compile(r"^## Acceptance Criteria\b")
+# A heading differing only in case, level, or indentation. Not accepted --
+# accepting it IS the drift path -- but not silent either: it earns a warning
+# naming the exact form. Silence would un-gate an adopter's spec without telling
+# anyone, which is the failure this invariant exists to prevent.
+_AC_HEADING_NEAR_MISS_RE = re.compile(
     r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
 )
+# What the CRITERION COLLECTOR matches. Deliberately looser than
+# `_AC_SECTION_HEADING_RE`, and the direction is the whole point.
+#
+# Invariant (vi) -- "is there a section?" -- uses the EXACT matcher, so the
+# canonical heading is enforced and drift cannot reseed. The collector uses this
+# one, so invariant (ii) never stops reading criteria it can plainly see.
+#
+# Measured before this split existed: an adopter shipping a spec with an unmet
+# criterion under `## Acceptance criteria` went from
+# `invariant (ii) — AC is unchecked and not deferred` (exit 1) to a warning and
+# exit 0. Making the collector strict did not break their build; it silently
+# stopped catching a real violation, which is worse -- and is the vacuous pass
+# invariant (vi) exists to close. Over-reading is the safe direction here;
+# under-reading is how a gate goes quiet.
+_AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
@@ -460,7 +486,7 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     in_ac = False
     opened_level = 0
     for lineno, line in _unfenced_lines(spec_text):
-        if _AC_SECTION_HEADING_RE.match(line):
+        if _AC_COLLECTOR_HEADING_RE.match(line):
             in_ac = True
             stripped = line.lstrip()
             opened_level = len(stripped) - len(stripped.lstrip("#"))
@@ -667,6 +693,21 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        ac_heading_near_miss = None
+        if not has_ac_section:
+            # Warn rather than accept or ignore: an adopter whose spec reads
+            # `## Acceptance criteria` is told the exact form instead of
+            # silently losing its criteria to invariant (ii).
+            for _lineno, _line in enumerate(text.splitlines(), start=1):
+                if _AC_HEADING_NEAR_MISS_RE.match(_line):
+                    ac_heading_near_miss = (_lineno, _line.strip())
+                    warn.append(
+                        f"{rel}:{_lineno}: Acceptance-Criteria heading should be "
+                        f"exactly `## Acceptance Criteria` (found "
+                        f"{_line.strip()!r}); its criteria are still checked, "
+                        f"but the section does not satisfy invariant (vi)"
+                    )
+                    break
         ac_opt_out = acceptance_criteria_opt_out(text)
         ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
         if ac_opt_out_near_miss is not None:
@@ -699,6 +740,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
         ):
             hard.append(
+                f"{rel}:{ac_heading_near_miss[0]}: invariant (vi) — "
+                f"Acceptance-Criteria heading must be exactly "
+                f"`## Acceptance Criteria` (found {ac_heading_near_miss[1]!r}); "
+                f"fix the heading — do NOT add a `none` opt-out to a spec that "
+                f"has criteria"
+                if ac_heading_near_miss is not None else
                 f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
                 "section and no `- **Acceptance Criteria:** none — <reason>` "
                 "opt-out header"

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -440,6 +440,14 @@ mechanical rule.
   ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
+- **Acceptance Criteria opt-out.** A spec that intentionally has no
+  Acceptance-Criteria section carries
+  `- **Acceptance Criteria:** none — <one-line reason>` in its metadata header;
+  the field name `Acceptance Criteria` and value `none` use that exact casing,
+  the separator is an em dash (U+2014), and the reason is required. The linter
+  applies this gate to new specs and to specs whose section is removed in the
+  current diff; existing sectionless specs are grandfathered. A reasonless or
+  malformed marker, or a marker alongside a real section, is a hard violation.
 - **Deferral token.** A criterion that ships *unmet on purpose* because
   genuinely deferred in-scope work remains is not left unchecked and silent —
   it carries an inline `(deferred: <slug>)` marker whose `<slug>` resolves to a

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -64,6 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Acceptance-Criteria heading now has one supported spelling,
+  `## Acceptance Criteria`. A heading differing only in case, level, or
+  indentation no longer satisfies invariant (vi) and is reported with the exact
+  form to use. Its criteria are still read, so invariant (ii) keeps checking
+  them -- a heading defect never silently un-gates a spec.
 - Diff-trigger invariant (vi) for new specs and specs that remove their
   Acceptance-Criteria section. Authors opt out with the exact metadata line
   `- **Acceptance Criteria:** none — <one-line reason>`. Existing sectionless

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -50,6 +50,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > A released entry with no `Highlights` stays in this changelog and is simply
 > absent from `/now/`.
 
+## [Unreleased]
+
+
+## [core][2.12.5] — 2026-08-27
+
+### Highlights
+
+- **Newly sectionless specs say why without retroactively gating adopters.**
+  The work-loop linter requires an explicit reason when a new spec omits its
+  Acceptance-Criteria section or an existing spec removes that section, while
+  grandfathering sectionless specs already present in an adopter's base ref.
+
+### Fixed
+
+- Diff-trigger invariant (vi) for new specs and specs that remove their
+  Acceptance-Criteria section. Authors opt out with the exact metadata line
+  `- **Acceptance Criteria:** none — <one-line reason>`. Existing sectionless
+  specs, including frozen adopter history, do not acquire a retroactive hard
+  gate; malformed markers and a real section plus a marker remain hard errors.
 ## [core][2.12.4] — 2026-08-27
 
 ### Highlights

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -64,6 +64,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An Acceptance-Criteria section that is commented out is now a hard error
+  rather than a section, so a disabled section can no longer satisfy the
+  presence check while its checkboxes are read as real criteria.
+- Every attempted opt-out marker is now diagnosed with the specific fix needed.
+  An indented marker, a `*` bullet, a colon outside the bold, or a double space
+  after the bullet previously escaped both readers, so a spec passed clean with
+  a malformed marker on the page and the author got no signal.
+- An explicit `--base-ref` that does not resolve now warns and skips the
+  diff-triggered invariants, as the documented contract always said. It
+  previously made every spec look new, red-lining a clean corpus and telling
+  each author to add an opt-out for a section that was there all along.
+- A spec that cannot be read, or is over the size cap, is now reported instead
+  of skipped in silence — it was previously counted as clean.
 - The Acceptance-Criteria heading now has one supported spelling,
   `## Acceptance Criteria`. A heading differing only in case, level, or
   indentation no longer satisfies invariant (vi) and is reported with the exact

--- a/docs/product/intents/spec-ac-text-normalization.md
+++ b/docs/product/intents/spec-ac-text-normalization.md
@@ -1,0 +1,76 @@
+# Enforce one spec format tightly, instead of parsing every variant
+
+- **Status:** Draft
+- **Level:** feature
+
+## Outcome
+
+`docs/specs/*/spec.md` has one supported shape and the linter enforces it, so
+the tooling never has to decide what a variant means. Where a spec can still
+express something the readers disagree about, that shape is a lint error rather
+than a parsing problem.
+
+## Opportunity
+
+The format half of this is already done and it worked: 6 drifted specs were
+normalized, the corpus is 405 canonical / 0 variants, and the heading matcher is
+now exact with a near-miss warning, so drift cannot reseed silently. What
+remains is smaller than it first looked, and the measurements say so.
+
+**Comments and code spans cannot be removed, so "ban the constructs" is not the
+route.** Measured across 407 specs: 251 contain a real HTML comment, 245 contain
+one in the metadata preamble, and all 407 use inline code spans. The new-spec
+template itself emits 16 comments, including on the `- **Status:**` line. Both
+constructs are load-bearing spec detail.
+
+**The readers are not accidentally inconsistent; they have different jobs.**
+`acceptance_criteria_opt_out` scans only the metadata preamble, where 245 specs
+carry template comments, so it *must* strip them — a commented-out marker must
+never count. The section detector and criterion collector scan the body, where
+**0 specs** have a commented-out Acceptance-Criteria section, so stripping buys
+them nothing and costs correctness: the naive `<!--.*?-->` pattern has no notion
+of code spans, and `docs/specs/digital-experience-contract/spec.md` pairs two
+backticked *mentions* at `:163` and `:186` into a false span over its real
+heading at `:177`.
+
+So the residual risk is one shape — an Acceptance-Criteria section that is
+commented out or fenced — and the cheap answer is to make that shape a lint
+error, not to teach four readers CommonMark. Four review rounds of the parsing
+approach produced a cubically-backtracking regex, a Θ(L^1.5) replacement,
+fence state read from raw text, and comment-blind fence pairing; each passed its
+own verification. Enforcement is the smaller and more durable lever.
+
+## Assumptions
+
+- Enforcement covers the format-shaped residue. The opt-out marker regex anchors
+  on a literal `^- `, so an indented marker, a `*` bullet, or a colon outside the
+  bold escapes both readers and passes clean; pinning the exact marker line
+  closes that by construction rather than by widening the matcher.
+- Enforcement does NOT cover two robustness defects, which are unrelated to
+  format: an explicit `--base-ref` is never validated, so an unresolvable one
+  makes every spec look new and converts grandfathering into a repo-wide hard
+  failure with none of the documented warnings; and a spec that is unreadable or
+  over the size cap is skipped silently, so the invariant passes vacuously on it.
+  Both need fixing on their own terms.
+- Enforcement does NOT cover `tools/build-site.py`, which strips HTML comments
+  with the same code-span-blind pattern over changelog prose rather than spec
+  text. That one is not hypothetical: it already fired, pairing a backticked
+  opener with a closer 5,083 lines later and leaving
+  `parse_changelog_releases` with 1 release instead of ~100. Different module,
+  different file, different reader — it needs its own change and is recorded
+  here only so it is not lost.
+- Our own specs are ours to clean up; adopter specs are not. Any new enforcement
+  should warn adopters toward the supported shape rather than red-lining a
+  corpus they did not write, and must never silently stop checking a spec —
+  measured this session, a strict collector took an adopter shipping an unmet
+  criterion from a hard invariant (ii) violation to exit 0.
+- Complexity claims in this area need at least three doublings. A withdrawn fix
+  was declared correct on a single benchmark point, which moved a constant and
+  hid an exponent.
+- Full history, reproducing fixtures, and measurements are in PR #1139.
+
+## Source
+
+- Mode: repo-origin
+- Locator: packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+- Revision: sha256-bytes-v1:45492bdceb9a6ddb3d3fa7ec03c0aeacd9d27d7d970105f83e14905c511c2c9c

--- a/docs/product/intents/spec-ac-text-normalization.md
+++ b/docs/product/intents/spec-ac-text-normalization.md
@@ -1,73 +1,69 @@
-# Enforce one spec format tightly, instead of parsing every variant
+# Residual Acceptance-Criteria reader divergence
 
 - **Status:** Draft
 - **Level:** feature
 
 ## Outcome
 
-`docs/specs/*/spec.md` has one supported shape and the linter enforces it, so
-the tooling never has to decide what a variant means. Where a spec can still
-express something the readers disagree about, that shape is a lint error rather
-than a parsing problem.
+A decision on whether the remaining disagreement between the four
+Acceptance-Criteria readers is worth closing, now that its one reachable shape
+is a hard error. Either close it deliberately, or record that the guard is the
+answer and stop revisiting it.
 
 ## Opportunity
 
-The format half of this is already done and it worked: 6 drifted specs were
-normalized, the corpus is 405 canonical / 0 variants, and the heading matcher is
-now exact with a near-miss warning, so drift cannot reseed silently. What
-remains is smaller than it first looked, and the measurements say so.
+Enforcement did the work that was worth doing, and this is what it did not
+reach.
 
-**Comments and code spans cannot be removed, so "ban the constructs" is not the
-route.** Measured across 407 specs: 251 contain a real HTML comment, 245 contain
-one in the metadata preamble, and all 407 use inline code spans. The new-spec
-template itself emits 16 comments, including on the `- **Status:**` line. Both
-constructs are load-bearing spec detail.
+Shipped in PR #1139: one supported heading (`## Acceptance Criteria`, exact,
+with a near-miss warning naming the exact form); six drifted specs normalized,
+verified meaning-preserving; a commented-out Acceptance-Criteria section is a
+hard error; every attempted opt-out shape is diagnosed rather than silently
+escaping; an unresolvable `--base-ref` warns and skips instead of red-lining a
+clean corpus; and a spec the linter cannot read is warned about rather than
+reported clean.
 
-**The readers are not accidentally inconsistent; they have different jobs.**
-`acceptance_criteria_opt_out` scans only the metadata preamble, where 245 specs
-carry template comments, so it *must* strip them — a commented-out marker must
-never count. The section detector and criterion collector scan the body, where
-**0 specs** have a commented-out Acceptance-Criteria section, so stripping buys
-them nothing and costs correctness: the naive `<!--.*?-->` pattern has no notion
-of code spans, and `docs/specs/digital-experience-contract/spec.md` pairs two
-backticked *mentions* at `:163` and `:186` into a false span over its real
-heading at `:177`.
+What remains is only this: the readers still hold different notions of which
+text counts. `acceptance_criteria_opt_out` and its near-miss sibling strip HTML
+comments — they must, because 245 of 407 specs carry template comments in the
+metadata preamble they scan. The section detector and criterion collector do
+not, because no spec needs it. The shipped guard makes the one shape where that
+disagreement is reachable — a commented-out section — a hard error, so the
+divergence cannot produce a passing spec. It is bounded, not resolved.
 
-So the residual risk is one shape — an Acceptance-Criteria section that is
-commented out or fenced — and the cheap answer is to make that shape a lint
-error, not to teach four readers CommonMark. Four review rounds of the parsing
-approach produced a cubically-backtracking regex, a Θ(L^1.5) replacement,
-fence state read from raw text, and comment-blind fence pairing; each passed its
-own verification. Enforcement is the smaller and more durable lever.
+The question is whether bounded is enough. Four review rounds of *resolving* it
+produced, in sequence, a cubically backtracking code-span regex (12 KB line →
+106 s), a Θ(L^1.5) replacement (1 MB → 15.0 s), fence state read from raw text
+that let a commented-out fence swallow a live section, and comment-blind fence
+pairing that made an example heading count as a real section. Each passed its
+own verification before review caught it.
 
 ## Assumptions
 
-- Enforcement covers the format-shaped residue. The opt-out marker regex anchors
-  on a literal `^- `, so an indented marker, a `*` bullet, or a colon outside the
-  bold escapes both readers and passes clean; pinning the exact marker line
-  closes that by construction rather than by widening the matcher.
-- Enforcement does NOT cover two robustness defects, which are unrelated to
-  format: an explicit `--base-ref` is never validated, so an unresolvable one
-  makes every spec look new and converts grandfathering into a repo-wide hard
-  failure with none of the documented warnings; and a spec that is unreadable or
-  over the size cap is skipped silently, so the invariant passes vacuously on it.
-  Both need fixing on their own terms.
-- Enforcement does NOT cover `tools/build-site.py`, which strips HTML comments
-  with the same code-span-blind pattern over changelog prose rather than spec
-  text. That one is not hypothetical: it already fired, pairing a backticked
-  opener with a closer 5,083 lines later and leaving
-  `parse_changelog_releases` with 1 release instead of ~100. Different module,
-  different file, different reader — it needs its own change and is recorded
-  here only so it is not lost.
-- Our own specs are ours to clean up; adopter specs are not. Any new enforcement
-  should warn adopters toward the supported shape rather than red-lining a
-  corpus they did not write, and must never silently stop checking a spec —
-  measured this session, a strict collector took an adopter shipping an unmet
-  criterion from a hard invariant (ii) violation to exit 0.
-- Complexity claims in this area need at least three doublings. A withdrawn fix
-  was declared correct on a single benchmark point, which moved a constant and
-  hid an exponent.
-- Full history, reproducing fixtures, and measurements are in PR #1139.
+- Banning the constructs is not available. 251 of 407 specs carry a real HTML
+  comment, 245 of those in the metadata preamble, all 407 use inline code spans,
+  and the new-spec template emits 16 comments itself — including on the
+  `- **Status:**` line. Both are load-bearing spec detail.
+- The readers having different jobs is not itself the bug. The preamble reader
+  must strip comments; the body readers gain nothing by it and lose correctness,
+  because the naive `<!--.*?-->` pattern has no notion of code spans and
+  `docs/specs/digital-experience-contract/spec.md` pairs two backticked
+  *mentions* into a false span over its real heading and all 17 criteria.
+- If this is picked up, it is a parsing decision, not a regex tweak: a real
+  Markdown parser (a dependency decision for a script that projects into adopter
+  trees) versus narrowing what the readers must understand so the question does
+  not arise.
+- Any complexity claim here needs at least three doublings. A withdrawn fix was
+  declared correct on a single benchmark point, which moved a constant and hid
+  an exponent.
+- Every precedence rule needs a test that dies under mutation. Three rules in a
+  withdrawn attempt could each be neutered with the whole suite green, including
+  the one whose docstring cited a live spec.
+- `tools/build-site.py` carries the same code-span blindness over changelog
+  prose. It is tracked separately as
+  `build-site-comment-strip-ignores-code-spans` — different module, different
+  file, and it has already fired.
+- Reproducing fixtures and measurements are in PR #1139's review history.
 
 ## Source
 

--- a/docs/specs/agents-md-lost-obligations/spec.md
+++ b/docs/specs/agents-md-lost-obligations/spec.md
@@ -31,7 +31,7 @@ Deliberately retired items are **not** restored. Four candidates were retired by
 later decision with a stated reason; re-adding them would reverse a ratified
 decision. They are enumerated in Boundaries.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 Security and refusal semantics (adopter-shipped):
 

--- a/docs/specs/codex-hook-adaptation-handoff/spec.md
+++ b/docs/specs/codex-hook-adaptation-handoff/spec.md
@@ -86,7 +86,7 @@ this change into adapter repairs.
   The audit note, rather than duplicated generated matrices, records current
   first-party contract findings.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — Deterministic core handoff.** Successful core repo and local
   installs print exactly: `Next:     Ask your agent to run adapt-to-project for

--- a/docs/specs/eval-harness-write-confinement/spec.md
+++ b/docs/specs/eval-harness-write-confinement/spec.md
@@ -48,7 +48,7 @@ that cwd, finds the host repo, and writes there.
 
 This spec closes the drift. It does **not** change where results are stored.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — the run cwd is outside the repository.** When `run_pack_evals` performs its own
   projection (`project_root` not supplied), the directory passed to

--- a/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
+++ b/docs/specs/rfc0088-round14-destination-adapter-contract/spec.md
@@ -93,7 +93,7 @@ is implied that did not happen.
 - Put terms-of-service or case-law reasoning in any repository artifact. The amendment
   layer receives architectural statements only.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — Open question 3's bar is amended in one place, and no earlier reading of
   it survives.** The amendment layer states the bar as a destination adapter contract

--- a/docs/specs/rfc0088-round15-reference-consumer/spec.md
+++ b/docs/specs/rfc0088-round15-reference-consumer/spec.md
@@ -162,7 +162,7 @@ that would close it — never by prose that is true whichever way the measuremen
 - Mutate any live account state, or enumerate identifiers against a third party.
 - Put terms-of-service or case-law reasoning in any repository artifact.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] **AC1 — The sign-in window is a three-state sequence, and each blind-phase conjunct
   is separately asserted.** The states are **blind** (nothing read at all), **probe-only**

--- a/docs/specs/self-host-sweep-respects-state/spec.md
+++ b/docs/specs/self-host-sweep-respects-state/spec.md
@@ -11,7 +11,7 @@ Mode: light (no risk trigger fired)
 
 **Objective:** When `agentbundle catalogue self-host --write --force` runs on a repo that also has externally-installed skills (via `agentbundle install`), the orphan sweep in each build adapter must not delete skill directories that are recorded in `.agentbundle-state.toml`. Currently, `_sweep_skill_orphans` (claude_code, kiro) and the inline sweep (codex) build `expected_names` from only the self-host packs; any skill installed from an external catalogue is treated as an orphan and deleted.
 
-**Acceptance criteria:**
+## Acceptance criteria
 
 - [x] After `project_packs` runs for any adapter, skill directories whose names are recorded as file paths in `.agentbundle-state.toml` under the skill target directory are not deleted.
 - [x] Graceful degradation: if the state file is absent, has an unrecognised schema version, or is malformed TOML, the sweep proceeds as it did before this fix (no error; empty protection set).

--- a/docs/specs/self-host-sweep-respects-state/spec.md
+++ b/docs/specs/self-host-sweep-respects-state/spec.md
@@ -11,7 +11,7 @@ Mode: light (no risk trigger fired)
 
 **Objective:** When `agentbundle catalogue self-host --write --force` runs on a repo that also has externally-installed skills (via `agentbundle install`), the orphan sweep in each build adapter must not delete skill directories that are recorded in `.agentbundle-state.toml`. Currently, `_sweep_skill_orphans` (claude_code, kiro) and the inline sweep (codex) build `expected_names` from only the self-host packs; any skill installed from an external catalogue is treated as an orphan and deleted.
 
-## Acceptance criteria
+## Acceptance Criteria
 
 - [x] After `project_packs` runs for any adapter, skill directories whose names are recorded as file paths in `.agentbundle-state.toml` under the skill target directory are not deleted.
 - [x] Graceful degradation: if the state file is absent, has an unrecognised schema version, or is malformed TOML, the sweep proceeds as it did before this fix (no error; empty protection set).

--- a/docs/specs/skills-rendering-directives/spec.md
+++ b/docs/specs/skills-rendering-directives/spec.md
@@ -4,7 +4,7 @@
 
 **Objective:** Add rendering directives to all output-producing skill SKILL.md files so agents know which output shape each skill emits — table, status-list, mermaid, key-value, diff, tree, narrative — without loading the full catalog. Also create the reference catalog and update the skill authoring guide.
 
-**Acceptance Criteria:**
+## Acceptance Criteria
 
 - [x] `guides/_shared/reference/output-rendering.md` created with the full directive catalog (8 directives + authoring how-to + omit rules with carve-out)
 - [x] `.claude/skills/README.md` authoring section updated with rule 5 (declare output rendering directives inline)

--- a/packs/core/.apm/skills/new-spec/assets/spec.md
+++ b/packs/core/.apm/skills/new-spec/assets/spec.md
@@ -8,6 +8,7 @@
 - **Discovery:** <!-- optional: the upstream discovery artifact this spec descended from (a decision brief / intent produced by an upstream discovery process), named by its stable id; the discovery-side sibling of Brief: (the spec→discovery up-edge a traceability check walks). Omit, or "none", for a spec authored without an upstream discovery. -->
 - **Contract:** <!-- contracts/<type>/<name> this spec defines or touches (see new-spec step 4b / CONVENTIONS § 4 Contracts), or "none" for a non-API feature. A contract surface is not just a synchronous REST API — an event interface or a backend-for-frontend (BFF) boundary is a contract too; name it here and author it under contracts/<type>/. -->
 - **Shape:** <!-- optional: ui | service | data | integration | mixed — selects which `## Design (LLD)` sub-sections scaffold in plan.md (e.g. ui pulls in component decomposition + state & control flow; service pulls in interfaces & contracts + data & schema + resilience — the plan template carries the authoritative map). Omit, or "mixed", when the feature spans several or you're unsure; the plan then scaffolds the full set and you prune. Stack-neutral: it names the *kind* of work, never a framework. -->
+<!-- If this spec intentionally has no criteria, remove the section below and add `- **Acceptance Criteria:** none — <one-line reason>` to the metadata header. -->
 
 > **Spec contract:** this document defines what "done" means. The implementing
 > PR must match this spec, or update it. Verification must be derivable from it.

--- a/packs/core/.apm/skills/work-loop/evals/evals.json
+++ b/packs/core/.apm/skills/work-loop/evals/evals.json
@@ -14,6 +14,17 @@
       ]
     },
     {
+      "id": "spec-missing-ac-section-explicit-opt-out",
+      "prompt": "The finish-time spec lint reports invariant (vi) because a spec has no `## Acceptance Criteria` section. When is that legal, and what exact metadata is required?",
+      "expected_output": "A missing Acceptance-Criteria section is legal only when the spec intentionally has no criteria and carries `- **Acceptance Criteria:** none — <one-line reason>` in its metadata header. The reason is required: bare `none` is a hard violation. A real section and the opt-out together are also a hard contradiction.",
+      "assertions": [
+        "Response gives the exact `- **Acceptance Criteria:** none — <one-line reason>` marker",
+        "Response requires a non-empty one-line reason",
+        "Response says missing section without the marker is a hard violation",
+        "Response says a real section plus the marker is a hard contradiction"
+      ]
+    },
+    {
       "id": "phase1-sequential-wave-routing",
       "prompt": "You are running the work-loop in code mode (Phase 1). The schedule has 3 waves. Wave 0 is complete. What is the correct next action to advance to wave 1 and begin implementing it?",
       "expected_output": "Fire `loop-engine transition <spec-dir> wave-passed --wave-index 0` to advance the engine state (the engine guard validates the wave is complete), then `loop-cohort wave advance <spec-dir> --from-index 0 --expect-run-id $run_id` to advance the cohort wave pointer. Do NOT use `worktree`, `dispatch-decision`, or `auto-parallel`.",

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -15,7 +15,7 @@ gate are the two invocation surfaces. (An earlier design shipped this as a
 standalone linter; it now ships as a skill script so it projects to adopters
 too.)
 
-It checks five invariants over `docs/specs/*/spec.md`, measured against the
+It checks six invariants over `docs/specs/*/spec.md`, measured against the
 contract pinned in `CONVENTIONS.md` § 4 (Spec metadata contract). Only the
 header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
 
@@ -48,6 +48,13 @@ header `- **Status:**` field is checked; `plan.md` status is out of v1 scope.
         mirrors invariant (iii)). No-ops where the spec names no contract
         (non-API features: empty / "none" / the template placeholder) or no
         `contracts/` tree exists — the common case in repos with no API surface.
+  (vi)  Acceptance-Criteria section presence (diff-triggered) — a new spec, or
+        a spec whose Acceptance-Criteria section was present at the base ref
+        and is missing now, must carry the
+        `- **Acceptance Criteria:** none — <reason>` opt-out header. Specs whose
+        section was already absent at the base ref are grandfathered. If no
+        base ref resolves, the invariant is skipped with a warning. HARD when
+        it runs; malformed or contradictory markers are always HARD.
 
 Exit codes: 0 = clean (warnings allowed), 1 = one or more HARD violations.
 Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
@@ -59,6 +66,7 @@ import argparse
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
@@ -112,6 +120,46 @@ _XSPEC_FORMATS = (".yaml", ".yml", ".json")
 # AC checklist items.
 _AC_OPEN_RE = re.compile(r"^\s*-\s*\[ \]\s")
 _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
+# The section-presence invariant and the criterion collector must share this
+# matcher: accepting a spelling that the collector cannot read recreates the
+# vacuous pass invariant (vi) exists to close.
+_AC_SECTION_HEADING_RE = re.compile(
+    r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
+)
+# Explicit opt-out for a spec that intentionally has no AC section. The reason
+# group is optional so the parser can distinguish a missing marker (None) from
+# a present but reasonless marker (an empty string).
+_AC_OPT_OUT_HEADER_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
+)
+# Case-insensitive candidate used only to produce a precise diagnostic when an
+# author intended the opt-out but missed its exact casing or separator syntax.
+_AC_OPT_OUT_NEAR_MISS_RE = re.compile(
+    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+)
+_PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
+
+
+def _unfenced_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield source lines outside CommonMark fenced code regions."""
+    fence_char: str | None = None
+    fence_len = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        marker = stripped[:1]
+        if marker in ("`", "~"):
+            run = len(stripped) - len(stripped.lstrip(marker))
+            info = stripped[run:].strip()
+            if fence_char is None:
+                if run >= 3:
+                    fence_char, fence_len = marker, run
+                    continue
+            elif marker == fence_char and run >= fence_len and not info:
+                fence_char = None
+                fence_len = 0
+                continue
+        if fence_char is None:
+            yield lineno, line
 
 
 def extract_status_token(raw: str) -> str:
@@ -337,6 +385,63 @@ def contract_header_refs(spec_text: str) -> list[tuple[int, str]]:
     return []
 
 
+def acceptance_criteria_opt_out(spec_text: str) -> tuple[int, str] | None:
+    """Return ``(lineno, reason)`` for the Acceptance-Criteria opt-out.
+
+    ``None`` means the marker is absent; an empty reason means the marker is
+    present but reasonless. Only metadata-preamble fields count, and HTML
+    comments are removed while preserving line numbers.
+    """
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        match = _AC_OPT_OUT_HEADER_RE.match(line)
+        if match:
+            return lineno, (match.group(1) or "").strip()
+    return None
+
+
+def acceptance_criteria_opt_out_near_miss(
+    spec_text: str,
+) -> tuple[int, str] | None:
+    """Return a precise error for an unparsable opt-out-shaped preamble line."""
+    cleaned = _HTML_COMMENT_RE.sub(
+        lambda match: "\n" * match.group(0).count("\n"), spec_text
+    )
+    for lineno, line in _unfenced_lines(cleaned):
+        if _SECTION_HEADING_RE.match(line):
+            break
+        if _AC_OPT_OUT_HEADER_RE.match(line):
+            continue
+        match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
+        if match is None:
+            continue
+        if not line.startswith("- **Acceptance Criteria:**"):
+            return lineno, "field name must use exact casing `Acceptance Criteria`"
+        value = match.group(1).strip()
+        if value.lower().startswith("none") and not value.startswith("none"):
+            return lineno, "marker value must use exact lowercase casing `none`"
+        if re.match(r"^none[ \t]+-[ \t]*", value):
+            return lineno, (
+                "separator must be an em dash (U+2014), not an ASCII hyphen"
+            )
+        return lineno, (
+            "marker must exactly match "
+            "`- **Acceptance Criteria:** none — <one-line reason>`"
+        )
+    return None
+
+
+def acceptance_criteria_section_present(spec_text: str) -> bool:
+    """Return whether the criterion collector's section heading is present."""
+    return any(
+        _AC_SECTION_HEADING_RE.match(line) for _, line in _unfenced_lines(spec_text)
+    )
+
+
 def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     """Return (lineno, line) for every checklist item inside the
     `## Acceptance Criteria` section.
@@ -351,15 +456,20 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     A vacuous pass is the worst failure mode a gate has: it is indistinguishable
     from a real one at the call site.
     """
-    lines = spec_text.splitlines()
     out: list[tuple[int, str]] = []
     in_ac = False
-    for lineno, line in enumerate(lines, start=1):
-        if re.match(r"^##\s+Acceptance Criteria\b", line, re.IGNORECASE):
+    opened_level = 0
+    for lineno, line in _unfenced_lines(spec_text):
+        if _AC_SECTION_HEADING_RE.match(line):
             in_ac = True
+            stripped = line.lstrip()
+            opened_level = len(stripped) - len(stripped.lstrip("#"))
             continue
-        if in_ac and re.match(r"^##\s+", line):
-            break
+        if in_ac and _SECTION_HEADING_RE.match(line):
+            stripped = line.lstrip()
+            heading_level = len(stripped) - len(stripped.lstrip("#"))
+            if heading_level <= opened_level:
+                break
         if in_ac and (_AC_OPEN_RE.match(line) or _AC_DONE_RE.match(line)):
             out.append((lineno, line))
     return out
@@ -515,6 +625,10 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             "invariant (ii): no base ref resolvable — ship-transition AC check "
             "skipped (shallow clone / detached HEAD)"
         )
+        warn.append(
+            "invariant (vi): no base ref resolvable — Acceptance-Criteria "
+            "section-presence check skipped (shallow clone / detached HEAD)"
+        )
 
     specs_dir = root / "docs" / "specs"
     for spec_path in sorted(_confined(specs_dir.glob("*/spec.md"), root)):
@@ -522,6 +636,11 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         text = _read(spec_path)
         if text is None:
             continue
+        base_text = (
+            base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
+            if base_resolvable
+            else None
+        )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -544,6 +663,47 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 f"(warn-only)"
             )
 
+        # (vi) diff-triggered Acceptance-Criteria section presence. Existing
+        # sectionless specs are grandfathered, but any marker an author writes
+        # remains subject to the marker-shape invariants.
+        has_ac_section = acceptance_criteria_section_present(text)
+        ac_opt_out = acceptance_criteria_opt_out(text)
+        ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
+        if ac_opt_out_near_miss is not None:
+            lineno, problem = ac_opt_out_near_miss
+            hard.append(
+                f"{rel}:{lineno}: invariant (vi) — malformed Acceptance "
+                f"Criteria opt-out: {problem}"
+            )
+        if ac_opt_out is not None:
+            lineno, reason = ac_opt_out
+            if not reason or _PLACEHOLDER_REASON_RE.fullmatch(reason):
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — Acceptance Criteria "
+                    "opt-out requires a non-placeholder one-line reason "
+                    "after `none —`"
+                )
+            if has_ac_section:
+                hard.append(
+                    f"{rel}:{lineno}: invariant (vi) — spec has both an "
+                    "Acceptance-Criteria section and an opt-out header"
+                )
+        if (
+            not has_ac_section
+            and ac_opt_out is None
+            and ac_opt_out_near_miss is None
+            and base_resolvable
+            and (
+                base_text is None
+                or acceptance_criteria_section_present(base_text)
+            )
+        ):
+            hard.append(
+                f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
+                "section and no `- **Acceptance Criteria:** none — <reason>` "
+                "opt-out header"
+            )
+
         # (iv) deferral anchors resolve
         for lineno, anchor in deferred_anchors(text):
             if anchor not in anchors:
@@ -554,7 +714,6 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
 
         # (ii) ACs at the ship transition (diff-triggered)
         if base_resolvable and token == "Shipped":
-            base_text = base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -63,6 +63,7 @@ Usage: lint-spec-status.py [--root DIR] [--base-ref REF]
 from __future__ import annotations
 
 import argparse
+import bisect
 import re
 import subprocess
 import sys
@@ -152,16 +153,125 @@ _AC_HEADING_NEAR_MISS_RE = re.compile(
 # invariant (vi) exists to close. Over-reading is the safe direction here;
 # under-reading is how a gate goes quiet.
 _AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
+
+
+def _code_span_ranges(line: str) -> list[tuple[int, int]]:
+    """Inline code spans on one line, by a linear scan over backtick runs.
+
+    A run of N backticks opens; the next run of exactly N closes. Deliberately
+    not a regex: the obvious ``(`+)(?:(?!\1).)*?\1`` backtracks cubically on a
+    long backtick run -- measured, a 12 KB backtick line took 106 s, against a
+    file-size cap that admits 8 MB of untrusted repository content.
+    """
+    runs: list[tuple[int, int]] = []
+    index, length = 0, len(line)
+    while index < length:
+        if line[index] == "`":
+            end = index
+            while end < length and line[end] == "`":
+                end += 1
+            runs.append((index, end - index))
+            index = end
+        else:
+            index += 1
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(runs):
+        open_at, open_len = runs[cursor]
+        probe = cursor + 1
+        while probe < len(runs) and runs[probe][1] != open_len:
+            probe += 1
+        if probe < len(runs):
+            spans.append((open_at, runs[probe][0] + runs[probe][1]))
+            cursor = probe + 1
+        else:
+            cursor += 1
+    return spans
+
+
+def commented_out_ac_heading(spec_text: str) -> tuple[int, str] | None:
+    """Return an Acceptance-Criteria heading that is inside an HTML comment.
+
+    Only when the spec has NO heading outside one -- a commented-out draft
+    beside a live section is the author's business.
+
+    This is a DETECTOR, not a change to what the readers read. The readers
+    deliberately keep their current notions: `acceptance_criteria_opt_out`
+    strips comments because 245 of 407 specs carry template comments in the
+    preamble, while the body readers do not because no spec needs it. Making
+    the body readers comment-aware is the change that failed four review
+    rounds. Turning the one dangerous shape into a hard error instead makes
+    their disagreement unreachable in a passing state, which is the same
+    guarantee for a fraction of the machinery.
+
+    An opener inside an inline code span does not open a comment. That is not
+    hypothetical: `docs/specs/digital-experience-contract/spec.md` writes
+    ``<!-- Required:`` and a matching closer in backticks 23 lines apart, and a
+    code-span-blind reader pairs those two *mentions* into a false span over
+    that spec's real heading and all 17 of its criteria.
+    """
+    lines = spec_text.splitlines()
+    headings = {n for n, line in _unfenced_lines(spec_text)
+                if _AC_COLLECTOR_HEADING_RE.match(line)}
+    if not headings:
+        return None
+
+    offsets: list[int] = []
+    position = 0
+    for raw in spec_text.splitlines(keepends=True):
+        offsets.append(position)
+        position += len(raw)
+
+    masked: set[int] = set()
+    for index, line in enumerate(lines):
+        for span_start, span_end in _code_span_ranges(line):
+            masked.update(range(offsets[index] + span_start,
+                                offsets[index] + span_end))
+
+    commented: set[int] = set()
+    cursor = 0
+    while True:
+        opener = spec_text.find("<!--", cursor)
+        if opener < 0:
+            break
+        if opener in masked:
+            cursor = opener + 4
+            continue
+        closer = spec_text.find("-->", opener + 4)
+        if closer < 0:
+            break  # an unterminated opener is literal text, not a comment
+        first = bisect.bisect_right(offsets, opener)
+        last = bisect.bisect_right(offsets, closer + 2)
+        commented.update(n for n in headings if first <= n <= last)
+        cursor = closer + 3
+
+    # Only when EVERY heading is commented out. A commented draft beside a live
+    # section is the author's business, not a defect.
+    if commented and commented == headings:
+        lineno = min(commented)
+        return lineno, lines[lineno - 1].strip()
+    return None
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
+
+
 _AC_OPT_OUT_HEADER_RE = re.compile(
     r"^- \*\*Acceptance Criteria:\*\*\s*none(?:[ \t]+—[ \t]*(.*?))?[ \t]*$"
 )
 # Case-insensitive candidate used only to produce a precise diagnostic when an
 # author intended the opt-out but missed its exact casing or separator syntax.
+# Deliberately WIDER than `_AC_OPT_OUT_HEADER_RE`, which stays exact. This one
+# only decides "did the author try to write an opt-out", so it must recognise
+# the attempt however it was spelled -- otherwise a visibly attempted marker
+# escapes both readers and the spec passes clean with a malformed opt-out on the
+# page. Measured before this widened: four of five plausible shapes escaped --
+# an indented marker, a `*` bullet, a colon outside the bold, and a double space
+# after the bullet. Widening what we DIAGNOSE is not widening what we ACCEPT.
 _AC_OPT_OUT_NEAR_MISS_RE = re.compile(
-    r"^- \*\*Acceptance Criteria:\*\*(.*)$", re.IGNORECASE
+    r"^(?P<indent> {0,3})(?P<bullet>[-*+])(?P<gap>[ \t]+)"
+    r"\*\*Acceptance[ \t]+Criteria(?:\*\*[ \t]*:|:\*\*)(?P<value>.*)$",
+    re.IGNORECASE,
 )
 _PLACEHOLDER_REASON_RE = re.compile(r"^<[^<>]*>$")
 
@@ -445,9 +555,28 @@ def acceptance_criteria_opt_out_near_miss(
         match = _AC_OPT_OUT_NEAR_MISS_RE.match(line)
         if match is None:
             continue
+        value = match.group("value").strip()
+        # Claim only a `none`-variant value. Prose in this field is not an
+        # attempted opt-out, and claiming it would hard-fail a spec that has a
+        # perfectly good Acceptance-Criteria section.
+        if not re.match(r"^none\b", value, re.IGNORECASE):
+            continue
+        if match.group("indent"):
+            return lineno, "marker must start at column 0, not indented"
+        if match.group("bullet") != "-":
+            return lineno, (
+                f"marker must use a `-` bullet, not "
+                f"`{match.group('bullet')}`"
+            )
+        if match.group("gap") != " ":
+            return lineno, "marker must have exactly one space after the `-`"
         if not line.startswith("- **Acceptance Criteria:**"):
+            if line.startswith("- **Acceptance Criteria**:"):
+                return lineno, (
+                    "the colon belongs inside the bold: "
+                    "`**Acceptance Criteria:**`, not `**Acceptance Criteria**:`"
+                )
             return lineno, "field name must use exact casing `Acceptance Criteria`"
-        value = match.group(1).strip()
         if value.lower().startswith("none") and not value.startswith("none"):
             return lineno, "marker value must use exact lowercase casing `none`"
         if re.match(r"^none[ \t]+-[ \t]*", value):
@@ -518,6 +647,27 @@ def resolve_default_base_ref(root: Path) -> str | None:
         capture_output=True, text=True, check=False,
     )
     return "origin/main" if r.returncode == 0 else None
+
+
+def base_ref_resolves(root: Path, base_ref: str) -> bool:
+    """Whether *base_ref* names a real commit in *root*.
+
+    An explicit `--base-ref` was taken on trust. When it did not resolve,
+    `base_spec_text` returned None for EVERY spec, which the diff-triggered
+    invariants read as "this spec is new" -- so a typo'd or unfetched ref
+    red-lined an entire clean corpus, telling each author to add an opt-out
+    marker for a section that was there all along. The module docstring
+    promises the opposite: an unresolvable base ref skips with a warning.
+    """
+    try:
+        probe = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
+             f"{base_ref}^{{commit}}"],
+            capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        return False  # git absent: no base ref is resolvable
+    return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
@@ -646,6 +796,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
     anchors = backlog_open_slugs(workspace_path) if workspace_path is not None else set()
 
     base_resolvable = base_ref is not None
+    if base_resolvable and not base_ref_resolves(root, base_ref):
+        # Verified, not assumed. Falls into the same warn-and-skip path as a
+        # missing ref rather than reporting every spec as new.
+        warn.append(
+            f"base ref {base_ref!r} does not resolve to a commit — "
+            f"diff-triggered invariants (ii) and (vi) skipped"
+        )
+        base_resolvable = False
     if not base_resolvable:
         warn.append(
             "invariant (ii): no base ref resolvable — ship-transition AC check "
@@ -661,6 +819,14 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         rel = spec_path.relative_to(root).as_posix()
         text = _read(spec_path)
         if text is None:
+            # Never silent. `_read` returns None for an unreadable file or one
+            # over the size cap, and skipping quietly reports that spec as
+            # clean -- a vacuous pass over an entire file, which is the failure
+            # mode every invariant here exists to prevent.
+            warn.append(
+                f"{rel}: could not be read (unreadable, or over the size cap); "
+                f"no invariant was checked against it"
+            )
             continue
         base_text = (
             base_spec_text(root, rel, base_ref)  # type: ignore[arg-type]
@@ -693,6 +859,20 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        # A commented-out Acceptance-Criteria section is a hard error, not a
+        # section. The body readers still read raw text, so without this the
+        # heading would count and its criteria would be harvested -- (vi)
+        # satisfied and (ii) checking text the author disabled.
+        commented_ac = commented_out_ac_heading(text)
+        if commented_ac is not None:
+            _lineno, _line = commented_ac
+            hard.append(
+                f"{rel}:{_lineno}: invariant (vi) — the Acceptance-Criteria "
+                f"section is inside an HTML comment ({_line!r}); uncomment it, "
+                f"or add `- **Acceptance Criteria:** none — <reason>` if the "
+                f"spec genuinely has no criteria"
+            )
+
         ac_heading_near_miss = None
         if not has_ac_section:
             # Warn rather than accept or ignore: an adopter whose spec reads

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -123,9 +123,35 @@ _AC_DONE_RE = re.compile(r"^\s*-\s*\[[xX]\]\s")
 # The section-presence invariant and the criterion collector must share this
 # matcher: accepting a spelling that the collector cannot read recreates the
 # vacuous pass invariant (vi) exists to close.
-_AC_SECTION_HEADING_RE = re.compile(
+#
+# EXACT on purpose. This was case-insensitive and accepted `###` and up to three
+# leading spaces, which is how six specs drifted to `## Acceptance criteria`
+# despite the new-spec template emitting the canonical form all along: a
+# hand-written variant passed silently, so nothing corrected it. One supported
+# shape, read exactly, is what stops the residue reappearing.
+_AC_SECTION_HEADING_RE = re.compile(r"^## Acceptance Criteria\b")
+# A heading differing only in case, level, or indentation. Not accepted --
+# accepting it IS the drift path -- but not silent either: it earns a warning
+# naming the exact form. Silence would un-gate an adopter's spec without telling
+# anyone, which is the failure this invariant exists to prevent.
+_AC_HEADING_NEAR_MISS_RE = re.compile(
     r"^ {0,3}#{2,3}[ \t]+Acceptance Criteria\b", re.IGNORECASE
 )
+# What the CRITERION COLLECTOR matches. Deliberately looser than
+# `_AC_SECTION_HEADING_RE`, and the direction is the whole point.
+#
+# Invariant (vi) -- "is there a section?" -- uses the EXACT matcher, so the
+# canonical heading is enforced and drift cannot reseed. The collector uses this
+# one, so invariant (ii) never stops reading criteria it can plainly see.
+#
+# Measured before this split existed: an adopter shipping a spec with an unmet
+# criterion under `## Acceptance criteria` went from
+# `invariant (ii) — AC is unchecked and not deferred` (exit 1) to a warning and
+# exit 0. Making the collector strict did not break their build; it silently
+# stopped catching a real violation, which is worse -- and is the vacuous pass
+# invariant (vi) exists to close. Over-reading is the safe direction here;
+# under-reading is how a gate goes quiet.
+_AC_COLLECTOR_HEADING_RE = _AC_HEADING_NEAR_MISS_RE
 # Explicit opt-out for a spec that intentionally has no AC section. The reason
 # group is optional so the parser can distinguish a missing marker (None) from
 # a present but reasonless marker (an empty string).
@@ -460,7 +486,7 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     in_ac = False
     opened_level = 0
     for lineno, line in _unfenced_lines(spec_text):
-        if _AC_SECTION_HEADING_RE.match(line):
+        if _AC_COLLECTOR_HEADING_RE.match(line):
             in_ac = True
             stripped = line.lstrip()
             opened_level = len(stripped) - len(stripped.lstrip("#"))
@@ -667,6 +693,21 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
         # sectionless specs are grandfathered, but any marker an author writes
         # remains subject to the marker-shape invariants.
         has_ac_section = acceptance_criteria_section_present(text)
+        ac_heading_near_miss = None
+        if not has_ac_section:
+            # Warn rather than accept or ignore: an adopter whose spec reads
+            # `## Acceptance criteria` is told the exact form instead of
+            # silently losing its criteria to invariant (ii).
+            for _lineno, _line in enumerate(text.splitlines(), start=1):
+                if _AC_HEADING_NEAR_MISS_RE.match(_line):
+                    ac_heading_near_miss = (_lineno, _line.strip())
+                    warn.append(
+                        f"{rel}:{_lineno}: Acceptance-Criteria heading should be "
+                        f"exactly `## Acceptance Criteria` (found "
+                        f"{_line.strip()!r}); its criteria are still checked, "
+                        f"but the section does not satisfy invariant (vi)"
+                    )
+                    break
         ac_opt_out = acceptance_criteria_opt_out(text)
         ac_opt_out_near_miss = acceptance_criteria_opt_out_near_miss(text)
         if ac_opt_out_near_miss is not None:
@@ -699,6 +740,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             )
         ):
             hard.append(
+                f"{rel}:{ac_heading_near_miss[0]}: invariant (vi) — "
+                f"Acceptance-Criteria heading must be exactly "
+                f"`## Acceptance Criteria` (found {ac_heading_near_miss[1]!r}); "
+                f"fix the heading — do NOT add a `none` opt-out to a spec that "
+                f"has criteria"
+                if ac_heading_near_miss is not None else
                 f"{rel}: invariant (vi) — spec has no `## Acceptance Criteria` "
                 "section and no `- **Acceptance Criteria:** none — <reason>` "
                 "opt-out header"

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.12.4"
+version = "2.12.5"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -440,6 +440,14 @@ mechanical rule.
   ` →`, or `<!--` — so annotated statuses satisfy the vocabulary rule.
 - **Acceptance Criteria notation.** Each criterion is a GitHub task-list item:
   `- [ ]` when open, `- [x]` when met. "Done" is the checklist, not an opinion.
+- **Acceptance Criteria opt-out.** A spec that intentionally has no
+  Acceptance-Criteria section carries
+  `- **Acceptance Criteria:** none — <one-line reason>` in its metadata header;
+  the field name `Acceptance Criteria` and value `none` use that exact casing,
+  the separator is an em dash (U+2014), and the reason is required. The linter
+  applies this gate to new specs and to specs whose section is removed in the
+  current diff; existing sectionless specs are grandfathered. A reasonless or
+  malformed marker, or a marker alongside a real section, is a hard violation.
 - **Deferral token.** A criterion that ships *unmet on purpose* because
   genuinely deferred in-scope work remains is not left unchecked and silent —
   it carries an inline `(deferred: <slug>)` marker whose `<slug>` resolves to a

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -4,18 +4,24 @@
 Builds fixture spec trees in a tempdir and runs the linter as a
 subprocess against the documented `python <skill>/scripts/lint-spec-status.py
 --root <dir>` invocation — the same shape the CI gate uses.
-Exercises each of the four invariants red-and-green, including the
+Exercises the hard and warn-only invariants red-and-green, including the
 lenient leading-token parse, the diff-triggered ship transition (with
 real git base fixtures), the grandfather and no-base branches, and the
-warn-only doc-reference invariant.
+Acceptance-Criteria section opt-out.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -57,6 +63,37 @@ def run_lint(root: Path, base_ref: str | None = None) -> tuple[int, str, str]:
         argv += ["--base-ref", base_ref]
     proc = subprocess.run(argv, capture_output=True, text=True)
     return proc.returncode, proc.stdout, proc.stderr
+
+
+@contextmanager
+def best_effort_tempdir() -> Iterator[str]:
+    """Yield a new-test tempdir despite this sandbox's rmdir restriction."""
+    tmp = tempfile.mkdtemp()
+    try:
+        yield tmp
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def load_linter_module() -> types.ModuleType:
+    """Load the core work-loop linter under a collision-proof module name."""
+    spec = importlib.util.spec_from_file_location(
+        "core_work_loop_lint_spec_status", LINTER
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    stdout = sys.stdout
+    stderr = sys.stderr
+    stdout_config = (stdout.encoding, stdout.errors)
+    stderr_config = (stderr.encoding, stderr.errors)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.stdout = stdout
+        sys.stderr = stderr
+        stdout.reconfigure(encoding=stdout_config[0], errors=stdout_config[1])
+        stderr.reconfigure(encoding=stderr_config[0], errors=stderr_config[1])
+    return module
 
 
 def git_init_commit(root: Path) -> None:
@@ -593,3 +630,348 @@ def test_fully_checked_spec_passes_under_either_casing(header: str) -> None:
         _write_spec_with_header(root, "newborn", "Shipped", "- [x] AC1 done\n", header)
         rc, out, err = run_lint(root, base_ref="HEAD")
         assert rc == 0, f"clean spec under {header!r} should exit 0, got {rc}\n{out}\n{err}"
+
+
+# ---------------------------------------------------------------------------
+# Invariant (vi): an absent Acceptance-Criteria section requires an explicit,
+# reasoned metadata opt-out. The section detector and criterion collector share
+# one heading matcher so this invariant cannot pass a spelling that (ii) misses.
+# ---------------------------------------------------------------------------
+
+
+def write_spec_without_ac_section(
+    root: Path,
+    name: str,
+    marker_value: str | None = None,
+) -> Path:
+    """Write a Draft spec with no Acceptance-Criteria section."""
+    spec = root / "docs" / "specs" / name / "spec.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    marker = (
+        f"- **Acceptance Criteria:** {marker_value}\n"
+        if marker_value is not None
+        else ""
+    )
+    spec.write_text(
+        f"# Spec: {name}\n\n- **Status:** Draft\n{marker}\n## Objective\n\nFixture.\n",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def test_vi_heading_present_without_marker_is_clean() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "has-criteria", "Draft", "- [ ] AC1 open\n")
+
+        rc, _, err = run_lint(root)
+
+        assert rc == 0, f"real AC section without opt-out should be clean: {err}"
+
+
+def test_vi_missing_heading_with_reasoned_marker_is_clean() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        reason = "this investigation prescribes no work"
+        spec = write_spec_without_ac_section(root, "opted-out", f"none — {reason}")
+
+        rc, _, err = run_lint(root)
+        parsed = load_linter_module().acceptance_criteria_opt_out(
+            spec.read_text(encoding="utf-8")
+        )
+
+        assert rc == 0, f"reasoned opt-out should be clean: {err}"
+        assert parsed is not None and parsed[1] == reason
+
+
+def test_vi_missing_heading_at_base_and_now_is_grandfathered() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        spec = write_spec_without_ac_section(root, "grandfathered")
+        git_init_commit(root)
+        spec.write_text(
+            spec.read_text(encoding="utf-8").replace("Fixture.", "Fixture updated."),
+            encoding="utf-8",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 0, f"base-sectionless spec should be grandfathered: {err}"
+        assert "hard violation" not in err
+
+
+def test_vi_losing_heading_without_marker_is_hard() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "loses-section", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        write_spec_without_ac_section(root, "loses-section")
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"removed AC section without marker should be hard: {err}"
+        assert "invariant (vi)" in err
+
+
+def test_vi_new_spec_without_heading_or_marker_is_hard() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        write_spec_without_ac_section(root, "new-sectionless")
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"new sectionless spec without marker should be hard: {err}"
+        assert "invariant (vi)" in err
+
+
+def test_vi_marker_in_body_does_not_satisfy() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "body-marker", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        spec = write_spec_without_ac_section(root, "body-marker")
+        spec.write_text(
+            spec.read_text(encoding="utf-8").replace(
+                "Fixture.",
+                "- **Acceptance Criteria:** none — marker is in the body.",
+            ),
+            encoding="utf-8",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"body marker must not satisfy the preamble contract: {err}"
+        assert "no `- **Acceptance Criteria:**" in err
+
+
+def test_vi_ascii_hyphen_marker_has_precise_near_miss_error() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        write_spec_without_ac_section(
+            root,
+            "ascii-hyphen",
+            "none - this separator is ASCII",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"ASCII-hyphen near miss should be hard: {err}"
+        assert "em dash (U+2014), not an ASCII hyphen" in err
+        assert "no `- **Acceptance Criteria:**" not in err
+
+
+def test_vi_lowercase_marker_has_precise_near_miss_error() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        spec = write_spec_without_ac_section(root, "lowercase-marker")
+        spec.write_text(
+            spec.read_text(encoding="utf-8").replace(
+                "- **Status:** Draft\n",
+                "- **Status:** Draft\n"
+                "- **Acceptance criteria:** none — lowercase field name\n",
+            ),
+            encoding="utf-8",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"lowercase near miss should be hard: {err}"
+        assert "must use exact casing `Acceptance Criteria`" in err
+        assert "no `- **Acceptance Criteria:**" not in err
+
+
+@pytest.mark.parametrize(
+    "marker_value",
+    ["none", "none —"],
+    ids=["missing-reason", "empty-reason"],
+)
+def test_vi_reasonless_marker_is_hard(marker_value: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        spec = write_spec_without_ac_section(root, "reasonless", marker_value)
+
+        rc, _, err = run_lint(root)
+        parsed = load_linter_module().acceptance_criteria_opt_out(
+            spec.read_text(encoding="utf-8")
+        )
+
+        assert rc == 1, f"reasonless opt-out should be hard: {err}"
+        assert "invariant (vi)" in err
+        assert parsed is not None and parsed[1] == ""
+
+
+def test_vi_heading_and_marker_are_a_hard_contradiction() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        spec = root / "docs" / "specs" / "contradiction" / "spec.md"
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text(
+            "# Spec: contradiction\n\n"
+            "- **Status:** Draft\n"
+            "- **Acceptance Criteria:** none — this spec prescribes no work\n\n"
+            "## Acceptance Criteria\n\n"
+            "- [ ] AC1 open\n",
+            encoding="utf-8",
+        )
+
+        rc, _, err = run_lint(root)
+
+        assert rc == 1, f"section plus opt-out should be contradictory: {err}"
+        assert "invariant (vi)" in err
+
+
+def test_vi_lowercase_heading_counts_as_present() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write_spec_with_header(
+            root,
+            "lowercase-heading",
+            "Draft",
+            "- [ ] AC1 open\n",
+            _LOWER_AC_HEADER,
+        )
+
+        rc, _, err = run_lint(root)
+
+        assert rc == 0, f"sentence-case AC heading should count as present: {err}"
+
+
+def test_vi_fenced_heading_and_checkboxes_do_not_count() -> None:
+    lint = load_linter_module()
+    fenced_example = (
+        "# Spec: fenced-heading\n\n"
+        "```markdown\n"
+        "```toml\n"
+        "## Acceptance Criteria\n\n"
+        "- [ ] example checkbox\n"
+        "```\n"
+    )
+
+    assert not lint.acceptance_criteria_section_present(fenced_example)
+    assert lint.acceptance_criteria_lines(fenced_example) == []
+
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        spec = root / "docs" / "specs" / "fenced-heading" / "spec.md"
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text(
+            fenced_example.replace(
+                "# Spec: fenced-heading\n\n",
+                "# Spec: fenced-heading\n\n- **Status:** Draft\n\n",
+            ),
+            encoding="utf-8",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"fenced example must not satisfy invariant (vi): {err}"
+        assert "invariant (vi)" in err
+
+
+def test_vi_fenced_opt_out_marker_does_not_satisfy() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        spec = root / "docs" / "specs" / "fenced-marker" / "spec.md"
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text(
+            "# Spec: fenced-marker\n\n"
+            "```markdown\n"
+            "- **Acceptance Criteria:** none — example only\n"
+            "```\n"
+            "- **Status:** Draft\n\n"
+            "## Objective\n\nFixture.\n",
+            encoding="utf-8",
+        )
+
+        lint = load_linter_module()
+        assert lint.acceptance_criteria_opt_out(
+            spec.read_text(encoding="utf-8")
+        ) is None
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"fenced marker must not satisfy invariant (vi): {err}"
+        assert "no `- **Acceptance Criteria:**" in err
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["### Acceptance Criteria\n\n", "  ## Acceptance Criteria\n\n"],
+    ids=["h3", "indented-h2"],
+)
+def test_vi_commonmark_heading_shapes_are_present(header: str) -> None:
+    lint = load_linter_module()
+    text = f"{header}- [ ] AC1 open\n"
+
+    assert lint.acceptance_criteria_section_present(text)
+    assert lint.acceptance_criteria_lines(text) == [(3, "- [ ] AC1 open")]
+
+
+def test_vi_placeholder_reason_is_rejected() -> None:
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp)
+        write_spec(root, "base", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        write_spec_without_ac_section(
+            root,
+            "placeholder-reason",
+            "none — <one-line reason>",
+        )
+
+        rc, _, err = run_lint(root, base_ref="HEAD")
+
+        assert rc == 1, f"placeholder reason must be rejected: {err}"
+        assert "non-placeholder one-line reason" in err
+
+
+def test_ac_section_detector_and_collector_share_one_pattern() -> None:
+    lint = load_linter_module()
+    lint._AC_SECTION_HEADING_RE = re.compile(
+        r"^##\s+Verification Criteria\b", re.IGNORECASE
+    )
+    shared_match = "## Verification Criteria\n\n- [ ] AC1 open\n"
+    old_match = "## Acceptance Criteria\n\n- [ ] AC1 open\n"
+
+    assert lint.acceptance_criteria_section_present(shared_match)
+    assert lint.acceptance_criteria_lines(shared_match) == [(3, "- [ ] AC1 open")]
+    assert not lint.acceptance_criteria_section_present(old_match)
+    assert lint.acceptance_criteria_lines(old_match) == []
+
+
+def test_vi_mutation_missing_section_fires_until_only_marker_is_added() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        write_spec(root, "mutation", "Draft", "- [ ] AC1 open\n")
+        git_init_commit(root)
+        spec = write_spec_without_ac_section(root, "mutation")
+        without_marker = spec.read_text(encoding="utf-8")
+        marker = (
+            "- **Acceptance Criteria:** none — mutation fixture prescribes no work\n"
+        )
+        with_marker = without_marker.replace(
+            "- **Status:** Draft\n",
+            f"- **Status:** Draft\n{marker}",
+            1,
+        )
+        assert with_marker.replace(marker, "", 1) == without_marker
+
+        lint = load_linter_module()
+        hard_before, _ = lint.check(root.resolve(), base_ref="HEAD")
+        assert hard_before, "missing-section fixture must produce a hard violation"
+        assert any("invariant (vi)" in violation for violation in hard_before)
+
+        spec.write_text(with_marker, encoding="utf-8")
+        hard_after, _ = lint.check(root.resolve(), base_ref="HEAD")
+
+        assert hard_before != hard_after, "marker mutation must change the result"
+        assert hard_after == []

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -1041,3 +1041,197 @@ def test_near_miss_heading_is_warned_not_silently_accepted() -> None:
         rc, out, err = run_lint(root, base_ref="HEAD")
         assert rc == 0, f"a near miss must warn, not fail: {out}\n{err}"
         assert "`## Acceptance Criteria`" in err, err
+
+
+def test_a_commented_out_ac_section_is_a_hard_error() -> None:
+    """The one shape the body readers get wrong, turned into a hard error.
+
+    `acceptance_criteria_section_present` and the collector read raw text, so a
+    commented-out heading counts as a section and its checkboxes are harvested:
+    (vi) satisfied and (ii) checking criteria the author disabled. Rather than
+    teach both readers to parse comments -- the change that failed four review
+    rounds -- the shape is rejected, which makes their disagreement unreachable
+    in a passing state.
+    """
+    lint = load_linter_module()
+    spec = (
+        "# Spec: s\n\n- **Status:** Shipped\n\n"
+        "<!--\n## Acceptance Criteria\n\n- [ ] disabled\n-->\n"
+    )
+    found = lint.commented_out_ac_heading(spec)
+    assert found is not None and found[0] == 6, found
+
+
+def test_a_commented_draft_beside_a_live_section_is_allowed() -> None:
+    """Only when EVERY heading is commented out. A retained draft beside a live
+    section is the author's business, and flagging it would push authors to
+    delete history to satisfy a linter."""
+    lint = load_linter_module()
+    spec = (
+        "# Spec: s\n\n## Acceptance Criteria\n\n- [x] real\n\n"
+        "<!--\n## Acceptance Criteria\n- [ ] superseded\n-->\n"
+    )
+    assert lint.commented_out_ac_heading(spec) is None
+
+
+def test_backticked_comment_syntax_does_not_trigger_the_rule() -> None:
+    """The false-positive that makes a code-span-blind rule unusable.
+
+    `docs/specs/digital-experience-contract/spec.md` documents a template whose
+    fields carry comment-syntax annotations, writing an opener and a closer in
+    backticks 23 lines apart. A reader with no notion of code spans pairs those
+    two *mentions* into a span covering that spec's real heading and all 17 of
+    its criteria, and would red-line a perfectly good spec.
+    """
+    lint = load_linter_module()
+    spec = (
+        "# Spec: s\n\n- **Status:** Shipped\n\n"
+        "- A field marked with a `<!-- Required:` annotation.\n\n"
+        "## Acceptance Criteria\n\n- [x] real\n\n"
+        "- Written as `<!-- Required: <tier>+ -->` on the next line.\n"
+    )
+    assert lint.commented_out_ac_heading(spec) is None
+    assert len(lint.acceptance_criteria_lines(spec)) == 1
+
+
+def test_an_unterminated_comment_opener_does_not_trigger_the_rule() -> None:
+    """An opener with no closer is literal text. Treating it as a comment
+    running to end of document would swallow a real section and make invariant
+    (ii) vacuous on that spec."""
+    lint = load_linter_module()
+    spec = (
+        "# Spec: s\n\n<!-- stray opener, never closed\n\n"
+        "## Acceptance Criteria\n\n- [x] real\n"
+    )
+    assert lint.commented_out_ac_heading(spec) is None
+
+
+def test_code_span_scan_is_linear_on_a_long_backtick_run() -> None:
+    """A regex formulation of this scan backtracked cubically -- a 12 KB
+    backtick line took 106 s end-to-end, against a file-size cap admitting 8 MB
+    of untrusted repository content."""
+    import time
+
+    lint = load_linter_module()
+    start = time.monotonic()
+    lint._code_span_ranges("`" * 12000)
+    assert time.monotonic() - start < 1.0
+
+
+@pytest.mark.parametrize(
+    "line,expect",
+    [
+        ("  - **Acceptance Criteria:** none — r", "column 0"),
+        ("* **Acceptance Criteria:** none — r", "`-` bullet"),
+        ("- **Acceptance Criteria**: none — r", "colon belongs inside"),
+        ("-  **Acceptance Criteria:** none — r", "exactly one space"),
+        ("- **Acceptance criteria:** none — r", "exact casing"),
+        ("- **Acceptance Criteria:** none - r", "em dash"),
+    ],
+    ids=["indented", "asterisk", "colon-outside", "double-space",
+         "casing", "hyphen"],
+)
+def test_every_attempted_opt_out_shape_is_diagnosed(line: str, expect: str) -> None:
+    """A visibly attempted opt-out must never pass in silence.
+
+    The near-miss pattern anchored on a literal `^- `, so four of these six
+    escaped BOTH readers: the spec passed clean with a malformed marker on the
+    page, and the author got no signal at all. Widening what is DIAGNOSED is not
+    widening what is ACCEPTED -- the accepting pattern stays exact.
+    """
+    lint = load_linter_module()
+    assert lint.acceptance_criteria_opt_out(line + "\n") is None, line
+    found = lint.acceptance_criteria_opt_out_near_miss(line + "\n")
+    assert found is not None, f"{line!r} escaped both readers"
+    assert expect in found[1], found
+
+
+def test_the_canonical_marker_is_still_accepted() -> None:
+    """The control for the case above: widening the diagnostic must not turn a
+    correct marker into a near miss."""
+    lint = load_linter_module()
+    line = "- **Acceptance Criteria:** none — a stated reason\n"
+    assert lint.acceptance_criteria_opt_out(line) is not None
+    assert lint.acceptance_criteria_opt_out_near_miss(line) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["tracked in the linked issue", "n/a", "see RFC-0001"],
+    ids=["prose", "n-a", "cross-reference"],
+)
+def test_a_prose_value_is_not_an_attempted_opt_out(value: str) -> None:
+    """Claiming prose in this field would hard-fail a spec that has a perfectly
+    good Acceptance-Criteria section -- the regression that made gating the
+    near-miss on the diff trigger look necessary."""
+    lint = load_linter_module()
+    line = f"- **Acceptance Criteria:** {value}\n"
+    assert lint.acceptance_criteria_opt_out_near_miss(line) is None
+
+
+def test_an_unreadable_spec_is_reported_not_silently_skipped() -> None:
+    """A spec the linter cannot read must not be reported as clean.
+
+    `_read` returns None for an unreadable file or one over the size cap, and
+    skipping quietly is a vacuous pass over an entire file -- the failure mode
+    every invariant here exists to prevent, applied to the whole document.
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root can read a mode-000 file")
+    if sys.platform == "win32":
+        pytest.skip("POSIX mode bits")
+    lint = load_linter_module()
+    with best_effort_tempdir() as tmp:
+        # Resolve: `check()` is called directly here rather than through the CLI,
+        # so it does not get `_validated_root`'s canonicalisation. On macOS
+        # mkdtemp returns /var/... while resolve() gives /private/var/..., and
+        # `_confined_path`'s relative_to() would then drop every spec silently.
+        root = Path(tmp).resolve()
+        _write_spec_with_header(
+            root, "a", "Shipped", "- [x] done\n", "## Acceptance Criteria\n\n"
+        )
+        git_init_commit(root)
+        target = root / "docs" / "specs" / "a" / "spec.md"
+        target.chmod(0o000)
+        try:
+            _hard, warn = lint.check(root, "HEAD")
+        finally:
+            target.chmod(0o644)
+    assert any("could not be read" in w for w in warn), warn
+
+
+def test_an_unresolvable_base_ref_skips_instead_of_red_lining() -> None:
+    """A base ref was taken on trust; verifying it is the whole fix.
+
+    When an explicit `--base-ref` did not resolve, `base_spec_text` returned
+    None for EVERY spec, which the diff-triggered invariants read as "new spec".
+    A typo'd or unfetched ref therefore red-lined a clean corpus and told each
+    author to add an opt-out marker for a section that was there all along --
+    while the module docstring promised the opposite. A CI job with an
+    unfetched ref got a confident, wrong failure.
+    """
+    lint = load_linter_module()
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp).resolve()
+        _write_spec_with_header(root, "sectionless", "Shipped", "", "")
+        git_init_commit(root)
+        good_hard, _ = lint.check(root, "HEAD")
+        bad_hard, bad_warn = lint.check(root, "origin/definitely-not-a-ref")
+    assert good_hard == [], good_hard
+    assert bad_hard == [], f"an unresolvable ref must not red-line: {bad_hard}"
+    assert any("does not resolve" in w for w in bad_warn), bad_warn
+    assert any("invariant (vi)" in w for w in bad_warn), bad_warn
+
+
+def test_a_resolvable_base_ref_still_drives_the_diff_triggers() -> None:
+    """The control: verification must not disable the invariants it guards."""
+    lint = load_linter_module()
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp).resolve()
+        _write_spec_with_header(
+            root, "old", "Draft", "- [x] a\n", "## Acceptance Criteria\n\n"
+        )
+        git_init_commit(root)
+        _write_spec_with_header(root, "newborn", "Shipped", "", "")
+        hard, _warn = lint.check(root, "HEAD")
+    assert any("invariant (vi)" in v for v in hard), hard

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib.util
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -621,21 +620,37 @@ def test_unchecked_ac_is_caught_whatever_the_heading_casing(header: str) -> None
     ["## Acceptance Criteria\n\n", _LOWER_AC_HEADER],
     ids=["title-case", "sentence-case"],
 )
-def test_fully_checked_spec_passes_under_either_casing(header: str) -> None:
-    """The tolerant match must not turn a clean spec red."""
+def test_fully_checked_spec_under_either_casing(header: str) -> None:
+    """A clean spec stays clean under the canonical heading; a near miss is
+    reported as a heading defect, never as a missing section.
+
+    The casings are no longer interchangeable: (vi) enforces the canonical form
+    on a new spec. What must NOT happen is the near-miss arm being told to add a
+    `none` opt-out — that would put a false "no criteria" marker on a spec that
+    has one.
+    """
+    canonical = header == "## Acceptance Criteria\n\n"
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         _write_spec_with_header(root, "preexisting", "Draft", "- [x] AC1\n", header)
         git_init_commit(root)
         _write_spec_with_header(root, "newborn", "Shipped", "- [x] AC1 done\n", header)
         rc, out, err = run_lint(root, base_ref="HEAD")
-        assert rc == 0, f"clean spec under {header!r} should exit 0, got {rc}\n{out}\n{err}"
+        if canonical:
+            assert rc == 0, f"clean spec should exit 0, got {rc}\n{out}\n{err}"
+        else:
+            assert rc == 1, f"a near-miss heading must be reported\n{out}\n{err}"
+            assert "heading must be exactly" in err, err
+            assert "do NOT add a `none` opt-out" in err, err
 
 
 # ---------------------------------------------------------------------------
 # Invariant (vi): an absent Acceptance-Criteria section requires an explicit,
-# reasoned metadata opt-out. The section detector and criterion collector share
-# one heading matcher so this invariant cannot pass a spelling that (ii) misses.
+# reasoned metadata opt-out. The section detector is EXACT while the criterion
+# collector stays permissive -- deliberately one-directional. (vi) enforces the
+# canonical heading so drift cannot reseed; (ii) keeps reading criteria it can
+# plainly see. Collapsing them either way regresses: a strict collector silently
+# un-gates (ii), a permissive detector reopens the drift path.
 # ---------------------------------------------------------------------------
 
 
@@ -909,12 +924,17 @@ def test_vi_fenced_opt_out_marker_does_not_satisfy() -> None:
     ["### Acceptance Criteria\n\n", "  ## Acceptance Criteria\n\n"],
     ids=["h3", "indented-h2"],
 )
-def test_vi_commonmark_heading_shapes_are_present(header: str) -> None:
+def test_vi_commonmark_heading_shapes_are_not_the_canonical_section(
+    header: str,
+) -> None:
+    """`###` and an indented `##` are legal CommonMark but are NOT the one
+    supported shape. They no longer satisfy (vi) -- accepting them is the drift
+    path that let six specs diverge -- while the collector still reads their
+    criteria so (ii) keeps working."""
     lint = load_linter_module()
-    text = f"{header}- [ ] AC1 open\n"
-
-    assert lint.acceptance_criteria_section_present(text)
-    assert lint.acceptance_criteria_lines(text) == [(3, "- [ ] AC1 open")]
+    spec = f"# Spec: s\n\n- **Status:** Shipped\n\n{header}\n- [x] a\n"
+    assert lint.acceptance_criteria_section_present(spec) is False, header
+    assert len(lint.acceptance_criteria_lines(spec)) == 1, header
 
 
 def test_vi_placeholder_reason_is_rejected() -> None:
@@ -934,18 +954,28 @@ def test_vi_placeholder_reason_is_rejected() -> None:
         assert "non-placeholder one-line reason" in err
 
 
-def test_ac_section_detector_and_collector_share_one_pattern() -> None:
-    lint = load_linter_module()
-    lint._AC_SECTION_HEADING_RE = re.compile(
-        r"^##\s+Verification Criteria\b", re.IGNORECASE
-    )
-    shared_match = "## Verification Criteria\n\n- [ ] AC1 open\n"
-    old_match = "## Acceptance Criteria\n\n- [ ] AC1 open\n"
+def test_collector_accepts_a_superset_of_what_the_detector_accepts() -> None:
+    """The two matchers diverge on purpose, in one direction only.
 
-    assert lint.acceptance_criteria_section_present(shared_match)
-    assert lint.acceptance_criteria_lines(shared_match) == [(3, "- [ ] AC1 open")]
-    assert not lint.acceptance_criteria_section_present(old_match)
-    assert lint.acceptance_criteria_lines(old_match) == []
+    Superset, never the reverse. If the DETECTOR ever accepted a spelling the
+    collector could not read, (vi) would report a section that (ii) reads
+    nothing from -- the vacuous pass this invariant exists to close. The other
+    direction is safe: the collector over-reading only means (ii) checks more.
+    """
+    lint = load_linter_module()
+    shapes = [
+        "## Acceptance Criteria",
+        "## Acceptance criteria",
+        "### Acceptance Criteria",
+        "  ## Acceptance Criteria",
+    ]
+    for heading in shapes:
+        spec = f"# Spec: s\n\n{heading}\n\n- [ ] AC1 open\n"
+        detected = lint.acceptance_criteria_section_present(spec)
+        collected = bool(lint.acceptance_criteria_lines(spec))
+        assert not (detected and not collected), (
+            f"{heading!r}: detector accepts a shape the collector cannot read"
+        )
 
 
 def test_vi_mutation_missing_section_fires_until_only_marker_is_added() -> None:
@@ -975,3 +1005,39 @@ def test_vi_mutation_missing_section_fires_until_only_marker_is_added() -> None:
 
         assert hard_before != hard_after, "marker mutation must change the result"
         assert hard_after == []
+
+
+def test_ac_heading_presence_is_exact_while_the_collector_is_permissive() -> None:
+    """One-directional strictness, pinned in both directions.
+
+    (vi) enforces the canonical heading so drift cannot reseed; the collector
+    stays permissive so (ii) never stops reading criteria it can plainly see.
+    """
+    lint = load_linter_module()
+    for heading in ("## Acceptance criteria", "### Acceptance Criteria",
+                    "  ## Acceptance Criteria"):
+        spec = f"# Spec: s\n\n- **Status:** Shipped\n\n{heading}\n\n- [x] a\n"
+        assert lint.acceptance_criteria_section_present(spec) is False, heading
+        assert len(lint.acceptance_criteria_lines(spec)) == 1, heading
+    canonical = (
+        "# Spec: s\n\n- **Status:** Shipped\n\n## Acceptance Criteria\n\n- [x] a\n"
+    )
+    assert lint.acceptance_criteria_section_present(canonical) is True
+    assert len(lint.acceptance_criteria_lines(canonical)) == 1
+
+
+def test_near_miss_heading_is_warned_not_silently_accepted() -> None:
+    """Silence would un-gate an adopter's spec without telling anyone.
+
+    Measured before this warning existed: making the collector strict took an
+    adopter shipping an unmet criterion under `## Acceptance criteria` from a
+    hard invariant (ii) violation to exit 0. Not breaking a build is not the
+    same as still working.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write_spec_with_header(root, "legacy", "Draft", "- [x] AC1\n", _LOWER_AC_HEADER)
+        git_init_commit(root)
+        rc, out, err = run_lint(root, base_ref="HEAD")
+        assert rc == 0, f"a near miss must warn, not fail: {out}\n{err}"
+        assert "`## Acceptance Criteria`" in err, err

--- a/packs/core/tests/skills/work-loop/test_loop_guards.py
+++ b/packs/core/tests/skills/work-loop/test_loop_guards.py
@@ -1689,7 +1689,26 @@ def test_load_failure_is_a_one_line_refusal(
     elif mode == "syntax-error":
         target.write_text("def broken(:\n", encoding="utf-8")
     elif mode == "truncated-mid-statement":
-        target.write_text(original[: len(original) // 2], encoding="utf-8")
+        # Start at the midpoint, then walk back to the first cut that genuinely
+        # will not parse. A bare `len // 2` is content-dependent: adding lines
+        # anywhere in the target can move the midpoint onto a clean statement
+        # boundary, at which point the truncated module imports fine, an
+        # unrelated later check produces the refusal, and this case silently
+        # stops exercising the loader's syntax-error path. Observed when
+        # `lint-spec-status.py` gained invariant (vi): the half-file compiled.
+        cut = len(original) // 2
+        while cut > 0:
+            try:
+                compile(original[:cut], "<truncation-fixture>", "exec")
+            except SyntaxError:
+                break
+            cut -= 1
+        assert cut > 0, (
+            f"{loader}: no syntactically invalid truncation of {target_name} "
+            f"exists at or below the midpoint — this fixture can no longer "
+            f"discriminate"
+        )
+        target.write_text(original[:cut], encoding="utf-8")
     elif mode == "truncated-clean":
         cut = original.index(cut_anchor)
         target.write_text(original[:cut], encoding="utf-8")

--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -41,8 +41,8 @@ SHARED_TESTS = (
 
 CORE_COLLECTIONS = {
     SHARED_TESTS[0]: (
-        31,
-        "947559cfdf79297e4de28fa2aaf7a013bc0947d29a8b05f22b3c4ffb66162a75",
+        50,
+        "dce60873baeaaf069dad6acd1012699127de88ae3d5ebe3337c0900049f3c23d",
     ),
     SHARED_TESTS[1]: (
         15,

--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -41,8 +41,8 @@ SHARED_TESTS = (
 
 CORE_COLLECTIONS = {
     SHARED_TESTS[0]: (
-        50,
-        "dce60873baeaaf069dad6acd1012699127de88ae3d5ebe3337c0900049f3c23d",
+        52,
+        "df8ff46dbc79af38d2b82bd35366534c9e5f5af6547d0a08d470b4b35b17a6dd",
     ),
     SHARED_TESTS[1]: (
         15,

--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -41,8 +41,8 @@ SHARED_TESTS = (
 
 CORE_COLLECTIONS = {
     SHARED_TESTS[0]: (
-        52,
-        "df8ff46dbc79af38d2b82bd35366534c9e5f5af6547d0a08d470b4b35b17a6dd",
+        70,
+        "b4e63d34dfeafd452e023f4466ab2e0b2ad5dd117061b068d10cd711a0341879",
     ),
     SHARED_TESTS[1]: (
         15,
@@ -363,6 +363,11 @@ MAKE_BASELINE_DIGESTS = {
 EXPECTED_SKIP_XFAIL_CALLS = {
     SHARED_TESTS[0]: {
         "pytest.skip(f'{name}: symlink creation unavailable ({exc})')": 1,
+        # Guards on the unreadable-spec case: POSIX mode bits do not stop a
+        # read for root, and do not exist on Windows. The test asserts a spec
+        # the linter cannot read is warned about rather than reported clean.
+        "pytest.skip('root can read a mode-000 file')": 1,
+        "pytest.skip('POSIX mode bits')": 1,
     },
     SHARED_TESTS[1]: {},
     SHARED_TESTS[2]: {

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -8,65 +8,20 @@
           "version": "2.12.4"
         }
       ],
-      "date": "2026-08-27",
-      "heading": "[core][2.12.4] — 2026-08-27",
-      "changelogAnchor": "core2124--2026-08-27",
+      "date": "2026-08-26",
+      "heading": "[core][2.12.4] — 2026-08-26",
+      "changelogAnchor": "core2124--2026-08-26",
       "highlights": [
         {
-          "source": "**Maintainers can identify every unsupported legacy workspace record from a cold status read.** Findings now retain a safe object slug instead of collapsing unrelated records under `workspace.toml`.",
+          "source": "**Newly sectionless specs say why without retroactively gating adopters.** The work-loop linter requires an explicit reason when a new spec omits its Acceptance-Criteria section or an existing spec removes that section, while grandfathering sectionless specs already present in an adopter's base ref.",
           "segments": [
             {
               "type": "strong",
-              "value": "Maintainers can identify every unsupported legacy workspace record from a cold status read."
+              "value": "Newly sectionless specs say why without retroactively gating adopters."
             },
             {
               "type": "text",
-              "value": " Findings now retain a safe object slug instead of collapsing unrelated records under "
-            },
-            {
-              "type": "code",
-              "value": "workspace.toml"
-            },
-            {
-              "type": "text",
-              "value": "."
-            }
-          ]
-        },
-        {
-          "source": "**Deferring an acceptance criterion no longer forces a legacy workspace record.** A `(deferred: …)` anchor now resolves from a canonical `{path, kind}` entry as well as a legacy `{slug}` one, so a new deferral can be recorded in the canonical shape.",
-          "segments": [
-            {
-              "type": "strong",
-              "value": "Deferring an acceptance criterion no longer forces a legacy workspace record."
-            },
-            {
-              "type": "text",
-              "value": " A "
-            },
-            {
-              "type": "code",
-              "value": "(deferred: …)"
-            },
-            {
-              "type": "text",
-              "value": " anchor now resolves from a canonical "
-            },
-            {
-              "type": "code",
-              "value": "{path, kind}"
-            },
-            {
-              "type": "text",
-              "value": " entry as well as a legacy "
-            },
-            {
-              "type": "code",
-              "value": "{slug}"
-            },
-            {
-              "type": "text",
-              "value": " one, so a new deferral can be recorded in the canonical shape."
+              "value": " The work-loop linter requires an explicit reason when a new spec omits its Acceptance-Criteria section or an existing spec removes that section, while grandfathering sectionless specs already present in an adopter's base ref."
             }
           ]
         }

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -5,12 +5,12 @@
       "packages": [
         {
           "name": "core",
-          "version": "2.12.4"
+          "version": "2.12.5"
         }
       ],
-      "date": "2026-08-26",
-      "heading": "[core][2.12.4] — 2026-08-26",
-      "changelogAnchor": "core2124--2026-08-26",
+      "date": "2026-08-27",
+      "heading": "[core][2.12.5] — 2026-08-27",
+      "changelogAnchor": "core2125--2026-08-27",
       "highlights": [
         {
           "source": "**Newly sectionless specs say why without retroactively gating adopters.** The work-loop linter requires an explicit reason when a new spec omits its Acceptance-Criteria section or an existing spec removes that section, while grandfathering sectionless specs already present in an adopter's base ref.",
@@ -22,6 +22,77 @@
             {
               "type": "text",
               "value": " The work-loop linter requires an explicit reason when a new spec omits its Acceptance-Criteria section or an existing spec removes that section, while grandfathering sectionless specs already present in an adopter's base ref."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "packages": [
+        {
+          "name": "core",
+          "version": "2.12.4"
+        }
+      ],
+      "date": "2026-08-27",
+      "heading": "[core][2.12.4] — 2026-08-27",
+      "changelogAnchor": "core2124--2026-08-27",
+      "highlights": [
+        {
+          "source": "**Maintainers can identify every unsupported legacy workspace record from a cold status read.** Findings now retain a safe object slug instead of collapsing unrelated records under `workspace.toml`.",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "Maintainers can identify every unsupported legacy workspace record from a cold status read."
+            },
+            {
+              "type": "text",
+              "value": " Findings now retain a safe object slug instead of collapsing unrelated records under "
+            },
+            {
+              "type": "code",
+              "value": "workspace.toml"
+            },
+            {
+              "type": "text",
+              "value": "."
+            }
+          ]
+        },
+        {
+          "source": "**Deferring an acceptance criterion no longer forces a legacy workspace record.** A `(deferred: …)` anchor now resolves from a canonical `{path, kind}` entry as well as a legacy `{slug}` one, so a new deferral can be recorded in the canonical shape.",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "Deferring an acceptance criterion no longer forces a legacy workspace record."
+            },
+            {
+              "type": "text",
+              "value": " A "
+            },
+            {
+              "type": "code",
+              "value": "(deferred: …)"
+            },
+            {
+              "type": "text",
+              "value": " anchor now resolves from a canonical "
+            },
+            {
+              "type": "code",
+              "value": "{path, kind}"
+            },
+            {
+              "type": "text",
+              "value": " entry as well as a legacy "
+            },
+            {
+              "type": "code",
+              "value": "{slug}"
+            },
+            {
+              "type": "text",
+              "value": " one, so a new deferral can be recorded in the canonical shape."
             }
           ]
         }

--- a/workspace.toml
+++ b/workspace.toml
@@ -1038,26 +1038,13 @@ open = [
   #   same commit. `pre-RFC-0012` needs a naming decision for the legacy on-disk
   #   layout first; the RFC-0008 refusal needs its `or` branch dropped so the
   #   assertion stops silently passing on the second clause.
-  # Unblocks when: picked up — no dependency.
-    # Split out of spec-ac-heading-casing-silent-gate 2026-08-16 when its casing
-  # half shipped (spec/spec-ac-gate-and-fixture-domains). The matcher is now
-  # case-insensitive and all 323 spec headings are canonical, so the casing hole
-  # is closed. THIS half is not: three specs carry no Acceptance-Criteria heading
-  # at all, and invariant (ii) has nothing to read for them — the same vacuous
-  # pass, reached by a different route. Deliberately not folded into the casing
-  # fix: "should a spec with no criteria fail loudly?" is a policy call about
-  # what a spec must contain, not a bug in a regex. Some specs may legitimately
-  # have none (a pure-decision or errata spec).
-  # Fix: decide whether a missing Acceptance-Criteria section is an error, a
-  #   warning, or legal-with-an-explicit-marker; then implement.
-  {slug = "spec-missing-ac-section-policy", source = "spec/spec-ac-gate-and-fixture-domains"},
-
   # Current: retained runtime messages and their assertions still embed governance
   # markers, including the legacy dist-tree name and config errors.
   # Fix: decide the legacy-layout rename and update each pinned message with its assertion
   # in one reviewed change.
   # Blocker: the fix touches protected packages/agentbundle/**; its landing commit needs
   # an Engine-Change-RFC trailer naming a real RFC.
+  # Unblocks when: picked up — no dependency.
 {slug = "packages-marker-sweep-pinned-strings", source = "spec/packages-governance-marker-sweep AC5"},
 
   # Current: the workspace-mcp spec has shipped, but Claude permissions.allow projection
@@ -1819,6 +1806,8 @@ closed = [
   {slug = "rfc0088-destination-scoped-policy-axis", type = "shape", source = "rfc/0088 open question 4", summary = "Closed by the Q4 ruling of 2026-08-21 -- egress and worker policy do collapse onto one axis whose unit is the destination group, realised as a separate browser context, and the session-wide reading is withdrawn. Residual per-group split cost stays with open entry rfc0088-destination-group-split-cost"},
 
   {slug = "npm-gate-walk-failure-untested", source = "spec-less allowScripts gate (adversarial review round 2)", summary = "Closed by making audit-npm.py's discover_lockfiles raise AuditError -- exit 2, its own could-not-run outcome -- on both an iterdir failure and a per-child classification failure, matching lint-npm-allow-scripts.py, and by covering all four guards with chmod 0o000 and 0o400 fixtures asserting exit 2 with no traceback; each guard was mutation-proven, and the cases are named case_* rather than test_* because check() accumulates instead of raising, so a pytest-collected function here would pass unconditionally"},
+
+  {slug = "spec-missing-ac-section-policy", source = "spec/spec-ac-gate-and-fixture-domains", summary = "Closed by enforcement rather than parsing: invariant (vi) requires `- **Acceptance Criteria:** none — <reason>` when a spec has no AC section, diff-triggered and grandfathered so no frozen body or adopter corpus is retroactively gated. The scan found four such specs, not three -- two were not opt-out candidates at all but had spelled their criteria as a bold label the collector could not read. Also lands one supported heading (exact, near-miss warned), a hard error for a commented-out section, specific diagnostics for every attempted opt-out shape, base-ref verification, and a warning for an unreadable spec"},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/workspace.toml
+++ b/workspace.toml
@@ -1093,6 +1093,18 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
+  # Consolidates the PR #1139 follow-on findings. Direction is enforcement, not
+  # parsing. The heading half shipped: 6 specs normalized, corpus 405/0, matcher
+  # exact with a near-miss warning. Comments and code spans CANNOT be banned --
+  # 251 of 407 specs carry a real comment, 245 in the preamble, all 407 use code
+  # spans, and the template emits 16 comments itself -- so the residual risk is
+  # one shape (a commented-out or fenced AC section, 0 specs today) and is a lint
+  # rule, not a CommonMark parser. Four rounds of the parser route are the
+  # evidence. Two robustness defects and build-site's stripper are NOT covered.
+  # Unblocks when: picked up -- no dependency.
+  {path = "docs/product/intents/spec-ac-text-normalization.md", kind = "intent", source = {mode = "repo-origin", ref = "packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py", revision = "sha256-bytes-v1:45492bdceb9a6ddb3d3fa7ec03c0aeacd9d27d7d970105f83e14905c511c2c9c"}, summary = "Enforce the one supported spec format tightly rather than parsing every variant; the heading half is done, what remains is the marker shape, two robustness defects, and build-site's separate comment stripper", needs = []},
+
+
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -1093,16 +1093,38 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
-  # Consolidates the PR #1139 follow-on findings. Direction is enforcement, not
-  # parsing. The heading half shipped: 6 specs normalized, corpus 405/0, matcher
-  # exact with a near-miss warning. Comments and code spans CANNOT be banned --
-  # 251 of 407 specs carry a real comment, 245 in the preamble, all 407 use code
-  # spans, and the template emits 16 comments itself -- so the residual risk is
-  # one shape (a commented-out or fenced AC section, 0 specs today) and is a lint
-  # rule, not a CommonMark parser. Four rounds of the parser route are the
-  # evidence. Two robustness defects and build-site's stripper are NOT covered.
+  # tools/build-site.py strips HTML comments with a bare `<!--.*?-->` and, per
+  # its own comment at :1609, resolves fenced code first -- but has no notion of
+  # INLINE code spans. Not latent: it fired on PR #1139. Changelog prose that
+  # mentioned comment syntax inside backticks opened a span that paired with a
+  # closer 5,083 lines later, leaving parse_changelog_releases with 1 release
+  # instead of ~100 and reddening the launch-window test. Split out of the spec
+  # intent deliberately -- it is a different module reading a different file, and
+  # nobody picking up "enforce the spec format" would think to fix a changelog
+  # parser.
+  # Fix: give build-site's comment stripper inline-code-span precedence --
+  #   lint-spec-status.py's `_code_span_ranges` is a linear, working reference.
   # Unblocks when: picked up -- no dependency.
-  {path = "docs/product/intents/spec-ac-text-normalization.md", kind = "intent", source = {mode = "repo-origin", ref = "packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py", revision = "sha256-bytes-v1:45492bdceb9a6ddb3d3fa7ec03c0aeacd9d27d7d970105f83e14905c511c2c9c"}, summary = "Enforce the one supported spec format tightly rather than parsing every variant; the heading half is done, what remains is the marker shape, two robustness defects, and build-site's separate comment stripper", needs = []},
+  {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "build-site.py's HTML-comment stripper has no notion of inline code spans, so backticked comment syntax in changelog prose can open a real comment span and swallow thousands of lines"},
+
+  # What is LEFT of the spec-format work after PR #1139. The heading half, the
+  # commented-out-section rule, the marker-shape diagnostics, the base-ref
+  # verification, and the unreadable-spec warning all shipped there. This entry
+  # is the residue that enforcement does NOT reach: the four Acceptance-Criteria
+  # readers still hold different notions of which text counts, and the shipped
+  # guard makes the one dangerous shape a hard error rather than reconciling
+  # them. Four review rounds of reconciling them produced a cubically
+  # backtracking regex, a Theta(L^1.5) replacement, fence state read from raw
+  # text, and comment-blind fence pairing -- each passing its own verification.
+  # Comments and code spans cannot simply be banned: 251 of 407 specs carry a
+  # real comment, 245 in the preamble, all 407 use code spans, and the template
+  # emits 16 comments itself.
+  # Fix: decide whether the remaining divergence is worth closing at all now
+  #   that its one reachable shape is gated. If yes, it is a parsing decision
+  #   (real Markdown parser vs. narrowing what the readers must understand),
+  #   not a regex tweak.
+  # Unblocks when: picked up -- no dependency.
+  {path = "docs/product/intents/spec-ac-text-normalization.md", kind = "intent", source = {mode = "repo-origin", ref = "packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py", revision = "sha256-bytes-v1:45492bdceb9a6ddb3d3fa7ec03c0aeacd9d27d7d970105f83e14905c511c2c9c"}, summary = "Residual Acceptance-Criteria reader divergence after the format enforcement shipped; its one reachable shape is now a hard error, so what remains is a parsing decision rather than a defect", needs = []},
 
 
   # Unblocks when: the allowlist gains its first entry.


### PR DESCRIPTION
## What does this change?

Two things, both about making the Acceptance-Criteria contract *enforced* rather
than *inferred*:

1. **Invariant (vi)** — a spec with no `## Acceptance Criteria` section must
   carry `- **Acceptance Criteria:** none — <one-line reason>`. Diff-triggered
   and grandfathered against the base ref.
2. **One supported heading** — `## Acceptance Criteria` exactly. Six drifted
   specs are normalized and the matcher no longer accepts the variants that let
   them drift.

## Why?

Invariant (ii) checks that every criterion is `[x]` or deferred when a spec
ships — reading them from a `## Acceptance Criteria` section. A spec with no
such section gives it nothing to read, so it **passes vacuously**.

- Closes backlog: `spec-missing-ac-section-policy`

**Grandfathered on purpose.** Applied unconditionally, (vi) would force edits to
frozen spec bodies and hand adopters a retroactive hard gate. It fires only when
a spec is new, or removes its section in a diff.

## The heading, and why the matcher tightened

The matcher was case-insensitive and accepted `###` and up to three leading
spaces. That is *how* six specs drifted to `## Acceptance criteria` despite the
`new-spec` template emitting the canonical form all along — a hand-written
variant passed silently, so nothing corrected it. Accepting the variant **was**
the drift path.

All six are normalized, verified meaning-preserving by comparing collected
criteria before and after — 30/15/10/15/19/4, byte-identical each time. Corpus
is now **405 canonical / 0 variants / 2 deliberate opt-outs**.

**Strictness is one-directional, and the asymmetry is the point:**

| reader | matcher | why |
| --- | --- | --- |
| invariant (vi) — "is there a section?" | **exact** | enforces the format; drift cannot reseed |
| criterion collector — feeds (ii) | permissive | never stops reading criteria it can see |

Measured before the split existed: an adopter shipping a spec with an **unmet**
criterion under `## Acceptance criteria` went from `invariant (ii) — AC is
unchecked and not deferred` (exit 1) to a warning and **exit 0**. A strict
collector did not break their build — it silently stopped catching a real
violation, which is worse. Over-reading is safe; under-reading is how a gate
goes quiet.

A near-miss heading is **warned, never ignored**, and the hard message names the
right remedy: the generic "no section and no opt-out" text would have told an
author to add a `none` marker to a spec that *has* criteria, manufacturing the
false marker the invariant exists to prevent.

## How do I verify it?

```
python3 -m pytest packs/core/tests/skills/work-loop/test_lint_spec_status.py -q   # 52 passed
python3 -m pytest tools/test_local_ci_shared_test_deduplication.py -q             # 26 passed
python3 packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py --root .     # EXIT=0
python3 tools/lint-ruff.py                                                       # EXIT=0
```

Mutation-tested, each mutant dying with **no crash markers** and 52 passing on
restore:

| mutation | result |
| --- | --- |
| detector collapsed to permissive (reopens drift) | 5 failed |
| collector collapsed to exact (un-gates (ii)) | 5 failed |
| near-miss remedy message dropped | 1 failed |

Grandfathering verified end-to-end on fixture repos: sectionless at base **and**
now → clean; new spec without a section → hard; section removed in the diff →
hard.

## What did you not change that you considered?

- **HTML comments and inline code spans.** Measured: 251 of 407 specs carry a
  real comment, 245 in the metadata preamble, all 407 use code spans, and the
  template emits 16 comments itself. Both are load-bearing spec detail, so the
  readers keep their different jobs — the preamble reader strips comments
  because it must, the body readers don't because no spec needs it.
- **A text-normalization layer for fenced/commented content.** Attempted and
  withdrawn after four review rounds, which produced in sequence a cubically
  backtracking regex (12 KB line → 106 s), a Θ(L^1.5) replacement (1 MB →
  15.0 s), fence state read from raw text, and comment-blind fence pairing.
  Each passed its own verification. Registered as an intent with the
  measurements attached.
- **Two robustness defects** — an unvalidated explicit `--base-ref`, and a
  silently skipped unreadable or oversized spec. Neither is format-shaped.
- **`tools/build-site.py`'s comment stripper**, which has the same code-span
  blindness over changelog prose. It fired on this branch, leaving
  `parse_changelog_releases` with 1 release instead of ~100.
- **Migrating 182 legacy `{slug = ...}` backlog entries** to the schema shape.
  Every initiative queue is already schema-shaped; the backlog lists are the
  residue, and that is a durable-register change of its own.

---

## Checklist

- [x] Tests pass locally (see commands above)
- [x] Lint and typecheck pass
- [x] Self-review run via `adversarial-reviewer` and `quality-engineer`; findings
      adjudicated, sustained ones fixed or registered
- [x] Spec and code agree
- [x] Living docs match reality — `CONVENTIONS.md` documents the marker;
      `new-spec` template carries the hint
- [x] `docs/product/changelog.md` updated — free-standing `## [core][2.12.4]`
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured