### PR TITLE
test(credbroker): add Windows arm to killed-holder test, discharge AC11

### DIFF
--- a/docs/specs/sso-store-transition-serialization/spec.md
+++ b/docs/specs/sso-store-transition-serialization/spec.md
@@ -274,17 +274,16 @@ new concurrency module must be collected by that step rather than skipped.
       model the 2 s bar was not derived from. The run is recorded in
       [`manual-qa.md`](./manual-qa.md) with the machine, the OS version, and the
       twenty timings.
-- [ ] **AC11.** (deferred: sso-ac11-windows-kill-arm) A process killed with
+- [x] **AC11.** A process killed with
       `SIGKILL` (POSIX) while holding the lock leaves the profile usable: a
       subsequent invocation acquires the lock and completes. No lockfile is
-      deleted, recreated, or aged out to achieve this. The POSIX arm is
+      deleted, recreated, or aged out to achieve this. The POSIX arm was
       implemented and passing. The Windows `TerminateProcess` equivalent —
-      eventual acquisition within the retry budget — is **not**: the kill tests
-      are `skipif`-ed on `os.name != "posix"`, which this spec records as a gap
-      rather than a justified skip, since `Popen.kill()` *is*
-      `TerminateProcess` and nothing establishes the runner cannot drive it.
-      The contention test is deliberately not skipped — it sends no signal and
-      runs everywhere, including the platform that needs it most.
+      eventual acquisition within the retry budget — was added with
+      `Popen.kill()`. The `pytest credbroker (windows)` job runs it on a
+      `windows-latest` runner. The contention test is deliberately not skipped
+      — it sends no signal and runs everywhere, including the platform that
+      needs it most.
 - [x] **AC12.** Contention is classified by **which call raised and on
       `exc.errno`** — never by exception type. A refusal from the acquire call
       itself is contention and retries toward the budget, then exits `6`:

--- a/packages/credbroker/tests/unit/test_sso_lock_wiring.py
+++ b/packages/credbroker/tests/unit/test_sso_lock_wiring.py
@@ -14,7 +14,6 @@ import importlib.util
 import json
 import os
 import pathlib
-import signal
 import subprocess
 import sys
 import textwrap
@@ -242,7 +241,6 @@ def test_a_second_process_contends_with_a_real_holder(broker, tmp_path):
         child.wait(10)
 
 
-@pytest.mark.skipif(os.name != "posix", reason="SIGKILL semantics")
 def test_a_killed_holder_leaves_the_profile_usable(broker, tmp_path):
     """AC11: no profile is bricked by a lock, and nothing reaps one to achieve it.
 
@@ -256,12 +254,19 @@ def test_a_killed_holder_leaves_the_profile_usable(broker, tmp_path):
         stdout=subprocess.PIPE, text=True,
     )
     assert child.stdout.readline().strip() == "held"
-    child.send_signal(signal.SIGKILL)
+    child.kill()
     child.wait(10)
 
-    # No sleep, no retry loop, no cleanup step: the lock is simply free.
-    with broker._profile_lock("jira", budget_s=2):
-        pass
+    if os.name == "posix":
+        # `budget_s=0` permits one attempt: no sleep, retry loop, or cleanup;
+        # the lock must already be free when the killed holder is reaped.
+        with broker._profile_lock("jira", budget_s=0):
+            pass
+    else:
+        # TerminateProcess may release asynchronously, so use the bounded
+        # retry path: eventual acquisition within AC11's two-second budget.
+        with broker._profile_lock("jira", budget_s=2):
+            pass
     assert broker._sso_lock_path("jira").exists(), (
         "the lockfile must survive; unlinking it would let two processes hold "
         "locks on different inodes for the same profile"

--- a/workspace.toml
+++ b/workspace.toml
@@ -800,14 +800,6 @@ open = [
   # Settle with operator consent on macOS by recording twenty projected-broker timings in
   # the existing manual-QA artifact.
   {slug = "sso-ac10-end-to-end-timing", source = "spec/sso-store-transition-serialization AC10"},
-    # AC11 promises a Windows arm for the killed-holder case — eventual reacquisition within the
-    # retry budget — and the T7 kill tests are skipif-ed on os.name != "posix" instead.
-    # Popen.kill() is TerminateProcess and nothing establishes the windows-latest runner cannot
-    # drive it, so this is a gap rather than a justified skip. Fix: add the Windows arm to
-    # test_a_killed_holder_leaves_the_profile_usable, or record the concrete runner limitation.
-    # Unblocks: now. Note the contention test is deliberately NOT skipped — it sends no signal.
-  {slug = "sso-ac11-windows-kill-arm", source = "spec/sso-store-transition-serialization AC11"},
-
   # Current: at-most-once recapture is process-local, so repeated agent invocations can
   # launch a headless refresh each time.
   # Fix: persist a per-profile last-attempt timestamp and enforce a cooldown.
@@ -1838,6 +1830,8 @@ closed = [
   {slug = "rfc0088-token-replay-consumer-contract", type = "shape", source = "rfc/0088 open question 5", summary = "Closed by the Q5 ruling of 2026-08-22 -- scoped-token replay is supported and the residual exposure is declared per destination. The declaration carrier is owned by open entry rfc0088-spec-2-result-policy-contracts; note RFC-0088 assigns that carrier to Spec 1 while the open entry places it on Spec 2, which the Spec 1/2 authors must reconcile"},
 
   {slug = "rfc0088-destination-scoped-policy-axis", type = "shape", source = "rfc/0088 open question 4", summary = "Closed by the Q4 ruling of 2026-08-21 -- egress and worker policy do collapse onto one axis whose unit is the destination group, realised as a separate browser context, and the session-wide reading is withdrawn. Residual per-group split cost stays with open entry rfc0088-destination-group-split-cost"},
+
+  {slug = "sso-ac11-windows-kill-arm", source = "spec/sso-store-transition-serialization AC11", summary = "Closed by dropping the os.name != 'posix' skipif from test_a_killed_holder_leaves_the_profile_usable and driving the kill through Popen.kill(), which is TerminateProcess on Windows -- the arm runs in build-check-windows.yml's `pytest credbroker (windows)` job, so the runner limitation the entry offered as the alternative does not exist. The two platforms now assert different things rather than the same thing twice: POSIX takes budget_s=0, measured at 1ms against 2001ms for budget_s=2, so it proves the lock is free the instant the holder is reaped; Windows keeps the bounded retry path AC11 actually promises there. AC11 was discharged in the frozen spec following the e2f6da41b precedent -- box checked, deferral marker removed, status commentary rewritten in past tense, criterion proper untouched"},
 
   {slug = "npm-gate-walk-failure-untested", source = "spec-less allowScripts gate (adversarial review round 2)", summary = "Closed by making audit-npm.py's discover_lockfiles raise AuditError -- exit 2, its own could-not-run outcome -- on both an iterdir failure and a per-child classification failure, matching lint-npm-allow-scripts.py, and by covering all four guards with chmod 0o000 and 0o400 fixtures asserting exit 2 with no traceback; each guard was mutation-proven, and the cases are named case_* rather than test_* because check() accumulates instead of raising, so a pytest-collected function here would pass unconditionally"},
 


### PR DESCRIPTION
## What

Closes backlog item `sso-ac11-windows-kill-arm`.

AC11 in the `sso-store-transition-serialization` spec promised a Windows arm for the killed-holder case (eventual reacquisition within the retry budget), but `test_a_killed_holder_leaves_the_profile_usable` was `skipif`-ed on `os.name != 'posix'`. The alternative branch of the backlog entry — record the concrete runner limitation — required showing the runner cannot drive it. It can: `.github/workflows/build-check-windows.yml:111-133` already runs the full credbroker suite on `windows-latest`, so this was a coverage gap, not a justified skip.

## Changes

- **`packages/credbroker/tests/unit/test_sso_lock_wiring.py`** — Drop the `skipif`; replace `child.send_signal(signal.SIGKILL)` with `child.kill()` (cross-platform: SIGKILL on POSIX, TerminateProcess on Windows). Add platform-branched assertion: POSIX uses `budget_s=0` (single-attempt, no retry loop — proves lock is free the instant the killed holder is reaped; measured 1 ms vs 2001 ms for `budget_s=2`); Windows uses `budget_s=2` (bounded retry, which is what AC11 actually promises there).
- **`docs/specs/sso-store-transition-serialization/spec.md`** — AC11 discharged following the `e2f6da41b` precedent: checkbox flipped to `[x]`, `(deferred: sso-ac11-windows-kill-arm)` marker removed, status commentary rewritten in past tense, criterion proper untouched.
- **`workspace.toml`** — Slug moved from `[backlog].open` to `[backlog].closed`.

## Gates (POSIX/macOS)

| Gate | Result |
|---|---|
| `make lint-ruff` | ✅ exit 0 |
| `SKIP_SAST=1 make build-check` | ✅ exit 0 |
| `make sast` | ✅ exit 0 |

## Mutation proofs

- `child.kill()` removed → `TimeoutExpired` from `child.wait(10)` — **caught**
- `budget_s=0` → `budget_s=2` on POSIX branch → test still passes (more permissive, not less) — **survived** (expected; POSIX strictness is a design claim, not a gate assertion; documented rather than hidden)

## Windows evidence

The Windows arm's only real execution evidence is the `pytest credbroker (windows)` job in this PR's CI. Do not merge until that job is green.

## Waiver note

Repository owner waived full-mode durable artifacts (spec/plan authoring, approval gates) for this batch of mechanical chores in-session, on the record. Groups G1 (#1140) and G2 (#1141) already merged under it.