### PR TITLE
test(tools): re-pin the shared-test dedup node contract at 85

### DIFF
--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -60,9 +60,30 @@ CORE_COLLECTIONS = {
     # timeout degradation, nothing was removed or renamed, and the other two
     # entries below still reproduce. Adding a test here is expected; leaving this
     # number behind is what makes the contract stop meaning anything.
+    # Re-pinned 2026-08-31: 78 -> 85, in two steps neither of which re-pinned this
+    # contract, so it has been red on main since the first of them. Recomputing the
+    # static node set at each revision of the pinned file gives 78 at `34f00cf29`
+    # (digest `dd567702b9`, the value replaced here), 82 at `d5192da9a`, and 85 at
+    # `487b298c4`; nothing was removed or renamed at either step, and the surviving
+    # 78 keep their original relative order.
+    # `d5192da9a` ("scope lint-spec-status to the specs a session touched") added
+    # four tests for the selection it introduced —
+    # test_default_scope_checks_changed_spec_but_not_unchanged_specs,
+    # test_all_scope_checks_unchanged_specs_too,
+    # test_unresolvable_base_ref_falls_back_to_full_per_spec_checks, and
+    # test_scoped_run_keeps_dangling_reference_warnings_repo_wide.
+    # `487b298c4` ("keep the deferral-anchor invariant repo-wide, and close three
+    # more fail-opens") added three more —
+    # test_scoped_run_keeps_deferral_anchors_repo_wide,
+    # test_scoped_run_reports_the_coverage_it_achieved, and
+    # test_undetermined_changed_set_sweeps_and_says_so.
+    # Dispositioned rather than taken from either side, as the note above requires:
+    # each of the seven asserts a distinct way scoped selection could silently check
+    # nothing, which is the failure the two commits set out to prevent, and the other
+    # two entries below still reproduce.
     SHARED_TESTS[0]: (
-        78,
-        "dd567702b9fe8bdbcff7c8da65b501c64ccaba1fb1cf009fd438befd67db51fc",
+        85,
+        "72b3433894c9eb06912b0c98f437490aed4cb8cf6c111af6ee92ae9224f64675",
     ),
     SHARED_TESTS[1]: (
         16,


### PR DESCRIPTION
## What does this change?

Re-pins one entry of `CORE_COLLECTIONS` in `tools/test_local_ci_shared_test_deduplication.py` from 78 nodes to 85, and records the disposition of that delta in the block comment above the dict. No production code changes.

## Why?

`test_core_pytest_semantic_node_contracts_are_exact` has been red on `main` since `d5192da9a`. `packs/core/tests/skills/work-loop/test_lint_spec_status.py` gained tests without the guard being re-pinned alongside them, so every branch cut from `main` inherits the failure.

There is no spec: this is a single bounded correction to a stale pin, run in work-loop direct-light mode. No risk trigger fires — one file, one constant plus a comment, no structure, no dependency, no security boundary, and fully reversible.

The block comment is explicit that a delta must be **dispositioned**, not absorbed, so the numbers were derived rather than taken from the failure message. Recomputing the static node contract at every revision of the pinned file:

| Commit | Nodes | Change |
| --- | ---: | --- |
| `34f00cf29` | 78 | digest `dd567702b9…` — reproduces the pin being replaced, byte for byte |
| `d5192da9a` | 82 | +4, none removed |
| `487b298c4` | 85 | +3, none removed |

Nothing was removed or renamed at either step, and the surviving 78 node IDs keep their original relative order. The seven additions:

- `d5192da9a` ("scope lint-spec-status to the specs a session touched") — `test_default_scope_checks_changed_spec_but_not_unchanged_specs`, `test_all_scope_checks_unchanged_specs_too`, `test_unresolvable_base_ref_falls_back_to_full_per_spec_checks`, `test_scoped_run_keeps_dangling_reference_warnings_repo_wide`.
- `487b298c4` ("keep the deferral-anchor invariant repo-wide, and close three more fail-opens") — `test_scoped_run_keeps_deferral_anchors_repo_wide`, `test_scoped_run_reports_the_coverage_it_achieved`, `test_undetermined_changed_set_sweeps_and_says_so`.

Each asserts a distinct way scoped selection could silently check nothing — the failure those two commits set out to prevent. The other two `CORE_COLLECTIONS` entries still reproduce their pinned count and digest exactly, so the delta is confined to this one entry.

## How do I verify it?

```bash
python3 -m pytest tools/test_local_ci_shared_test_deduplication.py -q   # 26 passed in 128s
make lint-ruff                                                          # exit 0
make lint-mypy                                                          # exit 0, 125 files
make build-check                                                        # exit 0, SAST included
```

The guard was proven falsifiable on **both** halves of the assertion, with each mutation confirmed applied before the run:

- appending one test to the pinned file → `assert 86 == 85` (count half);
- renaming one test with the count held constant → digest mismatch (digest half, which a count-only pin would miss).

Both were reverted and `git status` is clean.

## What did you not change that you considered?

- **Wiring this module into a PR-time gate.** Review established that `.github/` references it nowhere and `build-check.yml` runs no pytest, so only `make test` locally exercises it — which is why two consecutive deltas went undetected. That is real, but it is CI-wiring work outside this unit, and the DECIDE contract does not grant an out-of-intent discovery a backlog entry by default. Raising it for a scope decision rather than absorbing it here.
- **Hardening `_static_core_node_ids`.** It walks only top-level functions and stops at the first `parametrize`, so a class-based or doubly-parametrized test could in principle drift from a live collection. A live `pytest --collect-only` confirmed 85 node IDs byte-identical and in the same order today, so nothing is currently wrong; redesigning the deriver is separate work.
- **Rewriting the existing `73 → 78` paragraph.** It is a prior author's disposition and the form this entry was asked to match; shortening it would edit the record rather than extend it.
- **A regenerator for the pin.** The comment's whole purpose is that a human accounts for each delta; automating it would erase the control.

---

## Checklist

- [x] Tests pass locally (`python3 -m pytest tools/test_local_ci_shared_test_deduplication.py -q` — 26 passed)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy`)
- [x] Self-review run via `adversarial-reviewer`, every report routed through `finding-adjudicator`; 3 of 5 findings refuted, 2 sustained and applied
- [x] Spec and code agree (no spec — direct-light; rationale above)
- [x] Living docs match reality — no released artifact version bumped, no user-facing behavior changed, no structural change
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured

## Review verdict

```json review-verdict.v1
{
  "schema_version": "review-verdict.v1",
  "state": "READY",
  "mode": "light",
  "review_unit": "repin-shared-test-dedup-guard",
  "warranted_reviewers": [
    {"role": "adversarial-reviewer", "mandatory": true, "outcome": "findings", "report_ref": ".context/reviews/bccad3d2-dce5-4431-976c-0eae3606b2d5/1-post-gates-adversarial-reviewer-raw.md"}
  ],
  "named_skips": [],
  "findings": [
    {"id": "3", "source_role": "adversarial-reviewer", "severity": "nit", "effective_severity": "nit", "citation": ".context/reviews/bccad3d2-dce5-4431-976c-0eae3606b2d5/commit-b293da75c-message.txt:8", "text": "Commit body said 'Dispositioned rather than re-pinned', but the block comment requires disposition before re-pinning; the two are sequential, not alternatives.", "status": "resolved"},
    {"id": "4", "source_role": "adversarial-reviewer", "severity": "nit", "effective_severity": "nit", "citation": ".context/reviews/bccad3d2-dce5-4431-976c-0eae3606b2d5/commit-b293da75c-message.txt:13", "text": "Commit body attributed the fail-opens to both commits; d5192da9a introduced the scoped-selection fail-open class and 487b298c4 closed three of them.", "status": "resolved"}
  ],
  "required_gates": [
    {"name": "pytest tools/test_local_ci_shared_test_deduplication.py", "outcome": "passed", "evidence": "26 passed in 127.69s"},
    {"name": "make lint-ruff", "outcome": "passed", "evidence": "exit 0, all checks passed"},
    {"name": "make lint-mypy", "outcome": "passed", "evidence": "exit 0, no issues in 125 source files"},
    {"name": "make build-check", "outcome": "passed", "evidence": "exit 0, every leg invoked, SAST/SCA included"},
    {"name": "mutation proof (count half)", "outcome": "passed", "evidence": "appended test to pinned file, mutation confirmed applied, guard red with assert 86 == 85"},
    {"name": "mutation proof (digest half)", "outcome": "passed", "evidence": "renamed one test with count held at 85, mutation confirmed applied, guard red on digest mismatch"}
  ],
  "deferrals": [],
  "blind_spots": [],
  "human_gate_status": "pending",
  "non_authoritative_score": null
}
```
