### PR TITLE
test(core): restore the shared-test node contract, red on main since 885176fad

### DIFF
--- a/packs/core/tests/skills/author-delivery-brief/test_lint_brief_coverage.py
+++ b/packs/core/tests/skills/author-delivery-brief/test_lint_brief_coverage.py
@@ -162,6 +162,14 @@ def test_shipped_requires_nonempty_all_shipped_map() -> None:
         ("Cancelled", "Implementing", 0),
         ("Cancelled", "Shipped", 0),
     ],
+    ids=[
+        "withdrawn-approved-allows",
+        "withdrawn-implementing-blocks",
+        "withdrawn-shipped-blocks",
+        "cancelled-approved-blocks",
+        "cancelled-implementing-allows",
+        "cancelled-shipped-allows",
+    ],
 )
 def test_terminated_brief_child_scope(
     brief_status: str,
@@ -244,7 +252,11 @@ def test_untracked_backlink_informational() -> None:
         expect("gamma" in combined, f"untracked spec named: {out}{err}")
 
 
-@pytest.mark.parametrize("brief_status", ["Ready", "Withdrawn"])
+@pytest.mark.parametrize(
+    "brief_status",
+    ["Ready", "Withdrawn"],
+    ids=["ready", "withdrawn"],
+)
 def test_untracked_backlink_contributes_execution_evidence(
     brief_status: str,
 ) -> None:

--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -85,9 +85,30 @@ CORE_COLLECTIONS = {
         85,
         "72b3433894c9eb06912b0c98f437490aed4cb8cf6c111af6ee92ae9224f64675",
     ),
+    # Re-pinned 2026-09-01: 16 -> 27 after `885176fad`. This is the first
+    # re-pin triggered by a hard AssertionError rather than count/digest drift:
+    # `_parametrize_ids` refuses an ids-less `parametrize` outright, so this
+    # contract could not derive a node set. The repair adds explicit IDs to the
+    # two parametrizes that commit introduced, not a relaxation that teaches the
+    # static contract pytest's default ID rules; that would couple this deliberately
+    # static derivation to pytest's own ID generation, which it exists to avoid.
+    # Static arithmetic is 16 - 1 removed + 12 added = 27. The removed
+    # `test_all_shipped_delivered` was renamed and strengthened, not lost: its
+    # successor `test_explicitly_shipped_all_shipped_map_is_delivered` has the
+    # same body except that `write_brief` now receives the `status="Shipped"`
+    # required by `885176fad`. Three genuine new siblings cover the commit's
+    # refusals — `test_all_shipped_map_requires_explicit_shipped_status`,
+    # `test_shipped_requires_nonempty_all_shipped_map`, and
+    # `test_statusless_all_shipped_map_fails_closed`. Eight of the twelve
+    # additions are parameter expansions newly derivable from the explicit IDs:
+    # six from `test_terminated_brief_child_scope` and two from
+    # `test_untracked_backlink_contributes_execution_evidence`; 16 -> 27 thus
+    # records both new coverage and newly visible parameters, not eleven new test
+    # functions. The fifteen survivors preserve relative order, and the other two
+    # entries below still reproduce unchanged.
     SHARED_TESTS[1]: (
-        16,
-        "9eb21215317b77e1b24e1433a4219c87aa09ee9220462850475b0431fe1b8bcd",
+        27,
+        "f227c460b916f2414275bc9d8b76560aecd9589aaccb0925ca88db251a1a1597",
     ),
     SHARED_TESTS[2]: (
         45,


### PR DESCRIPTION
`tools/test_local_ci_shared_test_deduplication.py::test_core_pytest_semantic_node_contracts_are_exact` has been **red on `main`**. It reproduces in 0.24s on a clean tree:

```
AssertionError: test_terminated_brief_child_scope must declare explicit parameter IDs
tools/test_local_ci_shared_test_deduplication.py:602
```

## Why it survived

`885176fad` ("feat(core)!: separate brief withdrawal from cancellation") added **two** `pytest.mark.parametrize` decorators with no `ids=` to `packs/core/tests/skills/author-delivery-brief/test_lint_brief_coverage.py` — `SHARED_TESTS[1]`, one of the three files pinned in `CORE_COLLECTIONS`. `_parametrize_ids` raises rather than falling back to pytest's implicit IDs, so the contract could not derive a node set at all and died before reaching either the count or the digest assertion.

No workflow invokes that module — only the `Makefile` does. So CI on main is green while `make ci` is red locally, and nothing surfaced it.

## Why explicit IDs, not a guard relaxation

The alternative was teaching `_parametrize_ids` to synthesise pytest's default IDs. That would couple a deliberately static, reviewed derivation to pytest's own ID-generation rules — exactly the coupling `_static_core_node_ids` exists to avoid by never launching pytest. So the repair is on the test side.

The IDs are chosen to be readable in CI output. `test_terminated_brief_child_scope` gets `<brief-status>-<child-status>-<outcome>`, which makes the Withdrawn/Cancelled asymmetry legible (a Withdrawn brief blocks on a live child; a Cancelled brief blocks on an Approved one). `test_untracked_backlink_contributes_execution_evidence` deliberately gets only `["ready", "withdrawn"]` — both of its cases reject, so an outcome suffix would carry no information and would mislead.

## The re-pin, and the disposition behind it

`SHARED_TESTS[1]` moves `(16, 9eb2121531…)` → `(27, f227c460b9…)`. The other two entries reproduce byte-identically and are untouched.

The ledger entry **deliberately breaks the earlier entries' "nothing was removed or renamed" formula**, because that would be false here:

| | |
|---|---|
| Arithmetic | `16 − 1 removed + 12 added = 27` |
| Removed | `test_all_shipped_delivered` |
| Disposition | **Renamed and strengthened, not lost.** Successor `test_explicitly_shipped_all_shipped_map_is_delivered` has an identical body except `write_brief(..., status="Shipped")` — precisely what `885176fad` made mandatory. |
| Genuinely new | `test_all_shipped_map_requires_explicit_shipped_status`, `test_shipped_requires_nonempty_all_shipped_map`, `test_statusless_all_shipped_map_fails_closed` — covering that commit's new refusals |
| Parameter expansions | 8 of the 12 additions, visible only because the IDs are now explicit |
| Survivor order | preserved across all 15 |

A future reader must not read 16 → 27 as eleven new test functions; the count moved for two reasons at once, and the ledger says so.

## Verification

| Check | Result |
|---|---|
| `pytest tools/test_local_ci_shared_test_deduplication.py` | 26 passed |
| Static derivation vs live `pytest --collect-only` on the pinned file | 27 vs 27, identical **including order** |
| `SHARED_TESTS[0]` / `SHARED_TESTS[2]` | 85 and 45, digests byte-identical |
| `pytest packs/core/tests/skills/author-delivery-brief/` | 61 passed |
| `make lint-ruff`, `make lint-mypy` | exit 0 |

Mutation proofs, each applied then restored **by editing back** (never `git checkout`) — all three red the guard:

1. Drop one `ids` entry → count assertion fails.
2. Swap two `ids` entries (count unchanged) → digest assertion fails.
3. Revert the pin to `(16, 9eb2…)` → count assertion fails.

**Not read locally:** the SAST leg of `make build-check`. Three attempts hit semgrep `--strict` per-rule `WARN Timeout` on files this diff does not touch (`workspace_status_engine.py`, `loop-cohort.py`) at host load 23–107 from peer worktrees; the same target passed at load 8.3 earlier in the session. CI's dedicated `gate-sast` job runs that scan on a clean runner and is the authority here per ADR-0086.

## Scope

Two files. No pack version bump, changelog, or `build-self` reprojection: `packs/` and `tools/` are non-release-impacting in `tools/repo/check_release_impact.py`, and `packs/AGENTS.md` records that pack tests are not projected. `workspace.toml` untouched.

Reviewed by an independent agent that did not write the change. It re-read both test bodies at `885176fad^` to check the rename claim itself, confirmed no assertion was lost, mapped each of the six IDs to its `(brief_status, child_status, expected_rc)` row, and searched all three pinned files for further `ids`-less decorators — none remain.