### PR TITLE
build(deps): land astro 7.2.4, mermaid 11.17.0, vitest 4.1.11 (supersedes #1112, #1113)

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,13 +8,13 @@
       "name": "agent-ready-repo-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/markdown-remark": "7.2.2",
+        "@astrojs/markdown-remark": "7.2.4",
         "@astrojs/starlight": "0.41.7",
         "@fontsource-variable/inter": "5.3.0",
         "@fontsource-variable/source-serif-4": "5.3.0",
         "@fontsource/jetbrains-mono": "5.3.0",
-        "astro": "7.2.2",
-        "mermaid": "11.16.1",
+        "astro": "7.2.4",
+        "mermaid": "11.17.0",
         "unist-util-visit": "5.1.0"
       },
       "engines": {
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
-      "integrity": "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
+      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -239,12 +239,12 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.2.tgz",
-      "integrity": "sha512-FGfmK84zSNcrsBd0dl1gXE9JvZYElp8EXQa2jpHVAxG4deGKAp43wspxFupjADJX7MSsMRHwYCnfT6EyVmgeFQ==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.4.tgz",
+      "integrity": "sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/internal-helpers": "0.10.4",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -264,26 +264,213 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
-      "integrity": "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.7.tgz",
+      "integrity": "sha512-NHcHbrKW/opbZnTZQ5nH293BdcK2VV0tjuzI88CLnvy2njiEJVwUQ5KFnYd4NoWgHJCY/I1CyjGWCR4Vv3khXQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/internal-helpers": "0.10.4",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "satteri": "^0.9.1"
+        "satteri": "^0.10.3"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri/node_modules/satteri": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.5",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.5.tgz",
-      "integrity": "sha512-wEM/HH1RiEntyPVagdiF+yArzfcYLKBB0C1RZspVidKZ97rRMbaqP1Nbl/GR0sJs8zwaceqxRymw8aOKKJRdYw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.7.tgz",
+      "integrity": "sha512-hv+NJh2s+/KDrjXaYNOaS344e3M2ekMXHBR7x9EwBwE3VvE1y/9Ifh1rhR1H2zK2sMgXoUnakI9e9ZeCKPX9/Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.2",
-        "@astrojs/markdown-remark": "7.2.2",
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-remark": "7.2.4",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.16.0",
         "es-module-lexer": "^2.0.0",
@@ -1797,9 +1984,9 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
@@ -2834,14 +3021,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.2.tgz",
-      "integrity": "sha512-OvLWCpXpb43lVYcWzSBJ0sk44qcEYYRZCjadtalLfAwb2RaC3P/zT+blZykBw/o6suw6sQQkn00ugN36akD8Mw==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.4.tgz",
+      "integrity": "sha512-+cuLsBns2wwUHI9a10xZMbjrF91m7+QNwqTVeljTx0B8Lf+8h0LgVGjdVIL2FALDKD2I565lczeeS3BFC+KdZg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.2",
-        "@astrojs/internal-helpers": "0.10.2",
-        "@astrojs/markdown-satteri": "0.3.5",
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-satteri": "0.3.7",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2885,7 +3072,7 @@
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.4",
+        "unifont": "~0.7.5",
         "unstorage": "^1.17.5",
         "vite": "^8.0.13",
         "vitefu": "^1.1.2",
@@ -2909,7 +3096,7 @@
         "sharp": "^0.34.0 || ^0.35.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.2"
+        "@astrojs/markdown-remark": "7.2.4"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -4249,6 +4436,15 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
       }
     },
     "node_modules/fdir": {
@@ -5686,26 +5882,27 @@
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
-      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
+      "integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -6563,9 +6760,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
@@ -7484,6 +7681,12 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7653,6 +7856,15 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -7679,14 +7891,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
-        "ofetch": "^1.5.1",
-        "ohash": "^2.0.11"
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
       }
     },
     "node_modules/unist-util-find-after": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -14,13 +14,13 @@
     "test:plugins": "node --test src/plugins/rehype-scrollable-tables.test.ts src/components/shared-chrome.test.ts"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "7.2.2",
+    "@astrojs/markdown-remark": "7.2.4",
     "@astrojs/starlight": "0.41.7",
     "@fontsource-variable/inter": "5.3.0",
     "@fontsource-variable/source-serif-4": "5.3.0",
     "@fontsource/jetbrains-mono": "5.3.0",
-    "astro": "7.2.2",
-    "mermaid": "11.16.1",
+    "astro": "7.2.4",
+    "mermaid": "11.17.0",
     "unist-util-visit": "5.1.0"
   },
   "allowScripts": {

--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -14,8 +14,8 @@
 - `packages/credbroker/` is also Python standard-library-only and is the only
   credential path. Credentialed primitives use its public API and never read
   credential stores directly.
-- `web/` uses Astro 7.1.0; `docs-site/` uses Astro 7.1.0 with Starlight
-  0.41.4.
+- `web/` uses Astro 7.2.4; `docs-site/` uses Astro 7.2.4 with Starlight
+  0.41.7.
 - Portable contracts are TOML plus JSON Schema in `contracts/`; compatible
   changes preserve both the contract declaration and its schema validation.
 - Python quality tooling is pytest, ruff, and mypy. The SAST/SCA floor is

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,14 +11,14 @@
         "@astrojs/sitemap": "3.7.3",
         "@fontsource-variable/inter": "5.3.0",
         "@fontsource/jetbrains-mono": "5.3.0",
-        "astro": "7.2.2"
+        "astro": "7.2.4"
       },
       "devDependencies": {
         "@playwright/test": "1.62.1",
-        "@vitest/ui": "4.1.10",
+        "@vitest/ui": "4.1.11",
         "axe-core": "4.13.0",
         "jsdom": "30.0.1",
-        "vitest": "4.1.10"
+        "vitest": "4.1.11"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
-      "integrity": "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
+      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -262,16 +262,15 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
-      "integrity": "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.7.tgz",
+      "integrity": "sha512-NHcHbrKW/opbZnTZQ5nH293BdcK2VV0tjuzI88CLnvy2njiEJVwUQ5KFnYd4NoWgHJCY/I1CyjGWCR4Vv3khXQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/internal-helpers": "0.10.4",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "satteri": "^0.9.1"
+        "satteri": "^0.10.3"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -372,9 +371,9 @@
       }
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
       "cpu": [
         "arm64"
       ],
@@ -385,9 +384,9 @@
       ]
     },
     "node_modules/@bruits/satteri-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
       "cpu": [
         "x64"
       ],
@@ -398,9 +397,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
-      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
       "cpu": [
         "arm64"
       ],
@@ -414,9 +413,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
-      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
       ],
@@ -430,9 +429,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
-      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
       "cpu": [
         "x64"
       ],
@@ -446,9 +445,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
-      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
       ],
@@ -462,9 +461,9 @@
       ]
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
-      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
       "cpu": [
         "wasm32"
       ],
@@ -473,7 +472,7 @@
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@napi-rs/wasm-runtime": "^1.2.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -501,9 +500,9 @@
       }
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
-      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
       "cpu": [
         "arm64"
       ],
@@ -514,9 +513,9 @@
       ]
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
-      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
       "cpu": [
         "x64"
       ],
@@ -2299,16 +2298,16 @@
       "license": "ISC"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2317,13 +2316,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2343,20 +2342,10 @@
         }
       }
     },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2367,13 +2356,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2381,14 +2370,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2397,9 +2386,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2407,13 +2396,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.10.tgz",
-      "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.11.tgz",
+      "integrity": "sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -2425,17 +2414,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.10"
+        "vitest": "4.1.11"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2527,14 +2516,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.2.tgz",
-      "integrity": "sha512-OvLWCpXpb43lVYcWzSBJ0sk44qcEYYRZCjadtalLfAwb2RaC3P/zT+blZykBw/o6suw6sQQkn00ugN36akD8Mw==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.4.tgz",
+      "integrity": "sha512-+cuLsBns2wwUHI9a10xZMbjrF91m7+QNwqTVeljTx0B8Lf+8h0LgVGjdVIL2FALDKD2I565lczeeS3BFC+KdZg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.2",
-        "@astrojs/internal-helpers": "0.10.2",
-        "@astrojs/markdown-satteri": "0.3.5",
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-satteri": "0.3.7",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2578,7 +2567,7 @@
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.4",
+        "unifont": "~0.7.5",
         "unstorage": "^1.17.5",
         "vite": "^8.0.13",
         "vitefu": "^1.1.2",
@@ -2602,7 +2591,7 @@
         "sharp": "^0.34.0 || ^0.35.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.2"
+        "@astrojs/markdown-remark": "7.2.4"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -3084,18 +3073,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
@@ -3141,6 +3118,16 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -3334,57 +3321,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -3415,23 +3351,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4138,9 +4057,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
@@ -4208,18 +4127,6 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
       "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
       "license": "MIT"
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4461,26 +4368,26 @@
       }
     },
     "node_modules/satteri": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
-      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/mdast": "^4.0.4",
         "@types/unist": "^3.0.3"
       },
       "optionalDependencies": {
-        "@bruits/satteri-darwin-arm64": "0.9.5",
-        "@bruits/satteri-darwin-x64": "0.9.5",
-        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
-        "@bruits/satteri-linux-arm64-musl": "0.9.5",
-        "@bruits/satteri-linux-x64-gnu": "0.9.5",
-        "@bruits/satteri-linux-x64-musl": "0.9.5",
-        "@bruits/satteri-wasm32-wasi": "0.9.5",
-        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
-        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
       }
     },
     "node_modules/sax": {
@@ -4904,7 +4811,6 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
       "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -4936,14 +4842,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
-        "ofetch": "^1.5.1",
-        "ohash": "^2.0.11"
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
       }
     },
     "node_modules/unist-util-is": {
@@ -5124,20 +5030,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -5249,19 +5141,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5289,12 +5181,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5349,16 +5241,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,16 +16,16 @@
   },
   "devDependencies": {
     "@playwright/test": "1.62.1",
-    "@vitest/ui": "4.1.10",
+    "@vitest/ui": "4.1.11",
     "axe-core": "4.13.0",
     "jsdom": "30.0.1",
-    "vitest": "4.1.10"
+    "vitest": "4.1.11"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.7.3",
     "@fontsource-variable/inter": "5.3.0",
     "@fontsource/jetbrains-mono": "5.3.0",
-    "astro": "7.2.2"
+    "astro": "7.2.4"
   },
   "overrides": {
     "fsevents": "2.3.3"


### PR DESCRIPTION
Lands the two open Dependabot group updates as one change, plus one declared
bundled fix. Supersedes #1112 and #1113.

| PR | Head SHA | Directory | Bump |
| --- | --- | --- | --- |
| #1112 | `6c87ccaecda840e0daa4b60a73c73e4036e042d4` | `web/` | `astro` 7.2.2→7.2.4, `vitest` 4.1.10→4.1.11, `@vitest/ui` 4.1.10→4.1.11 |
| #1113 | `046801b88c23e1ae4e58ad698b92aa5644374b34` | `docs-site/` | `astro` 7.2.2→7.2.4, `@astrojs/markdown-remark` 7.2.2→7.2.4, `mermaid` 11.16.1→11.17.0 |

Both commits are cherry-picked unmodified. `git diff <head-sha> HEAD` over each
directory's `package.json` + `package-lock.json` is **empty**, so the landed
bytes are provably the bytes CI already went green on. (Positive control: the
same pathspecs against the branch point yield 706 and 461 diff lines, proving the
pathspecs resolve — "empty output" alone is also what a mistyped pathspec
produces.)

**Why one PR, not two.** Both site builds compose into one `build/` tree and
`web/src/test/rendered-output.test.ts` asserts against the emitted HTML of both,
so landing one alone would leave the published site built by two astro minors and
make that suite's verdict ambiguous. Independently, `docs-site`'s
`@astrojs/markdown-remark` pin must equal astro's exact optional-peer version, so
astro and that package must move together within #1113.

## What did you change, and why?

Six version strings and two lockfiles. Plus one line of
`docs/architecture/reference.md` — see *Bundled fix* below.

### Impact assessment — measured from the lockfiles, not the release notes

**1. `web/`'s markdown renderer moves: satteri 0.9.5 → 0.10.5.**
`web/astro.config.ts` sets no `markdown` config, so it renders through astro's
default processor, which is Sätteri. `web/AGENTS.md` states the split outright:
the two co-deployed sites are deliberately on different engines. The
HTML-parsing path is *replaced*, not churned — `hast-util-from-html`,
`hast-util-from-parse5`, `hast-util-parse-selector`, `hastscript`,
`vfile-location`, and `web-namespaces` are removed, while `parse5` and `entities`
lose a duplicate resolution each. 42 markdown files render through it (22 packs +
20 journeys, the only two globs in `web/src/content.config.ts`).

**2. `docs-site/`'s markdown renderer also moves:** `@astrojs/markdown-remark`
7.2.2 → 7.2.4 and `@astrojs/mdx` 7.0.5 → 7.0.7. `docs-site/astro.config.ts`
imports `unified` *from* `@astrojs/markdown-remark` and builds
`markdown.processor` from it, so the package supplying this site's processor is
itself bumped. The pin gate proves version *agreement*, not output stability.

**3. `docs-site/` ends up with two Sätteri minors at once.**
`@astrojs/starlight@0.41.7` declares `satteri: ^0.9.1` and is not in #1113's
bump set, so the lockfile retains hoisted `satteri` 0.9.5 *and* adds nested
0.10.5 under `@astrojs/markdown-satteri` 0.3.7 — 12 → 21 `@bruits/satteri-*`
packages. Regenerating the lockfile would not change this; `^0.9.1` forces the
same resolution. Nothing gates satteri:
`tools/test_browser_gate_subset.py` scopes its pin guard to
`@astrojs/markdown-remark` only.

**4. The `@astrojs/markdown-remark` pin gate — checked, clean.** All four values
agree: astro 7.2.4's exact optional peer is `7.2.4`, the `docs-site/package.json`
pin is `7.2.4`, the lockfile resolves `7.2.4`, and Starlight's `^7.2.0` peer
still accepts it.

**5. mermaid 11.17.0 changes the one published diagram.** See *User-visible
change* below.

**6. Net-new packages and their provenance.** `fastdom` 1.0.12, `strictdom`
1.0.1, and `undici` 8.10.0 are net-new to `docs-site/`. **Only `fastdom` reaches
the published client bundle** — measured against the emitted tree, not inferred
from the lockfile:

- `fastdom` is present in `build/docs/_astro/chunk-GMAD6QVW.BD_evIy5.js`,
  imported by `Footer.astro`'s script chunk and every mermaid diagram chunk.
- `strictdom` is **absent** from every emitted JS file: none of its distinctive
  literals (`Can only get `, `Can only set `, `getPropertyCSSValue`,
  `create prototype properties`) appears anywhere in `build/`. It is reachable
  only through `fastdom/fastdom-strict.js`, which is not fastdom's `main`
  (`"main": "fastdom.js"`) and which mermaid does not import. It is a
  build-tree-only transitive.

An earlier revision of this PR body claimed both packages reach visitors'
browsers. That took a lockfile edge for bundle reach without measuring the
bundle; corrected here.

| Package | Published | Maintainers | Provenance attestation |
| --- | --- | --- | --- |
| `strictdom@1.0.1` | 2016-08-05 (3 versions total) | 1 | **no** |
| `fastdom@1.0.12` | 2024-02-20 | 1 | **no** |
| `undici@8.10.0` | 2026-08-03 | 3 | yes |
| `mermaid@11.17.0` | 2026-08-19 | 5 | yes |
| `satteri@0.10.5` | 2026-08-19 | 1 | yes |
| `astro@7.2.4` | 2026-08-19 | 2 | yes |

**Accepted risk, with a retirement condition.** **One** package newly reaching
visitors' browsers lacks build-provenance attestation: `fastdom@1.0.12`
(single-maintainer, 2024-02-20; it does carry a registry signature).
`strictdom@1.0.1` — the 2016 release — also lacks attestation but never reaches
the browser, so its exposure is build-time only. This was put to the repository
owner with the measured figures above; the decision was to record it and land the
bump. The correction narrows the accepted risk rather than widening it.
Following the shape `tools/npm-audit-allowlist.toml` requires — a blank
`unblocked_when` is a tool error there, because "an allowlist that decays into an
undocumented mute list is worse than no allowlist":

- `fastdom@1.0.12` — `sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==`
- `strictdom@1.0.1` — `sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==`
- **Retired when** `fastdom` publishes with provenance, or mermaid drops the
  dependency, or the `sast-javascript-coverage` lens lands and covers the bundle.
  (`strictdom` is build-tree-only; it is recorded for completeness, not as
  browser-reaching exposure.)

`undici` adds no new outbound-HTTP capability class, and the mechanism is
measured rather than inferred: `unifont` 0.7.4's `{css-tree, ofetch, ohash}`
becomes 0.7.5's `{css-tree, ohash, undici}` — a substitution. In `web/`, `undici`
stays at 8.9.0 but flips from `dev: true` to a production edge via that same
change. Both sites self-host fonts via `@fontsource` with no remote provider
configured, so no new outbound call is exercised.

**Release-age exposure, stated rather than implied.** `mermaid@11.17.0`,
`satteri@0.10.5`, and `astro@7.2.4` were all published 2026-08-19, nine days
before this landing, and they are the packages carrying new code into both
bundles. `.github/dependabot.yml` configures no `cooldown:` and CodeQL is
Python-only. The one real mitigation here is that `tools/audit-npm.py` queries
the live advisory database at merge time — and it did, confirming its endpoint
live via the `lodash@4.17.11` canary. Whether to adopt a `cooldown:` policy is a
separate owner decision, not a gap in this change.

**7. astro's base path-segment stripping fix.** Both sites configure `base`
(`/agent-ready-repo` and `/agent-ready-repo/docs`), which sit on a clean
path-segment boundary, and both are statically built rather than served by
astro's router. Evidence: `tools/check-rendered-site-links.py --build-dir build`
exit 0 over **69,567 emitted links across 283 pages**, clean.

**8. `astro preview` agent-daemonization.** astro 7.2 extends agent-triggered
daemonization to `astro preview`; `web/playwright.config.ts` records that the
browser gate survives only because it sets `ASTRO_PREVIEW_BACKGROUND`, and that no
CI variable appears in `am-i-vibing`'s detector list — so a green gate in a
non-detected shell would prove nothing. Evidence: `make web-browser-gate` exit 0
(182 passed, 0 skipped) **with** an agent-detection probe from `web/` returning
`{"isAgentic":true,"id":"claude-code","name":"Claude Code","type":"agent"}`. The
environment is agent-detected, so the insulation was genuinely exercised and
still holds at 7.2.4.

**9. `vitest` 4.1.11.** Patch bump to `web/`'s runner. Evidence:
`npm test --prefix web` 18/18 files, 129/129 tests, zero skips, run after
rebuilding both sites.

**Ruled out with evidence, not assumed:**

- **Install-script allowlist.** The `hasInstallScript` set is
  `{esbuild@0.28.1, fsevents@2.3.3}` before *and* after in both lockfiles — the
  native-binary packages are prebuilt. No `allowScripts` edit needed, and
  `lint-npm-allow-scripts` confirms it at exit 0.
- **A new native execution surface.** All nine `@bruits/satteri-*` binaries and
  `satteri` were already resident at 0.9.5 on `main` in **both** lockfiles. This
  moves an already-native component's version; it does not introduce native code
  into an all-JS build.
- **Typosquat / registry substitution.** Every entry in both post-bump lockfiles
  resolves to `registry.npmjs.org` with a `sha512` integrity hash. Publisher
  identity was read separately from the registry (`maintainers`), not inferred
  from the lockfile, which records `resolved` and `integrity` only.
- **Lockfile staleness.** `main` has not touched either manifest since the merge
  bases, so the Dependabot resolutions apply unchanged.

## How do you know it works?

| Check | Result |
| --- | --- |
| Emitted HTML, 283 pages, vs same-source pre-bump baseline | **0 regressions** (2 byte-identical, 281 differing only in asset hashes + generator version) |
| Non-HTML: page→asset referent graph | **0 changed pages** |
| pagefind indexed URLs | 232 → 232 |
| sitemaps | no referent-set change |
| `npm test --prefix web` | 18/18 files, 129/129 tests, **zero skips** |
| `tools/lint-npm-allow-scripts.py --root .` | exit 0 |
| `tools/audit-npm.py --root .` | exit 0, advisory endpoint confirmed live |
| `tools/check-rendered-site-links.py --build-dir build` | exit 0 — 69,567 links across 283 pages, clean |
| `make lint-ruff` | exit 0 |
| `make lint-mypy` | exit 0 — 125 source files |
| `make build-check` | completed with `complete — every leg of this target was invoked, SAST/SCA included.` |
| mermaid, real browser at 11.17.0 | all invariants hold, 0 console errors |

**The headline result.** Both markdown renderers moved and the emitted HTML is
structurally identical on every one of 283 pages. That is the question no release
note could answer.

**Scope of that claim.** Every comparison above was measured on **macOS /
darwin-arm64**, using `@bruits/satteri-darwin-arm64`. Both lockfiles carry nine
per-platform native binaries, and the deployed site is built on `ubuntu-latest`
with `satteri-linux-x64-gnu` (`.github/workflows/pages.yml`). So byte-level
equivalence is proven for the darwin binary only. The cross-platform evidence is
weaker but real: the pages `build` job ran green on this head, executing the Linux
build plus the link check, the web vitest suite, and the browser quality gate —
which assert invariants rather than equivalence against a pre-bump baseline.

Two things about how that was measured, because they nearly produced a false
green:

- The comparison had to be **HTML-first with normalisation**. A whole-tree
  content-hash diff drowns 283 meaningful pages in ~495 churning hashed assets
  and a rebuilt pagefind index. And `<meta name="generator" content="Astro
  v7.2.2">` appears on 281 of the 283 pages and moves to `v7.2.4` — unnormalised,
  that is 281 false regressions on its own.
- Bundler chunks carry **two** version-varying tokens. Normalising only the
  trailing one reported 74 assets "gone" and 73 "new"; after normalising both,
  exactly **one** real item remained. The real finding was 1 in 148.

That one item: `docs/_astro/map.<hash>.js`, a 5 KB graphlib/dagre internal chunk,
disappears.

**The mechanical classifier fails on it.** `classify-nonhtml.py` exits **1** with
`"verdict": "REGRESSION"` and `"findings": ["1 hashed asset identity(ies)
disappeared"]`. AC7 ends "Every regression is fixed, not accepted", so that
verdict was overridden by judgement, and this PR says so rather than presenting
the run as clean.

The basis for the override, stated so it can be checked:

- **Zero references to any `map.*.js` remain** anywhere in the emitted JS. This
  is the load-bearing evidence.
- Its four baseline referrers (`dagre.*`, `mermaid.core.*`, two `chunk-*`) all
  show content changes, consistent with Rollup inlining the module into its
  consumers.
- The browser observation independently confirms the lazy-import graph still
  resolves at runtime.

**What the referent graph could *not* tell us.** `classify-nonhtml.py` builds the
page→asset graph from `*.html` only, and `map.<hash>.js` was referenced
exclusively from other JS chunks. So "referent graph: 0 changed pages" is silent
about chunk-to-chunk edges by construction and does **not** corroborate this
disposition — the emitted-JS reference sweep does. Cited here with its scope
rather than as blanket reassurance.

The baseline also had to be **re-captured mid-run**: `main` advanced 35 commits
during review (INI-009 merged), adding two published pages, so the original
baseline was no longer same-source. It was rebuilt at current `main` with the
four manifests reverted to pre-bump — 283 pages on both sides.

## User-visible change: the three-loops diagram is laid out differently

mermaid 11.17.0 ships `#8005`, reverting `#7672`'s subgraph-direction behaviour,
and `getting-started/three-loops` is exactly the shape that revert targets: three
`subgraph` blocks each with `direction TB`, joined by three inter-subgraph edges.

Observed in chromium at 1280x900, `waitUntil: 'load'` plus a 2500 ms settle
(mermaid is a lazy dynamic import and is not ready at load):

| Measure | 11.16.1 | 11.17.0 |
| --- | --- | --- |
| nodes / edges / clusters | 10 / 10 / 3 | 10 / 10 / 3 |
| svg viewBox | `0 0 637.90625 993` | `0 0 379.52734375 1204` |
| DOM node order | RE, PE, CO — not source order | **PE, CO, RE — source order** |
| console warnings + errors | 0 | 0 |

All three invariants hold: three labelled subgraph boxes; each holding its nodes
in TB order; and `G3` → `CO1`, `G4` → `RE1`, dashed `findings` → `CO1`. The
diagram now stacks vertically in source order rather than two-up in scrambled
order, and the pre-existing quirk where `Raw idea` overlapped the top border of
its own subgraph is **gone** — that quirk was a plausible symptom of the very
behaviour this release reverts.

This is a real change to a published page, and an improvement. Worth knowing
about rather than discovering.

A green build proves nothing here: the build emits an empty
`.mermaid-diagram[data-mermaid]` placeholder and
`docs-site/src/components/Footer.astro` catches a render rejection and only
`console.warn`s it, so total failure is a blank gap with no page error. Only a
browser can see it.

## What did you not change that you considered?

- **Splitting the two PRs.** The coupling above makes one PR the smaller
  *reviewable* unit even though it is the larger diff.
- **Regenerating the lockfiles.** That would substitute today's registry state
  for the resolution CI already went green on, and break the provenance check.
- **`mermaid` 11.17.2**, which exists. Outside #1113's resolution; taking it
  would break the byte-provenance guarantee.
- **A JS SAST pass over the shipped bundle**, a **satteri pin guard**, and an
  **emitted-markdown regression test**. Each would add or tighten a gate, which
  this change's scope bars. Reported below instead.
- **Upgrading Starlight** to collapse the dual-satteri resolution — in neither
  PR, and it would trigger `docs-site/AGENTS.md`'s own post-Starlight
  re-verification duty.

## Bundled fix (declared)

`docs/architecture/reference.md` read "`web/` uses Astro 7.1.0; `docs-site/`
uses Astro 7.1.0 with Starlight 0.41.4". Actual values were astro **7.2.2** and
Starlight **0.41.7** — the line was already two minors stale *before* this
change, and this change moves astro again. The document declares itself the
normative reference architecture, and root `AGENTS.md` forbids leaving
documented guidance in conflict with code.

Admitted as a Tier 3 bundled fix: one line, same concern (which astro version the
sites use), both values mechanically readable from the manifests. The correction
preserves the document's existing exact-version form rather than rewriting it to
a range, which would be a design call the bundled-fixes tiers fail closed on.
**The staleness is pre-existing and not caused by this bump.**

## Reportable gaps (not fixed here)

1. **No JS SAST/SCA over emitted bundles.** CodeQL is Python-only and no
   JS ruleset exists, so nothing inspects the shipped client bundle — the surface
   ADR-0083 explicitly recorded as "vendored mermaid's entire transitive tree
   into shipped output". Tracked as `sast-javascript-coverage`.
2. **No satteri pin guard.** `tools/test_browser_gate_subset.py` guards the
   `@astrojs/markdown-remark` pin but has no satteri equivalent, so the
   dual-minor resolution in `docs-site/` is ungated.
3. **No provenance/attestation verification anywhere.** `npm audit signatures`
   appears nowhere in the repository; lockfile integrity hashes detect
   post-resolution tampering only, not a malicious upstream publish.
4. **No emitted-markdown regression test.** This PR establishes by measurement
   that a parser swap changed nothing; nothing would catch the next one.
5. **No Dependabot `cooldown:`.** Nothing imposes a minimum release age.
