### PR TITLE
test(deps): cover the npm gates' could-not-run walks and fail audit-npm closed

### DIFF
--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -56,7 +56,8 @@ facts, and reporting the second as the first is how a gate sits green for weeks)
   1  at least one non-allowlisted advisory at or above the blocking threshold.
   2  the gate could not run: npm absent, unreadable or unparseable audit output,
      an error payload, an unrecognised report schema, a malformed allowlist,
-     no lockfile discovered at all, or a canary probe that came back silent.
+     an unreadable directory during lockfile discovery, no lockfile discovered
+     at all, or a canary probe that came back silent.
 """
 
 from __future__ import annotations
@@ -150,20 +151,23 @@ def discover_lockfiles(root: Path) -> list[Path]:
         try:
             entries = list(current.iterdir())
         except OSError as exc:
-            # Not silent: an unreadable directory is almost always a permissions
-            # artifact, but a walk that quietly skipped the one directory holding
-            # a lockfile would under-cover and still print green. The
-            # no-lockfile-found guard in main() only catches total failure, so
-            # partial failure has to announce itself.
-            print(f"audit-npm: warning: cannot read {current}: {exc}", file=sys.stderr)
-            continue
+            # A partial walk could skip a project and report a clean audit over
+            # an under-covered tree, so it is a tool error rather than a warning.
+            raise AuditError(f"cannot read {current}: {exc}") from exc
         for entry in entries:
-            if entry.is_dir():
+            try:
+                is_directory = entry.is_dir()
+                is_symlink = entry.is_symlink()
+            except OSError as exc:
+                # A directory may list successfully but deny traversal, making
+                # per-child classification fail after iterdir() has succeeded.
+                raise AuditError(f"cannot classify {entry}: {exc}") from exc
+            if is_directory:
                 # Symlinked directories are skipped for loop safety; symlinked
                 # *files* are not, so a lockfile linked into place is still
                 # audited rather than silently dropped.
                 if (
-                    entry.is_symlink()
+                    is_symlink
                     or entry.name in _PRUNED_DIR_NAMES
                     or entry.name.startswith(".")
                 ):
@@ -455,7 +459,11 @@ def main(argv: list[str]) -> int:
         print(f"audit-npm: {exc}", file=sys.stderr)
         return 2
 
-    lockfiles = discover_lockfiles(root)
+    try:
+        lockfiles = discover_lockfiles(root)
+    except AuditError as exc:
+        print(f"audit-npm: {exc}", file=sys.stderr)
+        return 2
     if not lockfiles:
         # Fail closed. Zero lockfiles means discovery broke or the tree moved —
         # both of which would otherwise present as a green gate over nothing.

--- a/tools/test-audit-npm.py
+++ b/tools/test-audit-npm.py
@@ -22,8 +22,12 @@ Exit 0 = every case passed; 1 = at least one failed.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import os
 import pathlib
+import shutil
 import sys
 import tempfile
 
@@ -153,6 +157,82 @@ def expect_error(name: str, fn) -> None:
     else:
         FAILURES.append(name)
         print(f"  ✖ {name}: returned normally, expected AuditError", file=sys.stderr)
+
+
+def _permission_fixtures_supported() -> bool:
+    """Whether POSIX mode bits can make the synthetic walk paths inaccessible."""
+    return os.name == "posix" and os.geteuid() != 0
+
+
+def _write_allowlist(root: pathlib.Path) -> None:
+    """Give audit-npm's CLI the empty allowlist it requires before discovery."""
+    allowlist = root / "tools" / "npm-audit-allowlist.toml"
+    allowlist.parent.mkdir()
+    allowlist.write_text("", encoding="utf-8")
+
+
+def _assert_walk_failure(name: str, root: pathlib.Path, diagnostic: str) -> None:
+    """Assert the CLI reports a bounded discovery error instead of a traceback."""
+    m = _load_subject()
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        exit_code = m.main(["--root", str(root)])
+    output = stderr.getvalue()
+    check(name, exit_code == 2, f"exit_code={exit_code}; stderr={output}")
+    check(f"{name}_names_failure", diagnostic in output, output)
+    check(f"{name}_has_no_traceback", "Traceback" not in output, output)
+
+
+# Avoid a test_ prefix: these stdlib self-tests run through main(), while pytest would pass this because check() accumulates failures.
+def case_discovery_iterdir_permission_failure() -> None:
+    """An unreadable directory makes the audit CLI exit 2 without a traceback."""
+    if not _permission_fixtures_supported():
+        print(
+            "  - discovery_iterdir_permission_failure skipped (root or non-POSIX)"
+        )
+        return
+    root = pathlib.Path(tempfile.mkdtemp(prefix="audit-npm-unreadable-"))
+    unreadable = root / "unreadable"
+    try:
+        _write_allowlist(root)
+        unreadable.mkdir()
+        unreadable.chmod(0o000)
+        try:
+            _assert_walk_failure(
+                "discovery_iterdir_permission_failure_exits_2",
+                root,
+                "cannot read",
+            )
+        finally:
+            unreadable.chmod(0o700)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def case_discovery_child_classification_permission_failure() -> None:
+    """A listable but untraversable directory fails per-child classification."""
+    if not _permission_fixtures_supported():
+        print(
+            "  - discovery_child_classification_permission_failure skipped "
+            "(root or non-POSIX)"
+        )
+        return
+    root = pathlib.Path(tempfile.mkdtemp(prefix="audit-npm-listable-"))
+    listable = root / "listable"
+    try:
+        _write_allowlist(root)
+        (listable / "child").mkdir(parents=True)
+        listable.chmod(0o400)
+        try:
+            _assert_walk_failure(
+                "discovery_child_classification_permission_failure_exits_2",
+                root,
+                "cannot classify",
+            )
+        finally:
+            listable.chmod(0o700)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
 
 
 def main() -> int:
@@ -287,6 +367,10 @@ def main() -> int:
               f"found={found}")
         check("still_finds_symlinked_lockfile", "third/package-lock.json" in found,
               f"found={found}")
+
+    print("discover_lockfiles() — permission failures")
+    case_discovery_iterdir_permission_failure()
+    case_discovery_child_classification_permission_failure()
 
     print("advisory_id() — GHSA/CVE from url, else npm source id")
     check("id_from_ghsa_url",

--- a/tools/test-lint-npm-allow-scripts.py
+++ b/tools/test-lint-npm-allow-scripts.py
@@ -9,6 +9,7 @@ least one assertion failed.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -95,8 +96,67 @@ def combined(proc: subprocess.CompletedProcess[str]) -> str:
     return f"{proc.stdout}\n{proc.stderr}"
 
 
+def permission_fixtures_supported() -> bool:
+    """Whether POSIX mode bits can make the synthetic walk paths inaccessible."""
+    return os.name == "posix" and os.geteuid() != 0
+
+
+# Avoid a test_ prefix: these stdlib self-tests run through main(), while pytest would pass this because check() accumulates failures.
+def case_discovery_iterdir_permission_failure() -> None:
+    """An unreadable directory makes the checker exit 2 without a traceback."""
+    if not permission_fixtures_supported():
+        print("  skip discovery_iterdir_permission_failure (root or non-POSIX)")
+        return
+    root = fixture_root("npm-allow-unreadable-")
+    unreadable = root / "unreadable"
+    try:
+        unreadable.mkdir()
+        unreadable.chmod(0o000)
+        proc = run(root)
+        check(
+            "discovery iterdir permission failure exits 2",
+            proc.returncode == 2,
+            combined(proc),
+        )
+        check("discovery iterdir permission failure names the read error",
+              "cannot read" in proc.stderr, combined(proc))
+        check("discovery iterdir permission failure has no traceback",
+              "Traceback" not in combined(proc), combined(proc))
+    finally:
+        unreadable.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def case_discovery_child_classification_permission_failure() -> None:
+    """A listable but untraversable directory reaches the child-stat guard."""
+    if not permission_fixtures_supported():
+        print(
+            "  skip discovery_child_classification_permission_failure "
+            "(root or non-POSIX)"
+        )
+        return
+    root = fixture_root("npm-allow-listable-")
+    listable = root / "listable"
+    try:
+        (listable / "child").mkdir(parents=True)
+        listable.chmod(0o400)
+        proc = run(root)
+        check("discovery child classification permission failure exits 2",
+              proc.returncode == 2, combined(proc))
+        check("discovery child classification permission failure names the classification error",
+              "cannot inspect" in proc.stderr, combined(proc))
+        check("discovery child classification permission failure has no traceback",
+              "Traceback" not in combined(proc), combined(proc))
+    finally:
+        listable.chmod(0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
 def main() -> int:
     print("test-lint-npm-allow-scripts:")
+
+    case_discovery_iterdir_permission_failure()
+    case_discovery_child_classification_permission_failure()
 
     root = fixture_root("npm-allow-clean-")
     try:

--- a/workspace.toml
+++ b/workspace.toml
@@ -1132,21 +1132,6 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
-  # Both npm gates decide "the walk could not complete" and neither has a
-  # regression test for it. lint-npm-allow-scripts.py now raises CheckError and
-  # exits 2 on an iterdir failure AND on a per-child stat failure (a dir at mode
-  # 0o400 lists but does not traverse) — the second path shipped broken and was
-  # caught by review, not by a test, because no fixture plants an unreadable
-  # directory. Its sibling tools/audit-npm.py still warns-and-continues on the
-  # same error, which is the "never actually ran, reported as clean" outcome its
-  # own three-outcome exit contract exists to prevent.
-  # Fix: plant chmod 0o000 and chmod 0o400 fixtures in
-  #   tools/test-lint-npm-allow-scripts.py asserting exit 2 with no traceback
-  #   (skip under root and on Windows), and give audit-npm.py the same
-  #   could-not-run treatment.
-  # Unblocks when: picked up — no dependency.
-  {slug = "npm-gate-walk-failure-untested", source = "spec-less allowScripts gate (adversarial review round 2)", summary = "Neither npm gate has a regression test for a partial directory walk, and audit-npm.py still treats one as a clean result"},
-
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
 
@@ -1845,6 +1830,8 @@ closed = [
   {slug = "selftest-mutates-tracked-makefile", summary = "Closed for tracked-file mutation; lint-performance-p0 moved plants to fixtures, while selftest-untracked-plant-window owns the residual untracked-file risk", source = "spec/npm-sca-gate (unrelated find)"},
 
   {slug = "npm-allowscripts-enforcement", source = "spec/npm-sca-gate", summary = "Closed by repinning web's fsevents to 2.3.3 through a package.json overrides entry -- playwright pins 2.3.2 exactly, so npm install alone could never dedupe it -- and adding tools/lint-npm-allow-scripts.py, which compares each project's lockfile install-script set against its allowScripts map in both directions"},
+
+  {slug = "npm-gate-walk-failure-untested", source = "spec-less allowScripts gate (adversarial review round 2)", summary = "Closed by making audit-npm.py's discover_lockfiles raise AuditError -- exit 2, its own could-not-run outcome -- on both an iterdir failure and a per-child classification failure, matching lint-npm-allow-scripts.py, and by covering all four guards with chmod 0o000 and 0o400 fixtures asserting exit 2 with no traceback; each guard was mutation-proven, and the cases are named case_* rather than test_* because check() accumulates instead of raising, so a pytest-collected function here would pass unconditionally"},
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes backlog item **`npm-gate-walk-failure-untested`**.

## The defect

Both npm gates decide "the walk could not complete" and neither had a regression test for it.

- `tools/lint-npm-allow-scripts.py` already raised `CheckError` on an `iterdir` failure *and* on a per-child stat failure (a directory at mode `0o400` lists but does not traverse). The second path **shipped broken and was caught by review, not by a test**, because no fixture planted an unreadable directory.
- `tools/audit-npm.py` warned and continued on the same error — the "never actually ran, reported as clean" outcome that its own three-outcome exit contract exists to prevent.

## The change

`discover_lockfiles` now raises `AuditError` on both failure modes, each reaching the existing exit-2 path. Both `is_dir()` and `is_symlink()` sit inside one `try`, matching the sibling — hoisting only the first left an `OSError` able to escape as a traceback, which independent review caught here too.

Four fixtures (`chmod 0o000` and `0o400`) cover all four guards, asserting exit 2 with the bounded diagnostic and no traceback. Skipped under root and off POSIX; the mode is restored before cleanup so no unreadable directory is left behind.

The new cases are named `case_*`, not `test_*`. Both files accumulate through a `check()` that never raises, so a pytest-collected function here passes unconditionally — verified: `pytest tools/test-audit-npm.py` reported "2 passed" both with the guard present and with it deleted.

## Gates — all run locally against the final tree

| Gate | Result |
|---|---|
| `python3 tools/test-audit-npm.py` | exit 0 |
| `python3 tools/test-lint-npm-allow-scripts.py` | exit 0 |
| `python3 tools/audit-npm.py --root .` (live) | exit 0, 2 lockfiles audited |
| `make lint-ruff` | exit 0 |
| `SKIP_SAST=1 make build-check` | exit 0 |
| `make sast` | exit 0 (pip-audit, npm SCA, semgrep, argv-boundary 8/8) |
| `pytest tools/test-audit-npm.py` | collects 0 items — intended |

## Mutation proofs

Anchor uniqueness asserted, real runner used, restore verified by sha256. Each guard's `raise` replaced with `continue`:

| Guard | Baseline | Mutated | Restore |
|---|---|---|---|
| `audit-npm` `iterdir` | 0 | **1** | byte-identical |
| `audit-npm` per-child | 0 | **1** | byte-identical |
| `lint-npm-allow-scripts` `iterdir` | 0 | **1** | byte-identical |
| `lint-npm-allow-scripts` per-child | 0 | **1** | byte-identical |

The widened `is_symlink()` half is defensive parity with the sibling and is **not** independently test-reachable: on a `0o400` parent both calls fail and `is_dir()` raises first.

## Review

Independent Codex session (Terra/medium), given the diff, gates and conventions, told not to edit. Returned one major finding — the unprotected `entry.is_symlink()` — which I verified against `lint-npm-allow-scripts.py:104-108` before applying. Fixed, then the full gate set and all four mutation proofs were re-run.

## Routing

Full-mode durable artifacts (spec + plan) were **waived in-session by the repository owner** for this batch of mechanical backlog chores. Gates, mutation proofs, and independent review were kept.