### PR TITLE
fix(tools): stop a fence info-string comment swallowing later releases

### DIFF
--- a/tools/build-site.py
+++ b/tools/build-site.py
@@ -1814,15 +1814,11 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
             # comment's body would publish. Rendering stays CommonMark; this
             # reports the authoring mistake instead of shipping it in silence.
             split_comments.append((lineno, lines[lineno - 1].strip()))
-        if stripped.opens_comment:
-            in_comment = True
-            comment_opened_at = lineno
-            # Deliberate divergence from lint-spec-status.py: this builder does
-            # not treat an unterminated real opener as literal text. The final
-            # raise prevents one typo from silently swallowing later releases.
 
         opener = _FENCE_RE_CHANGELOG.match(raw)
         if opener is not None:
+            # A `<!--` that left this fence marker behind was in its info string,
+            # so it is sample text rather than cross-line comment state.
             # The opener is matched LOOSELY on indentation. A fence indented four
             # spaces is the ordinary shape inside a list item, and tightening
             # this to `^ {0,3}` while fixing the closer rule regressed those into
@@ -1834,6 +1830,13 @@ def parse_changelog_releases(text: str) -> ParsedChangelog:
             fence_opened_at = lineno
             fence_marker = opener.group(2)
             continue
+
+        if stripped.opens_comment:
+            in_comment = True
+            comment_opened_at = lineno
+            # Deliberate divergence from lint-spec-status.py: this builder does
+            # not treat an unterminated real opener as literal text. The final
+            # raise prevents one typo from silently swallowing later releases.
 
         heading = _CHANGELOG_HEADING_RE.match(raw)
         if heading is None:

--- a/tools/test_build_site_routing.py
+++ b/tools/test_build_site_routing.py
@@ -1545,6 +1545,92 @@ def test_a_comment_inside_a_fenced_block_is_sample_text_not_a_comment():
     assert [g["packages"][0]["name"] for g in _groups(text)] == ["later", "pkg"]
 
 
+def test_a_comment_opener_in_a_fence_info_string_does_not_swallow_later_releases():
+    """An opener's info string is sample text, not cross-line comment state."""
+    text = """# Changelog
+
+## [core][2.0.0] - 2026-01-02
+
+### Highlights
+
+- second release
+
+```bash <!-- setup
+echo hi
+```
+
+## [core][1.0.0] - 2026-01-01
+
+### Highlights
+
+- first release
+
+<!-- template -->
+"""
+    releases = build_site.parse_changelog_releases(text).releases
+    assert [(release["date"], release["highlights"]) for release in releases] == [
+        ("2026-01-02", ["second release"]),
+        ("2026-01-01", ["first release"]),
+    ]
+
+
+def test_a_comment_before_a_fence_marker_in_real_comment_state_stays_a_comment():
+    """A fence marker inside a real comment cannot suppress that comment state."""
+    text = """# Changelog
+
+## [core][2.0.0] - 2026-01-02
+
+### Highlights
+
+- second release
+
+<!-- ```bash
+
+## [core][1.0.0] - 2026-01-01
+
+### Highlights
+
+- first release
+"""
+    try:
+        build_site.parse_changelog_releases(text)
+    except ValueError as exc:
+        assert "unterminated HTML comment" in str(exc)
+        assert "line 9" in str(exc), str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("an unclosed comment did not name its opener")
+
+
+def test_an_unclosed_fence_with_a_comment_in_its_info_string_names_the_fence():
+    """Fence precedence must retain the original unterminated-fence diagnostic."""
+    text = """# Changelog
+
+## [core][2.0.0] - 2026-01-02
+
+### Highlights
+
+- second release
+
+```bash <!-- setup
+echo hi
+
+## [core][1.0.0] - 2026-01-01
+
+### Highlights
+
+- first release
+
+<!-- template
+"""
+    try:
+        build_site.parse_changelog_releases(text)
+    except ValueError as exc:
+        assert "unterminated code fence" in str(exc)
+        assert "line 9" in str(exc), str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("an unclosed fence did not name its opener")
+
+
 def test_a_backticked_comment_opener_does_not_swallow_later_releases():
     """A code-span mention must not open a comment or trigger the final raise.
 


### PR DESCRIPTION
## What

`tools/build-site.py`'s `parse_changelog_releases` stripped HTML comments **before** matching
the fence opener, so a `<!--` in an opener's **info string** set `in_fence` and `in_comment`
together:

```
```bash <!-- setup
```

The `if in_fence` branch then `continue`d past the `in_comment` handler, so while the fence was
open the comment state was never consulted. Once the fence closed, the first `-->` after it
silently absorbed everything between.

## Premise, measured on origin/main before the fix

A 2-release fixture with such an opener parses **one** release — no raise, no diagnostic. The
same silent-collapse class as `build-site-comment-strip-ignores-code-spans`, and the >=130
release floor has ~42 releases of slack before it would notice.

The comment at `:1795` claims "fenced code wins over comment syntax". That holds for lines
*inside* a fence, not for the opener line itself — which is the bug.

## The fix

Commit `opens_comment` to cross-line state only **after** the fence-opener match, so a line that
turns out to be an opener never opens a comment.

**Correct parse rather than a diagnostic.** Unlike the three prior fixes in this state machine
(`5705da46`, `12f37231`, `e6bbe787`), which each added a diagnostic for an *ambiguous* authoring
shape, this syntax is unambiguous CommonMark info-string text — raising would withhold valid
releases rather than prevent a leak.

Unterminated cases are unchanged: an unclosed fence still raises naming the **fence**, and a real
`<!--` before the marker still raises naming the **comment**.

## Mutation proofs (all three run and confirmed)

| Invariant | Mutation | Result |
|---|---|---|
| An info-string `<!--` cannot suppress later releases | revert the reorder | the collapse test fails, losing exactly one release |
| A fence marker inside a *real* comment cannot suppress comment state | suppress comment state on any line containing a fence marker | the comment-before-marker test is the **sole** catcher |
| The unterminated-fence diagnostic survives fence precedence | delete the `if in_fence:` raise | the fence-precedence test fails |

The second mutation is the one that matters: it is the plausible *wrong* fix, and without that
test the suite does not distinguish it from the correct one.

## Gates

`pytest tools/test_build_site_routing.py` (93 passed, 1 skipped) · `make lint-ruff` ·
`make lint-mypy` · `SKIP_SAST=1 make build-check` · `make sast` (semgrep clean, argv-boundary
8/8) · `make test` (**EXIT=0**, full suite)

Independent review by a fresh session: **CLEAN WITH NITS**; its one finding (the test could not
distinguish the correct fix from a broad wrong one) is addressed by the second case above.

## Scope

`tools/**` only — ships in no release, so no changelog entry and no pack version bump
(`docs/CONVENTIONS.md:687-698`, confirmed rather than assumed). No state-machine refactor, no
change to `_strip_changelog_comments`, no change to the opener's loose indentation match.

Closes: `build-site-fence-info-string-opens-a-comment`