### PR TITLE
test(credbroker): tolerate timer epsilon in the socket-budget assertion

### DIFF
--- a/packages/credbroker/tests/unit/test_sso_derivation.py
+++ b/packages/credbroker/tests/unit/test_sso_derivation.py
@@ -366,7 +366,9 @@ def test_socket_timeout_reaches_the_opener_and_tracks_the_budget():   # STUB: AC
         # It shrinks with the shared budget, so a late hop cannot outlive it.
         with pytest.raises(_sso._DerivationAbort):
             _sso._derive_open(f"{BASE}/x", _sso._DerivationBudget(1.0), trusted_origin=_sso._origin(BASE))
-        assert seen[-1] <= 1.0
+        # Windows observed 1.0000000000000142 from timer arithmetic (~1.4e-14).
+        # One nanosecond absorbs float noise but is 1,000,000x below a real 1 ms overrun.
+        assert seen[-1] <= 1.0 + 1e-9
     finally:
         m._derivation_opener = real
 


### PR DESCRIPTION
Closes the `credbroker-socket-budget-float-tolerance` backlog item (`workspace.toml` `[backlog].open`), whose intent is [`docs/product/intents/credbroker-socket-budget-float-tolerance.md`](docs/product/intents/credbroker-socket-budget-float-tolerance.md).

## What was wrong

`test_socket_timeout_reaches_the_opener_and_tracks_the_budget` compared the derived per-hop socket timeout against its 1.0s budget exactly:

```python
assert seen[-1] <= 1.0
```

On Windows the value came back as `1.0000000000000142` — over by 1.4e-14 — which reddened `pytest credbroker (windows)` and through it `make build-check (windows)`, on PR #1161 whose diff touched no credbroker path and no Windows-specific path. The same suite passed on Linux in the same run.

## What changed

One assertion, in one file. The invariant it protects is real and kept: a late hop must not outlive the shared budget. Only the exact-comparison form was wrong.

## Why `1e-9`, and why it cannot mask a defect

The value has an origin rather than being tuned until the suite went green:

- The ULP of 1.0 is 2.22e-16, so the observed artifact is ~63 ULPs.
- A genuine budget overrun is a scheduling/timeout event, so its floor is the millisecond scale.
- `1e-9` sits ~70,000x above the artifact and ~1,000,000x below the smallest real overrun.

Measured on the dev host, the value is `0.9999804999679327` — already **1.95e-5 under** the budget from elapsed time. The assertion therefore already carried four orders of magnitude more natural slack than this tolerance adds, so the tolerance is not what bounds its sensitivity.

The first draft used `2e-14`, only 1.43x a single observation on a single machine. That was rejected as too thin: a marginally different timer reds the suite again, which is the exact failure this change exists to prevent.

## Mutation proof

Run against worktree production code, restored by editing the line back (never `git checkout`):

| Mutation to `packages/credbroker/credbroker/_sso.py:951` | Result |
|---|---|
| Delete the budget clamp: `timeout = min(_DERIVE_SOCKET_TIMEOUT_S, max(0.001, budget.remaining()))` → `timeout = _DERIVE_SOCKET_TIMEOUT_S` | **red at the changed line** — `assert 5.0 <= (1.0 + 1e-09)` |
| Constant `+ 1e-6` overrun | **red**, at the sibling `0 < seen[-1] <= _DERIVE_SOCKET_TIMEOUT_S` bound |
| Scale remaining budget by `1 + 1e-7` | green — pre-existing, caused by the 1.95e-5 elapsed-time slack above, not by this change |

Intent Assumption 2 holds: the neighbouring `0 < seen[-1] <= _DERIVE_SOCKET_TIMEOUT_S` bound is untouched and still exact.

## Gates

| Gate | Result |
|---|---|
| `make lint-ruff` | pass |
| `make lint-mypy` | pass — 135 files |
| `pytest packages/credbroker/` | pass — 505 tests |
| `make build-check` (full, SAST/SCA included) | pass |
| `make ci` | one failure, **pre-existing and unrelated** — see below |

`make ci` fails at `tools/test_local_ci_shared_test_deduplication.py::test_core_pytest_semantic_node_contracts_are_exact` with `test_terminated_brief_child_scope must declare explicit parameter IDs`. That reproduces in 0.34s at `origin/main` with no working-tree changes; it was introduced by `885176fad`, which added a `pytest.mark.parametrize` without `ids=` to a pinned file. Both files the guard reads are byte-identical between this branch and `origin/main`. No workflow invokes that file, so main's CI is green while `make ci` is red locally. Tracked separately; not fixed here to keep this change to one thing.

## Scope

No production code, no changelog, no version bump — `packages/credbroker/tests/**` matches neither `RELEASE_IMPACTING_PREFIXES` nor `NON_IMPACTING_PREFIXES` in `tools/repo/check_release_impact.py`, so `is_release_impacting` is false. `workspace.toml` and the intent's `**Status:**` are deliberately untouched: `work-loop` does not own closeout, so closing the backlog entry stays with its owner.

Reviewed by an independent agent that did not write the change; clean with evidence lines on invariant retention, the arithmetic, intent Assumption 2, the security lens, scope drift, and whether a smaller change existed.