### PR TITLE
ci: key non-PR concurrency groups on run_id so security scans cannot be evicted

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -16,8 +16,8 @@ name: ci-security
 #   - gitleaks --redact: matched secret values never reach (public) CI logs.
 #   - Binary checksums: SHA-256 hardcoded in this file (not fetched from the same
 #     origin as the binary) — upstream tampering fails the gate at-rest.
-#   - cancel-in-progress: gated to pull_request events only — push-to-main scans
-#     run to completion.
+#   - concurrency: pull-request runs share a ref group; each non-PR run gets a
+#     unique run_id group, so push-to-main scans cannot be evicted while pending.
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-security-${{ github.ref }}
+  group: ci-security-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,10 +28,13 @@ on:
     # Weekly re-scan catches newly-published queries against unchanged code.
     - cron: "27 4 * * 1"
 
-# A newer push to the same ref supersedes an in-flight scan.
+# Pull-request runs share a ref group, so a newer PR push supersedes an in-flight
+# scan. Every non-PR run (push or schedule) gets a unique run_id group, preventing
+# a push-to-main from evicting the weekly re-scan; for a security scanner, a
+# redundant scan is safer than one silently evicted while pending.
 concurrency:
-  group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  group: codeql-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default floor for any future job. The analyzer's elevated permissions remain
 # scoped to that job below.

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -75,8 +75,17 @@ def main() -> int:
                 f"workflow-level contents:read is sufficient — no escalation allowed"
             )
 
-    # Concurrency: cancel-in-progress must be conditional on pull_request only.
+    # Concurrency: PR runs share a ref group; non-PR runs must be unique.
     concurrency = doc.get("concurrency", {})
+    expected_group = (
+        "ci-security-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+    )
+    if concurrency.get("group") != expected_group:
+        fail(
+            "concurrency.group must be "
+            f"{expected_group!r} so non-PR scans cannot be evicted; "
+            f"got: {concurrency.get('group')!r}"
+        )
     cancel = str(concurrency.get("cancel-in-progress", ""))
     if "pull_request" not in cancel:
         fail(

--- a/workspace.toml
+++ b/workspace.toml
@@ -468,16 +468,32 @@ open = [
   # fixture. Its eight assertions now BLOCK make build-check with no automated proof
   # they can fail, so a silently-weakened one would pass. Building that harness was
   # outside the wiring chore and needs an owner decision.
-  # The SECOND IS STILL OPEN. This is why the slug survives — docs/adr/0086 and
-  # spec/ci-gate-parallelization both cite it, and both are frozen:
-  # ci-security.yml documents "cancel-in-progress gated to pull_request only —
-  # push-to-main scans run to completion", and codeql.yml uses unconditional
-  # cancel-in-progress on a push trigger. Both rest on a false belief — GitHub
-  # allows one running plus one PENDING run per concurrency group regardless of
-  # that flag, so a third queued run cancels the pending one. See AC12 of
-  # spec/ci-gate-parallelization for the group expression that avoids it.
-  # To close: fix both workflows' concurrency-group expressions, and decide whether
-  # the posture test earns a mutation harness.
+  # The SECOND IS ALSO CLOSED (2026-08-27). ci-security.yml and codeql.yml both
+  # keyed their concurrency group on bare github.ref, and GitHub allows one
+  # running plus one PENDING run per group regardless of cancel-in-progress, so a
+  # third queued run evicted the pending one and a commit could go unscanned with
+  # no signal. Both now carry AC12's expression from spec/ci-gate-parallelization
+  # — PR runs share a ref group, every non-PR run keys on github.run_id — and
+  # ci-security.yml's literal is pinned in test-ci-security-workflow.py, so a
+  # regression to the bare-ref form now fails build-check. codeql.yml's
+  # cancel-in-progress moved to the pull_request gate, so pushes to main and the
+  # weekly re-scan run to completion instead of superseding each other. The two
+  # frozen citations (docs/adr/0086 lines 111-118, spec/ci-gate-parallelization)
+  # stand as the historical record; ADR-0086's "note for the next author" is what
+  # authorised the fix. Accepted consequence, recorded rather than discovered
+  # later: two concurrent CodeQL runs on different main commits can now upload
+  # SARIF out of order, so the Security tab can transiently reflect the older
+  # commit until the next analysis. That is judged better than the previous
+  # behaviour, where the newer commit was simply never scanned.
+  # THE RESIDUAL, and the only reason the slug survives: test-ci-security-workflow.py
+  # still has no --self-test and no fixture. Unlike its chain neighbour
+  # test-build-check-workflow.py, which runs a mutation matrix on every
+  # invocation, its now-nine assertions block make build-check with no automated
+  # proof they can fail, so a silently-weakened one would pass. codeql.yml has no
+  # posture test at all — a mutation of its group expression is caught by nothing,
+  # confirmed by a deliberate control run on 2026-08-27.
+  # To close: decide whether the posture test earns a mutation harness, and
+  # whether codeql.yml earns a posture test of its own. Owner decision, not a chore.
   {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions


### PR DESCRIPTION
Closes the open half of backlog item **`ci-security-posture-test-unwired`**. The entry survives for a residual owner decision — see the bottom of this description.

## The defect

`ci-security.yml` and `codeql.yml` both keyed their concurrency group on bare `github.ref`. GitHub permits **one running plus one pending** run per group *regardless of `cancel-in-progress`*, so a third queued run evicts the pending one. On a secret scanner and a taint analyser that means a commit can go unscanned with no signal.

`docs/adr/0086-*.md:111-118` names this exactly:

> **A note for the next author:** `ci-security.yml` documents "cancel-in-progress gated to pull_request only — push-to-main scans run to completion", and `codeql.yml` uses unconditional `cancel-in-progress` on a push trigger. Both rest on a false premise […] Do not copy that group shape; see the spec's AC12 for one that keys non-PR events uniquely.

## The change

Both workflows now carry AC12's expression (already live in `build-check.yml:27-29` and `pages.yml:64-66`):

```yaml
group: <name>-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR runs share a ref group and still supersede. Every non-PR run keys on `run_id`, so nothing can evict it. `github.head_ref` is not used — it is fork-supplied, so two fork PRs on one branch name could cancel each other.

`codeql.yml`'s `cancel-in-progress` moves to the `pull_request` gate. Pushes to `main` and the weekly re-scan now run to completion instead of superseding each other; previously a push could evict the scheduled re-scan, since both resolved to `refs/heads/main`.

Both header comments were rewritten — the originals stated the false premise, and after this change they would have been *accidentally* true for the wrong reason.

`ci-security.yml`'s group is pinned as a **literal** in `tools/test-ci-security-workflow.py`; AC12 requires the literal because "a property statement is not pinnable".

### Accepted consequence, recorded rather than discovered later

Two concurrent CodeQL runs on different `main` commits can now upload SARIF out of order, so the Security tab may transiently reflect the older commit until the next analysis. Judged better than the previous behaviour, where the newer commit was simply never scanned.

## Gates — all run locally against the final tree

| Gate | Result |
|---|---|
| `python3 tools/test-ci-security-workflow.py` | exit 0 |
| `actionlint` on both changed workflows | exit 0 |
| `python3 tools/check-zizmor-excessive-permissions.py` | clean |
| `python3 tools/lint-ci-parity.py` | ok — 79 steps, all dispositioned |
| `pytest tools/test_build_gate_chain.py` | 40 passed, 28 subtests |
| `make lint-ruff` | exit 0 |
| `SKIP_SAST=1 make build-check` | exit 0 |
| `make sast` | exit 0 |

## Mutation proofs

Anchor uniqueness asserted, restore verified by sha256:

| Mutation | Outcome |
|---|---|
| `ci-security.yml` group → `ci-security-${{ github.ref }}` | **caught** |
| `ci-security.yml` `cancel-in-progress` → `true` | **caught** |
| *control:* `codeql.yml` group → `codeql-${{ github.ref }}` | **survived — nothing pins `codeql.yml`** |

The control is deliberate. It is the honest measurement of what this PR does and does not pin.

## Review

Independent Codex session (Terra/medium), given the diff, gates, ADR-0086, AC12 and conventions, told not to edit. Returned **clean with evidence** — it worked through the three-rapid-pushes case before and after, checked `github.ref`/`event_name` under `schedule:`, verified `github.head_ref` is absent, checked each rewritten comment against the YAML it describes, and investigated the SARIF-upload-ordering risk rather than asserting it away.

## Residual — the backlog entry stays open

`tools/test-ci-security-workflow.py` still has no `--self-test` and no fixture. Unlike its chain neighbour `test-build-check-workflow.py`, which runs a mutation matrix on every invocation, its nine assertions block `make build-check` with no automated proof they can fail. `codeql.yml` has no posture test at all. Both are owner decisions, not chores, and were explicitly declined as out of scope here.

## Routing

Full-mode durable artifacts (spec + plan) were **waived in-session by the repository owner** for this batch of mechanical backlog chores. Gates, mutation proofs, and independent review were kept.