### PR TITLE
test(tools): assert site contracts against parsed structure, not source text

### DIFF
--- a/tools/test_catalogue_navigation.py
+++ b/tools/test_catalogue_navigation.py
@@ -22,6 +22,16 @@ MARKDOWN_SURFACES = (
     REPO_ROOT / "docs-site/src/content/docs/index.mdx",
 )
 EXCLUDED_PACKS = {"user-guide-diataxis"}
+CATALOGUE_IMPORT = re.compile(
+    r"^import\s+\{\s*(?P<bindings>[^}]+?)\s*\}\s+from\s+"
+    r"['\"](?P<module>(?:\.\./)+lib/catalogue-navigation(?:\.ts)?)['\"]\s*;?\s*$",
+    flags=re.MULTILINE,
+)
+# This detects only direct `const|let|var outcomes =` declarations; aliased or
+# destructured bindings and object-literal `outcomes:` values remain outside regex coverage.
+LOCAL_OUTCOMES_DECLARATION = re.compile(
+    r"^\s*(?:const|let|var)\s+outcomes\s*=", flags=re.MULTILINE
+)
 
 
 def _navigation_source() -> str:
@@ -53,8 +63,20 @@ def test_all_active_packs_have_an_outcome() -> None:
 def test_marketing_surfaces_import_the_canonical_map() -> None:
     for surface in MARKETING_SURFACES:
         content = surface.read_text(encoding="utf-8")
-        assert "../../lib/catalogue-navigation" in content, surface
-        assert "const outcomes = [" not in content, surface
+        import_match = CATALOGUE_IMPORT.search(content)
+        assert import_match is not None, f"{surface}: imports catalogue-navigation"
+        bindings = {
+            binding.strip()
+            for binding in import_match.group("bindings").split(",")
+        }
+        assert "catalogueOutcomes" in bindings, f"{surface}: imports catalogueOutcomes"
+        imported_module = surface.parent / import_match.group("module")
+        assert imported_module.with_suffix(".ts").resolve() == NAVIGATION_SOURCE.resolve(), (
+            f"{surface}: catalogueOutcomes import resolves to canonical navigation source"
+        )
+        assert not LOCAL_OUTCOMES_DECLARATION.search(content), (
+            f"{surface}: must not declare a local outcomes map"
+        )
 
 
 def test_markdown_entry_points_keep_canonical_outcome_labels() -> None:

--- a/tools/test_check_rendered_site_links.py
+++ b/tools/test_check_rendered_site_links.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CHECKER = REPO_ROOT / "tools" / "check-rendered-site-links.py"
@@ -333,15 +334,64 @@ def test_local_site_gate_builds_before_audit_and_aggregates_focused_tests() -> N
 
 
 def test_pages_gate_runs_after_both_builds_before_upload_and_has_path_filters() -> None:
-    workflow = (REPO_ROOT / ".github/workflows/pages.yml").read_text(encoding="utf-8")
-
-    marketing_build = workflow.index("run: npm run build --prefix web")
-    docs_build = workflow.index("run: npm run build --prefix docs-site")
-    link_check = workflow.index(
-        "run: python3 tools/check-rendered-site-links.py --build-dir build"
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/pages.yml").read_text(encoding="utf-8")
     )
-    upload = workflow.index("uses: actions/upload-pages-artifact@")
+    assert isinstance(workflow, dict), "pages workflow must decode to a mapping"
 
-    assert marketing_build < docs_build < link_check < upload
-    assert workflow.count("- 'tools/check-rendered-site-links.py'") == 2
-    assert workflow.count("- 'tools/test_check_rendered_site_links.py'") == 2
+    # PyYAML follows YAML 1.1 here, where an unquoted `on` key becomes Boolean true.
+    if True in workflow:
+        triggers = workflow[True]
+    elif "on" in workflow:
+        triggers = workflow["on"]
+    else:
+        raise AssertionError("pages workflow must define an 'on' trigger mapping")
+    assert isinstance(triggers, dict), "pages workflow must define trigger mappings"
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "pages workflow must define job mappings"
+    build_job = jobs.get("build")
+    assert isinstance(build_job, dict), "pages workflow must define the build job"
+    steps = build_job.get("steps")
+    assert isinstance(steps, list), "pages build job must define an ordered steps list"
+
+    def step_index(run: str) -> int:
+        matches = [
+            index
+            for index, step in enumerate(steps)
+            if isinstance(step, dict)
+            and isinstance(step.get("run"), str)
+            and step["run"].strip() == run
+        ]
+        assert len(matches) == 1, f"build job must contain exactly one step running {run!r}"
+        return matches[0]
+
+    marketing_build = step_index("npm run build --prefix web")
+    docs_build = step_index("npm run build --prefix docs-site")
+    link_check = step_index("python3 tools/check-rendered-site-links.py --build-dir build")
+    upload_steps = [
+        index
+        for index, step in enumerate(steps)
+        if isinstance(step, dict)
+        and isinstance(step.get("uses"), str)
+        and step["uses"].startswith("actions/upload-pages-artifact@")
+    ]
+
+    assert len(upload_steps) == 1, (
+        "build job must contain exactly one Pages artifact upload"
+    )
+    assert marketing_build < docs_build < link_check < upload_steps[0], (
+        "build job must build web, then docs, check links, then upload the artifact"
+    )
+
+    for trigger_name in ("push", "pull_request"):
+        trigger = triggers.get(trigger_name)
+        assert isinstance(trigger, dict), f"{trigger_name} trigger must be a mapping"
+        paths = trigger.get("paths")
+        assert isinstance(paths, list), f"{trigger_name} trigger must define a paths list"
+        for path in (
+            "tools/check-rendered-site-links.py",
+            "tools/test_check_rendered_site_links.py",
+        ):
+            assert paths.count(path) == 1, (
+                f"{trigger_name} paths must include {path!r} exactly once"
+            )


### PR DESCRIPTION
Two tests asserted against raw source text, so they broke on reformatting that changed nothing
and stayed green on changes that mattered. Test-only change.

## Measured old-vs-new — every mutation applied and run

| Mutation | Old test | New test |
|---|---|---|
| Web build moved to a different job, **source order preserved** | **survives** | catches |
| Required path duplicated under `push`, removed from `pull_request` (total still 2) | **survives** | catches |
| `run:` refolded to a `>-` block scalar (semantic no-op) | **fails wrongly** | passes |
| `const  outcomes = [` (two spaces) | **survives** | catches |

The second is a real gate hole rather than a hypothetical: `pull_request` loses the filter
entirely, so the link-check gate stops running on PRs that touch that file — while the whole-file
`count(...) == 2` stays satisfied and the old assertion stays green.

## pages.yml

`str.index()` on run-command substrings ordered four steps by their position **in the file** —
it could not even tell you they were in the same job. Now parsed with PyYAML: the four steps are
ordered *within* `jobs.build.steps`, and each required path must appear **exactly once under each
of** `push` and `pull_request`.

Triggers are read as either `workflow[True]` or `workflow["on"]`. PyYAML follows YAML 1.1, where
an unquoted `on:` resolves to boolean true — but `"on":` is an equally legal Actions spelling and
would otherwise raise an opaque `KeyError: True`. That is the same class of false-failure-on-a-
legal-reformat this change exists to remove, so accepting one spelling and not the other would
have traded one brittleness for another. Absent both, the failure names what was expected.
Container lookups are assertion-backed so every failure in this test reads alike.

## Astro surfaces

`"..." in content` matched a substring anywhere — including inside a comment or a string literal
— and the negative `"const outcomes = [" not in content` passed for any spelling the author did
not anticipate.

No Astro parser is available and adding a dependency was out of scope, so the check is now an
anchored ES import pattern that verifies the `catalogueOutcomes` binding and **resolves the
import to a real file on disk** against the canonical source — structural, not textual — plus a
whitespace-tolerant local-declaration guard.

**Its residual limit is named in a comment rather than papered over.** The local check is
name-based, so an alias, a destructured binding, or an object-literal property still passes. That
is not lost coverage (the old test missed the same shapes), and a cleverer regex would *look*
stronger than it is — which is precisely the defect this change removes.

## Gates

`pytest` both files **26 passed** · `make lint-ruff` · `make lint-mypy` ·
`SKIP_SAST=1 make build-check` **exit 0, 0 errors**

Independent review: **CHANGES REQUIRED** → all findings resolved. I re-ran the two decisive
mutations by hand: the quoted `"on":` spelling now passes, and a workflow with neither spelling
fails with the new assertion message rather than a `KeyError`.

## Scope

`tools/**` test files only — ships in no release, so no changelog entry and no version bump.
`pages.yml`, `web/src/**` and the deliberately stdlib-only `tools/test-build-check-workflow.py`
are untouched. PyYAML needs no new dependency (`tools/requirements.txt:4`).

Closes: `site-test-source-substring-assertions`