### PR TITLE
ci: give catalogue-tooling-ci-gates a least-privilege token posture

### DIFF
--- a/.github/workflows/catalogue-tooling-ci-gates.yml
+++ b/.github/workflows/catalogue-tooling-ci-gates.yml
@@ -35,6 +35,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
 
   # ── Gate A-tests: complete agentbundle test discovery ─────────────────────
@@ -64,6 +67,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
@@ -129,6 +134,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python }}
@@ -212,6 +219,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
@@ -279,6 +288,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
@@ -371,6 +382,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
@@ -449,6 +462,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
@@ -506,6 +521,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
@@ -525,6 +542,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"

--- a/tools/check-zizmor-excessive-permissions.py
+++ b/tools/check-zizmor-excessive-permissions.py
@@ -4,7 +4,14 @@
 The broad zizmor gate intentionally retains its high-severity floor. Lowering it
 would also make the repository's unrelated medium/low findings block this job.
 This focused companion run keeps `excessive-permissions` continuously enforced
-for the two workflows closed by the CI-posture backlog item.
+for the three workflows closed by the CI-posture backlog items.
+
+Scope note, because the two halves of a token posture are separate zizmor
+audits: this guard filters on `excessive-permissions` alone, so it makes a
+workflow's `permissions:` block durable and says nothing about
+`persist-credentials:` on its checkouts — that is the `artipacked` ident, still
+only visible to the broad gate at its high-severity floor. The uncovered half is
+recorded in `workflow-posture-guard-coverage-gaps`.
 """
 
 from __future__ import annotations
@@ -18,6 +25,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = (
     ".github/workflows/build-check-windows.yml",
+    ".github/workflows/catalogue-tooling-ci-gates.yml",
     ".github/workflows/codeql.yml",
 )
 AUDIT = "excessive-permissions"

--- a/workspace.toml
+++ b/workspace.toml
@@ -543,6 +543,17 @@ open = [
   # present — which would make the no-install state fully green and consistent with
   # ADR-0094 — or whether the local gate should provision per worktree.
   {slug = "pre-existing-marketplace-parity-needs-an-editable-agentbundle", source = "pre-flight/2026-08-28"},
+  # Added 2026-08-31 by the catalogue-tooling token-posture change, so the gap is
+  # registered rather than assumed covered: tools/check-zizmor-excessive-permissions.py
+  # filters on the `excessive-permissions` ident alone, so adding a workflow to its
+  # WORKFLOWS tuple makes that workflow's top-level `permissions:` block durable and
+  # asserts NOTHING about `persist-credentials:` on its checkouts. That is zizmor's
+  # separate `artipacked` ident, visible only to the broad gate, which runs at
+  # --min-severity high while artipacked is medium — so removing
+  # `persist-credentials: false` from any checkout in any workflow still lands green.
+  # To close: decide whether this guard grows a second ident (its name and docstring
+  # are scoped to one), whether a sibling guard owns artipacked, or whether the broad
+  # gate's floor drops for that ident alone.
   {slug = "workflow-posture-guard-coverage-gaps", source = "security+quality review of the posture assertion-proof change"},
   # permissions: contents: read + persist-credentials: false for
   # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions

--- a/workspace.toml
+++ b/workspace.toml
@@ -555,17 +555,6 @@ open = [
   # are scoped to one), whether a sibling guard owns artipacked, or whether the broad
   # gate's floor drops for that ident alone.
   {slug = "workflow-posture-guard-coverage-gaps", source = "security+quality review of the posture assertion-proof change"},
-  # permissions: contents: read + persist-credentials: false for
-  # catalogue-tooling-ci-gates.yml — one of three workflows with no permissions
-  # block. Deliberately NOT bundled into spec/ci-gate-parallelization's Gate A
-  # split even though that change already has the file open: this is a seven-gate
-  # workflow whose Gates D and E upload and download an artifact, and nothing in
-  # that spec reviewed Gates B–G for token use. (The artifact actions use
-  # ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN, so contents: read is very
-  # likely safe — but "very likely safe" is a verification, not the mechanical
-  # ride-along the bundled-fixes carve-out admits.) To close: review all seven
-  # gates for token use, artifact movement and git writes, then apply.
-  {slug = "catalogue-tooling-workflow-hardening", source = "spec/ci-gate-parallelization AC12"},
   # DECISION, recorded so it is not re-proposed: a GitHub merge queue was evaluated
   # as the fix for branch protection's strict:true rebase-and-rerun thrash and was
   # REJECTED. Two reasons, in order. (1) It does not address the complaint that
@@ -1897,6 +1886,8 @@ open = [
 # Resolved repo-durable items. Kept rather than deleted so a reader who arrives
 # from a stale reference finds the disposition instead of a silent gap.
 closed = [
+  {slug = "catalogue-tooling-workflow-hardening", source = "spec/ci-gate-parallelization AC12", summary = "Closed 2026-08-31 by PR #1184. catalogue-tooling-ci-gates.yml was the only workflow with no top-level permissions block; the entry's \"one of three\" was already stale. All eight jobs reviewed before applying: no step references GITHUB_TOKEN, github.token or any secret, none writes to git, and the artifact actions authenticate with ACTIONS_RUNTIME_TOKEN while download-artifact's optional github-token input is unset -- so the entry's \"very likely safe\" is now measured. Gate G keeps fetch-depth: 0 because check_release_impact.py shells out to git diff alone. zizmor --min-severity low on the file went from 17 medium findings (8 artipacked plus excessive-permissions) to none; the broad gate runs at high, so this was never a red gate and its threshold is unchanged. Security review then found the new posture unasserted, so the workflow joins check-zizmor-excessive-permissions.py's WORKFLOWS tuple -- mutation-proven, deleting the block exits 1. The persist-credentials half stays uncovered because artipacked is a separate ident below the broad gate's floor; that gap is recorded against workflow-posture-guard-coverage-gaps rather than left implied"},
+
   {slug = "tdd-stub-replaces-prose", source = "docs/product/intents/tdd-stub-replaces-prose.md", summary = "Closed 2026-08-30 as delivered in core 2.16.3. The accepted semantic rule stands: exact executable test code replaces behavior-restating prose. PLAN now owns bounded, no-network, timeout-limited, filesystem-confined validation from disposable scratch and writes no repository test; failed compile or intended-red proof blocks approval unless the closed implementation-discovered exception applies. Code-mode EXECUTE materializes the approved payload only after CODE-IMPLEMENTATION, using an explicit one-terminal-newline byte contract, then completes red-green-refactor. RFC-0028 errata, conventions, architecture, adopter guides, evals, projections, and regression tests carry the durable result"},
 
   {slug = "contract-amendment-pre-wave-window", source = "docs/product/intents/contract-amendment-pre-wave-window.md", summary = "Closed 2026-08-29 as a bug fix in core 2.15.5. contract-amendment refused until a task had completed, so the pre-wave window — baseline sealed, current_wave_index 0, review finding a defect before wave 1 — had no legal correction route. RFC-0099 section 7 (Accepted 2026-08-27) declares that route legal from implementation, verification, or review with no completed-work precondition; the guard landed 2026-08-26 in be51a9847, one day earlier, and was never re-checked when the decision landed. Four guards, not the three the intent named: the fourth was parse_completed_task_evidence_entries rejecting an empty tuple. missing_evidence remains the sole enforcer and is mutation-proven — neutering it fails exactly one test. Two deliberately written assertions had to be removed, contradicting the intent's assumption that no test asserted the refusal"},


### PR DESCRIPTION
## What does this change?

Adds a top-level `permissions: contents: read` block to
`.github/workflows/catalogue-tooling-ci-gates.yml` and `persist-credentials: false` to
each of its eight `actions/checkout` steps. No other change to the file.

## Why?

`[backlog].open` item `catalogue-tooling-workflow-hardening`. No spec; a chore.

It was the **only** workflow in `.github/workflows/` with no top-level `permissions:`
block, so its `GITHUB_TOKEN` carried the repository default, and every checkout left
credentials in the runner's git config for the rest of the job.

The entry is explicit that the mechanical edit is not the deliverable — *"To close:
review all seven gates for token use, artifact movement and git writes, then apply"* —
and it flags the artifact question as the load-bearing uncertainty rather than
something to assume. So here is the review, one row per job:

| Job | Uses `GITHUB_TOKEN`? | Writes to git? | Artifact movement |
| --- | --- | --- | --- |
| `agentbundle-tests` | no | no | none |
| `pack-hook-tests` | no | no | none |
| `external-catalogue-smoke` | no | no | none |
| `enterprise-agentbundle-distribution` | no | no | none |
| `catalogue-artifact-smoke` | no | no | uploads via `actions/upload-artifact@v4.6.2` |
| `catalogue-disconnected-smoke` | no | no | downloads via `actions/download-artifact@v4.3.0` |
| `catalogue-repo-rewire` | no | no | none |
| `agentbundle-release-impact` | no | no | none; `fetch-depth: 0` |

Verified against the file rather than assumed:

- **No step** references `GITHUB_TOKEN`, `github.token` or any `secrets.*`, and no step
  runs `git fetch/push/pull/clone/ls-remote/submodule/tag`. A grep for all of those
  returns nothing.
- The artifact actions authenticate with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`;
  `download-artifact`'s optional `github-token` input is not supplied, so no
  cross-run/cross-repo path is in use.
- The one job that needs history, Gate G, runs `tools/repo/check_release_impact.py`,
  whose only git calls are two local `git diff` invocations. `fetch-depth: 0` is
  preserved; it needs history at clone time, not credentials afterwards.

The eight job ids map to the seven historical gate labels A–G because Gate A is split
into `A-tests` and `A-packs`.

## How do I verify it?

```
zizmor --min-severity low .github/workflows/catalogue-tooling-ci-gates.yml
actionlint .github/workflows/catalogue-tooling-ci-gates.yml
python3 tools/check-zizmor-excessive-permissions.py
python3 tools/lint-ci-parity.py
```

Measured with the repository's own scanner, before → after:

| | before | after |
| --- | --- | --- |
| `artipacked` (persisted credentials) | 8 | **0** |
| `excessive-permissions` | 1 | **0** |
| total findings at `--min-severity low` | 17 medium | **none** |

`actionlint`, `check-zizmor-excessive-permissions.py` and `lint-ci-parity.py` all exit 0.

## What did you not change that you considered?

- **The gate's severity threshold.** `ci-security.yml:121` runs `zizmor
  --min-severity high`, and all 17 findings were *medium*, so this was never a red
  gate. It is a posture improvement, and lowering the threshold to manufacture a
  failing check would be a separate decision.
- **The `persist-credentials:` half is deliberately left unasserted, and registered.**
  Independent security review corrected my first read here. I had assumed the missing
  assertion was already deferred to `workflow-posture-guard-coverage-gaps`; it was not —
  that entry is an explicit named enumeration and never mentioned this guard's scope, so
  the gap was neither asserted nor registered. The second commit therefore adds this
  workflow to `tools/check-zizmor-excessive-permissions.py`'s `WORKFLOWS` tuple, which
  makes the `permissions:` block durable (mutation-proved: deleting it exits 1), and
  records the uncovered half in that register entry. The half stays uncovered because
  persisted credentials are zizmor's separate `artipacked` ident at medium severity,
  below the broad gate's `--min-severity high` floor, and extending a guard whose name
  and docstring are scoped to one audit is a design call, not a ride-along.
- **Line 141 and the `for`-loop.** `docs/specs/pack-test-compatibility-classes/`
  (Status: Implementing) has this file open at its `for`-loop and stale comments. This
  diff stays entirely on the token posture so the two changes do not collide.
- **No job-level `permissions:` override.** No job needs more than `contents: read`, so
  a single top-level block is the whole requirement.
