### PR TITLE
docs(changelog): re-seat the [Unreleased] note I displaced

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- The block-scalar and CAT-L027 entries that sat here are published under [agentbundle][0.41.0] and [core][2.16.3] below; one canonical location per change. -->
+
 ## [core][2.19.0] — 2026-09-01
 
 ### Highlights
@@ -115,8 +117,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The session-resumption guidance tells a resuming session to compare the
   recorded id before deciding whether a round was written, and states that the
   clean-round replay risk applies to a replay without a matching id.
-
-<!-- The block-scalar and CAT-L027 entries that sat here are published under [agentbundle][0.41.0] and [core][2.16.3] below; one canonical location per change. -->
 
 ## [core][2.18.1] — 2026-08-31
 


### PR DESCRIPTION
## What

Moves the `<!-- The block-scalar and CAT-L027 entries that sat here... -->` note back to directly under `## [Unreleased]`, where it sat at `9b6bc3847:docs/product/changelog.md:55`.

## Why

The note explains why `[Unreleased]` is empty. Its text says the entries "sat **here**", so its position carries its meaning. At line 119 — between `[core][2.18.2]` and `[core][2.18.1]` — it read as a claim about the 2.18.1 release, which is false.

## Cause

Mine. Merge commit `81c2d2b65` (PR #1192) resolved a changelog conflict by keeping the note with main's `[core][2.18.1]` block, because main's side of the conflict led with it. The note actually belonged to `[Unreleased]`, and inserting `[core][2.18.2]` above it displaced it. It drifted further when 2.19.0 landed.

Found by session `auto-backlog-review-run-2-20260831t1400-c6`, which correctly declined to relocate what it took to be another PR's line, and confirmed by `work-loop-controller-b-19`.

## Notes for the next editor of this file

- There are **four** `## [Unreleased]` headings, not one. The live region is at the top; three legacy regions sit deeper, documented by the `[core][2.16.3]` entry as holding 48 interleaved bare sections. A script assuming a single match either fails or edits the wrong region.
- `web/src/lib/now-highlights.generated.json` is **byte-unchanged** by this commit — the projection does not read HTML comments. Regenerated with `tools/build-site.py` to confirm rather than assume, which is the evidence `/now/` output cannot have moved.

## Verification

| Gate | Result |
| --- | --- |
| `tools/test_build_site_routing.py`, `test_check_release_impact.py`, `test_build_site_link_rewrites.py` | 112 passed, 1 skipped |
| `tests/roster/` (`-k "changelog or release or highlight or now"`) | 56 passed |
| `tools/build-site.py` | exit 0, projection byte-identical |
| Diff size | 2 added / 2 removed, as expected |

`web/src/test/rendered-output.test.ts` skips all 26 cases without a built docs-site, so it gave no local coverage; CI builds the site.