### PR TITLE
fix(tests): measure AC36 admission cost without the allocation tracer

### DIFF
--- a/packages/agentbundle/tests/performance/test_direct_family2_budget_cost.py
+++ b/packages/agentbundle/tests/performance/test_direct_family2_budget_cost.py
@@ -95,14 +95,30 @@ def test_family2_budget_cost_stays_inside_the_ac36_ceiling(tmp_path: Path):
     cpu_durations: list[float] = []
     peak_mib = 0.0
     classification = None
+    # TIMED runs carry no instrumentation. `tracemalloc` traces every allocation,
+    # and this admission path is allocation-heavy, so leaving it running across
+    # the timed region measured the tracer rather than the code: 3.8x on
+    # wall-clock and 3.1x on CPU, measured on 3.13 by running this same shape
+    # both ways. That overhead is also interpreter-sensitive, which is the whole
+    # of the 3.2x gap between the ubuntu-latest py3.11 and py3.12 jobs — 1.56s
+    # against 4.99s for identical work — and it pushed the reported figure onto
+    # AC36's 5s ceiling and failed the release gate. The ceiling was never
+    # actually exceeded; the harness was timing itself.
     for _ in range(RUNS):
-        tracemalloc.start()
         cpu_started = time.process_time()
         started = time.monotonic()
         classification = admit_direct_source(root)
         durations.append(time.monotonic() - started)
         cpu_durations.append(time.process_time() - cpu_started)
-        peak_mib = max(peak_mib, tracemalloc.get_traced_memory()[1] / (1024 * 1024))
+
+    # Memory gets its own run, because AC36 asks for both numbers and each one
+    # is only honest when the other is not being collected. This run is never
+    # timed.
+    tracemalloc.start()
+    try:
+        classification = admit_direct_source(root)
+        peak_mib = tracemalloc.get_traced_memory()[1] / (1024 * 1024)
+    finally:
         tracemalloc.stop()
 
     assert classification is not None
@@ -119,7 +135,8 @@ def test_family2_budget_cost_stays_inside_the_ac36_ceiling(tmp_path: Path):
         f"total={DIRECT_MAX_TOTAL_BYTES} | collected={classification.files} "
         f"bytes={classification.total_bytes} | wall-clock median {median:.2f}s "
         f"range {min(durations):.2f}-{max(durations):.2f}s over {RUNS} runs | "
-        f"cpu median {cpu_median:.2f}s | admission peak {peak_mib:.1f} MiB | "
+        f"cpu median {cpu_median:.2f}s (untraced) | admission peak {peak_mib:.1f} MiB "
+        f"(separate traced run) | "
         f"load/core {load_per_core:.1f} | ceiling {CEILING_SECONDS}s / {CEILING_MIB} MiB",
         UserWarning,
         stacklevel=2,


### PR DESCRIPTION
Unblocks main and the `agentbundle-v0.41.0` release. `Gate A-tests (ubuntu-latest / py3.12)` is failing on main, and the same failure skipped `publish-pypi` on the release tag.

## The defect

`tracemalloc` was left running across the timed region of `test_direct_family2_budget_cost.py`, so every timing run measured the allocation tracer as well as the admission path.

Measured on 3.13 by running the same reference shape both ways:

| | wall-clock | CPU |
| --- | ---: | ---: |
| With `tracemalloc` running | 4.87s | 2.41s |
| Without | 1.29s | 0.79s |
| **Overhead** | **3.8×** | **3.1×** |

That overhead is interpreter-sensitive, and it accounts for the entire gap between the two `ubuntu-latest` jobs on main — **wall-clock median 1.56s on py3.11 against 4.99s on py3.12** for identical work, at `load/core 0.2`, so not contention. The py3.12 figure landed on AC36's 5s ceiling with 0.2% headroom, which is why it fails intermittently and took the release with it.

**AC36's ceiling was never exceeded.** The harness was timing itself.

## The fix

Timing runs carry no instrumentation. The memory peak comes from one separate, untimed run with the tracer on, so AC36 still gets both numbers and neither is collected while the other is being measured. Reported figures are labelled `(untraced)` and `(separate traced run)` so a later reader cannot mistake which is which.

Locally, the same shape moves from 4.87s wall / 2.41s CPU to **1.11s / 0.83s**, with the memory figure unchanged at 27.4 MiB.

## What did not change

No budget, no ceiling, no reference configuration. AC36 says a cost exceeding the ceiling is *"refused rather than negotiated"* and that raising a budget is *Ask first* — nothing here does either. The measurement was wrong; the bound was not.

## Verification

The number that matters is the py3.12 job on this PR, since that is the one that has been failing and the one this claims to fix. Local runs cannot settle it — this machine has no 3.12.

## Credit

Found because `reviewer-improvements` reported the test blocking an unrelated PR with two consecutive failures and the main-branch measurements to prove it was pre-existing. Their conclusion — ~0.2% headroom on the runner it must pass on, and it will keep hitting whoever is unlucky — was exactly right.
