### PR TITLE
fix(desk-research,governance-extras): name a producer contract, not the pack release

### DIFF
--- a/.agents/skills/new-adr/SKILL.md
+++ b/.agents/skills/new-adr/SKILL.md
@@ -233,11 +233,13 @@ construct the strict published request, and invoke `project-knowledge --capture`
 Supply `contract_version`, `lesson`, `kind`, `project_scope`,
 `competency_facets`, `destination_hint`, `producer`, `semantic_gate`,
 `provenance`, `freshness_anchor`, `observed_at`, and `privacy_attestation`.
-Set `producer.workflow: new-adr`, use the shipped governance-extras pack
-version for `producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
+Set `producer.workflow: new-adr`, use `new-adr-producer-profile.v1` — the
+producer contract this section defines, never the pack's shipped release — for
+`producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
 and name the repository-relative ADR as the artifact. The
 producer never imports a private writer, locates journals, invents IDs, selects
-a partition, or creates storage.
+a partition, or creates storage. The identifier changes only when this
+contract's emitted shape changes.
 
 Before a provenance line or byte-digest read, discover the repository root
 with Git relocation variables removed, reject lexical dot-segment traversal,

--- a/.agents/skills/new-rfc/SKILL.md
+++ b/.agents/skills/new-rfc/SKILL.md
@@ -212,10 +212,12 @@ implementation review for a reversible, time-bounded trial with exit criteria.
    `project_scope`, `competency_facets`, `destination_hint`, `producer`,
    `semantic_gate`, `provenance`, `freshness_anchor`, `observed_at`, and
    `privacy_attestation`. Set `producer.workflow: new-rfc`, use
-   the shipped governance-extras pack version for `producer.workflow_version`,
+   `new-rfc-producer-profile.v1` — the producer contract this section defines,
+   never the pack's shipped release — for `producer.workflow_version`,
    set `semantic_gate.name: rfc-handoff-ready`, and name the repository-relative
    RFC as the artifact. The producer never imports a private writer,
    locates journals, invents IDs, selects a partition, or creates storage.
+   The identifier changes only when this contract's emitted shape changes.
 
    Before a provenance line or `sha256-bytes-v1` read,
    discover the repository root with Git relocation variables removed,

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -187,7 +187,7 @@
         "source": "git-subdir",
         "url": "https://github.com/eugenelim/agent-ready-repo.git"
       },
-      "version": "1.1.6"
+      "version": "1.1.7"
     },
     {
       "author": {

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -233,11 +233,13 @@ construct the strict published request, and invoke `project-knowledge --capture`
 Supply `contract_version`, `lesson`, `kind`, `project_scope`,
 `competency_facets`, `destination_hint`, `producer`, `semantic_gate`,
 `provenance`, `freshness_anchor`, `observed_at`, and `privacy_attestation`.
-Set `producer.workflow: new-adr`, use the shipped governance-extras pack
-version for `producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
+Set `producer.workflow: new-adr`, use `new-adr-producer-profile.v1` — the
+producer contract this section defines, never the pack's shipped release — for
+`producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
 and name the repository-relative ADR as the artifact. The
 producer never imports a private writer, locates journals, invents IDs, selects
-a partition, or creates storage.
+a partition, or creates storage. The identifier changes only when this
+contract's emitted shape changes.
 
 Before a provenance line or byte-digest read, discover the repository root
 with Git relocation variables removed, reject lexical dot-segment traversal,

--- a/.claude/skills/new-rfc/SKILL.md
+++ b/.claude/skills/new-rfc/SKILL.md
@@ -212,10 +212,12 @@ implementation review for a reversible, time-bounded trial with exit criteria.
    `project_scope`, `competency_facets`, `destination_hint`, `producer`,
    `semantic_gate`, `provenance`, `freshness_anchor`, `observed_at`, and
    `privacy_attestation`. Set `producer.workflow: new-rfc`, use
-   the shipped governance-extras pack version for `producer.workflow_version`,
+   `new-rfc-producer-profile.v1` — the producer contract this section defines,
+   never the pack's shipped release — for `producer.workflow_version`,
    set `semantic_gate.name: rfc-handoff-ready`, and name the repository-relative
    RFC as the artifact. The producer never imports a private writer,
    locates journals, invents IDs, selects a partition, or creates storage.
+   The identifier changes only when this contract's emitted shape changes.
 
    Before a provenance line or `sha256-bytes-v1` read,
    discover the repository root with Git relocation variables removed,

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -52,6 +52,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [desk-research][1.1.7] — 2026-08-31
+
+### Changed
+
+- The `desk-research` capture gate records `producer.workflow_version` as
+  `desk-research-producer-profile.v1`, the identifier of the producer contract
+  that gate defines, rather than the pack's shipped release. The recorded value
+  now changes when that contract's emitted shape changes, so a pack release no
+  longer requires a matching edit to the skill.
+
+## [governance-extras][0.10.4] — 2026-08-31
+
+### Changed
+
+- The `new-adr` and `new-rfc` capture gates record `producer.workflow_version`
+  as `new-adr-producer-profile.v1` and `new-rfc-producer-profile.v1` — the
+  identifiers of the producer contracts those gates define — rather than the
+  pack's shipped release. Each value changes when its own contract's emitted
+  shape changes, so a pack release no longer requires a matching edit to the
+  skills.
+
 ## [agent-skill-engineering][0.3.0] — 2026-08-31
 
 ### Highlights

--- a/packs/desk-research/.apm/skills/desk-research/SKILL.md
+++ b/packs/desk-research/.apm/skills/desk-research/SKILL.md
@@ -398,8 +398,11 @@ admitted observation, construct the published typed request with
 `destination_hint`, `producer`, `semantic_gate`, `provenance`,
 `freshness_anchor`, `observed_at`, and `privacy_attestation`; include optional
 fields only when their contract facts exist. Set `producer.workflow` to
-`desk-research` and `producer.workflow_version` to the current pack version.
-Invoke only the public `project-knowledge --capture` seam.
+`desk-research` and `producer.workflow_version` to
+`desk-research-producer-profile.v1` — the producer contract this section
+defines, never the pack's shipped release. The identifier changes only when
+this contract's emitted shape changes. Invoke only the public
+`project-knowledge --capture` seam.
 
 The producer must not locate journals, must not import the private writer, must
 not invent capture IDs, must not select partitions, and must not create storage.

--- a/packs/desk-research/.claude-plugin/plugin.json
+++ b/packs/desk-research/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "desk-research",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Ask a question, get an answer with citations you can check. It runs from a two-minute lookup to a multi-week investigation with its own folder, and argues against its own findings before handing them over."
 }

--- a/packs/desk-research/pack.toml
+++ b/packs/desk-research/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "desk-research"
-version = "1.1.6"
+version = "1.1.7"
 description = "Ask a question, get an answer with citations you can check. It runs from a two-minute lookup to a multi-week investigation with its own folder, and argues against its own findings before handing them over."
 readme = "README.md"
 display_name = "Desk Research"

--- a/packs/desk-research/tests/skills/desk-research/test_project_knowledge_boundary.py
+++ b/packs/desk-research/tests/skills/desk-research/test_project_knowledge_boundary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import tomllib
 from pathlib import Path
 
 PACK_ROOT = Path(__file__).resolve().parents[3]
@@ -103,6 +104,26 @@ def test_terminal_survey_uses_typed_capture_and_only_same_gate_receipts() -> Non
     assert "must not select partitions" in section
     assert "must not mine transcripts" in section
     assert "must not copy a raw source corpus" in section
+
+
+def test_instructed_producer_version_is_decoupled_from_the_pack_release() -> None:
+    """The gate must instruct a contract identifier, not the pack release.
+
+    Instructing the shipped release made every desk-research bump a prose edit
+    here, and recorded a release number in a field whose job is to say which
+    producer contract emitted the observation — free text the schema never
+    parses and no consumer branches on. Asserting the literal, and that the
+    release string is absent, means re-introducing the mirror reddens this test
+    instead of shipping.
+    """
+    release = tomllib.loads((PACK_ROOT / "pack.toml").read_text(encoding="utf-8"))[
+        "pack"
+    ]["version"]
+    section = _knowledge_section()
+
+    assert "`desk-research-producer-profile.v1`" in section
+    assert release != "desk-research-producer-profile.v1"
+    assert release not in section
 
 
 def test_capture_artifact_and_freshness_mapping_is_exact_by_gate() -> None:

--- a/packs/governance-extras/.apm/skills/new-adr/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-adr/SKILL.md
@@ -233,11 +233,13 @@ construct the strict published request, and invoke `project-knowledge --capture`
 Supply `contract_version`, `lesson`, `kind`, `project_scope`,
 `competency_facets`, `destination_hint`, `producer`, `semantic_gate`,
 `provenance`, `freshness_anchor`, `observed_at`, and `privacy_attestation`.
-Set `producer.workflow: new-adr`, use the shipped governance-extras pack
-version for `producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
+Set `producer.workflow: new-adr`, use `new-adr-producer-profile.v1` — the
+producer contract this section defines, never the pack's shipped release — for
+`producer.workflow_version`, set `semantic_gate.name: adr-accepted`,
 and name the repository-relative ADR as the artifact. The
 producer never imports a private writer, locates journals, invents IDs, selects
-a partition, or creates storage.
+a partition, or creates storage. The identifier changes only when this
+contract's emitted shape changes.
 
 Before a provenance line or byte-digest read, discover the repository root
 with Git relocation variables removed, reject lexical dot-segment traversal,

--- a/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
+++ b/packs/governance-extras/.apm/skills/new-rfc/SKILL.md
@@ -212,10 +212,12 @@ implementation review for a reversible, time-bounded trial with exit criteria.
    `project_scope`, `competency_facets`, `destination_hint`, `producer`,
    `semantic_gate`, `provenance`, `freshness_anchor`, `observed_at`, and
    `privacy_attestation`. Set `producer.workflow: new-rfc`, use
-   the shipped governance-extras pack version for `producer.workflow_version`,
+   `new-rfc-producer-profile.v1` — the producer contract this section defines,
+   never the pack's shipped release — for `producer.workflow_version`,
    set `semantic_gate.name: rfc-handoff-ready`, and name the repository-relative
    RFC as the artifact. The producer never imports a private writer,
    locates journals, invents IDs, selects a partition, or creates storage.
+   The identifier changes only when this contract's emitted shape changes.
 
    Before a provenance line or `sha256-bytes-v1` read,
    discover the repository root with Git relocation variables removed,

--- a/packs/governance-extras/.claude-plugin/plugin.json
+++ b/packs/governance-extras/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "governance-extras",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Write the RFC, record the ADR, and keep track of which ones are still open. Templates come with it, so nobody argues about format."
 }

--- a/packs/governance-extras/pack.toml
+++ b/packs/governance-extras/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "governance-extras"
-version = "0.10.3"
+version = "0.10.4"
 description = "Write the RFC, record the ADR, and keep track of which ones are still open. Templates come with it, so nobody argues about format."
 readme = "README.md"
 display_name = "Governance Extras"

--- a/packs/governance-extras/tests/skills/new-adr/test_project_knowledge_handoff.py
+++ b/packs/governance-extras/tests/skills/new-adr/test_project_knowledge_handoff.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
-SKILL = (
-    Path(__file__).resolve().parents[3]
-    / ".apm"
-    / "skills"
-    / "new-adr"
-    / "SKILL.md"
-)
+PACK_ROOT = Path(__file__).resolve().parents[3]
+SKILL = PACK_ROOT / ".apm" / "skills" / "new-adr" / "SKILL.md"
 
 
 def _gate() -> str:
@@ -74,3 +70,23 @@ def test_adr_gate_preserves_decision_authority_and_public_seam() -> None:
     assert "selects" in section
     assert "a partition" in section
     assert "verification and review barrier" in section
+
+
+def test_instructed_producer_version_is_decoupled_from_the_pack_release() -> None:
+    """The gate must instruct a contract identifier, not the pack release.
+
+    Instructing the shipped release made every governance-extras bump a prose
+    edit here, and recorded a release number in a field whose job is to say
+    which producer contract emitted the observation — free text the schema
+    never parses and no consumer branches on. Asserting the literal, and that
+    the release string is absent, means re-introducing the mirror reddens this
+    test instead of shipping.
+    """
+    release = tomllib.loads((PACK_ROOT / "pack.toml").read_text(encoding="utf-8"))[
+        "pack"
+    ]["version"]
+    section = _gate()
+
+    assert "`new-adr-producer-profile.v1`" in section
+    assert release != "new-adr-producer-profile.v1"
+    assert release not in section

--- a/packs/governance-extras/tests/skills/new-rfc/test_project_knowledge_handoff.py
+++ b/packs/governance-extras/tests/skills/new-rfc/test_project_knowledge_handoff.py
@@ -109,7 +109,7 @@ def test_rfc_gate_uses_public_typed_capture_and_same_gate_receipts() -> None:
         "drain another workflow",
         # what may be captured at all
         "reusable research-navigation",
-        "shipped governance-extras pack version",
+        "new-rfc-producer-profile.v1",
         # the verification barrier before the completion receipt
         "claim persistence or reconciliation",
         "no-diff outcome",
@@ -119,6 +119,27 @@ def test_rfc_gate_uses_public_typed_capture_and_same_gate_receipts() -> None:
         assert clause in section, f"gate section lost load-bearing clause: {clause!r}"
     assert "verification and review barrier" in section
     assert "Before step 9 emits the completion receipt" in section
+
+
+def test_instructed_producer_version_is_decoupled_from_the_pack_release() -> None:
+    """The gate must instruct a contract identifier, not the pack release.
+
+    Instructing the shipped release made every governance-extras bump a prose
+    edit here, and recorded a release number in a field whose job is to say
+    which producer contract emitted the observation — free text the schema
+    never parses and no consumer branches on. Asserting the literal, and that
+    the release string is absent, means re-introducing the mirror reddens this
+    test instead of shipping.
+    """
+    pack_root = Path(__file__).resolve().parents[3]
+    release = tomllib.loads((pack_root / "pack.toml").read_text(encoding="utf-8"))[
+        "pack"
+    ]["version"]
+    section = _gate()
+
+    assert "`new-rfc-producer-profile.v1`" in section
+    assert release != "new-rfc-producer-profile.v1"
+    assert release not in section
 
 
 def test_governance_handoff_metadata_is_descriptive_and_keeps_absence() -> None:


### PR DESCRIPTION
## What does this change?

Three producers outside core — `desk-research`, `new-adr`, and `new-rfc` — still told agents to write the shipped pack version into `producer.workflow_version`. Each now names its own producer-profile contract instead: `desk-research-producer-profile.v1`, `new-adr-producer-profile.v1`, and `new-rfc-producer-profile.v1`.

## Why?

Core 2.17.1 (#1181) made `producer.workflow_version` record *which producer contract emitted an observation* rather than the shipped release, because mirroring the release coupled every bump to a source constant to populate a field the schema validates as free text and no consumer branches on. `docs/specs/project-knowledge-authoring-integrations/spec.md` carries the Status-line supersession pointer.

**The naming decision, stated explicitly.** Each pack's producer gets its own identifier, keyed to its `producer.workflow` exactly as core's `work-loop-producer-profile.v1` is keyed to `work-loop`. `--producer-profile <workflow>` is already the seam's own unit (`docs/architecture/knowledge-capture.md:23`), so this extends a shipped naming shape rather than establishing a repository-wide convention — which is what would have needed an RFC.

A single shared cross-pack value was rejected on the merits, not just on cost. These packs release independently, and one identifier across three producers would make the three contracts indistinguishable in the store — deleting exactly the discrimination the field exists for — while coupling one pack's contract shape to another's release cadence.

## How do I verify it?

```bash
FORCE=1 make build-self      # tree stays clean
make site-sync               # tree stays clean — neither entry carries Highlights
make ci                      # REAL_EXIT=0
```

Targeted suites (one process per directory; basenames collide across `new-adr`/`new-rfc`):

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packs/desk-research/tests/skills/desk-research/ -q      # 16 passed
PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packs/governance-extras/tests/skills/new-adr/ -q        # 10 passed
PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packs/governance-extras/tests/skills/new-rfc/ -q        # 17 passed
```

**Guards proved by mutation.** One guard per skill asserts the backticked literal is present, that it differs from `pack.toml`, and that the release string is absent from the gate section. Two mutations redden all three:

| Mutation | desk-research | new-adr | new-rfc |
| --- | --- | --- | --- |
| restore the "shipped pack version" prose | FAILED | FAILED | FAILED (+1 collateral) |
| hardcode the release literal (`1.1.6` / `0.10.3`) | FAILED | FAILED | FAILED |

One existing assertion pinned the defect itself — new-rfc's suite required the literal string `"shipped governance-extras pack version"` — and is replaced by the contract identifier.

## What did you not change that you considered?

- **No `Highlights` on either changelog entry — a verdict, not an omission.** The recorded value changes, but nothing a pack consumer can *do* changes: no new capability, no adopter action, and the field is free text no consumer reads for a decision. `make site-sync` leaving `web/src/lib/now-highlights.generated.json` untouched is the independent confirmation.
- **Did not wire governance-extras into CI.** `tools/lint-pack-test-boundary.py` records `packs/governance-extras/tests/skills/new-adr` and `.../new-rfc` in `_NO_RUNNER` as "never gated", so **two of the three new guards do not run in CI** (desk-research's does, via `Makefile:574`). Turning them on means a Makefile line plus `--import-mode=importlib` and deleting two `_NO_RUNNER` entries — a change to the repository gate set, deliberately left out of this PR rather than made silently.
- **Did not touch core's `author-delivery-brief`.** Its prose says "the producer-profile contract version" without naming a literal, so an agent has to invent one. Real gap, but core's and outside this change.
- **Did not edit any spec body.** The authoring-integrations spec is Shipped and already carries its Status-line pointer.
- **Did not add eval cases.** Neither pack's `evals.json` probes the project-knowledge capture gate at all, and no gate ties `evals.json` to `SKILL.md`; a case asserting a one-token metadata value would be noise.
