### PR TITLE
fix(tools): bound the age of the publish-control evidence

### DIFF
--- a/tools/lint-claude-plugin-publish-control.py
+++ b/tools/lint-claude-plugin-publish-control.py
@@ -9,6 +9,7 @@ import json
 import re
 import sys
 import tomllib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -21,6 +22,13 @@ EVIDENCE_PATH = (
     / "publish-control-evidence.json"
 )
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publish-claude-plugins.yml"
+
+# Capturing this evidence requires a maintainer-only GitHub App private key and
+# has no automated refresh. Warn at 30 days so stale controls are visible
+# without breaking routine gates, but fail at 90 days so the artifact cannot
+# certify settings indefinitely.
+EVIDENCE_WARN_AFTER = timedelta(days=30)
+EVIDENCE_FAIL_AFTER = timedelta(days=90)
 
 # AC36 — the workflow must authenticate with the identity that actually exists.
 # Presence of the committed evidence file is the only offline signal for whether
@@ -393,7 +401,52 @@ def validate_desired(desired: dict) -> list[str]:
     return errors
 
 
-def compare_evidence(desired: dict, evidence: dict) -> list[str]:
+def _validate_evidence_freshness(
+    evidence: dict, now_utc: datetime | None = None
+) -> tuple[list[str], list[str]]:
+    """Return timestamp errors and non-fatal freshness warnings for evidence."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    observed_at = evidence.get("observed_at")
+    if not isinstance(observed_at, str) or not observed_at:
+        return ["evidence must include a non-empty observed_at timestamp"], warnings
+    try:
+        observed = datetime.fromisoformat(observed_at)
+    except ValueError:
+        return ["evidence observed_at must be an ISO 8601 timestamp"], warnings
+    if observed.tzinfo is None or observed.utcoffset() is None:
+        return ["evidence observed_at must include a timezone offset"], warnings
+
+    current = datetime.now(UTC) if now_utc is None else now_utc
+    if current.tzinfo is None or current.utcoffset() is None:
+        raise ValueError("now_utc must be timezone-aware")
+    age = current.astimezone(UTC) - observed.astimezone(UTC)
+    if age < timedelta(0):
+        # Future evidence cannot demonstrate that controls were actually
+        # observed; accepting it would let a hand-edited timestamp bypass both
+        # freshness thresholds.
+        errors.append("evidence observed_at must not be in the future")
+    elif age > EVIDENCE_FAIL_AFTER:
+        errors.append(
+            "evidence observed_at is older than "
+            f"{EVIDENCE_FAIL_AFTER.days} days; recapture publish-control evidence"
+        )
+    elif age > EVIDENCE_WARN_AFTER:
+        warnings.append(
+            "evidence observed_at is older than "
+            f"{EVIDENCE_WARN_AFTER.days} days; recapture publish-control evidence "
+            f"before {EVIDENCE_FAIL_AFTER.days} days"
+        )
+    return errors, warnings
+
+
+def compare_evidence(
+    desired: dict,
+    evidence: dict,
+    *,
+    now_utc: datetime | None = None,
+    warnings: list[str] | None = None,
+) -> list[str]:
     """Compare independently captured sanitized state with desired state."""
     errors: list[str] = []
     # Against the literal, not against each other: `.get(...) != .get(...)`
@@ -445,16 +498,19 @@ def compare_evidence(desired: dict, evidence: dict) -> list[str]:
         )
     if evidence.get("canary") != desired.get("canary"):
         errors.append("evidence canary differs from desired control")
-    observed_at = evidence.get("observed_at")
-    if not isinstance(observed_at, str) or not observed_at:
-        errors.append("evidence must include a non-empty observed_at timestamp")
+    freshness_errors, freshness_warnings = _validate_evidence_freshness(
+        evidence, now_utc
+    )
+    errors.extend(freshness_errors)
+    if warnings is not None:
+        warnings.extend(freshness_warnings)
     source = evidence.get("observation_source")
     if source != "github-api-sanitized":
         errors.append("evidence observation_source must be github-api-sanitized")
     return errors
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None, *, now_utc: datetime | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--desired", type=Path, default=DESIRED_PATH)
     parser.add_argument("--evidence", type=Path, default=EVIDENCE_PATH)
@@ -478,6 +534,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"lint-claude-plugin-publish-control: {exc}", file=sys.stderr)
         return 1
     errors = validate_desired(desired)
+    warnings: list[str] = []
     if args.subject is not None and args.subject != desired.get("repo"):
         errors.append(
             f"this run is in {args.subject!r} but the publication control is "
@@ -496,7 +553,11 @@ def main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             errors.append(str(exc))
         else:
-            errors.extend(compare_evidence(desired, evidence))
+            errors.extend(
+                compare_evidence(
+                    desired, evidence, now_utc=now_utc, warnings=warnings
+                )
+            )
     elif (
         desired.get("control_status") == "decommissioned"
         and not args.require_live_evidence
@@ -518,6 +579,8 @@ def main(argv: list[str] | None = None) -> int:
 
     for error in errors:
         print(f"lint-claude-plugin-publish-control: {error}", file=sys.stderr)
+    for warning in warnings:
+        print(f"lint-claude-plugin-publish-control: warning: {warning}", file=sys.stderr)
     return 1 if errors else 0
 
 

--- a/tools/test-lint-claude-plugin-publish-control.py
+++ b/tools/test-lint-claude-plugin-publish-control.py
@@ -7,6 +7,7 @@ import copy
 import importlib.util
 import json
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 SCRIPT = Path(__file__).with_name("lint-claude-plugin-publish-control.py")
@@ -14,6 +15,8 @@ SPEC = importlib.util.spec_from_file_location("publish_control_lint", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 lint = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(lint)
+
+TEST_NOW = datetime(2026, 8, 28, tzinfo=UTC)
 
 
 def main() -> int:
@@ -145,7 +148,37 @@ def main() -> int:
             "observation_source": "github-api-sanitized",
         }
     )
-    check("matching independent evidence passes", not lint.compare_evidence(desired, evidence))
+    check(
+        "matching independent evidence passes",
+        not lint.compare_evidence(desired, evidence, now_utc=TEST_NOW),
+    )
+
+    def freshness_result(observed_at: str) -> tuple[list[str], list[str]]:
+        changed = copy.deepcopy(evidence)
+        changed["observed_at"] = observed_at
+        warnings: list[str] = []
+        errors = lint.compare_evidence(
+            desired, changed, now_utc=TEST_NOW, warnings=warnings
+        )
+        return errors, warnings
+
+    fresh_errors, fresh_warnings = freshness_result("2026-08-27T00:00:00Z")
+    check(
+        "fresh evidence has no warning or error", not fresh_errors and not fresh_warnings
+    )
+    warn_errors, warn_warnings = freshness_result("2026-07-28T00:00:00Z")
+    check(
+        "31-day-old evidence warns without an error",
+        not warn_errors and bool(warn_warnings),
+    )
+    fail_errors, fail_warnings = freshness_result("2026-05-29T00:00:00Z")
+    check("91-day-old evidence fails", bool(fail_errors) and not fail_warnings)
+    malformed_errors, _ = freshness_result("not-a-timestamp")
+    check("non-ISO observed_at fails", bool(malformed_errors))
+    naive_errors, _ = freshness_result("2026-08-10T00:00:00")
+    check("naive observed_at fails without a TypeError", bool(naive_errors))
+    future_errors, _ = freshness_result("2026-08-29T00:00:00Z")
+    check("future-dated evidence fails", bool(future_errors))
 
     mutations = {
         "bypass actor": ("branch", "bypass", "actor_type", "OrganizationAdmin"),
@@ -166,20 +199,20 @@ def main() -> int:
         changed["repo"] = value
         check(
             f"evidence naming {label} fails",
-            bool(lint.compare_evidence(desired, changed)),
+            bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
         )
     changed = copy.deepcopy(evidence)
     changed.pop("repo")
     check(
         "evidence with no repo at all fails",
-        bool(lint.compare_evidence(desired, changed)),
+        bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
     )
     # Both keys absent compare EQUAL, so without a self-standing check the
     # binding would rest on validate_desired happening to run first.
     stripped_desired = {k: v for k, v in desired.items() if k != "repo"}
     check(
         "evidence and desired BOTH missing repo still fails",
-        bool(lint.compare_evidence(stripped_desired, changed)),
+        bool(lint.compare_evidence(stripped_desired, changed, now_utc=TEST_NOW)),
     )
     # The schema-version comparison is the only thing that rejects a stale v1
     # artifact against the v2 desired file -- the migration this change makes.
@@ -187,7 +220,7 @@ def main() -> int:
     changed["version"] = 1
     check(
         "stale v1 evidence against a v2 desired control fails",
-        bool(lint.compare_evidence(desired, changed)),
+        bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
     )
 
     # --subject: the one half of the binding a fork or clone cannot satisfy,
@@ -210,14 +243,27 @@ def main() -> int:
             ("an empty subject is refused", "", 1),
         ):
             argv = list(base) if subject is None else [*base, "--subject", subject]
-            check(f"--subject: {label}", lint.main(argv) == expected)
+            check(
+                f"--subject: {label}", lint.main(argv, now_utc=TEST_NOW) == expected
+            )
+
+        warning_evidence = copy.deepcopy(evidence)
+        warning_evidence["observed_at"] = "2026-07-28T00:00:00Z"
+        evidence_path.write_text(json.dumps(warning_evidence), encoding="utf-8")
+        check(
+            "31-day warning does not change the lint exit code",
+            lint.main(base, now_utc=TEST_NOW) == 0,
+        )
     for name, (group, key, nested, value) in mutations.items():
         changed = copy.deepcopy(evidence)
         if nested is None:
             changed[group][key] = value
         else:
             changed[group][key][nested] = value
-        check(f"mutated {name} fails", bool(lint.compare_evidence(desired, changed)))
+        check(
+            f"mutated {name} fails",
+            bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
+        )
 
     for label, mutate in (
         ("absent", lambda e: e.pop("identities_agree")),
@@ -228,7 +274,7 @@ def main() -> int:
         mutate(changed)
         check(
             f"identities_agree {label} fails",
-            bool(lint.compare_evidence(desired, changed)),
+            bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
         )
 
     for label, path in (
@@ -243,7 +289,7 @@ def main() -> int:
         cursor[path[-1]] = 4242424
         check(
             f"a leaked {label} fails",
-            bool(lint.compare_evidence(desired, changed)),
+            bool(lint.compare_evidence(desired, changed, now_utc=TEST_NOW)),
         )
     check(
         "a nested identifier anywhere is caught by the walk",


### PR DESCRIPTION
## The gap

`tools/lint-claude-plugin-publish-control.py:448-450` validated `observed_at` as a non-empty
string and nothing else, so a stale artifact could certify branch-protection settings that had
since changed. The committed evidence is **16 days old** today.

## Why two tiers rather than one

Regenerating this evidence requires `tools/capture-publish-control-evidence.py` with a
maintainer-only GitHub App private key, and there is **no automated refresh**. A single 30-day
hard bound on a 16-day-old artifact would have reddened `make build-check` and the publish
workflow in ~14 days, with nobody but the credential holder able to clear it — trading a silent
gap for a scheduled outage.

| Age | Behaviour |
|---|---|
| ≤ 30 days | quiet |
| > 30 days | **warn** — exit code unchanged |
| > 90 days | **error** |

The warning cannot change the exit code: `main` derives status solely from `errors`, and
freshness warnings accumulate in a separate list that is only printed. Verified across the
`--subject`, `--require-live-evidence` and `decommissioned` branches.

## Errors at any age

Three shapes error regardless of age, because each would otherwise be a worse fail-open than the
gap being closed:

- **non-ISO** `observed_at`
- **naive** timestamp with no offset (would also have raised `TypeError` on the comparison)
- **future-dated** — accepting it would let a hand-edited timestamp bypass *both* thresholds

## The `now_utc` seam

Age is computed against an injected keyword argument, not `datetime.now()` read at the call site.
The existing test fixture's timestamp is already older than 90 days against a real clock, so
reading the clock directly would have rotted that fixture and every future one.

## Mutation proofs — 5, each caught by exactly its own named test

| Mutation | Caught by |
|---|---|
| warn tier → hard error | `31-day-old evidence warns without an error` **and** `31-day warning does not change the lint exit code` |
| fail tier disabled | `91-day-old evidence fails` |
| future check disabled | `future-dated evidence fails` |
| naive check disabled | `naive observed_at fails without a TypeError` |
| non-ISO check disabled | `non-ISO observed_at fails` |

The first is the one that mattered: "warns without failing" is the property most likely to be
asserted vacuously, and it is pinned by a dedicated exit-code assertion.

## Gates

`python3 tools/test-lint-claude-plugin-publish-control.py` exit 0 · `make lint-ruff` ·
`make lint-mypy` · `SKIP_SAST=1 make build-check` **exit 0, 0 errors** · `make sast` exit 0 ·
the real committed evidence still exits 0 today.

Independent security + adversarial review: **CLEAN**, with per-axis evidence including
publish-path reachability (no workflow flag can skip the age check) and threshold boundary
behaviour.

## Scope

`tools/**` only — ships in no release, so no changelog entry and no version bump. The evidence
JSON, the capture tool and the publish workflow are untouched.

Closes: `publish-control-evidence-max-age`