### PR TITLE
docs(rfc): record the RFC-0099 follow-on ledger

### DIFF
--- a/docs/rfc/0099-cut-before-adding-and-artifact-shaping.md
+++ b/docs/rfc/0099-cut-before-adding-and-artifact-shaping.md
@@ -1033,3 +1033,28 @@ record. Corrections are appended here, Approver-signed.
   change, so it belongs to the next change that touches the work-loop
   re-drafting path rather than to a spec of its own. Until it lands, an
   amendment reseals without the cold contract review this RFC requires.
+- **2026-08-31 (Approver: eugenelim) — follow-on ledger: five of six discharged;
+  the status field stays `Accepted`.** This RFC's declared vocabulary is
+  `Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn |
+  Experimental`. There is no implemented or shipped status, so `Accepted`
+  remains terminal and the header does not move; delivery is recorded here
+  instead. **#1 Charter and decision records — discharged.** The reviewer-ceiling
+  amendment is live in the charter, ADR-0098 and ADR-0099 exist, and the
+  RFC-0083 and RFC-0096 Errata entries are in place. **#2 Core guidance and
+  artifact routing — Shipped.** **#3 Shaping review and author integrations —
+  Shipped.** **#4 RFC and architecture simplification — Shipped.** **#5
+  Sealed-baseline replacement — discharged as delivered** and Archived; see the
+  2026-08-30 entries. **#6 Migration and validation record — partly open.** Its
+  route and alias migration guidance is published, and the alias removal window
+  is recorded as at least two minor Core releases and 90 days, whichever is
+  later, with removal gated and rollback named. Its executable fixtures were
+  discharged per-spec rather than centrally, as section 6 intended: each shipped
+  spec carries its applicable families as satisfied acceptance items. Two pieces
+  remain. The adopter routing study evidence has no published artifact — the
+  answer key and pass condition exist only in this document, so the study that
+  gated acceptance cannot be independently re-read. And the versioned fixture
+  specification that section 6 required before acceptance was never created, so
+  no central register proves all seven fixture families are covered across the
+  three shipped specs. Both are records of completed work, not new capability;
+  closing them is a publication task. Until they close, this RFC is delivered
+  but not auditable end to end.


### PR DESCRIPTION
## Why

Four of six follow-ons are delivered and the fifth is discharged, but the RFC still reads as if all six are outstanding — `## Follow-on artifacts` is preserved body text, so a reader of this document alone cannot tell what is done.

## The status field does not move

The declared vocabulary in `new-rfc/assets/rfc.md` is `Draft | Open | Final Comment Period | Accepted | Rejected | Withdrawn | Experimental`. There is no "Implemented" or "Shipped" value — across 100 RFCs on `main`, 99 are `Accepted` and one is `Draft`. **`Accepted` is terminal.** Delivery is recorded in Errata instead.

## Ledger

| Follow-on | State |
|---|---|
| #1 Charter and decision records | Discharged — charter amendment live, ADR-0098 + ADR-0099 exist, RFC-0083 + RFC-0096 errata in place |
| #2 Core guidance and artifact routing | Shipped |
| #3 Shaping review and author integrations | Shipped |
| #4 RFC and architecture simplification | Shipped (#1178) |
| #5 Sealed-baseline replacement | Discharged as delivered; Archived |
| #6 Migration and validation record | **Partly open** |

## What #6 still owes

**Closed:** route and alias migration guidance is published, and the alias removal window is recorded as at least two minor Core releases and 90 days, whichever is later, with removal gated and rollback named.

**Also closed, distributed rather than central:** the executable fixtures. §Contract fixtures says "each follow-on spec must run its applicable set clean before shipping," and the shipped specs carry their families as satisfied acceptance items.

**Open — two records:**
1. The **adopter routing study evidence** has no published artifact. The R1–R12 answer key and pass condition exist only inside the RFC, so the study that gated acceptance cannot be independently re-read.
2. The **versioned fixture specification** that §Contract fixtures required *before* acceptance was never created, so nothing proves all seven fixture families are covered across the three shipped specs rather than five or six.

Both are publication tasks over completed work, not new capability. Until they close, RFC-0099 is delivered but not auditable end to end.

## Verification

- Every claim checked against the repository before staging: the status vocabulary in `new-rfc`'s template, all four spec statuses, and the alias window text at `work-intake-maintenance.md:125-127`.
- `SKIP_SAST=1 make build-check` → `MAKE_EXIT=0`.
- **First run failed** with `MAKE_EXIT=2`, `CAT-V-014 dist/claude-plugins/marketplace.json generated output differs`. Cause was a stale gitignored `dist/` in the worktree carrying `architect 0.15.4` against source `0.15.5` after #1178's bump — unrelated to this diff. Regenerated with `make build` (the chain's own `agentbundle catalogue build`) rather than hand-patching the generated JSON, then re-verified clean.