### PR TITLE
fix(tools): give build-site's changelog comment stripper code-span precedence

### DIFF
--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1457,19 +1457,21 @@ _BULLET_RE = re.compile(r"^[ \t]*[-*+][ \t]+(.*)$")
 _FENCE_RE_CHANGELOG = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
 
 
-# Copied from packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py.
-# Importing from a shipped pack would couple this repository tool to a
-# content-pinned, independently versioned artifact.
-def _code_span_ranges(line: str) -> list[tuple[int, int]]:
-    r"""Inline code spans on one line, by a linear scan over backtick runs.
+# `_backtick_runs` and the run-pairing rule below are COPIED from
+# packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py:158
+# (`_code_span_ranges`), not imported: tools/ must not couple to a
+# content-pinned, independently versioned pack tree. Copied as a run scanner
+# plus an interleaved pairing step rather than as one whole-line helper,
+# because a whole-line span list cannot express "a comment's interior
+# contributes no delimiters" -- see `_strip_changelog_comments`. The pairing
+# is also precomputed here instead of probed per run: upstream's probe loop
+# rescans on every unmatched run, measured 0.46 s against this file's 0.17 s
+# on 2,000 strictly-increasing runs.
+def _backtick_runs(line: str) -> list[tuple[int, int]]:
+    """Every maximal backtick run on one line, as ``(start, length)``.
 
-    A run of N backticks opens; the next run of exactly N closes. Deliberately
-    not a regex: the obvious ``(`+)(?:(?!\1).)*?\1`` backtracks cubically on a
-    long backtick run -- measured, a 12 KB backtick line took 106 s.
-
-    RAW docstring on purpose. The upstream copy is not, so its two `\1`
-    backreferences parse as chr(1) and the regex it warns you off is unreadable
-    at runtime -- which defeats the only job this docstring has.
+    Split out of `_code_span_ranges` so the comment stripper can pair runs
+    lazily. The scan itself is unchanged.
     """
     runs: list[tuple[int, int]] = []
     index, length = 0, len(line)
@@ -1482,77 +1484,82 @@ def _code_span_ranges(line: str) -> list[tuple[int, int]]:
             index = end
         else:
             index += 1
-    spans: list[tuple[int, int]] = []
-    cursor = 0
-    while cursor < len(runs):
-        open_at, open_len = runs[cursor]
-        probe = cursor + 1
-        while probe < len(runs) and runs[probe][1] != open_len:
-            probe += 1
-        if probe < len(runs):
-            spans.append((open_at, runs[probe][0] + runs[probe][1]))
-            cursor = probe + 1
-        else:
-            cursor += 1
-    return spans
+    return runs
 
 
 def _strip_changelog_comments(line: str) -> tuple[str, bool]:
-    """Strip real HTML comments and report an unclosed opener on this line.
+    r"""Strip real HTML comments and report an unclosed opener on this line.
 
-    An opener inside a same-line code span is a mention, not a comment. Once a
-    real opener is found its closer stays code-span blind: Markdown is not
-    parsed inside HTML comments, so backticks there are literal text.
+    ONE left-to-right pass in which comment detection and code-span pairing
+    interleave; whichever construct starts earlier at the cursor consumes its
+    extent. An opener inside a code span is a mention. Once a real opener is
+    found, its closer search is code-span blind -- Markdown is not parsed
+    inside an HTML comment.
 
-    A span is honoured only while it starts inside the CURRENT segment — the
-    text after the last comment already consumed. Without that rule a backtick
-    inside one real comment paired with a backtick inside the NEXT one, and the
-    bogus span covered the second comment's opener, so it read as a mention and
-    its body published. Measured on
-    ``- Ship it <!-- don`t publish --> <!-- TODO: internal `note` --> ``, whose
-    maintainer note reached the public page instead of being stripped. Same rule
-    as the blind closer search: a comment's interior contributes no delimiters,
-    because Markdown is not parsed inside it.
+    The interleaving is the correctness argument, and two earlier shapes got it
+    wrong in ways worth naming, because both looked right:
 
-    Recomputing spans per segment would also be correct, but is quadratic —
-    measured 4.6 s on 3,000 inline pairs, reintroducing the denial-of-service
-    the linear scan exists to avoid. Both cursors below only move forward, so
-    one pass over the span list serves every segment.
+    1. Pair over the WHOLE line, then mask openers that fall inside a span. A
+       backtick inside one real comment paired with a backtick inside the NEXT
+       one; the bogus span covered the second comment's opener, so it read as a
+       mention and its body published. Measured leak:
+       ``- Ship it <!-- don`t publish --> <!-- TODO: internal `note` -->``.
+    2. Same, plus discarding spans that start before the current segment. That
+       stops a comment interior CREATING a bogus span, but not from STEALING
+       the partner of a later legitimate mention -- the interior still supplies
+       a delimiter, one level down. Measured hard failure:
+       ``<!-- drop the ` here --> Write `<!--` to mention it`` raised
+       "unterminated HTML comment" on a line containing no such thing, failing
+       the whole site build.
+
+    Both are the same root cause: filtering the OUTPUT of a whole-line pairing
+    cannot express "a comment's interior contributes no delimiters". Only
+    interleaving can, because a skipped comment's runs are never examined.
+
+    Linear by construction. `_next_run_of_same_length` is precomputed in one
+    backward pass, so pairing is O(1) per run and never rescans -- no quadratic
+    recompute (a per-segment re-pair measured 4.6 s on 3,000 inline pairs) and
+    no backtracking regex (measured 74 s on a 12 KB backtick run).
     """
-    code_spans = _code_span_ranges(line)
+    runs = _backtick_runs(line)
+    # run index -> index of the next run of identical length, or -1.
+    next_same: list[int] = [-1] * len(runs)
+    latest: dict[int, int] = {}
+    for index in range(len(runs) - 1, -1, -1):
+        next_same[index] = latest.get(runs[index][1], -1)
+        latest[runs[index][1]] = index
+    run_at = {start: index for index, (start, _) in enumerate(runs)}
+
     pieces: list[str] = []
-    search_from = 0
     kept_from = 0
-    segment_start = 0
-    span_index = 0
+    position = 0
+    length = len(line)
 
-    while True:
-        opener = line.find("<!--", search_from)
-        if opener < 0:
-            pieces.append(line[kept_from:])
-            return "".join(pieces), False
-
-        # Skip spans that cannot mask this opener: one that ends before it, and
-        # one that starts in a comment already consumed (or straddles it).
-        while span_index < len(code_spans) and (
-            code_spans[span_index][0] < segment_start
-            or code_spans[span_index][1] <= opener
-        ):
-            span_index += 1
-        if (
-            span_index < len(code_spans)
-            and code_spans[span_index][0] <= opener < code_spans[span_index][1]
-        ):
-            search_from = opener + len("<!--")
+    while position < length:
+        if line.startswith("<!--", position):
+            # A real comment: emit what precedes it and skip its whole extent.
+            # Its interior is never scanned, so nothing inside it can pair.
+            pieces.append(line[kept_from:position])
+            closer = line.find("-->", position + len("<!--"))
+            if closer < 0:
+                return "".join(pieces), True
+            kept_from = closer + len("-->")
+            position = kept_from
             continue
+        if line[position] == "`":
+            index = run_at[position]
+            partner = next_same[index]
+            if partner < 0:
+                # An unpaired run is literal text, not a delimiter.
+                position += runs[index][1]
+            else:
+                # A code span: skip it whole, mention and all.
+                position = runs[partner][0] + runs[partner][1]
+            continue
+        position += 1
 
-        pieces.append(line[kept_from:opener])
-        closer = line.find("-->", opener + len("<!--"))
-        if closer < 0:
-            return "".join(pieces), True
-        kept_from = closer + len("-->")
-        segment_start = kept_from
-        search_from = kept_from
+    pieces.append(line[kept_from:])
+    return "".join(pieces), False
 
 
 def _slug_base(text: str) -> str:

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1455,7 +1455,85 @@ _BULLET_RE = re.compile(r"^[ \t]*[-*+][ \t]+(.*)$")
 #    highlight prose. Being permissive here fails closed: more content skipped,
 #    never less.
 _FENCE_RE_CHANGELOG = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
-_COMMENT_INLINE_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+# Copied from packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py.
+# Importing from a shipped pack would couple this repository tool to a
+# content-pinned, independently versioned artifact.
+def _code_span_ranges(line: str) -> list[tuple[int, int]]:
+    r"""Inline code spans on one line, by a linear scan over backtick runs.
+
+    A run of N backticks opens; the next run of exactly N closes. Deliberately
+    not a regex: the obvious ``(`+)(?:(?!\1).)*?\1`` backtracks cubically on a
+    long backtick run -- measured, a 12 KB backtick line took 106 s.
+
+    RAW docstring on purpose. The upstream copy is not, so its two `\1`
+    backreferences parse as chr(1) and the regex it warns you off is unreadable
+    at runtime -- which defeats the only job this docstring has.
+    """
+    runs: list[tuple[int, int]] = []
+    index, length = 0, len(line)
+    while index < length:
+        if line[index] == "`":
+            end = index
+            while end < length and line[end] == "`":
+                end += 1
+            runs.append((index, end - index))
+            index = end
+        else:
+            index += 1
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    while cursor < len(runs):
+        open_at, open_len = runs[cursor]
+        probe = cursor + 1
+        while probe < len(runs) and runs[probe][1] != open_len:
+            probe += 1
+        if probe < len(runs):
+            spans.append((open_at, runs[probe][0] + runs[probe][1]))
+            cursor = probe + 1
+        else:
+            cursor += 1
+    return spans
+
+
+def _strip_changelog_comments(line: str) -> tuple[str, bool]:
+    """Strip real HTML comments and report an unclosed opener on this line.
+
+    An opener inside a same-line code span is a mention, not a comment. Once a
+    real opener is found its closer stays code-span blind: Markdown is not
+    parsed inside HTML comments, so backticks there are literal text.
+    """
+    code_spans = _code_span_ranges(line)
+    pieces: list[str] = []
+    search_from = 0
+    kept_from = 0
+    span_index = 0
+
+    while True:
+        opener = line.find("<!--", search_from)
+        if opener < 0:
+            pieces.append(line[kept_from:])
+            return "".join(pieces), False
+
+        while (
+            span_index < len(code_spans)
+            and code_spans[span_index][1] <= opener
+        ):
+            span_index += 1
+        if (
+            span_index < len(code_spans)
+            and code_spans[span_index][0] <= opener < code_spans[span_index][1]
+        ):
+            search_from = opener + len("<!--")
+            continue
+
+        pieces.append(line[kept_from:opener])
+        closer = line.find("-->", opener + len("<!--"))
+        if closer < 0:
+            return "".join(pieces), True
+        kept_from = closer + len("-->")
+        search_from = kept_from
 
 
 def _slug_base(text: str) -> str:
@@ -1637,16 +1715,20 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
         # slot that `github-slugger` never sees, which would shift every later
         # `-N` suffix and point source links at the wrong release.
         if in_comment:
+            # Deliberately code-span blind: Markdown is not parsed inside an
+            # HTML comment, so backticks cannot mask its real closer.
             if "-->" not in raw:
                 continue
             in_comment = False
             comment_opened_at = None
             raw = raw.split("-->", 1)[1]
-        raw = _COMMENT_INLINE_RE.sub("", raw)
-        if "<!--" in raw:
-            raw = raw.split("<!--", 1)[0]
+        raw, opens_comment = _strip_changelog_comments(raw)
+        if opens_comment:
             in_comment = True
             comment_opened_at = lineno
+            # Deliberate divergence from lint-spec-status.py: this builder does
+            # not treat an unterminated real opener as literal text. The final
+            # raise prevents one typo from silently swallowing later releases.
 
         opener = _FENCE_RE_CHANGELOG.match(raw)
         if opener is not None:

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1503,11 +1503,27 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
     An opener inside a same-line code span is a mention, not a comment. Once a
     real opener is found its closer stays code-span blind: Markdown is not
     parsed inside HTML comments, so backticks there are literal text.
+
+    A span is honoured only while it starts inside the CURRENT segment — the
+    text after the last comment already consumed. Without that rule a backtick
+    inside one real comment paired with a backtick inside the NEXT one, and the
+    bogus span covered the second comment's opener, so it read as a mention and
+    its body published. Measured on
+    ``- Ship it <!-- don`t publish --> <!-- TODO: internal `note` --> ``, whose
+    maintainer note reached the public page instead of being stripped. Same rule
+    as the blind closer search: a comment's interior contributes no delimiters,
+    because Markdown is not parsed inside it.
+
+    Recomputing spans per segment would also be correct, but is quadratic —
+    measured 4.6 s on 3,000 inline pairs, reintroducing the denial-of-service
+    the linear scan exists to avoid. Both cursors below only move forward, so
+    one pass over the span list serves every segment.
     """
     code_spans = _code_span_ranges(line)
     pieces: list[str] = []
     search_from = 0
     kept_from = 0
+    segment_start = 0
     span_index = 0
 
     while True:
@@ -1516,9 +1532,11 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
             pieces.append(line[kept_from:])
             return "".join(pieces), False
 
-        while (
-            span_index < len(code_spans)
-            and code_spans[span_index][1] <= opener
+        # Skip spans that cannot mask this opener: one that ends before it, and
+        # one that starts in a comment already consumed (or straddles it).
+        while span_index < len(code_spans) and (
+            code_spans[span_index][0] < segment_start
+            or code_spans[span_index][1] <= opener
         ):
             span_index += 1
         if (
@@ -1533,6 +1551,7 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
         if closer < 0:
             return "".join(pieces), True
         kept_from = closer + len("-->")
+        segment_start = kept_from
         search_from = kept_from
 
 

--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1465,13 +1465,15 @@ _FENCE_RE_CHANGELOG = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
 # because a whole-line span list cannot express "a comment's interior
 # contributes no delimiters" -- see `_strip_changelog_comments`. The pairing
 # is also precomputed here instead of probed per run: upstream's probe loop
-# rescans on every unmatched run, measured 0.46 s against this file's 0.17 s
-# on 2,000 strictly-increasing runs.
+# rescans on every unmatched run, which is quadratic when many distinct-length
+# runs precede a long tail of equal-length ones -- measured 2.25 s against this
+# file's 0.06 s on 300 distinct-length runs followed by 120,000 length-1 runs.
 def _backtick_runs(line: str) -> list[tuple[int, int]]:
     """Every maximal backtick run on one line, as ``(start, length)``.
 
-    Split out of `_code_span_ranges` so the comment stripper can pair runs
-    lazily. The scan itself is unchanged.
+    The run scan of lint-spec-status.py's `_code_span_ranges`, split from its
+    pairing half so the comment stripper can pair runs as it goes. The scan
+    itself is byte-identical to the original.
     """
     runs: list[tuple[int, int]] = []
     index, length = 0, len(line)
@@ -1487,7 +1489,38 @@ def _backtick_runs(line: str) -> list[tuple[int, int]]:
     return runs
 
 
-def _strip_changelog_comments(line: str) -> tuple[str, bool]:
+def _span_splits_a_comment(line: str, span_start: int, span_end: int) -> bool:
+    """Does this code span hold a comment opener whose closer is outside it?
+
+    That is the authoring mistake worth reporting: the span swallows the
+    `<!--`, so the comment is never stripped and its body publishes. A `<!--`
+    fully enclosed with its `-->`, or one with no closer anywhere, is an
+    ordinary backticked mention -- the changelog carries many, and reporting
+    those would bury the real signal.
+    """
+    opener = line.find("<!--", span_start, span_end)
+    while opener >= 0:
+        closer = line.find("-->", opener + len("<!--"))
+        if closer >= 0 and closer + len("-->") > span_end:
+            return True
+        opener = line.find("<!--", opener + len("<!--"), span_end)
+    return False
+
+
+class _StrippedLine(NamedTuple):
+    """One changelog line with its real HTML comments removed.
+
+    `masks_split_comment` is the authoring diagnostic: a code span swallowed
+    the opener of a comment whose closer sits outside it, so that comment's
+    body survives into published copy.
+    """
+
+    text: str
+    opens_comment: bool
+    masks_split_comment: bool
+
+
+def _strip_changelog_comments(line: str) -> _StrippedLine:
     r"""Strip real HTML comments and report an unclosed opener on this line.
 
     ONE left-to-right pass in which comment detection and code-span pairing
@@ -1516,10 +1549,24 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
     cannot express "a comment's interior contributes no delimiters". Only
     interleaving can, because a skipped comment's runs are never examined.
 
-    Linear by construction. `_next_run_of_same_length` is precomputed in one
-    backward pass, so pairing is O(1) per run and never rescans -- no quadratic
-    recompute (a per-segment re-pair measured 4.6 s on 3,000 inline pairs) and
-    no backtracking regex (measured 74 s on a 12 KB backtick run).
+    Linear by construction. `next_same` below is precomputed in one backward
+    pass, so pairing is O(1) per run and never rescans -- no quadratic recompute
+    (a per-segment re-pair measured 4.6 s on 3,000 inline pairs) and no
+    backtracking regex (measured 74 s on a 12 KB backtick run).
+
+    Leftmost-wins, so it is CommonMark-faithful, and that has a consequence:
+    an UNBALANCED backtick in prose pairs into a following real comment, so
+    that comment's body sits inside a code span, is literal text, and
+    publishes. The old whole-line regex stripped it. Rendering stays
+    CommonMark, but the pipeline errs toward withholding (see the module note
+    on Highlights above), so the third return value reports it rather than
+    letting it publish in silence.
+
+    Reported only when the span CUTS A COMMENT IN HALF -- its extent holds a
+    `<!--` whose matching `-->` is not also inside it. A fully enclosed
+    ``` `<!-- x -->` ``` is an ordinary mention, and so is a `<!--` with no
+    closer at all; the changelog is full of both, and flagging them would make
+    the diagnostic fire on every correct line.
     """
     runs = _backtick_runs(line)
     # run index -> index of the next run of identical length, or -1.
@@ -1534,6 +1581,7 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
     kept_from = 0
     position = 0
     length = len(line)
+    masks_split_comment = False
 
     while position < length:
         if line.startswith("<!--", position):
@@ -1542,11 +1590,16 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
             pieces.append(line[kept_from:position])
             closer = line.find("-->", position + len("<!--"))
             if closer < 0:
-                return "".join(pieces), True
+                return _StrippedLine("".join(pieces), True, masks_split_comment)
             kept_from = closer + len("-->")
             position = kept_from
             continue
         if line[position] == "`":
+            # `position` always lands on a run START, never mid-run, so this
+            # subscript cannot KeyError: an unpaired run advances to its own
+            # end, a paired one to its partner's end, the comment branch to
+            # just after `>`, and `+= 1` from a non-backtick -- and a run is
+            # maximal, so the character after one is never a backtick.
             index = run_at[position]
             partner = next_same[index]
             if partner < 0:
@@ -1554,12 +1607,17 @@ def _strip_changelog_comments(line: str) -> tuple[str, bool]:
                 position += runs[index][1]
             else:
                 # A code span: skip it whole, mention and all.
-                position = runs[partner][0] + runs[partner][1]
+                span_end = runs[partner][0] + runs[partner][1]
+                if not masks_split_comment:
+                    masks_split_comment = _span_splits_a_comment(
+                        line, position, span_end
+                    )
+                position = span_end
             continue
         position += 1
 
     pieces.append(line[kept_from:])
-    return "".join(pieces), False
+    return _StrippedLine("".join(pieces), False, masks_split_comment)
 
 
 def _slug_base(text: str) -> str:
@@ -1708,6 +1766,7 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
     comment_opened_at: int | None = None
     ambiguous: list[tuple[int, str]] = []
     misplaced: list[tuple[int, int, str]] = []
+    split_comments: list[tuple[int, str]] = []
 
     for lineno, raw in enumerate(lines, start=1):
         # Fenced code wins over comment syntax: `<!--` inside a shell sample is
@@ -1748,8 +1807,14 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
             in_comment = False
             comment_opened_at = None
             raw = raw.split("-->", 1)[1]
-        raw, opens_comment = _strip_changelog_comments(raw)
-        if opens_comment:
+        stripped = _strip_changelog_comments(raw)
+        raw = stripped.text
+        if stripped.masks_split_comment:
+            # An unbalanced backtick paired into a real comment, so that
+            # comment's body would publish. Rendering stays CommonMark; this
+            # reports the authoring mistake instead of shipping it in silence.
+            split_comments.append((lineno, lines[lineno - 1].strip()))
+        if stripped.opens_comment:
             in_comment = True
             comment_opened_at = lineno
             # Deliberate divergence from lint-spec-status.py: this builder does
@@ -1871,6 +1936,7 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
             ],
             "misplaced_highlights": misplaced,
             "unreleased_regions": ambiguous,
+            "code_span_split_comments": split_comments,
         },
     )
 

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1545,6 +1545,118 @@ def test_a_comment_inside_a_fenced_block_is_sample_text_not_a_comment():
     assert [g["packages"][0]["name"] for g in _groups(text)] == ["later", "pkg"]
 
 
+def test_a_backticked_comment_opener_does_not_swallow_later_releases():
+    """A code-span mention must not open a comment or trigger the final raise.
+
+    Without code-span precedence, this prose opened an unterminated HTML
+    comment and generation failed instead of publishing the later release.
+    """
+    text = """# Changelog
+
+## [first][1.0.0] — 2026-08-05
+
+### Highlights
+
+- First.
+
+A note mentioning `<!--` in backticks.
+
+## [later][2.0.0] — 2026-08-06
+
+### Highlights
+
+- Later.
+"""
+    assert [g["packages"][0]["name"] for g in _groups(text)] == ["later", "first"]
+
+
+def test_backticked_comment_markers_on_separate_lines_are_both_inert():
+    """Separate code-span mentions must not hide a release between them.
+
+    A code-span-blind parser paired these mentions as an HTML comment and
+    published only one of the three releases.
+    """
+    text = """# Changelog
+
+## [first][1.0.0] — 2026-08-05
+
+A note mentioning `<!--` in backticks.
+
+## [middle][2.0.0] — 2026-08-06
+
+A note mentioning `-->` in backticks.
+
+## [last][3.0.0] — 2026-08-07
+"""
+    releases = build_site.parse_changelog_releases(text).releases
+    assert [release["packages"][0]["name"] for release in releases] == [
+        "first", "middle", "last",
+    ]
+
+
+def test_backticks_inside_a_real_comment_do_not_mask_its_closer():
+    """Backticks are literal inside HTML comments, so `-->` still closes one.
+
+    Applying the code-span mask while already inside a comment would leave this
+    real comment unterminated and swallow both releases below it.
+    """
+    text = """# Changelog
+
+<!--
+Backticks are literal inside a comment, so this `-->` closes it.
+
+## [first][1.0.0] — 2026-08-05
+
+## [later][2.0.0] — 2026-08-06
+"""
+    releases = build_site.parse_changelog_releases(text).releases
+    assert [release["packages"][0]["name"] for release in releases] == [
+        "first", "later",
+    ]
+
+
+def test_a_backticked_comment_opener_inside_a_fence_remains_sample_text():
+    """Fence handling must stay ahead of code-span-aware comment handling.
+
+    Moving the new masking ahead of the established fence state machine could
+    make a backticked sample opener swallow the later real release.
+    """
+    text = """# Changelog
+
+```markdown
+A sample mentions `<!--` without a closer.
+```
+
+## [real][1.0.0] — 2026-08-05
+"""
+    releases = build_site.parse_changelog_releases(text).releases
+    assert [release["packages"][0]["name"] for release in releases] == ["real"]
+
+
+def test_comment_mentions_respect_matching_backtick_run_lengths():
+    """Only an equal-length backtick run closes an inline code span.
+
+    Treating any nearby backtick as a delimiter would miss the double-backtick
+    span and the single-backtick span nested inside a longer run.
+    """
+    text = """# Changelog
+
+## [first][1.0.0] — 2026-08-05
+
+A double-backtick span mentions ``<!--`` safely.
+
+## [middle][2.0.0] — 2026-08-06
+
+A longer span contains a single-backtick span: ``` `<!--` ```.
+
+## [last][3.0.0] — 2026-08-07
+"""
+    releases = build_site.parse_changelog_releases(text).releases
+    assert [release["packages"][0]["name"] for release in releases] == [
+        "first", "middle", "last",
+    ]
+
+
 def test_an_unterminated_html_comment_fails_instead_of_swallowing_the_file():
     text = """# Changelog
 
@@ -1707,6 +1819,9 @@ def test_the_window_does_not_filter_the_projection():
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CHANGELOG = _REPO_ROOT / "docs" / "product" / "changelog.md"
+# Measured at 171 releases on 2026-08-27. A floor of 130 is about 76% of that,
+# leaving headroom for ordinary changelog churn while still detecting collapse.
+_MIN_REAL_CHANGELOG_RELEASES = 130
 _PROJECTION = _REPO_ROOT / "web" / "src" / "lib" / "now-highlights.generated.json"
 _MARKETING_SHARED_CHROME_PROJECTION = (
     _REPO_ROOT / "web" / "src" / "lib" / "shared-chrome.generated.json"
@@ -1791,6 +1906,20 @@ def test_the_real_changelog_has_no_silently_withheld_highlights():
         for lineno, title in parsed.diagnostics["unreleased_regions"]
     ]
     assert not regions, "\n".join(regions)
+
+
+def test_the_real_changelog_parser_keeps_a_sane_release_population():
+    """A parser state leak must not silently collapse the real release history."""
+    parsed = build_site.parse_changelog_releases(
+        _CHANGELOG.read_text(encoding="utf-8")
+    )
+    actual = len(parsed.releases)
+    assert actual >= _MIN_REAL_CHANGELOG_RELEASES, (
+        f"the real changelog parsed only {actual} releases, below the safety floor "
+        f"of {_MIN_REAL_CHANGELOG_RELEASES}; parser state likely swallowed the "
+        "remaining release history — inspect HTML-comment and fenced-code handling "
+        "in tools/build-site.py::parse_changelog_releases"
+    )
 
 
 def test_no_projected_release_heading_lives_under_an_unreleased_region():

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1664,6 +1664,93 @@ A longer span contains a single-backtick span: ``` `<!--` ```.
     ]
 
 
+def test_a_backtick_in_one_comment_does_not_mask_the_next_comments_opener():
+    """Two real comments on one line are both stripped, not just the first.
+
+    Code spans are resolved per comment-free segment for exactly this input.
+    Resolving them once over the whole line paired the lone backtick inside
+    comment one with the backtick inside comment two; the bogus span covered
+    comment two's opener, so it read as a mention and its body published. This
+    bullet shipped an internal maintainer note to the public /now/ page.
+    """
+    text = """# Changelog
+
+## [pkg][1.0.0] — 2026-08-05
+
+### Highlights
+
+- Ship it <!-- don`t publish --> <!-- TODO: internal `note` for us -->.
+"""
+    assert _bullets(_groups(text)[0]) == ["Ship it  ."]
+
+
+def test_every_inline_comment_pair_on_a_line_is_stripped_not_just_the_first():
+    """The deleted `_COMMENT_INLINE_RE.sub` was GLOBAL; that must not regress.
+
+    A stripper handling only the first pair per line passes every other test
+    here and still parses the real changelog identically, so nothing else
+    pins this. Its real failure is the companion test below: the trailing
+    unterminated opener goes unnoticed and later releases publish silently.
+    """
+    text = """# Changelog
+
+## [pkg][1.0.0] — 2026-08-05
+
+### Highlights
+
+- Fixed <!-- t1 --> a bug <!-- TODO --> today <!-- t3 -->.
+"""
+    assert _bullets(_groups(text)[0]) == ["Fixed  a bug  today ."]
+
+
+def test_an_opener_after_a_closed_pair_on_the_same_line_still_opens_a_comment():
+    """`<!-- a --><!--` leaves a real comment open, and the parse must say so.
+
+    This is what a first-pair-only stripper gets wrong in a way that matters:
+    it would consume the pair, never see the trailing opener, and publish the
+    release below instead of failing.
+    """
+    text = """# Changelog
+
+<!-- a --><!--
+
+## [b][2.0.0] — 2026-08-06
+
+### Highlights
+
+- Would vanish.
+"""
+    try:
+        build_site.project_now_highlights(text)
+    except ValueError as exc:
+        assert "unterminated HTML comment" in str(exc)
+        assert "line 3" in str(exc), str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("a trailing opener after a closed pair was missed")
+
+
+def test_the_code_span_scan_stays_linear_on_a_long_backtick_run():
+    """The copied scan must not be "simplified" into the cubic regex.
+
+    Upstream pins this at packs/core/tests/skills/work-loop/
+    test_lint_spec_status.py; the copy needs its own guard, since no changelog
+    line would ever exercise it. The regex the docstring warns off took a
+    measured 106 s on this input; the scan takes under a millisecond, so a
+    generous ceiling still fails loudly if someone swaps it back.
+    """
+    import time
+
+    line = "`" * 12_000
+    started = time.monotonic()
+    build_site._code_span_ranges(line)
+    build_site._strip_changelog_comments(line + "<!--")
+    elapsed = time.monotonic() - started
+    assert elapsed < 5.0, (
+        f"the code-span scan took {elapsed:.1f}s on a 12 KB backtick run; a "
+        "backtracking regex was measured at 106s here — restore the linear scan"
+    )
+
+
 def test_an_unterminated_html_comment_fails_instead_of_swallowing_the_file():
     text = """# Changelog
 
@@ -1826,8 +1913,12 @@ def test_the_window_does_not_filter_the_projection():
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _CHANGELOG = _REPO_ROOT / "docs" / "product" / "changelog.md"
-# Measured at 171 releases on 2026-08-27. A floor of 130 is about 76% of that,
-# leaving headroom for ordinary changelog churn while still detecting collapse.
+# CANONICAL statement of this figure; cite it from elsewhere rather than
+# restating it. Measured at 172 releases on 2026-08-27. A floor of 130 is about
+# 76% of that, leaving headroom for ordinary churn while still catching a
+# collapse. Deliberately NOT an exact pin: the count moved 171 -> 172 during
+# this change from one unrelated merge, which is precisely how an exact floor
+# breaks on the next release.
 _MIN_REAL_CHANGELOG_RELEASES = 130
 _PROJECTION = _REPO_ROOT / "web" / "src" / "lib" / "now-highlights.generated.json"
 _MARKETING_SHARED_CHROME_PROJECTION = (

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1667,11 +1667,12 @@ A longer span contains a single-backtick span: ``` `<!--` ```.
 def test_a_backtick_in_one_comment_does_not_mask_the_next_comments_opener():
     """Two real comments on one line are both stripped, not just the first.
 
-    Code spans are resolved per comment-free segment for exactly this input.
-    Resolving them once over the whole line paired the lone backtick inside
-    comment one with the backtick inside comment two; the bogus span covered
-    comment two's opener, so it read as a mention and its body published. This
-    bullet shipped an internal maintainer note to the public /now/ page.
+    A skipped comment's interior is never scanned, so it contributes no pairing
+    delimiter. Pairing once over the whole line instead paired the lone backtick
+    inside comment one with the backtick inside comment two; the bogus span
+    covered comment two's opener, so it read as a mention and its body
+    published. This bullet shipped an internal maintainer note to the public
+    /now/ page.
     """
     text = """# Changelog
 
@@ -1682,6 +1683,32 @@ def test_a_backtick_in_one_comment_does_not_mask_the_next_comments_opener():
 - Ship it <!-- don`t publish --> <!-- TODO: internal `note` for us -->.
 """
     assert _bullets(_groups(text)[0]) == ["Ship it  ."]
+
+
+def test_a_backtick_in_a_comment_does_not_steal_a_later_mentions_partner():
+    """A comment interior must not supply a PAIRING delimiter either.
+
+    The near-miss this pins is subtler than masking a later opener, and it
+    survived the first repair: an unbalanced backtick inside a real comment
+    paired with the backtick that should have OPENED the mention below, leaving
+    that mention unpaired and therefore unmasked. Generation then raised
+    "unterminated HTML comment" for a line containing no such thing, failing
+    the whole site build rather than publishing wrongly.
+
+    Only interleaving comment detection with pairing fixes this; filtering a
+    whole-line span list cannot, because the partner is already consumed.
+    """
+    text = """# Changelog
+
+## [pkg][1.0.0] — 2026-08-05
+
+### Highlights
+
+- <!-- reviewer: drop the ` here --> Write `<!--` to mention the opener.
+"""
+    assert _bullets(_groups(text)[0]) == [
+        "Write `<!--` to mention the opener."
+    ]
 
 
 def test_every_inline_comment_pair_on_a_line_is_stripped_not_just_the_first():
@@ -1730,25 +1757,32 @@ def test_an_opener_after_a_closed_pair_on_the_same_line_still_opens_a_comment():
 
 
 def test_the_code_span_scan_stays_linear_on_a_long_backtick_run():
-    """The copied scan must not be "simplified" into the cubic regex.
+    """The copied scan must not be "simplified" into the backtracking regex.
 
-    Upstream pins this at packs/core/tests/skills/work-loop/
-    test_lint_spec_status.py; the copy needs its own guard, since no changelog
-    line would ever exercise it. The regex the docstring warns off took a
-    measured 106 s on this input; the scan takes under a millisecond, so a
-    generous ceiling still fails loudly if someone swaps it back.
+    Upstream pins its own copy at packs/core/tests/skills/work-loop/
+    test_lint_spec_status.py; this one needs its own guard, because no changelog
+    line would ever exercise it and the trap is a one-line edit away. Measured
+    here: the scan takes under 2 ms on both inputs, while substituting
+    ``(`+)(?:(?!\\1).)*?\\1`` took 74 s on the first (the source docstring cites
+    106 s from its own measurement). The ceiling is deliberately far above the
+    real cost so a loaded CI box cannot flake it, and still 4 orders of
+    magnitude below the regex.
+
+    Both shapes are covered: one long run exercises the scan, and many
+    strictly-increasing runs exercise the PAIRING, which is the axis upstream's
+    probe loop rescans on.
     """
     import time
 
-    line = "`" * 12_000
-    started = time.monotonic()
-    build_site._code_span_ranges(line)
-    build_site._strip_changelog_comments(line + "<!--")
-    elapsed = time.monotonic() - started
-    assert elapsed < 5.0, (
-        f"the code-span scan took {elapsed:.1f}s on a 12 KB backtick run; a "
-        "backtracking regex was measured at 106s here — restore the linear scan"
-    )
+    for line in ("`" * 12_000, "x".join("`" * (n + 1) for n in range(2_000))):
+        started = time.monotonic()
+        build_site._strip_changelog_comments(line + "<!--")
+        elapsed = time.monotonic() - started
+        assert elapsed < 5.0, (
+            f"the code-span scan took {elapsed:.1f}s on a {len(line)}-char "
+            "backtick input; a backtracking regex was measured at 74s here — "
+            "restore the linear scan and the precomputed pairing"
+        )
 
 
 def test_an_unterminated_html_comment_fails_instead_of_swallowing_the_file():

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1618,13 +1618,20 @@ Backticks are literal inside a comment, so this `-->` closes it.
 def test_a_backticked_comment_opener_inside_a_fence_remains_sample_text():
     """Fence handling must stay ahead of code-span-aware comment handling.
 
-    Moving the new masking ahead of the established fence state machine could
-    make a backticked sample opener swallow the later real release.
+    The backtick here is deliberately UNMATCHED, so it forms no code span and
+    the new mask cannot rescue this line. Only the fence can, which is what
+    makes the assertion discriminating: hoisting comment handling ahead of the
+    fence state machine turns this sample into a real unterminated comment and
+    the later release vanishes.
+
+    Written with a matched pair first, it was inert for two independent reasons
+    and passed under both that hoist and the code-span-blind parser it was
+    added to catch — a test that could not go red for the reason it named.
     """
     text = """# Changelog
 
 ```markdown
-A sample mentions `<!--` without a closer.
+A sample mentions `<!-- without a closing backtick or closer.
 ```
 
 ## [real][1.0.0] — 2026-08-05

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1711,6 +1711,48 @@ def test_a_backtick_in_a_comment_does_not_steal_a_later_mentions_partner():
     ]
 
 
+def test_a_code_span_that_swallows_a_comment_opener_is_reported():
+    """The one leak CommonMark leaves open is reported, not shipped silently.
+
+    An unbalanced backtick pairs into the following real comment, so that
+    comment's opener sits inside a code span, is never stripped, and its body
+    publishes as literal code. Rendering stays CommonMark-faithful — the old
+    whole-line regex stripped it, which was not — but this pipeline errs toward
+    withholding, so the case earns a diagnostic that fails the required suite.
+    """
+    text = """# Changelog
+
+## [pkg][1.0.0] — 2026-08-05
+
+### Highlights
+
+- Fixed a `quote issue <!-- TODO: don`t publish this internal note -->
+"""
+    parsed = build_site.parse_changelog_releases(text)
+    assert [line for line, _ in parsed.diagnostics["code_span_split_comments"]] == [7]
+
+
+def test_an_ordinary_backticked_mention_is_not_reported_as_a_split_comment():
+    """The diagnostic must not fire on the shape this whole change exists for.
+
+    Both legitimate forms stay silent: a mention with no closer anywhere, and
+    one that fully encloses its own `-->`. The changelog carries many of each,
+    and a diagnostic that flagged them would be noise on every correct line —
+    which is how a fail-closed check gets disabled.
+    """
+    text = """# Changelog
+
+## [pkg][1.0.0] — 2026-08-05
+
+### Highlights
+
+- A note mentioning `<!--` in backticks.
+- A fully enclosed `<!-- x -->` mention.
+"""
+    parsed = build_site.parse_changelog_releases(text)
+    assert parsed.diagnostics["code_span_split_comments"] == []
+
+
 def test_every_inline_comment_pair_on_a_line_is_stripped_not_just_the_first():
     """The deleted `_COMMENT_INLINE_RE.sub` was GLOBAL; that must not regress.
 
@@ -1761,27 +1803,40 @@ def test_the_code_span_scan_stays_linear_on_a_long_backtick_run():
 
     Upstream pins its own copy at packs/core/tests/skills/work-loop/
     test_lint_spec_status.py; this one needs its own guard, because no changelog
-    line would ever exercise it and the trap is a one-line edit away. Measured
-    here: the scan takes under 2 ms on both inputs, while substituting
-    ``(`+)(?:(?!\\1).)*?\\1`` took 74 s on the first (the source docstring cites
-    106 s from its own measurement). The ceiling is deliberately far above the
-    real cost so a loaded CI box cannot flake it, and still 4 orders of
-    magnitude below the regex.
+    line would ever exercise it and either trap is a one-line edit away.
 
-    Both shapes are covered: one long run exercises the scan, and many
-    strictly-increasing runs exercise the PAIRING, which is the axis upstream's
-    probe loop rescans on.
+    TWO independent axes, because each catches a different regression and
+    neither catches the other:
+
+    1. One long run — the SCAN. Substituting ``(`+)(?:(?!\\1).)*?\\1`` here was
+       measured at 74 s against 0.4 ms (the source docstring cites 106 s from
+       its own measurement of the same trap).
+    2. A few hundred distinct-length runs followed by a long tail of length-1
+       runs — the PAIRING. Reverting `next_same` to upstream's probe loop, which
+       rescans on every unmatched run, was measured at 8.8 s against 0.11 s.
+
+    The generator for (2) is load-bearing and was got wrong once: with only
+    strictly-increasing runs the line length grows quadratically in run count,
+    so BOTH implementations come out effectively linear in input size and the
+    probe loop passed at 0.19 s — a guard that could not fail on the axis it
+    named. The lead-plus-tail shape is what separates them.
+
+    The 5 s ceiling sits ~45x above the real cost so a loaded CI box cannot
+    flake it, and still well below either regression.
     """
     import time
 
-    for line in ("`" * 12_000, "x".join("`" * (n + 1) for n in range(2_000))):
+    scan_axis = "`" * 12_000
+    pairing_axis = "x".join("`" * (n + 2) for n in range(600)) + "x" + "`x" * 240_000
+    for line in (scan_axis, pairing_axis):
         started = time.monotonic()
         build_site._strip_changelog_comments(line + "<!--")
         elapsed = time.monotonic() - started
         assert elapsed < 5.0, (
             f"the code-span scan took {elapsed:.1f}s on a {len(line)}-char "
-            "backtick input; a backtracking regex was measured at 74s here — "
-            "restore the linear scan and the precomputed pairing"
+            "backtick input; the backtracking regex measured 74s on the scan "
+            "axis and the probe-loop pairing 8.8s on this one — restore the "
+            "linear scan and the precomputed pairing"
         )
 
 
@@ -2038,6 +2093,18 @@ def test_the_real_changelog_has_no_silently_withheld_highlights():
         for lineno, title in parsed.diagnostics["unreleased_regions"]
     ]
     assert not regions, "\n".join(regions)
+
+    # Fails closed for the same reason as the two above: the leak is invisible
+    # on the page, because what publishes is a maintainer note that reads as
+    # ordinary copy. Zero on the changelog today, so pinning it is free.
+    split = [
+        f"{rel}:{lineno}: an unbalanced backtick pairs into the HTML comment on "
+        f"this line, so the comment's body publishes as code instead of being "
+        f"stripped — close the backtick, or move the comment to its own line: "
+        f"{source!r}"
+        for lineno, source in parsed.diagnostics["code_span_split_comments"]
+    ]
+    assert not split, "\n".join(split)
 
 
 def test_the_real_changelog_parser_keeps_a_sane_release_population():

--- a/workspace.toml
+++ b/workspace.toml
@@ -1828,7 +1828,7 @@ closed = [
   # Also closed the measurement gap that let this reach production: nothing
   # asserted a release-count FLOOR, and _MAROONED_RELEASE_BASELINE is an upper
   # bound on a different population that passes when releases collapse to zero.
-  {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a >=130-release floor on the real changelog (measured 171); the backticked-opener case went 0 -> 171 releases while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled"},
+  {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a release-count floor on the real changelog; the backticked-opener case went from 0 releases to the full population while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled. The floor and its measured baseline are stated canonically at _MIN_REAL_CHANGELOG_RELEASES in tools/test_build_site_routing.py"},
 
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Closed; successor docs/product/design/workspace-anchor-staleness-invariant.md owns dependency and membership staleness detection"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -1104,20 +1104,6 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
-  # tools/build-site.py strips HTML comments with a bare `<!--.*?-->` and, per
-  # its own comment at :1609, resolves fenced code first -- but has no notion of
-  # INLINE code spans. Not latent: it fired on PR #1139. Changelog prose that
-  # mentioned comment syntax inside backticks opened a span that paired with a
-  # closer 5,083 lines later, leaving parse_changelog_releases with 1 release
-  # instead of ~100 and reddening the launch-window test. Split out of the spec
-  # intent deliberately -- it is a different module reading a different file, and
-  # nobody picking up "enforce the spec format" would think to fix a changelog
-  # parser.
-  # Fix: give build-site's comment stripper inline-code-span precedence --
-  #   lint-spec-status.py's `_code_span_ranges` is a linear, working reference.
-  # Unblocks when: picked up -- no dependency.
-  {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "build-site.py's HTML-comment stripper has no notion of inline code spans, so backticked comment syntax in changelog prose can open a real comment span and swallow thousands of lines"},
-
 
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
@@ -1830,6 +1816,19 @@ closed = [
   {slug = "okf012-nondeterminism-guard-untested", source = "spec/okf-authoring-projection (whole-spec quality review)", summary = "Closed by spec/okf-follow-ons; a mutation-proven compile_pack test asserts exit 2, diagnostics exactly OKF012, and no pack mutation when the two renders differ"},
 
   {slug = "architect-okf-bundle-root-missing-license", source = "spec/okf-authoring-projection (adversarial review, reproduced)", summary = "Closed by spec/okf-follow-ons; architect's authored OKF root declares the shared content licence, distinguishes source from projection, and passes discovery and show with a regression test. Owner review by architect's maintainer is still outstanding and is required before architect becomes the INI-009 M3 integration pilot; see the variance record in docs/product/initiatives/ini-009-agent-skill-engineering.md"},
+
+  # Two of the three sites that read comment syntax in parse_changelog_releases
+  # are now code-span aware, via a linear-scan `_code_span_ranges` COPIED from
+  # lint-spec-status.py rather than imported -- tools/ must not couple to a
+  # content-pinned pack tree. The third, the `-->` search inside an open
+  # comment, deliberately stays blind and now carries a comment saying so:
+  # Markdown is not parsed inside an HTML comment, so masking there would be a
+  # NEW bug. build-site keeps its raise where lint-spec-status returns what it
+  # has; that divergence is intentional and commented at both ends.
+  # Also closed the measurement gap that let this reach production: nothing
+  # asserted a release-count FLOOR, and _MAROONED_RELEASE_BASELINE is an upper
+  # bound on a different population that passes when releases collapse to zero.
+  {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a >=130-release floor on the real changelog (measured 171); the backticked-opener case went 0 -> 171 releases while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled"},
 
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Closed; successor docs/product/design/workspace-anchor-staleness-invariant.md owns dependency and membership staleness detection"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -1104,6 +1104,28 @@ open = [
   # open for tuning; a reader should not read one as the other.
   {slug = "docs-site-print-styles", source = "spec/docs-site-design-refresh"},
 
+  # PRE-EXISTING and verified identical on origin/main -- NOT introduced by the
+  # code-span fix, which is why that change left it alone. In
+  # parse_changelog_releases, comment stripping runs BEFORE the fence-opener
+  # match, so a `<!--` in a fence opener's INFO STRING (```bash <!-- setup)
+  # sets in_fence and in_comment together. The `if in_fence` branch then
+  # `continue`s past the in_comment handler, and the first `-->` after the
+  # fence silently absorbs everything between. Measured: a 2-release fixture
+  # with such an opener parses ONE release, no raise, no diagnostic -- the same
+  # silent-collapse class as build-site-comment-strip-ignores-code-spans, and
+  # the >=130 release floor has ~42 releases of slack before it notices.
+  # Without a trailing `-->` it instead hard-fails naming the fence line.
+  # The comment at :1795 claims "fenced code wins over comment syntax"; that
+  # holds for lines INSIDE a fence, not for the opener line itself.
+  # Fix: when _FENCE_RE_CHANGELOG matches, do not honour that line's
+  #   opens_comment -- the `<!--` was sample text in the info string -- or
+  #   strip comments only from the text preceding the fence marker.
+  # Deliberately NOT bundled: the fence state machine has a documented history
+  #   of fail-open regressions, and this is a different root cause from
+  #   code-span blindness. It wants its own change and its own review.
+  # Unblocks when: picked up -- no dependency.
+  {slug = "build-site-fence-info-string-opens-a-comment", source = "adversarial review of the code-span fix (2026-08-27)", summary = "build-site.py strips HTML comments before matching a fence opener, so `<!--` in a fence info string sets in_fence and in_comment together and the next `-->` swallows every release between; pre-existing on origin/main, silent, and invisible to the release floor"},
+
 
   # Unblocks when: the allowlist gains its first entry.
   {slug = "npm-allowlist-expiry-enforcement", summary = "Give npm-audit-allowlist.toml a machine-checked expiry like .snyk's, so a suppression cannot outlive its justification", source = "spec/npm-sca-gate (ADR-0083 revisit)"},
@@ -1818,9 +1840,12 @@ closed = [
   {slug = "architect-okf-bundle-root-missing-license", source = "spec/okf-authoring-projection (adversarial review, reproduced)", summary = "Closed by spec/okf-follow-ons; architect's authored OKF root declares the shared content licence, distinguishes source from projection, and passes discovery and show with a regression test. Owner review by architect's maintainer is still outstanding and is required before architect becomes the INI-009 M3 integration pilot; see the variance record in docs/product/initiatives/ini-009-agent-skill-engineering.md"},
 
   # Two of the three sites that read comment syntax in parse_changelog_releases
-  # are now code-span aware, via a linear-scan `_code_span_ranges` COPIED from
-  # lint-spec-status.py rather than imported -- tools/ must not couple to a
-  # content-pinned pack tree. The third, the `-->` search inside an open
+  # are now code-span aware. The run scan of lint-spec-status.py's
+  # `_code_span_ranges` was COPIED into `_backtick_runs` rather than imported --
+  # tools/ must not couple to a content-pinned pack tree -- and its pairing half
+  # is interleaved with comment detection instead of applied whole-line, because
+  # a whole-line span list cannot express "a comment's interior contributes no
+  # delimiters". The third site, the `-->` search inside an open
   # comment, deliberately stays blind and now carries a comment saying so:
   # Markdown is not parsed inside an HTML comment, so masking there would be a
   # NEW bug. build-site keeps its raise where lint-spec-status returns what it
@@ -1828,6 +1853,16 @@ closed = [
   # Also closed the measurement gap that let this reach production: nothing
   # asserted a release-count FLOOR, and _MAROONED_RELEASE_BASELINE is an upper
   # bound on a different population that passes when releases collapse to zero.
+  # One residual is reported rather than stripped: leftmost-wins pairing is
+  # CommonMark-faithful, so an UNBALANCED backtick pairs into a following real
+  # comment and that comment's body publishes as code where the old whole-line
+  # regex stripped it. Rendering stays CommonMark; the new
+  # `code_span_split_comments` diagnostic fails the required suite on it, since
+  # this pipeline errs toward withholding. Fires only when a span cuts a
+  # comment in half -- an enclosed or closer-less mention is the ordinary shape.
+  # Separately found and NOT fixed here: the fence-info-string collapse, filed
+  # as build-site-fence-info-string-opens-a-comment. Pre-existing, different
+  # root cause, and the fence state machine was explicitly out of scope.
   {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a release-count floor on the real changelog; the backticked-opener case went from 0 releases to the full population while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled. The floor and its measured baseline are stated canonically at _MIN_REAL_CHANGELOG_RELEASES in tools/test_build_site_routing.py"},
 
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Closed; successor docs/product/design/workspace-anchor-staleness-invariant.md owns dependency and membership staleness detection"},


### PR DESCRIPTION
## What does this change?

`parse_changelog_releases` in `tools/build-site.py` walked the changelog with an
`in_comment` state machine that asked only `if "<!--" in raw:`, so a *backticked
mention* of comment syntax in prose opened a real HTML comment running to the next
`-->` anywhere in the file. Two of the three sites that read comment syntax are now
code-span aware; the third deliberately stays blind and says so.

## Why?

Not latent — it fired in production on PR #1139, pairing a mention with a closer
5,083 lines later and collapsing ~100 releases to 1. A human noticed the number
because nothing in the suite could: there was no release-count **floor** anywhere,
and the nearest guard (`_MAROONED_RELEASE_BASELINE`) is an *upper* bound on a
different population that passes happily when releases collapse to zero.

- Closes: `[backlog].open` → `build-site-comment-strip-ignores-code-spans`
- No spec: single bounded fix to one function plus its missing guard, no security
  boundary, no public interface change, no new dependency (work-loop light mode).

## How do I verify it?

| Case | Before (`a4fbb563`) | After |
| --- | ---: | ---: |
| Real changelog, unmodified | 171 | 175 |
| Same, plus a line with a backticked `` `<!--` `` | 0 | 175 |
| Control: same line with a **bare** `<!--` | 0 | 0 |
| Minimal 3-release synthetic, backticked opener + closer | 1 of 3 | 3 of 3 |

The control moves independently of the backticked cases — comment handling was made
span-aware, not disabled. (171 → 175 is unrelated churn landing during the change,
which is exactly why the floor is 130 rather than an exact pin.)

```bash
make build && SKIP_SAST=1 make build-check   # `make build` regenerates dist/
make lint-ruff && make lint-mypy
python3 -m pytest tools/test_build_site_routing.py -q
python3 tools/build-site.py && python3 tools/build-site.py --journeys-only
make site-build && npm test --prefix web     # make ci does NOT cover web vitest
```

**Correctness evidence.** The interleaved scan was verified by differential fuzzing
against an independent brute-force reference written from the definition:
**0 divergences** over 300,000 random inputs, all 5,278 real changelog lines, and
**exhaustively over all 335,923 strings of length ≤ 7** — which also proves no
`KeyError` and no non-termination. Ten mutations were planted; every new assertion
is killed by at least one, and the release floor was driven red twice (the
production shape under the pre-fix parser, and any collapse under the fixed one).

## What did you not change that you considered?

- **The `-->` search inside an open comment stays code-span blind.** Markdown is not
  parsed inside an HTML comment, so backticks there are literal; masking would be a
  new bug. It now carries a comment saying so, and a test that reddens if someone
  "finishes the job".
- **The fence state machine.** Untouched — it has a documented history of fail-open
  regressions.
- **`_code_span_ranges` is copied, not imported.** `tools/` must not couple to a
  content-pinned pack tree. It was ultimately deleted rather than kept for
  provenance: after the rewrite no production path reached it, and only a test
  called it. The citation moved to `_backtick_runs`, which holds the scan verbatim.
- **build-site keeps its `raise`** where `lint-spec-status.py` returns what it has.
  Deliberate divergence, commented at both ends.
- **A fence-info-string collapse found during review, filed not fixed.** Comment
  stripping runs *before* the fence-opener match, so `<!--` in a fence info string
  sets `in_fence` and `in_comment` together and the next `-->` swallows every
  release between. Verified identical on `origin/main`, so pre-existing; different
  root cause. Filed as `build-site-fence-info-string-opens-a-comment`.
- **A code-span-blind link rewriter**, same class, different construct, live today:
  the shared `](path)` rewriter is neither span- nor fence-aware, and rewrites a
  backticked sample in `guides/converters/how-to/render-mermaid-diagrams.md:43`
  into an absolute GitHub blob URL on the published page. Out of scope here.
- **No changelog entry, no version bump.** Repository tooling that ships in no
  release; no `[repo]`/`[tools]` heading exists.

### One behaviour change worth reviewing

Leftmost-wins pairing is CommonMark-faithful, so an **unbalanced** backtick in prose
pairs into a following real comment, putting that comment's body inside a code span
where it is literal and therefore publishes — where the old whole-line regex stripped
it. Rendering stays CommonMark; rather than diverge from it, this adds a
`code_span_split_comments` diagnostic that fails the required suite, since the
pipeline errs toward withholding. It fires only when a span *cuts a comment in half*,
never on an ordinary backticked mention. Zero on the changelog today.

---

## Checklist

- [x] Tests pass locally (`pytest tools/test_build_site_routing.py -q`, `npm test --prefix web`)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy`)
- [x] Self-review run via `adversarial-reviewer` — three rounds; two rejected
      implementations, findings sustained and fixed, final round independent
- [x] Spec and code agree (no spec; light-mode direct work)
- [x] Living docs match reality — no changelog entry required (tooling ships in no release)

> **Local gate note.** `make test-after-build-check` fails here on
> `lint-editable-install`: a global `pip install -e` points at the `ci-wiring`
> worktree, which was actively running its own gates. Re-pointing or uninstalling
> would have killed a peer mid-run, so it was left alone — CI has no editable
> install and is the authority for that leg. Every other gate is green locally,
> including `SKIP_SAST=1 make build-check` after `make build` regenerated `dist/`.
