### PR TITLE
test(ci): prove the workflow posture assertions, and wire a CodeQL posture test

### DIFF
--- a/tools/posture_harness.py
+++ b/tools/posture_harness.py
@@ -45,6 +45,22 @@ def family(label: str) -> str:
     return re.sub(r"\[.*\]$", "[*]", label)
 
 
+def replace_once(text: str, old: str, new: str, workflow: str) -> str:
+    """Substitute exactly one occurrence, or raise.
+
+    Driver-shaped, not a per-file predicate: it enforces the same
+    mutate-or-prove-nothing contract as the no-op rule below. A compound
+    transform whose other half still fires is not a no-op, so without this a
+    drifted literal reports "caught" while proving nothing.
+    """
+    if text.count(old) != 1:
+        raise AssertionError(
+            f"mutation literal is not present exactly once ({text.count(old)}x): "
+            f"{old!r} — re-pin it against {workflow}"
+        )
+    return text.replace(old, new, 1)
+
+
 def run(
     *,
     workflow: Path,

--- a/tools/posture_harness.py
+++ b/tools/posture_harness.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Shared self-test driver for the workflow posture harnesses.
+
+Four posture tests — ci-security, pack-evals, build-check-windows and CodeQL —
+carried a byte-identical copy of this driver. The duplication was created by the
+change that gave them mutation matrices in the first place, so it is that
+change's debt to pay rather than a pre-existing condition to register and leave.
+
+**Scope, deliberately narrow.** Only the driver moves: the baseline-clean
+precondition, the no-op rejection, the expected-label check, family accounting,
+the failure and success reports. Every `audit`, `_MUTATIONS` and per-file
+predicate stays in its own module, because those are what each harness is *for*
+and sharing them would couple four unrelated workflow contracts.
+
+**Not converged here, and not this change's debt:** `tools/test-pages-workflow.py`
+and `tools/test-build-check-workflow.py` predate that change and carry different
+shapes — build-check has a bash differential and a shape-stable fixture, pages
+has crafted-input predicates — and `tools/test-pages-concurrency.py` uses a
+four-element mutation tuple with no family rule at all. Converging those means
+changing three already-working harnesses and is registered separately.
+
+**Import contract.** The callers run as scripts (`python tools/test-x.py`,
+including from `tools/repo/build_gate_chain.py`), so `sys.path[0]` is `tools/`
+and a plain `import posture_harness` resolves. It deliberately does not insert
+anything on `sys.path`: `tools/test_import_time_path_leaks.py` exists because an
+import-time insert here once made a suite's result depend on file order. If the
+import ever fails, the caller fails loudly rather than skipping its self-test.
+
+Pure stdlib, as required for new ``tools/`` additions.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+# (mutation id, expected violation label, text transform)
+Mutation = tuple[str, str, Callable[[str], str]]
+
+
+def family(label: str) -> str:
+    """Collapse repeated indexed assertions into one mutation family."""
+    return re.sub(r"\[.*\]$", "[*]", label)
+
+
+def run(
+    *,
+    workflow: Path,
+    baseline: Callable[[], str],
+    audit: Callable[..., list[str]],
+    mutations: Sequence[Mutation],
+    extra_failures: Callable[[], list[str]] | None = None,
+    extra_summary: Callable[[], str] | None = None,
+) -> int:
+    """Prove the real baseline and every assertion family it evaluates.
+
+    Returns 0 when the baseline is clean, every mutation is caught for the
+    reason it names, and every family the baseline evaluated carries at least
+    one mutation.
+
+    ``extra_failures`` lets a caller append checks the driver knows nothing
+    about — build-check-windows uses it for a differential against bash — and
+    ``extra_summary`` lets that caller say so on the success line, so a check
+    that did not run cannot read as one that passed.
+    """
+    failures: list[str] = []
+    good = baseline()
+    evaluated: list[str] = []
+
+    baseline_violations = audit(good, evaluated)
+    if baseline_violations:
+        # Return before the matrix. Every transform is pinned to the real
+        # workflow's text, so a dirty or missing baseline turns each one into a
+        # no-op — or, where a transform asserts its literal, into an exception —
+        # burying the one true cause under a wall of derived noise that names
+        # neither the cause nor the file to edit.
+        print(
+            f"✖ self-test: {workflow} is not clean; "
+            f"{len(baseline_violations)} posture violation(s) before any mutation:",
+            file=sys.stderr,
+        )
+        for violation in baseline_violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+
+    for mutation_id, expected, transform in mutations:
+        try:
+            mutated = transform(good)
+        except AssertionError as exc:
+            # A pinned literal drifted. Report it in this harness's own verdict
+            # format rather than letting the exception escape as a traceback,
+            # and keep going so every drifted literal is listed at once.
+            failures.append(f"{mutation_id}: {exc}")
+            continue
+        if mutated == good:
+            failures.append(
+                f"{mutation_id}: transform was a no-op against {workflow.name} — "
+                "proves nothing; re-pin its literal against that file"
+            )
+            continue
+        got = audit(mutated)
+        if expected not in got:
+            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
+
+    covered = {family(expected) for _, expected, _ in mutations}
+    uncovered = sorted({family(label) for label in evaluated} - covered)
+    if uncovered:
+        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    if extra_failures is not None:
+        failures.extend(extra_failures())
+
+    if failures:
+        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    summary = (
+        f"✓ self-test: baseline clean; {len(mutations)} mutations each caught; "
+        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    )
+    if extra_summary is not None:
+        summary += f"; {extra_summary()}"
+    print(summary)
+    return 0

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -473,6 +473,13 @@ def build_check(args: argparse.Namespace) -> int:
             "test-ci-security-workflow",
             "tools", "test-ci-security-workflow.py",
         ),
+        # ADR-0017's advisory CodeQL signal is security-load-bearing even though
+        # branch protection does not yet require it. The posture test proves the
+        # query suite, permission split, analyzed surface and per-ref concurrency.
+        _script_step(
+            "test-codeql-workflow",
+            "tools", "test-codeql-workflow.py",
+        ),
         # AC10: no CI path executes `build-check`'s `$(MAKE) sast` branch after
         # ADR-0086, so nothing else would notice it being deleted or made
         # unreachable. Skips cleanly where `make` is absent.

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -481,7 +481,8 @@ def build_check(args: argparse.Namespace) -> int:
         # `pull_request_target`, no `paths:` allowlist, `main` branches, the
         # weekly re-scan), an elevated-grant backstop over every job but
         # `analyze`, and the literal AC12 concurrency group and cancellation
-        # expressions. It does not pin the analyze job's own permission mapping.
+        # expressions, with `analyze` pinned as the sole `security-events`
+        # writer. It does not pin ADDITIONAL grants on the analyze job itself.
         _script_step(
             "test-codeql-workflow",
             "tools", "test-codeql-workflow.py",

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -475,7 +475,11 @@ def build_check(args: argparse.Namespace) -> int:
         ),
         # ADR-0017's advisory CodeQL signal is security-load-bearing even though
         # branch protection does not yet require it. The posture test proves the
-        # query suite, permission split, analyzed surface and per-ref concurrency.
+        # query suite, the read-only default floor against the analyzer's
+        # elevated grant, an exhaustive analysis-config `paths-ignore` list, the
+        # presence of the analyze step, and the literal AC12 concurrency group
+        # and cancellation expressions. It does not pin the analyze job's own
+        # permission mapping or forbid a `pull_request_target` trigger.
         _script_step(
             "test-codeql-workflow",
             "tools", "test-codeql-workflow.py",

--- a/tools/repo/build_gate_chain.py
+++ b/tools/repo/build_gate_chain.py
@@ -477,9 +477,11 @@ def build_check(args: argparse.Namespace) -> int:
         # branch protection does not yet require it. The posture test proves the
         # query suite, the read-only default floor against the analyzer's
         # elevated grant, an exhaustive analysis-config `paths-ignore` list, the
-        # presence of the analyze step, and the literal AC12 concurrency group
-        # and cancellation expressions. It does not pin the analyze job's own
-        # permission mapping or forbid a `pull_request_target` trigger.
+        # presence of the analyze step, the trigger surface (no
+        # `pull_request_target`, no `paths:` allowlist, `main` branches, the
+        # weekly re-scan), an elevated-grant backstop over every job but
+        # `analyze`, and the literal AC12 concurrency group and cancellation
+        # expressions. It does not pin the analyze job's own permission mapping.
         _script_step(
             "test-codeql-workflow",
             "tools", "test-codeql-workflow.py",

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -2,9 +2,10 @@
 """Pin and mutation-test the split Windows workflow's blocking topology.
 
 Two properties are asserted about the aggregate: it reads every work job's
-result, and its guard — which must be the run body's first statement, with the
-failing `exit 1` directly inside it and no nested opener or subshell wrapper in
-between — exits non-zero when one of them is not `success`.
+result, and its guard exits non-zero when one of them is not `success`. The
+guard must be the run body's first statement, its condition must equal
+`GUARD_CONDITION` exactly, and the failing `exit 1` must be reached without
+crossing an `else`/`elif` branch, a nested opener, or a subshell wrapper.
 
 Deliberately not asserted, and so not claimed: anything outside that run body.
 A step-level `continue-on-error: true` or `if:` on the aggregate step defeats
@@ -71,7 +72,16 @@ GUARD_RUN_MARKER = "        run: |\n"
 # A statement that opens a block bash may never enter. An `exit 1` beneath one
 # of these is conditional on something this checker does not model, so it is
 # refused rather than guessed at.
-_BLOCK_OPENERS = ("if ", "case ", "while ", "until ", "for ", "select ")
+_BLOCK_OPENERS = frozenset(
+    {"if", "case", "while", "until", "for", "select", "else", "elif"}
+)
+
+
+def _bash_path() -> str | None:
+    """Return the bash interpreter, or None where the platform has none."""
+    import shutil
+
+    return shutil.which("bash")
 
 
 def _guard_body(aggregate: str) -> str:
@@ -111,6 +121,12 @@ def _guard_blocks_on_failure(aggregate: str) -> bool:
     this check. That is the documented rule, not an oversight — the guard is
     then not the first statement — and it errs toward reporting a blocking guard
     as unproven rather than the reverse.
+
+    The first two requirements are fail-closed. The third, the reachability
+    scan, is permissive for a line it does not recognize: it passes over such a
+    line and keeps looking for `exit 1`. A heredoc'd exit and a backslash
+    continuation that swallows the next line are both unmodelled and would be
+    accepted; they are not claimed.
     """
     body = [line for line in _guard_body(aggregate).splitlines() if line.strip()]
     if not body:
@@ -123,11 +139,13 @@ def _guard_blocks_on_failure(aggregate: str) -> bool:
             return False
         if stripped == "exit 1":
             return True
-        # `else`/`elif` put the exit on a branch bash need not take: the advisory
-        # echo goes in the `then` arm and every suite stops blocking.
-        if stripped == "else" or stripped.startswith("elif "):
+        if stripped.startswith(("(", "{")):
             return False
-        if stripped.startswith(_BLOCK_OPENERS) or stripped.startswith(("(", "{")):
+        # Compared as a token, not a prefix: `else true`, `else # advisory`, and
+        # a tab-separated `elif`/`if`/`while`/`case` all walked past a
+        # spelling-specific test and put the exit on a branch bash need not take.
+        head = stripped.split(maxsplit=1)[0].rstrip(";")
+        if head in _BLOCK_OPENERS:
             return False
     return False
 
@@ -398,6 +416,13 @@ _DIFFERENTIAL_VARIANTS: list[tuple[str, Callable[[str], str]]] = [
         ),
     ),
     (
+        # Proves the condition-equality pin: with `&&`, the first conjunct is
+        # false for a succeeding suite, so the guard is skipped and bash exits 0.
+        # Nothing else in the matrix perturbs the condition line.
+        "or-to-and",
+        lambda body: body.replace("] || [", "] && ["),
+    ),
+    (
         "subshell-or-true",
         lambda body: body.replace("if [", "( if [", 1).replace(
             "\nfi", "\nfi ) || true", 1
@@ -421,15 +446,19 @@ def _differential_failures() -> list[str]:
     rejecting a body bash would also fail is merely conservative.
     """
     import os
-    import shutil
     import subprocess
 
-    if not shutil.which("bash"):
-        # The make-free Windows contributor path is a shipped acceptance
-        # criterion, so a hard shell dependency would fail a gate it has no
-        # business failing. Announced, not silent: an unrun differential must
-        # not read as a passing one.
-        return ["differential: SKIPPED — bash unavailable, shell model unproven"]
+    if _bash_path() is None:
+        # Announced, never fatal. `build_gate_chain.py build-check` is the shipped
+        # make-free Windows contributor entry point, so turning an absent shell
+        # into a gate failure would fail a gate it has no business failing — the
+        # same call the build-check sibling and assert-sast-chain-reachable make.
+        # The success line reports the skip so it cannot read as a pass.
+        print(
+            "differential: SKIPPED — bash unavailable, shell model unproven",
+            file=sys.stderr,
+        )
+        return []
     good = _baseline()
     indented = "\n".join(
         f"          {line}".rstrip() for line in _GUARD_BASE.splitlines()
@@ -461,7 +490,7 @@ def _differential_failures() -> list[str]:
         accepted = not audit(spliced)
         green = (
             subprocess.run(
-                ["bash", "-c", variant],
+                [str(_bash_path()), "-c", variant],
                 env=env,
                 capture_output=True,
                 text=True,
@@ -548,10 +577,16 @@ def self_test() -> int:
         for failure in failures:
             print(f"  - {failure}", file=sys.stderr)
         return 1
+    # Never a static count: an unrun differential must not report agreements.
+    agreed = (
+        f"{len(_DIFFERENTIAL_VARIANTS) - 1} guard bodies agreed with bash"
+        if _bash_path() is not None
+        else "differential skipped, bash unavailable"
+    )
     print(
         f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
         f"every one of {len(covered)} assertion families has ≥1 mutation; "
-        f"{len(_DIFFERENTIAL_VARIANTS) - 1} guard bodies agreed with bash"
+        f"{agreed}"
     )
     return 0
 

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 """Pin and mutation-test the split Windows workflow's blocking topology.
 
-Blocking means two things and both are asserted: the aggregate reads every work
-job's result, and its guard exits non-zero when one of them is not `success`.
+Two properties are asserted about the aggregate: it reads every work job's
+result, and its guard — which must be the run body's first statement, with the
+failing `exit 1` directly inside it and no nested opener or subshell wrapper in
+between — exits non-zero when one of them is not `success`.
+
+Deliberately not asserted, and so not claimed: anything outside that run body.
+A step-level `continue-on-error: true` or `if:` on the aggregate step defeats
+the required check while both properties above stay true, and no assertion here
+covers it.
+
+The blocking property is additionally checked against bash rather than only
+modelled, because a text model of a shell is not the shell: see
+``_differential_failures``. That seam is ported from
+``tools/test-build-check-workflow.py``, which found the same class by execution.
 """
 
 from __future__ import annotations
@@ -37,31 +49,61 @@ RESULT_VARIABLES = (
 )
 
 
-def _guard_blocks_on_failure(aggregate: str) -> bool:
-    """Return whether one guard makes *every* work job's failure exit non-zero.
+GUARD_RUN_MARKER = "        run: |\n"
+# A statement that opens a block bash may never enter. An `exit 1` beneath one
+# of these is conditional on something this checker does not model, so it is
+# refused rather than guessed at.
+_BLOCK_OPENERS = ("if ", "case ", "while ", "until ", "for ", "select ")
 
-    The comparisons alone prove only that the aggregate reads the results, and
-    a first-match scan proves only that *some* guard exits. Splitting the guard
-    into one blocking `if` plus two advisory ones satisfied both, leaving two of
-    three Windows suites non-blocking behind the required check. So the matched
-    condition must carry all three comparisons itself before the body is
-    scanned for `exit 1`.
+
+def _guard_body(aggregate: str) -> str:
+    """Return the aggregate guard step's run body, dedented, or the empty string."""
+    if GUARD_RUN_MARKER not in aggregate:
+        return ""
+    tail = aggregate[aggregate.index(GUARD_RUN_MARKER) + len(GUARD_RUN_MARKER) :]
+    body: list[str] = []
+    for line in tail.splitlines():
+        if line.strip() and not line.startswith("          "):
+            break
+        body.append(line[10:])
+    return "\n".join(body).rstrip("\n")
+
+
+def _guard_blocks_on_failure(aggregate: str) -> bool:
+    """Return whether one guard makes every work job's failure exit non-zero.
+
+    The comparisons alone prove only that the aggregate reads the results, and a
+    first-match scan proves only that some guard exits. Splitting the guard into
+    one blocking `if` plus two advisory ones satisfied both, leaving two of three
+    Windows suites non-blocking behind the required check.
+
+    Three structural requirements, each fail-closed, and each answering a body
+    bash takes green that a looser reading accepted: the guard is the run body's
+    first statement (anything before it can `exit 0`, reassign a result, or open
+    a wrapper); its condition carries all three comparisons itself; and the
+    `exit 1` is reached without crossing a nested block opener or a subshell.
     """
-    lines = aggregate.splitlines()
-    for index, line in enumerate(lines):
-        if not line.rstrip().endswith("; then"):
-            continue
-        if any(
-            f'[ "${variable}" != "success" ]' not in line
-            for variable in RESULT_VARIABLES
-        ):
-            continue
-        for following in lines[index + 1 :]:
-            stripped = following.strip()
-            if stripped == "fi":
-                return False
-            if stripped == "exit 1":
-                return True
+    body = [line for line in _guard_body(aggregate).splitlines() if line.strip()]
+    if not body:
+        return False
+    first = body[0].strip()
+    if first.startswith(("(", "{")):
+        return False
+    if not first.endswith("; then"):
+        return False
+    if any(
+        f'[ "${variable}" != "success" ]' not in first
+        for variable in RESULT_VARIABLES
+    ):
+        return False
+    for line in body[1:]:
+        stripped = line.strip()
+        if stripped == "fi":
+            return False
+        if stripped == "exit 1":
+            return True
+        if stripped.startswith(_BLOCK_OPENERS) or stripped.startswith(("(", "{")):
+            return False
     return False
 
 
@@ -279,6 +321,125 @@ _MUTATIONS: list[Mutation] = [
 ]
 
 
+# ── Differential check: this file's model of bash, against bash ──────────────
+#
+# `aggregate-blocks-on-failure` encodes a BELIEF about what a shell does with a
+# guard body. The mutation matrix proves the assertion fires; it cannot prove
+# the belief is true. So for the one body whose behaviour decides the required
+# Windows status check, ask bash directly.
+#
+# The property is an implication, not an equality: if bash exits 0 with a suite
+# reported `failure`, `audit` MUST reject. The converse is not required —
+# rejecting a body bash would also fail is merely conservative. That asymmetry
+# is what makes this a safety check rather than a brittle equivalence test.
+_EXIT_LINE = "  exit 1"
+
+_DIFFERENTIAL_VARIANTS: list[tuple[str, Callable[[str], str]]] = [
+    ("baseline", lambda body: body),
+    ("exit-0-prefix", lambda body: f"exit 0\n{body}"),
+    ("bare-exit-prefix", lambda body: f"exit\n{body}"),
+    ("exit-000-prefix", lambda body: f"exit 000\n{body}"),
+    (
+        "reassign-every-result",
+        lambda body: "".join(f"{name}=success\n" for name in RESULT_VARIABLES) + body,
+    ),
+    (
+        "default-if-unset",
+        lambda body: "".join(
+            f"{name}=${{{name}:+success}}\n" for name in RESULT_VARIABLES
+        )
+        + body,
+    ),
+    (
+        "unreachable-nested-exit",
+        lambda body: body.replace(
+            _EXIT_LINE, "  if false; then\n    exit 1\n  fi", 1
+        ),
+    ),
+    (
+        "unmatched-case-arm-exit",
+        lambda body: body.replace(
+            _EXIT_LINE, "  case unmatched in matched)\n    exit 1\n  ;;\n  esac", 1
+        ),
+    ),
+    (
+        "subshell-or-true",
+        lambda body: body.replace("if [", "( if [", 1).replace(
+            "\nfi", "\nfi ) || true", 1
+        ),
+    ),
+]
+
+
+def _differential_failures() -> list[str]:
+    """Guard bodies bash takes green with a suite failed, that `audit` accepts."""
+    import os
+    import shutil
+    import subprocess
+
+    if not shutil.which("bash"):
+        # The make-free Windows contributor path is a shipped acceptance
+        # criterion, so a hard shell dependency would fail a gate it has no
+        # business failing. Same reasoning as the build-check sibling.
+        return []
+    good = _baseline()
+    body = _guard_body(_job_block(good, "build-check-windows"))
+    if not body:
+        return ["differential: guard body not found — the harness is blind"]
+    indented = "\n".join(f"          {line}".rstrip() for line in body.splitlines())
+    if indented not in good:
+        return ["differential: guard body did not round-trip — the harness is blind"]
+
+    # EVERY result variable must be bound: an unset one is not a failure signal,
+    # it just changes which comparison short-circuits, and a variant that is
+    # never green is never reported green-and-accepted — it silently stops
+    # proving anything.
+    env = dict(os.environ)
+    env.update(dict.fromkeys(RESULT_VARIABLES, "success"))
+    env["LOCK_SEMANTICS_RESULT"] = "failure"
+
+    out: list[str] = []
+    for name, transform in _DIFFERENTIAL_VARIANTS:
+        variant = transform(body)
+        if name != "baseline" and variant == body:
+            out.append(f"differential[{name}]: transform was a no-op — proves nothing")
+            continue
+        spliced = good.replace(
+            indented,
+            "\n".join(f"          {line}".rstrip() for line in variant.splitlines()),
+            1,
+        )
+        accepted = not audit(spliced)
+        green = (
+            subprocess.run(
+                ["bash", "-c", variant],
+                env=env,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+        if name == "baseline":
+            # The harness's own premise. If an unmodified guard is green with a
+            # suite failed, every "blocked" verdict below is vacuous.
+            if green:
+                out.append(
+                    "differential[baseline]: the clean guard exits 0 with "
+                    "lock-semantics failed — the harness proves nothing"
+                )
+            if not accepted:
+                out.append("differential[baseline]: the clean guard is rejected by audit")
+            continue
+        if green and accepted:
+            out.append(
+                f"differential[{name}]: bash exits 0 with lock-semantics failed, "
+                "and audit accepts it"
+            )
+    return out
+
+
 def _family(label: str) -> str:
     """Collapse repeated indexed assertions into one mutation family."""
     return re.sub(r"\[.*\]$", "[*]", label)
@@ -306,6 +467,8 @@ def self_test() -> int:
     uncovered = sorted({_family(label) for label in evaluated} - covered)
     if uncovered:
         failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    failures.extend(_differential_failures())
 
     if failures:
         print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -30,17 +30,31 @@ def _job_block(workflow: str, job_name: str) -> str:
     return match.group(1) if match is not None else ""
 
 
-def _guard_blocks_on_failure(aggregate: str) -> bool:
-    """Return whether the results guard's failure branch exits non-zero.
+RESULT_VARIABLES = (
+    "AGENTBUNDLE_RESULT",
+    "CREDBROKER_RESULT",
+    "LOCK_SEMANTICS_RESULT",
+)
 
-    The three ``!= "success"`` comparisons prove only that the aggregate reads
-    the work jobs' results. Without this, flipping the guard body's ``exit 1``
-    to ``exit 0`` leaves every other label satisfied while the required check
-    reports success on a failing Windows job.
+
+def _guard_blocks_on_failure(aggregate: str) -> bool:
+    """Return whether one guard makes *every* work job's failure exit non-zero.
+
+    The comparisons alone prove only that the aggregate reads the results, and
+    a first-match scan proves only that *some* guard exits. Splitting the guard
+    into one blocking `if` plus two advisory ones satisfied both, leaving two of
+    three Windows suites non-blocking behind the required check. So the matched
+    condition must carry all three comparisons itself before the body is
+    scanned for `exit 1`.
     """
     lines = aggregate.splitlines()
     for index, line in enumerate(lines):
-        if '!= "success"' not in line or not line.rstrip().endswith("; then"):
+        if not line.rstrip().endswith("; then"):
+            continue
+        if any(
+            f'[ "${variable}" != "success" ]' not in line
+            for variable in RESULT_VARIABLES
+        ):
             continue
         for following in lines[index + 1 :]:
             stripped = following.strip()
@@ -131,11 +145,7 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     ):
         check(f"aggregate-result-reference[{result}]", result in aggregate)
 
-    for result_variable in (
-        "AGENTBUNDLE_RESULT",
-        "CREDBROKER_RESULT",
-        "LOCK_SEMANTICS_RESULT",
-    ):
+    for result_variable in RESULT_VARIABLES:
         comparison = f'[ "${result_variable}" != "success" ]'
         check(
             f"aggregate-requires-success[{result_variable}]",
@@ -236,6 +246,24 @@ _MUTATIONS: list[Mutation] = [
         "make-the-guard-exit-zero",
         "aggregate-blocks-on-failure",
         lambda text: text.replace("            exit 1\n", "            exit 0\n", 1),
+    ),
+    (
+        # The subtler fail-open: every comparison string survives, so the
+        # per-variable family stays satisfied, but only one job blocks.
+        "split-the-guard-so-only-one-job-blocks",
+        "aggregate-blocks-on-failure",
+        lambda text: text.replace(
+            '          if [ "$AGENTBUNDLE_RESULT" != "success" ]'
+            ' || [ "$CREDBROKER_RESULT" != "success" ]'
+            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n',
+            '          if [ "$AGENTBUNDLE_RESULT" != "success" ]; then\n'
+            '            echo "agentbundle failed" >&2\n'
+            "            exit 1\n"
+            "          fi\n"
+            '          if [ "$CREDBROKER_RESULT" != "success" ]'
+            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n',
+            1,
+        ),
     ),
 ]
 

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -82,20 +82,6 @@ _BLOCK_OPENERS = frozenset(
 )
 
 
-def _replace_once(text: str, old: str, new: str) -> str:
-    """Substitute exactly one occurrence, or raise.
-
-    Mirrors the ci-security sibling: a mutation whose literal drifts must fail
-    loudly rather than silently become a no-op the matrix reports as caught.
-    """
-    if text.count(old) != 1:
-        raise AssertionError(
-            f"mutation literal is not present exactly once ({text.count(old)}x): "
-            f"{old!r} — re-pin it against {WORKFLOW.name}"
-        )
-    return text.replace(old, new, 1)
-
-
 def _bash_path() -> str | None:
     """Return the bash interpreter, or None where the platform has none."""
     import shutil
@@ -268,16 +254,23 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     # The 8-space anchor cannot match the run body, which is indented 10.
     guard_step = ""
     if GUARD_RUN_MARKER in aggregate:
-        head = aggregate[: aggregate.index(GUARD_RUN_MARKER)]
+        marker = aggregate.index(GUARD_RUN_MARKER)
+        head = aggregate[:marker]
         if "      - " in head:
             start = head.rindex("      - ")
-            rest = aggregate[aggregate.index(GUARD_RUN_MARKER) :]
-            stop = rest.find("\n      - ")
-            guard_step = aggregate[start:] if stop == -1 else aggregate[start:][: len(head) - start + stop]
+            stop = aggregate[marker:].find("\n      - ")
+            guard_step = (
+                aggregate[start:] if stop == -1 else aggregate[start : marker + stop]
+            )
     check(
         "aggregate-step-unconditional",
         bool(guard_step)
-        and not re.search(r"^        (?:continue-on-error|if):", guard_step, re.M),
+        # Optional quote: `"continue-on-error": true` resolves to the same active
+        # key. The ci-security sibling reads the parsed step dict and is immune;
+        # this one reads text, so it has to admit the spelling explicitly.
+        and not re.search(
+            r"^        [\"']?(?:continue-on-error|if)[\"']?:", guard_step, re.M
+        ),
     )
 
     return violations
@@ -380,10 +373,35 @@ _MUTATIONS: list[Mutation] = [
         # and this is the position the previous slice could not see.
         "gate-the-guard-step-off-after-the-run-block",
         "aggregate-step-unconditional",
-        lambda text: _replace_once(
+        lambda text: posture_harness.replace_once(
             text,
             '          echo "Windows suites passed"\n',
             '          echo "Windows suites passed"\n        if: ${{ false }}\n',
+            WORKFLOW.name,
+        ),
+    ),
+    (
+        "quote-the-guard-step-key",
+        "aggregate-step-unconditional",
+        lambda text: posture_harness.replace_once(
+            text,
+            "      - name: Require all Windows suites\n",
+            '      - name: Require all Windows suites\n        "continue-on-error": true\n',
+            WORKFLOW.name,
+        ),
+    ),
+    (
+        # Exercises the bounded branch of the step slice, dead while the guard is
+        # the aggregate's only step: appends a trailing step so `stop` is no
+        # longer -1, and defeats the guard from the post-run position.
+        "add-a-trailing-step-and-gate-the-guard-off",
+        "aggregate-step-unconditional",
+        lambda text: posture_harness.replace_once(
+            text,
+            '          echo "Windows suites passed"\n',
+            '          echo "Windows suites passed"\n        if: ${{ false }}\n'
+            "      - name: Trailing step\n        run: echo trailing\n",
+            WORKFLOW.name,
         ),
     ),
     (

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -1,96 +1,270 @@
 #!/usr/bin/env python3
-"""Pin the blocking topology of the split Windows compatibility workflow."""
+"""Pin and mutation-test the split Windows workflow's blocking topology."""
 
 from __future__ import annotations
 
 import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
-WORKFLOW = ROOT / ".github" / "workflows" / "build-check-windows.yml"
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-check-windows.yml"
+
+Mutation = tuple[str, str, Callable[[str], str]]
 
 
-def fail(message: str) -> None:
-    print(f"build-check-windows workflow: {message}", file=sys.stderr)
-    raise SystemExit(1)
-
-
-def job_block(workflow: str, job_name: str) -> str:
-    """Return one top-level job block from the repository-owned workflow."""
+def _job_block(workflow: str, job_name: str) -> str:
+    """Return one top-level job block, or the empty string when absent."""
     match = re.search(
         rf"(?ms)^  {re.escape(job_name)}:\n(.*?)(?=^  [a-z0-9_-]+:\n|\Z)",
         workflow,
     )
-    if match is None:
-        fail(f"job {job_name!r} is missing")
-    return match.group(1)
+    return match.group(1) if match is not None else ""
 
 
-def main() -> int:
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-    agentbundle = job_block(workflow, "agentbundle-windows")
-    credbroker = job_block(workflow, "credbroker-tests-windows")
-    lock_semantics = job_block(workflow, "lock-semantics-windows")
-    aggregate = job_block(workflow, "build-check-windows")
+def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
+    """Return stable violation labels for one workflow text."""
+    violations: list[str] = []
 
-    if "    runs-on: windows-latest\n" not in agentbundle:
-        fail("AgentBundle compatibility job must run on windows-latest")
-    if "    runs-on: windows-latest\n" not in credbroker:
-        fail("CredBroker test job must run on windows-latest")
-    if "    runs-on: windows-latest\n" not in lock_semantics:
-        fail("lock semantics job must run on windows-latest")
-    for job_name, block, expected_timeout in (
-        ("AgentBundle", agentbundle, 15),
-        ("CredBroker", credbroker, 10),
-        ("aggregate", aggregate, 5),
+    def check(label: str, condition: bool) -> None:
+        if evaluated is not None:
+            evaluated.append(label)
+        if not condition:
+            violations.append(label)
+
+    check("workflow-file-present", bool(text))
+    if not text:
+        return violations
+
+    blocks = {
+        "agentbundle-windows": _job_block(text, "agentbundle-windows"),
+        "credbroker-tests-windows": _job_block(text, "credbroker-tests-windows"),
+        "lock-semantics-windows": _job_block(text, "lock-semantics-windows"),
+        "build-check-windows": _job_block(text, "build-check-windows"),
+    }
+    for job_name, block in blocks.items():
+        check(f"job-present[{job_name}]", bool(block))
+
+    for job_name in (
+        "agentbundle-windows",
+        "credbroker-tests-windows",
+        "lock-semantics-windows",
     ):
-        if f"    timeout-minutes: {expected_timeout}\n" not in block:
-            fail(f"{job_name} job must retain its bounded timeout")
+        check(
+            f"windows-runner[{job_name}]",
+            "    runs-on: windows-latest\n" in blocks[job_name],
+        )
+
+    for job_name, expected_timeout in (
+        ("agentbundle-windows", 15),
+        ("credbroker-tests-windows", 10),
+        ("build-check-windows", 5),
+    ):
+        check(
+            f"bounded-timeout[{job_name}]",
+            f"    timeout-minutes: {expected_timeout}\n" in blocks[job_name],
+        )
 
     suite_step = (
         "      - name: Run CredBroker suite\n"
         "        working-directory: packages/credbroker\n"
         "        run: python -m pytest\n"
     )
-    if credbroker.count(suite_step) != 1:
-        fail("CredBroker job must run its complete package suite")
-    lease_suite_step = "        run: python -m pytest tools/test_coordination_lease.py -q\n"
-    if lock_semantics.count(lease_suite_step) != 1:
-        fail("lock semantics job must run the real coordination lease suite")
+    check(
+        "credbroker-full-suite",
+        blocks["credbroker-tests-windows"].count(suite_step) == 1,
+    )
 
-    if "    name: make build-check (windows)\n" not in aggregate:
-        fail("aggregate must preserve the required check name")
+    lease_suite_step = "        run: python -m pytest tools/test_coordination_lease.py -q\n"
+    check(
+        "lock-semantics-real-suite",
+        blocks["lock-semantics-windows"].count(lease_suite_step) == 1,
+    )
+
+    aggregate = blocks["build-check-windows"]
+    check(
+        "aggregate-required-name",
+        "    name: make build-check (windows)\n" in aggregate,
+    )
     required_needs = (
         "    needs:\n"
         "      - agentbundle-windows\n"
         "      - credbroker-tests-windows\n"
         "      - lock-semantics-windows\n"
     )
-    if required_needs not in aggregate:
-        fail("aggregate must depend on all Windows jobs")
-    if "    if: ${{ always() }}\n" not in aggregate:
-        fail("aggregate must run even when a dependency fails or is cancelled")
+    check("aggregate-needs-all", required_needs in aggregate)
+    check("aggregate-always-runs", "    if: ${{ always() }}\n" in aggregate)
 
     for result in (
         "needs.agentbundle-windows.result",
         "needs.credbroker-tests-windows.result",
         "needs.lock-semantics-windows.result",
     ):
-        if result not in aggregate:
-            fail(f"aggregate does not check {result}")
+        check(f"aggregate-result-reference[{result}]", result in aggregate)
+
     for result_variable in (
         "AGENTBUNDLE_RESULT",
         "CREDBROKER_RESULT",
         "LOCK_SEMANTICS_RESULT",
     ):
         comparison = f'[ "${result_variable}" != "success" ]'
-        if comparison not in aggregate:
-            fail(f"aggregate does not require {result_variable} to succeed")
+        check(
+            f"aggregate-requires-success[{result_variable}]",
+            comparison in aggregate,
+        )
 
-    print("build-check-windows workflow: ok")
+    return violations
+
+
+def _baseline() -> str:
+    """Return the real workflow, or the empty missing-file sentinel."""
+    if WORKFLOW.is_file():
+        return WORKFLOW.read_text(encoding="utf-8")
+    return ""
+
+
+_MUTATIONS: list[Mutation] = [
+    ("remove-workflow-file", "workflow-file-present", lambda _text: ""),
+    (
+        "rename-agentbundle-job",
+        "job-present[agentbundle-windows]",
+        lambda text: text.replace(
+            "  agentbundle-windows:\n", "  agentbundle-windows-disabled:\n", 1
+        ),
+    ),
+    (
+        "move-agentbundle-off-windows",
+        "windows-runner[agentbundle-windows]",
+        lambda text: text.replace("    runs-on: windows-latest\n", "    runs-on: ubuntu-latest\n", 1),
+    ),
+    (
+        "remove-agentbundle-timeout",
+        "bounded-timeout[agentbundle-windows]",
+        lambda text: text.replace("    timeout-minutes: 15\n", "    timeout-minutes: 16\n", 1),
+    ),
+    (
+        "narrow-credbroker-suite",
+        "credbroker-full-suite",
+        lambda text: text.replace(
+            "        run: python -m pytest\n",
+            "        run: python -m pytest -q\n",
+            1,
+        ),
+    ),
+    (
+        "replace-real-lease-suite",
+        "lock-semantics-real-suite",
+        lambda text: text.replace(
+            "python -m pytest tools/test_coordination_lease.py -q",
+            "python -m pytest tools/test_windows_lock_semantics.py -q",
+            1,
+        ),
+    ),
+    (
+        "rename-required-check",
+        "aggregate-required-name",
+        lambda text: text.replace(
+            "    name: make build-check (windows)\n",
+            "    name: Windows aggregate\n",
+            1,
+        ),
+    ),
+    (
+        "drop-lock-semantics-need",
+        "aggregate-needs-all",
+        lambda text: text.replace("      - lock-semantics-windows\n", "", 1),
+    ),
+    (
+        "make-aggregate-conditional",
+        "aggregate-always-runs",
+        lambda text: text.replace(
+            "    if: ${{ always() }}\n", "    if: ${{ success() }}\n", 1
+        ),
+    ),
+    (
+        "drop-lock-result-reference",
+        "aggregate-result-reference[needs.lock-semantics-windows.result]",
+        lambda text: text.replace(
+            "${{ needs.lock-semantics-windows.result }}",
+            "${{ needs.agentbundle-windows.result }}",
+            1,
+        ),
+    ),
+    (
+        "stop-requiring-lock-success",
+        "aggregate-requires-success[LOCK_SEMANTICS_RESULT]",
+        lambda text: text.replace(
+            '[ "$LOCK_SEMANTICS_RESULT" != "success" ]',
+            '[ "$LOCK_SEMANTICS_RESULT" = "failure" ]',
+            1,
+        ),
+    ),
+]
+
+
+def _family(label: str) -> str:
+    """Collapse repeated indexed assertions into one mutation family."""
+    return re.sub(r"\[.*\]$", "[*]", label)
+
+
+def self_test() -> int:
+    """Prove the real baseline and every evaluated assertion family."""
+    failures: list[str] = []
+    good = _baseline()
+    evaluated: list[str] = []
+    baseline_violations = audit(good, evaluated)
+    if baseline_violations:
+        failures.append(f"baseline should be clean, got {baseline_violations}")
+
+    for mutation_id, expected, transform in _MUTATIONS:
+        mutated = transform(good)
+        if mutated == good:
+            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            continue
+        got = audit(mutated)
+        if expected not in got:
+            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
+
+    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
+    uncovered = sorted({_family(label) for label in evaluated} - covered)
+    if uncovered:
+        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    if failures:
+        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
+        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    """Run the harness, then audit the repository workflow."""
+    if "--self-test" in argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    violations = audit(_baseline())
+    if violations:
+        print(
+            f"✖ build-check-windows.yml: {len(violations)} posture violation(s):",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+    print("✓ build-check-windows.yml posture OK")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -7,10 +7,13 @@ guard must be the run body's first statement, its condition must equal
 `GUARD_CONDITION` exactly, and the failing `exit 1` must be reached without
 crossing an `else`/`elif` branch, a nested opener, or a subshell wrapper.
 
-Deliberately not asserted, and so not claimed: anything outside that run body.
-A step-level `continue-on-error: true` or `if:` on the aggregate step defeats
-the required check while both properties above stay true, and no assertion here
-covers it.
+The aggregate's guard STEP is asserted too: `aggregate-step-unconditional`
+refuses a `continue-on-error` or an `if:` on it, in either key position, because
+either defeats the required check while the guard body stays perfectly correct.
+
+Deliberately not asserted, and so not claimed: a JOB-level `continue-on-error`
+on `build-check-windows` itself, and anything outside the aggregate job. Both
+are registered.
 
 The blocking property is additionally checked against bash rather than only
 modelled, because a text model of a shell is not the shell: see
@@ -77,6 +80,20 @@ GUARD_RUN_MARKER = "        run: |\n"
 _BLOCK_OPENERS = frozenset(
     {"if", "case", "while", "until", "for", "select", "else", "elif"}
 )
+
+
+def _replace_once(text: str, old: str, new: str) -> str:
+    """Substitute exactly one occurrence, or raise.
+
+    Mirrors the ci-security sibling: a mutation whose literal drifts must fail
+    loudly rather than silently become a no-op the matrix reports as caught.
+    """
+    if text.count(old) != 1:
+        raise AssertionError(
+            f"mutation literal is not present exactly once ({text.count(old)}x): "
+            f"{old!r} — re-pin it against {WORKFLOW.name}"
+        )
+    return text.replace(old, new, 1)
 
 
 def _bash_path() -> str | None:
@@ -244,13 +261,19 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     # `continue-on-error: true` or `if:` on the step that runs it leaves every
     # assertion above satisfied while the required check reports success over
     # three failed Windows suites.
-    guard_step = (
-        aggregate[: aggregate.index(GUARD_RUN_MARKER)]
-        if GUARD_RUN_MARKER in aggregate
-        else ""
-    )
-    if "      - " in guard_step:
-        guard_step = guard_step[guard_step.rindex("      - ") :]
+    # The WHOLE step, not just what precedes `run:`. YAML mapping keys are
+    # unordered, so `continue-on-error: true` written under the final echo has
+    # identical effect and the earlier slice never looked there — while both
+    # mutations happened to insert above `run:`, the one position it did look at.
+    # The 8-space anchor cannot match the run body, which is indented 10.
+    guard_step = ""
+    if GUARD_RUN_MARKER in aggregate:
+        head = aggregate[: aggregate.index(GUARD_RUN_MARKER)]
+        if "      - " in head:
+            start = head.rindex("      - ")
+            rest = aggregate[aggregate.index(GUARD_RUN_MARKER) :]
+            stop = rest.find("\n      - ")
+            guard_step = aggregate[start:] if stop == -1 else aggregate[start:][: len(head) - start + stop]
     check(
         "aggregate-step-unconditional",
         bool(guard_step)
@@ -353,12 +376,14 @@ _MUTATIONS: list[Mutation] = [
         ),
     ),
     (
-        "gate-the-guard-step-off",
+        # Deliberately AFTER the run block: key order is irrelevant to Actions,
+        # and this is the position the previous slice could not see.
+        "gate-the-guard-step-off-after-the-run-block",
         "aggregate-step-unconditional",
-        lambda text: text.replace(
-            "      - name: Require all Windows suites\n",
-            "      - name: Require all Windows suites\n        if: ${{ false }}\n",
-            1,
+        lambda text: _replace_once(
+            text,
+            '          echo "Windows suites passed"\n',
+            '          echo "Windows suites passed"\n        if: ${{ false }}\n',
         ),
     ),
     (

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -221,12 +221,12 @@ _MUTATIONS: list[Mutation] = [
         lambda text: text.replace("    runs-on: windows-latest\n", "    runs-on: ubuntu-latest\n", 1),
     ),
     (
-        "remove-agentbundle-timeout",
+        "bump-agentbundle-timeout-past-the-pin",
         "bounded-timeout[agentbundle-windows]",
         lambda text: text.replace("    timeout-minutes: 15\n", "    timeout-minutes: 16\n", 1),
     ),
     (
-        "narrow-credbroker-suite",
+        "add-args-to-credbroker-suite",
         "credbroker-full-suite",
         lambda text: text.replace(
             "        run: python -m pytest\n",
@@ -452,12 +452,27 @@ def self_test() -> int:
     evaluated: list[str] = []
     baseline_violations = audit(good, evaluated)
     if baseline_violations:
-        failures.append(f"baseline should be clean, got {baseline_violations}")
+        # Return before the matrix. Every transform is pinned to the real
+        # workflow's text, so a dirty or missing baseline turns each one into a
+        # no-op — or, where a transform asserts its literal, into an exception —
+        # burying the one true cause under a wall of derived noise that names
+        # neither the cause nor the file to edit.
+        print(
+            f"\u2716 self-test: {WORKFLOW} is not clean; "
+            f"{len(baseline_violations)} posture violation(s) before any mutation:",
+            file=sys.stderr,
+        )
+        for violation in baseline_violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
 
     for mutation_id, expected, transform in _MUTATIONS:
         mutated = transform(good)
         if mutated == good:
-            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            failures.append(
+                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
+                "proves nothing; re-pin its literal against that file"
+            )
             continue
         got = audit(mutated)
         if expected not in got:

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -105,12 +105,12 @@ def _guard_blocks_on_failure(aggregate: str) -> bool:
     one blocking `if` plus two advisory ones satisfied both, leaving two of three
     Windows suites non-blocking behind the required check.
 
-    Three structural requirements, each fail-closed, and each answering a body
-    bash takes green that a looser reading accepted: the guard is the run body's
-    first statement (anything before it can `exit 0`, reassign a result, or open
-    a wrapper); its condition equals `GUARD_CONDITION` exactly; and the `exit 1`
-    is reached without crossing a nested opener, an `else`/`elif` branch, or a
-    subshell.
+    Three structural requirements, the first two fail-closed, each answering a
+    body bash takes green that a looser reading accepted: the guard is the run
+    body's first statement (anything before it can `exit 0`, reassign a result,
+    or open a wrapper); its condition equals `GUARD_CONDITION` exactly; and the
+    `exit 1` is reached without crossing a nested opener, an `else`/`elif`
+    branch, or a subshell.
 
     The condition is compared by equality, not by containment of the three
     comparisons: substring containment accepted `] && [` in place of `] || [`, a

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -249,19 +249,30 @@ _MUTATIONS: list[Mutation] = [
     ),
     (
         # The subtler fail-open: every comparison string survives, so the
-        # per-variable family stays satisfied, but only one job blocks.
+        # per-variable family stays satisfied, but only agentbundle blocks —
+        # credbroker and lock-semantics merely log. Replacing the whole guard
+        # block matters: substituting only the `if` line would leave the
+        # original `exit 1` body attached to the second branch, and the mutant
+        # would still block on all three.
         "split-the-guard-so-only-one-job-blocks",
         "aggregate-blocks-on-failure",
         lambda text: text.replace(
             '          if [ "$AGENTBUNDLE_RESULT" != "success" ]'
             ' || [ "$CREDBROKER_RESULT" != "success" ]'
-            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n',
+            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n'
+            '            echo "Windows suites failed: agentbundle='
+            "$AGENTBUNDLE_RESULT credbroker=$CREDBROKER_RESULT "
+            'lock-semantics=$LOCK_SEMANTICS_RESULT" >&2\n'
+            "            exit 1\n"
+            "          fi\n",
             '          if [ "$AGENTBUNDLE_RESULT" != "success" ]; then\n'
             '            echo "agentbundle failed" >&2\n'
             "            exit 1\n"
             "          fi\n"
             '          if [ "$CREDBROKER_RESULT" != "success" ]'
-            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n',
+            ' || [ "$LOCK_SEMANTICS_RESULT" != "success" ]; then\n'
+            '            echo "credbroker/lock-semantics failed (advisory)" >&2\n'
+            "          fi\n",
             1,
         ),
     ),

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -25,6 +25,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import posture_harness
+
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
@@ -561,69 +563,20 @@ def _differential_failures() -> list[str]:
     return out
 
 
-def _family(label: str) -> str:
-    """Collapse repeated indexed assertions into one mutation family."""
-    return re.sub(r"\[.*\]$", "[*]", label)
-
-
 def self_test() -> int:
-    """Prove the real baseline and every evaluated assertion family."""
-    failures: list[str] = []
-    good = _baseline()
-    evaluated: list[str] = []
-    baseline_violations = audit(good, evaluated)
-    if baseline_violations:
-        # Return before the matrix. Every transform is pinned to the real
-        # workflow's text, so a dirty or missing baseline turns each one into a
-        # no-op — or, where a transform asserts its literal, into an exception —
-        # burying the one true cause under a wall of derived noise that names
-        # neither the cause nor the file to edit.
-        print(
-            f"\u2716 self-test: {WORKFLOW} is not clean; "
-            f"{len(baseline_violations)} posture violation(s) before any mutation:",
-            file=sys.stderr,
-        )
-        for violation in baseline_violations:
-            print(f"  - {violation}", file=sys.stderr)
-        return 1
-
-    for mutation_id, expected, transform in _MUTATIONS:
-        mutated = transform(good)
-        if mutated == good:
-            failures.append(
-                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
-                "proves nothing; re-pin its literal against that file"
-            )
-            continue
-        got = audit(mutated)
-        if expected not in got:
-            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
-
-    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
-    uncovered = sorted({_family(label) for label in evaluated} - covered)
-    if uncovered:
-        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
-
-    differential = _differential_failures()
-    failures.extend(differential)
-
-    if failures:
-        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
-        for failure in failures:
-            print(f"  - {failure}", file=sys.stderr)
-        return 1
-    # Never a static count: an unrun differential must not report agreements.
-    agreed = (
-        f"{len(_DIFFERENTIAL_VARIANTS) - 1} guard bodies agreed with bash"
-        if _bash_path() is not None
-        else "differential skipped, bash unavailable"
+    """Prove the baseline, the mutation matrix, and the model against bash."""
+    return posture_harness.run(
+        workflow=WORKFLOW,
+        baseline=_baseline,
+        audit=audit,
+        mutations=_MUTATIONS,
+        extra_failures=_differential_failures,
+        extra_summary=lambda: (
+            f"{len(_DIFFERENTIAL_VARIANTS) - 1} guard bodies agreed with bash"
+            if _bash_path() is not None
+            else "differential skipped, bash unavailable"
+        ),
     )
-    print(
-        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
-        f"every one of {len(covered)} assertion families has ≥1 mutation; "
-        f"{agreed}"
-    )
-    return 0
 
 
 def main(argv: list[str]) -> int:

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -238,6 +238,22 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         )
 
     check("aggregate-blocks-on-failure", _guard_blocks_on_failure(aggregate))
+    # The guard body can be perfectly correct and still not block: a step-level
+    # `continue-on-error: true` or `if:` on the step that runs it leaves every
+    # assertion above satisfied while the required check reports success over
+    # three failed Windows suites.
+    guard_step = (
+        aggregate[: aggregate.index(GUARD_RUN_MARKER)]
+        if GUARD_RUN_MARKER in aggregate
+        else ""
+    )
+    if "      - " in guard_step:
+        guard_step = guard_step[guard_step.rindex("      - ") :]
+    check(
+        "aggregate-step-unconditional",
+        bool(guard_step)
+        and not re.search(r"^        (?:continue-on-error|if):", guard_step, re.M),
+    )
 
     return violations
 
@@ -322,6 +338,24 @@ _MUTATIONS: list[Mutation] = [
         lambda text: text.replace(
             '[ "$LOCK_SEMANTICS_RESULT" != "success" ]',
             '[ "$LOCK_SEMANTICS_RESULT" = "failure" ]',
+            1,
+        ),
+    ),
+    (
+        "make-the-guard-step-advisory",
+        "aggregate-step-unconditional",
+        lambda text: text.replace(
+            "      - name: Require all Windows suites\n",
+            "      - name: Require all Windows suites\n        continue-on-error: true\n",
+            1,
+        ),
+    ),
+    (
+        "gate-the-guard-step-off",
+        "aggregate-step-unconditional",
+        lambda text: text.replace(
+            "      - name: Require all Windows suites\n",
+            "      - name: Require all Windows suites\n        if: ${{ false }}\n",
             1,
         ),
     ),
@@ -448,6 +482,17 @@ def _differential_failures() -> list[str]:
     import os
     import subprocess
 
+    good = _baseline()
+    indented = "\n".join(
+        f"          {line}".rstrip() for line in _GUARD_BASE.splitlines()
+    )
+    # Ordered before the bash check on purpose: this is string containment and
+    # needs no shell, so a bash-less platform still gets the drift diagnostic.
+    if indented not in good:
+        return [
+            "differential: the constructed guard body is not in "
+            f"{WORKFLOW.name} — re-pin GUARD_CONDITION/GUARD_FAIL_ECHO against it"
+        ]
     if _bash_path() is None:
         # Announced, never fatal. `build_gate_chain.py build-check` is the shipped
         # make-free Windows contributor entry point, so turning an absent shell
@@ -459,16 +504,6 @@ def _differential_failures() -> list[str]:
             file=sys.stderr,
         )
         return []
-    good = _baseline()
-    indented = "\n".join(
-        f"          {line}".rstrip() for line in _GUARD_BASE.splitlines()
-    )
-    if indented not in good:
-        return [
-            "differential: the constructed guard body is not in "
-            f"{WORKFLOW.name} — re-pin GUARD_CONDITION/GUARD_FAIL_ECHO against it"
-        ]
-
     # Every result variable is bound: an unset one changes which comparison
     # short-circuits rather than signalling failure. The environment is minimal
     # rather than inherited, so nothing the parent holds reaches the child.

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Pin and mutation-test the split Windows workflow's blocking topology."""
+"""Pin and mutation-test the split Windows workflow's blocking topology.
+
+Blocking means two things and both are asserted: the aggregate reads every work
+job's result, and its guard exits non-zero when one of them is not `success`.
+"""
 
 from __future__ import annotations
 
@@ -24,6 +28,27 @@ def _job_block(workflow: str, job_name: str) -> str:
         workflow,
     )
     return match.group(1) if match is not None else ""
+
+
+def _guard_blocks_on_failure(aggregate: str) -> bool:
+    """Return whether the results guard's failure branch exits non-zero.
+
+    The three ``!= "success"`` comparisons prove only that the aggregate reads
+    the work jobs' results. Without this, flipping the guard body's ``exit 1``
+    to ``exit 0`` leaves every other label satisfied while the required check
+    reports success on a failing Windows job.
+    """
+    lines = aggregate.splitlines()
+    for index, line in enumerate(lines):
+        if '!= "success"' not in line or not line.rstrip().endswith("; then"):
+            continue
+        for following in lines[index + 1 :]:
+            stripped = following.strip()
+            if stripped == "fi":
+                return False
+            if stripped == "exit 1":
+                return True
+    return False
 
 
 def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
@@ -117,6 +142,8 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
             comparison in aggregate,
         )
 
+    check("aggregate-blocks-on-failure", _guard_blocks_on_failure(aggregate))
+
     return violations
 
 
@@ -202,6 +229,13 @@ _MUTATIONS: list[Mutation] = [
             '[ "$LOCK_SEMANTICS_RESULT" = "failure" ]',
             1,
         ),
+    ),
+    (
+        # The fail-open shape: the guard still reads every result, still logs,
+        # and still reports the required check green.
+        "make-the-guard-exit-zero",
+        "aggregate-blocks-on-failure",
+        lambda text: text.replace("            exit 1\n", "            exit 0\n", 1),
     ),
 ]
 

--- a/tools/test-build-check-windows-workflow.py
+++ b/tools/test-build-check-windows-workflow.py
@@ -47,6 +47,24 @@ RESULT_VARIABLES = (
     "CREDBROKER_RESULT",
     "LOCK_SEMANTICS_RESULT",
 )
+# The guard body this harness owns. It is built here, pinned against the
+# workflow by equality, and it — never workflow text — is what reaches `bash`.
+# Handing file text to a shell would let a one-file PR run arbitrary commands on
+# any machine executing `make build-check`; the sibling avoids that by
+# construction and so does this.
+GUARD_CONDITION = (
+    "if "
+    + " || ".join(f'[ "${variable}" != "success" ]' for variable in RESULT_VARIABLES)
+    + "; then"
+)
+GUARD_FAIL_ECHO = (
+    '  echo "Windows suites failed: agentbundle=$AGENTBUNDLE_RESULT '
+    'credbroker=$CREDBROKER_RESULT lock-semantics=$LOCK_SEMANTICS_RESULT" >&2'
+)
+GUARD_FINAL_ECHO = 'echo "Windows suites passed"'
+_GUARD_BASE = "\n".join(
+    [GUARD_CONDITION, GUARD_FAIL_ECHO, "  exit 1", "fi", GUARD_FINAL_ECHO]
+)
 
 
 GUARD_RUN_MARKER = "        run: |\n"
@@ -80,21 +98,24 @@ def _guard_blocks_on_failure(aggregate: str) -> bool:
     Three structural requirements, each fail-closed, and each answering a body
     bash takes green that a looser reading accepted: the guard is the run body's
     first statement (anything before it can `exit 0`, reassign a result, or open
-    a wrapper); its condition carries all three comparisons itself; and the
-    `exit 1` is reached without crossing a nested block opener or a subshell.
+    a wrapper); its condition equals `GUARD_CONDITION` exactly; and the `exit 1`
+    is reached without crossing a nested opener, an `else`/`elif` branch, or a
+    subshell.
+
+    The condition is compared by equality, not by containment of the three
+    comparisons: substring containment accepted `] && [` in place of `] || [`, a
+    two-character edit that leaves the required Windows check green over any one
+    failed suite. Same treatment the concurrency literals get in the siblings.
+
+    A leading `set -euo pipefail`, comment, or line continuation therefore fails
+    this check. That is the documented rule, not an oversight — the guard is
+    then not the first statement — and it errs toward reporting a blocking guard
+    as unproven rather than the reverse.
     """
     body = [line for line in _guard_body(aggregate).splitlines() if line.strip()]
     if not body:
         return False
-    first = body[0].strip()
-    if first.startswith(("(", "{")):
-        return False
-    if not first.endswith("; then"):
-        return False
-    if any(
-        f'[ "${variable}" != "success" ]' not in first
-        for variable in RESULT_VARIABLES
-    ):
+    if body[0].strip() != GUARD_CONDITION:
         return False
     for line in body[1:]:
         stripped = line.strip()
@@ -102,6 +123,10 @@ def _guard_blocks_on_failure(aggregate: str) -> bool:
             return False
         if stripped == "exit 1":
             return True
+        # `else`/`elif` put the exit on a branch bash need not take: the advisory
+        # echo goes in the `then` arm and every suite stops blocking.
+        if stripped == "else" or stripped.startswith("elif "):
+            return False
         if stripped.startswith(_BLOCK_OPENERS) or stripped.startswith(("(", "{")):
             return False
     return False
@@ -363,6 +388,16 @@ _DIFFERENTIAL_VARIANTS: list[tuple[str, Callable[[str], str]]] = [
         ),
     ),
     (
+        # The advisory echo takes the `then` arm and the exit moves to `else`, so
+        # bash never reaches it with a suite failed.
+        "else-branch-exit",
+        lambda body: body.replace(
+            f"{GUARD_FAIL_ECHO}\n{_EXIT_LINE}",
+            f"{GUARD_FAIL_ECHO}\nelse\n  exit 1",
+            1,
+        ),
+    ),
+    (
         "subshell-or-true",
         lambda body: body.replace("if [", "( if [", 1).replace(
             "\nfi", "\nfi ) || true", 1
@@ -372,7 +407,19 @@ _DIFFERENTIAL_VARIANTS: list[tuple[str, Callable[[str], str]]] = [
 
 
 def _differential_failures() -> list[str]:
-    """Guard bodies bash takes green with a suite failed, that `audit` accepts."""
+    """Guard bodies bash takes green with a suite failed, that `audit` accepts.
+
+    `audit` encodes a BELIEF about what a shell does with the guard. The mutation
+    matrix proves the assertion fires; it cannot prove the belief. So ask bash —
+    but ask it only about `_GUARD_BASE`, which this module builds from its own
+    constants. Workflow text is never executed; it is tied to `_GUARD_BASE` by
+    the round-trip assertion below, so drift shows up as a blind harness rather
+    than as a shell running whatever a PR put in the file.
+
+    The property is an implication, not an equality: if bash exits 0 with a suite
+    reported `failure`, `audit` MUST reject. The converse is not required —
+    rejecting a body bash would also fail is merely conservative.
+    """
     import os
     import shutil
     import subprocess
@@ -380,28 +427,30 @@ def _differential_failures() -> list[str]:
     if not shutil.which("bash"):
         # The make-free Windows contributor path is a shipped acceptance
         # criterion, so a hard shell dependency would fail a gate it has no
-        # business failing. Same reasoning as the build-check sibling.
-        return []
+        # business failing. Announced, not silent: an unrun differential must
+        # not read as a passing one.
+        return ["differential: SKIPPED — bash unavailable, shell model unproven"]
     good = _baseline()
-    body = _guard_body(_job_block(good, "build-check-windows"))
-    if not body:
-        return ["differential: guard body not found — the harness is blind"]
-    indented = "\n".join(f"          {line}".rstrip() for line in body.splitlines())
+    indented = "\n".join(
+        f"          {line}".rstrip() for line in _GUARD_BASE.splitlines()
+    )
     if indented not in good:
-        return ["differential: guard body did not round-trip — the harness is blind"]
+        return [
+            "differential: the constructed guard body is not in "
+            f"{WORKFLOW.name} — re-pin GUARD_CONDITION/GUARD_FAIL_ECHO against it"
+        ]
 
-    # EVERY result variable must be bound: an unset one is not a failure signal,
-    # it just changes which comparison short-circuits, and a variant that is
-    # never green is never reported green-and-accepted — it silently stops
-    # proving anything.
-    env = dict(os.environ)
-    env.update(dict.fromkeys(RESULT_VARIABLES, "success"))
+    # Every result variable is bound: an unset one changes which comparison
+    # short-circuits rather than signalling failure. The environment is minimal
+    # rather than inherited, so nothing the parent holds reaches the child.
+    env = dict.fromkeys(RESULT_VARIABLES, "success")
     env["LOCK_SEMANTICS_RESULT"] = "failure"
+    env["PATH"] = os.environ.get("PATH", "")
 
     out: list[str] = []
     for name, transform in _DIFFERENTIAL_VARIANTS:
-        variant = transform(body)
-        if name != "baseline" and variant == body:
+        variant = transform(_GUARD_BASE)
+        if name != "baseline" and variant == _GUARD_BASE:
             out.append(f"differential[{name}]: transform was a no-op — proves nothing")
             continue
         spliced = good.replace(
@@ -414,7 +463,6 @@ def _differential_failures() -> list[str]:
             subprocess.run(
                 ["bash", "-c", variant],
                 env=env,
-                cwd=REPO_ROOT,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -423,7 +471,7 @@ def _differential_failures() -> list[str]:
         )
         if name == "baseline":
             # The harness's own premise. If an unmodified guard is green with a
-            # suite failed, every "blocked" verdict below is vacuous.
+            # suite failed, every verdict below is vacuous.
             if green:
                 out.append(
                     "differential[baseline]: the clean guard exits 0 with "
@@ -432,7 +480,16 @@ def _differential_failures() -> list[str]:
             if not accepted:
                 out.append("differential[baseline]: the clean guard is rejected by audit")
             continue
-        if green and accepted:
+        if not green:
+            # A variant that is never green is never reported green-and-accepted,
+            # so it silently stops proving anything — the class the no-op rule
+            # catches only for an identical transform.
+            out.append(
+                f"differential[{name}]: variant is not green under bash "
+                "— proves nothing"
+            )
+            continue
+        if accepted:
             out.append(
                 f"differential[{name}]: bash exits 0 with lock-semantics failed, "
                 "and audit accepts it"
@@ -483,7 +540,8 @@ def self_test() -> int:
     if uncovered:
         failures.append(f"assertion families evaluated but unmutated: {uncovered}")
 
-    failures.extend(_differential_failures())
+    differential = _differential_failures()
+    failures.extend(differential)
 
     if failures:
         print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
@@ -492,7 +550,8 @@ def self_test() -> int:
         return 1
     print(
         f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
-        f"every one of {len(covered)} assertion families has ≥1 mutation"
+        f"every one of {len(covered)} assertion families has ≥1 mutation; "
+        f"{len(_DIFFERENTIAL_VARIANTS) - 1} guard bodies agreed with bash"
     )
     return 0
 

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -1,168 +1,369 @@
 #!/usr/bin/env python3
-"""Posture check for .github/workflows/ci-security.yml.
+"""Posture test for ``.github/workflows/ci-security.yml``.
 
-Security-load-bearing invariants (parallel to tools/test-pack-evals-workflow.py):
-  - Triggers: pull_request + push only; pull_request_target absent.
-  - Permissions: top-level contents:read; no broader job-level permissions.
-  - gitleaks checkout: fetch-depth: 0 in the secret-scan job.
-  - gitleaks shell body: no ${{ }} interpolation (env-var pattern).
-  - gitleaks step: --redact flag present.
-  - Binary installs: sha256sum check appears before tar extraction.
-  - Concurrency: cancel-in-progress uses the pull_request gate expression.
+Security-load-bearing invariants:
 
-Pure-stdlib + PyYAML (already a tools/ dependency).
+* pull-request and push triggers only; never ``pull_request_target``;
+* top-level ``contents: read`` and no job-level permission escalation;
+* full-history checkout for the gitleaks range scan;
+* no Actions expression interpolation in the gitleaks shell body;
+* ``--redact`` on every gitleaks detect invocation;
+* checksum verification before every binary archive extraction; and
+* pull-request-only concurrency cancellation with unique non-PR groups.
+
+The mutation matrix runs on every invocation.  It uses the real workflow as its
+baseline, rejects no-op transforms, expects a specific label from each mutant,
+and covers every assertion family evaluated by the clean baseline.
 """
 
 from __future__ import annotations
 
-import pathlib
+import re
 import sys
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
 
 import yaml
 
-# Windows cp1252 guard — this script prints non-ASCII verdict marks, and
-# `build_gate_chain.py`'s own guard covers only the parent process: `_script_step`
-# spawns children with the inherited environment and nothing forcing PYTHONUTF8.
-# A redirected or piped stdout on Windows falls back to the legacy ANSI code page,
-# where even the SUCCESS print raises UnicodeEncodeError and a passing check
-# returns non-zero. Same shape as `tools/test-test-all.py`.
+# Windows cp1252 guard — the parent gate does not force UTF-8 for child Python.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-security.yml"
+EXPECTED_GROUP = (
+    "ci-security-${{ github.event_name == 'pull_request' && github.ref || "
+    "github.run_id }}"
+)
+
+Mutation = tuple[str, str, Callable[[str], str]]
 
 
-def fail(msg: str) -> None:
-    print(f"✖ ci-security.yml: {msg}", file=sys.stderr)
-    sys.exit(1)
-
-
-def main() -> int:
-    if not WORKFLOW.exists():
-        fail(f"not found at {WORKFLOW}")
-
-    text = WORKFLOW.read_text(encoding="utf-8")
-    try:
-        doc = yaml.safe_load(text)
-    except yaml.YAMLError as exc:
-        fail(f"does not parse as YAML: {exc}")
-
-    # PyYAML parses the bareword `on:` key as the boolean True.
-    triggers = doc.get("on", doc.get(True))
-    if not isinstance(triggers, dict):
-        fail("`on:` must be a mapping of trigger types")
-    if "pull_request" not in triggers or "push" not in triggers:
-        fail("must trigger on both `pull_request` and `push`")
-    if "pull_request_target" in triggers:
-        fail("must NOT trigger on `pull_request_target` — fork PRs could reach secrets")
-
-    # Least-privilege permissions at workflow level.
-    perms = doc.get("permissions")
-    if perms != {"contents": "read"}:
-        fail(f"top-level permissions must be {{contents: read}}, got {perms!r}")
-
-    jobs = doc.get("jobs", {})
-    if not jobs:
-        fail("no jobs found")
-
-    # No job-level permission escalation beyond workflow-level.
+def _steps(jobs: object) -> Iterable[tuple[str, dict[Any, Any]]]:
+    """Yield mapping-shaped steps with their owning job name."""
+    if not isinstance(jobs, dict):
+        return
     for job_name, job in jobs.items():
-        job_perms = job.get("permissions")
-        if job_perms is not None:
-            fail(
-                f"job `{job_name}` sets explicit permissions {job_perms!r}; "
-                f"workflow-level contents:read is sufficient — no escalation allowed"
-            )
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                yield str(job_name), step
 
-    # Concurrency: PR runs share a ref group; non-PR runs must be unique.
-    concurrency = doc.get("concurrency", {})
-    expected_group = (
-        "ci-security-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}"
+
+def _checksum_precedes_extract(run_body: str) -> bool:
+    """Return whether a checksum command occurs before the first tar extract."""
+    extract_positions = [
+        position
+        for marker in ("tar xz", "tar xzf")
+        if (position := run_body.find(marker)) != -1
+    ]
+    if not extract_positions:
+        return True
+    extract_at = min(extract_positions)
+    checksum_positions = [
+        position
+        for marker in ("sha256sum", "shasum")
+        if (position := run_body.find(marker)) != -1
+    ]
+    return bool(checksum_positions) and min(checksum_positions) < extract_at
+
+
+def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
+    """Return stable violation labels for one workflow text."""
+    violations: list[str] = []
+
+    def check(label: str, condition: bool) -> None:
+        if evaluated is not None:
+            evaluated.append(label)
+        if not condition:
+            violations.append(label)
+
+    check("workflow-file-present", bool(text))
+    if not text:
+        return violations
+
+    try:
+        loaded: Any = yaml.safe_load(text)
+    except yaml.YAMLError:
+        check("yaml-parses", False)
+        return violations
+    check("yaml-parses", isinstance(loaded, dict))
+    if not isinstance(loaded, dict):
+        return violations
+    doc: dict[Any, Any] = loaded
+
+    # PyYAML 1.1 resolves the bareword ``on`` as boolean True.
+    triggers = doc.get("on", doc.get(True))
+    check("triggers-mapping", isinstance(triggers, dict))
+    if isinstance(triggers, dict):
+        check(
+            "triggers-required",
+            "pull_request" in triggers and "push" in triggers,
+        )
+        check(
+            "trigger-forbidden[pull_request_target]",
+            "pull_request_target" not in triggers,
+        )
+
+    check("permissions-read", doc.get("permissions") == {"contents": "read"})
+
+    jobs = doc.get("jobs")
+    check("jobs-present", isinstance(jobs, dict) and bool(jobs))
+    check(
+        "jobs-mapping",
+        isinstance(jobs, dict)
+        and bool(jobs)
+        and all(isinstance(job, dict) for job in jobs.values()),
     )
-    if concurrency.get("group") != expected_group:
-        fail(
-            "concurrency.group must be "
-            f"{expected_group!r} so non-PR scans cannot be evicted; "
-            f"got: {concurrency.get('group')!r}"
-        )
+    if isinstance(jobs, dict):
+        for job_name, job in jobs.items():
+            if isinstance(job, dict):
+                check(
+                    f"job-steps-list[{job_name}]",
+                    isinstance(job.get("steps", []), list),
+                )
+                check(
+                    f"job-permissions[{job_name}]",
+                    job.get("permissions") is None,
+                )
+
+    concurrency = doc.get("concurrency")
+    concurrency = concurrency if isinstance(concurrency, dict) else {}
+    check("concurrency-group", concurrency.get("group") == EXPECTED_GROUP)
     cancel = str(concurrency.get("cancel-in-progress", ""))
-    if "pull_request" not in cancel:
-        fail(
-            "concurrency.cancel-in-progress must be conditional on github.event_name == "
-            "'pull_request' so push-to-main scans complete; "
-            f"got: {cancel!r}"
+    check("concurrency-cancel", "pull_request" in cancel)
+
+    secret_job = jobs.get("secret-scan") if isinstance(jobs, dict) else None
+    check("secret-job-present", isinstance(secret_job, dict))
+    secret_steps = (
+        secret_job.get("steps", []) if isinstance(secret_job, dict) else []
+    )
+    secret_steps = secret_steps if isinstance(secret_steps, list) else []
+
+    checkout_steps = [
+        step
+        for step in secret_steps
+        if isinstance(step, dict) and "checkout" in str(step.get("uses", ""))
+    ]
+    check("checkout-present", bool(checkout_steps))
+    for index, step in enumerate(checkout_steps):
+        with_block = step.get("with")
+        fetch_depth = with_block.get("fetch-depth") if isinstance(with_block, dict) else None
+        check(f"checkout-depth[{index}]", fetch_depth == 0)
+
+    gitleaks_steps = [
+        step
+        for step in secret_steps
+        if isinstance(step, dict)
+        and "gitleaks" in str(step.get("run", "")).lower()
+        and "detect" in str(step.get("run", "")).lower()
+    ]
+    check("gitleaks-step-present", bool(gitleaks_steps))
+    for index, step in enumerate(gitleaks_steps):
+        run_body = str(step.get("run", ""))
+        check(f"gitleaks-no-expression[{index}]", "${{" not in run_body)
+        check(f"gitleaks-redact[{index}]", "--redact" in run_body)
+
+    install_steps = [
+        step
+        for _job_name, step in _steps(jobs)
+        if "tar xz" in str(step.get("run", ""))
+        or "tar xzf" in str(step.get("run", ""))
+    ]
+    for index, step in enumerate(install_steps):
+        name = str(step.get("name", index))
+        check(
+            f"binary-checksum-before-extract[{name}]",
+            _checksum_precedes_extract(str(step.get("run", ""))),
         )
 
-    # secret-scan job: fetch-depth: 0 for gitleaks history range.
-    secret_job = jobs.get("secret-scan")
-    if secret_job is None:
-        fail("no `secret-scan` job found")
-    checkout_steps = [
-        s for s in secret_job.get("steps", [])
-        if "checkout" in str(s.get("uses", ""))
-    ]
-    if not checkout_steps:
-        fail("secret-scan job: no checkout step found")
-    for step in checkout_steps:
-        with_block = step.get("with", {})
-        if with_block.get("fetch-depth") != 0:
-            fail("secret-scan checkout: fetch-depth must be 0 for history range scan")
+    return violations
 
-    # gitleaks detect step: env-var pattern (no ${{ }} in shell body).
-    gitleaks_steps = [
-        s for s in secret_job.get("steps", [])
-        if "gitleaks" in str(s.get("run", "")).lower()
-        and "detect" in str(s.get("run", "")).lower()
-    ]
-    if not gitleaks_steps:
-        fail("secret-scan job: no gitleaks detect step found")
-    for step in gitleaks_steps:
-        run_body = step.get("run", "")
-        if "${{" in run_body:
-            fail(
-                "gitleaks detect step: ${{ }} found in shell body — "
-                "use env: block to pass GitHub-context values (injection sink pattern)"
-            )
-        if "--redact" not in run_body:
-            fail(
-                "gitleaks detect step: --redact flag missing — "
-                "matched secret values must never reach (public) CI logs"
-            )
 
-    # Binary install steps: sha256sum check before tar extraction.
-    install_steps = [
-        s for s in (secret_job.get("steps", []) + sum(
-            (j.get("steps", []) for j in jobs.values()), []
-        ))
-        if "tar xz" in str(s.get("run", "")) or "tar xzf" in str(s.get("run", ""))
-    ]
-    # Deduplicate by id
-    seen_ids: set[int] = set()
-    deduped = []
-    for s in install_steps:
-        sid = id(s)
-        if sid not in seen_ids:
-            seen_ids.add(sid)
-            deduped.append(s)
-    for step in deduped:
-        run_body = step.get("run", "")
-        if "sha256sum" not in run_body and "shasum" not in run_body:
-            name = step.get("name", "(unnamed)")
-            fail(
-                f"install step '{name}': no sha256sum/shasum verification found before "
-                f"tar extraction — binary must be verified against checksums.txt"
-            )
+def _baseline() -> str:
+    """Return the real workflow, or the empty missing-file sentinel."""
+    if WORKFLOW.is_file():
+        return WORKFLOW.read_text(encoding="utf-8")
+    return ""
 
+
+_MUTATIONS: list[Mutation] = [
+    ("remove-workflow-file", "workflow-file-present", lambda _text: ""),
+    ("break-yaml", "yaml-parses", lambda _text: "[unterminated\n"),
+    (
+        "replace-trigger-map-with-list",
+        "triggers-mapping",
+        lambda text: text.replace("on:\n", "on: []\nlegacy-on:\n", 1),
+    ),
+    (
+        "drop-push-trigger",
+        "triggers-required",
+        lambda text: text.replace("  push:\n", "  publish:\n", 1),
+    ),
+    (
+        "add-pull-request-target",
+        "trigger-forbidden[pull_request_target]",
+        lambda text: text.replace(
+            "  pull_request:\n    branches: [main]\n",
+            "  pull_request:\n    branches: [main]\n"
+            "  pull_request_target:\n    branches: [main]\n",
+            1,
+        ),
+    ),
+    (
+        "widen-top-level-permissions",
+        "permissions-read",
+        lambda text: text.replace("  contents: read\n", "  contents: write\n", 1),
+    ),
+    (
+        "remove-jobs-map",
+        "jobs-present",
+        lambda text: text.replace("jobs:\n", "disabled-jobs:\n", 1),
+    ),
+    (
+        "add-malformed-job",
+        "jobs-mapping",
+        lambda text: text.replace("jobs:\n", "jobs:\n  malformed: true\n", 1),
+    ),
+    (
+        "add-job-with-malformed-steps",
+        "job-steps-list[malformed]",
+        lambda text: text.replace(
+            "jobs:\n", "jobs:\n  malformed:\n    steps: true\n", 1
+        ),
+    ),
+    (
+        "add-job-permission-escalation",
+        "job-permissions[secret-scan]",
+        lambda text: text.replace(
+            "  secret-scan:\n",
+            "  secret-scan:\n    permissions:\n      contents: write\n",
+            1,
+        ),
+    ),
+    (
+        "make-concurrency-group-per-ref-only",
+        "concurrency-group",
+        lambda text: text.replace(EXPECTED_GROUP, "ci-security-${{ github.ref }}", 1),
+    ),
+    (
+        "cancel-non-pr-runs",
+        "concurrency-cancel",
+        lambda text: text.replace(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            "cancel-in-progress: true",
+            1,
+        ),
+    ),
+    (
+        "rename-secret-scan-job",
+        "secret-job-present",
+        lambda text: text.replace("  secret-scan:\n", "  secrets-scan:\n", 1),
+    ),
+    (
+        "remove-secret-scan-checkout",
+        "checkout-present",
+        lambda text: text.replace("actions/checkout@", "actions/source-copy@", 1),
+    ),
+    (
+        "shallow-secret-scan-checkout",
+        "checkout-depth[0]",
+        lambda text: text.replace("          fetch-depth: 0\n", "          fetch-depth: 1\n", 1),
+    ),
+    (
+        "remove-gitleaks-detect-step",
+        "gitleaks-step-present",
+        lambda text: text.replace("gitleaks detect", "gitleaks scan"),
+    ),
+    (
+        "interpolate-context-in-gitleaks-shell",
+        "gitleaks-no-expression[0]",
+        lambda text: text.replace(
+            "          ZEROS=",
+            "          echo '${{ github.ref }}' >/dev/null\n          ZEROS=",
+            1,
+        ),
+    ),
+    (
+        "remove-gitleaks-redaction",
+        "gitleaks-redact[0]",
+        lambda text: text.replace("--redact", "--no-redact"),
+    ),
+    (
+        "move-first-binary-checksum-after-extract",
+        "binary-checksum-before-extract[Install gitleaks v8.30.1]",
+        lambda text: text.replace(
+            "          echo \"551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz\" | sha256sum -c\n"
+            "          tar xzf gl.tar.gz -C /usr/local/bin gitleaks\n",
+            "          tar xzf gl.tar.gz -C /usr/local/bin gitleaks\n"
+            "          echo \"551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz\" | sha256sum -c\n",
+            1,
+        ),
+    ),
+]
+
+
+def _family(label: str) -> str:
+    """Collapse repeated indexed assertions into one mutation family."""
+    return re.sub(r"\[.*\]$", "[*]", label)
+
+
+def self_test() -> int:
+    """Prove the real baseline and every evaluated assertion family."""
+    failures: list[str] = []
+    good = _baseline()
+    evaluated: list[str] = []
+    baseline_violations = audit(good, evaluated)
+    if baseline_violations:
+        failures.append(f"baseline should be clean, got {baseline_violations}")
+
+    for mutation_id, expected, transform in _MUTATIONS:
+        mutated = transform(good)
+        if mutated == good:
+            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            continue
+        got = audit(mutated)
+        if expected not in got:
+            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
+
+    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
+    uncovered = sorted({_family(label) for label in evaluated} - covered)
+    if uncovered:
+        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    if failures:
+        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
     print(
-        "✓ ci-security.yml: pull_request+push only (no pull_request_target), "
-        "contents:read, no job-level escalation, fetch-depth:0 in secret-scan, "
-        "env-var injection pattern, --redact on gitleaks, "
-        "sha256sum before all binary extractions, "
-        "cancel-in-progress conditional on pull_request. YAML parses."
+        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
+        f"every one of {len(covered)} assertion families has ≥1 mutation"
     )
     return 0
 
 
+def main(argv: list[str]) -> int:
+    """Run the harness, then audit the repository workflow."""
+    if "--self-test" in argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    violations = audit(_baseline())
+    if violations:
+        print(f"✖ ci-security.yml: {len(violations)} posture violation(s):", file=sys.stderr)
+        for violation in violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+    print("✓ ci-security.yml posture OK")
+    return 0
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -307,10 +307,10 @@ def _replace_once(text: str, old: str, new: str) -> str:
     mutation reports caught while the property it names is proven by nothing.
     Raising converts that silent hole into a harness failure.
     """
-    if text.count(old) < 1:
+    if text.count(old) != 1:
         raise AssertionError(
-            f"mutation literal no longer present in the workflow: {old!r} — "
-            "re-pin it against .github/workflows/ci-security.yml"
+            f"mutation literal is not present exactly once ({text.count(old)}x): "
+            f"{old!r} — re-pin it against {WORKFLOW.name}"
         )
     return text.replace(old, new, 1)
 
@@ -578,7 +578,14 @@ def self_test() -> int:
         return 1
 
     for mutation_id, expected, transform in _MUTATIONS:
-        mutated = transform(good)
+        try:
+            mutated = transform(good)
+        except AssertionError as exc:
+            # A pinned literal drifted. Report it in this harness's own verdict
+            # format rather than letting the exception escape as a traceback,
+            # and keep going so every drifted literal is listed at once.
+            failures.append(f"{mutation_id}: {exc}")
+            continue
         if mutated == good:
             failures.append(
                 f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -4,11 +4,14 @@
 Security-load-bearing invariants:
 
 * pull-request and push triggers only; never ``pull_request_target``;
-* top-level ``contents: read`` and no job-level permission escalation;
+* top-level ``contents: read`` and no job-level ``permissions`` key at all —
+  deliberately stricter than "no escalation", because AC12's posture is that a
+  job inherits the top-level grant rather than restating it;
 * full-history checkout for the gitleaks range scan;
 * no Actions expression interpolation in the gitleaks shell body;
 * ``--redact`` on every gitleaks detect invocation;
-* checksum verification before every binary archive extraction; and
+* a checksum command *naming the archive* before *every* archive extraction in
+  a step, however the extraction is spelled; and
 * pull-request-only concurrency cancellation with unique non-PR groups.
 
 The mutation matrix runs on every invocation.  It uses the real workflow as its
@@ -55,22 +58,71 @@ def _steps(jobs: object) -> Iterable[tuple[str, dict[Any, Any]]]:
                 yield str(job_name), step
 
 
-def _checksum_precedes_extract(run_body: str) -> bool:
-    """Return whether a checksum command occurs before the first tar extract."""
-    extract_positions = [
-        position
-        for marker in ("tar xz", "tar xzf")
-        if (position := run_body.find(marker)) != -1
-    ]
-    if not extract_positions:
-        return True
-    extract_at = min(extract_positions)
-    checksum_positions = [
-        position
-        for marker in ("sha256sum", "shasum")
-        if (position := run_body.find(marker)) != -1
-    ]
-    return bool(checksum_positions) and min(checksum_positions) < extract_at
+# Short flags a tar extraction can legitimately carry. Membership is checked as
+# a set so `--exclude=` on a *create* invocation cannot be mistaken for the `x`
+# in an extract cluster.
+_TAR_SHORT_FLAGS = frozenset("xzjJfvkOCp")
+_CHECKSUM_RE = re.compile(r"\b(?:sha256sum|shasum)\b")
+_ARCHIVE_RE = re.compile(r"[\w.@/-]+\.(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)\b")
+
+
+def _is_extraction(line: str) -> bool:
+    """Return whether one shell line extracts an archive, however spelled.
+
+    Structural, not substring. The two literal markers this replaced (``tar xz``
+    and ``tar xzf``, the second subsumed by the first) matched one spelling, so
+    respelling an extraction as ``tar -xzf`` dropped its step out of the audited
+    set entirely — losing the assertion rather than failing it.
+    """
+    tokens = line.split()
+    for index, token in enumerate(tokens):
+        if token == "unzip":
+            return True
+        if token == "7z" and tokens[index + 1 : index + 2] in (["x"], ["e"]):
+            return True
+        if token not in ("tar", "bsdtar"):
+            continue
+        for candidate in tokens[index + 1 :]:
+            if candidate == "--extract":
+                return True
+            flags = candidate.lstrip("-")
+            if flags and set(flags) <= _TAR_SHORT_FLAGS and "x" in flags:
+                return True
+    return False
+
+
+def _unverified_archives(run_body: str) -> list[str]:
+    """Return archives this step extracts with no prior checksum naming them.
+
+    Every extraction is checked, not just the first, and the checksum has to
+    name the archive the extraction consumes — a bare ``sha256sum --version``
+    earlier in the body verifies nothing. Deliberately no vacuously-true early
+    return: a step with no extraction yields no extraction loop iterations and
+    therefore an empty list, without a fail-open branch to reach.
+    """
+    lines = run_body.splitlines()
+    checksum_at: dict[str, int] = {}
+    for index, line in enumerate(lines):
+        if not _CHECKSUM_RE.search(line):
+            continue
+        for archive in _ARCHIVE_RE.findall(line):
+            checksum_at.setdefault(archive, index)
+
+    unverified: list[str] = []
+    for index, line in enumerate(lines):
+        if not _is_extraction(line):
+            continue
+        archives = _ARCHIVE_RE.findall(line)
+        if not archives:
+            # An extraction naming no archive path cannot be tied to any
+            # checksum, so it is reported rather than waved through.
+            unverified.append(line.strip())
+            continue
+        for archive in archives:
+            verified_at = checksum_at.get(archive)
+            if verified_at is None or verified_at >= index:
+                unverified.append(archive)
+    return unverified
 
 
 def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
@@ -172,14 +224,19 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     install_steps = [
         step
         for _job_name, step in _steps(jobs)
-        if "tar xz" in str(step.get("run", ""))
-        or "tar xzf" in str(step.get("run", ""))
+        if any(_is_extraction(line) for line in str(step.get("run", "")).splitlines())
     ]
+    # Presence floor, matching `checkout-present` and `gitleaks-step-present`.
+    # Without it the whole family can collapse to zero members and the
+    # family-coverage rule — which compares evaluated labels against mutated
+    # ones — reports nothing, because an unevaluated family is not uncovered.
+    check("install-steps-present", bool(install_steps))
     for index, step in enumerate(install_steps):
-        name = str(step.get("name", index))
+        # Keyed on the index, not the step name: the name carries the pinned
+        # tool version, so a routine bump would silently retarget the label.
         check(
-            f"binary-checksum-before-extract[{name}]",
-            _checksum_precedes_extract(str(step.get("run", ""))),
+            f"binary-checksum-before-extract[{index}]",
+            not _unverified_archives(str(step.get("run", ""))),
         )
 
     return violations
@@ -190,6 +247,58 @@ def _baseline() -> str:
     if WORKFLOW.is_file():
         return WORKFLOW.read_text(encoding="utf-8")
     return ""
+
+
+def _checksum_extract_pairs(lines: list[str]) -> list[int]:
+    """Return indexes of checksum lines immediately followed by an extraction.
+
+    Every transform below is derived from these pairs rather than from a pinned
+    digest or version string, so a routine tool bump cannot turn a mutation into
+    a no-op and redden the gate with a message about the harness.
+    """
+    return [
+        index
+        for index in range(len(lines) - 1)
+        if _CHECKSUM_RE.search(lines[index]) and _is_extraction(lines[index + 1])
+    ]
+
+
+def _swap_first_checksum_and_extract(text: str) -> str:
+    """Move the first checksum line to after the extraction it guards."""
+    lines = text.splitlines(keepends=True)
+    pairs = _checksum_extract_pairs(lines)
+    if not pairs:
+        return text
+    index = pairs[0]
+    lines[index], lines[index + 1] = lines[index + 1], lines[index]
+    return "".join(lines)
+
+
+def _misname_first_checksum_archive(text: str) -> str:
+    """Point the first checksum at an archive nothing extracts."""
+    lines = text.splitlines(keepends=True)
+    pairs = _checksum_extract_pairs(lines)
+    if not pairs:
+        return text
+    index = pairs[0]
+    lines[index] = _ARCHIVE_RE.sub("unrelated.tar.gz", lines[index], count=1)
+    return "".join(lines)
+
+
+def _respell_second_extraction_unverified(text: str) -> str:
+    """Drop the second step's checksum and respell its extraction.
+
+    This is the exact pair of edits the previous literal-marker filter could not
+    see: the step left the audited set, so no label failed and no family was
+    reported uncovered.
+    """
+    lines = text.splitlines(keepends=True)
+    pairs = _checksum_extract_pairs(lines)
+    if len(pairs) < 2:
+        return text
+    index = pairs[1]
+    respelled = lines[index + 1].replace("tar xzf", "tar -xzf", 1)
+    return "".join(lines[:index] + [respelled] + lines[index + 2 :])
 
 
 _MUTATIONS: list[Mutation] = [
@@ -296,14 +405,25 @@ _MUTATIONS: list[Mutation] = [
     ),
     (
         "move-first-binary-checksum-after-extract",
-        "binary-checksum-before-extract[Install gitleaks v8.30.1]",
-        lambda text: text.replace(
-            "          echo \"551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz\" | sha256sum -c\n"
-            "          tar xzf gl.tar.gz -C /usr/local/bin gitleaks\n",
-            "          tar xzf gl.tar.gz -C /usr/local/bin gitleaks\n"
-            "          echo \"551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz\" | sha256sum -c\n",
-            1,
-        ),
+        "binary-checksum-before-extract[0]",
+        _swap_first_checksum_and_extract,
+    ),
+    (
+        # Ordering alone is not verification: the checksum has to name the
+        # archive the extraction consumes.
+        "verify-an-archive-nothing-extracts",
+        "binary-checksum-before-extract[0]",
+        _misname_first_checksum_archive,
+    ),
+    (
+        "respell-second-extraction-and-drop-its-checksum",
+        "binary-checksum-before-extract[1]",
+        _respell_second_extraction_unverified,
+    ),
+    (
+        "remove-every-install-extraction",
+        "install-steps-present",
+        lambda text: text.replace("tar xzf", "tar czf"),
     ),
 ]
 

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -32,6 +32,7 @@ from collections.abc import Callable, Iterable
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+import posture_harness
 import yaml
 
 # Windows cp1252 guard — the parent gate does not force UTF-8 for child Python.
@@ -603,66 +604,11 @@ _MUTATIONS: list[Mutation] = [
 ]
 
 
-def _family(label: str) -> str:
-    """Collapse repeated indexed assertions into one mutation family."""
-    return re.sub(r"\[.*\]$", "[*]", label)
-
-
 def self_test() -> int:
     """Prove the real baseline and every evaluated assertion family."""
-    failures: list[str] = []
-    good = _baseline()
-    evaluated: list[str] = []
-    baseline_violations = audit(good, evaluated)
-    if baseline_violations:
-        # Return before the matrix. Every transform is pinned to the real
-        # workflow's text, so a dirty or missing baseline turns each one into a
-        # no-op — or, where a transform asserts its literal, into an exception —
-        # burying the one true cause under a wall of derived noise that names
-        # neither the cause nor the file to edit.
-        print(
-            f"\u2716 self-test: {WORKFLOW} is not clean; "
-            f"{len(baseline_violations)} posture violation(s) before any mutation:",
-            file=sys.stderr,
-        )
-        for violation in baseline_violations:
-            print(f"  - {violation}", file=sys.stderr)
-        return 1
-
-    for mutation_id, expected, transform in _MUTATIONS:
-        try:
-            mutated = transform(good)
-        except AssertionError as exc:
-            # A pinned literal drifted. Report it in this harness's own verdict
-            # format rather than letting the exception escape as a traceback,
-            # and keep going so every drifted literal is listed at once.
-            failures.append(f"{mutation_id}: {exc}")
-            continue
-        if mutated == good:
-            failures.append(
-                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
-                "proves nothing; re-pin its literal against that file"
-            )
-            continue
-        got = audit(mutated)
-        if expected not in got:
-            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
-
-    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
-    uncovered = sorted({_family(label) for label in evaluated} - covered)
-    if uncovered:
-        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
-
-    if failures:
-        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
-        for failure in failures:
-            print(f"  - {failure}", file=sys.stderr)
-        return 1
-    print(
-        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
-        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    return posture_harness.run(
+        workflow=WORKFLOW, baseline=_baseline, audit=audit, mutations=_MUTATIONS
     )
-    return 0
 
 
 def main(argv: list[str]) -> int:

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -81,9 +81,10 @@ _CHECK_FLAG_RE = re.compile(r"(?:\s-{1,2}c\b|\s--check\b)")
 _ARCHIVE_EXT = r"(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)"
 # The trailing guard is not `\b`: `\b` matched `gl.tar.gz` inside
 # `gl.tar.gz.sha256`, so a digest file credited the archive it merely names.
-# A same-origin digest file is exactly what this workflow says it must not use
-# (see its header), so no crediting path for one is provided — which is what
-# makes `fetch-the-digest-from-the-same-origin` below an expressible mutation.
+# NO digest-file form is credited, whatever its origin — not a fetched one and
+# not a repo-committed at-rest one. The guard reads text and cannot tell where a
+# `.sha256` file came from, so crediting any of them would credit the fetched
+# same-origin form this workflow's header forbids. Inline the SHA-256 here.
 _ARCHIVE_RE = re.compile(rf"[\w.@/-]{{1,200}}\.{_ARCHIVE_EXT}(?![\w.-])")
 
 
@@ -333,22 +334,6 @@ def _baseline() -> str:
     return ""
 
 
-def _replace_once(text: str, old: str, new: str) -> str:
-    """Substitute exactly one occurrence, or raise.
-
-    A compound mutation can go half-inert: if the literal below drifts, the
-    other half still changes the text, so the no-op rule stays satisfied and the
-    mutation reports caught while the property it names is proven by nothing.
-    Raising converts that silent hole into a harness failure.
-    """
-    if text.count(old) != 1:
-        raise AssertionError(
-            f"mutation literal is not present exactly once ({text.count(old)}x): "
-            f"{old!r} — re-pin it against {WORKFLOW.name}"
-        )
-    return text.replace(old, new, 1)
-
-
 def _checksum_extract_pairs(lines: list[str]) -> list[int]:
     """Return indexes of checksum lines immediately followed by an extraction.
 
@@ -423,7 +408,7 @@ def _respell_second_extraction_unverified(text: str) -> str:
     if len(pairs) < 2:
         return text
     index = pairs[1]
-    respelled = _replace_once(lines[index + 1], "tar xzf", "tar -xzf")
+    respelled = posture_harness.replace_once(lines[index + 1], "tar xzf", "tar -xzf", WORKFLOW.name)
     return "".join(lines[:index] + [respelled] + lines[index + 2 :])
 
 
@@ -512,8 +497,11 @@ _MUTATIONS: list[Mutation] = [
         # The one-character inversion the substring test walked past.
         "invert-cancel-condition",
         "concurrency-cancel",
-        lambda text: _replace_once(
-            text, EXPECTED_CANCEL, "${{ github.event_name != 'pull_request' }}"
+        lambda text: posture_harness.replace_once(
+            text,
+            EXPECTED_CANCEL,
+            "${{ github.event_name != 'pull_request' }}",
+            WORKFLOW.name,
         ),
     ),
     (
@@ -572,10 +560,11 @@ _MUTATIONS: list[Mutation] = [
         # caught by the substring form it replaced.
         "path-qualify-the-extraction-and-drop-its-checksum",
         "binary-checksum-before-extract[0]",
-        lambda text: _replace_once(
+        lambda text: posture_harness.replace_once(
             _drop_first_checksum(text),
             "          tar xzf gl.tar.gz",
             "          /usr/bin/tar xzf gl.tar.gz",
+            WORKFLOW.name,
         ),
     ),
     (
@@ -588,46 +577,73 @@ _MUTATIONS: list[Mutation] = [
     (
         "make-the-secret-scan-advisory",
         "gitleaks-blocks[0]",
-        lambda text: _replace_once(
-            text, "      - name: Scan for secrets", "      - name: Scan for secrets\n        continue-on-error: true"
+        lambda text: posture_harness.replace_once(
+            text, "      - name: Scan for secrets", "      - name: Scan for secrets\n        continue-on-error: true",
+            WORKFLOW.name,
         ),
     ),
     (
         "skip-the-secret-scan-with-a-step-if",
         "gitleaks-blocks[0]",
-        lambda text: _replace_once(
+        lambda text: posture_harness.replace_once(
             text,
             "      - name: Scan for secrets\n",
             "      - name: Scan for secrets\n        if: ${{ false }}\n",
+            WORKFLOW.name,
         ),
     ),
     (
         "disable-the-exit-code-with-an-equals-sign",
         "gitleaks-blocks[0]",
-        lambda text: _replace_once(
+        lambda text: posture_harness.replace_once(
             text,
             "gitleaks detect --source . --redact --verbose --exit-code 1",
             "gitleaks detect --source . --redact --verbose --exit-code=0",
+            WORKFLOW.name,
         ),
     ),
     (
-        # Proves the archive-match lookahead: the digest is fetched from the same
-        # origin as the binary, the form the workflow header forbids, and nothing
-        # credits it.
-        "fetch-the-digest-from-the-same-origin",
+        # Proves the archive-match lookahead: no digest-file form is credited,
+        # because the guard cannot see where the file came from. Shown here with
+        # the same-origin fetch the workflow header forbids.
+        "verify-via-a-digest-file-instead-of-an-inline-sha",
         "binary-checksum-before-extract[0]",
-        lambda text: _replace_once(
+        lambda text: posture_harness.replace_once(
             text,
             '          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz" | sha256sum -c\n',
             '          curl -sfL "${BASE_URL}/${TARBALL}.sha256" -o gl.tar.gz.sha256\n'
             "          sha256sum -c gl.tar.gz.sha256\n",
+            WORKFLOW.name,
+        ),
+    ),
+    (
+        # The conjunct round 7 rewrote, and the only one the family rule can
+        # never demand a mutation for: all four share one label.
+        "append-or-true-to-the-gitleaks-scan",
+        "gitleaks-blocks[0]",
+        lambda text: posture_harness.replace_once(
+            text,
+            "gitleaks detect --source . --redact --verbose --exit-code 1",
+            "gitleaks detect --source . --redact --verbose --exit-code 1 || true",
+            WORKFLOW.name,
+        ),
+    ),
+    (
+        "append-or-colon-to-the-gitleaks-scan",
+        "gitleaks-blocks[0]",
+        lambda text: posture_harness.replace_once(
+            text,
+            "gitleaks detect --source . --redact --verbose --exit-code 1",
+            "gitleaks detect --source . --redact --verbose --exit-code 1 || :",
+            WORKFLOW.name,
         ),
     ),
     (
         "compute-the-checksum-without-checking-it",
         "binary-checksum-before-extract[0]",
-        lambda text: _replace_once(
-            text, 'gl.tar.gz" | sha256sum -c', 'gl.tar.gz" >/dev/null; sha256sum gl.tar.gz'
+        lambda text: posture_harness.replace_once(
+            text, 'gl.tar.gz" | sha256sum -c', 'gl.tar.gz" >/dev/null; sha256sum gl.tar.gz',
+            WORKFLOW.name,
         ),
     ),
     (

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -11,7 +11,11 @@ Security-load-bearing invariants:
 * no Actions expression interpolation in the gitleaks shell body;
 * ``--redact`` on every gitleaks detect invocation;
 * a checksum command *naming the archive* before *every* archive extraction in
-  a step, however the extraction is spelled; and
+  a step. "Extraction" is recognized for a ``tar``/``bsdtar`` invocation
+  carrying an extract flag, ``unzip``, or ``7z x``/``7z e``, path-qualified or
+  not, with shell comments stripped first. Deliberately not recognized, and so
+  not claimed: an extraction split across a backslash continuation, or an
+  alternative binary such as ``7za``; and
 * pull-request-only concurrency cancellation with unique non-PR groups.
 
 The mutation matrix runs on every invocation.  It uses the real workflow as its
@@ -24,7 +28,7 @@ from __future__ import annotations
 import re
 import sys
 from collections.abc import Callable, Iterable
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
@@ -66,16 +70,48 @@ _CHECKSUM_RE = re.compile(r"\b(?:sha256sum|shasum)\b")
 _ARCHIVE_RE = re.compile(r"[\w.@/-]+\.(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)\b")
 
 
+def _strip_comments(text: str) -> str:
+    """Remove shell comments so a comment cannot satisfy a posture assertion.
+
+    Same seam and semantics as ``tools/test-pages-concurrency.py``. Without it a
+    line reading ``# sha256sum gl.tar.gz was checked upstream`` discharges the
+    checksum assertion on prose, and a line mentioning an extraction inside a
+    comment injects a phantom member into the audited step list.
+    """
+    lines: list[str] = []
+    for line in text.splitlines():
+        quote: str | None = None
+        cut = len(line)
+        for index, char in enumerate(line):
+            if quote:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == "#":
+                cut = index
+                break
+        lines.append(line[:cut].rstrip())
+    return "\n".join(lines)
+
+
 def _is_extraction(line: str) -> bool:
-    """Return whether one shell line extracts an archive, however spelled.
+    """Return whether one shell line extracts an archive.
 
     Structural, not substring. The two literal markers this replaced (``tar xz``
     and ``tar xzf``, the second subsumed by the first) matched one spelling, so
     respelling an extraction as ``tar -xzf`` dropped its step out of the audited
     set entirely — losing the assertion rather than failing it.
+
+    The command token is compared by basename, because an exact-token test
+    silently stopped recognizing ``/usr/bin/tar xzf`` — which the substring form
+    did match. Recognized: ``tar``/``bsdtar`` with an extract flag, ``unzip``,
+    ``7z x``/``7z e``. Not recognized, and not claimed: a backslash-continued
+    invocation, or an alternative binary such as ``7za``.
     """
     tokens = line.split()
-    for index, token in enumerate(tokens):
+    for index, raw_token in enumerate(tokens):
+        token = PurePosixPath(raw_token).name
         if token == "unzip":
             return True
         if token == "7z" and tokens[index + 1 : index + 2] in (["x"], ["e"]):
@@ -100,7 +136,7 @@ def _unverified_archives(run_body: str) -> list[str]:
     return: a step with no extraction yields no extraction loop iterations and
     therefore an empty list, without a fail-open branch to reach.
     """
-    lines = run_body.splitlines()
+    lines = _strip_comments(run_body).splitlines()
     checksum_at: dict[str, int] = {}
     for index, line in enumerate(lines):
         if not _CHECKSUM_RE.search(line):
@@ -224,7 +260,10 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     install_steps = [
         step
         for _job_name, step in _steps(jobs)
-        if any(_is_extraction(line) for line in str(step.get("run", "")).splitlines())
+        if any(
+            _is_extraction(line)
+            for line in _strip_comments(str(step.get("run", ""))).splitlines()
+        )
     ]
     # Presence floor, matching `checkout-present` and `gitleaks-step-present`.
     # Without it the whole family can collapse to zero members and the
@@ -282,6 +321,29 @@ def _misname_first_checksum_archive(text: str) -> str:
         return text
     index = pairs[0]
     lines[index] = _ARCHIVE_RE.sub("unrelated.tar.gz", lines[index], count=1)
+    return "".join(lines)
+
+
+def _drop_first_checksum(text: str) -> str:
+    """Delete the first checksum line outright."""
+    lines = text.splitlines(keepends=True)
+    pairs = _checksum_extract_pairs(lines)
+    if not pairs:
+        return text
+    index = pairs[0]
+    return "".join(lines[:index] + lines[index + 1 :])
+
+
+def _comment_out_first_checksum(text: str) -> str:
+    """Turn the first checksum line into a comment that still names it."""
+    lines = text.splitlines(keepends=True)
+    pairs = _checksum_extract_pairs(lines)
+    if not pairs:
+        return text
+    index = pairs[0]
+    body = lines[index]
+    indent = body[: len(body) - len(body.lstrip(" "))]
+    lines[index] = f"{indent}# {body.strip()}\n"
     return "".join(lines)
 
 
@@ -419,6 +481,22 @@ _MUTATIONS: list[Mutation] = [
         "respell-second-extraction-and-drop-its-checksum",
         "binary-checksum-before-extract[1]",
         _respell_second_extraction_unverified,
+    ),
+    (
+        # The net regression an exact-token test introduced: this spelling was
+        # caught by the substring form it replaced.
+        "path-qualify-the-extraction-and-drop-its-checksum",
+        "binary-checksum-before-extract[0]",
+        lambda text: _drop_first_checksum(text).replace(
+            "          tar xzf gl.tar.gz", "          /usr/bin/tar xzf gl.tar.gz", 1
+        ),
+    ),
+    (
+        # A comment is not a command: prose naming the archive must not
+        # discharge the assertion.
+        "replace-the-first-checksum-with-a-comment",
+        "binary-checksum-before-extract[0]",
+        lambda text: _comment_out_first_checksum(text),
     ),
     (
         "remove-every-install-extraction",

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -563,12 +563,27 @@ def self_test() -> int:
     evaluated: list[str] = []
     baseline_violations = audit(good, evaluated)
     if baseline_violations:
-        failures.append(f"baseline should be clean, got {baseline_violations}")
+        # Return before the matrix. Every transform is pinned to the real
+        # workflow's text, so a dirty or missing baseline turns each one into a
+        # no-op — or, where a transform asserts its literal, into an exception —
+        # burying the one true cause under a wall of derived noise that names
+        # neither the cause nor the file to edit.
+        print(
+            f"\u2716 self-test: {WORKFLOW} is not clean; "
+            f"{len(baseline_violations)} posture violation(s) before any mutation:",
+            file=sys.stderr,
+        )
+        for violation in baseline_violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
 
     for mutation_id, expected, transform in _MUTATIONS:
         mutated = transform(good)
         if mutated == good:
-            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            failures.append(
+                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
+                "proves nothing; re-pin its literal against that file"
+            )
             continue
         got = audit(mutated)
         if expected not in got:

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -45,6 +45,11 @@ EXPECTED_GROUP = (
     "ci-security-${{ github.event_name == 'pull_request' && github.ref || "
     "github.run_id }}"
 )
+# Pinned by equality, not by substring: `"pull_request" in cancel` accepts the
+# inverted `!=` form, which stops PR runs superseding one another while reading
+# as though it were asserted. Same treatment as the group above and the CodeQL
+# twin.
+EXPECTED_CANCEL = "${{ github.event_name == 'pull_request' }}"
 
 Mutation = tuple[str, str, Callable[[str], str]]
 
@@ -69,9 +74,18 @@ def _steps(jobs: object) -> Iterable[tuple[str, dict[Any, Any]]]:
 # in an extract cluster.
 _TAR_SHORT_FLAGS = frozenset("xzjJfvkOCp")
 _CHECKSUM_RE = re.compile(r"\b(?:sha256sum|shasum)\b")
+_CHECK_FLAG_RE = re.compile(r"(?:\s-{1,2}c\b|\s--check\b)")
 # Bounded quantifier: the unbounded form backtracked quadratically, so one
 # very long committed line stalled this control instead of answering it.
-_ARCHIVE_RE = re.compile(r"[\w.@/-]{1,200}\.(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)\b")
+_ARCHIVE_EXT = r"(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)"
+# The trailing guard is not `\b`: `\b` matched `gl.tar.gz` inside
+# `gl.tar.gz.sha256`, so a digest file credited the archive it merely names.
+_ARCHIVE_RE = re.compile(rf"[\w.@/-]{{1,200}}\.{_ARCHIVE_EXT}(?![\w.-])")
+# ...but a digest file IS how a checksum legitimately names its archive, so that
+# form is recognised explicitly rather than by a loose boundary.
+_DIGEST_FILE_RE = re.compile(
+    rf"([\w.@/-]{{1,200}}\.{_ARCHIVE_EXT})\.(?:sha256sum|sha256|sha512|sha1|md5)(?![\w.-])"
+)
 
 
 def _strip_comments(text: str) -> str:
@@ -143,9 +157,13 @@ def _unverified_archives(run_body: str) -> list[str]:
     lines = _strip_comments(run_body).splitlines()
     checksum_at: dict[str, int] = {}
     for index, line in enumerate(lines):
-        if not _CHECKSUM_RE.search(line):
+        # `sha256sum -c` / `--check` verifies; a bare `sha256sum foo.tar.gz`
+        # computes a digest and discards it, which the token test alone accepted.
+        if not (_CHECKSUM_RE.search(line) and _CHECK_FLAG_RE.search(line)):
             continue
         for archive in _ARCHIVE_RE.findall(line):
+            checksum_at.setdefault(archive, index)
+        for archive in _DIGEST_FILE_RE.findall(line):
             checksum_at.setdefault(archive, index)
 
     unverified: list[str] = []
@@ -234,8 +252,10 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     concurrency = doc.get("concurrency")
     concurrency = concurrency if isinstance(concurrency, dict) else {}
     check("concurrency-group", concurrency.get("group") == EXPECTED_GROUP)
-    cancel = str(concurrency.get("cancel-in-progress", ""))
-    check("concurrency-cancel", "pull_request" in cancel)
+    check(
+        "concurrency-cancel",
+        concurrency.get("cancel-in-progress") == EXPECTED_CANCEL,
+    )
 
     secret_job = jobs.get("secret-scan") if isinstance(jobs, dict) else None
     check("secret-job-present", isinstance(secret_job, dict))
@@ -267,6 +287,16 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         run_body = str(step.get("run", ""))
         check(f"gitleaks-no-expression[{index}]", "${{" not in run_body)
         check(f"gitleaks-redact[{index}]", "--redact" in run_body)
+        # The flags above prove how the scan runs, not that a hit fails the job.
+        # `continue-on-error`, a trailing `|| true`, or `--exit-code 0` each
+        # yield a passing secret-scan job over a committed secret.
+        stripped = _strip_comments(run_body)
+        check(
+            f"gitleaks-blocks[{index}]",
+            step.get("continue-on-error") is not True
+            and "--exit-code 0" not in stripped
+            and not re.search(r"\|\|\s*(?:true|:)\b", stripped),
+        )
 
     install_steps = [
         step
@@ -475,6 +505,14 @@ _MUTATIONS: list[Mutation] = [
         ),
     ),
     (
+        # The one-character inversion the substring test walked past.
+        "invert-cancel-condition",
+        "concurrency-cancel",
+        lambda text: _replace_once(
+            text, EXPECTED_CANCEL, "${{ github.event_name != 'pull_request' }}"
+        ),
+    ),
+    (
         "rename-secret-scan-job",
         "secret-job-present",
         lambda text: text.replace("  secret-scan:\n", "  secrets-scan:\n", 1),
@@ -542,6 +580,20 @@ _MUTATIONS: list[Mutation] = [
         "replace-the-first-checksum-with-a-comment",
         "binary-checksum-before-extract[0]",
         lambda text: _comment_out_first_checksum(text),
+    ),
+    (
+        "make-the-secret-scan-advisory",
+        "gitleaks-blocks[0]",
+        lambda text: _replace_once(
+            text, "      - name: Scan for secrets", "      - name: Scan for secrets\n        continue-on-error: true"
+        ),
+    ),
+    (
+        "compute-the-checksum-without-checking-it",
+        "binary-checksum-before-extract[0]",
+        lambda text: _replace_once(
+            text, 'gl.tar.gz" | sha256sum -c', 'gl.tar.gz" >/dev/null; sha256sum gl.tar.gz'
+        ),
     ),
     (
         "remove-every-install-extraction",

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -3,7 +3,8 @@
 
 Security-load-bearing invariants:
 
-* pull-request and push triggers only; never ``pull_request_target``;
+* pull-request and push triggers only, asserted as an allowlist — a denylist
+  admits ``workflow_run`` and ``issue_comment``, which run in base context;
 * top-level ``contents: read`` and no job-level ``permissions`` key at all —
   deliberately stricter than "no escalation", because AC12's posture is that a
   job inherits the top-level grant rather than restating it;
@@ -39,6 +40,7 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-security.yml"
+ALLOWED_TRIGGERS = frozenset({"pull_request", "push"})
 EXPECTED_GROUP = (
     "ci-security-${{ github.event_name == 'pull_request' && github.ref || "
     "github.run_id }}"
@@ -67,7 +69,9 @@ def _steps(jobs: object) -> Iterable[tuple[str, dict[Any, Any]]]:
 # in an extract cluster.
 _TAR_SHORT_FLAGS = frozenset("xzjJfvkOCp")
 _CHECKSUM_RE = re.compile(r"\b(?:sha256sum|shasum)\b")
-_ARCHIVE_RE = re.compile(r"[\w.@/-]+\.(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)\b")
+# Bounded quantifier: the unbounded form backtracked quadratically, so one
+# very long committed line stalled this control instead of answering it.
+_ARCHIVE_RE = re.compile(r"[\w.@/-]{1,200}\.(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)\b")
 
 
 def _strip_comments(text: str) -> str:
@@ -197,6 +201,13 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
             "trigger-forbidden[pull_request_target]",
             "pull_request_target" not in triggers,
         )
+        # The named denial stays so a regression to it reports the specific
+        # trigger; the allowlist closes the gap between it and the "only" the
+        # docstring claims.
+        check(
+            "triggers-allowlist",
+            {str(name) for name in triggers} <= set(ALLOWED_TRIGGERS),
+        )
 
     check("permissions-read", doc.get("permissions") == {"contents": "read"})
 
@@ -288,12 +299,31 @@ def _baseline() -> str:
     return ""
 
 
+def _replace_once(text: str, old: str, new: str) -> str:
+    """Substitute exactly one occurrence, or raise.
+
+    A compound mutation can go half-inert: if the literal below drifts, the
+    other half still changes the text, so the no-op rule stays satisfied and the
+    mutation reports caught while the property it names is proven by nothing.
+    Raising converts that silent hole into a harness failure.
+    """
+    if text.count(old) < 1:
+        raise AssertionError(
+            f"mutation literal no longer present in the workflow: {old!r} — "
+            "re-pin it against .github/workflows/ci-security.yml"
+        )
+    return text.replace(old, new, 1)
+
+
 def _checksum_extract_pairs(lines: list[str]) -> list[int]:
     """Return indexes of checksum lines immediately followed by an extraction.
 
-    Every transform below is derived from these pairs rather than from a pinned
-    digest or version string, so a routine tool bump cannot turn a mutation into
-    a no-op and redden the gate with a message about the harness.
+    Transforms locate their edit point through these pairs rather than through a
+    pinned digest or version string, so a routine tool bump cannot turn a
+    mutation into a no-op. Two of them additionally substitute a literal drawn
+    from the workflow; those go through ``_replace_once``, because a compound
+    transform whose other half still fires is not a no-op and would otherwise
+    stay green while proving nothing.
     """
     return [
         index
@@ -359,7 +389,7 @@ def _respell_second_extraction_unverified(text: str) -> str:
     if len(pairs) < 2:
         return text
     index = pairs[1]
-    respelled = lines[index + 1].replace("tar xzf", "tar -xzf", 1)
+    respelled = _replace_once(lines[index + 1], "tar xzf", "tar -xzf")
     return "".join(lines[:index] + [respelled] + lines[index + 2 :])
 
 
@@ -375,6 +405,19 @@ _MUTATIONS: list[Mutation] = [
         "drop-push-trigger",
         "triggers-required",
         lambda text: text.replace("  push:\n", "  publish:\n", 1),
+    ),
+    (
+        # Not on the denylist, and it runs in base repository context with
+        # secrets: a workflow_run-triggered scan would check out base main and
+        # report green over commits it never read.
+        "add-workflow-run-trigger",
+        "triggers-allowlist",
+        lambda text: text.replace(
+            "\non:\n",
+            "\non:\n  workflow_run:\n    workflows: [build-check]\n"
+            "    types: [completed]\n",
+            1,
+        ),
     ),
     (
         "add-pull-request-target",
@@ -487,8 +530,10 @@ _MUTATIONS: list[Mutation] = [
         # caught by the substring form it replaced.
         "path-qualify-the-extraction-and-drop-its-checksum",
         "binary-checksum-before-extract[0]",
-        lambda text: _drop_first_checksum(text).replace(
-            "          tar xzf gl.tar.gz", "          /usr/bin/tar xzf gl.tar.gz", 1
+        lambda text: _replace_once(
+            _drop_first_checksum(text),
+            "          tar xzf gl.tar.gz",
+            "          /usr/bin/tar xzf gl.tar.gz",
         ),
     ),
     (

--- a/tools/test-ci-security-workflow.py
+++ b/tools/test-ci-security-workflow.py
@@ -81,12 +81,10 @@ _CHECK_FLAG_RE = re.compile(r"(?:\s-{1,2}c\b|\s--check\b)")
 _ARCHIVE_EXT = r"(?:tar\.gz|tar\.xz|tar\.bz2|tgz|tar|zip)"
 # The trailing guard is not `\b`: `\b` matched `gl.tar.gz` inside
 # `gl.tar.gz.sha256`, so a digest file credited the archive it merely names.
+# A same-origin digest file is exactly what this workflow says it must not use
+# (see its header), so no crediting path for one is provided — which is what
+# makes `fetch-the-digest-from-the-same-origin` below an expressible mutation.
 _ARCHIVE_RE = re.compile(rf"[\w.@/-]{{1,200}}\.{_ARCHIVE_EXT}(?![\w.-])")
-# ...but a digest file IS how a checksum legitimately names its archive, so that
-# form is recognised explicitly rather than by a loose boundary.
-_DIGEST_FILE_RE = re.compile(
-    rf"([\w.@/-]{{1,200}}\.{_ARCHIVE_EXT})\.(?:sha256sum|sha256|sha512|sha1|md5)(?![\w.-])"
-)
 
 
 def _strip_comments(text: str) -> str:
@@ -163,8 +161,6 @@ def _unverified_archives(run_body: str) -> list[str]:
         if not (_CHECKSUM_RE.search(line) and _CHECK_FLAG_RE.search(line)):
             continue
         for archive in _ARCHIVE_RE.findall(line):
-            checksum_at.setdefault(archive, index)
-        for archive in _DIGEST_FILE_RE.findall(line):
             checksum_at.setdefault(archive, index)
 
     unverified: list[str] = []
@@ -292,11 +288,18 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         # `continue-on-error`, a trailing `|| true`, or `--exit-code 0` each
         # yield a passing secret-scan job over a committed secret.
         stripped = _strip_comments(run_body)
+        # Every spelling of each bypass this label names, not one apiece:
+        # `--exit-code=0` is as valid as the spaced form; a trailing word
+        # boundary after `:` made the `|| :` arm dead code; `continue-on-error`
+        # is honoured when it is an expression or a quoted string, so anything
+        # but None/False blocks; and a step-level `if:` skips the scan entirely,
+        # which the Windows sibling already tests for its own guard step.
         check(
             f"gitleaks-blocks[{index}]",
-            step.get("continue-on-error") is not True
-            and "--exit-code 0" not in stripped
-            and not re.search(r"\|\|\s*(?:true|:)\b", stripped),
+            step.get("continue-on-error") in (None, False)
+            and step.get("if") is None
+            and not re.search(r"--exit-code[= ]+0(?![\w-])", stripped)
+            and not re.search(r"\|\|\s*(?:true|:)(?![\w-])", stripped),
         )
 
     install_steps = [
@@ -587,6 +590,37 @@ _MUTATIONS: list[Mutation] = [
         "gitleaks-blocks[0]",
         lambda text: _replace_once(
             text, "      - name: Scan for secrets", "      - name: Scan for secrets\n        continue-on-error: true"
+        ),
+    ),
+    (
+        "skip-the-secret-scan-with-a-step-if",
+        "gitleaks-blocks[0]",
+        lambda text: _replace_once(
+            text,
+            "      - name: Scan for secrets\n",
+            "      - name: Scan for secrets\n        if: ${{ false }}\n",
+        ),
+    ),
+    (
+        "disable-the-exit-code-with-an-equals-sign",
+        "gitleaks-blocks[0]",
+        lambda text: _replace_once(
+            text,
+            "gitleaks detect --source . --redact --verbose --exit-code 1",
+            "gitleaks detect --source . --redact --verbose --exit-code=0",
+        ),
+    ),
+    (
+        # Proves the archive-match lookahead: the digest is fetched from the same
+        # origin as the binary, the form the workflow header forbids, and nothing
+        # credits it.
+        "fetch-the-digest-from-the-same-origin",
+        "binary-checksum-before-extract[0]",
+        lambda text: _replace_once(
+            text,
+            '          echo "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb  gl.tar.gz" | sha256sum -c\n',
+            '          curl -sfL "${BASE_URL}/${TARBALL}.sha256" -o gl.tar.gz.sha256\n'
+            "          sha256sum -c gl.tar.gz.sha256\n",
         ),
     ),
     (

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -2,9 +2,19 @@
 """Posture test for ``.github/workflows/codeql.yml``.
 
 The workflow supplies ADR-0017's interprocedural taint lens. This checker pins
-only the security-extended query suite, split permissions, the two intentional
-``paths-ignore`` surfaces, Python language containment, and per-ref
-concurrency. Action SHA pinning remains zizmor-owned.
+only the security-extended query suite, the split between the read-only default
+floor and the analyzer's elevated grant, both ``paths-ignore`` surfaces (the
+trigger-level one and the analysis-config one, the latter as an exhaustive list
+so a widening entry cannot silently exempt everything), the presence of the
+analyze step that turns extraction into an uploaded result, Python language
+containment, and the literal concurrency group and cancellation expressions.
+Action SHA pinning remains zizmor-owned.
+
+The concurrency group is pinned as a literal, not as a property: AC12 of
+spec/ci-gate-parallelization requires PR runs to share a ref group while every
+non-PR run keys on ``github.run_id``, and a substring test for ``github.ref``
+would accept the bare-ref form that ADR-0086 lines 111-117 tells the next
+author not to copy.
 
 Known limitation: CodeQL is advisory until the repository owner makes it a
 required branch-protection check. This posture test protects that advisory
@@ -32,6 +42,13 @@ CONFIG_PATH_IGNORES = (
     "**/tests/**",
     "**/test_*.py",
     "**/test-*.py",
+)
+# Pinned as the literal expression, matching the ci-security sibling. AC12's
+# shape is "PR runs share a ref group; every non-PR run is unique", which a
+# property test cannot express.
+EXPECTED_GROUP = (
+    "codeql-${{ github.event_name == 'pull_request' && github.ref || "
+    "github.run_id }}"
 )
 
 Mutation = tuple[str, str, Callable[[str], str]]
@@ -211,11 +228,29 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         ignored = _sequence(config, "paths-ignore", 12)
         for path in CONFIG_PATH_IGNORES:
             check(f"config-path-ignore[{path}]", path in ignored)
+        # Presence alone is not enough: one added `- '**'` exempts the whole
+        # repository while every per-glob check above still passes, which would
+        # zero the analysis and leave this gate green.
+        check(
+            "config-path-ignore-exhaustive",
+            set(ignored) == set(CONFIG_PATH_IGNORES),
+        )
+
+    analyze_steps = [
+        step
+        for step in _steps(analyze)
+        if re.search(r"^        uses: github/codeql-action/analyze@", step, re.MULTILINE)
+    ]
+    # Initialization extracts; only the analyze step uploads a result. Without
+    # this, a workflow that inits and never analyzes reports no violation.
+    check("analyze-step-present", len(analyze_steps) == 1)
 
     concurrency_block = _named_block(text, "concurrency", 0)
     check("concurrency-block-present", bool(concurrency_block))
-    group = _mapping(concurrency_block, 2).get("group", "")
-    check("concurrency-per-ref", "github.ref" in group)
+    concurrency = _mapping(concurrency_block, 2)
+    check("concurrency-group", concurrency.get("group") == EXPECTED_GROUP)
+    cancel = str(concurrency.get("cancel-in-progress", ""))
+    check("concurrency-cancel", "pull_request" in cancel)
 
     return violations
 
@@ -312,19 +347,51 @@ _MUTATIONS: list[Mutation] = [
         lambda text: text.replace("              - '**/test-*.py'\n", "", 1),
     ),
     (
+        "widen-config-path-ignores",
+        "config-path-ignore-exhaustive",
+        lambda text: text.replace(
+            "              - '**/test-*.py'\n",
+            "              - '**/test-*.py'\n              - '**'\n",
+            1,
+        ),
+    ),
+    (
+        "remove-analyze-step",
+        "analyze-step-present",
+        lambda text: text.replace(
+            "github/codeql-action/analyze@", "github/codeql-action/upload@", 1
+        ),
+    ),
+    (
         "remove-concurrency-block",
         "concurrency-block-present",
         lambda text: text.replace("concurrency:\n", "run-concurrency:\n", 1),
     ),
     (
         "make-concurrency-group-constant",
-        "concurrency-per-ref",
+        "concurrency-group",
         lambda text: re.sub(
             r"^  group: .*github\.ref.*$",
             "  group: codeql",
             text,
             count=1,
             flags=re.MULTILINE,
+        ),
+    ),
+    (
+        # The specific regression ADR-0086 lines 111-117 warns about: a bare-ref
+        # group lets a third queued non-PR run evict the pending one.
+        "make-concurrency-group-bare-ref",
+        "concurrency-group",
+        lambda text: text.replace(EXPECTED_GROUP, "codeql-${{ github.ref }}", 1),
+    ),
+    (
+        "cancel-non-pr-runs",
+        "concurrency-cancel",
+        lambda text: text.replace(
+            "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}\n",
+            "  cancel-in-progress: true\n",
+            1,
         ),
     ),
 ]

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Posture test for ``.github/workflows/codeql.yml``.
+
+The workflow supplies ADR-0017's interprocedural taint lens. This checker pins
+only the security-extended query suite, split permissions, the two intentional
+``paths-ignore`` surfaces, Python language containment, and per-ref
+concurrency. Action SHA pinning remains zizmor-owned.
+
+Known limitation: CodeQL is advisory until the repository owner makes it a
+required branch-protection check. This posture test protects that advisory
+signal; it does not claim to make the signal merge-blocking.
+
+The real workflow is the self-test baseline. Every invocation runs a mutation
+matrix that rejects no-op transforms, expects a specific label from each
+mutant, and covers every assertion family evaluated by the clean baseline.
+Pure stdlib, as required for new ``tools/`` additions.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="strict")
+sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "codeql.yml"
+CONFIG_PATH_IGNORES = (
+    "**/tests/**",
+    "**/test_*.py",
+    "**/test-*.py",
+)
+
+Mutation = tuple[str, str, Callable[[str], str]]
+
+
+def _indent(line: str) -> int:
+    """Return a line's leading-space count."""
+    return len(line) - len(line.lstrip(" "))
+
+
+def _named_block(text: str, key: str, indent: int) -> str:
+    """Return the body of one mapping key at ``indent``, or ``""``."""
+    lines = text.splitlines(keepends=True)
+    header = " " * indent + key + ":"
+    for index, line in enumerate(lines):
+        if line.rstrip("\n").rstrip() != header:
+            continue
+        body: list[str] = []
+        for following in lines[index + 1 :]:
+            if following.strip() and _indent(following) <= indent:
+                break
+            body.append(following)
+        return "".join(body)
+    return ""
+
+
+def _child_blocks(block: str, indent: int) -> dict[str, str]:
+    """Return direct child mapping blocks keyed by their unquoted names."""
+    lines = block.splitlines(keepends=True)
+    starts: list[tuple[int, str]] = []
+    pattern = re.compile(rf"^ {{{indent}}}([a-zA-Z0-9_-]+):\s*$")
+    for index, line in enumerate(lines):
+        if match := pattern.match(line):
+            starts.append((index, match.group(1)))
+    result: dict[str, str] = {}
+    for position, (start, name) in enumerate(starts):
+        stop = starts[position + 1][0] if position + 1 < len(starts) else len(lines)
+        result[name] = "".join(lines[start + 1 : stop])
+    return result
+
+
+def _mapping(block: str, indent: int) -> dict[str, str]:
+    """Parse scalar entries directly beneath one known mapping block."""
+    result: dict[str, str] = {}
+    pattern = re.compile(rf"^ {{{indent}}}([a-zA-Z0-9_-]+):\s*([^#\n]+?)\s*$")
+    for line in block.splitlines():
+        if match := pattern.match(line):
+            result[match.group(1)] = match.group(2).strip().strip("'\"")
+    return result
+
+
+def _sequence(block: str, key: str, key_indent: int) -> list[str]:
+    """Return one block-style sequence beneath a known key."""
+    lines = block.splitlines()
+    header = " " * key_indent + key + ":"
+    for index, line in enumerate(lines):
+        if line.rstrip() != header:
+            continue
+        values: list[str] = []
+        for following in lines[index + 1 :]:
+            if following.strip() and _indent(following) <= key_indent:
+                break
+            item = re.match(r"^\s+-\s+(.+?)\s*$", following)
+            if item:
+                values.append(item.group(1).strip().strip("'\""))
+        return values
+    return []
+
+
+def _steps(job_block: str) -> list[str]:
+    """Return step-shaped chunks from one job block."""
+    lines = job_block.splitlines(keepends=True)
+    starts = [index for index, line in enumerate(lines) if line.startswith("      - ")]
+    if not starts:
+        return []
+    return [
+        "".join(lines[start:stop])
+        for start, stop in zip(starts, starts[1:] + [len(lines)], strict=True)
+    ]
+
+
+def _field_tokens(block: str, key: str, indent: int) -> set[str]:
+    """Normalize a scalar, inline-list, or block-list action input."""
+    pattern = re.compile(rf"^ {{{indent}}}{re.escape(key)}:\s*(.*?)\s*$", re.MULTILINE)
+    match = pattern.search(block)
+    if match is None:
+        return set()
+    value = match.group(1).strip()
+    if value:
+        return {
+            token
+            for token in re.split(r"[\s,\[\]'\"]+", value)
+            if token
+        }
+    return set(_sequence(block, key, indent))
+
+
+def _block_scalar(block: str, key: str, indent: int) -> str:
+    """Return a literal block scalar's indented body."""
+    lines = block.splitlines(keepends=True)
+    pattern = re.compile(rf"^ {{{indent}}}{re.escape(key)}:\s*[|>]\s*$")
+    for index, line in enumerate(lines):
+        if not pattern.match(line):
+            continue
+        body: list[str] = []
+        for following in lines[index + 1 :]:
+            if following.strip() and _indent(following) <= indent:
+                break
+            body.append(following)
+        return "".join(body)
+    return ""
+
+
+def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
+    """Return stable violation labels for one CodeQL workflow text."""
+    violations: list[str] = []
+
+    def check(label: str, condition: bool) -> None:
+        if evaluated is not None:
+            evaluated.append(label)
+        if not condition:
+            violations.append(label)
+
+    check("workflow-file-present", bool(text))
+    if not text:
+        return violations
+
+    on_block = _named_block(text, "on", 0)
+    check("on-block-present", bool(on_block))
+    trigger_blocks = _child_blocks(on_block, 2)
+    for trigger_name in ("pull_request", "push"):
+        ignored = _sequence(trigger_blocks.get(trigger_name, ""), "paths-ignore", 4)
+        check(
+            f"trigger-docs-path-ignore[{trigger_name}]",
+            "docs/**" in ignored,
+        )
+
+    permissions_block = _named_block(text, "permissions", 0)
+    check(
+        "permissions-read",
+        _mapping(permissions_block, 2) == {"contents": "read"},
+    )
+
+    jobs_block = _named_block(text, "jobs", 0)
+    check("jobs-block-present", bool(jobs_block))
+    jobs = _child_blocks(jobs_block, 2)
+    analyze = jobs.get("analyze", "")
+    check("analyze-job-present", bool(analyze))
+
+    security_writers = [
+        job_name
+        for job_name, job_block in jobs.items()
+        if _mapping(_named_block(job_block, "permissions", 4), 6).get(
+            "security-events"
+        )
+        == "write"
+    ]
+    check("security-events-only-analyze", security_writers == ["analyze"])
+
+    init_steps = [
+        step
+        for step in _steps(analyze)
+        if re.search(r"^        uses: github/codeql-action/init@", step, re.MULTILINE)
+    ]
+    check("init-step-present", len(init_steps) == 1)
+    if init_steps:
+        init_step = init_steps[0]
+        check(
+            "languages-contain-python",
+            "python" in _field_tokens(init_step, "languages", 10),
+        )
+        queries = _mapping(init_step, 10).get("queries")
+        check("queries-security-extended", queries == "security-extended")
+
+        config = _block_scalar(init_step, "config", 10)
+        check("config-block-present", bool(config))
+        ignored = _sequence(config, "paths-ignore", 12)
+        for path in CONFIG_PATH_IGNORES:
+            check(f"config-path-ignore[{path}]", path in ignored)
+
+    concurrency_block = _named_block(text, "concurrency", 0)
+    check("concurrency-block-present", bool(concurrency_block))
+    group = _mapping(concurrency_block, 2).get("group", "")
+    check("concurrency-per-ref", "github.ref" in group)
+
+    return violations
+
+
+def _baseline() -> str:
+    """Return the real workflow, or the empty missing-file sentinel."""
+    if WORKFLOW.is_file():
+        return WORKFLOW.read_text(encoding="utf-8")
+    return ""
+
+
+_MUTATIONS: list[Mutation] = [
+    ("remove-workflow-file", "workflow-file-present", lambda _text: ""),
+    (
+        "rename-on-block",
+        "on-block-present",
+        lambda text: text.replace("on:\n", "triggers:\n", 1),
+    ),
+    (
+        "drop-pr-docs-ignore",
+        "trigger-docs-path-ignore[pull_request]",
+        lambda text: text.replace('      - "docs/**"\n', "", 1),
+    ),
+    (
+        "drop-push-docs-ignore",
+        "trigger-docs-path-ignore[push]",
+        lambda text: text.replace(
+            '  push:\n    branches: [main]\n    paths-ignore:\n      - "docs/**"\n',
+            "  push:\n    branches: [main]\n    paths-ignore:\n",
+            1,
+        ),
+    ),
+    (
+        "widen-top-level-permissions",
+        "permissions-read",
+        lambda text: text.replace("  contents: read\n", "  contents: write\n", 1),
+    ),
+    (
+        "rename-jobs-block",
+        "jobs-block-present",
+        lambda text: text.replace("jobs:\n", "disabled-jobs:\n", 1),
+    ),
+    (
+        "rename-analyze-job",
+        "analyze-job-present",
+        lambda text: text.replace("  analyze:\n", "  analysis:\n", 1),
+    ),
+    (
+        "grant-security-events-to-another-job",
+        "security-events-only-analyze",
+        lambda text: text.replace(
+            "jobs:\n",
+            "jobs:\n  advisory:\n    permissions:\n      security-events: write\n",
+            1,
+        ),
+    ),
+    (
+        "remove-init-step",
+        "init-step-present",
+        lambda text: text.replace("github/codeql-action/init@", "github/codeql-action/setup@", 1),
+    ),
+    (
+        "drop-python-language",
+        "languages-contain-python",
+        lambda text: text.replace("          languages: python\n", "          languages: ruby\n", 1),
+    ),
+    (
+        "drop-security-extended-queries",
+        "queries-security-extended",
+        lambda text: text.replace(
+            "          queries: security-extended\n",
+            "          queries: security-and-quality\n",
+            1,
+        ),
+    ),
+    (
+        "remove-config-block",
+        "config-block-present",
+        lambda text: text.replace("          config: |\n", "          configuration: |\n", 1),
+    ),
+    (
+        "drop-tests-tree-ignore",
+        "config-path-ignore[**/tests/**]",
+        lambda text: text.replace("              - '**/tests/**'\n", "", 1),
+    ),
+    (
+        "drop-test-underscore-ignore",
+        "config-path-ignore[**/test_*.py]",
+        lambda text: text.replace("              - '**/test_*.py'\n", "", 1),
+    ),
+    (
+        "drop-test-hyphen-ignore",
+        "config-path-ignore[**/test-*.py]",
+        lambda text: text.replace("              - '**/test-*.py'\n", "", 1),
+    ),
+    (
+        "remove-concurrency-block",
+        "concurrency-block-present",
+        lambda text: text.replace("concurrency:\n", "run-concurrency:\n", 1),
+    ),
+    (
+        "make-concurrency-group-constant",
+        "concurrency-per-ref",
+        lambda text: re.sub(
+            r"^  group: .*github\.ref.*$",
+            "  group: codeql",
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        ),
+    ),
+]
+
+
+def _family(label: str) -> str:
+    """Collapse repeated indexed assertions into one mutation family."""
+    return re.sub(r"\[.*\]$", "[*]", label)
+
+
+def self_test() -> int:
+    """Prove the real baseline and every evaluated assertion family."""
+    failures: list[str] = []
+    good = _baseline()
+    evaluated: list[str] = []
+    baseline_violations = audit(good, evaluated)
+    if baseline_violations:
+        failures.append(f"baseline should be clean, got {baseline_violations}")
+
+    for mutation_id, expected, transform in _MUTATIONS:
+        mutated = transform(good)
+        if mutated == good:
+            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            continue
+        got = audit(mutated)
+        if expected not in got:
+            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
+
+    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
+    uncovered = sorted({_family(label) for label in evaluated} - covered)
+    if uncovered:
+        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    if failures:
+        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
+        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    """Run the harness, then audit the repository workflow."""
+    if "--self-test" in argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    violations = audit(_baseline())
+    if violations:
+        print(f"✖ codeql.yml: {len(violations)} posture violation(s):", file=sys.stderr)
+        for violation in violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+    print("✓ codeql.yml posture OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -43,6 +43,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import posture_harness
+
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
@@ -494,59 +496,11 @@ _MUTATIONS: list[Mutation] = [
 ]
 
 
-def _family(label: str) -> str:
-    """Collapse repeated indexed assertions into one mutation family."""
-    return re.sub(r"\[.*\]$", "[*]", label)
-
-
 def self_test() -> int:
     """Prove the real baseline and every evaluated assertion family."""
-    failures: list[str] = []
-    good = _baseline()
-    evaluated: list[str] = []
-    baseline_violations = audit(good, evaluated)
-    if baseline_violations:
-        # Return before the matrix. Every transform is pinned to the real
-        # workflow's text, so a dirty or missing baseline turns each one into a
-        # no-op — or, where a transform asserts its literal, into an exception —
-        # burying the one true cause under a wall of derived noise that names
-        # neither the cause nor the file to edit.
-        print(
-            f"\u2716 self-test: {WORKFLOW} is not clean; "
-            f"{len(baseline_violations)} posture violation(s) before any mutation:",
-            file=sys.stderr,
-        )
-        for violation in baseline_violations:
-            print(f"  - {violation}", file=sys.stderr)
-        return 1
-
-    for mutation_id, expected, transform in _MUTATIONS:
-        mutated = transform(good)
-        if mutated == good:
-            failures.append(
-                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
-                "proves nothing; re-pin its literal against that file"
-            )
-            continue
-        got = audit(mutated)
-        if expected not in got:
-            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
-
-    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
-    uncovered = sorted({_family(label) for label in evaluated} - covered)
-    if uncovered:
-        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
-
-    if failures:
-        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
-        for failure in failures:
-            print(f"  - {failure}", file=sys.stderr)
-        return 1
-    print(
-        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
-        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    return posture_harness.run(
+        workflow=WORKFLOW, baseline=_baseline, audit=audit, mutations=_MUTATIONS
     )
-    return 0
 
 
 def main(argv: list[str]) -> int:

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -193,11 +193,28 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     on_block = _named_block(text, "on", 0)
     check("on-block-present", bool(on_block))
     trigger_blocks = _child_blocks(on_block, 2)
+    check(
+        "trigger-forbidden[pull_request_target]",
+        "pull_request_target" not in trigger_blocks,
+    )
+    check("trigger-schedule-present", "schedule" in trigger_blocks)
     for trigger_name in ("pull_request", "push"):
-        ignored = _sequence(trigger_blocks.get(trigger_name, ""), "paths-ignore", 4)
+        block = trigger_blocks.get(trigger_name, "")
+        ignored = _sequence(block, "paths-ignore", 4)
+        # Exhaustive, not membership: an added `- "**"` skips every run while a
+        # membership test still sees `docs/**` and reports the surface pinned.
         check(
             f"trigger-docs-path-ignore[{trigger_name}]",
-            "docs/**" in ignored,
+            set(ignored) == {"docs/**"},
+        )
+        # A `paths:` allowlist narrows from the other side to the same effect.
+        check(
+            f"trigger-no-paths-allowlist[{trigger_name}]",
+            not _sequence(block, "paths", 4),
+        )
+        check(
+            f"trigger-branches-main[{trigger_name}]",
+            "main" in _field_tokens(block, "branches", 4),
         )
 
     permissions_block = _named_block(text, "permissions", 0)
@@ -221,6 +238,16 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         == "write"
     ]
     check("security-events-only-analyze", security_writers == ["analyze"])
+    # Backstop, spelling-independent and fail-closed: the structured read above
+    # only recognises a block-style `permissions:` under a bare job header, so a
+    # flow mapping, a `write-all` scalar, or a header with a trailing comment was
+    # never enumerated. Scanning the jobs block with the analyze job removed
+    # needs no parse at all.
+    outside_analyze = jobs_block.replace(analyze, "", 1) if analyze else jobs_block
+    check(
+        "no-elevated-grant-outside-analyze",
+        not re.search(r"security-events|write-all", outside_analyze),
+    )
 
     init_steps = [
         step
@@ -297,6 +324,52 @@ _MUTATIONS: list[Mutation] = [
             '  push:\n    branches: [main]\n    paths-ignore:\n      - "docs/**"\n',
             "  push:\n    branches: [main]\n    paths-ignore:\n",
             1,
+        ),
+    ),
+    (
+        "add-pull-request-target",
+        "trigger-forbidden[pull_request_target]",
+        lambda text: text.replace(
+            "\n  push:\n", "\n  pull_request_target:\n    branches: [main]\n  push:\n", 1
+        ),
+    ),
+    (
+        "drop-the-weekly-rescan",
+        "trigger-schedule-present",
+        lambda text: text.replace("\n  schedule:\n", "\n  cadence:\n", 1),
+    ),
+    (
+        "widen-trigger-paths-ignore",
+        "trigger-docs-path-ignore[pull_request]",
+        lambda text: text.replace(
+            '    paths-ignore:\n      - "docs/**"\n',
+            '    paths-ignore:\n      - "docs/**"\n      - "**"\n',
+            1,
+        ),
+    ),
+    (
+        "narrow-with-a-paths-allowlist",
+        "trigger-no-paths-allowlist[pull_request]",
+        lambda text: text.replace(
+            '    paths-ignore:\n      - "docs/**"\n',
+            '    paths:\n      - "nonexistent/**"\n    paths-ignore:\n      - "docs/**"\n',
+            1,
+        ),
+    ),
+    (
+        "retarget-pr-branches",
+        "trigger-branches-main[pull_request]",
+        lambda text: text.replace(
+            "  pull_request:\n    branches: [main]\n",
+            "  pull_request:\n    branches: [retired]\n",
+            1,
+        ),
+    ),
+    (
+        "grant-write-all-to-another-job",
+        "no-elevated-grant-outside-analyze",
+        lambda text: text.replace(
+            "jobs:\n", "jobs:\n  advisory:  # helper\n    permissions: write-all\n", 1
         ),
     ),
     (

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -31,6 +31,11 @@ and ``write-all`` by text, so a second job granted ``contents: write``,
 ``id-token: write`` or ``read-all`` is not detected, and a comment containing
 either token fails it closed. Both are registered, neither is asserted here.
 
+``trigger-forbidden[pull_request_target]`` carries the same caveat and for the
+same reason: it is a raw substring over the ``on`` block, chosen so a flow
+mapping and a commented header cannot slip past, which also means a comment
+merely naming the trigger fails it closed.
+
 Known limitation: CodeQL is advisory until the repository owner makes it a
 required branch-protection check. This posture test protects that advisory
 signal; it does not claim to make the signal merge-blocking.
@@ -153,7 +158,11 @@ def _steps(job_block: str) -> list[str]:
 
 def _field_tokens(block: str, key: str, indent: int) -> set[str]:
     """Normalize a scalar, inline-list, or block-list action input."""
-    pattern = re.compile(rf"^ {{{indent}}}{re.escape(key)}:\s*(.*?)\s*$", re.MULTILINE)
+    # Optional quote: `"paths": [...]` resolves to the same key, and missing it
+    # let a quoted allowlist narrow analysis to nothing while the check passed.
+    pattern = re.compile(
+        rf"^ {{{indent}}}[\"']?{re.escape(key)}[\"']?:\s*(.*?)\s*$", re.MULTILINE
+    )
     match = pattern.search(block)
     if match is None:
         return set()
@@ -391,6 +400,15 @@ _MUTATIONS: list[Mutation] = [
         "trigger-forbidden[pull_request_target]",
         lambda text: text.replace(
             "\n  push:\n", "\n  pull_request_target: {branches: [main]}\n  push:\n", 1
+        ),
+    ),
+    (
+        "narrow-with-a-quoted-paths-allowlist",
+        "trigger-no-paths-allowlist[pull_request]",
+        lambda text: text.replace(
+            '    paths-ignore:\n      - "docs/**"\n',
+            '    "paths": ["nope/**"]\n    paths-ignore:\n      - "docs/**"\n',
+            1,
         ),
     ),
     (

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -324,7 +324,7 @@ _MUTATIONS: list[Mutation] = [
         ),
     ),
     (
-        "remove-init-step",
+        "retarget-init-action",
         "init-step-present",
         lambda text: text.replace("github/codeql-action/init@", "github/codeql-action/setup@", 1),
     ),
@@ -372,7 +372,7 @@ _MUTATIONS: list[Mutation] = [
         ),
     ),
     (
-        "remove-analyze-step",
+        "retarget-analyze-action",
         "analyze-step-present",
         lambda text: text.replace(
             "github/codeql-action/analyze@", "github/codeql-action/upload@", 1
@@ -433,12 +433,27 @@ def self_test() -> int:
     evaluated: list[str] = []
     baseline_violations = audit(good, evaluated)
     if baseline_violations:
-        failures.append(f"baseline should be clean, got {baseline_violations}")
+        # Return before the matrix. Every transform is pinned to the real
+        # workflow's text, so a dirty or missing baseline turns each one into a
+        # no-op — or, where a transform asserts its literal, into an exception —
+        # burying the one true cause under a wall of derived noise that names
+        # neither the cause nor the file to edit.
+        print(
+            f"\u2716 self-test: {WORKFLOW} is not clean; "
+            f"{len(baseline_violations)} posture violation(s) before any mutation:",
+            file=sys.stderr,
+        )
+        for violation in baseline_violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
 
     for mutation_id, expected, transform in _MUTATIONS:
         mutated = transform(good)
         if mutated == good:
-            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            failures.append(
+                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
+                "proves nothing; re-pin its literal against that file"
+            )
             continue
         got = audit(mutated)
         if expected not in got:

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -16,6 +16,16 @@ non-PR run keys on ``github.run_id``, and a substring test for ``github.ref``
 would accept the bare-ref form that ADR-0086 lines 111-117 tells the next
 author not to copy.
 
+Recognition boundary, stated because a check that silently fails to enumerate
+is worse than one that admits its edge: job headers and ``permissions`` blocks
+are recognized only in block style — a bare ``  <name>:`` header line and a
+``    permissions:`` mapping. A job written with a flow mapping
+(``permissions: {security-events: write}``), a ``write-all`` scalar, or a header
+carrying a trailing comment is not enumerated, so
+``security-events-only-analyze`` is a claim about block-style jobs, not about
+every spelling YAML admits. Widening it is registered follow-up work, not a
+claim made here.
+
 Known limitation: CodeQL is advisory until the repository owner makes it a
 required branch-protection check. This posture test protects that advisory
 signal; it does not claim to make the signal merge-blocking.
@@ -50,6 +60,10 @@ EXPECTED_GROUP = (
     "codeql-${{ github.event_name == 'pull_request' && github.ref || "
     "github.run_id }}"
 )
+# Pinned by equality for the same reason as the group: a substring test for
+# "pull_request" accepts the inverted `!=` form, which stops PR runs superseding
+# one another while reading as if it were asserted.
+EXPECTED_CANCEL = "${{ github.event_name == 'pull_request' }}"
 
 Mutation = tuple[str, str, Callable[[str], str]]
 
@@ -249,8 +263,10 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     check("concurrency-block-present", bool(concurrency_block))
     concurrency = _mapping(concurrency_block, 2)
     check("concurrency-group", concurrency.get("group") == EXPECTED_GROUP)
-    cancel = str(concurrency.get("cancel-in-progress", ""))
-    check("concurrency-cancel", "pull_request" in cancel)
+    check(
+        "concurrency-cancel",
+        concurrency.get("cancel-in-progress") == EXPECTED_CANCEL,
+    )
 
     return violations
 
@@ -393,6 +409,14 @@ _MUTATIONS: list[Mutation] = [
             "  cancel-in-progress: true\n",
             1,
         ),
+    ),
+    (
+        # A one-character inversion the previous substring test walked past: PR
+        # runs stop superseding one another while the line still names the
+        # trigger the assertion looked for.
+        "invert-cancel-condition",
+        "concurrency-cancel",
+        lambda text: text.replace(EXPECTED_CANCEL, "${{ github.event_name != 'pull_request' }}", 1),
     ),
 ]
 

--- a/tools/test-codeql-workflow.py
+++ b/tools/test-codeql-workflow.py
@@ -4,10 +4,12 @@
 The workflow supplies ADR-0017's interprocedural taint lens. This checker pins
 only the security-extended query suite, the split between the read-only default
 floor and the analyzer's elevated grant, both ``paths-ignore`` surfaces (the
-trigger-level one and the analysis-config one, the latter as an exhaustive list
-so a widening entry cannot silently exempt everything), the presence of the
-analyze step that turns extraction into an uploaded result, Python language
-containment, and the literal concurrency group and cancellation expressions.
+trigger-level one and the analysis-config one, both exhaustive so a widening
+entry cannot silently exempt everything), the absence of a ``paths:`` allowlist
+and of a ``pull_request_target`` trigger, the ``main`` branch targets, the
+weekly re-scan, the presence of the analyze step that turns extraction into an
+uploaded result, Python language containment, and the literal concurrency group
+and cancellation expressions.
 Action SHA pinning remains zizmor-owned.
 
 The concurrency group is pinned as a literal, not as a property: AC12 of
@@ -17,14 +19,17 @@ would accept the bare-ref form that ADR-0086 lines 111-117 tells the next
 author not to copy.
 
 Recognition boundary, stated because a check that silently fails to enumerate
-is worse than one that admits its edge: job headers and ``permissions`` blocks
-are recognized only in block style — a bare ``  <name>:`` header line and a
-``    permissions:`` mapping. A job written with a flow mapping
-(``permissions: {security-events: write}``), a ``write-all`` scalar, or a header
-carrying a trailing comment is not enumerated, so
-``security-events-only-analyze`` is a claim about block-style jobs, not about
-every spelling YAML admits. Widening it is registered follow-up work, not a
-claim made here.
+is worse than one that admits its edge. ``security-events-only-analyze`` reads
+the structured form and so sees only block style — a bare ``  <name>:`` header
+and a ``    permissions:`` mapping. ``no-elevated-grant-outside-analyze`` is the
+backstop for the rest: a parse-free text scan over the jobs block with the
+analyze job removed, which catches a flow mapping, a ``write-all`` scalar, and a
+header carrying a trailing comment.
+
+What that backstop does NOT claim: it matches the two tokens ``security-events``
+and ``write-all`` by text, so a second job granted ``contents: write``,
+``id-token: write`` or ``read-all`` is not detected, and a comment containing
+either token fails it closed. Both are registered, neither is asserted here.
 
 Known limitation: CodeQL is advisory until the repository owner makes it a
 required branch-protection check. This posture test protects that advisory
@@ -178,6 +183,37 @@ def _block_scalar(block: str, key: str, indent: int) -> str:
     return ""
 
 
+def _outside(jobs_block: str, job_name: str) -> str:
+    """Return the jobs block with one job's own lines removed.
+
+    Not `replace(analyze, "", 1)`: `_child_blocks` only recognises a bare
+    `  name:` header, so a following job whose header carries a trailing comment
+    or a quoted key was never a block start and was swallowed by the preceding
+    block — deleting it here took the escalation with it. Bounding on the next
+    indent-2 key in ANY spelling is what makes the backstop fail closed.
+    """
+    lines = jobs_block.splitlines(keepends=True)
+    start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if re.match(rf"^ {{2}}\"?{re.escape(job_name)}\"?:", line)
+        ),
+        None,
+    )
+    if start is None:
+        return jobs_block
+    stop = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if lines[index].strip() and re.match(r"^ {2}\S", lines[index])
+        ),
+        len(lines),
+    )
+    return "".join(lines[:start] + lines[stop:])
+
+
 def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     """Return stable violation labels for one CodeQL workflow text."""
     violations: list[str] = []
@@ -195,9 +231,12 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     on_block = _named_block(text, "on", 0)
     check("on-block-present", bool(on_block))
     trigger_blocks = _child_blocks(on_block, 2)
+    # Raw text, not the child-block map: a `pull_request_target:  # mirror`
+    # header or a `pull_request_target: {branches: [main]}` flow mapping is not
+    # enumerated by `_child_blocks`, so a membership test on it audits clean.
     check(
         "trigger-forbidden[pull_request_target]",
-        "pull_request_target" not in trigger_blocks,
+        "pull_request_target" not in on_block,
     )
     check("trigger-schedule-present", "schedule" in trigger_blocks)
     for trigger_name in ("pull_request", "push"):
@@ -210,9 +249,12 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
             set(ignored) == {"docs/**"},
         )
         # A `paths:` allowlist narrows from the other side to the same effect.
+        # `_field_tokens`, not `_sequence`: the block-list parser returns an
+        # empty list for `paths: ["x"]` and for a bare scalar, so negating it
+        # reported clean on two spellings that zero analysis just as effectively.
         check(
             f"trigger-no-paths-allowlist[{trigger_name}]",
-            not _sequence(block, "paths", 4),
+            not _field_tokens(block, "paths", 4),
         )
         check(
             f"trigger-branches-main[{trigger_name}]",
@@ -245,7 +287,7 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
     # flow mapping, a `write-all` scalar, or a header with a trailing comment was
     # never enumerated. Scanning the jobs block with the analyze job removed
     # needs no parse at all.
-    outside_analyze = jobs_block.replace(analyze, "", 1) if analyze else jobs_block
+    outside_analyze = _outside(jobs_block, "analyze")
     check(
         "no-elevated-grant-outside-analyze",
         not re.search(r"security-events|write-all", outside_analyze),
@@ -334,6 +376,38 @@ _MUTATIONS: list[Mutation] = [
         lambda text: text.replace(
             "\n  push:\n", "\n  pull_request_target:\n    branches: [main]\n  push:\n", 1
         ),
+    ),
+    (
+        # A commented header is not a child block, so the membership test that
+        # this replaced audited it clean.
+        "add-pull-request-target-with-a-comment",
+        "trigger-forbidden[pull_request_target]",
+        lambda text: text.replace(
+            "\n  push:\n", "\n  pull_request_target:  # mirror\n    branches: [main]\n  push:\n", 1
+        ),
+    ),
+    (
+        "add-pull-request-target-as-a-flow-mapping",
+        "trigger-forbidden[pull_request_target]",
+        lambda text: text.replace(
+            "\n  push:\n", "\n  pull_request_target: {branches: [main]}\n  push:\n", 1
+        ),
+    ),
+    (
+        "narrow-with-a-flow-paths-allowlist",
+        "trigger-no-paths-allowlist[pull_request]",
+        lambda text: text.replace(
+            '    paths-ignore:\n      - "docs/**"\n',
+            '    paths: ["nope/**"]\n    paths-ignore:\n      - "docs/**"\n',
+            1,
+        ),
+    ),
+    (
+        # Appended AFTER analyze, the position the previous bound swallowed.
+        "grant-write-all-to-a-job-after-analyze",
+        "no-elevated-grant-outside-analyze",
+        lambda text: text.rstrip("\n")
+        + "\n\n  advisory:  # helper\n    permissions: write-all\n",
     ),
     (
         "drop-the-weekly-rescan",

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -1,100 +1,296 @@
 #!/usr/bin/env python3
-"""Posture check for .github/workflows/pack-evals.yml (pack-activation-evals
-AC8 / AC9 / AC10). Security-load-bearing: the schedule-only trigger keeps an
-untrusted-fork PR from reaching the ANTHROPIC_API_KEY secret, and the
-least-privilege permissions block keeps a compromised run from pushing commits.
+"""Posture test for ``.github/workflows/pack-evals.yml``.
 
-Pure-stdlib + PyYAML (already a tools/ dependency). Asserts a posture rather
-than running the workflow.
+This workflow is the repository's managed-secret boundary for activation evals.
+It must remain schedule/manual-only so an untrusted fork pull request cannot
+reach ``ANTHROPIC_API_KEY``.  The mutation matrix runs on every invocation: a
+posture assertion without a mutation that makes it fail is not treated as proof.
+
+The baseline is the real workflow, deliberately.  If the workflow itself is
+weakened, the harness fails before it can claim that any derived mutation was
+caught.  Pure-stdlib plus PyYAML (already a tools dependency).
 """
 
 from __future__ import annotations
 
-import pathlib
+import re
 import sys
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Any
 
 import yaml
 
-# Windows cp1252 guard — reconfigure stdout/stderr to UTF-8 before any print.
+# Windows cp1252 guard — reconfigure stdout/stderr before printing verdict marks.
 sys.stdout.reconfigure(encoding="utf-8", errors="strict")
 sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pack-evals.yml"
 
-
-def fail(msg: str) -> None:
-    print(f"✖ pack-evals.yml: {msg}", file=sys.stderr)
-    sys.exit(1)
+Mutation = tuple[str, str, Callable[[str], str]]
 
 
-def main() -> int:
-    if not WORKFLOW.exists():
-        fail(f"not found at {WORKFLOW}")
-    text = WORKFLOW.read_text(encoding="utf-8")
+def _steps(jobs: object) -> Iterable[dict[Any, Any]]:
+    """Yield mapping-shaped steps from jobs whose step collection is a list."""
+    if not isinstance(jobs, dict):
+        return
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                yield step
+
+
+def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
+    """Return stable violation labels for one workflow text.
+
+    ``text == ""`` is the pure-function representation of a missing workflow;
+    the CLI maps a missing file to that value rather than exiting through an
+    untestable imperative branch.
+    """
+    violations: list[str] = []
+
+    def check(label: str, condition: bool) -> None:
+        if evaluated is not None:
+            evaluated.append(label)
+        if not condition:
+            violations.append(label)
+
+    check("workflow-file-present", bool(text))
+    if not text:
+        return violations
+
     try:
-        doc = yaml.safe_load(text)
-    except yaml.YAMLError as exc:
-        fail(f"does not parse as YAML: {exc}")
+        loaded: Any = yaml.safe_load(text)
+    except yaml.YAMLError:
+        check("yaml-parses", False)
+        return violations
+    check("yaml-parses", isinstance(loaded, dict))
+    if not isinstance(loaded, dict):
+        return violations
+    doc: dict[Any, Any] = loaded
 
-    # PyYAML parses the bareword `on:` key as the boolean True.
+    # PyYAML 1.1 resolves the bareword ``on`` as boolean True.
     triggers = doc.get("on", doc.get(True))
-    if not isinstance(triggers, dict):
-        fail("`on:` must be a mapping of trigger types")
-    if "schedule" not in triggers or "workflow_dispatch" not in triggers:
-        fail("must trigger on both `schedule` and `workflow_dispatch`")
-    for forbidden in ("push", "pull_request", "pull_request_target"):
-        if forbidden in triggers:
-            fail(
-                f"must NOT trigger on `{forbidden}` — an untrusted-fork PR could "
-                f"reach the ANTHROPIC_API_KEY secret (AC8)"
-            )
+    check("triggers-mapping", isinstance(triggers, dict))
+    if isinstance(triggers, dict):
+        check(
+            "triggers-required",
+            "schedule" in triggers and "workflow_dispatch" in triggers,
+        )
+        for forbidden in ("push", "pull_request", "pull_request_target"):
+            check(f"trigger-forbidden[{forbidden}]", forbidden not in triggers)
 
-    # Least-privilege permissions (AC9).
-    perms = doc.get("permissions")
-    if perms != {"contents": "read"}:
-        fail(f"top-level permissions must be {{contents: read}}, got {perms!r}")
+    check("permissions-read", doc.get("permissions") == {"contents": "read"})
 
-    # Consumes the API key from secrets (AC8), never a hardcoded value.
-    if "secrets.ANTHROPIC_API_KEY" not in text:
-        fail("must consume ANTHROPIC_API_KEY from repo secrets")
+    # The key must cross the Actions secrets boundary rather than coming from a
+    # variable or a hard-coded value.
+    check("secret-source", "secrets.ANTHROPIC_API_KEY" in text)
 
-    # Report-only: the eval step must not fail the build on a miss (AC8).
-    jobs = doc.get("jobs", {})
+    jobs = doc.get("jobs")
+    check(
+        "jobs-mapping",
+        isinstance(jobs, dict)
+        and bool(jobs)
+        and all(isinstance(job, dict) for job in jobs.values()),
+    )
+    if isinstance(jobs, dict):
+        for job_name, job in jobs.items():
+            if isinstance(job, dict):
+                check(
+                    f"job-steps-list[{job_name}]",
+                    isinstance(job.get("steps", []), list),
+                )
     eval_steps = [
         step
-        for job in jobs.values()
-        for step in job.get("steps", [])
+        for step in _steps(jobs)
         if "agentbundle pack evals run" in str(step.get("run", ""))
     ]
-    if not eval_steps:
-        fail("no step invokes agentbundle pack evals run")
-    for step in eval_steps:
-        if step.get("continue-on-error") is not True:
-            fail("the pack evals run step must be continue-on-error (report-only)")
+    check("eval-step-present", bool(eval_steps))
+    for index, step in enumerate(eval_steps):
+        check(
+            f"eval-step-report-only[{index}]",
+            step.get("continue-on-error") is True,
+        )
 
-    # Artifact upload is the bounded summary.json only — never the per-run
-    # outputs/ captures (AC10).
     upload_steps = [
         step
-        for job in jobs.values()
-        for step in job.get("steps", [])
+        for step in _steps(jobs)
         if "upload-artifact" in str(step.get("uses", ""))
     ]
-    if not upload_steps:
-        fail("must upload the activation summaries as an artifact")
-    for step in upload_steps:
-        path = str(step.get("with", {}).get("path", ""))
-        if "summary.json" not in path:
-            fail("the artifact path must target summary.json")
-        if "outputs" in path:
-            fail("the artifact path must EXCLUDE the per-run outputs/ captures (AC10)")
+    check("upload-step-present", bool(upload_steps))
+    for index, step in enumerate(upload_steps):
+        with_block = step.get("with")
+        path = str(with_block.get("path", "")) if isinstance(with_block, dict) else ""
+        check(f"upload-summary-only[{index}]", "summary.json" in path)
+        check(f"upload-excludes-outputs[{index}]", "outputs" not in path)
 
-    print("✓ pack-evals.yml: schedule+dispatch only (no push/PR), contents:read, "
-          "consumes ANTHROPIC_API_KEY, report-only eval step, bounded summary "
-          "artifact (outputs/ excluded). YAML parses.")
+    return violations
+
+
+def _baseline() -> str:
+    """Return the real workflow, or the empty missing-file sentinel."""
+    if WORKFLOW.is_file():
+        return WORKFLOW.read_text(encoding="utf-8")
+    return ""
+
+
+_MUTATIONS: list[Mutation] = [
+    (
+        "remove-workflow-file",
+        "workflow-file-present",
+        lambda _text: "",
+    ),
+    (
+        "break-yaml",
+        "yaml-parses",
+        lambda _text: "[unterminated\n",
+    ),
+    (
+        "replace-trigger-map-with-list",
+        "triggers-mapping",
+        lambda text: text.replace("on:\n", "on: []\nlegacy-on:\n", 1),
+    ),
+    (
+        "drop-schedule-trigger",
+        "triggers-required",
+        lambda text: text.replace("  schedule:\n", "  cadence:\n", 1),
+    ),
+    (
+        "add-fork-pr-trigger",
+        "trigger-forbidden[pull_request]",
+        lambda text: text.replace("on:\n", "on:\n  pull_request:\n", 1),
+    ),
+    (
+        "widen-token-permissions",
+        "permissions-read",
+        lambda text: text.replace("  contents: read\n", "  contents: write\n", 1),
+    ),
+    (
+        "move-api-key-out-of-secrets",
+        "secret-source",
+        lambda text: text.replace(
+            "secrets.ANTHROPIC_API_KEY", "vars.ANTHROPIC_API_KEY", 1
+        ),
+    ),
+    (
+        "add-malformed-job",
+        "jobs-mapping",
+        lambda text: text.replace("jobs:\n", "jobs:\n  malformed: true\n", 1),
+    ),
+    (
+        "add-job-with-malformed-steps",
+        "job-steps-list[malformed]",
+        lambda text: text.replace(
+            "jobs:\n", "jobs:\n  malformed:\n    steps: true\n", 1
+        ),
+    ),
+    (
+        "remove-eval-invocation",
+        "eval-step-present",
+        lambda text: text.replace(
+            "agentbundle pack evals run", "agentbundle pack evaluations run", 1
+        ),
+    ),
+    (
+        "make-eval-blocking",
+        "eval-step-report-only[0]",
+        lambda text: text.replace(
+            "        continue-on-error: true\n",
+            "        continue-on-error: false\n",
+            1,
+        ),
+    ),
+    (
+        "remove-artifact-upload",
+        "upload-step-present",
+        lambda text: text.replace("actions/upload-artifact@", "actions/download-artifact@", 1),
+    ),
+    (
+        "replace-summary-artifact",
+        "upload-summary-only[0]",
+        lambda text: text.replace(
+            ".eval-workspace/**/summary.json",
+            ".eval-workspace/**/report.json",
+            1,
+        ),
+    ),
+    (
+        "include-model-outputs",
+        "upload-excludes-outputs[0]",
+        lambda text: text.replace(
+            ".eval-workspace/**/summary.json",
+            ".eval-workspace/**/outputs/**/summary.json",
+            1,
+        ),
+    ),
+]
+
+
+def _family(label: str) -> str:
+    """Collapse repeated indexed assertions into one mutation family."""
+    return re.sub(r"\[.*\]$", "[*]", label)
+
+
+def self_test() -> int:
+    """Prove the real baseline and every evaluated assertion family."""
+    failures: list[str] = []
+    good = _baseline()
+    evaluated: list[str] = []
+    baseline_violations = audit(good, evaluated)
+    if baseline_violations:
+        failures.append(f"baseline should be clean, got {baseline_violations}")
+
+    for mutation_id, expected, transform in _MUTATIONS:
+        mutated = transform(good)
+        if mutated == good:
+            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            continue
+        got = audit(mutated)
+        if expected not in got:
+            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
+
+    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
+    uncovered = sorted({_family(label) for label in evaluated} - covered)
+    if uncovered:
+        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
+
+    if failures:
+        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print(
+        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
+        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    """Run the harness, then audit the repository workflow."""
+    if "--self-test" in argv:
+        return self_test()
+    if self_test() != 0:
+        return 1
+
+    violations = audit(_baseline())
+    if violations:
+        print(f"✖ pack-evals.yml: {len(violations)} posture violation(s):", file=sys.stderr)
+        for violation in violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
+    print(
+        "✓ pack-evals.yml posture OK: schedule+dispatch only, contents:read, "
+        "secret-backed key, report-only evals, bounded summaries"
+    )
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -267,12 +267,27 @@ def self_test() -> int:
     evaluated: list[str] = []
     baseline_violations = audit(good, evaluated)
     if baseline_violations:
-        failures.append(f"baseline should be clean, got {baseline_violations}")
+        # Return before the matrix. Every transform is pinned to the real
+        # workflow's text, so a dirty or missing baseline turns each one into a
+        # no-op — or, where a transform asserts its literal, into an exception —
+        # burying the one true cause under a wall of derived noise that names
+        # neither the cause nor the file to edit.
+        print(
+            f"\u2716 self-test: {WORKFLOW} is not clean; "
+            f"{len(baseline_violations)} posture violation(s) before any mutation:",
+            file=sys.stderr,
+        )
+        for violation in baseline_violations:
+            print(f"  - {violation}", file=sys.stderr)
+        return 1
 
     for mutation_id, expected, transform in _MUTATIONS:
         mutated = transform(good)
         if mutated == good:
-            failures.append(f"{mutation_id}: transform was a no-op — proves nothing")
+            failures.append(
+                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
+                "proves nothing; re-pin its literal against that file"
+            )
             continue
         got = audit(mutated)
         if expected not in got:

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -13,12 +13,12 @@ caught.  Pure-stdlib plus PyYAML (already a tools dependency).
 
 from __future__ import annotations
 
-import re
 import sys
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
+import posture_harness
 import yaml
 
 # Windows cp1252 guard — reconfigure stdout/stderr before printing verdict marks.
@@ -325,59 +325,11 @@ _MUTATIONS: list[Mutation] = [
 ]
 
 
-def _family(label: str) -> str:
-    """Collapse repeated indexed assertions into one mutation family."""
-    return re.sub(r"\[.*\]$", "[*]", label)
-
-
 def self_test() -> int:
     """Prove the real baseline and every evaluated assertion family."""
-    failures: list[str] = []
-    good = _baseline()
-    evaluated: list[str] = []
-    baseline_violations = audit(good, evaluated)
-    if baseline_violations:
-        # Return before the matrix. Every transform is pinned to the real
-        # workflow's text, so a dirty or missing baseline turns each one into a
-        # no-op — or, where a transform asserts its literal, into an exception —
-        # burying the one true cause under a wall of derived noise that names
-        # neither the cause nor the file to edit.
-        print(
-            f"\u2716 self-test: {WORKFLOW} is not clean; "
-            f"{len(baseline_violations)} posture violation(s) before any mutation:",
-            file=sys.stderr,
-        )
-        for violation in baseline_violations:
-            print(f"  - {violation}", file=sys.stderr)
-        return 1
-
-    for mutation_id, expected, transform in _MUTATIONS:
-        mutated = transform(good)
-        if mutated == good:
-            failures.append(
-                f"{mutation_id}: transform was a no-op against {WORKFLOW.name} — "
-                "proves nothing; re-pin its literal against that file"
-            )
-            continue
-        got = audit(mutated)
-        if expected not in got:
-            failures.append(f"{mutation_id}: expected {expected!r}, got {got}")
-
-    covered = {_family(expected) for _, expected, _ in _MUTATIONS}
-    uncovered = sorted({_family(label) for label in evaluated} - covered)
-    if uncovered:
-        failures.append(f"assertion families evaluated but unmutated: {uncovered}")
-
-    if failures:
-        print(f"✖ self-test: {len(failures)} problem(s):", file=sys.stderr)
-        for failure in failures:
-            print(f"  - {failure}", file=sys.stderr)
-        return 1
-    print(
-        f"✓ self-test: baseline clean; {len(_MUTATIONS)} mutations each caught; "
-        f"every one of {len(covered)} assertion families has ≥1 mutation"
+    return posture_harness.run(
+        workflow=WORKFLOW, baseline=_baseline, audit=audit, mutations=_MUTATIONS
     )
-    return 0
 
 
 def main(argv: list[str]) -> int:

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -120,10 +120,16 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
                     f"job-permissions[{job_name}]",
                     job.get("permissions") is None,
                 )
+    # The marker must be a command, not a mention. `eval_steps` is the exemption
+    # for the secret-binding check below, so a step that merely names the marker
+    # in a shell comment above `npm install -g` could otherwise self-issue it.
     eval_steps = [
         step
         for step in _steps(jobs)
-        if "agentbundle pack evals run" in str(step.get("run", ""))
+        if any(
+            "agentbundle pack evals run" in line and not line.lstrip().startswith("#")
+            for line in str(step.get("run", "")).splitlines()
+        )
     ]
     check("eval-step-present", bool(eval_steps))
     # Positive, not a two-location denylist. Forbidding only workflow- and
@@ -141,8 +147,19 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         bound_on.append("workflow")
     if isinstance(jobs, dict):
         for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
             if _binds(job):
                 bound_on.append(f"job:{job_name}")
+            # A container or service env reaches every step in the job, so it is
+            # the same exposure as a job-level binding by another name.
+            if _binds(job.get("container")):
+                bound_on.append(f"container:{job_name}")
+            services = job.get("services")
+            if isinstance(services, dict):
+                for service_name, service in services.items():
+                    if _binds(service):
+                        bound_on.append(f"service:{job_name}.{service_name}")
     for index, step in enumerate(_steps(jobs)):
         if _binds(step) and step not in eval_steps:
             bound_on.append(f"step:{step.get('name', index)}")
@@ -279,6 +296,29 @@ _MUTATIONS: list[Mutation] = [
             "      - name: Install the claude CLI (activation detector)\n",
             "      - name: Install the claude CLI (activation detector)\n        env:\n"
             "          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
+            1,
+        ),
+    ),
+    (
+        # A container env reaches every step in the job, including the installs.
+        "bind-secret-on-a-job-container",
+        "secret-bound-to-eval-step-only",
+        lambda text: text.replace(
+            "  activation-evals:\n",
+            "  activation-evals:\n    container:\n      image: python:3.11\n"
+            "      env:\n        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
+            1,
+        ),
+    ),
+    (
+        # The marker in a comment must not self-issue the eval-step exemption.
+        "name-the-eval-marker-in-a-comment-only",
+        "secret-bound-to-eval-step-only",
+        lambda text: text.replace(
+            "      - name: Install the claude CLI (activation detector)\n",
+            "      - name: Install the claude CLI (activation detector)\n        env:\n"
+            "          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n"
+            "        # agentbundle pack evals run — see the eval step below\n",
             1,
         ),
     ),

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -106,26 +106,12 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         and bool(jobs)
         and all(isinstance(job, dict) for job in jobs.values()),
     )
-    # The key must be bound on the step that uses it. Hoisting it to workflow- or
-    # job-level `env` puts the repository's highest-value secret in the
-    # environment of `pip install` and `npm install -g`, both of which execute
-    # third-party install scripts, while every other assertion stays satisfied.
-    top_env = doc.get("env")
-    check(
-        "secret-not-workflow-level",
-        not (isinstance(top_env, dict) and "ANTHROPIC_API_KEY" in top_env),
-    )
     if isinstance(jobs, dict):
         for job_name, job in jobs.items():
             if isinstance(job, dict):
                 check(
                     f"job-steps-list[{job_name}]",
                     isinstance(job.get("steps", []), list),
-                )
-                job_env = job.get("env")
-                check(
-                    f"secret-not-job-level[{job_name}]",
-                    not (isinstance(job_env, dict) and "ANTHROPIC_API_KEY" in job_env),
                 )
                 # Same posture the ci-security sibling enforces: a job inherits
                 # the top-level grant rather than restating it, so `write-all`
@@ -140,6 +126,28 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         if "agentbundle pack evals run" in str(step.get("run", ""))
     ]
     check("eval-step-present", bool(eval_steps))
+    # Positive, not a two-location denylist. Forbidding only workflow- and
+    # job-level `env` left the step-level route open, which is the very sink the
+    # comment named: binding the key on the `pip install` or `npm install -g`
+    # step reaches the same third-party install scripts. Collect every binding
+    # and require the set to be exactly the eval steps.
+
+    def _binds(scope: object) -> bool:
+        env = scope.get("env") if isinstance(scope, dict) else None
+        return isinstance(env, dict) and "ANTHROPIC_API_KEY" in env
+
+    bound_on: list[str] = []
+    if _binds(doc):
+        bound_on.append("workflow")
+    if isinstance(jobs, dict):
+        for job_name, job in jobs.items():
+            if _binds(job):
+                bound_on.append(f"job:{job_name}")
+    for index, step in enumerate(_steps(jobs)):
+        if _binds(step) and step not in eval_steps:
+            bound_on.append(f"step:{step.get('name', index)}")
+    check("secret-bound-to-eval-step-only", not bound_on)
+
     for index, step in enumerate(eval_steps):
         check(
             f"eval-step-report-only[{index}]",
@@ -245,7 +253,7 @@ _MUTATIONS: list[Mutation] = [
     ),
     (
         "hoist-secret-to-workflow-env",
-        "secret-not-workflow-level",
+        "secret-bound-to-eval-step-only",
         lambda text: text.replace(
             "\njobs:\n",
             "\nenv:\n  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n\njobs:\n",
@@ -254,11 +262,23 @@ _MUTATIONS: list[Mutation] = [
     ),
     (
         "hoist-secret-to-job-env",
-        "secret-not-job-level[activation-evals]",
+        "secret-bound-to-eval-step-only",
         lambda text: text.replace(
             "  activation-evals:\n",
             "  activation-evals:\n    env:\n"
             "      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
+            1,
+        ),
+    ),
+    (
+        # The route the two-location denylist left open, and the one its own
+        # comment named: the secret in the environment of `npm install -g`.
+        "bind-secret-on-the-npm-install-step",
+        "secret-bound-to-eval-step-only",
+        lambda text: text.replace(
+            "      - name: Install the claude CLI (activation detector)\n",
+            "      - name: Install the claude CLI (activation detector)\n        env:\n"
+            "          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
             1,
         ),
     ),

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -99,10 +99,6 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
 
     check("permissions-read", doc.get("permissions") == {"contents": "read"})
 
-    # The key must cross the Actions secrets boundary rather than coming from a
-    # variable or a hard-coded value.
-    check("secret-source", "secrets.ANTHROPIC_API_KEY" in text)
-
     jobs = doc.get("jobs")
     check(
         "jobs-mapping",
@@ -110,12 +106,33 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         and bool(jobs)
         and all(isinstance(job, dict) for job in jobs.values()),
     )
+    # The key must be bound on the step that uses it. Hoisting it to workflow- or
+    # job-level `env` puts the repository's highest-value secret in the
+    # environment of `pip install` and `npm install -g`, both of which execute
+    # third-party install scripts, while every other assertion stays satisfied.
+    top_env = doc.get("env")
+    check(
+        "secret-not-workflow-level",
+        not (isinstance(top_env, dict) and "ANTHROPIC_API_KEY" in top_env),
+    )
     if isinstance(jobs, dict):
         for job_name, job in jobs.items():
             if isinstance(job, dict):
                 check(
                     f"job-steps-list[{job_name}]",
                     isinstance(job.get("steps", []), list),
+                )
+                job_env = job.get("env")
+                check(
+                    f"secret-not-job-level[{job_name}]",
+                    not (isinstance(job_env, dict) and "ANTHROPIC_API_KEY" in job_env),
+                )
+                # Same posture the ci-security sibling enforces: a job inherits
+                # the top-level grant rather than restating it, so `write-all`
+                # on the secret-holding job cannot pass.
+                check(
+                    f"job-permissions[{job_name}]",
+                    job.get("permissions") is None,
                 )
     eval_steps = [
         step
@@ -127,6 +144,17 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         check(
             f"eval-step-report-only[{index}]",
             step.get("continue-on-error") is True,
+        )
+        # Asserted on the PARSED env value, not as a whole-file substring: a
+        # substring is satisfied by a comment that merely names the secret, so
+        # swapping the real binding to `vars.` while a comment still spelled
+        # `secrets.` passed. PyYAML drops comments, so this needs no
+        # comment-stripping helper — and adds no second copy of one.
+        env = step.get("env")
+        binding = env.get("ANTHROPIC_API_KEY") if isinstance(env, dict) else None
+        check(
+            f"secret-source[{index}]",
+            binding == "${{ secrets.ANTHROPIC_API_KEY }}",
         )
 
     upload_steps = [
@@ -196,9 +224,51 @@ _MUTATIONS: list[Mutation] = [
     ),
     (
         "move-api-key-out-of-secrets",
-        "secret-source",
+        "secret-source[0]",
         lambda text: text.replace(
-            "secrets.ANTHROPIC_API_KEY", "vars.ANTHROPIC_API_KEY", 1
+            "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}",
+            "ANTHROPIC_API_KEY: ${{ vars.ANTHROPIC_API_KEY }}",
+            1,
+        ),
+    ),
+    (
+        # The hole the whole-file substring left: the real binding moves to
+        # `vars.`, and a comment still spelling `secrets.` kept the check green.
+        "name-the-secret-in-a-comment-only",
+        "secret-source[0]",
+        lambda text: text.replace(
+            "ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}",
+            "ANTHROPIC_API_KEY: ${{ vars.ANTHROPIC_API_KEY }}"
+            "  # was secrets.ANTHROPIC_API_KEY",
+            1,
+        ),
+    ),
+    (
+        "hoist-secret-to-workflow-env",
+        "secret-not-workflow-level",
+        lambda text: text.replace(
+            "\njobs:\n",
+            "\nenv:\n  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n\njobs:\n",
+            1,
+        ),
+    ),
+    (
+        "hoist-secret-to-job-env",
+        "secret-not-job-level[activation-evals]",
+        lambda text: text.replace(
+            "  activation-evals:\n",
+            "  activation-evals:\n    env:\n"
+            "      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n",
+            1,
+        ),
+    ),
+    (
+        "grant-job-level-permissions",
+        "job-permissions[activation-evals]",
+        lambda text: text.replace(
+            "  activation-evals:\n",
+            "  activation-evals:\n    permissions:\n      contents: write\n",
+            1,
         ),
     ),
     (

--- a/tools/test-pack-evals-workflow.py
+++ b/tools/test-pack-evals-workflow.py
@@ -27,6 +27,10 @@ sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pack-evals.yml"
+# The workflow header claims "schedule + workflow_dispatch ONLY", so the check
+# has to be an allowlist. A denylist of the three obvious fork triggers admits
+# `workflow_run` and `issue_comment`, which do run in base context with secrets.
+ALLOWED_TRIGGERS = frozenset({"schedule", "workflow_dispatch"})
 
 Mutation = tuple[str, str, Callable[[str], str]]
 
@@ -85,6 +89,13 @@ def audit(text: str, evaluated: list[str] | None = None) -> list[str]:
         )
         for forbidden in ("push", "pull_request", "pull_request_target"):
             check(f"trigger-forbidden[{forbidden}]", forbidden not in triggers)
+        # The named three stay above so a regression to any of them reports the
+        # specific trigger. This closes the gap between them and the "only"
+        # claimed by the docstring and the printed verdict.
+        check(
+            "triggers-allowlist",
+            {str(name) for name in triggers} <= set(ALLOWED_TRIGGERS),
+        )
 
     check("permissions-read", doc.get("permissions") == {"contents": "read"})
 
@@ -165,6 +176,18 @@ _MUTATIONS: list[Mutation] = [
         "add-fork-pr-trigger",
         "trigger-forbidden[pull_request]",
         lambda text: text.replace("on:\n", "on:\n  pull_request:\n", 1),
+    ),
+    (
+        # Not on the denylist, and it runs in base context with secrets — the
+        # case that made presence-of-three insufficient.
+        "add-workflow-run-trigger",
+        "triggers-allowlist",
+        lambda text: text.replace(
+            "on:\n",
+            "on:\n  workflow_run:\n    workflows: [build-check]\n"
+            "    types: [completed]\n",
+            1,
+        ),
     ),
     (
         "widen-token-permissions",

--- a/tools/test_build_gate_chain.py
+++ b/tools/test_build_gate_chain.py
@@ -862,6 +862,7 @@ EXPECTED_SCRIPT_STEPS = [
     "tools/test-build-check-windows-workflow.py",
     "tools/test-build-check-workflow.py",
     "tools/test-ci-security-workflow.py",
+    "tools/test-codeql-workflow.py",
     "tools/assert-sast-chain-reachable.py",
     "tools/lint-ci-parity.py",
     "tools/test-test-all.py",

--- a/workspace.toml
+++ b/workspace.toml
@@ -416,46 +416,16 @@ open = [
   # test, making the bypass need a second human. This repo has no CODEOWNERS today.
   # To close: decide between the two (or both) and apply.
   {slug = "ci-gate-parallelization-required-workflow-pinned-ref", source = "spec/ci-gate-parallelization AC3"},
-  # Two defects shared this entry. The FIRST IS CLOSED (2026-08-26):
-  # tools/test-ci-security-workflow.py asserted ci-security.yml's security posture
-  # and was invoked by nothing, which also left a shipped AC in
-  # spec/secret-scanner-for-api-key-workflows live and false. It is now a step in
-  # tools/repo/build_gate_chain.py's build-check chain, pinned in
-  # test_build_gate_chain.py's EXPECTED_SCRIPT_STEPS — that list is the sole source
-  # of the step count, so there is no separate literal to keep in step.
-  # Recorded on the way past, because wiring it did not make its assertions
-  # trustworthy: unlike its chain neighbour test-build-check-workflow.py, which runs
-  # a mutation matrix on every invocation, that file has no --self-test and no
-  # fixture. Its eight assertions now BLOCK make build-check with no automated proof
-  # they can fail, so a silently-weakened one would pass. Building that harness was
-  # outside the wiring chore and needs an owner decision.
-  # The SECOND IS ALSO CLOSED (2026-08-27). ci-security.yml and codeql.yml both
-  # keyed their concurrency group on bare github.ref, and GitHub allows one
-  # running plus one PENDING run per group regardless of cancel-in-progress, so a
-  # third queued run evicted the pending one and a commit could go unscanned with
-  # no signal. Both now carry AC12's expression from spec/ci-gate-parallelization
-  # — PR runs share a ref group, every non-PR run keys on github.run_id — and
-  # ci-security.yml's literal is pinned in test-ci-security-workflow.py, so a
-  # regression to the bare-ref form now fails build-check. codeql.yml's
-  # cancel-in-progress moved to the pull_request gate, so pushes to main and the
-  # weekly re-scan run to completion instead of superseding each other. The two
-  # frozen citations (docs/adr/0086 lines 111-118, spec/ci-gate-parallelization)
-  # stand as the historical record; ADR-0086's "note for the next author" is what
-  # authorised the fix. Accepted consequence, recorded rather than discovered
-  # later: two concurrent CodeQL runs on different main commits can now upload
-  # SARIF out of order, so the Security tab can transiently reflect the older
-  # commit until the next analysis. That is judged better than the previous
-  # behaviour, where the newer commit was simply never scanned.
-  # THE RESIDUAL, and the only reason the slug survives: test-ci-security-workflow.py
-  # still has no --self-test and no fixture. Unlike its chain neighbour
-  # test-build-check-workflow.py, which runs a mutation matrix on every
-  # invocation, its now-nine assertions block make build-check with no automated
-  # proof they can fail, so a silently-weakened one would pass. codeql.yml has no
-  # posture test at all — a mutation of its group expression is caught by nothing,
-  # confirmed by a deliberate control run on 2026-08-27.
-  # To close: decide whether the posture test earns a mutation harness, and
-  # whether codeql.yml earns a posture test of its own. Owner decision, not a chore.
-  {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13"},
+  # Five workflow-posture tests now carry the pages-form baseline/mutation/family
+  # harness: pages, ci-security, pack-evals, build-check-windows and CodeQL. The
+  # sixth posture test, build-check, has the same core contract plus a specialized
+  # bash differential and shape-stable fixture. A shared helper is now plausible,
+  # but extracting it means changing two already-working harness shapes and should
+  # be reviewed independently rather than riding with the assertion-proof work.
+  # To close: identify the genuinely common surface, preserve build-check's
+  # differential and pages' crafted-input predicates, and prove every caller's
+  # mutation count/family coverage is unchanged by the extraction.
+  {slug = "workflow-posture-self-test-helper-extraction", source = "ci-security-posture-test-unwired closeout"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions
   # block. Deliberately NOT bundled into spec/ci-gate-parallelization's Gate A
@@ -1864,6 +1834,8 @@ closed = [
   # as build-site-fence-info-string-opens-a-comment. Pre-existing, different
   # root cause, and the fence state machine was explicitly out of scope.
   {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a release-count floor on the real changelog; the backticked-opener case went from 0 releases to the full population while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled. The floor and its measured baseline are stated canonically at _MIN_REAL_CHANGELOG_RELEASES in tools/test_build_site_routing.py"},
+
+  {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13", summary = "Closed by mutation harnesses for ci-security, pack-evals and build-check-windows plus a new mutation-tested CodeQL posture check wired into build-check"},
 
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Closed; successor docs/product/design/workspace-anchor-staleness-invariant.md owns dependency and membership staleness detection"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -425,8 +425,10 @@ open = [
   # its own module, because those are what each harness is FOR and sharing them
   # would couple four unrelated workflow contracts. Verified against this entry's
   # own acceptance criterion: every caller's mutation count and family coverage
-  # is byte-identical before and after the extraction (19/18, 28/22, 15/13 plus
-  # the bash differential, 28/22), and 188 lines left the four callers.
+  # was byte-identical before and after the extraction commit, and 188 lines left
+  # the four callers. The figures are deliberately not transcribed here — later
+  # commits add mutations, so a copied pair goes stale and a future author would
+  # read a satisfied criterion as violated. Re-measure across the commit.
   # WHAT REMAINS, and it is genuinely pre-existing rather than that change's
   # debt: three harnesses in two other shapes still carry their own drivers.
   # tools/test-build-check-workflow.py has the same core contract plus a bash

--- a/workspace.toml
+++ b/workspace.toml
@@ -416,28 +416,33 @@ open = [
   # test, making the bypass need a second human. This repo has no CODEOWNERS today.
   # To close: decide between the two (or both) and apply.
   {slug = "ci-gate-parallelization-required-workflow-pinned-ref", source = "spec/ci-gate-parallelization AC3"},
-  # The caller set is defined by a predicate, not a count, so a future extraction
-  # re-derives it instead of trusting a number that drifts: a module under tools/
-  # with a module-level `audit()` plus a `_MUTATIONS` self-test whose baseline is
-  # a real .github/workflows/*.yml file. That predicate admits exactly seven
-  # today, in three harness shapes. Five carry the pages-form
-  # baseline/mutation/family harness: pages, ci-security, pack-evals,
-  # build-check-windows and CodeQL. build-check has the same core contract plus
-  # a specialized bash differential and shape-stable fixture. test-pages-
-  # concurrency.py is the odd one out — a mutation-tested pages.yml posture check
-  # whose _MUTATIONS is a four-element (id, expected, old, new) tuple with no
-  # _family rule at all — and it is the caller an extraction scoped from a
-  # five-or-six count would silently miss. Deliberately OUTSIDE the predicate:
-  # tools/test_marketplace_envelope_parity.py, whose _MUTATIONS is a
-  # pytest-parametrized three-tuple over filesystem fixtures with no `audit()`
-  # and no workflow baseline, so a grep for _MUTATIONS alone returns eight.
-  # A shared helper is now plausible, but
-  # extracting it means changing already-working harness shapes and should be
-  # reviewed independently rather than riding with the assertion-proof work.
-  # To close: identify the genuinely common surface, preserve build-check's
-  # differential and pages' crafted-input predicates, decide whether the
-  # four-element tuple converges or stays out, and prove every caller's mutation
-  # count/family coverage is unchanged by the extraction.
+  # PARTIALLY CLOSED. The duplication this entry was opened for was created by
+  # the change that gave four posture tests mutation matrices, so that change
+  # paid it: ci-security, pack-evals, build-check-windows and CodeQL now share
+  # `tools/posture_harness.py` — the baseline-clean precondition, the no-op
+  # rejection, the expected-label check, family accounting, and the failure and
+  # success reports. Every `audit`, `_MUTATIONS` and per-file predicate stayed in
+  # its own module, because those are what each harness is FOR and sharing them
+  # would couple four unrelated workflow contracts. Verified against this entry's
+  # own acceptance criterion: every caller's mutation count and family coverage
+  # is byte-identical before and after the extraction (19/18, 28/22, 15/13 plus
+  # the bash differential, 28/22), and 188 lines left the four callers.
+  # WHAT REMAINS, and it is genuinely pre-existing rather than that change's
+  # debt: three harnesses in two other shapes still carry their own drivers.
+  # tools/test-build-check-workflow.py has the same core contract plus a bash
+  # differential and a shape-stable fixture; tools/test-pages-workflow.py has
+  # crafted-input predicates; tools/test-pages-concurrency.py uses a four-element
+  # (id, expected, old, new) mutation tuple with no family rule at all. The
+  # inclusion predicate stays the way to re-derive the set rather than a count: a
+  # module under tools/ with a module-level `audit()` plus a `_MUTATIONS`
+  # self-test whose baseline is a real .github/workflows/*.yml file. Deliberately
+  # outside it: tools/test_marketplace_envelope_parity.py, a pytest-parametrized
+  # three-tuple over filesystem fixtures with no `audit()` and no workflow
+  # baseline, so a bare `_MUTATIONS` grep returns one more than the predicate.
+  # To close: converge those three, preserving build-check's differential and
+  # pages' crafted-input predicates, decide whether the four-element tuple joins
+  # or stays out, and prove each caller's mutation count and family coverage is
+  # unchanged — the same criterion the four already satisfy.
   {slug = "workflow-posture-self-test-helper-extraction", source = "ci-security-posture-test-unwired closeout"},
   # Coverage gaps in the workflow posture guards that this change did NOT close.
   # The ones it did close are gone from this list rather than left overstating:

--- a/workspace.toml
+++ b/workspace.toml
@@ -489,6 +489,12 @@ open = [
   #    because both routes cost more than they look: duplicating _strip_comments
   #    into a fifth file cuts against the extraction entry above, and retargeting
   #    the assertion to the parsed env widens what the check claims.
+  #  - test-ci-security-workflow.py still tests `cancel-in-progress` by substring
+  #    (`"pull_request" in cancel`), so the inverted `!=` form passes while the
+  #    docstring claims "pull-request-only concurrency cancellation". The CodeQL
+  #    twin was pinned to equality with EXPECTED_CANCEL; porting that across is
+  #    coverage widening on a pre-existing gap, so it waits here rather than
+  #    riding along. Exposure is unchanged from 38e01732.
   #  - `pull_request_target` is not forbidden on codeql.yml by any checker. It is
   #    disclosed rather than asserted, in tools/repo/build_gate_chain.py's step
   #    comment; low impact today because the analyze job runs no repo-controlled

--- a/workspace.toml
+++ b/workspace.toml
@@ -416,15 +416,20 @@ open = [
   # test, making the bypass need a second human. This repo has no CODEOWNERS today.
   # To close: decide between the two (or both) and apply.
   {slug = "ci-gate-parallelization-required-workflow-pinned-ref", source = "spec/ci-gate-parallelization AC3"},
-  # Five workflow-posture tests now carry the pages-form baseline/mutation/family
-  # harness: pages, ci-security, pack-evals, build-check-windows and CodeQL. The
-  # sixth posture test, build-check, has the same core contract plus a specialized
-  # bash differential and shape-stable fixture. A shared helper is now plausible,
-  # but extracting it means changing two already-working harness shapes and should
-  # be reviewed independently rather than riding with the assertion-proof work.
+  # Seven callers, in three different harness shapes. Five carry the pages-form
+  # baseline/mutation/family harness: pages, ci-security, pack-evals,
+  # build-check-windows and CodeQL. build-check has the same core contract plus
+  # a specialized bash differential and shape-stable fixture. test-pages-
+  # concurrency.py is the odd one out — a mutation-tested pages.yml posture check
+  # whose _MUTATIONS is a four-element (id, expected, old, new) tuple with no
+  # _family rule at all — and it is the caller an extraction scoped from a
+  # five-or-six count would silently miss. A shared helper is now plausible, but
+  # extracting it means changing already-working harness shapes and should be
+  # reviewed independently rather than riding with the assertion-proof work.
   # To close: identify the genuinely common surface, preserve build-check's
-  # differential and pages' crafted-input predicates, and prove every caller's
-  # mutation count/family coverage is unchanged by the extraction.
+  # differential and pages' crafted-input predicates, decide whether the
+  # four-element tuple converges or stays out, and prove every caller's mutation
+  # count/family coverage is unchanged by the extraction.
   {slug = "workflow-posture-self-test-helper-extraction", source = "ci-security-posture-test-unwired closeout"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions

--- a/workspace.toml
+++ b/workspace.toml
@@ -416,14 +416,22 @@ open = [
   # test, making the bypass need a second human. This repo has no CODEOWNERS today.
   # To close: decide between the two (or both) and apply.
   {slug = "ci-gate-parallelization-required-workflow-pinned-ref", source = "spec/ci-gate-parallelization AC3"},
-  # Seven callers, in three different harness shapes. Five carry the pages-form
+  # The caller set is defined by a predicate, not a count, so a future extraction
+  # re-derives it instead of trusting a number that drifts: a module under tools/
+  # with a module-level `audit()` plus a `_MUTATIONS` self-test whose baseline is
+  # a real .github/workflows/*.yml file. That predicate admits exactly seven
+  # today, in three harness shapes. Five carry the pages-form
   # baseline/mutation/family harness: pages, ci-security, pack-evals,
   # build-check-windows and CodeQL. build-check has the same core contract plus
   # a specialized bash differential and shape-stable fixture. test-pages-
   # concurrency.py is the odd one out — a mutation-tested pages.yml posture check
   # whose _MUTATIONS is a four-element (id, expected, old, new) tuple with no
   # _family rule at all — and it is the caller an extraction scoped from a
-  # five-or-six count would silently miss. A shared helper is now plausible, but
+  # five-or-six count would silently miss. Deliberately OUTSIDE the predicate:
+  # tools/test_marketplace_envelope_parity.py, whose _MUTATIONS is a
+  # pytest-parametrized three-tuple over filesystem fixtures with no `audit()`
+  # and no workflow baseline, so a grep for _MUTATIONS alone returns eight.
+  # A shared helper is now plausible, but
   # extracting it means changing already-working harness shapes and should be
   # reviewed independently rather than riding with the assertion-proof work.
   # To close: identify the genuinely common surface, preserve build-check's
@@ -477,7 +485,14 @@ open = [
   #    `--config`; confirm gitleaks' config auto-load precedence before acting.
   #  - The pack-evals `secret-source` check is comment-satisfiable and should
   #    assert the parsed eval-step `env` value, matching the `_strip_comments`
-  #    discipline now used in test-ci-security-workflow.py.
+  #    discipline now used in test-ci-security-workflow.py. Not done inline
+  #    because both routes cost more than they look: duplicating _strip_comments
+  #    into a fifth file cuts against the extraction entry above, and retargeting
+  #    the assertion to the parsed env widens what the check claims.
+  #  - `pull_request_target` is not forbidden on codeql.yml by any checker. It is
+  #    disclosed rather than asserted, in tools/repo/build_gate_chain.py's step
+  #    comment; low impact today because the analyze job runs no repo-controlled
+  #    script, but it is the one disclosure that is not backed by a mutation.
   # Workflow-side, needing a repository-settings change and so not closable here:
   # `ANTHROPIC_API_KEY` is repository-scoped with no GitHub Environment gate, so
   # any write-access holder can dispatch pack-evals against an arbitrary ref with

--- a/workspace.toml
+++ b/workspace.toml
@@ -484,19 +484,32 @@ open = [
   # that way.
   # To close: decide which of these earn assertions, in which guard, and accept
   # that each widens what that posture test claims.
-  # Pre-flight, not diff-caused. tools/test_marketplace_envelope_parity.py::
-  # test_resolved_layer_refuses_a_module_from_another_tree fails locally because
-  # its premise is unmet: it asserts a "provenance mismatch" when an editable
-  # install resolves agentbundle from a SIBLING worktree, but this machine has no
-  # editable install at all, so the child dies with ModuleNotFoundError before
-  # the mismatch can be reported. Established as environmental, not a regression:
-  # the file is byte-identical to origin/main (so running it here runs main's
-  # test), it fails in isolation, and `import agentbundle` fails outright with no
-  # path hits. Deliberately NOT fixed by installing the package: a shared
-  # editable install is what makes worktree CI serial, and provisioning it here
-  # can break a peer worktree's in-flight `make ci`.
-  # To close: decide whether this test should skip when no install is present,
-  # or whether the local gate should provision one per worktree.
+  # Pre-flight, not diff-caused, and NOT STABLE LOCALLY: `make
+  # test-after-build-check` cannot be green in a worktree of this repository,
+  # whichever way the global editable-install state happens to sit. Measured both
+  # ways in one session, minutes apart, because a peer worktree installed the
+  # package in between:
+  #   no editable install        -> lint-editable-install PASSES, but
+  #     tools/test_marketplace_envelope_parity.py::
+  #     test_resolved_layer_refuses_a_module_from_another_tree FAILS: it asserts a
+  #     "provenance mismatch" when the finder resolves a SIBLING worktree, and with
+  #     nothing installed the child exits ModuleNotFoundError first. The child runs
+  #     with `-I`, so PYTHONPATH cannot satisfy it — only a real install can.
+  #   install -> another worktree -> lint-editable-install FAILS by design
+  #     (ADR-0094: this repository imports both packages from source), which is
+  #     what was observed, pointing at 30-day-cooling-specs.
+  # So the two gates are mutually exclusive here and the outcome is owned by
+  # whichever worktree bootstrapped last. Neither file is touched by the work that
+  # registered this, and both are byte-identical to origin/main, so main is red the
+  # same way.
+  # Deliberately NOT repaired by `pip uninstall -y agentbundle`, which the guard
+  # names as the permanent fix: it rewrites state shared by every worktree, the
+  # guard itself says to do it only when no peer gate is running, and 13 peer gate
+  # processes were live when this was measured. It is the owner's call, not a
+  # side effect of an unrelated PR.
+  # To close: decide whether the parity test should skip when no install is
+  # present — which would make the no-install state fully green and consistent with
+  # ADR-0094 — or whether the local gate should provision per worktree.
   {slug = "pre-existing-marketplace-parity-needs-an-editable-agentbundle", source = "pre-flight/2026-08-28"},
   {slug = "workflow-posture-guard-coverage-gaps", source = "security+quality review of the posture assertion-proof change"},
   # permissions: contents: read + persist-credentials: false for

--- a/workspace.toml
+++ b/workspace.toml
@@ -439,73 +439,30 @@ open = [
   # four-element tuple converges or stays out, and prove every caller's mutation
   # count/family coverage is unchanged by the extraction.
   {slug = "workflow-posture-self-test-helper-extraction", source = "ci-security-posture-test-unwired closeout"},
-  # Coverage gaps in the workflow posture guards, found by security and quality
-  # review during the assertion-proof work and deliberately NOT fixed there.
-  # Each was adjudicated as a pre-existing gap: exposure is identical before and
-  # after that change, no assertion ever covered it, and closing it widens what
-  # a posture test asserts rather than proving what it already claims. They are
-  # recorded here because a severe gap that is out of one PR's scope is still a
-  # gap, and the review that found it will not run again on its own.
-  # Highest value first:
-  #  - Nothing pins WHERE `ANTHROPIC_API_KEY` is bound. Hoisting it from the eval
-  #    step's `env:` to job- or workflow-level `env:` puts the repository's most
-  #    valuable secret in the environment of `pip install` and `npm install -g`,
-  #    both of which execute third-party install scripts. Every gate stays green
-  #    and zizmor reports nothing at any severity.
-  #  - test-pack-evals-workflow.py has no job-level `permissions` assertion, so
-  #    `permissions: write-all` on the secret-holding job passes. The sibling
-  #    ci-security guard forbids a job-level key outright; the asymmetry is on
-  #    the wrong workflow.
+  # Coverage gaps in the workflow posture guards that this change did NOT close.
+  # The ones it did close are gone from this list rather than left overstating:
+  # secret binding location, pack-evals job-level permissions, gitleaks failure
+  # propagation, the compute-and-discard checksum, the CodeQL trigger surface,
+  # the elevated-grant spelling enumeration, `pull_request_target` on codeql.yml,
+  # the Windows step-level bypass, and the bash-absent round-trip ordering are
+  # all now asserted with a mutation each. What remains needs either a different
+  # invariant or evidence this change does not have:
   #  - Nothing pins the actionlint, zizmor, or check-zizmor-excessive-permissions
   #    steps. Deleting them, appending `|| true`, dropping to `--min-severity
   #    critical`, or narrowing the scanned path removes Actions-injection and
   #    excessive-permissions coverage repo-wide with `make build-check` green.
   #    zizmor is the ONLY control covering template injection in run bodies the
-  #    hand-written gitleaks-no-expression check does not reach.
-  #  - No assertion pins gitleaks failure propagation: `continue-on-error: true`,
-  #    a trailing `|| true`, or `--exit-code 0` yields a passing secret-scan job
-  #    over a committed secret.
-  #  - The checksum invariant is keyed on extraction and on a checksum token
-  #    naming the archive, so a compute-and-discard `sha256sum` (no `-c`), a
-  #    same-origin digest file, and a non-extraction install such as
-  #    `curl -o /usr/local/bin/actionlint && chmod +x` or `curl … | sh` all pass
-  #    unaudited. `_ARCHIVE_RE` is also unanchored, so it can credit a longer
-  #    filename's prefix.
-  #  - The CodeQL trigger surface is membership-tested only: adding `- "**"` to
-  #    the trigger-level `paths-ignore`, adding a `paths:` allowlist, retargeting
-  #    `branches: [main]`, or deleting the weekly `schedule` zeroes analysis with
-  #    the gate green. A config-level `paths:` key narrows it the same way.
-  #  - test-build-check-windows-workflow.py asserts only the aggregate's run
-  #    body, so a step-level `continue-on-error: true` or `if:` defeats the
-  #    required Windows check while both asserted properties stay true.
-  #  - security-events-only-analyze enumerates block-style job headers and
-  #    permissions blocks only; a flow mapping, a `write-all` scalar, or a header
-  #    with a trailing comment is not enumerated.
+  #    hand-written gitleaks checks do not reach. Left open because pinning it
+  #    means choosing which flags are load-bearing, which is a decision about
+  #    the scanner contract rather than about this harness.
+  #  - The checksum invariant is keyed on EXTRACTION. A non-extraction install
+  #    such as `curl -o /usr/local/bin/actionlint && chmod +x` or `curl … | sh`
+  #    is never audited. Closing it means re-keying the invariant on every
+  #    download, which is a different invariant, not a tightening of this one.
   #  - No control asserts the absence of a repo-root `.gitleaks.toml` or a pinned
-  #    `--config`; confirm gitleaks' config auto-load precedence before acting.
-  #  - The pack-evals `secret-source` check is comment-satisfiable and should
-  #    assert the parsed eval-step `env` value, matching the `_strip_comments`
-  #    discipline now used in test-ci-security-workflow.py. Not done inline
-  #    because both routes cost more than they look: duplicating _strip_comments
-  #    into a fifth file cuts against the extraction entry above, and retargeting
-  #    the assertion to the parsed env widens what the check claims.
-  #  - On a platform with no bash, both this harness and its build-check sibling
-  #    return before the round-trip pin that ties the constructed guard body to
-  #    the workflow, even though that pin is pure string containment and needs no
-  #    shell. Live impact today is one informational echo, since condition drift
-  #    is caught bash-independently by `audit` and guard-block drift by the
-  #    split-guard mutation's no-op rule. Adjudicated out of this unit because the
-  #    ordering is ported byte-for-byte from the sibling and predates the change.
-  #  - test-ci-security-workflow.py still tests `cancel-in-progress` by substring
-  #    (`"pull_request" in cancel`), so the inverted `!=` form passes while the
-  #    docstring claims "pull-request-only concurrency cancellation". The CodeQL
-  #    twin was pinned to equality with EXPECTED_CANCEL; porting that across is
-  #    coverage widening on a pre-existing gap, so it waits here rather than
-  #    riding along. Exposure is unchanged from 38e01732.
-  #  - `pull_request_target` is not forbidden on codeql.yml by any checker. It is
-  #    disclosed rather than asserted, in tools/repo/build_gate_chain.py's step
-  #    comment; low impact today because the analyze job runs no repo-controlled
-  #    script, but it is the one disclosure that is not backed by a mutation.
+  #    `--config`. Left open deliberately: gitleaks' config auto-load precedence
+  #    was never confirmed, and an assertion resting on an unverified premise is
+  #    the defect this whole change set exists to remove.
   # Workflow-side, needing a repository-settings change and so not closable here:
   # `ANTHROPIC_API_KEY` is repository-scoped with no GitHub Environment gate, so
   # any write-access holder can dispatch pack-evals against an arbitrary ref with

--- a/workspace.toml
+++ b/workspace.toml
@@ -482,6 +482,20 @@ open = [
   # that way.
   # To close: decide which of these earn assertions, in which guard, and accept
   # that each widens what that posture test claims.
+  # Pre-flight, not diff-caused. tools/test_marketplace_envelope_parity.py::
+  # test_resolved_layer_refuses_a_module_from_another_tree fails locally because
+  # its premise is unmet: it asserts a "provenance mismatch" when an editable
+  # install resolves agentbundle from a SIBLING worktree, but this machine has no
+  # editable install at all, so the child dies with ModuleNotFoundError before
+  # the mismatch can be reported. Established as environmental, not a regression:
+  # the file is byte-identical to origin/main (so running it here runs main's
+  # test), it fails in isolation, and `import agentbundle` fails outright with no
+  # path hits. Deliberately NOT fixed by installing the package: a shared
+  # editable install is what makes worktree CI serial, and provisioning it here
+  # can break a peer worktree's in-flight `make ci`.
+  # To close: decide whether this test should skip when no install is present,
+  # or whether the local gate should provision one per worktree.
+  {slug = "pre-existing-marketplace-parity-needs-an-editable-agentbundle", source = "pre-flight/2026-08-28"},
   {slug = "workflow-posture-guard-coverage-gaps", source = "security+quality review of the posture assertion-proof change"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions

--- a/workspace.toml
+++ b/workspace.toml
@@ -1835,7 +1835,13 @@ closed = [
   # root cause, and the fence state machine was explicitly out of scope.
   {slug = "build-site-comment-strip-ignores-code-spans", source = "spec-less lint-spec-status work (CI failure on PR #1139)", summary = "Closed by giving build-site's changelog comment stripper inline-code-span precedence and adding a release-count floor on the real changelog; the backticked-opener case went from 0 releases to the full population while the bare-opener control stayed collapsed, proving comment handling was made span-aware rather than disabled. The floor and its measured baseline are stated canonically at _MIN_REAL_CHANGELOG_RELEASES in tools/test_build_site_routing.py"},
 
-  {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13", summary = "Closed by mutation harnesses for ci-security, pack-evals and build-check-windows plus a new mutation-tested CodeQL posture check wired into build-check"},
+  # Carries forward the accepted consequence the open entry recorded, because
+  # this closed entry is now the only place in the repository that holds it:
+  # keying non-PR concurrency on run_id means two concurrent CodeQL runs on
+  # different main commits can upload SARIF out of order, so the Security tab
+  # can transiently reflect the older commit until the next analysis. Judged
+  # better than the previous behaviour, where the newer commit went unscanned.
+  {slug = "ci-security-posture-test-unwired", source = "spec/ci-gate-parallelization AC13", summary = "Closed by mutation harnesses for ci-security, pack-evals and build-check-windows plus a new mutation-tested CodeQL posture check wired into build-check. Accepted consequence retained: concurrent CodeQL runs on different main commits can upload SARIF out of order, so the Security tab can transiently show the older commit"},
 
   {slug = "ini-008-anchor-staleness-check", type = "spec", source = "rfc/0083 Errata 2026-08-13", summary = "Closed; successor docs/product/design/workspace-anchor-staleness-invariant.md owns dependency and membership staleness detection"},
 

--- a/workspace.toml
+++ b/workspace.toml
@@ -431,6 +431,61 @@ open = [
   # four-element tuple converges or stays out, and prove every caller's mutation
   # count/family coverage is unchanged by the extraction.
   {slug = "workflow-posture-self-test-helper-extraction", source = "ci-security-posture-test-unwired closeout"},
+  # Coverage gaps in the workflow posture guards, found by security and quality
+  # review during the assertion-proof work and deliberately NOT fixed there.
+  # Each was adjudicated as a pre-existing gap: exposure is identical before and
+  # after that change, no assertion ever covered it, and closing it widens what
+  # a posture test asserts rather than proving what it already claims. They are
+  # recorded here because a severe gap that is out of one PR's scope is still a
+  # gap, and the review that found it will not run again on its own.
+  # Highest value first:
+  #  - Nothing pins WHERE `ANTHROPIC_API_KEY` is bound. Hoisting it from the eval
+  #    step's `env:` to job- or workflow-level `env:` puts the repository's most
+  #    valuable secret in the environment of `pip install` and `npm install -g`,
+  #    both of which execute third-party install scripts. Every gate stays green
+  #    and zizmor reports nothing at any severity.
+  #  - test-pack-evals-workflow.py has no job-level `permissions` assertion, so
+  #    `permissions: write-all` on the secret-holding job passes. The sibling
+  #    ci-security guard forbids a job-level key outright; the asymmetry is on
+  #    the wrong workflow.
+  #  - Nothing pins the actionlint, zizmor, or check-zizmor-excessive-permissions
+  #    steps. Deleting them, appending `|| true`, dropping to `--min-severity
+  #    critical`, or narrowing the scanned path removes Actions-injection and
+  #    excessive-permissions coverage repo-wide with `make build-check` green.
+  #    zizmor is the ONLY control covering template injection in run bodies the
+  #    hand-written gitleaks-no-expression check does not reach.
+  #  - No assertion pins gitleaks failure propagation: `continue-on-error: true`,
+  #    a trailing `|| true`, or `--exit-code 0` yields a passing secret-scan job
+  #    over a committed secret.
+  #  - The checksum invariant is keyed on extraction and on a checksum token
+  #    naming the archive, so a compute-and-discard `sha256sum` (no `-c`), a
+  #    same-origin digest file, and a non-extraction install such as
+  #    `curl -o /usr/local/bin/actionlint && chmod +x` or `curl … | sh` all pass
+  #    unaudited. `_ARCHIVE_RE` is also unanchored, so it can credit a longer
+  #    filename's prefix.
+  #  - The CodeQL trigger surface is membership-tested only: adding `- "**"` to
+  #    the trigger-level `paths-ignore`, adding a `paths:` allowlist, retargeting
+  #    `branches: [main]`, or deleting the weekly `schedule` zeroes analysis with
+  #    the gate green. A config-level `paths:` key narrows it the same way.
+  #  - test-build-check-windows-workflow.py asserts only the aggregate's run
+  #    body, so a step-level `continue-on-error: true` or `if:` defeats the
+  #    required Windows check while both asserted properties stay true.
+  #  - security-events-only-analyze enumerates block-style job headers and
+  #    permissions blocks only; a flow mapping, a `write-all` scalar, or a header
+  #    with a trailing comment is not enumerated.
+  #  - No control asserts the absence of a repo-root `.gitleaks.toml` or a pinned
+  #    `--config`; confirm gitleaks' config auto-load precedence before acting.
+  #  - The pack-evals `secret-source` check is comment-satisfiable and should
+  #    assert the parsed eval-step `env` value, matching the `_strip_comments`
+  #    discipline now used in test-ci-security-workflow.py.
+  # Workflow-side, needing a repository-settings change and so not closable here:
+  # `ANTHROPIC_API_KEY` is repository-scoped with no GitHub Environment gate, so
+  # any write-access holder can dispatch pack-evals against an arbitrary ref with
+  # no second approver — the repo already gates `pypi` and `claude-plugin-publish`
+  # that way.
+  # To close: decide which of these earn assertions, in which guard, and accept
+  # that each widens what that posture test claims.
+  {slug = "workflow-posture-guard-coverage-gaps", source = "security+quality review of the posture assertion-proof change"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions
   # block. Deliberately NOT bundled into spec/ci-gate-parallelization's Gate A

--- a/workspace.toml
+++ b/workspace.toml
@@ -460,6 +460,13 @@ open = [
   #    hand-written gitleaks checks do not reach. Left open because pinning it
   #    means choosing which flags are load-bearing, which is a decision about
   #    the scanner contract rather than about this harness.
+  #  - Registered by round-7 adjudication rather than closed: a JOB-level
+  #    `continue-on-error` on build-check-windows; a reusable-workflow route
+  #    binding ANTHROPIC_API_KEY via `secrets: inherit`; a second CodeQL job
+  #    granted `contents: write`, `id-token: write` or `read-all`, which the
+  #    two-token backstop does not match; and the backstop firing on a comment
+  #    that merely mentions a token. Each was adjudicated as neither created nor
+  #    claimed closed by this change.
   #  - The checksum invariant is keyed on EXTRACTION. A non-extraction install
   #    such as `curl -o /usr/local/bin/actionlint && chmod +x` or `curl … | sh`
   #    is never audited. Closing it means re-keying the invariant on every

--- a/workspace.toml
+++ b/workspace.toml
@@ -489,6 +489,13 @@ open = [
   #    because both routes cost more than they look: duplicating _strip_comments
   #    into a fifth file cuts against the extraction entry above, and retargeting
   #    the assertion to the parsed env widens what the check claims.
+  #  - On a platform with no bash, both this harness and its build-check sibling
+  #    return before the round-trip pin that ties the constructed guard body to
+  #    the workflow, even though that pin is pure string containment and needs no
+  #    shell. Live impact today is one informational echo, since condition drift
+  #    is caught bash-independently by `audit` and guard-block drift by the
+  #    split-guard mutation's no-op rule. Adjudicated out of this unit because the
+  #    ordering is ported byte-for-byte from the sibling and predates the change.
   #  - test-ci-security-workflow.py still tests `cancel-in-progress` by substring
   #    (`"pull_request" in cancel`), so the inverted `!=` form passes while the
   #    docstring claims "pull-request-only concurrency cancellation". The CodeQL


### PR DESCRIPTION
## What does this change?

Four GitHub Actions workflow posture tests asserted security-load-bearing invariants with no automated proof any assertion could fail. Each now runs a mutation matrix on every invocation, using the real tracked workflow as its baseline, rejecting no-op transforms, requiring a specific violation label per mutant, and requiring every assertion family the clean baseline evaluates to carry at least one mutation. `codeql.yml` had no posture test at all and gains one, wired into the `build-check` chain.

No `.github/workflows/*.yml` file is changed by this PR.

## Why?

- Closes `ci-security-posture-test-unwired` (`spec/ci-gate-parallelization` AC13). Its named residual was that `tools/test-ci-security-workflow.py` had no `--self-test` and no fixture, so its assertions blocked `make build-check` with no proof they could fail — and that `codeql.yml` had no posture test at all, confirmed by a deliberate control run.
- The CI-security checksum assertion was weaker than its own prose: it checked that a checksum command was *present*, not that verification *preceded* extraction. It now compares ordering, requires a `-c`/`--check` flag, and requires the checksum to name the archive the extraction consumes.

CodeQL remains **advisory**. It is not a required branch-protection check and this PR does not make it one.

## How do I verify it?

```
python3 tools/test-pack-evals-workflow.py            # and --self-test
python3 tools/test-ci-security-workflow.py           # and --self-test
python3 tools/test-build-check-windows-workflow.py   # and --self-test
python3 tools/test-codeql-workflow.py                # and --self-test
python3 -c "import tomllib; tomllib.load(open('workspace.toml','rb'))"
SKIP_SAST=1 make build-check    # runs all five posture tests in-chain
make lint-ruff && make lint-mypy
make test-after-build-check
make ci
```

**Mutation and family coverage**

| harness | mutations | families | extra |
| --- | --- | --- | --- |
| `pack-evals` | 22 | 17 | |
| `ci-security` | 33 | 22 | |
| `build-check-windows` | 17 | 13 | + 10 guard bodies executed against bash |
| `codeql` | 33 | 22 | |

**Every harness was proven to discriminate against the real tracked workflow**, not only against fixtures. Each mutation below was applied to the live file, the checker exited 1 naming the expected label, and the workflow was restored from HEAD:

| mutation | label |
| --- | --- |
| `pack-evals.yml` + `pull_request:` | `trigger-forbidden[pull_request]` |
| `ci-security.yml` + `pull_request_target:` | `trigger-forbidden[pull_request_target]` |
| `build-check-windows.yml` runner → `ubuntu-latest` | `windows-runner[agentbundle-windows]` |
| `codeql.yml` concurrency group → constant | `concurrency-group` |

The build-check-windows harness additionally runs a **differential against bash**: eleven guard-body variants are executed under `bash -c`, and the harness fails if bash exits 0 with a suite reported `failure` while `audit` accepts the body. The guard body it executes is assembled from module constants and tied to the workflow by a round-trip assertion — workflow text is never handed to a shell.

**Gate status at the time of opening:** gates 1–12 green. `make test-after-build-check` and `make ci` fail locally on a **registered pre-existing environmental condition** unrelated to this diff — see *Residual risk* below. CI provisions its own environment and is the authoritative signal for those two.

## What did you not change that you considered?

- **No workflow YAML.** Zero diff against `.github/workflows/`.
- **No branch-protection change.** CodeQL stays advisory; making it required is an owner decision.
- **No JS SAST expansion.**
- **No release metadata.** `tools/**` ships in no released artifact, so no changelog entry is owed (`docs/CONVENTIONS.md` §5b).
- **The helper extraction is only half done, deliberately.** This branch created the duplication (mutation-matrix callers went 3 → 7), so it paid that debt: the four harnesses it converged now share `tools/posture_harness.py`. The three pre-existing harnesses in two other shapes — `test-build-check-workflow.py` (bash differential plus a shape-stable fixture), `test-pages-workflow.py` (crafted-input predicates) and `test-pages-concurrency.py` (a four-element mutation tuple with no family rule) — are **not** converged. Registered as `workflow-posture-self-test-helper-extraction`.
- **Coverage gaps found but not closed**, registered as `workflow-posture-guard-coverage-gaps`: the zizmor/actionlint step pins (needs a decision about which scanner flags are load-bearing); a non-extraction install such as `curl -o … && chmod +x` (a different invariant, keyed on downloads not extractions); a repo-root `.gitleaks.toml` (its config-precedence premise was never verified, and asserting on an unverified premise is the defect this change removes); a job-level `continue-on-error` on `build-check-windows`; a reusable-workflow `secrets: inherit` route; a second CodeQL job granted `contents: write`/`id-token: write`/`read-all`; and the GitHub Environment gate on `ANTHROPIC_API_KEY`, which needs a repository-settings change.

## Residual risk

`tools/test_marketplace_envelope_parity.py::test_resolved_layer_refuses_a_module_from_another_tree` fails in this worktree and takes `make test-after-build-check` and `make ci` with it. Established as environmental, not a regression:

- the file is **byte-identical to `origin/main`**, so running it here runs main's test
- it fails **in isolation**, outside any gate
- `import agentbundle` fails outright with no path hits, and the test's child runs with `-I` (isolated, no environment), so `PYTHONPATH` cannot satisfy it — only a real install can

Deliberately not fixed by installing the package: an editable install would point the shared interpreter at *this* worktree, which is exactly the "resolves a sibling worktree" hazard the test exists to detect, and would make peer worktrees validate the wrong tree. Registered as `pre-existing-marketplace-parity-needs-an-editable-agentbundle`.

Also recorded: keying non-PR concurrency on `run_id` means two concurrent CodeQL runs on different `main` commits can upload SARIF out of order, so the Security tab can transiently show the older commit. Judged better than the previous behaviour, where the newer commit went unscanned. That consequence existed nowhere else in the repository and is carried in the closed backlog entry.

## Review verdict

See the `review-verdict.v1` block in the first comment.
