### PR TITLE
fix(core): confine loop-cohort spec dirs and bound lint-spec-status git calls

### DIFF
--- a/.agents/skills/work-loop/scripts/_loop_guards.py
+++ b/.agents/skills/work-loop/scripts/_loop_guards.py
@@ -22,8 +22,8 @@ scope: `validate_run_id` and `assert_status_legal` return `str | None`.
 
 `spec_dir` precondition: callers pass an absolute, already-resolved,
 already-confined `Path`. Confinement stays with the caller that owns it —
-`loop-engine._resolve_spec_dir` (repo-root anchored), `loop-cohort._resolve_spec_dir`
-(`..`-rejecting), and `check-spec-status.py`'s bare `resolve()`, which is the
+`loop-engine._resolve_spec_dir` and `loop-cohort._resolve_spec_dir` (both
+repo-root anchored), and `check-spec-status.py`'s bare `resolve()`, which is the
 weakest of the three and stays that way under its frozen argument surface. What a
 callee can actually check, it does: that `spec_dir` exists and is a directory.
 Re-testing "absolute, no `..`" would be dead code, because every caller resolves

--- a/.agents/skills/work-loop/scripts/_statelock.py
+++ b/.agents/skills/work-loop/scripts/_statelock.py
@@ -44,10 +44,10 @@ Hardening, each item a defect the older implementation still has:
   the path visible before the ownership record is written, so an empty record
   may belong to a live creator. It remains eligible for crash recovery, but
   only after the same ``stale_after`` budget as a complete recognised record.
-* **No ``mkdir``.** Creating the lock's parent is safe only for a confined state
-  path, and ``loop-cohort.py``'s spec-dir resolver does not confine to the repo
-  root — so it would gain an arbitrary-directory-creation side effect on a path
-  it then refuses.
+* **No ``mkdir``.** The lock synchronizes an existing state-file operation; it
+  does not initialize state directories. Creating a missing parent here would
+  add an unrelated filesystem mutation before the caller can report its
+  state-path error.
 * **Errors do not derive from ``OSError``.** Both callers carry broad
   ``except OSError`` / ``except Exception`` handlers around the regions that take
   this lock, so an ``OSError``-derived failure is one boundary-drift away from

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -698,22 +698,30 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     return out
 
 
+# Local git metadata and object reads must not indefinitely stall a lint run.
+# This matches the local-git bound used by the work-loop's engine and cohort.
+GIT_TIMEOUT_S = 20.0
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--abbrev-ref", "origin/HEAD"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except FileNotFoundError:
-        return None  # git not installed
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None  # git unavailable or timed out
     if r.returncode == 0 and r.stdout.strip():
         return r.stdout.strip()
     # Fall back to origin/main if it exists.
-    r = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return "origin/main" if r.returncode == 0 else None
 
 
@@ -731,19 +739,23 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
         probe = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
              f"{base_ref}^{{commit}}"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except OSError:
-        return False  # git absent: no base ref is resolvable
+    except (OSError, subprocess.TimeoutExpired):
+        return False  # git unavailable: no base ref is resolvable
     return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
-    r = subprocess.run(
-        ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
-        capture_output=True, text=True, errors="replace", check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
+            capture_output=True, text=True, errors="replace", check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return r.stdout if r.returncode == 0 else None
 
 
@@ -844,11 +856,11 @@ def _repo_root() -> Path:
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         # `git` may be unavailable on PATH; fall through to the
         # script-relative root, which is the intended fallback.
         pass

--- a/.agents/skills/work-loop/scripts/lint-spec-status.py
+++ b/.agents/skills/work-loop/scripts/lint-spec-status.py
@@ -703,6 +703,18 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
 GIT_TIMEOUT_S = 20.0
 
 
+class _BaseTextUndetermined:
+    """Private sentinel for a base object read that did not complete.
+
+    This is deliberately distinct from ``None``, which means the path was
+    absent at an otherwise-resolvable base.  The union return type requires a
+    caller to handle this state before using the text in a diff invariant.
+    """
+
+
+_BASE_TEXT_UNDETERMINED = _BaseTextUndetermined()
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
@@ -746,8 +758,14 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
     return probe.returncode == 0
 
 
-def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
-    """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
+def base_spec_text(
+    root: Path, relpath: str, base_ref: str
+) -> str | None | _BaseTextUndetermined:
+    """Return base content, ``None`` when absent, or a timeout sentinel.
+
+    The sentinel cannot be treated as a new spec: callers must skip their
+    diff-triggered checks and report the undetermined base read.
+    """
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
@@ -755,7 +773,7 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
             timeout=GIT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
-        return None
+        return _BASE_TEXT_UNDETERMINED
     return r.stdout if r.returncode == 0 else None
 
 
@@ -913,6 +931,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if base_resolvable
             else None
         )
+        base_text_undetermined = base_text is _BASE_TEXT_UNDETERMINED
+        if base_text_undetermined:
+            warn.append(
+                f"{rel}: git show at base ref {base_ref!r} timed out — "
+                "diff-triggered invariants (ii) and (vi) skipped"
+            )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -997,6 +1021,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             and ac_opt_out is None
             and ac_opt_out_near_miss is None
             and base_resolvable
+            and not base_text_undetermined
             and (
                 base_text is None
                 or acceptance_criteria_section_present(base_text)
@@ -1023,7 +1048,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)
-        if base_resolvable and token == "Shipped":
+        if base_resolvable and not base_text_undetermined and token == "Shipped":
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/.agents/skills/work-loop/scripts/loop-cohort.py
+++ b/.agents/skills/work-loop/scripts/loop-cohort.py
@@ -122,13 +122,51 @@ def _emit(message: str | None) -> None:
         print(f"loop-cohort: {_diag(message)}")
 
 
+# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
+# separate scripts with no shared module — but deliberately the same number, so the
+# two files do not drift into disagreeing about how long a local git call may take.
+GIT_TIMEOUT_S = 20.0
+
+# Environment variables that could redirect git to a foreign repo root.
+_GIT_OVERRIDE_VARS = frozenset({
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+})
+
+
+def _get_repo_root() -> Path:
+    """Return the repository root without caller-controlled Git overrides."""
+    safe_env = {k: v for k, v in os.environ.items() if k not in _GIT_OVERRIDE_VARS}
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+            env=safe_env, timeout=GIT_TIMEOUT_S,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"could not determine repo root: {exc}") from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise ValueError("could not determine repo root (git rev-parse --show-toplevel failed)")
+    return Path(result.stdout.strip()).resolve()
+
+
 def _resolve_spec_dir(raw: str) -> Path:
-    """Resolve <spec-dir> to an absolute path; reject `..` traversal."""
-    p = Path(raw).resolve()
+    """Resolve and confine <spec-dir> to the current repository."""
     parts = Path(raw).parts
     if ".." in parts:
         raise ValueError(f"spec-dir must not contain '..': {raw!r}")
-    return p
+    resolved = Path(raw).resolve()
+    try:
+        repo_root = _get_repo_root()
+    except ValueError as exc:
+        raise ValueError(f"spec-dir confinement check failed: {exc}") from exc
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"spec-dir must be inside the repository ({repo_root}): {raw!r}"
+        ) from exc
+    return resolved
 
 
 def write_state_atomic(spec_dir: Path, state: dict) -> None:
@@ -231,12 +269,6 @@ def _locked(verb: str):
             return with_state_lock(spec_dir, verb, lambda: fn(args))
         return wrapper
     return decorate
-
-
-# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
-# separate scripts with no shared module — but deliberately the same number, so the
-# two files do not drift into disagreeing about how long a git call may take.
-GIT_TIMEOUT_S = 20.0
 
 
 def run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:

--- a/.claude/skills/work-loop/scripts/_loop_guards.py
+++ b/.claude/skills/work-loop/scripts/_loop_guards.py
@@ -22,8 +22,8 @@ scope: `validate_run_id` and `assert_status_legal` return `str | None`.
 
 `spec_dir` precondition: callers pass an absolute, already-resolved,
 already-confined `Path`. Confinement stays with the caller that owns it —
-`loop-engine._resolve_spec_dir` (repo-root anchored), `loop-cohort._resolve_spec_dir`
-(`..`-rejecting), and `check-spec-status.py`'s bare `resolve()`, which is the
+`loop-engine._resolve_spec_dir` and `loop-cohort._resolve_spec_dir` (both
+repo-root anchored), and `check-spec-status.py`'s bare `resolve()`, which is the
 weakest of the three and stays that way under its frozen argument surface. What a
 callee can actually check, it does: that `spec_dir` exists and is a directory.
 Re-testing "absolute, no `..`" would be dead code, because every caller resolves

--- a/.claude/skills/work-loop/scripts/_statelock.py
+++ b/.claude/skills/work-loop/scripts/_statelock.py
@@ -44,10 +44,10 @@ Hardening, each item a defect the older implementation still has:
   the path visible before the ownership record is written, so an empty record
   may belong to a live creator. It remains eligible for crash recovery, but
   only after the same ``stale_after`` budget as a complete recognised record.
-* **No ``mkdir``.** Creating the lock's parent is safe only for a confined state
-  path, and ``loop-cohort.py``'s spec-dir resolver does not confine to the repo
-  root — so it would gain an arbitrary-directory-creation side effect on a path
-  it then refuses.
+* **No ``mkdir``.** The lock synchronizes an existing state-file operation; it
+  does not initialize state directories. Creating a missing parent here would
+  add an unrelated filesystem mutation before the caller can report its
+  state-path error.
 * **Errors do not derive from ``OSError``.** Both callers carry broad
   ``except OSError`` / ``except Exception`` handlers around the regions that take
   this lock, so an ``OSError``-derived failure is one boundary-drift away from

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -698,22 +698,30 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     return out
 
 
+# Local git metadata and object reads must not indefinitely stall a lint run.
+# This matches the local-git bound used by the work-loop's engine and cohort.
+GIT_TIMEOUT_S = 20.0
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--abbrev-ref", "origin/HEAD"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except FileNotFoundError:
-        return None  # git not installed
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None  # git unavailable or timed out
     if r.returncode == 0 and r.stdout.strip():
         return r.stdout.strip()
     # Fall back to origin/main if it exists.
-    r = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return "origin/main" if r.returncode == 0 else None
 
 
@@ -731,19 +739,23 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
         probe = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
              f"{base_ref}^{{commit}}"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except OSError:
-        return False  # git absent: no base ref is resolvable
+    except (OSError, subprocess.TimeoutExpired):
+        return False  # git unavailable: no base ref is resolvable
     return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
-    r = subprocess.run(
-        ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
-        capture_output=True, text=True, errors="replace", check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
+            capture_output=True, text=True, errors="replace", check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return r.stdout if r.returncode == 0 else None
 
 
@@ -844,11 +856,11 @@ def _repo_root() -> Path:
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         # `git` may be unavailable on PATH; fall through to the
         # script-relative root, which is the intended fallback.
         pass

--- a/.claude/skills/work-loop/scripts/lint-spec-status.py
+++ b/.claude/skills/work-loop/scripts/lint-spec-status.py
@@ -703,6 +703,18 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
 GIT_TIMEOUT_S = 20.0
 
 
+class _BaseTextUndetermined:
+    """Private sentinel for a base object read that did not complete.
+
+    This is deliberately distinct from ``None``, which means the path was
+    absent at an otherwise-resolvable base.  The union return type requires a
+    caller to handle this state before using the text in a diff invariant.
+    """
+
+
+_BASE_TEXT_UNDETERMINED = _BaseTextUndetermined()
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
@@ -746,8 +758,14 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
     return probe.returncode == 0
 
 
-def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
-    """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
+def base_spec_text(
+    root: Path, relpath: str, base_ref: str
+) -> str | None | _BaseTextUndetermined:
+    """Return base content, ``None`` when absent, or a timeout sentinel.
+
+    The sentinel cannot be treated as a new spec: callers must skip their
+    diff-triggered checks and report the undetermined base read.
+    """
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
@@ -755,7 +773,7 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
             timeout=GIT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
-        return None
+        return _BASE_TEXT_UNDETERMINED
     return r.stdout if r.returncode == 0 else None
 
 
@@ -913,6 +931,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if base_resolvable
             else None
         )
+        base_text_undetermined = base_text is _BASE_TEXT_UNDETERMINED
+        if base_text_undetermined:
+            warn.append(
+                f"{rel}: git show at base ref {base_ref!r} timed out — "
+                "diff-triggered invariants (ii) and (vi) skipped"
+            )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -997,6 +1021,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             and ac_opt_out is None
             and ac_opt_out_near_miss is None
             and base_resolvable
+            and not base_text_undetermined
             and (
                 base_text is None
                 or acceptance_criteria_section_present(base_text)
@@ -1023,7 +1048,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)
-        if base_resolvable and token == "Shipped":
+        if base_resolvable and not base_text_undetermined and token == "Shipped":
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/.claude/skills/work-loop/scripts/loop-cohort.py
+++ b/.claude/skills/work-loop/scripts/loop-cohort.py
@@ -122,13 +122,51 @@ def _emit(message: str | None) -> None:
         print(f"loop-cohort: {_diag(message)}")
 
 
+# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
+# separate scripts with no shared module — but deliberately the same number, so the
+# two files do not drift into disagreeing about how long a local git call may take.
+GIT_TIMEOUT_S = 20.0
+
+# Environment variables that could redirect git to a foreign repo root.
+_GIT_OVERRIDE_VARS = frozenset({
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+})
+
+
+def _get_repo_root() -> Path:
+    """Return the repository root without caller-controlled Git overrides."""
+    safe_env = {k: v for k, v in os.environ.items() if k not in _GIT_OVERRIDE_VARS}
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+            env=safe_env, timeout=GIT_TIMEOUT_S,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"could not determine repo root: {exc}") from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise ValueError("could not determine repo root (git rev-parse --show-toplevel failed)")
+    return Path(result.stdout.strip()).resolve()
+
+
 def _resolve_spec_dir(raw: str) -> Path:
-    """Resolve <spec-dir> to an absolute path; reject `..` traversal."""
-    p = Path(raw).resolve()
+    """Resolve and confine <spec-dir> to the current repository."""
     parts = Path(raw).parts
     if ".." in parts:
         raise ValueError(f"spec-dir must not contain '..': {raw!r}")
-    return p
+    resolved = Path(raw).resolve()
+    try:
+        repo_root = _get_repo_root()
+    except ValueError as exc:
+        raise ValueError(f"spec-dir confinement check failed: {exc}") from exc
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"spec-dir must be inside the repository ({repo_root}): {raw!r}"
+        ) from exc
+    return resolved
 
 
 def write_state_atomic(spec_dir: Path, state: dict) -> None:
@@ -231,12 +269,6 @@ def _locked(verb: str):
             return with_state_lock(spec_dir, verb, lambda: fn(args))
         return wrapper
     return decorate
-
-
-# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
-# separate scripts with no shared module — but deliberately the same number, so the
-# two files do not drift into disagreeing about how long a git call may take.
-GIT_TIMEOUT_S = 20.0
 
 
 def run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -52,6 +52,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [core][2.15.1] — 2026-08-28
+
+### Highlights
+
+- **Work-loop tools now reject execution state outside the current repository and
+  finish safely when local Git stops responding.**
+
+### Fixed
+
+- Confined `loop-cohort` spec directories to the current repository, including
+  paths redirected through symlinks.
+- Bounded local Git lookups in the spec-status lint so an unavailable Git process
+  skips the affected diff check instead of hanging or crashing the lint.
+
 ## [core][2.15.0] — 2026-08-28
 
 - **Delivered work can now cool on a recorded 30-day schedule.** `close-work`

--- a/packs/core/.apm/skills/work-loop/scripts/_loop_guards.py
+++ b/packs/core/.apm/skills/work-loop/scripts/_loop_guards.py
@@ -22,8 +22,8 @@ scope: `validate_run_id` and `assert_status_legal` return `str | None`.
 
 `spec_dir` precondition: callers pass an absolute, already-resolved,
 already-confined `Path`. Confinement stays with the caller that owns it —
-`loop-engine._resolve_spec_dir` (repo-root anchored), `loop-cohort._resolve_spec_dir`
-(`..`-rejecting), and `check-spec-status.py`'s bare `resolve()`, which is the
+`loop-engine._resolve_spec_dir` and `loop-cohort._resolve_spec_dir` (both
+repo-root anchored), and `check-spec-status.py`'s bare `resolve()`, which is the
 weakest of the three and stays that way under its frozen argument surface. What a
 callee can actually check, it does: that `spec_dir` exists and is a directory.
 Re-testing "absolute, no `..`" would be dead code, because every caller resolves

--- a/packs/core/.apm/skills/work-loop/scripts/_statelock.py
+++ b/packs/core/.apm/skills/work-loop/scripts/_statelock.py
@@ -44,10 +44,10 @@ Hardening, each item a defect the older implementation still has:
   the path visible before the ownership record is written, so an empty record
   may belong to a live creator. It remains eligible for crash recovery, but
   only after the same ``stale_after`` budget as a complete recognised record.
-* **No ``mkdir``.** Creating the lock's parent is safe only for a confined state
-  path, and ``loop-cohort.py``'s spec-dir resolver does not confine to the repo
-  root — so it would gain an arbitrary-directory-creation side effect on a path
-  it then refuses.
+* **No ``mkdir``.** The lock synchronizes an existing state-file operation; it
+  does not initialize state directories. Creating a missing parent here would
+  add an unrelated filesystem mutation before the caller can report its
+  state-path error.
 * **Errors do not derive from ``OSError``.** Both callers carry broad
   ``except OSError`` / ``except Exception`` handlers around the regions that take
   this lock, so an ``OSError``-derived failure is one boundary-drift away from

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -698,22 +698,30 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
     return out
 
 
+# Local git metadata and object reads must not indefinitely stall a lint run.
+# This matches the local-git bound used by the work-loop's engine and cohort.
+GIT_TIMEOUT_S = 20.0
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--abbrev-ref", "origin/HEAD"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except FileNotFoundError:
-        return None  # git not installed
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None  # git unavailable or timed out
     if r.returncode == 0 and r.stdout.strip():
         return r.stdout.strip()
     # Fall back to origin/main if it exists.
-    r = subprocess.run(
-        ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", "origin/main"],
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return "origin/main" if r.returncode == 0 else None
 
 
@@ -731,19 +739,23 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
         probe = subprocess.run(
             ["git", "-C", str(root), "rev-parse", "--verify", "--quiet",
              f"{base_ref}^{{commit}}"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
-    except OSError:
-        return False  # git absent: no base ref is resolvable
+    except (OSError, subprocess.TimeoutExpired):
+        return False  # git unavailable: no base ref is resolvable
     return probe.returncode == 0
 
 
 def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
     """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
-    r = subprocess.run(
-        ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
-        capture_output=True, text=True, errors="replace", check=False,
-    )
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
+            capture_output=True, text=True, errors="replace", check=False,
+            timeout=GIT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        return None
     return r.stdout if r.returncode == 0 else None
 
 
@@ -844,11 +856,11 @@ def _repo_root() -> Path:
     try:
         r = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, check=False, timeout=GIT_TIMEOUT_S,
         )
         if r.returncode == 0 and r.stdout.strip():
             return Path(r.stdout.strip())
-    except FileNotFoundError:
+    except (FileNotFoundError, subprocess.TimeoutExpired):
         # `git` may be unavailable on PATH; fall through to the
         # script-relative root, which is the intended fallback.
         pass

--- a/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
+++ b/packs/core/.apm/skills/work-loop/scripts/lint-spec-status.py
@@ -703,6 +703,18 @@ def acceptance_criteria_lines(spec_text: str) -> list[tuple[int, str]]:
 GIT_TIMEOUT_S = 20.0
 
 
+class _BaseTextUndetermined:
+    """Private sentinel for a base object read that did not complete.
+
+    This is deliberately distinct from ``None``, which means the path was
+    absent at an otherwise-resolvable base.  The union return type requires a
+    caller to handle this state before using the text in a diff invariant.
+    """
+
+
+_BASE_TEXT_UNDETERMINED = _BaseTextUndetermined()
+
+
 def resolve_default_base_ref(root: Path) -> str | None:
     """Resolve the diff base ref, preferring `origin/<default-branch>`."""
     try:
@@ -746,8 +758,14 @@ def base_ref_resolves(root: Path, base_ref: str) -> bool:
     return probe.returncode == 0
 
 
-def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
-    """Return the spec's content at `base_ref`, or None if absent/unresolvable."""
+def base_spec_text(
+    root: Path, relpath: str, base_ref: str
+) -> str | None | _BaseTextUndetermined:
+    """Return base content, ``None`` when absent, or a timeout sentinel.
+
+    The sentinel cannot be treated as a new spec: callers must skip their
+    diff-triggered checks and report the undetermined base read.
+    """
     try:
         r = subprocess.run(
             ["git", "-C", str(root), "show", f"{base_ref}:{relpath}"],
@@ -755,7 +773,7 @@ def base_spec_text(root: Path, relpath: str, base_ref: str) -> str | None:
             timeout=GIT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired:
-        return None
+        return _BASE_TEXT_UNDETERMINED
     return r.stdout if r.returncode == 0 else None
 
 
@@ -913,6 +931,12 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             if base_resolvable
             else None
         )
+        base_text_undetermined = base_text is _BASE_TEXT_UNDETERMINED
+        if base_text_undetermined:
+            warn.append(
+                f"{rel}: git show at base ref {base_ref!r} timed out — "
+                "diff-triggered invariants (ii) and (vi) skipped"
+            )
 
         # (i) status vocabulary
         token = parse_status(text)
@@ -997,6 +1021,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
             and ac_opt_out is None
             and ac_opt_out_near_miss is None
             and base_resolvable
+            and not base_text_undetermined
             and (
                 base_text is None
                 or acceptance_criteria_section_present(base_text)
@@ -1023,7 +1048,7 @@ def check(root: Path, base_ref: str | None) -> tuple[list[str], list[str]]:
                 )
 
         # (ii) ACs at the ship transition (diff-triggered)
-        if base_resolvable and token == "Shipped":
+        if base_resolvable and not base_text_undetermined and token == "Shipped":
             base_token = parse_status(base_text) if base_text is not None else None
             transitioned = base_token != "Shipped"  # incl. new spec (None)
             if transitioned:

--- a/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
+++ b/packs/core/.apm/skills/work-loop/scripts/loop-cohort.py
@@ -122,13 +122,51 @@ def _emit(message: str | None) -> None:
         print(f"loop-cohort: {_diag(message)}")
 
 
+# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
+# separate scripts with no shared module — but deliberately the same number, so the
+# two files do not drift into disagreeing about how long a local git call may take.
+GIT_TIMEOUT_S = 20.0
+
+# Environment variables that could redirect git to a foreign repo root.
+_GIT_OVERRIDE_VARS = frozenset({
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+})
+
+
+def _get_repo_root() -> Path:
+    """Return the repository root without caller-controlled Git overrides."""
+    safe_env = {k: v for k, v in os.environ.items() if k not in _GIT_OVERRIDE_VARS}
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+            env=safe_env, timeout=GIT_TIMEOUT_S,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise ValueError(f"could not determine repo root: {exc}") from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise ValueError("could not determine repo root (git rev-parse --show-toplevel failed)")
+    return Path(result.stdout.strip()).resolve()
+
+
 def _resolve_spec_dir(raw: str) -> Path:
-    """Resolve <spec-dir> to an absolute path; reject `..` traversal."""
-    p = Path(raw).resolve()
+    """Resolve and confine <spec-dir> to the current repository."""
     parts = Path(raw).parts
     if ".." in parts:
         raise ValueError(f"spec-dir must not contain '..': {raw!r}")
-    return p
+    resolved = Path(raw).resolve()
+    try:
+        repo_root = _get_repo_root()
+    except ValueError as exc:
+        raise ValueError(f"spec-dir confinement check failed: {exc}") from exc
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"spec-dir must be inside the repository ({repo_root}): {raw!r}"
+        ) from exc
+    return resolved
 
 
 def write_state_atomic(spec_dir: Path, state: dict) -> None:
@@ -231,12 +269,6 @@ def _locked(verb: str):
             return with_state_lock(spec_dir, verb, lambda: fn(args))
         return wrapper
     return decorate
-
-
-# Matches `loop-engine.py`'s SUBPROCESS_TIMEOUT_S. Not derived from it — these are
-# separate scripts with no shared module — but deliberately the same number, so the
-# two files do not drift into disagreeing about how long a git call may take.
-GIT_TIMEOUT_S = 20.0
 
 
 def run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.15.0"
+version = "2.15.1"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/tests/pack/conftest.py
+++ b/packs/core/tests/pack/conftest.py
@@ -1,0 +1,14 @@
+"""Shared pytest fixtures for core-pack contract tests."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide a temporary repository for fixtures requiring a repo root."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/packs/core/tests/pack/test_finding_adjudication_contract.py
+++ b/packs/core/tests/pack/test_finding_adjudication_contract.py
@@ -173,9 +173,10 @@ def test_finding_adjudicator_source_contract() -> None:
 
 def test_adjudication_shape_fingerprints_only_sustained_findings(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """Drive a representative adjudication through the existing cohort parser."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -226,9 +227,10 @@ None.
 
 def test_strict_adjudication_rejects_extra_main_loop_prose(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """Accept only sustained-entry paragraphs in the actionable section."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -281,9 +283,10 @@ None.
 
 def test_strict_adjudication_accepts_adjacent_sustained_findings(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """Accept adjacent file and architecture `Where:` sustained lines."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -346,10 +349,11 @@ None.
 )
 def test_strict_adjudication_rejects_incomplete_or_hidden_findings(
     tmp_path: Path,
+    git_repo: Path,
     main_result: str,
 ) -> None:
     """Reject finding prefixes that do not form one complete sustained line."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -402,11 +406,12 @@ None.
 @pytest.mark.parametrize("audit_prefix", ["", "- "])
 def test_adjudication_audit_cannot_create_actionable_fingerprint(
     tmp_path: Path,
+    git_repo: Path,
     tainted_audit: str,
     audit_prefix: str,
 ) -> None:
     """Reject finding-shaped audit text before it reaches fingerprinting."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -464,9 +469,10 @@ Clean — ready to commit.
 
 def test_strict_adjudication_rejects_indeterminate_signal_in_refuted_audit(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """Fail closed when the stop sentinel is hidden outside the main result."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -517,9 +523,10 @@ None.
 
 def test_strict_adjudication_mode_rejects_raw_without_breaking_legacy(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """Make the work-loop path strict while preserving the flagless CLI."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -567,9 +574,12 @@ def test_strict_adjudication_mode_rejects_raw_without_breaking_legacy(
     assert json.loads(legacy.stdout)["classification"] == "findings"
 
 
-def test_indeterminate_stops_before_sustained_fingerprinting(tmp_path: Path) -> None:
+def test_indeterminate_stops_before_sustained_fingerprinting(
+    tmp_path: Path,
+    git_repo: Path,
+) -> None:
     """Fail closed when an adjudication mixes sustained and indeterminate."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -630,12 +640,13 @@ None.
 )
 def test_strict_clean_requires_consistent_exact_envelope(
     tmp_path: Path,
+    git_repo: Path,
     main_result: str,
     indeterminate_audit: str,
     expected: str,
 ) -> None:
     """Reject unresolved audits and legacy clean matching in strict mode."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -859,6 +870,7 @@ def test_invalid_adjudication_names_the_rule_that_refused_it(
 )
 def test_indeterminate_refusal_does_not_depend_on_the_adjudication_flag(
     tmp_path: Path,
+    git_repo: Path,
     main_result: str,
     indeterminate_audit: str,
 ) -> None:
@@ -870,7 +882,7 @@ def test_indeterminate_refusal_does_not_depend_on_the_adjudication_flag(
     flagless `review inspect` — or a replayed `review record` — downgrade an
     indeterminate verdict to `clean`, which AC5 forbids outright.
     """
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -936,6 +948,7 @@ None.
 )
 def test_remaining_refusal_codes_are_pinned(
     tmp_path: Path,
+    git_repo: Path,
     body: str,
     expected_reason: str,
 ) -> None:
@@ -953,7 +966,7 @@ def test_remaining_refusal_codes_are_pinned(
         # first; root bypasses the permission bit this case depends on.
         pytest.skip("needs non-root POSIX")
 
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     (spec_dir / "state.json").write_text(
         json.dumps(
@@ -1037,6 +1050,7 @@ def run_record(spec_dir: Path, report: Path) -> subprocess.CompletedProcess[str]
 
 def test_review_record_rejects_a_raw_report_under_adjudication(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """A raw reviewer report must not record a clean round.
 
@@ -1046,7 +1060,7 @@ def test_review_record_rejects_a_raw_report_under_adjudication(
     the clean sentinel — exactly the bypass the gateway exists to prevent —
     so this asserts the refusal AND that `state.json` is left untouched.
     """
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     _record_state(spec_dir)
     before = (spec_dir / "state.json").read_text(encoding="utf-8")
@@ -1063,9 +1077,12 @@ def test_review_record_rejects_a_raw_report_under_adjudication(
     assert (spec_dir / "state.json").read_text(encoding="utf-8") == before
 
 
-def test_review_record_accepts_a_clean_adjudication_once(tmp_path: Path) -> None:
+def test_review_record_accepts_a_clean_adjudication_once(
+    tmp_path: Path,
+    git_repo: Path,
+) -> None:
     """A well-formed clean adjudication advances exactly one round."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     _record_state(spec_dir)
 
@@ -1094,9 +1111,10 @@ None.
 
 def test_review_record_rejects_an_indeterminate_adjudication(
     tmp_path: Path,
+    git_repo: Path,
 ) -> None:
     """An indeterminate adjudication can never be recorded as clean."""
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     _record_state(spec_dir)
     before = (spec_dir / "state.json").read_text(encoding="utf-8")

--- a/packs/core/tests/skills/work-loop/conftest.py
+++ b/packs/core/tests/skills/work-loop/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for the work-loop pack tests."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -8,4 +9,11 @@ import pytest
 @pytest.fixture
 def tmp(tmp_path: Path) -> Path:
     """Keep the legacy descriptive fixture name while using pytest lifecycle."""
+    return tmp_path
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Provide a temporary repository for CLI fixtures requiring a repo root."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
     return tmp_path

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import tempfile
 import types
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -120,6 +120,76 @@ def symlink_or_skip(name: str, link: Path, target: Path | str) -> bool:
             pytest.fail(f"{name}: CI must support this symlink regression: {exc}")
         pytest.skip(f"{name}: symlink creation unavailable ({exc})")
     return True
+
+
+def _timed_out_run(calls: list[float]) -> Callable[..., subprocess.CompletedProcess]:
+    """Return a subprocess seam that records and raises the configured timeout."""
+    def run(*args, **kwargs):
+        calls.append(kwargs["timeout"])
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+    return run
+
+
+def test_default_base_ref_primary_probe_timeout_degrades_to_no_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_linter_module()
+    calls: list[float] = []
+    monkeypatch.setattr(module.subprocess, "run", _timed_out_run(calls))
+
+    assert module.resolve_default_base_ref(Path("/repo")) is None
+    assert calls == [module.GIT_TIMEOUT_S]
+
+
+def test_default_base_ref_fallback_probe_timeout_degrades_to_no_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_linter_module()
+    calls: list[float] = []
+
+    def run(*args, **kwargs):
+        calls.append(kwargs["timeout"])
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(args[0], 1, "", "")
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+
+    assert module.resolve_default_base_ref(Path("/repo")) is None
+    assert calls == [module.GIT_TIMEOUT_S, module.GIT_TIMEOUT_S]
+
+
+def test_base_ref_probe_timeout_degrades_to_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_linter_module()
+    calls: list[float] = []
+    monkeypatch.setattr(module.subprocess, "run", _timed_out_run(calls))
+
+    assert not module.base_ref_resolves(Path("/repo"), "origin/main")
+    assert calls == [module.GIT_TIMEOUT_S]
+
+
+def test_base_spec_show_timeout_degrades_to_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_linter_module()
+    calls: list[float] = []
+    monkeypatch.setattr(module.subprocess, "run", _timed_out_run(calls))
+
+    assert module.base_spec_text(Path("/repo"), "docs/spec.md", "origin/main") is None
+    assert calls == [module.GIT_TIMEOUT_S]
+
+
+def test_repo_root_probe_timeout_degrades_to_script_relative_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_linter_module()
+    calls: list[float] = []
+    monkeypatch.setattr(module.subprocess, "run", _timed_out_run(calls))
+
+    assert module._repo_root() == Path(module.__file__).resolve().parent.parent
+    assert calls == [module.GIT_TIMEOUT_S]
 
 
 def test_clean() -> None:

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -170,15 +170,37 @@ def test_base_ref_probe_timeout_degrades_to_unresolvable(
     assert calls == [module.GIT_TIMEOUT_S]
 
 
-def test_base_spec_show_timeout_degrades_to_absent(
+def test_base_spec_show_timeout_skips_diff_invariants_for_unchanged_specs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A timed-out base object read is not evidence that a spec is new."""
     module = load_linter_module()
     calls: list[float] = []
-    monkeypatch.setattr(module.subprocess, "run", _timed_out_run(calls))
+    original_run = module.subprocess.run
 
-    assert module.base_spec_text(Path("/repo"), "docs/spec.md", "origin/main") is None
-    assert calls == [module.GIT_TIMEOUT_S]
+    def run(*args, **kwargs):
+        if "show" in args[0]:
+            calls.append(kwargs["timeout"])
+            raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+        return original_run(*args, **kwargs)
+
+    with best_effort_tempdir() as tmp:
+        root = Path(tmp).resolve()
+        sectionless = root / "docs" / "specs" / "sectionless" / "spec.md"
+        sectionless.parent.mkdir(parents=True)
+        sectionless.write_text(
+            "# Spec: sectionless\n\n- **Status:** Shipped\n", encoding="utf-8"
+        )
+        write_spec(root, "unchecked", "Shipped", "- [ ] grandfathered\n")
+        git_init_commit(root)
+
+        monkeypatch.setattr(module.subprocess, "run", run)
+        monkeypatch.setattr(module, "base_ref_resolves", lambda _root, _ref: True)
+        hard, warn = module.check(root, "HEAD")
+
+    assert hard == []
+    assert calls == [module.GIT_TIMEOUT_S, module.GIT_TIMEOUT_S], warn
+    assert sum("diff-triggered invariants (ii) and (vi) skipped" in item for item in warn) == 2
 
 
 def test_repo_root_probe_timeout_degrades_to_script_relative_root(

--- a/packs/core/tests/skills/work-loop/test_lint_spec_status.py
+++ b/packs/core/tests/skills/work-loop/test_lint_spec_status.py
@@ -57,10 +57,12 @@ def write_workspace_backlog(root: Path, slugs: list[str]) -> None:
 
 
 def run_lint(root: Path, base_ref: str | None = None) -> tuple[int, str, str]:
+    """Run the CLI from the temporary repository that owns ``root``."""
+    subprocess.run(["git", "init", "-q", str(root)], check=True, capture_output=True)
     argv = [sys.executable, str(LINTER), "--root", str(root)]
     if base_ref is not None:
         argv += ["--base-ref", base_ref]
-    proc = subprocess.run(argv, capture_output=True, text=True)
+    proc = subprocess.run(argv, capture_output=True, text=True, cwd=str(root))
     return proc.returncode, proc.stdout, proc.stderr
 
 
@@ -215,7 +217,7 @@ def test_repo_root_probe_timeout_degrades_to_script_relative_root(
 
 
 def test_clean() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "ok", "Draft", "- [ ] AC1 open\n")
         rc, _, err = run_lint(root)  # no base ref → invariant (ii) skipped
@@ -223,7 +225,7 @@ def test_clean() -> None:
 
 
 def test_invariant_i_out_of_vocab() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "bad", "Drafting", "- [ ] AC1\n")
         rc, out, err = run_lint(root)
@@ -232,7 +234,7 @@ def test_invariant_i_out_of_vocab() -> None:
 
 
 def test_invariant_i_lenient() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "annotated", "Shipped (2026-05-26)", "- [x] AC1\n")
         write_spec(root, "arrowed", "Approved → Shipped (landed)", "- [x] AC1\n")
@@ -241,7 +243,7 @@ def test_invariant_i_lenient() -> None:
 
 
 def test_invariant_ii_transition_fails() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "shipping", "Draft", "- [ ] AC1 open\n")
         git_init_commit(root)
@@ -253,7 +255,7 @@ def test_invariant_ii_transition_fails() -> None:
 
 
 def test_invariant_ii_transition_fails_when_deferred() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_workspace_backlog(root, ["later-work"])
         write_spec(root, "shipping", "Draft", "- [ ] AC1 open\n")
@@ -269,7 +271,7 @@ def test_invariant_ii_transition_fails_when_deferred() -> None:
 
 
 def test_invariant_ii_grandfather() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # Already Shipped on the base with an unchecked AC → grandfathered.
         write_spec(root, "old", "Shipped", "- [ ] AC1 never checked\n")
@@ -279,7 +281,7 @@ def test_invariant_ii_grandfather() -> None:
 
 
 def test_invariant_ii_no_base() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)  # plain dir, not a git repo, no base ref
         write_spec(root, "shipping", "Shipped", "- [ ] AC1 open\n")
         rc, _, err = run_lint(root)  # resolve_default_base_ref → None
@@ -288,7 +290,7 @@ def test_invariant_ii_no_base() -> None:
 
 
 def test_invariant_i_missing_status() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # A spec with no `- **Status:**` header line at all.
         p = root / "docs" / "specs" / "headless" / "spec.md"
@@ -300,7 +302,7 @@ def test_invariant_i_missing_status() -> None:
 
 
 def test_invariant_iv_resolves_workspace_slug() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # A slug in workspace.toml [backlog].open must resolve a (deferred:) marker.
         write_workspace_backlog(root, ["some-deferred-item"])
@@ -312,7 +314,7 @@ def test_invariant_iv_resolves_workspace_slug() -> None:
 
 # STUB: AC1 — repository metadata must not be read through an outside symlink.
 def test_workspace_symlink_outside_root_does_not_resolve_deferral() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         sandbox = Path(tmp)
         root = sandbox / "repo"
         root.mkdir()
@@ -344,7 +346,7 @@ def test_workspace_symlink_outside_root_does_not_resolve_deferral() -> None:
 
 # STUB: AC1 — link and code-reference probes must not consult outside targets.
 def test_reference_candidates_outside_root_do_not_resolve() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         sandbox = Path(tmp)
         root = sandbox / "repo"
         root.mkdir()
@@ -371,7 +373,7 @@ def test_reference_candidates_outside_root_do_not_resolve() -> None:
 
 # CONTRACT CONTROL: AC1 — the existing contract-file confinement stays pinned.
 def test_contract_file_symlink_outside_root_does_not_resolve() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         sandbox = Path(tmp)
         root = sandbox / "repo"
         root.mkdir()
@@ -399,7 +401,7 @@ def test_contract_file_symlink_outside_root_does_not_resolve() -> None:
 
 
 def test_invariant_ii_born_shipped_fails() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # A brand-new spec absent at base, born Shipped with an unchecked AC.
         write_spec(root, "preexisting", "Draft", "- [x] AC1\n")
@@ -411,7 +413,7 @@ def test_invariant_ii_born_shipped_fails() -> None:
 
 
 def test_invariant_iv_missing_anchor() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "deferring", "Draft",
                    "- [ ] AC1 (deferred: nonexistent-anchor)\n")
@@ -421,7 +423,7 @@ def test_invariant_iv_missing_anchor() -> None:
 
 
 def test_invariant_iv_placeholder_ignored() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # The template placeholder `<anchor>` must NOT be treated as a real
         # deferral marker (it would never resolve).
@@ -432,7 +434,7 @@ def test_invariant_iv_placeholder_ignored() -> None:
 
 
 def test_invariant_iii_warn_only() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         p = root / "docs" / "specs" / "linky" / "spec.md"
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -465,7 +467,7 @@ def touch(root: Path, rel: str) -> None:
 
 
 def test_iii_code_ref_resolves_and_missing() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         touch(root, "tools/real.py")
         write_spec_body(root, "coderef",
@@ -479,7 +481,7 @@ def test_iii_code_ref_resolves_and_missing() -> None:
 def test_iii_code_ref_exclusions_with_controls() -> None:
     # Each excluded shape is paired with a shape-matched full-path control that
     # IS flagged — so a no-op extractor (matching nothing) fails this case.
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec_body(
             root, "excl",
@@ -506,7 +508,7 @@ def test_iii_code_ref_exclusions_with_controls() -> None:
 
 
 def test_iii_code_ref_suffix_strip() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         touch(root, "tools/y.py")
         write_spec_body(
@@ -521,7 +523,7 @@ def test_iii_code_ref_suffix_strip() -> None:
 
 
 def test_iii_code_ref_markdown_link() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec_body(root, "linkref", "See [the helper](../../tools/nope.py).")
         rc, _, err = run_lint(root)
@@ -549,7 +551,7 @@ def write_contract(root: Path, relpath: str, content: str) -> None:
 
 
 def test_v_agreement_passes() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_contract(root, "contracts/openapi/orders.yaml",
                        "openapi: 3.1.0\nx-spec: [docs/specs/orders/]\n")
@@ -560,7 +562,7 @@ def test_v_agreement_passes() -> None:
 
 
 def test_v_forward_without_backward_warns() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # contract exists but carries no x-spec back-ref, and no REGISTRY.md
         write_contract(root, "contracts/openapi/orders.yaml", "openapi: 3.1.0\n")
@@ -571,7 +573,7 @@ def test_v_forward_without_backward_warns() -> None:
 
 
 def test_v_no_contracts_noop() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # template placeholder value + an explicit "none"; no contracts/ tree
         write_spec_with_contract(
@@ -583,7 +585,7 @@ def test_v_no_contracts_noop() -> None:
 
 
 def test_v_extensionless_registry_and_dangling() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         # extensionless format → REGISTRY.md is the backward channel
         write_contract(root, "contracts/proto/payments/v1/payments.proto",
@@ -606,7 +608,7 @@ def test_v_extensionless_registry_and_dangling() -> None:
 
 # STUB: AC1 — the contract registry must not be read through an outside symlink.
 def test_contract_registry_symlink_outside_root_does_not_supply_backref() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         sandbox = Path(tmp)
         root = sandbox / "repo"
         root.mkdir()
@@ -640,7 +642,7 @@ def test_multiline_comment_not_matched() -> None:
     """Regression: a **Status:** inside a multiline HTML comment must not
     be returned before the live status field (parse_status was applying
     _HTML_COMMENT_RE per-line, so block comments were never stripped)."""
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         spec = root / "docs" / "specs" / "commented" / "spec.md"
         spec.parent.mkdir(parents=True, exist_ok=True)
@@ -699,7 +701,7 @@ def test_unchecked_ac_is_caught_whatever_the_heading_casing(header: str) -> None
     sentence-case arm EXITED 0 — a clean bill of health for a spec shipping an
     unmet criterion, because the linter never found the section to read.
     """
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         _write_spec_with_header(root, "preexisting", "Draft", "- [x] AC1\n", header)
         git_init_commit(root)
@@ -724,7 +726,7 @@ def test_fully_checked_spec_under_either_casing(header: str) -> None:
     has one.
     """
     canonical = header == "## Acceptance Criteria\n\n"
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         _write_spec_with_header(root, "preexisting", "Draft", "- [x] AC1\n", header)
         git_init_commit(root)
@@ -769,7 +771,7 @@ def write_spec_without_ac_section(
 
 
 def test_vi_heading_present_without_marker_is_clean() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "has-criteria", "Draft", "- [ ] AC1 open\n")
 
@@ -779,7 +781,7 @@ def test_vi_heading_present_without_marker_is_clean() -> None:
 
 
 def test_vi_missing_heading_with_reasoned_marker_is_clean() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         reason = "this investigation prescribes no work"
         spec = write_spec_without_ac_section(root, "opted-out", f"none — {reason}")
@@ -901,7 +903,7 @@ def test_vi_lowercase_marker_has_precise_near_miss_error() -> None:
     ids=["missing-reason", "empty-reason"],
 )
 def test_vi_reasonless_marker_is_hard(marker_value: str) -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         spec = write_spec_without_ac_section(root, "reasonless", marker_value)
 
@@ -916,7 +918,7 @@ def test_vi_reasonless_marker_is_hard(marker_value: str) -> None:
 
 
 def test_vi_heading_and_marker_are_a_hard_contradiction() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         spec = root / "docs" / "specs" / "contradiction" / "spec.md"
         spec.parent.mkdir(parents=True, exist_ok=True)
@@ -936,7 +938,7 @@ def test_vi_heading_and_marker_are_a_hard_contradiction() -> None:
 
 
 def test_vi_lowercase_heading_counts_as_present() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         _write_spec_with_header(
             root,
@@ -1073,7 +1075,7 @@ def test_collector_accepts_a_superset_of_what_the_detector_accepts() -> None:
 
 
 def test_vi_mutation_missing_section_fires_until_only_marker_is_added() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         write_spec(root, "mutation", "Draft", "- [ ] AC1 open\n")
         git_init_commit(root)
@@ -1128,7 +1130,7 @@ def test_near_miss_heading_is_warned_not_silently_accepted() -> None:
     hard invariant (ii) violation to exit 0. Not breaking a build is not the
     same as still working.
     """
-    with tempfile.TemporaryDirectory() as tmp:
+    with best_effort_tempdir() as tmp:
         root = Path(tmp)
         _write_spec_with_header(root, "legacy", "Draft", "- [x] AC1\n", _LOWER_AC_HEADER)
         git_init_commit(root)

--- a/packs/core/tests/skills/work-loop/test_loop_cohort.py
+++ b/packs/core/tests/skills/work-loop/test_loop_cohort.py
@@ -72,14 +72,62 @@ def run_cohort(*args, spec_dir=None):
         # insert spec_dir after the verb where the parser expects it
         pass
     cmd.extend(str(a) for a in args)
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    spec_path = next((Path(a) for a in args if Path(a).is_dir()), None)
+    proc = subprocess.run(
+        cmd,
+        cwd=str(spec_path.parent) if spec_path is not None else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     return proc.returncode, proc.stdout, proc.stderr
 
 
 def make_spec_dir(tmp: Path, feature: str = "myfeature") -> Path:
+    import subprocess
+    subprocess.run(
+        ["git", "init", "-q", str(tmp)], check=True, capture_output=True
+    )
     d = tmp / feature
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def test_resolve_spec_dir_refuses_paths_outside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resolver must reject absolute and symlinked paths that escape root."""
+    repo_root = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo_root.mkdir()
+    outside.mkdir()
+    escaped_link = repo_root / "escaped-link"
+    symlink_or_skip("spec-dir confinement", escaped_link, outside)
+    monkeypatch.setattr(_mod, "_get_repo_root", lambda: repo_root.resolve())
+
+    with pytest.raises(ValueError, match="must be inside the repository"):
+        _mod._resolve_spec_dir(str(outside))
+    with pytest.raises(ValueError, match="must be inside the repository"):
+        _mod._resolve_spec_dir(str(escaped_link))
+
+
+def test_repo_root_ignores_git_relocation_environment(
+    tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Caller-set Git relocation must not redirect the confinement root."""
+    import subprocess
+
+    make_spec_dir(tmp)
+    foreign = tmp / "foreign"
+    foreign.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", str(foreign)], check=True, capture_output=True
+    )
+    monkeypatch.chdir(tmp)
+    monkeypatch.setenv("GIT_DIR", str(foreign / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(foreign))
+
+    assert _mod._get_repo_root() == tmp.resolve()
 
 
 def write_state(spec_dir: Path, state: dict) -> None:
@@ -129,7 +177,7 @@ def init_pair(tmp: Path, feature: str = "myfeature", mode: str = "code") -> tupl
     import subprocess
     proc = subprocess.run(
         [sys.executable, str(engine), "init", str(spec_dir), "--mode", mode, "--json"],
-        capture_output=True, text=True, check=False,
+        cwd=str(tmp), capture_output=True, text=True, check=False,
     )
     if proc.returncode != 0:
         raise RuntimeError(f"engine init failed: {proc.stderr.strip()}")
@@ -137,7 +185,7 @@ def init_pair(tmp: Path, feature: str = "myfeature", mode: str = "code") -> tupl
     # Cohort init
     proc2 = subprocess.run(
         [sys.executable, str(COHORT), "init", str(spec_dir), "--run-id", run_id],
-        capture_output=True, text=True, check=False,
+        cwd=str(tmp), capture_output=True, text=True, check=False,
     )
     if proc2.returncode != 0:
         raise RuntimeError(f"cohort init failed: {proc2.stderr.strip()}")
@@ -354,10 +402,13 @@ def test_status_rejects_symlinked_cohort_state(tmp: Path) -> None:
 
 
 # STUB: AC3 — a descriptor whose identity changes during the read is rejected.
-def test_cohort_state_reader_rejects_identity_change(tmp: Path) -> None:
+def test_cohort_state_reader_rejects_identity_change(
+    tmp: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     name = "cohort-state-reader-rejects-identity-change"
     sentinel = "identity-change-sentinel"
     spec_dir = make_spec_dir(tmp, name)
+    monkeypatch.chdir(tmp)
     path = spec_dir / "state.json"
     path.write_text(
         json.dumps({

--- a/packs/core/tests/skills/work-loop/test_loop_cohort_cli.py
+++ b/packs/core/tests/skills/work-loop/test_loop_cohort_cli.py
@@ -114,7 +114,10 @@ class LoopCohortCliTest(unittest.TestCase):
             prefix="loop-cohort-cli-", ignore_cleanup_errors=True
         )
         self.addCleanup(temporary.cleanup)
-        return Path(temporary.name)
+        root = Path(temporary.name)
+        subprocess.run(["git", "init", "-q", str(root)], check=True, capture_output=True)
+        self._cwd = root
+        return root
 
     def _spec_dir(self) -> Path:
         spec_dir = self._temp_root() / "spec1"
@@ -124,7 +127,7 @@ class LoopCohortCliTest(unittest.TestCase):
     def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [sys.executable, str(COHORT), *map(str, args)],
-            cwd=PACK_ROOT,
+            cwd=getattr(self, "_cwd", PACK_ROOT),
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/packs/core/tests/skills/work-loop/test_loop_cohort_schedule.py
+++ b/packs/core/tests/skills/work-loop/test_loop_cohort_schedule.py
@@ -213,31 +213,31 @@ def _schedule(tmp_path, plan_text):
             sys.executable, str(LC_PATH), "schedule", str(tmp_path),
             "--plan", str(plan), "--expect-run-id", run_id,
         ],
-        capture_output=True, text=True,
+        capture_output=True, text=True, cwd=str(tmp_path),
     )
 
 
-def test_schedule_prints_topological_order(tmp_path):
-    r = _schedule(tmp_path, _PLAN)
+def test_schedule_prints_topological_order(git_repo):
+    r = _schedule(git_repo, _PLAN)
     assert r.returncode == 0, r.stderr
     assert "wave 1: T1" in r.stdout
     assert "wave 2: T2" in r.stdout
 
 
-def test_schedule_exits_nonzero_on_cycle(tmp_path):
+def test_schedule_exits_nonzero_on_cycle(git_repo):
     r = _schedule(
-        tmp_path,
+        git_repo,
         "### T1: a\n**Depends on:** T2\n### T2: b\n**Depends on:** T1\n",
     )
     assert r.returncode != 0
     assert "cycle" in r.stderr.lower()
 
 
-def test_schedule_warns_but_reorders_on_forward_ref(tmp_path):
+def test_schedule_warns_but_reorders_on_forward_ref(git_repo):
     # a forward-ref is a valid acyclic edge: WARN (not fail) + reorder so the
     # dependency runs first. Cycles are the hard error (test above).
     r = _schedule(
-        tmp_path,
+        git_repo,
         "### T13: build\n**Depends on:** T15\n### T15: test\n**Depends on:** none\n",
     )
     assert r.returncode == 0, r.stderr
@@ -519,9 +519,9 @@ def test_wave_touches_disjoint_missing_blocks_yes_only():
 # ── PD-T3: schedule predicted-disjoint annotation + screen-only ──────────────
 
 
-def test_schedule_predicts_no_on_overlapping_touches(tmp_path):
+def test_schedule_predicts_no_on_overlapping_touches(git_repo):
     r = _schedule(
-        tmp_path,
+        git_repo,
         "### T1: a\n**Depends on:** none\n**Touches:** src/api/*\n"
         "### T2: b\n**Depends on:** none\n**Touches:** src/api/x.py\n",
     )
@@ -529,26 +529,26 @@ def test_schedule_predicts_no_on_overlapping_touches(tmp_path):
     assert "predicted-disjoint: no" in r.stdout
 
 
-def test_schedule_predicts_yes_on_disjoint_touches(tmp_path):
+def test_schedule_predicts_yes_on_disjoint_touches(git_repo):
     r = _schedule(
-        tmp_path,
+        git_repo,
         "### T1: a\n**Depends on:** none\n**Touches:** src/a/*\n"
         "### T2: b\n**Depends on:** none\n**Touches:** src/b/*\n",
     )
     assert "predicted-disjoint: yes" in r.stdout
 
 
-def test_schedule_predicts_unknown_when_a_task_omits_touches(tmp_path):
+def test_schedule_predicts_unknown_when_a_task_omits_touches(git_repo):
     r = _schedule(
-        tmp_path,
+        git_repo,
         "### T1: a\n**Depends on:** none\n**Touches:** src/a/*\n"
         "### T2: b\n**Depends on:** none\n",  # no Touches:
     )
     assert "predicted-disjoint: unknown" in r.stdout
 
 
-def test_schedule_no_annotation_on_single_task_wave(tmp_path):
-    r = _schedule(tmp_path, "### T1: a\n**Depends on:** none\n**Touches:** src/a/*\n")
+def test_schedule_no_annotation_on_single_task_wave(git_repo):
+    r = _schedule(git_repo, "### T1: a\n**Depends on:** none\n**Touches:** src/a/*\n")
     assert r.returncode == 0, r.stderr
     assert "predicted-disjoint" not in r.stdout  # single-task wave → no annotation
 
@@ -573,27 +573,27 @@ def test_schedule_is_screen_only_no_gate_call(tmp_path):
 import json as _json  # noqa: E402
 
 
-def _run_lc(*args):
+def _run_lc(*args, cwd: Path):
     return subprocess.run([sys.executable, str(LC_PATH), *args],
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, cwd=str(cwd))
 
 
-def test_init_state_has_auto_parallel_false(tmp_path):
-    spec = tmp_path / "spec"
+def test_init_state_has_auto_parallel_false(git_repo):
+    spec = git_repo / "spec"
     spec.mkdir()
     run_id = str(uuid.uuid4())
-    r = _run_lc("init", str(spec), "--run-id", run_id)
+    r = _run_lc("init", str(spec), "--run-id", run_id, cwd=git_repo)
     assert r.returncode == 0, r.stderr
     assert _json.loads((spec / "state.json").read_text())["auto_parallel"] is False
 
 
-def test_auto_parallel_verb_flips_both_ways(tmp_path):
+def test_auto_parallel_verb_flips_both_ways(git_repo):
     # Phase 1: auto-parallel verb is disabled — exits non-zero.
-    spec = tmp_path / "spec"
+    spec = git_repo / "spec"
     spec.mkdir()
     run_id = str(uuid.uuid4())
-    _run_lc("init", str(spec), "--run-id", run_id)
-    r = _run_lc("auto-parallel", str(spec))
+    _run_lc("init", str(spec), "--run-id", run_id, cwd=git_repo)
+    r = _run_lc("auto-parallel", str(spec), cwd=git_repo)
     assert r.returncode != 0
     assert "disabled in Phase 1" in r.stderr
 

--- a/packs/core/tests/skills/work-loop/test_loop_concurrency.py
+++ b/packs/core/tests/skills/work-loop/test_loop_concurrency.py
@@ -826,11 +826,9 @@ def test_lock_hold_budget() -> None:
 def test_the_guard_path_cannot_reach_lint_spec_status_git_calls() -> None:
     """AC21's reachability half: `lint-spec-status.py` is not scanned file-wide.
 
-    It imports `subprocess` and makes four `git` calls with no `timeout=`
-    (`resolve_default_base_ref`, `base_spec_text`, `_repo_root`). Those are fine
-    *because the guard path never invokes them* — and that claim is what needs an
-    artifact, since `workspace.toml`'s deferral record cites this assertion by name
-    as the reason the four calls are left unbounded.
+    Its Git calls are outside the engine's locked call graph. This assertion proves
+    that reachability boundary only: it does not scan `lint-spec-status.py` for
+    `timeout=` and must not grow into a separate lint gate.
 
     The guard path enters this module at exactly the symbols `_loop_guards.py`
     requires, so the roots are read from `_PARSER_SYMBOLS` rather than restated:

--- a/packs/core/tests/skills/work-loop/test_loop_guards.py
+++ b/packs/core/tests/skills/work-loop/test_loop_guards.py
@@ -1646,7 +1646,7 @@ _LOADERS = {
 )
 @pytest.mark.parametrize("loader", sorted(_LOADERS))
 def test_load_failure_is_a_one_line_refusal(
-    loader: str, mode: str, tmp_path: Path,
+    loader: str, mode: str, git_repo: Path,
 ) -> None:
     """Every way either module can fail to load produces a refusal, never a traceback.
 
@@ -1656,7 +1656,7 @@ def test_load_failure_is_a_one_line_refusal(
     """
     target_name, verb, cut_anchor, rename_symbol = _LOADERS[loader]
 
-    sandbox = tmp_path / "scripts"
+    sandbox = git_repo / "scripts"
     sandbox.mkdir()
     (sandbox.parent / "assets").mkdir()
     (sandbox.parent / "assets" / "state.json").write_bytes(
@@ -1739,7 +1739,7 @@ def test_load_failure_is_a_one_line_refusal(
             target.write_text(original.replace("_MODULE_COMPLETE = True", ""),
                               encoding="utf-8")
 
-    spec_dir = tmp_path / "spec"
+    spec_dir = git_repo / "spec"
     spec_dir.mkdir()
     if loader == "parser":
         # The parser is only reached once there is a status to read, so the fixture
@@ -1756,7 +1756,7 @@ def test_load_failure_is_a_one_line_refusal(
     # module and report a missing state.json instead of the load failure under test.
     run = subprocess.run(
         [sys.executable, str(sandbox / "loop-cohort.py"), *verb, str(spec_dir)],
-        capture_output=True, text=True, check=False, cwd=str(tmp_path),
+        capture_output=True, text=True, check=False, cwd=str(git_repo),
     )
     combined = run.stdout + run.stderr
     try:

--- a/packs/core/tests/skills/work-loop/test_loop_guards_parity.py
+++ b/packs/core/tests/skills/work-loop/test_loop_guards_parity.py
@@ -380,7 +380,7 @@ def _rows():
 @pytest.mark.parametrize(
     "key,kwargs,api,tool,argv", _rows(), ids=[r[0] for r in _rows()]
 )
-def test_api_and_cli_agree(key, kwargs, api, tool, argv, guards, goldens, tmp_path) -> None:
+def test_api_and_cli_agree(key, kwargs, api, tool, argv, guards, goldens, git_repo) -> None:
     golden = goldens.get(key)
     assert golden is not None, (
         f"{key} has no golden row. Every parity row must tie to T0's pre-change "
@@ -391,7 +391,7 @@ def test_api_and_cli_agree(key, kwargs, api, tool, argv, guards, goldens, tmp_pa
     kwargs = dict(kwargs)
     plan_status = kwargs.pop("plan_status_override", "Approved")
     dir_name = kwargs.pop("_dir_name", "spec")
-    spec_dir = build(guards, tmp_path, dir_name, plan_status=plan_status, **kwargs)
+    spec_dir = build(guards, git_repo, dir_name, plan_status=plan_status, **kwargs)
 
     api_result = api(guards, spec_dir)
     script = COHORT if tool == "cohort" else CHECK_STATUS
@@ -399,7 +399,7 @@ def test_api_and_cli_agree(key, kwargs, api, tool, argv, guards, goldens, tmp_pa
     assert any(a is spec_dir for a in resolved_argv), (
         f"{key}: argv has no {SPEC} placeholder, so the CLI would never see the fixture"
     )
-    rc, out, err = run_cli(script, resolved_argv, cwd=tmp_path)
+    rc, out, err = run_cli(script, resolved_argv, cwd=git_repo)
 
     # ── 1. verdict parity ──────────────────────────────────────────────────
     assert api_result.ok == (rc == 0), (

--- a/tests/roster/conftest.py
+++ b/tests/roster/conftest.py
@@ -1,0 +1,14 @@
+"""Shared pytest fixtures for roster tests that invoke Git-aware scripts."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide a temporary repository for fixtures requiring a repository root."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/roster/test_wave4_durable_outputs_and_release.py
+++ b/tests/roster/test_wave4_durable_outputs_and_release.py
@@ -7,6 +7,8 @@ import re
 import tomllib
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 SPEC_DIR = ROOT / "docs/specs/close-work-extraction-and-immediate-disposition"
 SURVEY = ROOT / "docs/rfc/0096-notes/open-source-context-lifecycle-survey.md"
@@ -15,6 +17,13 @@ SURVEY = ROOT / "docs/rfc/0096-notes/open-source-context-lifecycle-survey.md"
 def _read(relative: str) -> str:
     """Read one UTF-8 repository surface."""
     return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def _assert_core_manifest_versions_agree(
+    pack: dict[str, object], plugin: dict[str, object]
+) -> None:
+    """Require the shipped pack and plugin manifests to carry one version."""
+    assert pack["pack"]["version"] == plugin["version"]
 
 
 def test_every_planned_durable_output_exists_at_its_owner() -> None:
@@ -107,8 +116,7 @@ def test_core_release_metadata_and_history_agree() -> None:
     changelog = _read("docs/product/changelog.md")
     skill = _read("packs/core/.apm/skills/close-work/SKILL.md")
 
-    assert pack["pack"]["version"] == "2.15.0"
-    assert plugin["version"] == "2.15.0"
+    _assert_core_manifest_versions_agree(pack, plugin)
     assert "close-work" in pack["pack"]["evals"]["skills"]
     # Assert the invariant, not the calendar day. The release date is not this
     # test's to own — it moved twice while this branch was in review, and each
@@ -117,10 +125,19 @@ def test_core_release_metadata_and_history_agree() -> None:
     # the documented shape is all this line needs.
     assert re.search(
         r"^## \[core\]\[2\.15\.0\] — \d{4}-\d{2}-\d{2}$", changelog, re.M
-    ), "no dated top-level core 2.14.0 changelog heading"
+    ), "no dated top-level core changelog heading for this wave's release"
     assert "allowed-tools: Read Write Edit Bash" in skill
     for forbidden in ("WebFetch", "WebSearch", "MCP", "Browser", "Task"):
         assert forbidden not in skill.split("---", 2)[1]
+
+
+def test_core_release_metadata_rejects_manifest_version_drift() -> None:
+    """Mutation guard: a one-sided manifest-version change must be rejected."""
+    pack = {"pack": {"version": "2.15.1"}}
+    plugin = {"version": "2.15.0"}
+
+    with pytest.raises(AssertionError):
+        _assert_core_manifest_versions_agree(pack, plugin)
 
 
 def test_wave4_docs_keep_the_remaining_wave_boundary() -> None:

--- a/tests/roster/test_work_loop_root_validation.py
+++ b/tests/roster/test_work_loop_root_validation.py
@@ -118,7 +118,7 @@ def test_file_valued_root_exits_nonzero() -> None:
                 ok(name)
 
 
-def test_missing_report_classifies_invalid_not_crash() -> None:
+def test_missing_report_classifies_invalid_not_crash(git_repo: Path) -> None:
     """`review inspect --report <missing>` yields `invalid`, and still exits 0.
 
     `--report` is normalise-only at the boundary, unlike the two `--root`
@@ -132,35 +132,34 @@ def test_missing_report_classifies_invalid_not_crash() -> None:
     ever read — green for a reason that has nothing to do with `--report`.
     """
     name = "loop-cohort: missing --report classifies invalid (exit 0)"
-    with tempfile.TemporaryDirectory() as td:
-        spec_dir = Path(td) / "spec"
-        spec_dir.mkdir()
-        run_id = "00000000-1111-2222-3333-444444444444"
-        rc, out, err = run(LOOP_COHORT, "init", str(spec_dir), "--run-id", run_id)
-        if rc != 0 or not (spec_dir / "state.json").is_file():
-            fail(name, f"could not initialise a cohort fixture (rc={rc} err={err!r})")
-            return
+    spec_dir = git_repo / "spec"
+    spec_dir.mkdir()
+    run_id = "00000000-1111-2222-3333-444444444444"
+    rc, out, err = run(LOOP_COHORT, "init", str(spec_dir), "--run-id", run_id)
+    if rc != 0 or not (spec_dir / "state.json").is_file():
+        fail(name, f"could not initialise a cohort fixture (rc={rc} err={err!r})")
+        return
 
-        rc, out, err = run(
-            LOOP_COHORT, "review", "inspect", str(spec_dir),
-            "--report", "no-such-report.md", "--json",
-            cwd=Path(td),
-        )
-        combined = f"{out}\n{err}"
-        if "Traceback" in combined:
-            fail(name, f"raised a traceback instead of classifying:\n{combined}")
-        elif rc != 0:
-            fail(name, f"expected exit 0 for a report-content outcome, got {rc}: {combined!r}")
+    rc, out, err = run(
+        LOOP_COHORT, "review", "inspect", str(spec_dir),
+        "--report", "no-such-report.md", "--json",
+        cwd=git_repo,
+    )
+    combined = f"{out}\n{err}"
+    if "Traceback" in combined:
+        fail(name, f"raised a traceback instead of classifying:\n{combined}")
+    elif rc != 0:
+        fail(name, f"expected exit 0 for a report-content outcome, got {rc}: {combined!r}")
+    else:
+        try:
+            classification = json.loads(out)["classification"]
+        except (ValueError, KeyError) as exc:
+            fail(name, f"could not read classification from {out!r} ({exc})")
+            return
+        if classification != "invalid":
+            fail(name, f"expected classification 'invalid', got {classification!r}")
         else:
-            try:
-                classification = json.loads(out)["classification"]
-            except (ValueError, KeyError) as exc:
-                fail(name, f"could not read classification from {out!r} ({exc})")
-                return
-            if classification != "invalid":
-                fail(name, f"expected classification 'invalid', got {classification!r}")
-            else:
-                ok(name)
+            ok(name)
 
 
 def test_report_sites_route_through_resolver() -> None:

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -5,12 +5,12 @@
       "packages": [
         {
           "name": "core",
-          "version": "2.14.1"
+          "version": "2.15.1"
         }
       ],
       "date": "2026-08-28",
-      "heading": "[core][2.14.1] — 2026-08-28",
-      "changelogAnchor": "core2141--2026-08-28",
+      "heading": "[core][2.15.1] — 2026-08-28",
+      "changelogAnchor": "core2151--2026-08-28",
       "highlights": [
         {
           "source": "**Work-loop tools now reject execution state outside the current repository and finish safely when local Git stops responding.**",

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -5,6 +5,28 @@
       "packages": [
         {
           "name": "core",
+          "version": "2.14.1"
+        }
+      ],
+      "date": "2026-08-28",
+      "heading": "[core][2.14.1] — 2026-08-28",
+      "changelogAnchor": "core2141--2026-08-28",
+      "highlights": [
+        {
+          "source": "**Work-loop tools now reject execution state outside the current repository and finish safely when local Git stops responding.**",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "Work-loop tools now reject execution state outside the current repository and finish safely when local Git stops responding."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "packages": [
+        {
+          "name": "core",
           "version": "2.14.0"
         }
       ],


### PR DESCRIPTION
Two robustness fixes in `packs/core/.apm/skills/work-loop/scripts/`, sharing one pack version
bump (core 2.13.0 → 2.13.1). Independently reviewable.

## 1. Confinement (CWE-73) — `loop-cohort-resolve-spec-dir-confinement`

`loop-cohort.py`'s `_resolve_spec_dir` rejected only a literal `..` and called `.resolve()`
**before** any check, so an absolute or symlinked `--spec-dir` reached file operations
unconfined. Its twin `loop-engine.py:926` has always confined correctly; `loop-cohort` now
matches it.

The `GIT_DIR`/`GIT_WORK_TREE` stripping is not incidental — without it a caller-controlled
environment makes git report `/` as the toplevel and the containment check passes for any path
on the filesystem. Measured: `GIT_WORK_TREE=/tmp/x git rev-parse --show-toplevel` does redirect.

**Premise correction.** The backlog entry directs the fix through `append-knowledge.py`'s
`confine()`. **That function does not exist** — the only repo-wide match is
`confine_migration_path` in `workspace_status_engine.py`, a different contract. Parity with
`loop-engine` is the real fix.

`_get_repo_root` is duplicated rather than moved into `_loop_guards.py`, and that is the
module's own instruction: its contract says every public function "never spawns a process"
(`:17`), and its `spec_dir` precondition assigns confinement to each caller's own resolver by
name. Extraction would break both. That precondition's description of `loop-cohort` as
`..`-rejecting is updated here, since it is now repo-root anchored like its twin.

**Compatibility:** no invocation anywhere passes an absolute or out-of-tree `--spec-dir`; every
shipped example uses relative `docs/specs/<slug>`. No caller breaks.

## 2. Bounded git calls — `lint-spec-status-git-unbounded`

Five `subprocess.run` git calls had no `timeout=`, so a slow or wedged repository hung the lint
indefinitely. All five are now bounded at 20.0s — the local-git figure `loop-engine.py` and
`loop-cohort.py` already agree on — and each catches `TimeoutExpired` and degrades to that
site's pre-existing fallback.

`TimeoutExpired` is a `SubprocessError`, not an `OSError` or `FileNotFoundError`, so none of the
three existing handlers caught it: adding `timeout=` without a handler would have turned a hang
into a crash.

**Criterion:** no git call can block indefinitely, and a timeout produces the same observable
outcome as git being unavailable — never a traceback, never a false lint verdict.

### The review caught this criterion being violated

The first implementation returned `None` on timeout. But `None` already meant "absent at base",
and two diff-triggered invariants act on that — (vi) raised a hard violation against an
unchanged grandfathered spec, and (ii) treated an unchanged Shipped spec as newly transitioned.

Not hypothetical: `base_ref_resolves`'s own docstring records this exact failure, where a
`None`-for-every-spec result "red-lined an entire clean corpus, telling each author to add an
opt-out marker for a section that was there all along". That guard fixed it run-wide; the
timeout handler reintroduced it per-spec, underneath the guard.

A timeout now returns a private typed sentinel, so `None` keeps one meaning. The union return
type forces callers to handle the third state, and `check()` skips only (ii) and (vi) for that
spec — matching the run-wide `base_resolvable` precedent — while warning, so a skipped spec is
not silently unchecked.

The regression test asserts `check()`'s **observable output**, not the return value. Asserting
the return value is why the first test passed while the defect was live.

## Mutation proofs — 8, each run, each failing exactly its own test

| Invariant | Mutation |
|---|---|
| Confinement | delete `resolved.relative_to(repo_root)` |
| Git-env stripping | `safe_env` → `dict(os.environ)` |
| 5 × timeout degradation | remove `TimeoutExpired` from each handler |
| Base-read ambiguity | collapse the sentinel back to `None` → both false hard violations return |

## Gates

`test_lint_spec_status.py` 78 passed · `test_loop_cohort.py` 126 passed · `make lint-ruff` ·
`make lint-mypy` · `SKIP_SAST=1 make build-check` **EXIT=0, 0 errors** · `make sast` EXIT=0
(argv-boundary 8/8)

## Review

Independent security + adversarial review: **CHANGES REQUIRED** → all findings resolved.
One finding was **refuted with evidence**: the claim that `GIT_CONFIG_COUNT`/`core.worktree`
bypasses confinement does not reproduce on git 2.50.1, verified against a positive control
(`GIT_WORK_TREE` does redirect, and is already stripped).

A confirmed TOCTOU symlink-swap gap is **recorded, not fixed** — identical in `loop-engine.py`,
needs an `openat`/`O_NOFOLLOW` redesign, and a partial mitigation would read as a boundary that
is not one. It lands as a backlog entry.

Closes: `loop-cohort-resolve-spec-dir-confinement`
Closes: `lint-spec-status-git-unbounded`