### PR TITLE
test(tools): register the load-conditional sdist skip reason

### DIFF
--- a/tools/check-artifact-contents.py
+++ b/tools/check-artifact-contents.py
@@ -73,6 +73,14 @@ _EXPECTED_SKIP_REASONS = tuple(
         r"^Windows-only$",
         r"^hardcoded POSIX /tmp path$",
         r"^no seed primitives in core fixture; skip$",
+        # The only load-conditional entry, and deliberately the narrowest
+        # pattern here: every number is required, so it admits this one
+        # message shape and nothing else. Registered because
+        # `gate-export-boundary` fails on any skip at all, so an unregistered
+        # load spike reddens a required check on a property of the runner.
+        r"^wall-clock not asserted: load/core \d+(?:\.\d+)? exceeds "
+        r"\d+(?:\.\d+)?\. CPU \(\d+(?:\.\d+)?s\) and memory "
+        r"\(\d+(?:\.\d+)? MiB\) were asserted unconditionally\.$",
     )
 )
 _EXPECTED_STUB_MODULE_HASHES = {

--- a/tools/test_check_artifact_contents.py
+++ b/tools/test_check_artifact_contents.py
@@ -333,6 +333,9 @@ def test_sdist_skip_integrity_refuses_unrecognised_reasons(reason):
         "Windows-only",
         "hardcoded POSIX /tmp path",
         "no seed primitives in core fixture; skip",
+        # Observed verbatim on a loaded macOS host, 2026-09-01.
+        "wall-clock not asserted: load/core 2.8 exceeds 2.0. CPU (2.58s) "
+        "and memory (27.4 MiB) were asserted unconditionally.",
     ],
 )
 def test_sdist_skip_integrity_accepts_explicit_policy(reason):


### PR DESCRIPTION
## What does this change?

Registers one skip reason — the load-conditional wall-clock skip in `tests/performance/test_direct_family2_budget_cost.py` — in `_EXPECTED_SKIP_REASONS` in `tools/check-artifact-contents.py`, with its accept case in the existing parametrised test.

## Why?

`gate-export-boundary` fails on *any* skip the sdist suite reports. Two guards enforce that: the in-test allowlist refuses an unregistered reason, and the job additionally runs `! grep -Eq "^SKIPPED"` (`build-check.yml:894`). So when that performance test declines its wall-clock assertion above `load/core 2.0`, an unregistered skip reddens a required check for everyone — on a property of the runner, not a defect in the code.

`spec/direct-skill-repository-installation` added the skip without registering its reason. The check was working exactly as designed; the registration was simply missing.

This is latent rather than theoretical: `ubuntu-latest` runners have 2–4 cores, so `os.getloadavg()[0] / os.cpu_count()` can exceed 2.0 under contention. It has not fired on CI yet — it passed today at `80 passed in 165.53s` with zero skips — but nothing prevents it.

## How do I verify it?

```bash
python3 -m pytest tools/test_check_artifact_contents.py -q -k skip_integrity   # 38 passed
make lint-ruff && make lint-mypy                                               # 0, 0
```

**Verified in situ**, with the skip actually firing rather than simulated. On a host at `load/core 21.11`, the sdist suite emitted the load skip and the violation list came back containing only the unrelated case-insensitive-filesystem skip — the load reason was accepted:

```
ArtifactViolation: sdist suite used skips outside the explicit expected policy:
SKIPPED [1] tests/unit/test_direct_admission.py:937: case-insensitive filesystem cannot hold both spellings
```

Before this change the same run listed the load reason as well.

The pattern is the narrowest in the constant — every number is required. Probed directly against `_check_skip_integrity`:

| Reason | Verdict |
| --- | --- |
| the real message | accepted |
| same shape, different numbers | accepted |
| `…load/core 2.8 exceeds 2.0.` (truncated) | refused |
| `…load/core X exceeds 2.0. …` (non-numeric) | refused |
| the full message plus trailing text | refused |
| `case-insensitive filesystem cannot hold both spellings` | refused |
| `an unrecognised feature skip` | refused |

## What did you not change that you considered?

- **The case-insensitive-filesystem skip.** Left unregistered on purpose. It can only fire on a case-insensitive host, so it never reaches Linux CI; it costs a local `make ci` failure on macOS and nothing else. Deliberately *not* pinned as permanently-refused in the test either, which would make a future decision to register it harder to land.
- **Widening the pattern.** It is the only nondeterministic entry among fourteen fixed platform capabilities, so it is written to admit one message shape and no more.

---

## Checklist

- [x] Tests pass locally (`-k skip_integrity` 38 passed; in-situ verification above)
- [x] Lint and typecheck pass (`make lint-ruff`, `make lint-mypy`)
- [x] Self-review — single-constant change with a probed accept/refuse table
- [x] Spec and code agree — no spec; a one-entry registration in an existing policy
- [x] Living docs match reality — no released artifact version moves
- [x] No new top-level directories
- [x] Conventional commit format
