### PR TITLE
docs(product): land the authoring-quality split under a strategy intent

### DIFF
--- a/docs/product/briefs/agent-authoring-input-quality.md
+++ b/docs/product/briefs/agent-authoring-input-quality.md
@@ -18,7 +18,8 @@ Two things change:
 - **Criteria and tasks stop being fragile.** A criterion states an outcome that
   can fail, once, in one place. A task says what to verify rather than spelling
   out the assertion. Review then finds defects in the subject instead of in the
-  prose about the subject.
+  prose about the subject, and over a mechanism that should exist rather than one
+  that should not.
 - **A contract is not opened over an undefined outcome.** A pressure test at
   creation asks what the work descends from and whether its unknowns are closed,
   and hands the work to brief authoring when they are not.
@@ -26,6 +27,7 @@ Two things change:
 This only **partially** prevents non-convergence, and that is deliberate. A
 better contract still gets things wrong; what a loop does on that discovery is
 [`agent-loop-escalation-recovery.md`](../intents/agent-loop-escalation-recovery.md).
+
 ## Success metrics
 
 - Review rounds on a new contract find defects in the subject rather than in the
@@ -35,6 +37,11 @@ better contract still gets things wrong; what a loop does on that discovery is
   is written, and the redirect is recorded rather than inferred.
 - Every rule this work ships can be shown to have fired at least once. A rule
   with no firing is withdrawn, not re-worded.
+- Measured by classifying a round whose findings share a premise as one finding
+  about the mechanism, not several about the criteria. The first metric cannot
+  see that failure on its own: findings over a wrong mechanism are real, about
+  the subject, and not about wording, so they score there as success.
+
 ## Scope / Non-goals
 
 **In scope**
@@ -45,12 +52,28 @@ better contract still gets things wrong; what a loop does on that discovery is
   contract was found, alongside the imitation anchors the template already asks
   for.
 - Whether a narrow delegated worker should run the ownership survey before
-  authoring, given that every worker this repository defines today is a reviewer
-  or a retriever and none runs before a spec exists — including its source
-  selection, which delegates to the existing knowledge-surface contract rather
-  than defaulting to reading the tree.
-- The activation mechanism for both, and the measurement that says whether they
-  activate.
+  authoring. Nothing narrow and read-only runs inside the delivery loop before
+  criteria exist: `implementer` follows the plan gate, and `product-engineering`'s
+  `discovery-lead` runs before a spec but supervises a whole peer loop rather
+  than performing one step. That worker's source selection would delegate to the
+  existing knowledge-surface contract rather than defaulting to reading the tree.
+- The activation mechanism for the pressure test and the ownership survey.
+- Widening `new-spec`'s existing step 5a so a criterion's satisfiability is
+  probed before the spec gate. A scope change to a rule that exists, not a new
+  artifact.
+- The consumer-side readiness check at the two handoffs the pressure test does
+  not cover: `new-spec`'s input, and a spec and plan handed to an implementer.
+  Same question, asked by whoever must do the next piece of work.
+- **The activation measurement:** whether written guidance activates in this
+  repository at all, read on artifacts an author already wrote. It is the report
+  every deliverable above waits on, and it does not depend on any of them. It
+  starts from `docs/specs/pack-activation-evals/`, which is Shipped and whose
+  Phase 3 already runs a skill on a seeded prompt and grades post-conditions the
+  runner re-derives; what it does not measure is whether an author who had a rule
+  in context then followed it. Prefer generated evals to scavenged history —
+  past review artifacts are gitignored and machine-local. Its report must say
+  which result means written guidance binds, or the appetite below cannot
+  resolve.
 
 **Non-goals**
 
@@ -58,37 +81,73 @@ better contract still gets things wrong; what a loop does on that discovery is
   linked above.
 - Rewriting the cognitive-load or cut-before-adding rules. The question is why
   they do not activate, not whether they are well written.
-- Changing what reviewers do, or how findings are adjudicated.
+- Changing the review lens itself, or how findings are adjudicated. Amended
+  2026-09-02: sequencing a readiness gate *before* review is now in scope,
+  because the gate's whole value is being ahead of the findings it prevents.
+  What a reviewer looks for once it runs, and the adjudicator's contract, stay
+  out.
+
 ## Appetite
 
-The rubric and the instructions are cheap — they are distillation of evidence
-already in this repository. The pressure test is a small gate with one open
-design question (where it fires so it cannot be discharged by filling in a
-missing field). **Activation is the expensive part, and it gates the rest**: if
-the measurement says written guidance does not bind here, the deliverable becomes
-machinery and the appetite changes.
+The activation measurement is appetited now, first and alone. **Activation is the
+expensive part, and it gates the rest**: if the measurement says written guidance
+does not bind here, the deliverable becomes machinery — and machinery leaves this
+brief until an approved amendment sets its appetite. Everything else waits for
+its report — the rubric, the pressure test, the delegation anchor, the ownership
+survey, the step-5a widening, the two further readiness checks, and, if the
+explorer is admitted, the anchoring-prose move. A half that is
+mechanical from the outset waits with them rather than exiting: the amendment
+rule is for what the measurement *converts*.
+
 ## What actually works, and what does not
 
-The load-bearing finding, and it should shape every deliverable.
+Three findings, and each should shape every deliverable.
 
-Across the eleven review rounds that produced this evidence, every mechanism that
-caught a defect **on its first run** bound the document to something outside
-itself: criterion-identifier parity between spec and plan, assumption-citation
-parity in both directions, claims bound to a live symbol table, and mutation
-proofs. The rules that lived only as prose — the cognitive-load simplification,
-the cut-before-adding razor, the observable-outcome rule — were loaded in context
-throughout and fired never.
+Across the eleven review rounds recorded at `e1bdde746` that produced this
+evidence, every mechanism that caught a defect **on its first run** bound the
+document to something outside itself: criterion-identifier parity between spec
+and plan, assumption-citation parity in both directions, claims bound to a live
+symbol table, and mutation proofs. The rules that lived only as prose were loaded
+in context throughout and fired never.
 
-So a rule's value here is not how well it is written. It is whether it binds to
-code, to a sibling document, or to a mutation.
+So a rule's value here is not how well it is written. It is whether it binds to a
+sibling document (both parity checks), to code (the symbol table), or to a
+mutation.
+
+**A fourth target is a lean, not a finding.** A measurement taken before the claim
+is committed would bind the same way, and if it does, a bounded spike belongs in
+authoring and not only in review. Nothing in the corpus above exhibits it: the one
+pre-commitment rule this repository ships is step 5a, whose firing the appetited
+measurement is what settles. Reject this without touching the three above.
+
+**The second finding: a loop can fail to converge over a wrong mechanism.** The
+review question was "is this contract correct?" when the answer needed was "is
+this the right mechanism?" Correctness review over a wrong mechanism has no
+stopping point: every defect it finds is real, and every repair adds surface to a
+design that should not exist. The exhibit is the razor bullet below — several
+rounds spent refining an inline-restatement design this repository had already
+rejected — and decisively, the attempt ended in abandonment rather than repair.
+The discriminator is not viability in the abstract. It is concrete and cheap: has
+this repository already solved this responsibility, and does the mechanism match
+it?
+
+**The third finding: a readiness gate that checks presence cannot tell whether
+the next stage can work.** The same question belongs wherever authoring hands
+off, and it is the consumer's to ask rather than the producer's to assert — is
+this brief spec-authoring ready, is `new-spec`'s input spec-authoring ready, is
+this spec and plan implementable. A developer accepting a user story already asks
+the third. The gate this brief passed asks none of them: it verifies that
+Outcome, In scope and Non-goals exist, not that an author can write from them,
+which is why every review round so far passed a brief whose own first slice was
+unwritable. Presence, not activation, one layer up.
 
 ## Why rules here do not activate
 
 Four instances, all from work in this repository.
 
-- **Cognitive-load and cut-before-adding** were routed from the root context the
-  whole time. The artifacts authored under them were long and dense with precise
-  claims — the opposite of what they ask.
+- **Cognitive-load simplification** was routed from the root context the whole
+  time. The artifacts authored under it were long and dense with precise
+  claims — the opposite of what it asks.
 - **The observable-outcome rule** says a criterion naming a helper or a call
   sequence belongs in the plan. It was read, cited to reviewers as governing
   authority, and broken repeatedly.
@@ -126,11 +185,11 @@ silently does nothing is worse than an absent one.
 Ready review decides. Recorded this way so a reviewer can disagree with the
 conclusion without re-deriving the evidence.
 
-**A dedicated worker guarantees the rule activates, and that is the case for
-one.** A rule in a template may or may not fire. A step a worker performs either
-ran or did not — observably, and not by self-report. **The invocation is the
-activation.** Any rule restatable as a delegated step becomes
-activation-guaranteed; rules that can only be prose are the hard case.
+**A worker guarantees retrieval, not recognition — and retrieval was never the
+failure.** A rule in a template may or may not fire; a step a worker performs
+either ran or did not, observably and not by self-report. That gain is real, but
+it lands on the half that already worked. Rules that can only be prose are the
+hard case.
 
 **Scope: an ownership survey before criteria are written.** It returns a
 *landscape* — what exists in the area, what each component owns, which are
@@ -156,7 +215,7 @@ then manifests, agent and skill definitions, ownership-declaring references, wit
 reading the tree as the explicit expensive floor; a spec author wants decision
 records, conventions, prior specs, distilled topics, with asking the owner as the
 floor. The *contract* for using any such surface already exists in
-`knowledge-surfaces.md` — detect by **capability rather than name**, treat
+`packs/architect/.apm/skills/architect-design/references/knowledge-surfaces.md` — detect by **capability rather than name**, treat
 retrieved context as attributed and untrusted, degrade visibly when none is
 usable. Capability-not-name admits whatever indexer an adopter has without naming
 vendors. The survey cites that contract rather than restating it. The architect
@@ -199,9 +258,9 @@ test. Two moments, so not one worker.
   already recognise precedents reliably — the known misses being unlucky rather
   than typical. Or if a knowledge surface returns ownership directly, leaving
   nothing to organise.
-- **The satisfiability probe is unnecessary if** widening the existing
-  disconfirming-evidence step actually fires. That is an activation question and
-  the same measurement answers it.
+- **The satisfiability probe is unnecessary if** the existing
+  disconfirming-evidence step actually fires today. That is an activation
+  question and the same measurement answers it.
 - **A designer agent becomes necessary only if** one of the two existing owners
   turns out not to cover its half — which would be a finding about that owner,
   not grounds for a third agent beside it.
@@ -220,14 +279,11 @@ brief carries. Its categories, in the order they matter:
    where an owner already exists. Precedes every other shape, because no
    criterion craft rescues it. Its counter-intuitive repair: shortening or
    single-homing a long restatement is the *wrong* fix.
-2. **The criterion cannot fail** — absence claims without a positive control,
-   negative paths passing on an unstubbed collaborator, bounds asserted over a
-   domain that cannot vary them, instruments blind to their own layer.
+2. **The criterion cannot fail.**
 3. **The criterion is unsatisfiable or contradicts a sibling.**
 4. **The criterion decays** — exact counts over a growing corpus, line citations
    in portable artifacts, figures derived from other figures.
-5. **The criterion is too big** — past roughly 150 words it holds several
-   contracts, and a fix in one clause silently contradicts another.
+5. **The criterion is too big.**
 6. **The property is not mechanizable** — a gate over a judgment, or an artifact
    measuring itself.
 
@@ -249,7 +305,7 @@ The abandoned spec is the demonstration: authored with no brief and no workspace
 entry, nothing objected for its whole life, and registering it mid-flight
 *satisfied* the only detector that would have flagged it.
 
-So a test at the trigger, before any body is written: is there a defined outcome
+So a test before any body is written: is there a defined outcome
 or is this still shaping; what upstream does it descend from and is that upstream
 Ready; are load-bearing unknowns still open; and if there is no upstream, is
 direct authoring justified against the durability triggers and recorded rather
@@ -257,8 +313,23 @@ than assumed. **On a gap, redirect to `author-delivery-brief create`** rather th
 refuse — an agent told no finds another route, and that skill already refuses to
 invent missing content.
 
-Open by design: whether the test can be mechanical at all, and where it fires so
-it cannot be discharged the way the registration check was.
+**The ask fires at the routing decision, before `new-spec` is entered**, and its
+answer is recorded. A gate then asserts declared shape only — a claimed upstream
+resolves to a `Ready` brief, or the direct-authoring justification is recorded —
+while a named human owns whether the answer is true. Naming an upstream cannot
+discharge it, because that upstream must exist and be `Ready`. Recording is
+presence, not activation: the activation measurement is what tells the two apart
+here. Its failure mode is that the ask never fires, leaving the gate to catch a
+claimed upstream that does not resolve but never a resolvable one nobody
+considered.
+
+**An open unknown has two dispositions, not one:** a bounded spike that closes
+it, or the redirect. The instrument has step 5a's shape — cheapest disconfirming
+evidence, uncommitted — but not its position: 5a runs inside `new-spec`, and this
+runs at the routing decision, against a risk unknown rather than a draft
+criterion. Which ran and what it returned is recorded; whether it closed the
+unknown is that same named human's call. Its failure mode is the spike that
+becomes the work — an unbounded probe is shaping under another name.
 
 ## The LLD: no change
 
@@ -277,8 +348,8 @@ evidence, one fixture or measurement or read-only probe, uncommitted — so a
 criterion making a claim about live behaviour gets its probe **before the spec
 gate**, against the criterion's satisfiability rather than the plan's mechanism.
 A scope change to a rule that exists, no new artifact, and it composes with the
-pressure test and the survey as three answers to "what must be true before
-criteria are written." No LLD change is recommended; this is answered, not open.
+pressure test and the survey as three answers to "what must be true before the
+criteria are committed at the spec gate."
 
 ## Risks
 
@@ -290,34 +361,38 @@ criteria are written." No LLD change is recommended; this is answered, not open.
   answering whether the spec was warranted. A gate at creation can fail the same
   way.
 - **The rubric grows into doctrine on one instance.** A rule was shipped from
-  this same evidence, as a minor release, and withdrawn a day later as unearned.
+  this same evidence, as a minor release, and withdrawn the same day as unearned.
   The hypothesis is recorded in `[backlog].open` with what would earn it.
+
 ## Rabbit holes
 
 - **Do not mechanize a judgment.** "Is this criterion well-founded?" is not a
   predicate. Where the same gate is defeated twice by different surfaces, split
-  it: the gate asserts declared shape and required fields, a named human owns the
-  soundness call.
+  it, as § "The pressure test at spec creation" does.
 - **Do not verify guidance by parsing the guidance.** A check that a sentence
   exists in a file proves presence, which is the thing already known.
 - **Do not let the rubric become a review checklist.** It is authoring guidance.
   Handed to reviewers it becomes a source of nits, which is the problem it exists
   to reduce.
-## Ready gaps
 
-- **No appetite is set**, and activation's answer changes it.
-- **No slices are proposed.** `continue` selects them. The retrospective
-  activation measurement is the natural first, and it can run before any of the
-  rest is designed.
-- **Where the pressure test fires is undecided**, and it is the open design
-  question that matters most — see the boundary section above.
 ## Spec map
 
-None. No slices confirmed, no spec derived.
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+No slice is confirmed and no spec is authored. Two initial slices are *proposed*,
+in order: the activation measurement, then the pre-creation
+pressure test — whose gate half is mechanical by construction, while its routing
+ask is prose in a routing surface, the class this brief says does not fire. Both halves
+wait on the activation measurement, for the reason § Appetite gives. What else this brief slices into
+is not knowable before the measurement reports.
+
 ## Provenance
 
 - Source: repository origin. Distilled from this repository's memory, its
   `docs/knowledge/` topics, and one abandoned delivery attempt whose spec and
   plan are preserved at commit `e1bdde746`.
-- Promoted from a shaping intent of the same slug on 2026-09-02, which was itself
-  split out of `docs/product/briefs/work-loop-next-action.md`.
+- Promoted on 2026-09-02 from a shaping intent of the same slug, added at
+  `082285e73` and removed by that promotion; it was itself split out of
+  `docs/product/briefs/work-loop-next-action.md`.

--- a/docs/product/briefs/agent-authoring-input-quality.md
+++ b/docs/product/briefs/agent-authoring-input-quality.md
@@ -1,4 +1,4 @@
-# Brief: authoring contracts that survive review
+# Brief: contracts a review loop converges on
 
 - **Slug:** `agent-authoring-input-quality`
 - **Received:** 2026-09-02
@@ -8,272 +8,249 @@
 ## Outcome
 
 An author — human or agent — writes a spec and plan that a review loop can
-converge on, and does not open one at all when the upstream is not ready. Today
-neither holds: a contract can be authored with no upstream and no registration
-and nothing objects, and once authored, most of what review finds is not the
-subject but the way it was written.
+converge on. Today most of what review finds is not the subject but the way it
+was written, and a contract can be sized past every point where this repository
+has ever converged without anything objecting.
 
-Two things change:
+Three things change:
 
-- **Criteria and tasks stop being fragile.** A criterion states an outcome that
-  can fail, once, in one place. A task says what to verify rather than spelling
-  out the assertion. Review then finds defects in the subject instead of in the
-  prose about the subject, and over a mechanism that should exist rather than one
-  that should not.
-- **A contract is not opened over an undefined outcome.** A pressure test at
-  creation asks what the work descends from and whether its unknowns are closed,
-  and hands the work to brief authoring when they are not.
+- **A criterion states an outcome that can fail, once, in one place**, and a
+  plan task says what to verify rather than spelling out the assertion.
+- **A plan records whether an owner already exists** for the responsibility it
+  is about to design, alongside the imitation anchors the template asks for.
+- **A contract is sized before it is written**, against what this repository
+  has converged on rather than an author's sense of scope.
 
-This only **partially** prevents non-convergence, and that is deliberate. A
-better contract still gets things wrong; what a loop does on that discovery is
+This only **partially** prevents non-convergence, deliberately. A better
+contract still gets things wrong; what a loop does on that discovery is
 [`agent-loop-escalation-recovery.md`](../intents/agent-loop-escalation-recovery.md).
 
 ## Success metrics
 
-- Review rounds on a new contract find defects in the subject rather than in the
-  criteria's wording — measured by classifying a round's findings, not by
+- Review rounds on a new contract find defects in the subject rather than in
+  the criteria's wording — measured by classifying a round's findings, not by
   counting them.
-- A contract whose upstream is missing or unready is redirected before its body
-  is written, and the redirect is recorded rather than inferred.
-- Every rule this work ships can be shown to have fired at least once. A rule
-  with no firing is withdrawn, not re-worded.
-- Measured by classifying a round whose findings share a premise as one finding
-  about the mechanism, not several about the criteria. The first metric cannot
-  see that failure on its own: findings over a wrong mechanism are real, about
-  the subject, and not about wording, so they score there as success.
+- A round whose findings share a premise is classified as **one** finding about
+  the mechanism, not several about the criteria. The first metric cannot see
+  that failure alone: findings over a wrong mechanism score there as success.
+- Every rule shipped here can be shown to have fired at least once. A rule with
+  no firing is withdrawn, not re-worded.
+- A contract over the sizing band stalls at authoring, not at round six.
 
 ## Scope / Non-goals
 
 **In scope**
 
 - The failure-point rubric, and the authoring instructions derived from it.
-- The pre-creation pressure test and its redirect.
-- The delegation anchor: making a plan record whether an existing owner for the
-  contract was found, alongside the imitation anchors the template already asks
-  for.
-- Whether a narrow delegated worker should run the ownership survey before
-  authoring. Nothing narrow and read-only runs inside the delivery loop before
-  criteria exist: `implementer` follows the plan gate, and `product-engineering`'s
-  `discovery-lead` runs before a spec but supervises a whole peer loop rather
-  than performing one step. That worker's source selection would delegate to the
-  existing knowledge-surface contract rather than defaulting to reading the tree.
-- The activation mechanism for the pressure test and the ownership survey.
+- **The delegation anchor:** a plan records whether an existing owner for the
+  contract was found.
+- **Sizing discipline** — the band below, shipped as dated evidence plus the
+  derivation that lets any repository recompute it.
 - Widening `new-spec`'s existing step 5a so a criterion's satisfiability is
-  probed before the spec gate. A scope change to a rule that exists, not a new
-  artifact.
-- The consumer-side readiness check at the two handoffs the pressure test does
-  not cover: `new-spec`'s input, and a spec and plan handed to an implementer.
-  Same question, asked by whoever must do the next piece of work.
-- **The activation measurement:** whether written guidance activates in this
-  repository at all, read on artifacts an author already wrote. It is the report
-  every deliverable above waits on, and it does not depend on any of them. It
-  starts from `docs/specs/pack-activation-evals/`, which is Shipped and whose
-  Phase 3 already runs a skill on a seeded prompt and grades post-conditions the
-  runner re-derives; what it does not measure is whether an author who had a rule
-  in context then followed it. Prefer generated evals to scavenged history —
-  past review artifacts are gitignored and machine-local. Its report must say
-  which result means written guidance binds, or the appetite below cannot
-  resolve.
+  probed before the spec gate. A scope change to a rule that exists.
+- **The ownership survey.** Conditional; see § "The survey is a lean".
 
 **Non-goals**
 
-- What a loop does once it has discovered the contract is wrong. Separate item,
-  linked above.
-- Rewriting the cognitive-load or cut-before-adding rules. The question is why
-  they do not activate, not whether they are well written.
-- Changing the review lens itself, or how findings are adjudicated. Amended
-  2026-09-02: sequencing a readiness gate *before* review is now in scope,
-  because the gate's whole value is being ahead of the findings it prevents.
-  What a reviewer looks for once it runs, and the adjudicator's contract, stay
-  out.
+- Readiness at a stage handoff — the pre-creation pressure test, the checks at
+  `new-spec`'s input and at the spec-to-implementer handoff, and review
+  sequencing: [`stage-input-readiness.md`](stage-input-readiness.md).
+- Whether written guidance activates at all:
+  [`guidance-activation-measurement.md`](guidance-activation-measurement.md).
+- Rewriting the cognitive-load or cut-before-adding rules.
+- Changing the review lens, or how findings are adjudicated.
+- What a loop does once it has discovered the contract is wrong.
 
-## Appetite
+## Constraints / Appetite
 
-The activation measurement is appetited now, first and alone. **Activation is the
-expensive part, and it gates the rest**: if the measurement says written guidance
-does not bind here, the deliverable becomes machinery — and machinery leaves this
-brief until an approved amendment sets its appetite. Everything else waits for
-its report — the rubric, the pressure test, the delegation anchor, the ownership
-survey, the step-5a widening, the two further readiness checks, and, if the
-explorer is admitted, the anchoring-prose move. A half that is
-mechanical from the outset waits with them rather than exiting: the amendment
-rule is for what the measurement *converts*.
+**Everything here waits on the activation measurement's report** (owner
+decision, 2026-09-02). If that report says written guidance does not bind here,
+these deliverables become machinery — and machinery leaves this brief until an
+approved amendment sets its appetite.
+
+Every rule shipped here carries the activation contract owned by
+[`guidance-activation-measurement.md`](guidance-activation-measurement.md)
+§ "Constraints / Appetite".
+
+## Sizing discipline
+
+The abandoned contract at `e1bdde746` carried **39 acceptance criteria in
+11,258 words** — above the 96th percentile on criteria and within 3% of the
+longest spec ever written here. Six of its criteria ran over 150 words, the
+longest at 704. Eleven review rounds, no convergence, abandonment. Sizing is a
+lever on this brief's outcome, not a style preference.
+
+### Altitude precedes size
+
+**Check the artifact's altitude before applying any bound below.** Every bound
+in the band measures a property *within* an artifact. None of them asks whether
+this is the right artifact, and an altitude mismatch is the one sizing failure
+that trimming cannot repair — the repair is to re-home the work.
+
+The recognized altitudes run `product-vision > product-strategy > capability >
+feature`, and `decompose-intent` produces the levels beneath whichever is
+chosen. This repository carries 28 intents against 8 briefs, tagged 20
+`feature`, 6 `capability`, and 1 `product-strategy`. A delivery brief sits at
+capability altitude with feature-level slices beneath it.
+
+**Three tells that an artifact is above its altitude**, each cheaper to check
+than any percentile:
+
+- it proposes no slice a spec author could confirm, and the missing input is a
+  decision rather than a detail;
+- it carries a design position, an evidence base, an inventory, or a governance
+  concern, rather than citing one;
+- it changes the gating of its siblings, which a peer cannot do.
+
+The exhibit is this brief's own sibling set. An artifact authored on
+2026-09-02 to hold cross-adapter behavior enforcement reached 3,573 words as a
+delivery brief and showed all three tells. The band would have reported it as
+oversized, which was the symptom; the defect was product-strategy content in a
+capability container, and the repair was re-homing it as an intent rather than
+cutting it.
+
+This is the altitude analogue of rubric category 5. A criterion that is too big
+is cut; an artifact at the wrong altitude is moved.
+
+### Corpus
+
+The corpus has 416 specs, measured 2026-09-02. Its predicate, which the derivation states rather than re-derives: `docs/specs/*/spec.md` at exactly one
+directory level, whose `- **Status:**` reduces to the leading token `Shipped`
+once an annotation (`Shipped (2026-05-26)`) is stripped; a criterion is a
+checkbox bullet under `## Acceptance Criteria`, since roughly half the corpus
+labels them `**ACn —**` and half does not. Criteria per spec: p25 9, median 12,
+p75 18, p90 28, max 104. Words per spec: p25 1,027, median 1,599, p75 2,392,
+p90 3,969, max 11,569.
+
+### Band
+
+Each bound carries its origin; a bound without one cannot be
+argued with.
+
+| Dimension | Bound | Origin |
+| --- | --- | --- |
+| Owning surfaces | one primary surface per slice | Measured, not repo-local: 1 file → 95% resolution, 2 → 42% (SWE-bench Verified, Ganhotra 2025). |
+| Criteria per spec | ceiling of 10, **never a floor** | **Screening only.** Practitioner ceiling ~10. No causal evidence exists in the literature, and this corpus records scope but not outcome, so no percentile of it corroborates a ceiling. A slice with fewer genuine criteria ships with fewer. |
+| Criterion size | **not a word budget.** The gate is semantic atomicity, owned by `packs/core/.apm/skills/new-spec/assets/spec.md` § Acceptance Criteria — the conjunction/substitution test and worked examples E1–E5. Length only *orders* criteria for that test, longest first. | Hard AC word budgets are already rejected here: `docs/specs/shaping-review-contracts/spec.md` ships it as a ticked criterion, RFC-0099 states "no hard word budget is added", and `new-spec` SKILL.md:505 makes shaping review reject one. The length signal is real but is a sampler, not a bound: RFC-0098 took 16 rounds with ~60 findings concentrated in its three longest criteria (267–365 words) while its median 86-word criteria were quiet, and across 6,411 shipped criteria here p90 is 101 words and p96 is 162. |
+| Spec body | ≤1,599 words; past 2,392 needs a stated reason | Measured, repo-local: the corpus median and p75. |
+| Human-equivalent duration | under one hour | Measured: R² = 0.83 against success, ~1 hour ≈ 50% (METR 2025). |
+| Floor | never below one surface plus its verification and its guide | Measured: cutting 8,500 → 2,100 tokens per step raised turns-to-solve from 4.0 to 14.0 (Augment 2025). **Smaller is not safer.** |
+
+### Limit interaction
+
+As `assets/spec.md` requires of any quantity
+carrying two: both are reachable, because 10 criteria at the corpus median of
+35 words each is ~350 words against a 1,599-word body. Criterion size is not a
+limit, so it can neither dominate nor be dominated.
+
+### Corpus limits
+
+Files changed per spec is not obtainable — no spec-to-PR linkage, and slug-grep
+over-matches badly — so **no files-changed figure is quoted for this
+repository**; the surfaces bound is imported from SWE-bench. Nothing records
+review rounds per spec, so the corpus measures scope but not outcome. Nothing
+establishes a criteria *floor*.
+
+### Why no regenerator
+
+Rejected: a regenerator slice. Rubric category 4 below is "the criterion decays
+— exact counts over a growing corpus", and every figure here is a percentile of
+416 specs measured 2026-09-02. Decay is real but cheap to answer: two of the six
+rows are repo-derived percentiles, the rest are imported measurements, the corpus
+grows slowly, and a hand measurement is one command. The criteria ceiling is
+screening-only with no causal evidence behind it, so a stall threshold needs an
+order of magnitude rather than a maintained script.
+
+What an adopter needs is the **derivation**, which the guidance carries: the
+named glob, the status predicate, and the percentile. Shipping our percentiles
+as numbers would be wrong for every adopter on day one; shipping the derivation
+is right for each. The figures here are dated evidence, refreshed by hand, and a
+slice sized against them cites that date.
+
+### Corpus exclusion
+
+This brief does not grade its own sizing: an artifact measuring itself is
+rubric category 6, and the exculpation has to be checkable or it is that same
+defect. What happened: the percentiles were produced on 2026-09-02 by a
+throwaway instrument outside this brief, which first reproduced every figure
+the owner supplied independently. **The corpus-exclusion rule travels with the derivation:** A1, A3, A4 and A5's
+own specs are excluded from any recomputation, or the measurement grades specs
+written to the band it derives from them.
 
 ## What actually works, and what does not
 
 Three findings, and each should shape every deliverable.
+[`stage-input-readiness.md`](stage-input-readiness.md) cites this section by
+name rather than restating it;
+[`guidance-activation-measurement.md`](guidance-activation-measurement.md)
+cites this findings corpus rather than restating its exhibits.
 
-Across the eleven review rounds recorded at `e1bdde746` that produced this
-evidence, every mechanism that caught a defect **on its first run** bound the
-document to something outside itself: criterion-identifier parity between spec
-and plan, assumption-citation parity in both directions, claims bound to a live
-symbol table, and mutation proofs. The rules that lived only as prose were loaded
-in context throughout and fired never.
+### External binding
 
-So a rule's value here is not how well it is written. It is whether it binds to a
-sibling document (both parity checks), to code (the symbol table), or to a
-mutation.
+A rule's value is whether it binds to something outside the document. Across
+the eleven review rounds at `e1bdde746`, every mechanism
+that caught a defect **on its first run** bound the document to something
+external — criterion-identifier parity between spec and plan,
+assumption-citation parity in both directions, claims bound to a live symbol
+table, and mutation proofs. The rules that lived only as prose were loaded in
+context throughout and fired never.
 
-**A fourth target is a lean, not a finding.** A measurement taken before the claim
-is committed would bind the same way, and if it does, a bounded spike belongs in
-authoring and not only in review. Nothing in the corpus above exhibits it: the one
-pre-commitment rule this repository ships is step 5a, whose firing the appetited
-measurement is what settles. Reject this without touching the three above.
+Four non-activation exhibits from the corpus are concrete. Cognitive-load
+simplification was routed from the root context while artifacts remained long
+and dense with precise claims. The observable-outcome rule was read, cited as
+authority, and broken repeatedly. Repository-anchoring tests asserted that
+sentences existed in skill files, while the abandoned plan carried four
+imitation anchors and no record of whether an owner existed.
 
-**The second finding: a loop can fail to converge over a wrong mechanism.** The
-review question was "is this contract correct?" when the answer needed was "is
-this the right mechanism?" Correctness review over a wrong mechanism has no
-stopping point: every defect it finds is real, and every repair adds surface to a
-design that should not exist. The exhibit is the razor bullet below — several
-rounds spent refining an inline-restatement design this repository had already
-rejected — and decisively, the attempt ended in abandonment rather than repair.
-The discriminator is not viability in the abstract. It is concrete and cheap: has
-this repository already solved this responsibility, and does the mechanism match
-it?
+A fourth target is a lean, not a finding. A measurement taken before the
+claim is committed would bind the same way. Nothing in the corpus exhibits it,
+and the one pre-commitment rule this repository ships is step 5a, whose firing
+the activation measurement settles. Reject it without touching the three
+findings.
 
-**The third finding: a readiness gate that checks presence cannot tell whether
-the next stage can work.** The same question belongs wherever authoring hands
-off, and it is the consumer's to ask rather than the producer's to assert — is
-this brief spec-authoring ready, is `new-spec`'s input spec-authoring ready, is
-this spec and plan implementable. A developer accepting a user story already asks
-the third. The gate this brief passed asks none of them: it verifies that
-Outcome, In scope and Non-goals exist, not that an author can write from them,
-which is why every review round so far passed a brief whose own first slice was
-unwritable. Presence, not activation, one layer up.
+### Wrong mechanism
 
-## Why rules here do not activate
+A loop can fail to converge over a wrong mechanism. The review
+question was "is this contract correct?" when the answer needed was "is this
+the right mechanism?" Correctness review over a wrong mechanism has no stopping
+point: every defect it finds is real, and every repair adds surface to a design
+that should not exist. The exhibit is several rounds refining an
+inline-restatement design this repository had already rejected, ending in
+abandonment. The discriminator is cheap: has this repository already solved
+this responsibility, and does the mechanism match it?
 
-Four instances, all from work in this repository.
+The razor's bounded search found that precedent inside ten minutes. The
+failure was recognition, not retrieval.
 
-- **Cognitive-load simplification** was routed from the root context the whole
-  time. The artifacts authored under it were long and dense with precise
-  claims — the opposite of what it asks.
-- **The observable-outcome rule** says a criterion naming a helper or a call
-  sequence belongs in the plan. It was read, cited to reviewers as governing
-  authority, and broken repeatedly.
-- **The razor is the costliest.** Its second rung is one bounded search for an
-  adequate repository solution, reusing a hit. The search *ran*: `work-loop`'s
-  three-line delegation to the `project-knowledge` producer profile came back in
-  the opening grep, and the architect pack's `knowledge-surfaces.md` was read in
-  full, both inside ten minutes. Neither was recognised as the precedent for the
-  contract being designed, and several rounds went into an inline-restatement
-  design this repository had already rejected. **The failure is at recognition,
-  not retrieval** — which is why "search first" cannot fix it.
-- **Repository anchoring fails twice over.** Its tests assert that sentences
-  exist in the skill files; nothing reads an authored plan to see whether it has
-  anchors, whether they resolve, or whether they were used. And it was complied
-  with anyway — the abandoned plan carried four anchors, all imitation, because
-  the field asks what to copy rather than whether an owner exists.
+### Presence-only gates
 
-That last one is the strongest argument here: **a rule can be shipped, tested,
-and complied with, and still not do its job.**
+A readiness gate that checks presence cannot tell whether the next stage can
+work. Its exhibit is this brief's own predecessor, which passed
+seven review rounds while its first slice was unwritable, because the gate
+verified that Outcome, In scope and Non-goals existed rather than that an
+author could write from them. Acting on this belongs to
+[`stage-input-readiness.md`](stage-input-readiness.md).
+The abandoned spec was also authored with no brief and no workspace entry;
+nothing objected for its whole life, and registering it mid-flight satisfied
+the only detector that would have flagged it.
 
-Enforcement exists for some of these and is scoped elsewhere: the cognitive-load
-gates read the packs, root guidance, seeds, and changelog, and the
-progressive-disclosure lint has a case asserting an authored spec is *not* in its
-results. Authored artifacts sit outside the enforcement boundary by design.
+### Self-observed activation failure
 
-**So every rule this work ships carries three things:** an activation point (the
-moment something changes if it is ignored, not the file it is written in), a
-measurement (how to tell activation from presence, on artifacts the author
-wrote), and a stated failure mode when it does not activate — because a rule that
-silently does nothing is worse than an absent one.
-
-## Where this is leaning: an explorer, not a designer
-
-**Not an owner decision.** This is the lean and the facts it rests on; the
-Ready review decides. Recorded this way so a reviewer can disagree with the
-conclusion without re-deriving the evidence.
-
-**A worker guarantees retrieval, not recognition — and retrieval was never the
-failure.** A rule in a template may or may not fire; a step a worker performs
-either ran or did not, observably and not by self-report. That gain is real, but
-it lands on the half that already worked. Rules that can only be prose are the
-hard case.
-
-**Scope: an ownership survey before criteria are written.** It returns a
-*landscape* — what exists in the area, what each component owns, which are
-reusable — not a verdict. Judging "is this an owner for the contract I am about
-to write" needs the contract, which the worker does not have; forced to judge it
-would return confident wrong answers. Recognition stays with the author, and
-becomes cheap because the inventory is organised for that question.
-
-**Why not the host's built-in explorer.** Only Claude Code's `Explore` was
-inspectable; no claim is made about Codex, Cursor, Copilot, or Gemini. So the
-case rests on ownership, not capability — which probably favours the built-in,
-and that is fine, because searching was never the failure. A host built-in is not
-ours to shape: its output form, its authority inputs, its versioning, its
-shipping with the pack, and decisively **its instrumentation**. This brief's
-premise is that we cannot tell activation from presence; delegating a rule to a
-component whose firing we cannot measure reintroduces exactly that blindness one
-layer down. Reuse a host's isolation where it is offered; the survey
-instructions, return shape, authority binding, and eval surface stay ours.
-
-**Its sources are role-scoped, and delegated.** An ownership survey and a spec
-author ask different questions: the survey wants a code index or codebase model,
-then manifests, agent and skill definitions, ownership-declaring references, with
-reading the tree as the explicit expensive floor; a spec author wants decision
-records, conventions, prior specs, distilled topics, with asking the owner as the
-floor. The *contract* for using any such surface already exists in
-`packs/architect/.apm/skills/architect-design/references/knowledge-surfaces.md` — detect by **capability rather than name**, treat
-retrieved context as attributed and untrusted, degrade visibly when none is
-usable. Capability-not-name admits whatever indexer an adopter has without naming
-vendors. The survey cites that contract rather than restating it. The architect
-pack is also the warning: it ships three role-scoped copies and two duplicate
-their common half.
-
-**Leaning against a designer agent.** The work splits three ways and only one
-part is unowned.
-
-| The job | Owner | Verdict |
-| --- | --- | --- |
-| Produce the design | `plan.md`'s `## Design (LLD)` | Exists; moving it earlier inverts the contract/strategy split |
-| Critique a design artifact | `design-reviewer`, in the **architect** pack, which core does not depend on | Exists elsewhere. Core's answer is conditional routing with a named skip, as `new-spec` already does for `design-review` |
-| Test whether a draft criterion is satisfiable by any design | **Nobody** | The real gap — and it is a probe, not a designer |
-
-A named skip is acceptable for an optional enhancement and a hole for a
-load-bearing check. Design critique at spec stage is currently optional, so on
-this reading core needs nothing new; if this work later makes it load-bearing
-before the spec gate, that changes.
-
-**A consequence worth weighing: prose moves out of the always-loaded surface.**
-If the explorer owns the ownership survey, then some of the repository-anchoring
-prose currently carried in `work-loop` and `new-spec` no longer needs to be
-carried there — the instruction becomes "the survey ran, here is its landscape"
-rather than a restatement of how to search, what counts as an anchor, and what to
-do on absence. That is the delegation form applied to the anchoring rule itself,
-and it reduces an always-loaded surface rather than adding to one. It also means
-the explorer is not purely additive: it has a prose budget on the other side of
-the ledger, which the Ready review should net out rather than treating the worker
-as pure cost.
-
-**Sequence forbids merging the survey and the probe.** The survey must run
-*before* criteria exist, because its output shapes which criteria to write. The
-probe must run *after* a draft criterion exists, because it needs something to
-test. Two moments, so not one worker.
-
-### Pressure test
-
-- **The survey is unnecessary if** the activation measurement shows authors
-  already recognise precedents reliably — the known misses being unlucky rather
-  than typical. Or if a knowledge surface returns ownership directly, leaving
-  nothing to organise.
-- **The satisfiability probe is unnecessary if** the existing
-  disconfirming-evidence step actually fires today. That is an activation
-  question and the same measurement answers it.
-- **A designer agent becomes necessary only if** one of the two existing owners
-  turns out not to cover its half — which would be a finding about that owner,
-  not grounds for a third agent beside it.
-- **The honest cost:** three interventions around one authoring act is real
-  ceremony and the per-spec cost is unmeasured. If written steps do fire, most of
-  this collapses into widening rules that already exist. The brief should want
-  that answer.
+A fifth, self-observed non-activation instance shows that artifact guidance
+can be present through two routes and still lose every conflict.
+`author-delivery-brief/SKILL.md:37` requires descriptive headings, short
+resumable sections, one fact per sentence, no repeated summary, and at most one
+load-bearing point per section. On 2026-09-02, these three briefs measured
+1.4–1.6 load-bearing points per section; one predicate appeared three times in
+one file; and this brief had grown from 3,622 to 4,746 words. The clause had no
+oracle, preserving substance made adding safer than cutting, and the review
+loop had no subtractive move because every finding was closed by writing.
 
 ## The rubric is a deliverable, not content here
 
 The failure-point rubric is distilled from this repository's memory and its
-`docs/knowledge/` topics, and it is what the work produces rather than what the
-brief carries. Its categories, in the order they matter:
+`docs/knowledge/` topics. It is what the work produces, not what the brief
+carries. Its categories, in the order they matter:
 
 1. **The design should have delegated** — an obligation restated per consumer,
    where an owner already exists. Precedes every other shape, because no
@@ -281,112 +258,304 @@ brief carries. Its categories, in the order they matter:
    single-homing a long restatement is the *wrong* fix.
 2. **The criterion cannot fail.**
 3. **The criterion is unsatisfiable or contradicts a sibling.**
-4. **The criterion decays** — exact counts over a growing corpus, line citations
-   in portable artifacts, figures derived from other figures.
-5. **The criterion is too big.**
-6. **The property is not mechanizable** — a gate over a judgment, or an artifact
-   measuring itself.
+4. **The criterion decays** — exact counts over a growing corpus, line
+   citations in portable artifacts, figures derived from other figures.
+5. **The criterion is too big** — the band above is what mechanizes this one.
+6. **The property is not mechanizable** — a gate over a judgment, or an
+   artifact measuring itself.
+
+**A1 supplies family definitions; it does not register or enforce them.** The
+registry surface belongs to
+[`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md) and the
+deterministic check to
+[`policy-arrival-validator.md`](policy-arrival-validator.md). A1's own surfaces
+stay the rubric and its one consumer, so its slice remains one primary surface;
+without that split A1 would silently own a registry and an enforcement path it
+does not name.
+
+**Categories 2, 4 and 5 ship as policy families; 1 and 6 stay prose.** The
+checkable ones — a criterion that cannot fail, a criterion that decays on exact
+counts, a criterion that is too big — become families in the registry owned by
+[`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+delivered to the authoring agent for its phase and checked deterministically.
+Category 1 (the design should have delegated) and category 6 (the property is
+not mechanizable) have no decidable predicate and remain authoring guidance.
+
+**That supplies A1's activation contract**, which prose could not: the
+activation point is the phase gate, the measurement is the per-family verdict,
+and the stated failure mode is the recorded block rate. **The altitude check is
+one of these families** — the tell "carries a design position or an inventory
+rather than citing one" is not decidable, but "proposes no slice a spec author
+could confirm" is, against the slice table's own columns.
+
+**A family ships precise or advisory, never in between.** Applying an emphasis
+density predicate to everything `docs/AGENTS.md` governs blocks 405 of 1,477
+files, 27.4%, against a 0.4% per-family budget. A family that cannot be
+calibrated is delivered as guidance and never blocks.
 
 **For plan tasks:** name what to verify, not how. A bullet spelling out the
 assertion, the fixture, and the expected message is pseudo-code — reviewed as
 code while unable to run, and every detail in it is a claim the next round can
 falsify.
 
-## The pressure test at spec creation
-
-Nothing today tests whether a spec should exist. `new-spec` elicits well — it
-surfaces an Unverified list and waits — but that defends the spec's *content*.
-Its triggers are a disjunction in which "the user explicitly requests a spec" is
-sufficient; `Brief:` is stamped only when arriving from a confirmed slice, nothing
-checks it resolves, and `none` is accepted almost everywhere. The one detector
-that would notice, `unregistered_work`, fires at **dispatch**.
-
-The abandoned spec is the demonstration: authored with no brief and no workspace
-entry, nothing objected for its whole life, and registering it mid-flight
-*satisfied* the only detector that would have flagged it.
-
-So a test before any body is written: is there a defined outcome
-or is this still shaping; what upstream does it descend from and is that upstream
-Ready; are load-bearing unknowns still open; and if there is no upstream, is
-direct authoring justified against the durability triggers and recorded rather
-than assumed. **On a gap, redirect to `author-delivery-brief create`** rather than
-refuse — an agent told no finds another route, and that skill already refuses to
-invent missing content.
-
-**The ask fires at the routing decision, before `new-spec` is entered**, and its
-answer is recorded. A gate then asserts declared shape only — a claimed upstream
-resolves to a `Ready` brief, or the direct-authoring justification is recorded —
-while a named human owns whether the answer is true. Naming an upstream cannot
-discharge it, because that upstream must exist and be `Ready`. Recording is
-presence, not activation: the activation measurement is what tells the two apart
-here. Its failure mode is that the ask never fires, leaving the gate to catch a
-claimed upstream that does not resolve but never a resolvable one nobody
-considered.
-
-**An open unknown has two dispositions, not one:** a bounded spike that closes
-it, or the redirect. The instrument has step 5a's shape — cheapest disconfirming
-evidence, uncommitted — but not its position: 5a runs inside `new-spec`, and this
-runs at the routing decision, against a risk unknown rather than a draft
-criterion. Which ran and what it returned is recorded; whether it closed the
-unknown is that same named human's call. Its failure mode is the spike that
-becomes the work — an unbounded probe is shaping under another name.
-
-## The LLD: no change
+## Satisfiability is tested late, not designed late
 
 The LLD lives in `plan.md`, authored after the spec's criteria and locked after
 the spec's gate — so criteria are committed before the design that must satisfy
 them exists. That is late for exactly one thing: **satisfiability**. The
-abandoned contract had a criterion no design could satisfy, and an observability
-premise that was a design question never asked.
+abandoned contract had a criterion no design could satisfy, and an
+observability premise that was a design question never asked.
 
-But hoisting the LLD earlier inverts the contract/strategy split, and the plan is
-deliberately the document allowed to change. The problem is not that the LLD is
-late; it is that nothing tests satisfiability early.
+Hoisting the LLD earlier inverts the contract/strategy split, and the plan is
+deliberately the document allowed to change. So: **widen `new-spec`'s existing
+step 5a** — cheapest disconfirming evidence, one fixture or measurement or
+read-only probe, uncommitted — so that **a criterion making a claim about live
+behaviour gets its probe before the spec gate**, against the criterion's
+satisfiability rather than the plan's mechanism.
 
-**Recommendation: widen `new-spec`'s existing step 5a** — cheapest disconfirming
-evidence, one fixture or measurement or read-only probe, uncommitted — so a
-criterion making a claim about live behaviour gets its probe **before the spec
-gate**, against the criterion's satisfiability rather than the plan's mechanism.
-A scope change to a rule that exists, no new artifact, and it composes with the
-pressure test and the survey as three answers to "what must be true before the
-criteria are committed at the spec gate."
+### A4 firing predicate
 
-## Risks
+That clause is A4's firing predicate. Step 5a
+today probes the *plan's* load-bearing mechanism
+(`packs/core/.apm/skills/new-spec/SKILL.md:475`), and one probe cannot cover an
+unbounded set of criteria. "A claim about live behaviour" is what selects the
+criteria that get one.
 
-- **This brief ships another unactivated rule.** The most likely failure, and the
-  reason activation is scoped in rather than assumed. The withdrawal metric above
-  is the guard.
-- **The pressure test is discharged rather than answered.** The existing
-  registration check was satisfied by filling in the missing entry, not by
-  answering whether the spec was warranted. A gate at creation can fail the same
-  way.
-- **The rubric grows into doctrine on one instance.** A rule was shipped from
-  this same evidence, as a minor release, and withdrawn the same day as unearned.
-  The hypothesis is recorded in `[backlog].open` with what would earn it.
+[`stage-input-readiness.md`](stage-input-readiness.md)
+§ "What nothing checks today" owns the step-5a-versus-routing-spike
+distinction and its slicing consequence.
+
+## The survey is a lean
+
+This is not an owner decision. It lets a reviewer disagree with the
+conclusion without re-deriving the evidence.
+
+- **A worker guarantees retrieval, not recognition — and retrieval was never
+  the failure.** The gain lands on the half that already worked.
+- **Its scope is a landscape, not a verdict:** what exists in the area, what
+  each component owns, which are reusable. Judging "is this an owner for the
+  contract I am about to write" needs the contract, which the worker does not
+  have; forced to judge, it returns confident wrong answers. Recognition stays
+  with the author and becomes cheap because the inventory is organised for it.
+- **Not the host's built-in explorer** — on ownership, not capability. Only
+  Claude Code's `Explore` was inspectable, so no claim covers Codex, Cursor,
+  Copilot, or Gemini. A host built-in is not ours to **instrument**, and
+  delegating a rule to a component whose firing we cannot measure reintroduces
+  the blindness the activation measurement exists to remove.
+- **Its sources are role-scoped**, and only its *permission* behaviour is
+  already owned. `packs/architect/.apm/skills/architect-design/references/knowledge-surfaces.md`
+  governs detection by capability rather than product name, treating retrieved
+  context as attributed and untrusted, and degrading visibly when no surface is
+  usable. It does **not** govern which grounding technique to use — that is the
+  open question below. That pack is also the warning: three role-scoped copies, two
+  duplicating their common half.
+
+### Repository grounding is a developed field, and this is where the survey competes
+
+Naming the prior art matters because most of it optimises **retrieval**, and
+this brief's own evidence says the failure was **recognition**. The classes,
+roughly cheapest first:
+
+| Class | Exemplars | What it returns |
+| --- | --- | --- |
+| Lexical / agentic search | ripgrep, glob; the search loop coding agents run | Exact matches, no index, no staleness |
+| Symbol indexes | LSP, SCIP and LSIF, ctags | Definitions and references, not text matches |
+| Repo maps / code graphs | aider's tree-sitter map with graph ranking | A whole-repo skeleton ranked into a context budget |
+| Dense or hybrid chunk retrieval | embedding indexes, BM25 hybrids | High recall over prose and code, weak on ownership |
+| Build and dependency graphs | Bazel and Buck targets, Nx project graphs, package manifests | Module boundaries, declared mechanically |
+| Ownership declarations | `CODEOWNERS`, service catalogues such as Backstage | **Ownership, answered directly** |
+| Agentic localization | Agentless's localize-then-repair, AutoCodeRover's search APIs, SWE-agent's file viewer | A ranked file set; localization is a dominant error source |
+
+The first four are retrieval, and the razor's search already ran and already
+returned the precedent, so they address the half that worked. **The last two
+are the ones that bear on recognition**, because they make ownership a declared
+fact rather than an inference — and this repository ships neither: there is no
+`CODEOWNERS`, no service catalogue, and no target graph declaring module
+ownership.
+
+That reorders the options. A mechanical ownership declaration is cheaper than a
+worker, is inspectable, and fails loudly when stale; a survey that reads an
+undeclared tree infers ownership every time it runs. **Weigh adopting one
+before admitting A5** — the razor's second rung asks for exactly this, and A5
+is the addition it would screen.
+
+### Code graphs
+
+A code graph is not an ownership declaration, and the code-graph benchmark is
+not this work. [`code-graph-review-benchmark.md`](../intents/code-graph-review-benchmark.md)
+is a separate Draft intent asking whether graph-assisted exploration improves
+**code-review** findings, measured by valid finding yield, false-positive rate,
+and review time against repository-native exploration. Three reasons it stays
+separate rather than folding in here: it is a review-time question, which this
+brief's non-goals exclude; it explicitly does not authorize adopting a
+code-graph provider; and in the table above, repo maps and code graphs return a
+ranked skeleton while ownership declarations answer ownership directly. **So
+adopting a code graph would not fire A5's kill condition** — that condition
+needs a declaration that *records* an owner, not a retrieval surface that infers
+one. The two share prior art and should not duplicate it: that intent carries
+its own survey at
+`docs/specs/work-loop-review-verdicts/notes/code-graph-code-review-effectiveness-survey.md`,
+and this brief keeps the grounding-classes table.
+- **Against a designer agent.** `plan.md`'s `## Design (LLD)` owns producing a
+  design; `design-reviewer` in the architect pack owns critiquing one, reached
+  by conditional routing with a named skip as `new-spec` already does for
+  `design-review`. Only "is a draft criterion satisfiable by any design" is
+  unowned — a probe, not a designer.
+- **It has a prose budget on the other side of the ledger.** Some
+  repository-anchoring prose in `work-loop` and `new-spec` stops needing to be
+  carried there. Net that out rather than treating the worker as pure cost.
+- **The survey and the probe cannot merge.** The survey runs before criteria
+  exist, because its output shapes which to write; the probe runs after,
+  because it needs something to test.
+
+### Kill conditions
+
+Each condition names the row it kills and the report line that decides it.
+
+- **A5 dies** if M's verdict for **the repository-anchoring variant M1 selects**
+  is *fired*. Repository anchoring is a **rule family, not a rule**: measured
+  on 2026-09-02, at least `adapt-to-project`,
+  `contract-acquisition`, `new-spec` and `work-loop` each carry their own
+  normative anchoring span, plus `architect-design` in the architect pack, and
+  each is normative only inside its own skill's trigger context. M1 must pick
+  one variant and its artifact; this kill condition reads that one. If M1
+  instead records repository anchoring as *not gradable*, **this condition never
+  fires and A5 is decided by a named human at its confirmation gate** — it does
+  not silently pass.
+- **A5 also dies if this repository adopts a mechanical ownership
+  declaration** — a `CODEOWNERS`, a service catalogue, or a target graph naming
+  the owner of a surface. A declaration records ownership rather than judging
+  it, which is why it is the cheaper option the razor's second rung screens A5
+  against. Rejected: "a knowledge surface returns ownership directly", which is
+  unfirable, because judging *responsibility* ownership needs the contract no
+  retrieval surface has.
+  **The decision sits at A5's confirmation gate, not at this brief's Ready
+  gate** (owner decision, 2026-09-02). Verified absent from this repository on
+  that date: no `CODEOWNERS` at the root or under `.github/`, no service
+  catalogue, and no ownership-declaring target graph. A5 is gated after M
+  regardless, so nothing is blocked by leaving it open — and adopting a
+  root-level ownership declaration is a repository-wide change that belongs in
+  its own decision, not settled inside a brief's readiness review.
+- **A4 dies** if M's verdict for `new-spec` step 5a is *fired*: the widening
+  exists to make a step activate that may already activate. A4's Gating cell is
+  conditional in the same way A5's is. **This condition depends on M grading
+  process provenance, not authored artifacts alone** (owner decision,
+  2026-09-02): step 5a requires that the probe ran *before* review, stayed
+  side-effect-free, and was not committed, and none of that is recoverable from
+  an authored spec or plan. M's grading contract was widened to admit run and
+  revision provenance so this verdict is obtainable; if M nevertheless records
+  step 5a as *not gradable*, A4 is decided by a named human at its confirmation
+  gate rather than passing by default.
+- **A designer agent** becomes necessary only if one of the two existing owners
+  does not cover its half — a finding about that owner, not grounds for a third
+  agent.
+
+## Proposed slices
+
+None is confirmed and no spec is authored. Slice sizes are targets a spec
+author writes to under § "Sizing discipline". **The AC ceiling is a ceiling
+and a stall threshold, never a floor** — a slice with fewer genuine criteria
+ships with fewer.
+
+| # | Slice | Owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| A1 | The failure-point rubric and the authoring instructions derived from it | `packs/core/.apm/skills/new-spec/references/failure-point-rubric.md`, consumed by `packs/core/.apm/skills/new-spec/assets/spec.md` § Acceptance Criteria | an eval case in `new-spec/evals/` grading an authored criterion against a named rubric category | **new** `guides/core/reference/acceptance-criteria-authoring.md` | 10 | after M reports, and after `phase-scoped-policy-delivery` and `policy-arrival-validator` |
+| A3 | The delegation anchor | `packs/core/.apm/skills/new-spec/assets/plan.md`'s `Repository anchors` field | a plan authored with the field records whether an owner was found, and the recorded answer resolves | `guides/core/reference/spec-shape-and-lld.md` | 6 | after A1 |
+| A4 | Widening `new-spec` step 5a | step 5a in `packs/core/.apm/skills/new-spec/SKILL.md` | an eval case proving a criterion claiming live behaviour gets a probe before the spec gate, and one not claiming it does not | `guides/core/how-to/plan-and-execute-non-trivial-work.md` § "Step 1 — Run `new-spec`" | 6 | after A1; **conditional** — dies if M's step-5a verdict is *fired*, and decided by a named human if that verdict is *not gradable* |
+| A5 | The ownership survey — **a conditional candidate, not a sized slice** | named at confirmation | named at confirmation | named at confirmation | 10 | **conditional** — after M, and only if the kill conditions above do not fire |
+
+### Guide ownership
+
+A1 ships a new guide. Measured 2026-09-02: **no adopter-facing Core guide owns
+acceptance-criteria authoring.** `guides/core/reference/spec-shape-and-lld.md`
+owns the `Shape:` field, durable outputs and the plan's LLD — it notes that UI
+states and measurable NFRs rise to criteria but carries no criterion rubric — so
+A1 cannot extend it. A3 belongs there because the `Repository anchors` field
+lives in the plan that guide owns.
+
+### A1 home
+
+A1's home follows the precedent in the surface it extends. As of
+2026-09-02, `packs/core/.apm/skills/new-spec/references/` already holds exactly
+this artifact class — its only current file is `contract-types.md` — and
+`assets/spec.md` § Acceptance Criteria is already the named owner of the
+semantic-atomicity gate that rubric category 5 defers to, so the rubric lands
+next to its precedent and its one consumer is the file that already governs
+criterion shape. `docs/knowledge/topics/` stores observations rather than
+shipped guidance, so a rubric there would not reach adopters.
+
+### Slice relationships
+
+A1 and A3 share one guide, each extending its own section. The guide is
+the secondary surface, not the primary one, so sharing it does not breach the
+one-primary-surface bound; three slices editing three sections of one reference
+page is not one slice.
+
+- **A3 is the template field alone.** Rejected: pairing it with the repository-anchoring rule, which is a second surface in an unnamed home and breaches the one-surface bound. Whether that rule's prose also has to move is A5's prose-budget question. Whether repository-anchoring prose also has
+to move is A5's prose-budget question, not A3's.
+
+- **A1 keeps the rubric and its instructions together.** Two files, one
+deliverable: the rubric with no instruction change is content nobody reads, and
+the instruction change with no rubric has no source. Splitting them lands below
+the over-splitting floor.
+
+- **A3 and A4 are independent** and run in any order once A1 lands.
+
+**A5 is deliberately not size-assessable yet, and that is a state rather than a
+gap.** Its worker home, verification and guide are named at its confirmation
+gate, because two kill conditions may retire it first: M's verdict for the
+selected repository-anchoring variant, and this repository adopting a mechanical
+ownership declaration. Sizing a slice that two named conditions may delete would
+be work spent on a candidate, so the row records the conditionality instead of
+inventing a surface. A reviewer should read A5 as a candidate; a spec author
+should not attempt it before the gate. A2 is withdrawn and its number is not reused, so the identifiers cited elsewhere stay valid.
+
+## Assumptions / Risks
+
+- **This brief ships another unactivated rule.** The most likely failure, and
+  the reason everything waits on the activation report. The withdrawal metric
+  above is the guard.
+- **The ownership survey ships, observably runs, and leaves recognition still
+  failing.** Every kill condition above is a necessity condition; none covers
+  "it ran and did not work". A survey can return a correct landscape the author
+  still does not recognise the precedent in. Answer this before A5 is
+  confirmed.
+- **The rubric grows into doctrine on one instance.** The hypothesis is in
+  `[backlog].open` with what would earn it.
+- **The sizing band is screening evidence dressed as a bound.** The criteria
+  count has no causal evidence behind it. It should stall a contract for a
+  conversation, never silently refuse one.
+
+## Ready gaps (Draft only)
+
+- **Settled — A1's second upstream is named.** Categories 2, 4 and 5 ship as
+  policy families, so A1 waits on
+  [`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md) and
+  [`policy-arrival-validator.md`](policy-arrival-validator.md) as well as on M's
+  report. A3, A4 and A5 inherit that through A1.
+- **Open, but not a Ready blocker: the mechanical ownership declaration.** Its
+  decision sits at A5's confirmation gate by owner decision, recorded with the
+  evidence in § "The survey is a lean". A5 is gated after M, so no slice waits
+  on it.
+- **Carried, not closed: the "ran and did not work" assumption.** It is a Risks
+  bullet above and must be answered before A5 is confirmed. Recorded here so
+  the obligation is not lost between the brief and the slice cut.
 
 ## Rabbit holes
 
 - **Do not mechanize a judgment.** "Is this criterion well-founded?" is not a
-  predicate. Where the same gate is defeated twice by different surfaces, split
-  it, as § "The pressure test at spec creation" does.
-- **Do not verify guidance by parsing the guidance.** A check that a sentence
-  exists in a file proves presence, which is the thing already known.
-- **Do not let the rubric become a review checklist.** It is authoring guidance.
-  Handed to reviewers it becomes a source of nits, which is the problem it exists
-  to reduce.
+  predicate.
+- **Do not let the rubric become a review checklist.** It is authoring
+  guidance. Handed to reviewers it becomes a source of nits, which is the
+  problem it exists to reduce.
+- **Do not hardcode a percentile.** The band is a snapshot; the check
+  recomputes it.
 
 ## Spec map
 
 | Spec | Status |
 | --- | --- |
 |  |  |
-
-No slice is confirmed and no spec is authored. Two initial slices are *proposed*,
-in order: the activation measurement, then the pre-creation
-pressure test — whose gate half is mechanical by construction, while its routing
-ask is prose in a routing surface, the class this brief says does not fire. Both halves
-wait on the activation measurement, for the reason § Appetite gives. What else this brief slices into
-is not knowable before the measurement reports.
 
 ## Provenance
 
@@ -395,4 +564,12 @@ is not knowable before the measurement reports.
   plan are preserved at commit `e1bdde746`.
 - Promoted on 2026-09-02 from a shaping intent of the same slug, added at
   `082285e73` and removed by that promotion; it was itself split out of
-  `docs/product/briefs/work-loop-next-action.md`.
+  [`work-loop-next-action.md`](work-loop-next-action.md).
+- **Split on 2026-09-02 at commit `5ff0d3b19`**, where this brief had reached
+  3,622 words against a 2,619-word precedent. The activation measurement moved
+  to
+  [`guidance-activation-measurement.md`](guidance-activation-measurement.md)
+  and stage-handoff readiness to
+  [`stage-input-readiness.md`](stage-input-readiness.md). This file kept the
+  slug because two artifacts outside the split's scope link to it by path, and
+  it retains the findings corpus all three cite.

--- a/docs/product/briefs/guidance-activation-measurement.md
+++ b/docs/product/briefs/guidance-activation-measurement.md
@@ -1,0 +1,530 @@
+# Brief: does written guidance activate, here and elsewhere?
+
+- **Slug:** `guidance-activation-measurement`
+- **Received:** 2026-09-02
+- **Owner:** Repository maintainers (`ini-002`)
+- **Status:** Draft
+
+## Outcome
+
+We know whether the written-guidance mechanism binds — graded on what an author
+produced while a rule was in context, and on the run provenance of that
+authoring, rather than on whether the rule was loaded. Today we cannot tell
+binding from presence, so every rule this repository ships is unfalsifiable: it
+can be loaded, tested, cited to a reviewer as authority, and complied with, and
+still do nothing.
+
+### Grading contract
+
+The grading contract admits run and revision provenance. On 2026-09-02, a
+spike tested the six floor rules against an authored-artifact-only contract and
+found only two of them gradable: some rules are satisfied by *process* facts an
+authored artifact cannot record. `new-spec` step 5a requires that a probe ran
+before review, stayed side-effect-free, and was not committed; the razor's
+bounded-search rung requires that a search ran and its hit was recognised.
+Neither leaves a trace in the spec or plan that results from it. Grading those
+from authored output alone would mean reading absence as "did not fire", which
+fabricates observability the rules never asked for — so the contract admits tool
+traces and git evidence for the process half. **What it still refuses is the
+guidance file itself**: reading the rule to see whether the rule exists is the
+conflation this brief was written to end.
+
+### Portable estimand
+
+The estimand is portable: does this mechanism work across adopter repositories,
+not only here? External repositories have to be selected, read in temp
+read in temp and set up, and each sampled rule needs a task that
+makes it apply.
+
+### Separate strata
+
+The measurement runs a *local* stratum over
+named rules in this repository and an *external* stratum over anonymized
+adopter repositories read in temp, and the report keeps them separate. Aggregating them would
+dissolve the thing the siblings consume: three of their slices read individual
+local verdicts, and a blended score cannot resolve any of them. The local
+stratum is mandatory; the external stratum is what makes the claim portable.
+
+The graded artifacts are produced by the agent under test inside the eval run.
+"On artifacts the author wrote" means the rule is judged against authored
+output, not against the guidance file — it does not mean the corpus is
+scavenged from history.
+
+This brief produces one report. It ships no rule.
+
+## The measurement is an ablation, not an inspection
+
+**A compliant artifact does not show that a rule was used.** Webson and Pavlick
+found irrelevant and misleading prompts performing as well as instructive ones
+(NAACL 2022), so single-condition inspection cannot separate "the rule bound"
+from "the model would have done it anyway". The evidence and its limits are in
+[`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).
+
+This brief is therefore the **second** of a two-test design (owner decision,
+2026-09-02). The first test — a per-policy compliance validator — belongs to
+[`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+and this brief consumes it. What remains here is the causal question: **does the
+prose add behavioral value above the mechanical control?**
+
+**The design, and every element is load-bearing:**
+
+- **Three conditions per task:** the rule present, the rule removed, and a
+  **length-matched placebo**. The placebo is not optional — deleting text also
+  changes context length, position, and salience, so a two-condition test
+  measures "less text" rather than "no rule".
+- **Frozen for the run:** model, decoding configuration, surrounding prompt,
+  tool set, and evaluator. A change to any of them starts a new run.
+- **A challenge set with room to fail.** Tasks are selected so the control
+  condition *can* violate the rule. A ceiling hides the effect, and this
+  repository has a live ceiling: all three sibling briefs already pass the
+  cognitive-load grade threshold.
+- **The evaluator is blinded to condition**, or it rationalises the treatment
+  arm.
+- **Repetitions per task**, because generation is stochastic.
+- **Paired analysis** — McNemar for paired binary outcomes — with a
+  **pre-registered minimum effect**, not mere significance.
+- **A non-inferiority check on unrelated quality**, because a rule can "work" by
+  degrading the whole answer.
+
+**Every statistical outcome maps to a verdict, and the mapping is
+pre-registered.** M1 owns this table; without it the arms produce a result with
+no defined reading.
+
+| Outcome | Verdict |
+| --- | --- |
+| Treatment beats both removal and placebo, lower bound above the pre-registered effect | **fired** |
+| Treatment beats removal but not the length-matched placebo | **not gradable** — the effect is attributable to context length, not the rule |
+| Both arms comply | **not gradable** — redundant rule, ceiling, or blind evaluator; never read as fired |
+| Both arms fail | **not gradable** — ineffective rule, incapable model, or blind evaluator |
+| Treatment worse than removal | **did not fire**, and recorded as a rule that backfires |
+| Confidence bound spans the pre-registered effect, or variance is high | **not gradable**; expand cases rather than widen the threshold |
+| Non-inferiority fails on task correctness or another policy | **did not fire** — a rule that works by degrading the answer has not worked |
+
+**The verdict is per rule at suite level, never per artifact.** An ablation
+establishes a population-level effect; it cannot say a rule failed to influence
+one document. Slices reading a verdict — A4, A5, B2 — read "this rule
+demonstrated incremental behavioral value above the mechanical control, at or
+above the pre-registered effect", which is a stronger and better-defined line
+than compliance.
+
+**Two failure modes this design must report rather than resolve.** Both
+conditions good means the rule may be redundant, the set may have a ceiling, or
+the evaluator may be blind. High variance means no gating claim at all — expand
+the cases or improve the oracle, never widen the threshold.
+
+## Why it is separate, and first
+
+Two sibling briefs both ship written guidance, and both are worth building only
+if written guidance activates:
+
+- [`agent-authoring-input-quality.md`](agent-authoring-input-quality.md) — the
+  contracts a review loop converges on.
+- [`stage-input-readiness.md`](stage-input-readiness.md) — no stage starts on
+  input it cannot work from.
+
+Folding this measurement into either one would make the other wait on that
+brief's first slice for a report it does not otherwise depend on. It is
+separate so both can consume it, and first because neither can size its
+deliverable without it.
+
+`stage-input-readiness`'s gate half is mechanical by construction and never
+needed this report; it runs in parallel.
+
+Only the **local** stratum gates them. Both siblings read individual local
+verdicts, so M3 is the unblocking point and M4's portability result is additive
+— which is why the strata are separate slices rather than one pass.
+
+## Success metrics
+
+- The report states, **before the first run**, which result means written
+  guidance binds. A decision rule written after the results is not a decision
+  rule.
+- Every rule in the corpus gets a per-rule verdict — fired, did not fire, or
+  not gradable — rather than one aggregate score.
+- **The two strata are reported separately.** A reader can find each local
+  floor rule's verdict without reading the external stratum, and no figure in
+  the report blends the two. This is the metric that protects the siblings: a
+  portable claim that averaged the strata would leave A4, A5 and B2 unsourced.
+- A rule that cannot be given a decision rule is dropped from the corpus and
+  the drop is recorded, rather than graded loosely. This never applies to the
+  six local floor rules.
+
+## Scope / Non-goals
+
+**In scope**
+
+- **The corpus and the decision rule.** Which rules are under test, which
+  authored output they are graded on, and what converts a result into "binds"
+  or "does not bind".
+- **The local stratum — six named rules, and it is a floor M1 may not silently
+  drop.** Three are read directly by sibling slices: **repository anchoring**
+  (decides A5), **`new-spec` step 5a** (decides A4), and **`work-intake`'s
+  public routing precedence** — the rule at `work-intake/SKILL.md` § "Public
+  routing precedence" that routes an explicit status request straight to
+  `workspace-status`. As of 2026-09-02, this is the representative for prose in
+  a routing surface and already carries an eval case in that
+  skill's `evals/evals.json`. The other three widen the rule *shapes* covered:
+  **cognitive-load simplification**, **the observable-outcome rule**, and **the
+  razor's bounded-search rung**. Six rules chosen on purpose; this is not a
+  claim to cover every sentence in the repository.
+  If a floor rule comes back *not gradable*, that is an owner escalation, not a
+  silent drop — the drop rule stated in § "Success metrics" applies to the rest
+  of the corpus, never to the floor. A floor rule that fails blinded rubric validation is not
+  replaced by an external or synthetic substitute; `not gradable` is the honest
+  result.
+
+  **The floor's locators and gradability, measured 2026-09-02.** M1 owns
+  finalising this table; it is recorded here because two rows are the
+  escalation the paragraph above anticipates, and because sibling slices read
+  three of them.
+
+  | Floor rule | Canonical home | Status |
+  | --- | --- | --- |
+  | `work-intake` public routing precedence | `work-intake/SKILL.md` § "Public routing precedence" | **Gradable.** B2's deciding line. |
+  | The observable-outcome rule | `new-spec/assets/spec.md` § Acceptance Criteria | **Gradable** on authored criteria. |
+  | `new-spec` step 5a | `new-spec/SKILL.md:475` | **Gradable only with run provenance** — its obligations are process facts. A4's deciding line. |
+  | The razor's bounded-search rung | root `AGENTS.md`, the cut-before-adding ladder | **Gradable only with run provenance** — a search and its recognition leave no authored record. |
+  | Repository anchoring | **`new-spec`'s plan `Repository anchors` field** (owner decision, 2026-09-02). The rule is a family — `adapt-to-project`, `contract-acquisition`, `new-spec` and `work-loop` each carry a normative span, plus `architect-design` in the architect pack — and this variant is selected because it is the only one with an authored artifact a grader can read, and it is the variant A5's question is about. | **Gradable.** A5's deciding line. |
+  | Cognitive-load simplification | `.agents/rules/cognitive-load.md` § "Prose and artifacts" and § "Author load", activated by the `always` row in `AGENT_RULES.md`. The label is editorial — "simplification" appears nowhere in either file. **Not the readability target: the rule scopes that to chat prose.** | **Gradable in part; see below.** |
+  **The readability score is not this rule's decision rule, and the rule says so
+  itself.** Measured 2026-09-02, `tools/check-output-readability.py`
+  ships here, computes Flesch reading ease and Flesch–Kincaid grade level, and
+  accepts arbitrary paths, so grading an artifact with it is cheap. It is still
+  the wrong oracle, for two reasons taken from the rule's own text:
+
+  - **The target is scoped to chat prose.** The rule reads "For *common chat
+    prose*, aim for a Flesch Reading Ease score of at least 70 and a US school
+    grade of at most 8." A brief or a spec is not chat prose, so scoring one
+    against that threshold measures an obligation the rule never imposed, and a
+    failing score would be reported as "did not fire" for an artifact class the
+    rule does not govern.
+  - **The rule forbids the inference.** It states "A score is a clue. It is not
+    a reason to cut needed facts", alongside "Keep all asked-for depth, proof,
+    limits, warnings, code, diffs, errors, exact names, paths, and counts." A
+    decision rule that treated a low score as non-compliance would push authors
+    to delete substance to score well — the opposite of the rule.
+
+  Measured anyway, because the numbers bound what any future oracle can claim:
+  across 60 authored specs, grade level ran min 4.62, median 6.68, p90 10.58,
+  and 44 of 60 passed a ceiling of 8, while reading ease ran median 60.70
+  against a floor of 70 and the two together passed only 7 of 60. All three
+  briefs in this split already pass the grade ceiling. So the score does not
+  separate compliant from non-compliant authoring here; it mostly separates
+  technical prose from chat.
+
+  **What M1 grades instead**, and it is only part of the rule: the artifact-facing
+  clauses in § "Prose and artifacts" and § "Author load" that have observable
+  consequences — a form that fits the facts, one load-bearing point per part,
+  long lists grouped, and no point stated twice. **M1 must name the exact
+  clauses and their artifact class before M2b runs.** The remaining clauses are
+  judgment ("short parts that are easy to stop and resume") and stay
+  ungraded rather than being proxied by a score. If M1 cannot reduce the chosen
+  clauses to a decision rule, `not gradable` is the honest result for this row.
+
+- **The external stratum is one-time research, read in temp and anonymized**
+  (owner decision, 2026-09-03). Candidate repositories are read from a temporary
+  location, never vendored into this tree, and named generically in every
+  artifact. The unit under test is still *our* selected rule, run in a different
+  repository, because sampling their native rules would measure a different
+  thing.
+  **It is deliberately not reproducible, and that is the point.** Nothing is
+  pinned, no snapshot is stored, and no licence apparatus is needed: reading a
+  public repository is not redistribution, and storing one is what would have
+  been. This drops the vendoring precedent, the provenance file, and the
+  byte-identity test that a pinned corpus would have required.
+  **The durable artifact is a synthetic corpus derived from the learnings**, not
+  the external repositories. What survives M4 is a corpus we author and own,
+  which is storable, runnable, and reproducible — and which satisfies the rule
+  below, because the learnings shape *tasks* while the rules under test remain
+  ours.
+  **The two strata therefore carry different epistemic standards**, and this is
+  the reason they are never blended: the local stratum's per-rule verdicts are
+  consumed as decision inputs by A4, A5 and B2, so they must be reproducible,
+  while **no sibling slice reads the external result**. Applying the local bar
+  to exploratory research would reject it for failing a requirement it never
+  had.
+- **Synthetic material enters as tasks, not as rules.** Seeded tasks and
+  known-compliant / known-violating artifacts under the named rules give
+  verifier sensitivity and counterexamples. A synthetic *rule* cannot tell us
+  whether a recorded rule binds.
+- **The harness extension.** `docs/specs/pack-activation-evals/` is Shipped and
+  its Phase 3 already runs a skill on a seeded prompt and grades post-conditions
+  the runner re-derives. What it does not measure is whether an author who had a
+  rule in context then followed it.
+- **A rule-level corpus surface**, because the harness's unit is a skill: every
+  eval home sits at `packs/*/.apm/skills/*/evals/`, and the runner hard-codes
+  both `[pack.evals].skills` as the coverage unit and that path. Half the local
+  stratum is root-context — cognitive-load routes from `AGENT_RULES.md`, the
+  razor's rung lives in root `AGENTS.md` — and fabricating skills to host them
+  would change the context being measured. So the corpus gets its own home while
+  the runner and grader, which are one module, are extended rather than
+  duplicated.
+- **Generated evals rather than scavenged history**, because a past review
+  report does not record which rules were in the author's context, so a rule's
+  firing cannot be recovered from it. Not because the artifacts are missing:
+  116 tracked files match `docs/specs/*/notes/` with `review` in the path, and
+  none is ignored. What *is* machine-local is narrower — the loop's recorded
+  verdicts (`docs/specs/**/state.json`, `engine-state.json`, `.loop-run/`) and
+  implementer reports (`docs/specs/**/notes/implementer-*.md`).
+- **The report**, applying the pre-registered decision rule to the run and
+  keeping the two strata separate.
+
+**Non-goals**
+
+- Rewriting the cognitive-load or cut-before-adding rules. The question is why
+  they do not activate, not whether they are well written.
+- Shipping any rubric, gate, anchor, worker, or authoring instruction. Those
+  belong to the two sibling briefs and wait on this report.
+- Changing the review lens or how findings are adjudicated.
+
+## Constraints / Appetite
+
+### Current appetite
+
+As of 2026-09-02, activation is the
+expensive part and it gates the rest. If the
+measurement says written guidance does not bind, the sibling deliverables
+become machinery — and machinery leaves those briefs until an approved
+amendment sets its appetite. The amendment rule is for what this measurement
+*converts*, not for a half that was mechanical from the outset.
+
+### Unconfirmed portability appetite
+
+The portable estimand enlarges that appetite, and the enlargement is not yet
+appetited. "First and alone" applies to the local measurement. The
+external stratum adds repository selection and
+per-repository setup, and it is the slice no sibling waits on. The cut below
+keeps that separable: **the local stratum alone unblocks A and B**, so the
+portability work can be re-appetited, deferred, or dropped without stranding
+either sibling. Confirm the enlarged appetite before M4 is confirmed.
+
+### Activation contract
+
+The activation contract is defined here and cited by both siblings. Every
+rule any of the three briefs ships carries three things:
+
+1. an **activation point** — the moment something changes if the rule is
+   ignored, not the file it is written in;
+2. a **measurement** — how to tell activation from presence, on artifacts the
+   author wrote; and
+3. a **stated failure mode** when it does not activate.
+
+A rule that silently does nothing is worse than an absent one.
+
+## What is already known not to activate
+
+The findings corpus and its exhibits are owned by
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+§ "What actually works, and what does not". The consequence for this
+measurement is the only thing restated here: a rule can be shipped, tested and
+complied with while still doing nothing, which is why presence is not the
+measurement.
+
+### Scope is not the variable
+
+An artifact clause reaches an authoring skill by two independent routes at once:
+the `always` row in root `AGENT_RULES.md`, and the block injected into
+`packs/core/.apm/skills/author-delivery-brief/SKILL.md:37`. Artifacts produced
+under it breached it anyway, so **delivery scope does not explain the failure**
+and this measurement must vary something else. The exhibit and its measurements
+are owned by
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md); the
+consequence for the design is that a per-skill route and a global rule fail
+alike, which is why the ablation varies the rule rather than its delivery path.
+
+### Enforcement boundary
+
+Enforcement exists for some of these and is scoped elsewhere: the
+cognitive-load gates read the packs, root guidance, seeds, and changelog, and
+the progressive-disclosure lint has a case asserting an authored spec is *not*
+in its results. Authored artifacts sit outside the enforcement boundary by
+design, which is the gap this measurement reads.
+
+## Proposed slices
+
+None is confirmed and no spec is authored. Slice sizes use the targets owned by
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+§ "Sizing discipline".
+
+| # | Slice | Owning surface | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- |
+| M1 | The corpus contract: the six-rule floor with one selected variant each, external selection and pinning, the stratification rule, and the pre-registered decision rule | `docs/product/research/guidance-activation-methodology.md` | none — ships no capability | 8 | none |
+| M2a | The rule-corpus contract and its validator | `docs/product/research/guidance-activation-corpus/` plus a validator that does not require `skill_name` | none — ships no adopter-facing capability | 8 | after M1 |
+| M2b | The rule-level runner mode, local stratum | a rule-level mode on `pack_evals.py`, reached through the existing `agentbundle pack evals run` surface | `guides/_shared/how-to/author-a-skill.md` | 10 | after M2a and `policy-arrival-validator` V1 — the validator is the compliance baseline this ablation measures against |
+| M3 | Local run and report | `docs/product/research/guidance-activation-report.md` | none — ships no capability | 6 | after M2b |
+| M4a | External selection and acquisition: candidate choice, the anonymization rule, and the temp read path | the selection rule in the methodology | `guides/_shared/how-to/author-a-skill.md` | 6 | after M3; **appetite not yet confirmed** |
+| M4b | External execution, the synthetic corpus derived from the learnings, and the report's external section | the synthetic corpus and M3's report | `guides/_shared/how-to/author-a-skill.md` | 8 | after M4a |
+
+### M2 seam
+
+Measured 2026-09-02:
+
+- **The runner and grader do not split.** They are one module and one public CLI
+  surface (`agentbundle pack evals run`), with `grade_behavior`, `grade_judge`
+  and mode dispatch as separate internal functions. M2b extends that one
+  surface rather than creating a second.
+- **The corpus and the runner do split.** No existing validator fits: the
+  current one requires `skill_name` and confines fixtures beneath a skill
+  directory, and eval discovery only looks inside skill directories. A
+  rule-level corpus therefore needs its own contract and validator, which is a
+  distinct surface from a runner mode — so M2a ships first and M2b reads it.
+
+### M2b execution context
+
+M2b requires new execution machinery. The existing activation detector
+observes only the `Skill` tool event, and the
+temporary projection it builds contains just the one pack's projected skills —
+it never establishes the repository-root `AGENTS.md` plus `AGENT_RULES.md`
+routing context that half the floor lives in. Executing a root-context rule is
+**new execution machinery**, and that is the honest size of M2b.
+
+### M4 sampled unit
+
+M4 measures this repository's rules elsewhere, not other repositories' rules.
+Rules native to adopter repositories would estimate whether written
+guidance works across a population, not whether **our** six rules travel. M4
+therefore reads the selected local rules against anonymized adopter repositories in temp and
+measures them there.
+
+### Destinations
+
+The destinations fit their contract. Measured 2026-09-02,
+`docs/product/research/`
+imposes no mechanical contract on a new file — measured: no frontmatter, no
+discipline line, no index or README to update, and no verifier reads that tree
+for content — so it hosts a methodology and a report without ceremony.
+
+Rejected: a `docs/specs/<feature>/` home. It would place M1's decision rule
+inside the spec that implements M2b, which is the co-location the top-ranked
+risk below forbids. Also rejected as a precedent claim: the
+`architecture-assessment-*` trio does not hold "a methodology, its corpus and
+the report over it" — its survey is desk research and its corpus is source
+packets. The per-item-verdict precedent is
+`docs/specs/bug-fix-systematic-debugging/notes/manual-invocation.md`.
+`architecture-assessment-intents-survey.md` is a desk-research synthesis
+answering a research question, and `architecture-assessment-corpus/` is living
+maintenance evidence of source packets — not results produced by running the
+methodology over the corpus. The real per-item-verdict precedent is
+`docs/specs/bug-fix-systematic-debugging/notes/manual-invocation.md`, one row
+per criterion with observed evidence and a verdict. A `docs/specs/<feature>/`
+home would put M1's decision rule inside the spec that implements M2, which is
+the co-location the top-ranked risk below forbids.
+
+### M1 verification
+
+M1's verification binds a revision to a run. A methodology document cannot
+be verified by reading it — that is the "do not verify guidance by parsing the
+guidance" rabbit hole. **M1 lands as its own revision-bound reviewed
+change; every M2b run records the exact M1 revision it executed under; and M3
+cites that same immutable run evidence.** Ordering alone is insufficient: a
+commit proves sequence, not that the decision rule was reviewed before it ran.
+So the check also names **an independently recorded review result bound to that
+immutable M1 revision** — the same revision-bound form this repository already
+requires of a shaping verdict — and a run whose recorded M1 revision carries no
+such result is not a valid run. A post-run revision to the decision
+rule then appears as a new reviewed M1 against a different revision, which is
+visible rather than inferred, instead of an edit inside M3.
+
+The ceiling and stall-threshold semantics come from that same sizing section.
+
+### Slice relationships
+
+- **M1 is not over-split.** It carries no code, and the over-splitting floor
+  (below) warns against slices that small. It is separate for a correctness
+  reason that outranks the size heuristic: **the decision rule has to land as its
+  own reviewed change before M2b runs anything.** Folding M1 into M2a would not
+  preserve that — the Phase 3 plan validates its grader live on a covered skill
+  while that slice is being built, so M2 produces results as it is written, and a
+  decision rule sharing that change can be tuned to them.
+
+- **M2a and M2b are two slices.** The corpus needs its own contract and validator
+  because no existing one fits, while the runner and grader are one surface. The
+  sizing reason for that cut is the same one cited above.
+
+- **M3 applies M1's rule and does not restate or amend it.** A revision to the
+  decision rule after M2b has run is a new M1, reviewed as one, against a
+  different M1 revision.
+
+- **M3's report owns both strata's sections, and M4 amends it.** M3 runs the local
+  stratum only, but the success metric requires both strata reported separately —
+  so M3 creates the report with its external section reserved and explicitly not
+  run, and M4 fills that section in the same file. Without this, no slice owns the
+  external half of the report and the "reported separately" metric has no owning
+  surface. **No figure in the report combines the two.**
+
+## Assumptions / Risks
+
+- **The decision rule gets written to fit the result.** The most likely
+  failure. Guard: M1 lands as its own reviewed change before M2b runs anything.
+- **The harness measures the eval rather than the author.** A generated eval
+  can be satisfied by a runner that re-derives the post-condition without any
+  author ever following the rule. Each graded post-condition names the authored
+  artifact it reads.
+- **The report is inconclusive.** "Some rules bind, some do not" is a real
+  outcome and the per-rule verdict metric is what makes it usable rather than a
+  reason to re-run.
+- **This brief ships an unactivated measurement.** The measurement is itself
+  written guidance, so it cannot escape by claiming a report exists — "the
+  artifact is present" is the very conflation the Outcome condemns, and it
+  cannot see the failure ranked most likely above. The escape is external and
+  git-observable instead: M1's decision rule is committed and reviewed **before
+  M2b runs anything**, and any post-run revision to it appears as a new reviewed
+  M1 rather than an edit inside M3.
+
+## Ready gaps (Draft only)
+
+- Ready needs a revision-bound clean shaping review of this brief plus the
+  owner's explicit confirmation. Neither has happened for the split.
+- **M1's and M3's destinations are defined.** M1 is
+  `docs/product/research/guidance-activation-methodology.md`, M2a's corpus is
+  `docs/product/research/guidance-activation-corpus/`, and M3 is
+  `docs/product/research/guidance-activation-report.md`. The per-item-verdict
+  precedent is `docs/specs/bug-fix-systematic-debugging/notes/manual-invocation.md`.
+  M1's
+  verification is the git-observable ordering recorded in § "Proposed slices",
+  not a read of its own text.
+- **The guide shippability test is defined.** Applied per slice that
+  changes adopter-visible behaviour: M2b and M4 extend
+  `guides/_shared/how-to/author-a-skill.md`, which
+  `docs/specs/pack-activation-evals/spec.md:225` already names as the guide for
+  writing and running these evals. M1 and M3 ship a report rather than a
+  capability, so the rule's own scoping to "the capability the phase
+  introduces" leaves them out.
+- **The enlarged appetite for the portable estimand is unconfirmed.** Placing
+  local rules against anonymized
+adopter repositories is exploratory research rather than a reproducible
+  measurement. M4 cannot be confirmed until the appetite is confirmed. M1–M3
+  are unaffected, and the local stratum alone unblocks A and B.
+- **Dispositioned — candidates are surfaced at M4 confirmation** with the
+  selection reasoning, for owner review. Choosing them needs a public-repository
+  survey, so it cannot happen in this repository.
+
+  Selecting them needs a public-repository survey, which requires network
+  access the spike did not have, plus an owner-approved selection rule.
+- **`docs/specs/pack-activation-evals/spec.md` names a runner that no longer
+  exists** — `tools/run-pack-evals.py`, in a ticked criterion at `:207` and in
+  the guide requirement at `:225`; the CLI now lives in
+  `packages/agentbundle/agentbundle/commands/pack_evals.py`. M2b extends that
+  module, so it will read a shipped contract whose path is stale. Not this
+  brief's to fix, but it should not be discovered mid-slice.
+
+## Rabbit holes
+
+- **Do not verify guidance by parsing the guidance.** A check that a sentence
+  exists in a file proves presence, which is the thing already known.
+- **Do not scavenge past review artifacts.** They are gitignored and
+  machine-local, so a result read from them is not reproducible by anyone else.
+- **Do not grow the corpus to make a verdict come out.** A rule with no
+  decision rule is dropped and recorded, not graded loosely.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Source: repository origin. The split provenance is owned by
+  [`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+  § "Provenance".

--- a/docs/product/briefs/multi-adapter-eval-runner.md
+++ b/docs/product/briefs/multi-adapter-eval-runner.md
@@ -1,0 +1,254 @@
+# Brief: Measure pack behavior on Claude Code and Codex
+
+- **Slug:** `multi-adapter-eval-runner`
+- **Received:** 2026-09-03
+- **Owner:** eugenelim
+- **Status:** Draft
+- **Source / provenance:** Repository-origin capability 5 from [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md), accepted at the current checkout by owner decision.
+- **Parent intent:** [`cross-adapter-behavior-enforcement`](../intents/cross-adapter-behavior-enforcement.md)
+
+## Outcome
+
+Pack authors can opt into the existing `agentbundle pack evals run --adapter`
+surface to measure the same pack on `claude-code` and `codex`, with the host,
+model, CLI version, and inference configuration recorded for each result. The
+default remains `claude-code`; the scheduled workflow remains Claude Code-only
+and report-only. This supplies capability 5 within the parent intent's
+[three-layer shape and lifecycle allocation](../intents/cross-adapter-behavior-enforcement.md#where-the-lifecycle-holds-and-where-it-breaks)
+without changing either.
+
+## Success metrics
+
+- A local `--adapter codex` run measures every selected Tier-A query and emits a
+  bounded summary whose `adapter` is `codex`; a failed or unparseable host run is
+  reported as a harness error, not a clean non-activation.
+- The same case set can be run on `claude-code` and `codex`, with each result
+  bound to the qualification tuple required by
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md):
+  pack version, host adapter version, model snapshot, and inference/tool
+  configuration.
+- An invocation that omits `--adapter` still selects `claude-code` and preserves
+  its current report contract.
+- The weekly schedule in [`.github/workflows/pack-evals.yml`](../../../.github/workflows/pack-evals.yml)
+  still runs only the pinned `@anthropic-ai/claude-code@2.1.185` CLI, uses only
+  `ANTHROPIC_API_KEY`, and remains report-only.
+- No live pack eval enters `make ci`, `make pre-pr`, or the pre-PR aggregator.
+  Their existing runner self-test and workflow-posture test remain gates.
+- `get_judge(adapter, model, config)` remains independently selectable and every
+  judged summary continues to record `judge_adapter`; a Codex-authored artifact
+  can therefore use the existing Claude Code judge, and the reverse.
+
+## Current state
+
+**Measured — one exact detector assignment.** The exact text
+`adapter = "claude-code"` occurs once, at
+[`pack_evals.py:159`](../../../packages/agentbundle/agentbundle/commands/pack_evals.py):
+
+```text
+rg -n -F 'adapter = "claude-code"' packages/agentbundle/agentbundle/commands/pack_evals.py
+# 159:    adapter = "claude-code"
+```
+
+Three separate summary dictionaries still write the literal
+`"adapter": "claude-code"` at lines 696, 843, and 969. The headless summary at
+line 586 instead reads `detector.adapter` but falls back to `claude-code`.
+
+```text
+rg -n -F '"adapter": "claude-code"' packages/agentbundle/agentbundle/commands/pack_evals.py
+# 696, 843, 969 — 3 occurrences
+```
+
+**Measured — the detector seam exists but has one implementation.** The CLI
+already exposes `--adapter` with a `claude-code` default at
+[`pack_evals.py:1104`](../../../packages/agentbundle/agentbundle/commands/pack_evals.py),
+while `_DETECTORS` contains only `ClaudeCodeDetector` at line 223. The runner
+needs a second detector behind the existing parameter, not a second public
+flag. This corrects a wording conflict with the parent intent, which says the
+capability adds the parameter.
+
+**Measured — judging is already cross-family.** Built-in declarative judge
+backends name `claude-code` and `codex` at
+[`pack_evals.py:318`](../../../packages/agentbundle/agentbundle/commands/pack_evals.py).
+`get_judge(adapter, model, config)` selects either built-in or configured
+backend at line 374, and `grade_judge` records `judge_adapter` at line 972.
+Detector work must not duplicate or couple this judge seam. The repository
+inventory reaches the same finding in
+[`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md).
+
+**Measured — the scheduled boundary is narrow.** The current
+[`pack-evals.yml`](../../../.github/workflows/pack-evals.yml) has only `schedule`
+and `workflow_dispatch` triggers at lines 17–26; the dispatch input `packs` is
+already present at lines 22–26. It installs only
+`@anthropic-ai/claude-code@2.1.185` at line 52, binds only
+`ANTHROPIC_API_KEY` at line 59, and makes the eval step report-only with
+`continue-on-error: true` at line 56.
+
+[`tools/test-pack-evals-workflow.py`](../../../tools/test-pack-evals-workflow.py)
+currently asserts: the file exists and parses; triggers are exactly schedule
+plus dispatch; top-level permissions are `contents: read` with no job override;
+the Anthropic secret comes from `secrets`, reaches only the eval step, and the
+eval step is report-only; and uploads contain bounded `summary.json` files but
+not model outputs. Its mutation matrix proves each assertion family. It does
+not assert the CLI version pin, Claude-only default, or `packs` input.
+
+**Measured — local gates test the runner but never run a live eval.** This
+search returns no matches:
+
+```text
+rg -n 'agentbundle pack evals run|run-pack-evals\.py --pack' \
+  Makefile tools/catalogue/pre_pr_catalogue.py \
+  tools/repo/build_gate_chain.py tools/hooks/pre-pr.py
+```
+
+The pre-PR aggregator runs only `tools/test-run-pack-evals.py` and
+`tools/test-pack-evals-workflow.py` at
+[`pre_pr_catalogue.py:137`](../../../tools/catalogue/pre_pr_catalogue.py). This
+matches the report-only boundary recorded in
+[`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md).
+
+## Scope / Non-goals
+
+**In scope:**
+
+- A headless `codex` detector behind the existing `--adapter` registry, with
+  Codex projection, invocation, parsing, error classification, and truthful
+  result provenance.
+- Contract tests for both detector families, including default preservation,
+  adapter-specific event parsing, non-zero exits, timeouts, malformed streams,
+  missing terminal events, and summary labelling.
+- Local opt-in instructions for pack authors in
+  `guides/_shared/how-to/author-a-skill.md`.
+- A conditional, manual-only Codex workflow lane if the owner confirms that
+  slice after its secret, CLI pin, and posture contract are known.
+- `claude-code` and `codex` only. Evidence for one must never be presented as
+  evidence for another host.
+
+**Non-goals:**
+
+- Changing the default adapter, the weekly schedule, its Claude Code-only
+  execution, its named CLI pin, or its report-only behavior.
+- Adding a live pack eval to the Makefile, `make ci`, `make pre-pr`, or the
+  pre-PR chain.
+- Adding Copilot, Cursor, Gemini CLI, Kiro, or any other host before a later
+  host-specific probe establishes its contract.
+- Rebuilding the existing judge backend seam or treating judge support as
+  proof that live activation support exists.
+- Claiming portability beyond the exact measured qualification tuple.
+- Turning policy evaluation into a blanket blocking gate. The parent intent
+  owns where enforcement applies.
+
+## Constraints / Appetite
+
+- Keep this to one local detector slice and, only if confirmed, one manual
+  workflow slice. Reuse the existing CLI, detector registry, summary shape,
+  eval corpus, and judge seam.
+- The default and scheduled workflow do not change. Every additional workflow
+  adapter is opt-in, vendor-secret-bearing, manual-only, report-only, and pinned
+  to a named host CLI version.
+- Treat the workflow as a security boundary. Any manual Codex lane must retain
+  schedule-plus-dispatch-only triggers, `contents: read`, step-local secret
+  binding, bounded summary uploads, and no uploaded model outputs.
+- A policy family ships precise or advisory, never between the two. The cited
+  measurement in the [parent intent](../intents/cross-adapter-behavior-enforcement.md#de-risk)
+  found that a stylistic predicate blocked 405 of 1,477 governed files, 27.4%,
+  against a 0.4% per-family budget. Precise families may block; stylistic
+  families remain advisory. The calibration basis is in
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).
+- Never impose a hard per-criterion word budget. This is already rejected by
+  `new-spec`, RFC-0099, and the ticked Shipped criterion in
+  `docs/specs/shaping-review-contracts/spec.md`.
+
+## Proposed slices
+
+**E1 is the sole delivery slice.** Rejected: a conditional workflow lane adding
+Codex to CI. Each added adapter puts a vendor secret into a security-load-bearing
+workflow and needs every host CLI pinned on the runner, so additional adapters
+stay local and on-demand while the default adapter and the scheduled workflow are
+unchanged.
+
+None is confirmed and no spec is authored. Each acceptance-criteria number is
+a ceiling and a stall threshold, never a floor; a smaller complete contract
+ships with fewer criteria.
+
+| # | Slice | Owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| E1 | Local Codex Tier-A activation measurement through the existing adapter seam, including truthful provenance | `packages/agentbundle/agentbundle/commands/pack_evals.py` | `tools/test-run-pack-evals.py` covers the Codex projection/invocation/parser contract, failure modes, default preservation, and adapter-labelled summaries without calling a live model | update `guides/_shared/how-to/author-a-skill.md` because `--adapter codex` is adopter-visible | 8 | after the Codex CLI activation contract, version pin, and result tuple are resolved |
+
+E1 is independently shippable as a local capability. A CI lane is not required to
+claim local `claude-code`/`codex` measurement and disappears if the owner keeps
+the second adapter local-only.
+
+## Assumptions / Risks
+
+- **Assumption — inferred:** Codex exposes a headless, machine-readable event
+  contract from which actual skill activation can be distinguished from model
+  text. The repository proves this only for Claude Code today.
+- **Risk — cited:** A measurement on one adapter/model/configuration tuple will
+  be mistaken for portable behavior. The qualification and paired-evaluation
+  discipline live in
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md).
+- **Risk — measured:** Reusing the three hard-coded in-harness/judge summary
+  literals could mislabel Codex-produced artifacts as `claude-code` even after
+  a detector lands.
+- **Risk — inferred:** A shared parser could normalize away host-specific
+  event differences and turn an unmeasured Codex run into a false miss. Each
+  adapter needs fixtures from its pinned CLI contract.
+- **Risk — measured:** The workflow posture test does not yet pin the CLI
+  version, scheduled adapter, or `packs` input, so an on-demand extension could
+  regress an owner constraint while leaving the current test green.
+- **Risk — cited:** A cross-family judge reduces self-preference but does not
+  establish truth; calibration and abstention rules remain those of
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).
+
+## Ready gaps (Draft only)
+
+- **Open — reconcile the parent wording.** The parent says this capability adds
+  an opt-in adapter parameter, but `pack_evals.py:1104–1108` already exposes
+  `--adapter`; only the Codex detector is absent. Search:
+  `rg -n -- '--adapter|_DETECTORS|get_detector' packages/agentbundle/agentbundle/commands/pack_evals.py`.
+  The parent remains authoritative and needs an owner-approved wording fix
+  before this brief is Ready.
+- **Open — acquire the pinned Codex activation contract.** No repository source
+  defines a `CodexDetector`, Codex activation event parser, or Codex JSON/JSONL
+  activation invocation. Search:
+  `rg -n 'CodexDetector|parse_codex|codex.*activation|codex exec.*(--json|jsonl)' packages/agentbundle/agentbundle/commands/pack_evals.py tools/test-run-pack-evals.py guides/_shared/how-to/author-a-skill.md`
+  returned no matches. A later contract-acquisition step must record the exact
+  supported CLI version, argv, output fixtures, terminal-event rule, exit
+  behavior, skill-activation signal, model selector, and non-interactive auth
+  behavior before E1 can be specified.
+- **Open — name the first paired result tuple.** The repository does not select
+  the Codex model snapshot or inference/tool configuration that will pair with
+  the pinned Claude Code run. Record both sides of the tuple before comparison;
+  do not rely on either CLI's moving default.
+- Ready also requires a revision-bound clean shaping review and the owner's
+  explicit confirmation. Neither has happened.
+
+## Rabbit holes
+
+- Rejected: a second eval command because the public `--adapter` seam already
+  exists and owns detector selection.
+- Rejected: changing the scheduled job to a matrix because that changes the
+  owner-pinned Claude Code schedule and widens the managed-secret boundary.
+- Rejected: treating `get_judge("codex", ...)` as Codex activation support
+  because judging consumes an artifact while activation must observe the host
+  routing event.
+- Rejected: a generic multi-host parser because no untested host contract may
+  be inferred from Claude Code or Codex.
+- Rejected: a hard per-criterion word budget because semantic atomicity and
+  testability, not length, determine an acceptance criterion.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+
+## Provenance
+
+This brief is capability 5, `multi-adapter-eval-runner`, from
+[`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md).
+Its delivery boundary uses the parent's lifecycle and three-layer shape without
+restating them. Repository research remains at
+[`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md),
+[`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md),
+[`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md),
+and [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).

--- a/docs/product/briefs/phase-scoped-policy-delivery.md
+++ b/docs/product/briefs/phase-scoped-policy-delivery.md
@@ -1,0 +1,257 @@
+# Brief: phase-selected policy reaches each authoring agent
+
+- **Slug:** `phase-scoped-policy-delivery`
+- **Received:** 2026-09-03
+- **Owner:** Repository maintainers (`ini-002`)
+- **Status:** Draft
+- **Source / provenance:** Repository-origin capability 3 from
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+- **Parent intent:**
+  [`docs/product/intents/cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+
+## Outcome
+
+For `claude-code` and `codex`, a dispatched spec author or implementer receives
+the policy families selected for the current work-loop phase. One shared,
+phase-keyed delivery path extends the repository's existing module-selection
+pattern; it does not introduce a host hook or a second policy mechanism.
+
+This brief owns the parent's **Teach** layer. The parent owns the three-layer
+architecture and lifecycle placement, so this brief relies on its
+[`Where the lifecycle holds, and where it breaks`](../intents/cross-adapter-behavior-enforcement.md#where-the-lifecycle-holds-and-where-it-breaks)
+table rather than repeating them.
+
+## Success metrics
+
+- For every supported `engine-state.json.state`, the same registry produces a
+  deterministic ordered set of policy-family identifiers on `claude-code` and
+  `codex`.
+- A dispatched spec-author or implementer brief contains the complete teaching
+  payload and family identifiers selected for that phase.
+- An unknown phase, unknown family, ambiguous enforcement tier, missing module,
+  or duplicate family fails before dispatch.
+- The two tested adapters project byte-equivalent policy data from the same
+  skill source. No result is claimed for an untested host.
+
+## Scope / Non-goals
+
+**In scope**
+
+- A policy-family registry carried inside a skill directory.
+- Selection keyed first by `engine-state.json.state`.
+- Ordered module loading and inlining into the dispatched `spec-author` and
+  `implementer` briefs.
+- A delivery record containing the selected family identifiers and the exact
+  teaching payload identity needed by
+  [`policy-arrival-validator.md`](policy-arrival-validator.md).
+- Projection and behavior tests for `claude-code` and `codex` only.
+- An adopter guide for declaring, classifying, and troubleshooting a
+  phase-scoped family.
+
+**Non-goals**
+
+- Creating the `spec-author` agent or universal sequential implementer
+  dispatch. Those are capabilities 2 and 1 in the parent decomposition.
+- Deciding whether a policy was obeyed. That belongs to
+  [`policy-arrival-validator.md`](policy-arrival-validator.md) for precise
+  predicates and to later calibrated evaluation for semantic residue.
+- A model judge, finding adjudication, or multi-adapter eval runner.
+- Hooks, host-native prompt interception, or a new distribution primitive.
+- Cursor, Copilot, Gemini, Kiro, or any other host. They are later probes.
+- `Shape:`, task verification mode, or task flavour as policy-selection keys.
+- A hard per-criterion word budget.
+
+## Current delivery contract
+
+The current mechanism is **`Module index → select matching reference → inline
+into the subagent brief`**. It is prose-directed, not mechanical. The
+`operational-safety` instructions tell the orchestrator to detect failure
+modes, load matching modules, and inline their contents into a
+`quality-engineer` brief; `cloud-implementation-craft` uses the same steps for
+an implementer brief
+([cited](../../../packs/core/.apm/skills/operational-safety/SKILL.md#L45)).
+The module index is a deterministic table, but an agent applies it and composes
+the brief. No executable dispatcher performs that selection or insertion.
+The measured repository trace records both precedents and their consumers in
+[`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md#1-existing-inlining-precedents).
+
+`engine-state.json.state` is the only current phase signal recorded as
+tool-written data. Its legal FSM values are declared in
+[`state-schema.md`](../../../packs/core/.apm/skills/work-loop/references/state-schema.md#fields-in-engine-statejson-phase-1).
+`Shape:` is author-selected spec metadata; verification mode and task flavour
+are selected or inferred in prose. A measured search found no mechanical reader
+for any of them:
+
+```text
+rg -n "Shape:|verification mode|TDD|goal-based|visual/manual|infra/deploy|task flavour|task flavor" \
+  packs/core/.apm/skills/work-loop/scripts
+# exit 1: no matches
+```
+
+Skills are the available carrier because every adapter copies a skill directory
+byte-for-byte, while projection fans the same pack source to each host
+([cited](../../architecture/skill-and-pack-format.md#L28)).
+`evals/evals.json` already travels inside the optional, projected `evals/`
+directory
+([cited](../../architecture/pack-layout.md#L161)). A new
+top-level `policies/` directory is not neutral: `CAT-S004` warns on any
+top-level skill subdirectory outside `scripts`, `references`, `assets`, and
+`evals`
+([measured](../../../packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py#L39),
+[warning site](../../../packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py#L549)).
+
+## Delivery data contract
+
+The delivery record is the binding between this brief and the validator. For
+one dispatch it must identify:
+
+- the `engine-state.json.state` value used for selection;
+- the ordered, unique policy-family identifiers selected by that value;
+- each family's binary tier, `precise` or `advisory`;
+- the module identity and digest used as teaching text; and
+- the digest of the assembled brief that is handed to the dispatch seam.
+
+The record does not claim that a model followed the teaching. It lets the next
+capability prove that every selected family arrived and later received a
+verdict.
+
+**The registry contract and the tier model are the parent's, not this brief's.**
+[`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+owns the policy-family schema, the precise-versus-advisory rule, and the tier
+model. This brief owns the **selector and the delivery integration** and cites
+that contract; it does not define a second registry.
+
+## Proposed slices
+**D1's selector also covers the light path, where there is no engine state.**
+`engine-state.json.state` is the phase key whenever a loop exists. Direct-light
+creates none, so D1 admits a single reserved `DIRECT-LIGHT` selection token for
+that case. It stays deterministic — a constant, not an inference — and it keeps
+selection in one owner rather than giving the light path its own mechanism.
+Without it `universal-implementer-dispatch`'s U2 would require phase-selected
+policy that nothing selects.
+
+**The order is selection, then assembly, then validation, then the second
+envelope — and nothing depends backward.** An earlier cut had D1 emit the digest
+that `policy-arrival-validator`'s V1 checks while assembly lived in D2 and D3,
+which themselves waited on V1; that is a backward dependency and no spec could
+satisfy it.
+
+| Step | Owner | Produces |
+| --- | --- | --- |
+| Selection and the record format | D1 | which families a phase selects, and the shape of the delivery record |
+| Assembly and digest emission | D2 | the assembled brief for the spec author, and the digest over what was included |
+| Validation | V1, in `policy-arrival-validator` | that every selected family appears, against D2's digest |
+| Second envelope | D3 | the same assembly for the implementer, reusing the validated contract |
+
+So the chain is D1 → D2 → V1 → D3. **Neither brief delivers as a unit**, and a
+slice cut must follow that order rather than assume brief-atomic delivery.
+
+
+No slice is confirmed and no spec is authored. Each AC number below is a
+**ceiling and a stall threshold, never a floor**. A spec author stops below the
+ceiling when the feature is already atomic and testable; reaching it triggers a
+split or an explicit owner decision.
+
+| # | Slice | Owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| D1 | The phase-policy registry and deterministic selector, producing the delivery record above from `engine-state.json.state` | the work-loop policy-delivery boundary, with registry data in its blessed `references/` tree and one selector in `scripts/` | table-driven tests cover every legal FSM state, reject malformed or duplicate families, and prove identical registry bytes and selected identifiers in built `claude-code` and `codex` projections | `guides/core/reference/phase-scoped-policy-delivery.md` | 8 | none |
+| D2 | Spec-author delivery — inline D1's selected teaching into the spec-author dispatch brief and pass the exact assembled artifact to the arrival gate | the `spec-author` dispatch envelope created by capability 2 | an end-to-end fixture enters a `SPEC-PLAN-*` state, dispatches on each tested adapter, and proves the validated brief contains exactly D1's selected ordered family set | `guides/core/reference/phase-scoped-policy-delivery.md` | 7 | after D1 and capability 2 |
+| D3 | Implementer delivery — inline D1's selected teaching into every sequential implementer brief and pass the exact assembled artifact to the arrival gate | the work-loop sequential implementer-dispatch envelope created by capability 1 | an end-to-end fixture enters each implementation-bearing state, dispatches on each tested adapter, and proves no selected family is dropped, duplicated, or substituted | `guides/core/reference/phase-scoped-policy-delivery.md` | 7 | after V1 and capability 1 |
+
+D1 changes adopter-visible policy declaration and diagnostics, so it names the
+guide. D2 and D3 change which policy an adopter's authoring agent receives and
+cite the same guide rather than creating phase-specific duplicates.
+
+## Constraints / Appetite
+
+The appetite is one shared registry and selector plus two thin dispatch
+integrations. A host-specific registry, a second selection language, or a new
+primitive exceeds it and returns to shaping.
+
+- Policy data stays in a blessed skill subdirectory. A top-level `policies/`
+  directory is rejected because it warns under `CAT-S004`.
+- `engine-state.json.state` is the phase key. Other attributes may be added only
+  after they become declared, tool-written data with a mechanical reader.
+- Every family is declared `precise` or `advisory`; no intermediate blocking
+  tier exists.
+- The first implementation and all claims cover `claude-code` and `codex` only.
+- Delivery remains progressive: only phase-selected modules enter a brief.
+- Rejected: a hard per-criterion word budget because semantic atomicity and
+  testability own criterion shape. The rejection is already recorded in the
+  product brief, RFC, authoring skill, and a ticked Shipped criterion
+  ([cited evidence](agent-authoring-input-quality.md#L134),
+  [`RFC-0099`](../../rfc/0099-cut-before-adding-and-artifact-shaping.md#L901),
+  [`new-spec`](../../../packs/core/.apm/skills/new-spec/SKILL.md#L505),
+  [`shaping-review-contracts`](../../specs/shaping-review-contracts/spec.md#L230)).
+
+## Assumptions / Risks
+
+- **The dispatch seam can pass the same validated bytes it records.** If the
+  host API accepts only reconstructed prompt fields, a delivery-record digest
+  can prove assembly but not handoff identity.
+- **The shared registry remains portable.** Adapter-specific prompt rewriting
+  could make byte identity impossible even when family coverage is equivalent;
+  the contract must distinguish source-data identity from host envelope syntax.
+- **Phase is sufficient for the first policy cut.** If a family needs task
+  semantics that are not tool-written, it stays advisory or out of the first
+  registry rather than acquiring a prose-selected blocking branch.
+- **The two prerequisite agents preserve one envelope contract.** If
+  capability 1 or 2 creates incompatible dispatch inputs, D2 and D3 stop being
+  thin integrations.
+
+## Ready gaps (Draft only)
+
+- **BLOCKER — capability 1 has not supplied the sequential implementer
+  envelope.** D3 cannot name its final callable surface or end-to-end fixture
+  until `universal-implementer-dispatch` lands.
+- **BLOCKER — capability 2 has not supplied the spec-author envelope.** D2
+  cannot name its final callable surface or end-to-end fixture until
+  `spec-author-agent` lands.
+- **Open — the registry schema and exact files under the work-loop skill's
+  blessed `references/` tree are not chosen.** No policy-family registry exists
+  in runtime sources. Search:
+
+  ```text
+  rg -n "policy[_ -]famil|phase[_ -]polic|selected[_ -]famil|policy[_ -]verdict" \
+    packs/core/.apm packages/agentbundle/agentbundle tools \
+    -g '*.py' -g '*.json' -g '*.toml' -g '*.md'
+  # exit 1: no matches
+  ```
+
+- **Open — the initial phase-to-family map is not selected.** The parent names
+  candidate decompositions, but it does not authorize which families enter the
+  first registry or classify each one.
+- **Open — the dispatch API's exact byte handoff is not established.** D2 and
+  D3 need a construction test showing that the artifact validated by V1 is the
+  brief sent to the subagent, not a nearby copy.
+- Ready also requires a revision-bound clean shaping review and the owner's
+  explicit confirmation. Both remain outstanding.
+
+## Rabbit holes
+
+- Do not build a second router for each adapter. Projection differences are
+  fixtures around one source registry.
+- Do not infer phase from headings, task prose, filenames, or agent role when
+  `engine-state.json.state` exists.
+- Do not put every policy into every brief to make coverage easy. That removes
+  phase scoping and defeats progressive disclosure.
+- Do not treat a delivery record as proof of compliance. It proves what was
+  selected and assembled; the validator owns arrival and verdict checks.
+- Do not use a host hook to compensate for a missing dispatch envelope.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Parent intent:
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+  capability 3 in its Decomposition.
+- Repository inventory:
+  [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).
+- Research basis for the family-level enforcement unit and precise/advisory
+  boundary:
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).

--- a/docs/product/briefs/policy-arrival-validator.md
+++ b/docs/product/briefs/policy-arrival-validator.md
@@ -1,0 +1,267 @@
+# Brief: every selected policy has a recorded verdict
+
+- **Slug:** `policy-arrival-validator`
+- **Received:** 2026-09-03
+- **Owner:** Repository maintainers (`ini-002`)
+- **Status:** Draft
+- **Source / provenance:** Repository-origin capability 4 from
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+- **Parent intent:**
+  [`docs/product/intents/cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+
+## Outcome
+
+Before a spec author, an implementer, or a direct-light verdict dispatch
+begins, a deterministic gate proves that the exact brief sent for dispatch
+contains every policy family selected by
+[`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md). After the
+agent acts, the same validation boundary requires one verdict for every
+selected family. Missing or malformed coverage is an error; only a precise
+family's deterministic compliance predicate may block for non-compliance.
+
+This brief owns the parent's **Check** layer. It cites the parent's
+[`three-layer shape`](../intents/cross-adapter-behavior-enforcement.md#outcome)
+and the delivery brief's data contract rather than restating either.
+
+## Success metrics
+
+- Every selected family has exactly one verdict in a valid output artifact;
+  zero missing, duplicate, or unknown family identifiers are accepted.
+- A selected family's teaching digest is present in the exact assembled brief
+  before dispatch, or dispatch stops with an `ERROR` result.
+- A precise-family predicate failure blocks with a stable family identifier and
+  diagnostic; an advisory-family finding never changes the gate exit status.
+- Malformed delivery records, briefs, verdict artifacts, and predicate results
+  fail closed at one validator boundary.
+- The same fixtures pass against built `claude-code` and `codex` projections.
+  No result is claimed for another host.
+
+## Scope / Non-goals
+
+**In scope**
+
+- A policy-brief artifact kind and a policy-verdict artifact kind at the
+  existing review-artifact validation boundary.
+- Pre-dispatch arrival checks against the delivery record's selected family
+  identifiers, module digests, and assembled-brief digest.
+- Post-action coverage checks requiring one verdict for every selected family.
+- Deterministic compliance predicates for families explicitly classified
+  `precise`.
+- Consuming the family registry that `phase-scoped-policy-delivery`'s D1 owns
+  and the family contract the parent intent owns. **This brief defines no
+  registry.** It reads required-teaching and compliance metadata from D1 and
+  owns only the validation integration.
+- `ERROR` severity for malformed artifacts, missing arrival, missing verdicts,
+  and precise-family violations.
+- Gate-chain integration and tests for `claude-code` and `codex` only.
+
+**Non-goals**
+
+- Selecting policy families or assembling their teaching text. Capability 3
+  owns both in
+  [`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md).
+- Creating the `spec-author` or universal implementer dispatch envelopes.
+- Forcing a model to reason correctly or treating a recorded verdict as proof
+  of sound judgment.
+- Blocking on stylistic or otherwise semantic predicates.
+- Model judges, calibration infrastructure, disputed-finding adjudication, or
+  the multi-adapter eval runner.
+- Host hooks or validation claims for Cursor, Copilot, Gemini, Kiro, or any
+  other untested host.
+- A hard per-criterion word budget.
+
+## Existing validator boundary
+
+Nothing currently records or checks that a selected module reached a dispatched
+agent's brief. The repository inventory establishes that absence in
+[`Can module arrival be checked?`](../research/phase-scoped-policy-delivery.md#3-can-module-arrival-be-checked).
+The confirming searches are:
+
+```text
+rg -n "inlined.{0,40}(brief|prompt)|brief.{0,40}inlined|prompt.{0,40}module|selected modules.{0,40}brief" \
+  packs/core/tests packages/agentbundle/tests tools .github
+# exit 1: no matches
+
+rg -n "developer_instructions|\bprompt\b|\bbrief\b" \
+  packs/core/.apm/skills/work-loop/scripts/loop-cohort.py \
+  packs/core/.apm/skills/work-loop/scripts/loop-engine.py \
+  packs/core/.apm/skills/work-loop/scripts/_loop_guards.py
+# exit 1: no matches
+```
+
+`review-artifact.py` is the existing safe artifact boundary. It derives a
+closed path from orchestrator metadata; admits only `raw`, `adjudication`, and
+`evidence`; rejects unsafe, linked, oversized, unstable, or non-UTF-8 input;
+and returns only size and SHA-256 on success
+([size and kinds](../../../packs/core/.apm/skills/work-loop/scripts/review-artifact.py#L20),
+[safe open](../../../packs/core/.apm/skills/work-loop/scripts/review-artifact.py#L208),
+[validation](../../../packs/core/.apm/skills/work-loop/scripts/review-artifact.py#L225)).
+It validates artifact kinds but does not yet parse a brief or policy verdict.
+
+## Enforcement shape
+
+The validator follows `CAT-L031`: required teaching is data, executable
+prohibitions are data, both are checked in one place, and every violation is
+`Severity.ERROR`. The precedent keeps broker-specific teaching in
+`_CS_REQUIRED_PHRASES_BY_BROKER`, banned argv names in `_CS_BANNED_FLAGS`, and
+applies both inside `_check_credentialed_skills`
+([constants](../../../packages/agentbundle/agentbundle/catalogue_tooling/lint.py#L784),
+[single check](../../../packages/agentbundle/agentbundle/catalogue_tooling/lint.py#L1978)).
+
+The enforceable guarantee is **coverage**:
+
+- Arrival coverage: each family selected in the delivery record has its exact
+  teaching identity in the brief artifact whose digest is dispatched.
+- Verdict coverage: each selected family has exactly one verdict; extras,
+  omissions, duplicates, and malformed verdicts are errors regardless of
+  family tier.
+- Compliance: only a `precise` family's registered deterministic predicate may
+  turn a non-compliant verdict into a blocking error. An `advisory` family's
+  verdict is recorded but cannot block.
+
+A family is `precise` or `advisory`, never between them. The stylistic emphasis
+density predicate is the measured warning: it blocked **405 of 1,477 governed
+files, 27.4%**, against a **0.4% per-family budget**. This is a cited count, not
+a new measurement; the grounding command is:
+
+```text
+rg -n "405 of 1,477|0.4% per-family budget" \
+  docs/product/briefs/agent-authoring-input-quality.md
+# lines 283-284
+```
+
+The source and its policy consequence are retained in
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md#the-rubric-is-a-deliverable-not-content-here).
+
+## What counts as arrival
+
+**Arrival is decided on canonical framed module bytes, not on a prose match.**
+V1 cannot assert that "the teaching is present" without an equivalence rule, or
+the check is undecidable and a near-miss substitution passes. So D2 emits each
+included family as a canonically framed block with a recorded digest, and V1
+compares digests rather than text. Its fixtures must exercise **substitution** —
+a family replaced by a paraphrase fails, and a family reordered or re-indented
+passes — because a check that cannot distinguish those two proves nothing.
+
+**This brief owns validation integration only.** The registry contract and the
+tier model are the parent's; the selector and delivery are
+`phase-scoped-policy-delivery`'s. V1 and V2 read those and define no family
+registry of their own.
+
+## Proposed slices
+**This brief does not deliver as a unit, and the order is D1 → D2 → V1 → D3.**
+D1 selects and fixes the record format, D2 assembles the spec-author brief and
+emits the framed digest, V1 validates that digest, and D3 then reuses the
+validated contract for the implementer. V1 cannot precede D2, because there is
+no digest to validate until assembly exists.
+
+
+No slice is confirmed and no spec is authored. Each AC number below is a
+**ceiling and a stall threshold, never a floor**. A smaller complete contract
+stops early; a draft that reaches the ceiling must split or obtain an explicit
+owner decision.
+
+| # | Slice | Owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| V1 | Arrival and verdict coverage — add policy artifacts to the safe artifact boundary, validate the exact dispatched brief, and require one verdict per selected family | `packs/core/.apm/skills/work-loop/scripts/review-artifact.py` as the single validation boundary | construction tests reject every unsafe-artifact case already covered plus wrong brief digest, missing teaching, missing/duplicate/unknown verdicts, and prove a complete advisory-only run exits cleanly on built `claude-code` and `codex` projections | `guides/core/reference/phase-scoped-policy-delivery.md` | 10 | after D2 emits the framed digest; end-to-end dispatch proof also waits on capabilities 1 and 2 |
+| V2 | Precise-family compliance — dispatch registered deterministic predicates from the same boundary while advisory findings remain non-blocking | the precise-predicate branch of `review-artifact.py`, with predicate metadata cited from D1's registry | one positive and one negative fixture per admitted precise family; mutation cases prove an advisory family cannot acquire blocking behavior and an unregistered or non-boolean predicate result fails closed | `guides/core/reference/phase-scoped-policy-delivery.md` | 8 | after V1 and owner confirmation of at least one precise family |
+
+Both slices change adopter-visible gate results and artifact diagnostics, so
+both cite the delivery guide. V2 cites V1's artifact contract and does not
+create a second validator.
+
+## Constraints / Appetite
+
+The appetite is one extension of the existing safe artifact boundary, not a
+new validation service. If safe validation cannot remain in one place, the
+capability returns to shaping.
+
+- Required teaching and compliance metadata are co-located as data, following
+  the `CAT-L031` precedent.
+- Coverage errors use `ERROR` severity and fail closed.
+- Precise-family compliance failures may block. Advisory-family findings may
+  be recorded, displayed, and measured, but never block.
+- The validator consumes the exact delivery record and assembled brief from
+  [`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md); it may
+  not reconstruct selection from phase prose.
+- Existing `review-artifact.py` confinement, hard-link, size, stability, UTF-8,
+  and quiet-diagnostic guarantees remain intact.
+- The first implementation and all claims cover `claude-code` and `codex` only.
+- Rejected: a hard per-criterion word budget because semantic atomicity and
+  testability, not text length, determine whether an AC is valid. The four
+  existing rejection sites are cited by the delivery brief under
+  [`Constraints / Appetite`](phase-scoped-policy-delivery.md#constraints--appetite).
+
+## Assumptions / Risks
+
+- **A validated brief is the dispatched brief.** If the dispatch layer copies
+  or rewrites the artifact after validation, arrival coverage becomes a
+  preflight claim about the wrong bytes.
+- **Family identity is stable.** Renaming a family between delivery and verdict
+  production could look like both an omission and an extra unless the registry
+  defines versioned identity.
+- **A precise predicate stays closed over artifact data.** Filesystem,
+  network, model, clock, or environment-dependent checks would make the result
+  non-deterministic and therefore advisory.
+- **One boundary can serve both moments without conflating them.** Arrival runs
+  before dispatch; verdict coverage and compliance run after the agent acts.
+  Both use the same parser and registry but distinct artifact kinds.
+- **Stable diagnostics do not disclose untrusted artifact content.** Adding
+  family identifiers must not weaken `review-artifact.py`'s quiet refusal
+  contract.
+
+## Ready gaps (Draft only)
+
+- **BLOCKER — D1 has not fixed the delivery-record schema.** V1 cannot define
+  its parser or fixtures until
+  [`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md) resolves
+  the registry and record-format gap.
+- **BLOCKER — the final dispatch surfaces do not exist.** End-to-end proof that
+  the validated bytes are the dispatched bytes waits on capabilities 1 and 2.
+- **Open — no initial precise-family set is confirmed.** The parent and sibling
+  brief name candidates, but no owner-approved registry maps a family to a
+  closed predicate. V2 cannot be Ready without at least one such family or an
+  explicit decision to defer V2.
+- **Open — policy artifact filenames and bounded locations are not chosen.**
+  `review-artifact.py` currently derives only review-report filenames from
+  stage, reviewer role, and `raw | adjudication | evidence`; V1 must extend
+  that closed grammar without admitting arbitrary paths.
+- **Open — the stable `ERROR` diagnostic record is not specified.** The current
+  validator returns `VALID` or `INVALID` plus fixed codes, while `CAT-L031`
+  carries `Severity.ERROR`. The spec must select one schema that preserves
+  quiet diagnostics and exposes severity without reflecting artifact content.
+- Ready also requires a revision-bound clean shaping review and the owner's
+  explicit confirmation. Both remain outstanding.
+
+## Rabbit holes
+
+- Do not parse agent prose to rediscover which families should have been
+  selected. The delivery record is the external binding.
+- Do not count a verdict artifact's existence as coverage. Coverage is set
+  equality over the selected and emitted family identifiers.
+- Do not let an advisory predicate change the process exit status through a
+  default severity or aggregate threshold.
+- Do not route deterministic violations through a model or the
+  `finding-adjudicator`.
+- Do not weaken `review-artifact.py` by accepting a caller-supplied artifact
+  path.
+- Do not claim that brief arrival proves policy obedience.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Parent intent:
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+  capability 4 in its Decomposition.
+- Delivery dependency:
+  [`phase-scoped-policy-delivery.md`](phase-scoped-policy-delivery.md).
+- Repository inventory:
+  [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).
+- Research basis for coverage, family-level enforcement, calibration, and
+  abstention:
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).

--- a/docs/product/briefs/spec-author-agent.md
+++ b/docs/product/briefs/spec-author-agent.md
@@ -1,0 +1,232 @@
+# Brief: spec drafting gets the same sequential authoring envelope
+
+- **Slug:** `spec-author-agent`
+- **Received:** 2026-09-03
+- **Owner:** Repository maintainers
+- **Status:** Draft
+- **Source / provenance:** [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+- **Parent intent:** [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+
+## Outcome
+
+On `claude-code` and `codex`, spec and plan drafting runs through a dispatched
+`spec-author` agent instead of being authored in the primary session. The
+`new-spec` and `work-loop` skills keep intake, lifecycle, independent review,
+human approval, state, and registration authority.
+
+This is capability 2 of the parent intent. It reuses the sequential envelope,
+controller/actor boundary, host scope, policy precision rule, and AC discipline
+defined by
+[`universal-implementer-dispatch.md`](universal-implementer-dispatch.md). The
+parent intent remains the authority for lifecycle placement and the shared
+three-layer enforcement shape.
+
+## Success metrics
+
+- A construction test for each supported adapter proves that every in-scope
+  drafting turn dispatches one `spec-author` with a bounded artifact and
+  authority envelope.
+- The author can create or revise only the named `spec.md` and `plan.md`. It
+  cannot approve them, register workspace state, classify its own review, or
+  advance the work-loop FSM.
+- Standalone `new-spec` authoring and `SPEC-PLAN-DRAFTING` repair turns use the
+  same agent contract rather than parallel authoring paths.
+- Existing `shaping-reviewer`, `adversarial-reviewer`, human-gate, and
+  adjudication boundaries remain independent of the author.
+- The new agent projects and is invocable on `claude-code` and `codex`; no
+  result is generalized to another host.
+
+## Current-state evidence
+
+- **[Measured]** Core ships exactly six agents:
+  `adversarial-reviewer`, `finding-adjudicator`, `implementer`,
+  `quality-engineer`, `security-reviewer`, and `shaping-reviewer`.
+
+  ```bash
+  rg --files --hidden packs/core/.apm/agents | wc -l
+  # 6
+  rg --files --hidden packs/core/.apm/agents | sort
+  ```
+
+- **[Measured]** No pack contains a spec-authoring agent. The bounded search
+  was:
+
+  ```bash
+  rg -n --hidden -i -g '*/.apm/agents/*.md' 'spec[- ]author|author.*spec' packs
+  # exit 1; no matches
+  ```
+
+- **[Measured]** `new-spec` is a skill that creates `spec.md` and `plan.md`;
+  its current agent calls are review calls, including `shaping-reviewer` at
+  line 488 and `adversarial-reviewer` at line 512 of
+  [`new-spec/SKILL.md`](../../../packs/core/.apm/skills/new-spec/SKILL.md).
+  No author-agent dispatch is defined there, so **[inferred]** drafting remains
+  in the primary skill session.
+- **[Measured]** The work-loop FSM names `SPEC-PLAN-DRAFTING`,
+  `SPEC-PLAN-REVIEW`, and `SPEC-PLAN-APPROVED` in
+  [`state-schema.md`](../../../packs/core/.apm/skills/work-loop/references/state-schema.md),
+  line 92. Review already has dispatched reviewers and approval is a human
+  gate, so **[inferred]** the missing acting envelope belongs to drafting turns,
+  not to every phase bearing the prefix.
+- **[Cited]** The absence and intended `spec-author` role are capability 2 in
+  the parent intent's § "Decomposition". The underlying portability limits are
+  in
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md).
+
+## Scope / Non-goals
+
+**In scope:**
+
+- A core `spec-author` agent with a bounded create/revise artifact contract.
+- Sequential dispatch from standalone `new-spec` authoring.
+- Sequential dispatch for work-loop turns acting in
+  `SPEC-PLAN-DRAFTING`, including revision after sustained review findings.
+- Explicit separation between author output and controller-owned review,
+  approval, workspace registration, and FSM transitions.
+- Construction and projection coverage for `claude-code` and `codex` only.
+- Updating the adopter guide that describes what happens during spec and plan
+  authoring.
+
+**Non-goals:**
+
+- Changing spec or plan semantics, templates, acceptance criteria, review
+  rubrics, approval gates, or the Ready definition.
+- Making `spec-author` review, adjudicate, approve, register, execute, or
+  close its own work.
+- Re-enabling parallel fan-out or taking any Phase-2 orchestration decision.
+- Implementing policy delivery, verdict validation, deterministic predicates,
+  or the multi-adapter eval runner.
+- Supporting or making compatibility claims for any host other than
+  `claude-code` and `codex`.
+
+## Constraints / Appetite
+
+The appetite is two feature slices over one shared agent contract: first the
+standalone authoring path, then work-loop drafting and repair. The shared
+dispatch rules, rejection of hard per-criterion word budgets, AC-ceiling
+semantics, precise-versus-advisory policy boundary, and 405-of-1,477
+false-block measurement are inherited by citation from
+[`universal-implementer-dispatch.md`](universal-implementer-dispatch.md) rather
+than repeated here.
+
+- The primary session remains the lifecycle controller and the only surface
+  that can ask for human approval.
+- The agent receives named files and bounded source context. It does not search
+  for another feature to author or widen the accepted slice.
+- An AC ceiling is a stall threshold, never a floor. Each slice may ship with
+  fewer criteria.
+- A hard per-criterion word budget is forbidden; semantic atomicity and
+  testability remain the gate.
+
+## The controller-to-author contract
+
+Without these states an acceptance criterion cannot say what the author returns
+or what the controller accepts, so the contract is stated here rather than left
+to the spec.
+
+| Element | Contract |
+| --- | --- |
+| Request | the confirmed slice context, the target `docs/specs/<slug>/` path, the phase-selected policy families, and the governing spec and plan templates |
+| Permitted actions | write `spec.md` and `plan.md` under the named slug; read repository evidence; nothing else |
+| Forbidden | registering work, mutating `workspace.toml`, initialising or advancing `loop-engine`, invoking a reviewer, or declaring completeness |
+| Elicitation | the author cannot ask a human directly; an unresolved assumption is returned as a named `unresolved` item and the **controller** relays it |
+| Return states | `drafted` with the two paths, `blocked` with the exact missing input, or `refused` with the reason |
+| Continuity | a repair request carries the prior revision plus the sustained findings only, so the author never re-derives a settled decision |
+| Controller validation | the controller verifies both files exist, carry the required metadata, and that every returned `unresolved` item is either answered or recorded, before any transition fires |
+| Lifecycle ownership | the controller owns registration, status, and every FSM transition; the author owns only the two documents |
+
+**The author never advances the loop.** That keeps `loop-engine`'s guard
+enforcement in one place and matches how every existing dispatched agent in this
+repository is bounded.
+
+## Proposed slices
+
+No slice is confirmed and no spec is authored. Each AC number below is a
+ceiling and a stall threshold, not a required count.
+
+| # | Slice | Primary owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| S1 | Standalone `new-spec` dispatch through the new `spec-author` contract for both direct requests and confirmed delivery-brief slices | `packs/core/.apm/agents/spec-author.md` | Author write-boundary tests; reviewer-independence assertions; Claude Code and Codex agent projection and dispatch tests | `guides/core/how-to/plan-and-execute-non-trivial-work.md` | 8 | after U1 defines the shared envelope contract |
+| S2 | Work-loop `SPEC-PLAN-DRAFTING` and sustained-finding repair through the same `spec-author`, with FSM and human gates retained by the controller | `packs/core/.apm/skills/work-loop/SKILL.md` | Drafting-state dispatch and return tests; refusal outside drafting; proof that review, approval, registration, and state transitions remain controller-owned on both adapters | `guides/core/how-to/plan-and-execute-non-trivial-work.md` | 8 | after S1 |
+
+Both slices change adopter-visible authoring behavior, so they update the
+existing end-to-end how-to rather than inventing a second guide.
+
+**S1 owns every initial dispatch; S2 owns only repair.** The boundary is the
+request kind, not the caller: S1 handles a create request from any caller,
+including work-loop's first drafting entry, and S2 handles only a repair request
+carrying sustained findings. An earlier reading split them by caller, which
+overlapped at work-loop's initial drafting and left neither independently
+bounded.
+
+## Assumptions / Risks
+
+- **[Inferred]** One `spec-author` contract can serve initial drafting and
+  sustained-finding repair if the controller supplies the allowed operation,
+  named artifact paths, and accepted finding set.
+- Separating authoring from lifecycle control may lose context that currently
+  sits in the primary session. The envelope must make missing context visible
+  rather than letting the agent rediscover or invent it.
+- The author may appear independent while receiving the controller's preferred
+  solution. Independent review remains mandatory and must receive the authored
+  artifacts, not the author's self-assessment.
+- Adapter projection is already tested generically, but projection does not
+  prove runtime dispatch or equivalent write boundaries.
+
+## Ready gaps (Draft only)
+
+- A revision-bound clean shaping review and the owner's explicit Ready
+  confirmation have not happened.
+- The exact `spec-author` write and tool boundary is not defined. No existing
+  pack agent provides a spec-authoring precedent, as established by the
+  pack-agent search in § "Current-state evidence". The slice spec must name
+  the minimum files and actions the agent may perform.
+- The controller-to-author handoff schema is not defined. It must distinguish
+  initial create from repair, bind artifact paths, and carry only adjudicated
+  findings on a repair turn.
+- The ownership split for workspace registration and the transition from
+  standalone `new-spec` into work-loop state needs one explicit contract. The
+  current skill performs both authoring and lifecycle work. The bounded search
+  for an author-agent dispatch was:
+
+  ```bash
+  rg -n -i 'spec-author agent|matching.*spec-author|dispatch.*spec-author' packs/core/.apm/skills/new-spec/SKILL.md packs/core/.apm/skills/work-loop/SKILL.md
+  # exit 1; no matches
+  ```
+
+  S1 must settle where the author returns and the controller resumes.
+- Runtime dispatch assertions for `claude-code` and `codex` do not yet exist
+  for this role. The role itself is absent by the pack-agent search above;
+  generic projection tests are insufficient. The slice specs must select
+  construction-test seams before approval.
+
+## Rabbit holes
+
+- Giving `spec-author` approval, reviewer, adjudicator, workspace, or FSM
+  authority because those operations currently sit near drafting in the skill.
+- Creating separate agents for initial draft, plan draft, and repair before one
+  bounded role has failed to serve them.
+- Repeating the implementer brief's envelope and policy rules here instead of
+  sharing them by reference.
+- Claiming that a projected file proves the agent was invoked or obeyed.
+- Extending the role to a third host without a later host-specific probe.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Product-strategy parent:
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+  capability 2 in § "Decomposition".
+- Shared dispatch-envelope contract:
+  [`universal-implementer-dispatch.md`](universal-implementer-dispatch.md).
+- Research basis:
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md),
+  [`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md),
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md),
+  and
+  [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).

--- a/docs/product/briefs/stage-input-readiness.md
+++ b/docs/product/briefs/stage-input-readiness.md
@@ -1,0 +1,453 @@
+# Brief: no stage starts on input it cannot work from
+
+- **Slug:** `stage-input-readiness`
+- **Received:** 2026-09-02
+- **Owner:** Repository maintainers (`ini-002`)
+- **Status:** Draft
+
+## Outcome
+
+At each point where authoring hands work to the next stage, the stage that must
+do the work asks whether it can, and the answer is recorded rather than
+inferred. **No handoff asks this on the consumer's side today**: a contract can
+be opened over an undefined outcome with no upstream and no registration and
+nothing objects.
+
+### Existing gates
+
+No handoff asks on the consumer's side. As measured 2026-09-02,
+`author-delivery-brief`'s canonical Ready gate checks six semantic fields,
+requires an independent cold shaping
+review, and requires human confirmation before a brief transitions
+(SKILL.md:124) — that is considerably more than section presence. `new-spec`
+verifies assumptions against repository evidence and waits (SKILL.md:72), and
+step 4d runs a UI design-readiness check (SKILL.md:359). What none of them is,
+is **consumer-side**: every one of those gates is run by the stage *producing*
+the artifact, certifying its own output. Measured 2026-09-02 across skills,
+`.agents/rules/`, and `docs/specs/`, **no shared predicate exists that lets the
+receiving stage ask whether it can work from what it was handed** — and this
+brief must add one that coexists with those gates rather than replacing them.
+
+The finding and its exhibit are owned by
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+§ "What actually works, and what does not".
+
+The question belongs to the consumer, not the producer — is this brief
+spec-authoring ready, is `new-spec`'s input spec-authoring ready, is this spec
+and plan implementable. A developer accepting a user story already asks the
+third.
+
+## Success metrics
+
+- A contract whose upstream is missing or unready is redirected **before its
+  body is written**, and the redirect is recorded rather than inferred.
+- Each readiness check can be shown to have fired at least once on an artifact
+  an author wrote. A check with no firing is withdrawn, not re-worded.
+- A readiness answer is refused when it is merely satisfied. The cited exhibit
+  sets that failure shape; a check that can be closed that way scores as a
+  failure here, not a pass.
+
+## Scope / Non-goals
+
+**In scope**
+
+- **The pre-creation pressure test**, and its redirect to
+  `author-delivery-brief create` on a gap.
+- **Its two dispositions for an open unknown**: a bounded spike that closes it,
+  or the redirect.
+- **The consumer-side readiness check at two further handoffs**: `new-spec`'s
+  input, and a spec and plan handed to an implementer.
+- **Review sequencing** — putting a readiness gate ahead of the review round it
+  exists to prevent.
+
+**Non-goals**
+
+- The rubric, the authoring instructions, the delegation anchor, the ownership
+  survey, and the `new-spec` step-5a widening. Those are
+  [`agent-authoring-input-quality.md`](agent-authoring-input-quality.md).
+- Whether written guidance activates at all. That is
+  [`guidance-activation-measurement.md`](guidance-activation-measurement.md),
+  and the prose half of this brief waits on its report.
+- The review lens itself and how findings are adjudicated. *Sequencing* a
+  readiness gate before review is in scope because the gate's value is being
+  ahead of the findings it
+  prevents. What a reviewer looks for once it runs, and the adjudicator's
+  contract, stay out.
+- What a loop does once it has discovered the contract above it is wrong —
+  [`agent-loop-escalation-recovery.md`](../intents/agent-loop-escalation-recovery.md).
+- **Sizing discipline.** This brief consumes the sizing signal as a stall
+  condition; the band and its derivation stay with
+  `agent-authoring-input-quality.md`.
+
+## Constraints / Appetite
+
+The gate half is mechanical by construction and does not wait on the activation
+measurement: it asserts declared shape only, and lint precedent for exactly
+that shape already exists in `lint-brief-coverage.py` and
+`lint-spec-status.py`. It is unblocked and depends on no sibling slice.
+
+The routing-ask half is prose in a routing surface — the class the activation
+measurement exists to test — and waits on that report.
+
+### B2 activation verdict
+
+The verdict B2 reads is a named rule. "Prose in a routing surface" is a
+class, not something a report can return a verdict for. The owner accepted
+`work-intake`'s public routing precedence — an explicit status request routes
+straight to `workspace-status` — as the representative, on 2026-09-02. It is in
+[`guidance-activation-measurement.md`](guidance-activation-measurement.md)'s
+local corpus floor, so B2 has a resolving line. Only the *local* stratum gates
+B2; that brief's portability stratum is additive and B2 does not wait on it.
+
+Every check this brief ships carries the activation contract owned by
+[`guidance-activation-measurement.md`](guidance-activation-measurement.md)
+§ "Constraints / Appetite".
+
+## What nothing checks today
+
+Nothing tests whether a spec should exist. `new-spec` elicits well — it
+surfaces an Unverified list and waits — but that defends the spec's *content*.
+Its triggers are a disjunction in which "the user explicitly requests a spec"
+is sufficient; `Brief:` is stamped only when arriving from a confirmed slice,
+nothing checks it resolves, and `none` is accepted almost everywhere. The one
+detector that would notice, `unregistered_work`, fires at **dispatch**.
+
+The cited abandonment demonstration establishes this gap.
+
+So a test before any body is written: is there a defined outcome or is this
+still shaping; what upstream does it descend from and is that upstream live;
+are load-bearing unknowns still open; and if there is no upstream, is direct
+authoring justified against the durability triggers and recorded rather than
+assumed. **On a gap, redirect rather than refuse** — an agent told no finds
+another route, and `author-delivery-brief` already refuses to invent missing
+content.
+
+### Redirects
+
+The redirect is a set of four, each selected by a condition. A single target
+does not work: `author-delivery-brief create`
+refuses a single direct-light change and routes it back to `new-spec`
+(SKILL.md:76–80), so a one-change request with no upstream and no justification
+would have bounced between the two forever.
+
+| Condition at the gap | Redirect to |
+| --- | --- |
+| No defined outcome — still shaping | `intake-intent` |
+| A defined outcome spanning multiple slices or repositories | `author-delivery-brief create` |
+| A defined outcome, one direct-light change | `new-spec`, proceeding with the justification recorded |
+| Trivial or cosmetic, below a contract | the direct-light owner |
+| A claimed upstream that does not resolve | back to the author to fix the reference; not a redirect |
+| A claimed upstream that resolves but is `Draft` | `author-delivery-brief continue` on that upstream — it is unfinished, not absent |
+| A claimed upstream that is `Withdrawn` or `Cancelled` | treat as no upstream and re-enter this table at the top |
+| A load-bearing unknown is still open | a bounded spike that closes it, or the redirect above if it cannot be bounded |
+
+`intake-intent` is Core's owner for admitting a repository intent.
+`frame-intent` ships in the product-engineering pack, which Core does not
+depend on, so a Core-owned gate routes to `intake-intent`; an installation
+carrying `frame-intent` may route there instead.
+
+The set is now exhaustive over the gate's own branches, which is what makes
+B2b's dispositions closeable: a gap either has a defined outcome or does not; a
+defined outcome is multi-slice, single-change, or below a contract; and a
+claimed upstream either resolves and is live, resolves and is not, or does not
+resolve.
+
+### Firing point
+
+As of 2026-09-02, the ask fires at the routing decision, before `new-spec` is
+entered, and its answer is recorded. A gate then
+asserts declared shape only — a claimed upstream resolves and is live — while a
+named human owns whether the answer is true. Naming an upstream cannot
+discharge it, because that upstream must exist.
+
+### Upstream predicate
+
+The predicate is "resolves, and is not `Draft`, `Withdrawn` or `Cancelled`".
+Measured on the tree on 2026-09-02: 203 of 425 specs carry a `Brief:`
+header, 188 of them `none`, and 15 name a brief path — 9 to
+`tech-site-completion` (`Shipped`) and 6 to `agent-skill-engineering` and
+`distribution-routes-programme` (both `Executing`). **Not one resolves to a
+`Ready` brief.** A "must be `Ready`" check would fail all 15 while
+`lint-brief-coverage.py` simultaneously requires the
+`Executing` transition that causes those failures. The amended predicate fails
+none of the 15 and admits `Ready` and `Executing` alike, so it survives the
+upstream's lifecycle instead of fighting the lint that enforces it.
+
+Rejected: a diff-triggered check that preserves the earlier "must be `Ready`" wording. It inherits the path-gated-diff failure mode — passing locally while missing in CI unless an explicit base revision is supplied.
+
+### Rule home
+
+The ask lives in a root `AGENT_RULES.md` `always` row. As of 2026-09-02,
+the alternatives do not satisfy its firing-point constraints:
+
+- **`work-intake` cannot host it.** Its own § "Public routing precedence" step 2
+  routes a request that explicitly names `new-spec` straight to `new-spec`,
+  bypassing `work-intake` entirely — and "the user explicitly requests a spec"
+  is the sufficient trigger this brief already identifies as dominant. An ask
+  placed there would never fire for the case it exists to catch.
+- **Amending that precedence is an RFC amendment, not a lint.**
+  `docs/specs/core-guidance-artifact-routing/spec.md:105` AC2 is a **ticked
+  `Shipped`** criterion pinning `work-intake` to "the RFC-0099 precedence
+  exactly", and it separately ticks that direct `new-spec` requests acquire no
+  second public answer. Inserting a pressure test on that route contradicts
+  both ticks, so it needs an RFC-0099 amendment before B2 could be specced.
+- **Inside `new-spec` contradicts the firing point above**, which places the ask
+  before `new-spec` is entered, and it collides with B3's owning surface.
+
+An `always` row fires before any routing — `AGENT_RULES.md` instructs an agent
+to read every `always` row *before responding or doing unrelated work* — so it
+reaches the explicit route without touching a shipped contract. **The cost is
+named, not hidden:** the only existing `always` row is `cognitive-load.md`,
+which [`guidance-activation-measurement.md`](guidance-activation-measurement.md)
+records as a measured non-activation instance. That is a reason B2 waits on M's
+report, not a reason to prefer a home the dominant trigger never reaches: M
+tests exactly this surface class, and if the verdict is that root-context prose
+does not bind, B2's conversion is the same one the routing ask already owes.
+
+### Step 5a and the routing spike
+
+The spike is a different invocation from `new-spec` step 5a. It reuses 5a's
+*shape* — cheapest disconfirming evidence, one fixture or measurement or
+read-only probe, uncommitted — but not its position. Step 5a is a numbered step
+inside `new-spec`, and this fires before `new-spec` is entered, against a risk
+unknown rather than a draft criterion. Killing the step-5a widening in
+`agent-authoring-input-quality.md` leaves this spike intact, and the reverse
+also holds. Keep the two consistent in shape when either is specified; never
+cut them as one slice.
+
+## Proposed slices
+
+None is confirmed and no spec is authored. Slice sizes use the targets owned by
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+§ "Sizing discipline".
+
+| # | Slice | Owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| B1 | The declared-shape gate — a standing check of **`Brief:` resolution only** | a lint over the existing `Brief:` field | the lint fails a spec whose non-`none` `Brief:` does not resolve or is `Draft`/`Withdrawn`/`Cancelled`, and passes all current back-links | `guides/core/reference/product-brief-fields.md` | 7 | **none — unblocked** |
+| B2a | The record field for the ask's answer and the direct-authoring justification | the spec template, `new-spec`'s stamping instruction, and `docs/CONVENTIONS.md` § Spec metadata contract | a spec stamped with a justification that cites no durability trigger fails the check | `guides/core/reference/product-brief-fields.md` | 7 | after M reports |
+| B2b | The routing ask and its spike-or-redirect disposition | a guard on `loop-engine init` — see § "B2b is one surface: the init guard" | the guard refuses initialisation for a spec whose routing answer is absent from B2a's field, and admits one whose answer is present | `guides/core/reference/work-intake-routing-and-lifecycle.md` | 10 | after B2a |
+| B3 | Readiness of `new-spec`'s input — **owns the readiness predicate** | `packs/core/.apm/skills/new-spec/SKILL.md` | the predicate fires on an artifact an author wrote, and a recorded answer that names no durability trigger fails | `guides/core/how-to/receive-a-product-brief-and-decompose-it-into-specs.md` | 6 | none |
+| B4 | Readiness of a spec and plan handed to an implementer | `packs/core/.apm/agents/implementer.md`, which cites B3's predicate | a dispatch whose spec or plan fails B3's predicate returns `blocked` before work starts | `guides/core/how-to/plan-and-execute-non-trivial-work.md` | 6 | after B3 |
+| B5 | Review sequencing | the pre-EXECUTE review round in `work-loop` | the readiness gate is observably evaluated before the review round runs | none — re-sequences an existing round | 6 | after B4 |
+
+### Readiness predicate
+
+B3 owns the readiness predicate. B4 and B5 cite it.
+
+**The predicate is derived from each consumer's already-declared inputs** (owner
+decision, 2026-09-02), so it is read off the repository rather than invented.
+Its shape is constant — *every declared input resolves, and the answer is
+recorded* — and each consumer instantiates it from its own declaration.
+
+**B4's instance derives cleanly, because `implementer.md` declares its inputs in
+order** (`packs/core/.apm/agents/implementer.md:19`): project `AGENTS.md` and
+`docs/CONVENTIONS.md`, the targeted spec, the targeted plan focused on the one
+assigned task, any files the task body cites, and conditionally an inlined
+module. The predicate is therefore: every one of those paths resolves; **the
+assigned task body declares its verification mode and its tests**, which that
+declaration requires of it; and every file the task cites resolves. Its negative
+disposition already exists — the implementer returns `blocked` — so B4 moves an
+existing reactive check to before dispatch rather than inventing an outcome.
+
+**B3's instance does not derive symmetrically, and that asymmetry is the finding
+rather than a gap.** `new-spec` declares *triggers*, not inputs — its "When to
+invoke" is a disjunction in which an explicit user request suffices — so there is
+no input list to resolve against. B3's predicate is therefore stated over the
+routing decision's own subject: there is a defined outcome rather than open
+shaping; a claimed upstream resolves and is not `Draft`, `Withdrawn` or
+`Cancelled`; no load-bearing unknown is still open; and where there is no
+upstream, the direct-authoring justification cites a named durability trigger.
+**The answer is recorded in B2a's field in every branch**, which is what makes
+the predicate checkable rather than merely asked; B4 and B5 read that same
+field.
+The negative disposition is the redirect table above.
+
+**B5 cites B4's instance, not a third one.** It sequences the pre-EXECUTE review
+round, whose input is the spec and plan pair B4 already governs.
+
+The ceiling semantics come from that same sizing section.
+
+They ask the same question at three consumers, and an obligation restated per consumer is the
+top-ranked category of
+[`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)'s
+rubric — the one no criterion craft rescues. One home, two citers. This is the
+pattern
+[`guidance-activation-measurement.md`](guidance-activation-measurement.md) uses
+for the activation contract.
+
+### B2 seam
+
+B2's ask and its dispositions are one moment on one decision. Splitting the
+ask from its two dispositions would put a question and its answers in different
+contracts, so that seam stays closed.
+
+B2 carries two surfaces and must split at that seam when it is specced. The
+record field gives it the routing rule *and*
+the spec metadata contract, and this brief's own bound is one primary surface
+per slice. The split follows the sizing section cited above; it is a sizing
+consequence rather than a scope change:
+
+- **B2a — the record field.** The named field for the ask's answer and the
+  direct-authoring justification: the spec template, `new-spec`'s stamping
+  instruction, and `docs/CONVENTIONS.md` § Spec metadata contract. It ships
+  first, because the ask has nowhere to write its answer until it exists.
+- **B2b — the routing ask and its dispositions.** The `always` row, its rule
+  file, and the spike-or-redirect disposition, writing into B2a's field.
+
+### B2b no longer waits on the activation report
+
+**A deterministic guard does not need to know whether prose binds.** B2b was
+gated on M's report while the ask was prose in a routing surface, and M's local
+floor still carries `work-intake`'s public routing precedence as the
+representative for that class. As a `loop-engine init` guard, B2b asserts a
+recorded field and refuses initialisation, so no activation verdict changes what
+it does. The dependency is withdrawn; only B2a remains upstream.
+
+**M's floor row is unaffected.** That rule stays in the corpus on its own merits
+as a routing-surface representative; it simply no longer has B2b as a consumer.
+
+### B2b is one surface: the init guard
+
+B2b adds a guard to `loop-engine init`, so its primary surface is that verb.
+The answer it reads lives in B2a's recorded field, which makes B2a a
+prerequisite rather than a second surface — the same owner-and-citer shape B3
+uses with B4.
+
+Rejected: a root `AGENT_RULES.md` `always` row. It cost five surfaces — the row,
+its rule file, both `packs/core/seeds/` copies since core sets
+`lint-seeds = true`, and a registration in
+`_SEEDS_REQUIRED_PLACEHOLDERS`, without which `CAT-L029` fails
+`agent-rules-read-target-invalid` — and nothing mechanically proves an `always`
+row is followed, which is the class of failure this brief's parent exists to
+remove.
+
+### Activation limit
+
+Nothing mechanically proves a new `always` row is followed. The router lint
+verifies the table's shape, that paths are literal and confined, and that
+targets are declared; it cannot show an agent obeyed the rule. That is exactly
+the gap M measures, and it is why B2b waits on M's report.
+
+Both remain gated on M's report, and B1 is unblocked because it
+checks only the pre-existing `Brief:` field and needs neither half.
+
+### Remaining dependencies
+
+- **B3 and B4 are separate.** Each carries its own surface, verification, and
+  guide. The sizing reason for the split is the same one cited above.
+
+- **B5 follows B4, not B1.** It sequences the pre-EXECUTE review round, whose
+  readiness gate is B4's. A gate at spec creation already runs ahead of
+  `new-spec`'s own shaping and adversarial reviews, so B1 leaves B5 nothing to
+  sequence.
+
+## Assumptions / Risks
+
+- **The pressure test is discharged rather than answered.** The existing
+  exhibit shows that a gate at creation can fail the same way, so the
+  declared-shape gate is deliberately narrow and a named human owns soundness.
+- **The routing ask never fires.** Its stated failure mode: the gate then
+  catches a claimed upstream that does not resolve, but never a resolvable one
+  nobody considered. That is the whole reason the ask half waits on the
+  activation report.
+- **The spike becomes the work.** An unbounded probe is shaping under another
+  name.
+- **B3 and B4 carry a prose component whose activation is unmeasured.** The
+  routing ask alone is gated on the activation report, so these two proceed
+  without it. If the report
+  says prose in a stage surface does not bind, B3 and B4 need the same
+  conversion the routing ask does.
+- **Three checks around one authoring act is real ceremony** and the per-spec
+  cost is unmeasured. If written steps do fire, most of this collapses into
+  widening rules that already exist.
+
+## B1 decisions
+
+- **The predicate survives the upstream's lifecycle.** The upstream resolves
+  and is not `Draft`, `Withdrawn` or `Cancelled`, with the arithmetic in
+  § "What nothing checks today". `Ready` is defined as a brief with no
+  `Implementing` or `Shipped`
+  child (`author-delivery-brief` SKILL.md:221, enforced by
+  `lint-brief-coverage.py:_brief_lifecycle_is_valid`), so the moment a derived
+  spec starts implementing, its upstream must become `Executing`.
+- **B1 does not create the record field; B2a does.** `Brief:`
+  is stamped only on arrival from `author-delivery-brief continue`, is
+  additive, and accepts `none` (`new-spec` SKILL.md:188–194), which
+  `lint-brief-coverage.py` treats as no back-link. A named field means the spec
+  template, `new-spec`'s stamping instruction and `docs/CONVENTIONS.md`
+  § Spec metadata contract — three surfaces beyond "a lint", which would have
+  made B1 a four-file slice against a one-surface bound. **B1 is therefore
+  narrowed to checking that the existing `Brief:` field resolves**, which keeps
+  it at one surface and preserves its parallel start with M.
+- **The direct-authoring branch belongs to B2a with an external binding.** It
+  travels with the field that holds it. **The justification must cite a
+  named durability trigger, which the check resolves against the trigger list**
+  rather than merely confirming prose is present.
+- **B1 is a hard check because its reference class is clean.**
+  `lint-spec-status.py` invariant (iii) is warn-only and its
+  promotion "stays deferred pending the observed warn rate"
+  (`docs/specs/spec-code-ref-lint/spec.md:51`); measured 2026-09-02 it emits
+  **183 warnings across 425 specs**, which is why that deferral holds for the
+  broad dangling-reference class. B1's class is narrower by construction —
+  non-`none` `Brief:` values only — and **all 15 of them resolve today**, so a
+  hard check of exactly that class starts at zero violations and owes no
+  warn-rate evidence. It must stay scoped to that class; widening it to
+  arbitrary references would pull the deferral back in.
+
+## Ready gaps (Draft only)
+
+- **Settled — B2b fires as a `loop-engine init` guard** (owner decision,
+  2026-09-03). The routing decision is the only point in the lifecycle with no
+  dispatched agent, so B2b cannot use the parent's inlining mechanism and must
+  not stay prose in a rule file, which the parent records as the mechanism that
+  does not bind. It uses the established dispatcher instead: `work-loop` owns
+  routing and agent dispatch, and `loop-engine` already owns legal phase
+  ordering and guard enforcement, exposing `init` ("initialise
+  engine-state.json; output run_id") and `transition` ("fire an FSM event;
+  enforce guards"). **A loop cannot be initialised for a spec whose routing
+  answer is not recorded.** That is deterministic, needs no agent, hook or rule
+  row, and fires *before* a body is written, which the first success metric
+  requires. A guard on a transition would not: `SPEC-PLAN-DRAFTING` is the first
+  legal state with `last_event: null`, so there is no transition into it, and
+  guarding `spec-ready` would fire after the body exists.
+
+  **`init` guards entry to delivery, not file creation.** A spec file can be
+  written without initialising a loop, so B1's standing lint remains the other
+  half: the guard catches a spec entering the work-loop, the lint catches a spec
+  whose `Brief:` does not resolve. Neither subsumes the other.
+- **Settled — B's slices take their activation contract from M, not from the
+  registry.** Every check here is mechanical: B1 is a standing lint, B2a is a
+  spec metadata field, B2b is a `loop-engine init` guard, and B3, B4 and B5 are
+  readiness predicates over declared inputs. None consumes a policy family, so
+  none waits on `phase-scoped-policy-delivery` or `policy-arrival-validator`.
+  The three-part activation contract they each carry is
+  [`guidance-activation-measurement.md`](guidance-activation-measurement.md)'s,
+  and the earlier broader claim of a registry upstream is withdrawn.
+- Ready needs a revision-bound clean shaping review of this brief plus the
+  owner's explicit confirmation. Both remain outstanding.
+- **Open — B1's activation is unmeasured but it does not wait.** B1 is
+  mechanical, so it carries no prose-activation risk. The asymmetry with B2b is
+  deliberate.
+
+## Rabbit holes
+
+- **Do not mechanize a judgment.** "Is this criterion well-founded?" is not a
+  predicate. Where the same gate is defeated twice by different surfaces, split
+  it — as the ask/gate division above does.
+- **Do not verify a readiness rule by parsing the rule.** A check that a
+  sentence exists in a file proves presence, which is the thing already known.
+- **Do not let a readiness check become a section-presence check.** That is the
+  defect this brief exists to remove, and it is the cheapest thing to
+  accidentally ship.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Source: repository origin. The split provenance is owned by
+  [`agent-authoring-input-quality.md`](agent-authoring-input-quality.md)
+  § "Provenance".

--- a/docs/product/briefs/universal-implementer-dispatch.md
+++ b/docs/product/briefs/universal-implementer-dispatch.md
@@ -1,0 +1,264 @@
+# Brief: every implementation task gets a sequential implementer envelope
+
+- **Slug:** `universal-implementer-dispatch`
+- **Received:** 2026-09-03
+- **Owner:** Repository maintainers
+- **Status:** Draft
+- **Source / provenance:** [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+- **Parent intent:** [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+
+## Outcome
+
+On `claude-code` and `codex`, every implementation task accepted by
+`work-loop` runs through a dispatched `implementer` agent, including the normal
+sequential path. The primary session keeps lifecycle, ordering, gates, review,
+and recovery authority. Implementation procedure moves out of
+`work-loop/SKILL.md`, leaving that skill as the controller rather than a second
+implementation surface.
+
+This brief supplies capability 1 of the parent intent. The parent owns the
+lifecycle placement and the three-layer enforcement shape; this brief does not
+restate either contract.
+
+## Success metrics
+
+- A construction test for each supported adapter proves the dispatch path is
+  **wired**: the controller procedure names the projected agent, the task order
+  is declared, and at most one implementer is authorised at a time.
+- **Behavioural proof is not claimed here.** Whether a running agent actually
+  invokes the projected implementer for every task is discretionary at runtime,
+  and cross-adapter projection tests prove projection rather than honouring. The
+  paired dispatch-versus-inline comparison in
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md)
+  owns that claim. A construction test asserting runtime honouring would be a
+  control with no seam to observe.
+- The dispatched task carries the bounded task body, repository root, spec and
+  plan paths when they exist, verification mode, and applicable execution
+  context. Missing required context fails before the first implementation
+  write.
+- The main working tree and an explicitly supplied worktree are both valid
+  execution roots. The agent never infers or creates either root.
+- `work-loop` remains the sole owner of state transitions, task scheduling,
+  final gates, review dispatch, retry decisions, and closeout.
+- Implementation procedure has one normative home outside
+  `work-loop/SKILL.md`. A deep skill lint reports the post-change body count,
+  and the change does not add a second copy to compensate for extraction.
+- The parent intent's paired `inline` versus `dispatched` eval can identify the
+  selected adapter and delivery path. This capability does not claim improved
+  adherence before that eval runs.
+
+## Current-state evidence
+
+- **[Measured]** `implementer` is reached only when a plan has multiple tasks
+  declaring `Depends on: none`; that restriction is in
+  [`implementer.md`](../../../packs/core/.apm/agents/implementer.md), line 3.
+- **[Measured]** The only documented implementer dispatch is the parallel
+  supervisor path, while `dispatch-decision`, `worktree`, and `auto-parallel`
+  are disabled and exit non-zero in
+  [`supervisor-mode.md`](../../../packs/core/.apm/skills/work-loop/references/supervisor-mode.md),
+  lines 3–7 and 83–87. The same file states that Phase 1 runs tasks
+  sequentially in topological order at lines 9–14.
+- **[Measured]** The agent contract assumes a supervisor-created
+  `.worktrees/<task-id>/` and forbids edits in the primary worktree in
+  [`implementer.md`](../../../packs/core/.apm/agents/implementer.md), lines
+  48–51. Admitting an explicitly supplied main working tree is the bounded
+  agent-contract change.
+- **[Cited]** ADR-0061 defers parallel-wave orchestration at line 28 and records
+  the missing `pending_transition` schema at lines 30 and 47–49. Its erratum
+  freezes the decision at line 69. Sequential single-agent dispatch uses no
+  parallel worktree merge or collision decision, so **[inferred]** it needs no
+  Phase-2 decision. See
+  [`ADR-0061`](../../adr/0061-loop-infrastructure-phase-1.md).
+- **[Measured]** `pending_transition` is absent from both the Phase-1 state
+  schema and state asset. The bounded search was:
+
+  ```bash
+  rg -n 'pending_transition' packs/core/.apm/skills/work-loop/references/state-schema.md packs/core/.apm/skills/work-loop/assets/state.json
+  # exit 1; no matches
+  ```
+
+- **[Measured]** `work-loop/SKILL.md` is 832 total lines:
+
+  ```bash
+  wc -l packs/core/.apm/skills/work-loop/SKILL.md
+  # 832 packs/core/.apm/skills/work-loop/SKILL.md
+  ```
+
+  `CAT-S003` counts body lines, warns above 500, and errors above 1,000 in
+  [`skill_spec_lint.py`](../../../packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py),
+  lines 516–527. Moving implementation procedure out is therefore part of the
+  outcome, even if other work is needed later to clear the warning threshold.
+- **[Cited]** The compatibility and oracle limits remain those in
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md)
+  and
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).
+
+## Scope / Non-goals
+
+**In scope:**
+
+- Sequential implementer dispatch for spec-backed `CODE-IMPLEMENTATION` tasks.
+- Sequential implementer dispatch for direct-light implementation tasks, while
+  retaining direct-light's session-local and spec-less boundary.
+- The smallest change to `implementer.md` that accepts an explicit execution
+  root in the primary working tree or an already-created worktree.
+- Moving task implementation procedure out of `work-loop/SKILL.md` while
+  keeping lifecycle and orchestration authority in the skill.
+- Construction and projection coverage for `claude-code` and `codex` only.
+- Updating the adopter guide that explains what happens during EXECUTE.
+
+**Non-goals:**
+
+- Re-enabling parallel fan-out, implementing Phase 2, adding
+  `pending_transition`, creating or merging worktrees, or changing the
+  collision gate.
+- Changing task order, plan `Depends on:` semantics, retry caps, human gates,
+  final gates, reviewer routing, or closeout.
+- Adding the `spec-author` agent; capability 2 owns that envelope.
+- Delivering policy selection, policy-arrival validation, verdict artifacts,
+  deterministic policy predicates, or the multi-adapter eval runner.
+- Supporting or making compatibility claims for Cursor, Copilot, Gemini, Kiro,
+  or any other untested host.
+
+## Constraints / Appetite
+
+The appetite is the minimum two-slice change that makes dispatch universal on
+the two named adapters and removes duplicate implementation procedure from the
+controller. It is not an orchestration rewrite.
+
+- Dispatch is sequential: one task, one bounded agent brief, one returned
+  report, then the next task.
+- Existing lifecycle and safety gates remain in the primary session. The
+  implementer does not transition state, merge, review itself, or declare the
+  overall loop complete.
+- An acceptance-criterion count is a ceiling and stall threshold, never a
+  floor. Fewer independently testable criteria are correct when they cover the
+  slice.
+- No hard per-criterion word budget may be proposed. That form is rejected by
+  the Shipped criterion in
+  [`shaping-review-contracts/spec.md`](../../specs/shaping-review-contracts/spec.md),
+  line 230, by
+  [`RFC-0099`](../../rfc/0099-cut-before-adding-and-artifact-shaping.md), line
+  901, by `new-spec/SKILL.md`, line 505, and by
+  [`agent-authoring-input-quality.md`](agent-authoring-input-quality.md) §
+  "Sizing discipline".
+- A policy family later carried by this envelope ships precise or advisory,
+  never between those states. Precise predicates may block; stylistic
+  predicates remain advisory. The parent records why: the tested stylistic
+  predicate blocked 405 of 1,477 governed files, 27.4%, against a 0.4%
+  per-family budget. This capability does not implement that policy layer.
+
+## Proposed slices
+
+No slice is confirmed and no spec is authored. Each AC number below is a
+ceiling and a stall threshold, not a required count.
+
+| # | Slice | Primary owning surface | Verification | Guide | AC ceiling | Gating |
+| --- | --- | --- | --- | --- | --- | --- |
+| U1 | Spec-backed sequential implementer dispatch, including the explicit-main-tree envelope and extraction of the spec-backed implementation procedure | `packs/core/.apm/skills/work-loop/SKILL.md` | Task-order and single-active-agent contract tests; `implementer` envelope assertions; Claude Code and Codex projection tests; deep skill lint with reported body count | `guides/core/how-to/plan-and-execute-non-trivial-work.md` | 8 | none |
+| U2 | Direct-light **policy-verdict** dispatch: the dispatched agent receives the phase-selected policy and returns a verdict; the primary session performs every write | `packs/core/.apm/skills/work-loop/SKILL.md` | Direct-light verdict-dispatch test on `claude-code` and `codex`; missing-context refusal; proof that no spec, plan, workspace entry, or loop state is created, and that the dispatched agent performs no write | `guides/core/how-to/plan-and-execute-non-trivial-work.md` | 6 | after U1, D1's `DIRECT-LIGHT` selection, and V1's validation |
+
+**U2's prerequisites are named, because the light path has no engine state.**
+Selection comes from `phase-scoped-policy-delivery`'s reserved `DIRECT-LIGHT`
+token in D1, and the verdict artifact is validated by
+`policy-arrival-validator`'s V1, whose consumers include this path. U2 owns the
+dispatch and the controller boundary only; it owns neither selection nor
+validation.
+
+**U2 dispatches a verdict, not a build, and that is what keeps direct-light
+light.** Sending implementation to a second builder would mean "another builder
+needs a contract they can read without this session", which is a risk trigger
+that forces full mode and therefore a spec — contradicting the path's whole
+purpose. Narrowing U2 so the dispatched agent only evaluates policy and returns
+a verdict leaves the primary session as the sole builder, so the trigger does
+not fire, no durable artifact is created, and the light path still receives
+phase-scoped policy. This is why U2's owning surface is the controller rather
+than the agent contract.
+
+Both slices change adopter-visible workflow behavior, so both name the same
+existing how-to guide. The guide should explain the universal dispatch result
+once and preserve its current statement that parallel fan-out is disabled.
+
+## Assumptions / Risks
+
+- **[Inferred]** The parent's “every plan task” includes direct-light's
+  session-local implementation task. `work-loop/SKILL.md` records a direct-light
+  verification plan before EXECUTE but has no durable plan file; U2 keeps this
+  interpretation visible for owner confirmation.
+- **[Measured]** Both scoped adapters project pack agents:
+  `test_adapter_claude_code.py` covers `.claude/agents/*.md`, and
+  `test_adapter_codex.py` covers `.codex/agents/*.toml`. **[Inferred]**
+  projection alone does not prove identical runtime dispatch behavior; the
+  slices need adapter-specific execution-contract tests.
+- **[Inferred]** A main-tree implementer can remain bounded if the controller
+  supplies the resolved root and keeps all scheduling and state mutation.
+  Ambiguous or missing roots must fail before edits.
+- Dispatch adds context and latency to every task. The parent-owned paired eval
+  may show no adherence gain; its predeclared kill condition remains decisive.
+- Moving too little procedure leaves two normative implementation surfaces;
+  moving lifecycle authority into the agent breaks recovery and auditability.
+
+## Ready gaps (Draft only)
+
+- A revision-bound clean shaping review and the owner's explicit Ready
+  confirmation have not happened.
+- **Settled — U2 is in scope** (owner decision, 2026-09-03). Direct-light skips
+  `new-spec` and carries only a session-local task, so "every plan task" does
+  not reach it by wording. It dispatches anyway: direct-light is the path small
+  changes take, so excluding it would leave the most common changes with no
+  phase-scoped policy, reproducing the gap this work exists to remove. U2 must
+  keep its own ceremony minimal, because the light path exists to be light.
+- **Owed at slice confirmation, not at Ready** — the exact extraction destination is unchosen. The spec must identify one
+  existing or new file inside `work-loop/references/` or the agent contract,
+  then prove that `SKILL.md` retains only routing and controller invariants.
+  The bounded search for a current sequential-dispatch procedure was:
+
+  ```bash
+  rg -n 'sequential.*implementer|implementer.*sequential' packs/core/.apm/skills/work-loop packs/core/.apm/agents
+  ```
+
+  No existing normative sequential implementer procedure was found.
+- **Owed at slice confirmation, not at Ready** — the runtime dispatch assertion shape for `claude-code` and `codex` is not yet
+  selected. Existing adapter tests prove projection, not that every work-loop
+  task invokes the projected agent once. The absence search was:
+
+  ```bash
+  rg -n 'implementer|dispatch' packages/agentbundle/tests/build_pipeline/test_adapter_claude_code.py packages/agentbundle/tests/build_pipeline/test_adapter_codex.py
+  # exit 1; no matches
+  ```
+
+  The slice spec must name the construction-test seam before approval.
+- **Owed at slice confirmation, not at Ready** — the main-tree report and commit contract is not yet settled. Current
+  `implementer.md` requires the agent to commit inside a worktree, while the
+  primary-session controller owns the shared checkout. The spec must decide
+  who commits on the sequential path without expanding into parallel merge
+  behavior.
+
+## Rabbit holes
+
+- Re-enabling any Phase-2 verb to obtain sequential dispatch.
+- Treating a projected agent file as proof that the runtime dispatched it.
+- Copying all of EXECUTE into a new reference while leaving the same procedure
+  operative in `SKILL.md`.
+- Letting the implementer own state transitions, final gates, review, or
+  closeout because it now edits the primary working tree.
+- Claiming support for a host outside `claude-code` and `codex` without a later
+  host-specific probe.
+
+## Spec map
+
+| Spec | Status |
+| --- | --- |
+|  |  |
+
+## Provenance
+
+- Product-strategy parent:
+  [`cross-adapter-behavior-enforcement.md`](../intents/cross-adapter-behavior-enforcement.md),
+  capability 1 in § "Decomposition".
+- Research basis:
+  [`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md),
+  [`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md),
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md),
+  and
+  [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).

--- a/docs/product/intents/cross-adapter-behavior-enforcement.md
+++ b/docs/product/intents/cross-adapter-behavior-enforcement.md
@@ -1,0 +1,333 @@
+# Cross-adapter behavior enforcement
+
+- **Status:** Draft
+- **Level:** product-strategy
+
+## Outcome
+
+Every policy this repository publishes carries a **recorded verdict** for the
+work it governs, and a missing or malformed verdict fails a deterministic
+check — so a skipped policy is detectable rather than invisible.
+
+**The guarantee is coverage, not obedience** (owner decision, 2026-09-03). No
+mechanism can force a model to judge well. What is mechanically decidable is
+whether **every registered policy produced a verdict**, because the registry
+enumerates what must appear. That binds the output to something outside the
+document, which is the only class of mechanism this repository has ever seen
+catch a defect on its first run.
+
+**The shape: three layers, with a model in only one.**
+
+**1. Teach.** Policy families are data in a skill directory, which projects to
+every host with no special handling — `evals/evals.json` is the existing proof.
+Selection is keyed to **`engine-state.json.state`**, the FSM phase, because it
+is the only phase signal recorded as tool-written data; `Shape:`, task
+verification mode and task flavour are agent-selected prose with no mechanical
+reader. Delivery reuses the shipped `Module index → select matching reference →
+inline into the brief` pattern.
+
+**2. Act.** The dispatched authoring agent works with the phase-selected
+policies in context, enumerates them into a task list of one entry per rule, and
+emits a per-policy verdict.
+
+**3. Check, with no model in the path.** Two deterministic checks in the
+`CAT-L031` shape — required teaching as data, compliance as data, one place,
+`Severity.ERROR`:
+
+- **Coverage:** every family the phase key selected has a verdict in the emitted
+  artifact. A missing verdict fails. This closes the measured gap that nothing
+  today records or checks that a selected module reached the acting agent.
+- **Compliance:** for precise families only, a parse-level predicate over the
+  produced artifact. Stylistic families never block.
+
+**Two authoring agents, one machinery.** Every agent in the roster is a reviewer
+or adjudicator except `implementer`, and **no spec-authoring agent exists in any
+pack** — spec authoring is a skill running in the primary session. So neither
+authoring phase has a dispatch envelope, while review time has agents and does
+receive inlined modules. The shape needs a `spec-author` agent keyed to the
+`SPEC-PLAN-*` phases alongside `implementer` keyed to execution, carrying
+different policy sets over the same delivery and enforcement path.
+
+**A policy needing a reasoned verdict decomposes; it does not stay whole.** The
+blocking surface stays precise because most such policies split into a decidable
+part and a smaller semantic residue:
+
+| Policy | Decidable part | Semantic residue |
+| --- | --- | --- |
+| Cognitive load | emphasis-bearing paragraphs per section; near-duplicate paragraphs | "short resumable parts" |
+| The razor | whether a bounded search ran, from run provenance | whether the hit found was adequate |
+| Repository anchoring | whether the plan's `Repository anchors` entries resolve | whether an anchor is apt |
+
+The readability score is **not** the oracle for cognitive load: the rule scopes
+that target to chat prose and states that a score "is not a reason to cut needed
+facts".
+
+**The residue is judged, under the survey's conditions.** A model judge may
+block only after held-out labels, a per-policy confusion matrix, confidence
+bounds, and bias, swap, verbosity, self-preference and drift tests; until then
+the family is advisory. Verdicts route by severity — deterministic violations
+block, calibrated high-confidence semantic violations block or require review,
+low-confidence findings stay advisory, and **an abstention or a disagreement
+between validators goes to human review, never to an automatic pass.**
+Independence comes from judging across model families: `get_judge(adapter, …)`
+is already pluggable and records `judge_adapter`, so codex can judge
+claude-code-authored artifacts using the two adapters this intent already
+scopes. A prose policy earns its keep only if the ablation in
+[`guidance-activation-measurement.md`](../briefs/guidance-activation-measurement.md)
+shows it changes behaviour above the mechanical baseline.
+
+**Rejected: extending the finding-adjudicator's envelope as the enforcer.** It
+adjudicates disputed reviewer findings, which is a different job from evaluating
+a decidable predicate; routing a deterministic check through a model-mediated
+step would add a non-deterministic hop where none is needed, and it runs
+post-hoc when the preference is prevention. `review-artifact.py` already
+validates artifact kinds generically, so a policy-verdict artifact can be
+validated directly. The adjudicator keeps its existing job: if a policy finding
+is disputed, adjudicating that dispute is already what it does.
+
+**Hooks are deliberately not the mechanism.** They are the least standardized
+surface available: a new pre-tool event fails projection on Copilot and Gemini,
+drops with only a build log on Cursor, and no host's "nonzero means block"
+contract is encoded anywhere. Agents and skill directories are both more
+portable than hook events, so the enforcement edge sits on artifact validation
+in our own gate chain rather than in a host hook.
+
+## Opportunity
+
+The packs steer behavior almost entirely through prose, and prose is a
+probabilistic steering mechanism rather than a portable enforcement layer. A
+compatibility claim is only valid for one `pack version x host adapter version
+x model snapshot x inference configuration` tuple, so the current public claim
+of portability is broader than the mechanism supports. Evidence:
+[`cross-model-steering-survey.md`](../research/cross-model-steering-survey.md).
+
+Fourteen shipped controls do not enforce what they appear to, and the pattern
+across all of them is one thing: **construction is tested; application is not.**
+Block presence is gated while compliance is not; the rule-router's shape is
+linted while chain traversal is not; OKF module construction is tested while
+inlining is not. Evidence:
+[`behavior-controls-inventory.md`](../research/behavior-controls-inventory.md).
+
+The mechanism to fix it is largely present. Hook wiring already projects to all
+five hosts, and a structured, schema-validated per-skill artifact already ships
+in `evals/evals.json`. What is missing is a policy primitive, a control on the
+verdict artifact with a validator, and a detector that can drive a
+non-Claude model.
+
+## Assumptions
+
+- Enforcement must bind to an artifact a deterministic script can check.
+  Advice written into context is not model-invariant however reliably it is
+  delivered, and a host hook cannot be relied on because hook events are the
+  least standardized surface we ship to.
+- The unit of enforcement is a policy family, not a clause. Per-clause
+  validators would demand a 0.039% false-positive rate against 0.427% for a
+  dozen families, which is the difference between attainable and not. Evidence:
+  [`agent-behavior-oracle-patterns-survey.md`](../research/agent-behavior-oracle-patterns-survey.md).
+- A structured policy makes routing, applicability, severity, and calibration
+  mechanical. It does not make a semantic property decidable, and that is an
+  acceptable limit because the measured failures were selection and invocation
+  failures rather than judgment failures.
+- No host is yet known to admit a blocking verdict from a shipped hook. Both
+  bodies we ship return `0` by design, and Cursor drops an unmapped event with
+  only a build log. This is the load-bearing unknown and it should be settled by
+  a bounded spike before any capability is confirmed.
+- A validated policy registry is itself a control whose application must be
+  checked, or it recreates the pattern above one level up.
+
+## De-risk
+
+Reversibility: **one-way door** — a new primitive type projected to five hosts,
+adopter-extensible, changing behaviour inside adopters' loops. Approach:
+**`validate-first`** (the triage default for a one-way bet).
+
+Riskiest assumption: **routing every plan task through a sequential implementer
+activates policy reliably enough to be worth the delivery path.**
+
+The delivery pattern is not in question. Subagents plus an inlined module are a
+proven, shipped mechanism, and a **taught-and-checked** policy already blocks in
+production: `CAT-L031` is `Severity.ERROR`, requires the broker-specific
+teaching phrase, and AST-walks credentialed CLI scripts to reject banned argv
+flags, with both halves carried as data. It has been retained, not disabled.
+
+Rejected: a bespoke probe to discover whether a blocking control survives
+contact with us. `CAT-L031` already shows one does. The measurement that probe
+produced is kept, because it isolates *which* policies survive:
+
+- **A precise policy survives.** `CAT-L031` targets a closed list of argv flags
+  and blocks with essentially no false positives.
+- **A stylistic policy does not.** Applying "at most one emphasis-bearing
+  narrative paragraph per section" to the class `docs/AGENTS.md` governs blocks
+  **405 of 1,477 files, 27.4%**, against a 0.4% per-family budget — 68 times
+  over.
+
+So the design rule this replaces the probe with: **policy families ship precise
+or not at all.** A stylistic family may be advisory; it may not block.
+
+What would have to be true:
+
+- a sequential dispatch envelope exists at implementation time, which today it
+  does not;
+- the selected module demonstrably reaches the acting agent, which nothing
+  currently records or checks;
+- the resulting behaviour is measurable, which needs an eval on a
+  non-Claude adapter as well as claude-code.
+
+**Kill condition (predeclared 2026-09-03).** Kill if, once every task routes
+through the implementer, an eval of the sequential path shows **no improvement
+in policy adherence over the current inline path** at a pre-registered effect
+size, on either tested adapter.
+
+**This intent owns that comparison; it does not borrow the sibling's.** The two
+ablations vary different factors and must not be conflated:
+[`guidance-activation-measurement.md`](../briefs/guidance-activation-measurement.md)
+varies **the rule** — present, removed, length-matched placebo — to ask whether
+a rule binds. This intent varies **the delivery path** — inline versus
+dispatched — to ask whether an envelope improves adherence. A single experiment
+cannot answer both, and running one while claiming the other would confound the
+result.
+
+```
+validation_hook:
+  assumption: sequential implementer dispatch activates policy more reliably
+    than the current inline path
+  kill_condition: no improvement at a pre-registered effect size on either
+    tested adapter
+  activity: run the paired eval across claude-code and codex once universal
+    dispatch lands
+```
+
+Verdict: **pending**, and it is now an eval rather than a bespoke probe. Desk
+grounding is not validation, so this hook stays `to-validate`.
+
+## Where the lifecycle holds, and where it breaks
+
+Traced against the work-loop FSM as the artifacts are written. **Policy
+delivery works only at the review phases, because those are the only phases
+with a dispatched agent.**
+
+| Phase | Acting surface | Envelope | Policy delivery | Enforcement |
+| --- | --- | --- | --- | --- |
+| Routing, before `new-spec` | primary session | **none** | **impossible today** | B1's standing lint, at gate time not at routing |
+| `SPEC-PLAN-DRAFTING` | `new-spec` skill, primary session | **none** | **blocked on capability 2** | pre-EXECUTE reviewers |
+| `SPEC-PLAN-REVIEW` | reviewer agents | yes | works today | adjudication, `review-artifact.py` |
+| `SPEC-PLAN-APPROVED` | human gate | n/a | n/a | `approve-plan` status guard |
+| `EXECUTE`, code mode | inline in `work-loop` | **none**, implementer dormant | **blocked on capability 1** | gates |
+| gates | scripts | n/a, no model | n/a | deterministic, works today |
+| post-gates review | reviewer agents | yes | works today | adjudication |
+| closeout | `close-work` | n/a | n/a | `lint-spec-status`, coverage lint |
+
+Three breaks, each with a named owner: routing has no agent and is the hardest
+case, since it precedes every dispatch; spec authoring needs capability 2;
+implementation needs capability 1. **Nothing else in the chain is missing** —
+the review phases already deliver and enforce, and the gate and closeout phases
+need no model.
+
+**Nothing under this intent is dispatchable yet.** None of the five capabilities
+has a brief, so the intent → brief → confirmed slice → spec path has not been
+walked. That is the expected state after framing and de-risking, and it is
+recorded so a reader does not mistake the decomposition for delivery.
+
+## Decomposition
+
+The capability level beneath this intent, none confirmed. **The order is set by
+what unblocks what**, not by dependency alone.
+
+1. `universal-implementer-dispatch` — **the enabler, and unconditional.** Route
+   every plan task through the implementer agent sequentially rather than only
+   on the parallel path, and move implementation logic out of `work-loop`'s
+   `SKILL.md`.
+
+   Three measured reasons:
+
+   - **Implementation has no dispatch envelope today.** The implementer runs
+     only "when a plan has multiple tasks declaring `Depends on: none`"
+     (`packs/core/.apm/agents/implementer.md:3`), and that path is **disabled**
+     — `dispatch-decision`, the `worktree` verbs and `auto-parallel` exit
+     non-zero (`work-loop/references/supervisor-mode.md:3`). Sequential work
+     runs inside the skill, so there is no brief to inline a module into, and
+     **the two existing inlining precedents — `cloud-implementation-craft` and
+     `operational-safety` — therefore sit on a dormant path.**
+   - **It needs no Phase-2 decision.** Sequential dispatch is one task at a
+     time with no concurrency and no worktree merge, so it requires neither the
+     absent `pending_transition` schema nor the collision gate. ADR-0061 is
+     Frozen and deferred *parallel-wave* orchestration; it does not bear on
+     single-agent dispatch.
+   - **It relieves a live constraint.** `work-loop/SKILL.md` is 832 lines
+     against `CAT-S003`'s warn-at-500 and error-at-1000.
+
+   Bounded contract change: `implementer.md:48` assumes the supervisor created
+   `.worktrees/<task-id>/`, so sequential dispatch must admit the main tree.
+
+2. `spec-author-agent` — the missing authoring agent. Core ships six agents and
+   five are reviewers or adjudicators; the sixth is `implementer`. Spec
+   authoring runs as a skill in the primary session, so the `SPEC-PLAN-*`
+   phases have no dispatch envelope either. This capability gives spec
+   authoring a dispatched agent so authoring-time policy has somewhere to
+   arrive, reusing the same delivery and enforcement path as the implementer
+   rather than a parallel one.
+
+3. `phase-scoped-policy-delivery` — extends the existing mechanism rather than
+   inventing one. The `Module index → select matching reference → inline into
+   the subagent brief` pattern already exists; the addition is keying selection
+   to **`engine-state.json.state`**, the FSM phase, which is the only
+   phase signal already recorded as tool-written data. `Shape:`, task
+   verification mode and task flavour are all agent-selected prose with no
+   mechanical reader. Evidence:
+   [`phase-scoped-policy-delivery.md`](../research/phase-scoped-policy-delivery.md).
+
+4. `policy-arrival-validator` — makes delivery provable. Today both selection
+   and inlining are prose-directed and **nothing records or checks that the
+   selected module reached the acting agent's brief.** Follows the `CAT-L031`
+   shape: teaching required as data, compliance checked deterministically, both
+   in one place.
+
+5. `multi-adapter-eval-runner` — independent of the rest. Adds a **Codex
+   detector**, since `--adapter` and the codex *judge* backend already ship and
+   only the detector that drives the authoring is missing; nothing else here can
+   claim portability until it exists. **It must not
+   change the default or the scheduled workflow** (owner decision, 2026-09-02).
+   `.github/workflows/pack-evals.yml` already runs claude-code only, pinned to
+   a named CLI version because the activation event's stream shape is
+   version-sensitive; it is `schedule` plus `workflow_dispatch` only, so an
+   untrusted-fork PR cannot reach the API key; it is report-only via
+   `continue-on-error`; and it is already parameterised by a `packs` dispatch
+   input. Additional adapters stay local or on-demand, because each one adds a
+   vendor secret to a workflow whose posture is security-load-bearing and
+   asserted by `tools/test-pack-evals-workflow.py`, and requires every host CLI
+   installed and pinned on the runner.
+
+Three capability briefs already exist beneath this intent and are re-gated by
+it:
+
+- [`guidance-activation-measurement.md`](../briefs/guidance-activation-measurement.md)
+  asks whether a rule adds behavioral value above a mechanical control, varying
+  the rule rather than the delivery path. Its compliance test is the policy
+  registry's validator,
+  so it follows rather than leads.
+- [`agent-authoring-input-quality.md`](../briefs/agent-authoring-input-quality.md)
+  and
+  [`stage-input-readiness.md`](../briefs/stage-input-readiness.md)
+  both ship written guidance and wait on that ablation. `stage-input-readiness`'s
+  declared-shape gate is mechanical and does not wait.
+
+## Unresolved questions
+
+- Does any host admit a blocking verdict from a shipped hook, and by what exit
+  or output contract? Nothing here encodes it.
+- Does the public portability claim need amending to the qualification tuple
+  above? That is a governance decision rather than a delivery slice, and it
+  likely needs an RFC.
+- Which policy families ship first, and which tier does each fall into? A
+  deterministic family needs no judge; a semantic one needs a calibrated judge
+  and a measured false-block rate.
+- Does a `policies/` directory extend the blessed skill layout, or do policies
+  live under an existing directory? A non-blessed subdirectory warns under
+  `CAT-S004`.
+
+## Source
+
+- Mode: repo-origin
+- Locator: `docs/product/briefs/guidance-activation-measurement.md`
+- Framed 2026-09-02 while reviewing that brief's design, when its compliance
+  test proved to be a prerequisite rather than a part of the measurement.

--- a/docs/product/research/agent-behavior-oracle-patterns-survey.md
+++ b/docs/product/research/agent-behavior-oracle-patterns-survey.md
@@ -1,0 +1,431 @@
+# Oracle designs for non-deterministic behavioral policies
+
+> Discipline: applied (practitioner and peer-reviewed survey)
+
+Commissioned 2026-09-02 for the `cross-adapter-behavior-enforcement` brief. Independent desk research; findings are cited to their sources and labelled by evidence class. Retained so the briefs can cite it rather than restate it.
+
+---
+
+# Prior art: oracle designs for non-deterministic behavioral and stylistic policies
+
+The strongest conclusion is simple: no oracle becomes trustworthy merely because it returns `PASS` or `FAIL`. For an otherwise subjective policy, a blocking oracle needs an independently defined construct, evidence that it recognizes both compliant and violating cases, measured false-block and missed-violation rates, and proof that the check itself actually runs.
+
+For the specific question “did this rule bind?”, outcome inspection is insufficient. The closest valid design is a randomized, paired ablation over a challenge set, backed by a calibrated policy-specific outcome measure. Even that establishes a population-level causal effect, not that the rule influenced any single output.
+
+Source labels below distinguish peer-reviewed work from preprints and practitioner documentation.
+
+## Summary by oracle pattern
+
+| Oracle pattern | What it can establish | Binary gate? | Cost | Evidence |
+|---|---|---:|---:|---|
+| Formal or executable property | Artifact satisfies a specified predicate | Yes | Low–medium | High |
+| Metamorphic relation | Related runs obey an expected relation | Yes, sometimes statistical | Medium | High |
+| Differential or pseudo-oracle | Implementations or judges agree | Disagreement only; not correctness | Medium–high | High |
+| Guidance ablation | Adding the rule causally changes measured behavior | Yes, at suite level | High | Moderate |
+| Dedicated per-policy validator | One named policy was violated | Yes, after validation | Medium | Moderate |
+| LLM-as-judge | Rubric-defined semantic compliance | Yes, conditionally | Medium plus high setup | Moderate |
+| Human oracle | Human experts accept or reject | Yes | High | High, if labels are reliable |
+| Process/step oracle | Observable steps or trace obey policy | Yes for observable steps | High | Moderate, domain-limited |
+| Runtime monitor | Execution trace remains within a specification | Yes | Medium | High for formal properties |
+| Critique/revise or self-consistency | A second pass or consensus prefers an answer | Not safely by itself | Medium–high | Mixed |
+| Mutation oracle | The validator detects controlled policy violations | Yes; validates the validator | Medium–high | High |
+| Linter/warning oracle | A recognizable pattern should be corrected | Yes only at high precision | Low–medium | High for developer tooling |
+
+## 1. Specified properties and property-based testing
+
+A specified oracle turns the policy into an executable predicate. Property-based testing then supplies many generated inputs; the property, not the generator, remains the oracle. QuickCheck established this separation: users formulate properties and the system generates and shrinks counterexamples ([Claessen and Hughes, *QuickCheck*, ICFP 2000](https://research.chalmers.se/en/publication/237427), peer-reviewed).
+
+What it needs:
+
+- A precise observable: section count, repeated semantic proposition, reading level, prohibited operation, required source evidence.
+- A definition of equivalence where surface wording varies.
+- Generators that exercise boundary and adversarial cases.
+- A reviewed mapping from the prose policy to the predicate.
+
+Failure modes:
+
+- The executable property is only a proxy for the intended style.
+- Goodharting: authors satisfy the metric while defeating the purpose.
+- Generator blind spots.
+- Threshold disputes and unstable semantic clustering.
+- A “property-based” test without a real property merely generates more unjudgeable outputs.
+
+Cost is low once the predicate exists, but formalizing a subjective policy can be expensive. It yields a clean binary verdict and is the best blocking option when possible.
+
+Barr et al.’s test-oracle taxonomy puts this under “specified oracles.” The other categories are derived oracles, implicit failure signals, and cases where no automated oracle exists and human effort can only be reduced ([*The Oracle Problem in Software Testing: A Survey*, IEEE TSE 2015](https://discovery.ucl.ac.uk/id/eprint/1471263/), peer-reviewed).
+
+## 2. Metamorphic oracles
+
+Metamorphic testing avoids requiring the exact correct output. It states a relation that must hold across related executions. For example:
+
+- Reordering irrelevant source material must not change which claims are selected.
+- Paraphrasing the policy must not materially change compliance.
+- Duplicating a fact in the input must not cause duplicate summary claims.
+- Tightening “at most two” to “at most one” must not increase the measured count.
+- Removing irrelevant guidance should not change the target behavior.
+
+The established definition is a relation across multiple executions of one implementation. The main research challenge is discovering sound metamorphic relations; stochastic systems may require statistical rather than equality-based relations ([Segura et al., *A Survey on Metamorphic Testing*, IEEE TSE 2016](https://www.isa.us.es/publications/type/article-journal/2016/survey-metamorphic-testing), peer-reviewed; [Barr et al.](https://philmcminn.com/publications/barr2015.pdf), peer-reviewed).
+
+What it needs:
+
+- A transformation known not to change, or known predictably to change, the intended answer.
+- A measurable relation between outputs.
+- Repeated samples and a statistical tolerance for stochastic models.
+
+Failure modes:
+
+- A plausible but false relation.
+- Two outputs that differ harmlessly at the surface.
+- Both executions violating the policy in the same way.
+- Large sampling requirements for small behavioral effects.
+
+It can produce a binary gate. For stochastic generation, the binary is normally “the estimated violation exceeds a predeclared limit” rather than “one pair differs.”
+
+## 3. Differential testing, back-to-back testing, and pseudo-oracles
+
+Differential testing presents the same cases to comparable systems and flags disagreement. A pseudo-oracle is an independently produced alternative implementation. Neither requires knowing the exact answer beforehand ([McKeeman, *Differential Testing for Software*, Digital Technical Journal 1998](https://vmssoftware.com/docs/dtj-v10-01-1998.pdf), practitioner research journal; [Barr et al.](https://philmcminn.com/publications/barr2015.pdf), peer-reviewed).
+
+For agent guidance, comparators could include:
+
+- Different model families.
+- A model and a human reviewer.
+- A general judge and a policy-specific classifier.
+- Independent rubric implementations.
+- The current guidance and a known-good previous version.
+
+What it needs:
+
+- Genuine implementation diversity.
+- Output normalization that preserves material differences.
+- Adjudication for disagreements.
+
+Failure modes:
+
+- Shared training data and correlated blind spots.
+- Both systems being wrong.
+- Multiple valid stylistic outputs.
+- Treating majority vote as truth.
+- A “different” judge that is another checkpoint from the same model family.
+
+It yields a reliable binary for “disagreement occurred,” not for “the artifact is wrong.” A blocker therefore needs an adjudication rule or a trusted tie-breaker.
+
+## 4. Guidance ablation as a causal oracle
+
+This is the most direct pattern for determining whether a rule contributes behavior:
+
+\[
+\text{effect of rule} =
+\Pr(\text{violation}\mid\text{without rule})
+-
+\Pr(\text{violation}\mid\text{with rule})
+\]
+
+The valid experiment is not one before/after output. It is a randomized, repeated comparison over tasks selected to make the policy consequential.
+
+What it needs:
+
+1. A frozen model, decoding configuration, surrounding prompt, tools, and evaluator.
+2. A task set with room for the control to fail; otherwise ceiling effects hide the rule.
+3. Treatment and control prompts differing only in the rule.
+4. Preferably a length-matched placebo control, since deleting text also changes attention and context position.
+5. A predeclared policy-specific outcome measure.
+6. Multiple samples per task when generation is stochastic.
+7. Paired analysis: McNemar’s test for paired binary outcomes, or a hierarchical model when tasks and repetitions both vary.
+8. A minimum effect size, not merely statistical significance.
+9. A non-inferiority check on unrelated quality dimensions, since a rule can “work” by damaging the whole answer.
+
+The literature does support counterfactual prompt interventions as the identification strategy for prompt influence, but it does not yet provide a mature, standardized “instruction-binding oracle” for arbitrary prose rules:
+
+- Webson and Pavlick found that irrelevant or misleading prompts could perform as well as instructive prompts, showing why satisfactory output does not prove instruction use ([NAACL 2022](https://aclanthology.org/2022.naacl-main.167/), peer-reviewed).
+- Prompt-sensitivity work compares controlled prompt variants, although later results warn that rigid output metrics can manufacture apparent sensitivity ([Hua et al., EMNLP 2025](https://aclanthology.org/2025.emnlp-main.1006/), peer-reviewed).
+- Anthropic’s recent CHIVE work explicitly treats counterfactual prompt edits and their measured outcomes as evidence, while refusing to treat a model-generated explanation as ground truth ([*Would This Change Your Answer?*, 2026](https://alignment.anthropic.com/2026/chive/), practitioner research, not yet established peer-reviewed prior art).
+- IFEval largely sidesteps the subjective-oracle problem by selecting mechanically verifiable instructions ([Zhou et al., *Instruction-Following Evaluation for Large Language Models*](https://arxiv.org/abs/2311.07911), preprint).
+
+Ablation failure modes:
+
+- **Ceiling:** both conditions comply because the behavior is already learned.
+- **Floor:** neither condition can perform the task.
+- **Low power:** the challenge set rarely activates the rule.
+- **Prompt spillover:** removal changes context length, placement, or salience.
+- **Evaluator blindness:** the rule changes behavior that the metric does not capture.
+- **Evaluator leakage:** a judge shown the treatment condition rationalizes that the rule worked.
+- **Overfitting:** the rule was tuned on the same challenge cases.
+- **Interaction effects:** the rule only works in combination with another clause.
+
+Binary verdict: yes, at suite level. A defensible gate is:
+
+> Block if the lower confidence bound on the rule’s improvement is below the minimum useful effect, or if the rule causes a predeclared unacceptable regression.
+
+That gate answers “this rule has not demonstrated incremental behavioral value on the tested distribution.” It does not prove the rule failed to affect a particular artifact.
+
+## 5. Per-policy validators and policy-as-code
+
+OPA/Rego represents policies as separately versioned, executable decisions over structured input. Conftest applies those assertions to configuration artifacts ([OPA documentation](https://www.openpolicyagent.org/docs), official practitioner documentation; [Conftest](https://github.com/open-policy-agent/conftest), official project documentation).
+
+Guardrails AI uses the same modular shape for LLM output: each validator returns `PassResult` or `FailResult`, with a validator-specific failure action ([validator documentation](https://guardrailsai.com/guardrails/docs/concepts/validators), vendor documentation). NeMo Guardrails composes checks at input, retrieval, dialog, tool-execution, and output stages ([NeMo architecture](https://docs.nvidia.com/nemo/guardrails/about-nemo-guardrails-library/how-it-works), vendor documentation; its programmable-rails paper appeared as an [EMNLP 2023 system demonstration](https://aclanthology.org/2023.emnlp-demo.40.pdf), peer-reviewed demonstration paper).
+
+The advantage of one validator per policy is primarily operational:
+
+- Each policy has its own confusion matrix and owner.
+- A failure identifies the clause that fired.
+- Policies can be enabled, calibrated, or retired separately.
+- Different oracle types can coexist: deterministic checks first, learned checks only where necessary.
+- Mutation cases can target one policy.
+- Changes in one rubric do not silently redefine all other verdicts.
+
+Evidence that it is always more accurate than a global reviewer is weak:
+
+- EvalLM found that application-specific criteria produced 0.713 agreement and Fleiss’ κ of 0.485 with humans, versus 0.699 and κ 0.430 for overall-quality judgments. This is supportive but modest and task-specific ([Kim et al., CHI 2024](https://doi.org/10.1145/3613904.3642216), peer-reviewed).
+- The same study observed that equal weighting of separate criteria can be wrong when one criterion should dominate.
+- A 2026 prompt-controlled preprint found matched holistic judging equal or better than self-decomposing atomic judging on two of three reference-grounded QA benchmarks. Its scope does not cover independently implemented per-policy validators, but it is a useful counterexample to “decomposition always wins” ([Zhang, arXiv:2603.28005](https://arxiv.org/abs/2603.28005), preprint).
+
+### False-positive accumulation
+
+If a build fails when any of \(m\) independent validators falsely fires, the family-wise false-block probability is:
+
+\[
+1-(1-\alpha)^m
+\]
+
+For 132 validators:
+
+- At 1% false-positive probability each: about **73.5%** chance of at least one false block.
+- At 0.1% each: about **12.4%**.
+- To keep the total below 5% under independence, each validator needs roughly **0.039%** false-positive probability.
+
+Independence rarely holds, so those are illustrative rather than predictive. The union bound still gives a worst-case upper bound of \(\sum \alpha_i\).
+
+The practical answer is not one flat `AND` across every rule. Use applicability routing, severity tiers, correlated-rule consolidation, and explicit aggregation:
+
+- Deterministic safety or contract violations: block.
+- Calibrated high-confidence semantic violations: block or require review.
+- Low-confidence stylistic findings: advisory.
+- Multiple related validators: aggregate as one policy family.
+- Abstentions and validator disagreement: human review, not automatic pass.
+
+## 6. LLM-as-judge
+
+An LLM judge converts a rubric into a semantic classifier or ranker. It is useful precisely where a deterministic check is unavailable, but its output is still a learned measurement instrument.
+
+Evidence is mixed:
+
+- GPT-4 judges achieved over 80% agreement with human preferences in MT-Bench/Chatbot Arena, comparable to reported human-human agreement, while also showing position, verbosity, self-enhancement, and reasoning biases ([Zheng et al., NeurIPS 2023 Datasets and Benchmarks](https://papers.neurips.cc/paper_files/paper/2023/hash/91f18a1287b398d378ef22505bf41832-Abstract-Datasets_and_Benchmarks.html), peer-reviewed).
+- G-Eval reached Spearman correlation 0.514 with human summary judgments and warned of preference for LLM-generated text ([Liu et al., EMNLP 2023](https://aclanthology.org/2023.emnlp-main.153/), peer-reviewed).
+- Position alone can reverse pairwise results; balanced-order evaluation mitigates but does not eliminate this ([Wang et al., ACL 2024](https://aclanthology.org/2024.acl-long.511/), peer-reviewed).
+- LLM evaluators recognize and favor their own generations ([Panickssery et al., NeurIPS 2024](https://papers.nips.cc/paper_files/paper/2024/hash/7f1f0218e45f5414c79c0679633e47bc-Abstract-Conference.html), peer-reviewed).
+- LLMBar used 419 curated instruction-following pairs with 94% expert agreement. Some judges performed below chance on adversarial cases where a more attractive answer violated the instruction; even the best GPT-4 judge remained below experts ([Zeng et al., ICLR 2024](https://proceedings.iclr.cc/paper_files/paper/2024/file/afc8b034823271816d14f7c1aefe1dff-Paper-Conference.pdf), peer-reviewed).
+- JudgeBench found many strong models only slightly above random guessing on challenging knowledge, reasoning, math, and coding pairs ([Tan et al., ICLR 2025](https://openreview.net/pdf?id=G0dksFayVq), peer-reviewed).
+
+What a gating judge needs:
+
+- One operational criterion per verdict, or a documented precedence rule.
+- Positive, negative, boundary, and adversarial examples.
+- References or source material when the judgment depends on facts.
+- Blind model identity and blind treatment assignment.
+- Pair-order swaps for comparative evaluation.
+- Length- and formatting-controlled adversarial cases.
+- Structured output with `pass`, `fail`, and preferably `abstain`.
+- Exact offending spans or criterion evidence. This improves auditability, though the rationale is not proof.
+- A pinned judge model and prompt.
+- A held-out human-labelled calibration set from the actual artifact distribution.
+- Revalidation after judge, generator, rubric, or artifact-distribution changes.
+
+Metrics should include the full confusion matrix, false-block rate, missed-violation rate, and confidence intervals. Raw agreement should accompany Cohen’s κ or Krippendorff’s α; chance-corrected coefficients can behave oddly when violations are rare. Cohen’s original coefficient is documented in [*A Coefficient of Agreement for Nominal Scales*, 1960](https://doi.org/10.1177/001316446002000104), peer-reviewed.
+
+There is no defensible universal calibration-set size or κ threshold. Size follows the tolerated error rate:
+
+- If zero false blocks are seen in \(n\) clean examples, the approximate 95% upper bound is \(3/n\), the “rule of three” ([Hanley and Lippman-Hand, JAMA 1983](https://jamanetwork.com/journals/jama/articlepdf/385438/jama_249_13_031.pdf?resultClick=1), peer-reviewed).
+- To claim an observed zero-error false-block rate is below roughly 1%, about 300 clean cases are needed.
+- The same calculation applies separately to missed violations, requiring seeded or independently labelled violating cases.
+- Subgroup and policy-specific claims need their own effective sample sizes.
+
+An uncalibrated judge may be useful as an advisory reviewer. It is not evidence sufficient to block a build.
+
+## 7. Human and hybrid oracles
+
+When no automated oracle exists, the classical fallback is human judgment. Barr et al. treat reducing human-oracle cost as a distinct research category rather than pretending the oracle has been automated.
+
+A blocking human oracle needs:
+
+- A decision rubric with examples and boundary cases.
+- At least two independent labels during calibration.
+- Blinding to author, model, and treatment where possible.
+- Agreement measurement before consensus.
+- A documented adjudication path.
+- Periodic relabelling to detect drift.
+
+Failure modes include low agreement, expertise gaps, fatigue, halo effects, and consensus masking an ambiguous policy.
+
+A strong hybrid is “machine flags, human adjudicates.” OpenAI’s critic work found model critiques could help humans find code defects, but critics also hallucinated bugs; human–machine teams hallucinated fewer bugs than critics alone ([McAleese et al., *LLM Critics Help Catch LLM Bugs*](https://arxiv.org/abs/2407.00215), preprint/industry research).
+
+## 8. Process supervision and step-level verification
+
+Outcome supervision scores the final result. Process supervision scores intermediate steps. On math tasks:
+
+- Uesato et al. found similar final-answer error from pure outcome supervision with less labelling, but process feedback was needed to reduce reasoning errors among answers that happened to be correct ([*Solving Math Word Problems with Process- and Outcome-Based Feedback*](https://arxiv.org/abs/2211.14275), preprint).
+- Lightman et al. found process supervision outperformed outcome supervision on MATH ([*Let’s Verify Step by Step*, ICLR 2024](https://openreview.net/pdf?id=v8L0pN6EOi), peer-reviewed).
+
+The transfer to document policy is conditional. Step-level checks help when the policy concerns observable work:
+
+- Each material claim has a source.
+- Each identifier is resolved against a symbol table.
+- Each section passes a local redundancy check before assembly.
+- The agent ran the prescribed mutation or counterfactual.
+- A tool action was authorized before execution.
+
+They do not solve a subjective final-output oracle merely by asking for chain of thought. Private reasoning may be unavailable, unfaithful, or itself generated to satisfy the reviewer. Process reward models are also learned judges and require the same calibration as outcome judges.
+
+Binary gating is sound when the steps are externally observable and their predicates are executable. It is conditional when a learned process reward model supplies the step labels.
+
+## 9. Runtime verification and monitors
+
+Runtime verification checks an observed execution trace against a formal specification, often expressed as temporal logic, state machines, or rules ([Leucker and Schallhart, *A Brief Account of Runtime Verification*, Journal of Logic and Algebraic Programming 2009](https://christian.schallhart.net/publications/2009--jlap--a-brief-account-of-runtime-verification.pdf), peer-reviewed; [Falcone, Havelund, and Reger, *A Tutorial on Runtime Verification*, 2013](https://havelund.com/Publications/rv-tutorial-ios-2012.pdf), peer-reviewed book chapter).
+
+This transfers well to agent policies such as:
+
+- Never write outside the workspace.
+- Do not call a tool before approval.
+- Every external claim must be followed by a citation event.
+- Once a destructive action is proposed, execution requires an approval event.
+- Do not declare completion before required gates succeed.
+
+It transfers poorly to “be concise” or “emphasize only one point,” unless those are first reduced to an observable predicate. A runtime monitor changes when the check happens; it does not create the missing oracle.
+
+AgentSpec applies a DSL of triggers, predicates, and enforcement actions to agent execution. Its reported results are promising but domain-specific, and LLM-generated rules had high precision but materially lower recall in one embodied-agent setting ([Wang, Poskitt, and Sun, *AgentSpec*, ICSE 2026 author manuscript](https://cposkitt.github.io/files/publications/agentspec_llm_enforcement_icse26.pdf), peer-reviewed conference work).
+
+Runtime monitors yield strong binary gates for finite-trace safety properties. They cannot certify unobservable intent or arbitrary semantic quality.
+
+## 10. Constitutional critique, revision, self-consistency, and verifier–generator separation
+
+Constitutional AI asks a model to critique and revise its answer against written principles, then uses AI preferences for training ([Bai et al., *Constitutional AI: Harmlessness from AI Feedback*](https://arxiv.org/abs/2212.08073), industry preprint).
+
+Related patterns include:
+
+- Generate, critique, revise.
+- Generate many answers and take the modal answer.
+- Generate candidates and rank them with a verifier.
+- Use a distinct critic to assist a human.
+
+There is real evidence for verifier leverage in constrained domains:
+
+- Self-consistency improved arithmetic and commonsense reasoning by sampling diverse paths and selecting the common answer ([Wang et al., ICLR 2023](https://openreview.net/pdf?id=1PL1NIMMrw), peer-reviewed).
+- Trained verifiers improved selection among GSM8K candidates and scaled better than a fine-tuning baseline ([Cobbe et al., *Training Verifiers to Solve Math Word Problems*](https://arxiv.org/abs/2110.14168), preprint).
+- Process reward models likewise improve mathematical selection.
+
+But the “verifier is easier than generator” gap is not universal, especially for stylistic judgments where both generation and verification use the same latent preferences. Intrinsic self-correction can fail or degrade correct reasoning ([Huang et al., ICLR 2024](https://proceedings.iclr.cc/paper_files/paper/2024/hash/8b4add8b0aa8749d80a34ca5d941c355-Abstract-Conference.html), peer-reviewed). Other work finds improvement when verification is narrowed to key conditions, so the evidence is task- and feedback-dependent ([Wu et al., EMNLP 2024](https://aclanthology.org/2024.emnlp-main.714/), peer-reviewed).
+
+These patterns do not safely yield a blocking verdict by themselves. They become usable when the verifier is separately calibrated or grounded in external evidence.
+
+## 11. Mutation testing of the oracle
+
+Mutation testing asks whether a validator fails when controlled defects are introduced. It is especially valuable here because a check can execute, parse, and return green without being capable of detecting its target violation.
+
+For each policy validator, create:
+
+- A clean artifact.
+- A minimal violating mutation.
+- A near-boundary clean case.
+- A misleading case with attractive surface quality.
+- An unrelated mutation that must not trigger the validator.
+- Mutations of the rule itself: deletion, negation, weakened threshold, changed scope.
+
+The validator should:
+
+- Kill the violating mutations.
+- Preserve the clean and unrelated controls.
+- Fail closed if it cannot evaluate.
+- Report which policy and evidence caused the verdict.
+
+Mutation analysis is a mature test-adequacy technique ([Jia and Harman, IEEE TSE 2011](https://doi.org/10.1109/TSE.2010.62), peer-reviewed). Research specifically connects undetected mutants with inadequate oracles and shows mutation score reveals weaknesses missed by coverage ([Fraser and Zeller, IEEE TSE 2012](https://www.evosuite.org/wp-content/papercite-data/pdf/tse12_mutation.pdf), peer-reviewed; [Jain et al., *Mind the Gap*](https://clairelegoues.com/assets/papers/jainOracleGap.pdf), peer-reviewed version/preprint copy).
+
+This is one of the strongest additions to the listed patterns: use mutation testing not only on generated code, but on the policy evaluators and on the guidance treatment itself.
+
+## 12. Linters, blocking, autofix, and warning fatigue
+
+The static-analysis literature shows that warnings influence authors when they are timely, local, actionable, and trusted. False positives and poor presentation are major adoption barriers ([Johnson et al., ICSE 2013](https://research.google/pubs/why-dont-software-developers-use-static-analysis-tools-to-find-bugs/), peer-reviewed; [Christakis and Bird, ASE 2016](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/ASE-2016.pdf), peer-reviewed).
+
+Google’s Tricorder experience imposed a practical admission bar: warnings should be understandable, actionable, important, and perceived as correct at least 90% of the time. It integrated findings into code review, tracked “not useful” feedback, and supported suggested fixes. The paper reports codebase violations dropping or levelling off after checks were introduced, although this is observational rather than a randomized causal estimate ([Sadowski et al., ICSE 2015](https://research.google.com/pubs/archive/43322.pdf), peer-reviewed industrial study).
+
+For behavioral-policy linters:
+
+- Advisory mode is appropriate while precision is unknown.
+- Blocking should begin only after shadow-mode calibration.
+- Autofix is suitable for local, semantics-preserving transformations.
+- A proposed fix can also clarify the warning even when not applied.
+- Suppression must require a reason and remain observable.
+- Noisy validators should be demoted or disabled, not normalized as permanent build noise.
+
+Warnings can change behavior, but repeated low-value warnings train authors to ignore the system. The literature supports actionability and low false-positive rates far more strongly than it supports a universal “warnings always work” claim.
+
+## Which patterns are trustworthy enough to block?
+
+| Pattern | Blocking status | Minimum prior evidence |
+|---|---|---|
+| Deterministic contract or property | Strong | Reviewed mapping to policy; boundary tests; policy mutations killed |
+| External-reference check | Strong | Authoritative, versioned reference; explicit equivalence rules |
+| Runtime safety monitor | Strong | Observable event trace; monitorable property; fail-safe enforcement |
+| Metamorphic relation | Strong–conditional | Valid relation; repeated stochastic trials where needed |
+| Human adjudication | Strong–conditional | Independent trained raters; adequate agreement; conflict process |
+| Dedicated statistical classifier | Conditional | Held-out local labels; per-policy confusion matrix and confidence bounds |
+| LLM judge | Conditional | Same as classifier plus bias, swap, verbosity, self-preference, and drift tests |
+| Guidance ablation | Strong for suite-level causal regression | Randomized control; challenge set; minimum effect; confidence bound |
+| Differential agreement | Escalation signal | Independent comparators and trusted adjudicator |
+| Process reward model | Conditional | Observable steps or independently calibrated step labels |
+| Global LLM reviewer | Advisory by default | Full local calibration is harder because error causes are entangled |
+| Self-critique/self-consistency | Advisory or candidate selection | Independent final oracle still required |
+
+## Recommended design for detecting that a rule did not fire
+
+Use two separate tests because “artifact acceptable” and “rule contributed” are different hypotheses.
+
+### A. Outcome-compliance test
+
+A policy-specific validator asks whether the artifact violates the rule. It should be mutation-tested and locally calibrated. This is the ordinary artifact gate.
+
+### B. Instruction-contribution test
+
+A scheduled or change-time experiment asks whether the rule changes behavior:
+
+1. Build policy-challenge tasks from real failures plus minimal synthetic cases.
+2. Freeze a held-out set before editing the rule.
+3. Run treatment, removal, and length-matched placebo conditions.
+4. Blind the evaluator to the condition.
+5. Run enough repetitions to estimate the paired violation-rate difference.
+6. Require a lower confidence bound above a predeclared useful effect.
+7. Require non-inferiority on task correctness and other critical policies.
+8. Mutate or invert the rule and verify that the suite notices.
+9. Re-run after model or surrounding-context changes.
+
+Interpretation:
+
+- **Treatment better than control:** evidence that the rule binds on this distribution.
+- **Both good:** the rule may be redundant, the test may have a ceiling, or the rule may still influence unmeasured aspects.
+- **Both bad:** the rule is ineffective, the model is incapable, or the evaluator is blind.
+- **Treatment worse:** the rule backfires or competes with higher-priority objectives.
+- **High variance:** no gating claim; expand cases or improve the oracle.
+
+For a single execution, there is no output-only test that proves the rule fired. Instrumentation can prove that the rule was loaded or referenced, but access is not causal use. If per-run proof is required, the policy must be moved into an externally enforced step: a structured decision record, a per-section validator, or a runtime monitor.
+
+## Avoiding the self-reference trap
+
+In descending order of independence:
+
+1. Executable properties tied to an external specification or live system.
+2. Metamorphic relations and mutations whose expected relation is human-reviewed.
+3. Independently labelled human gold cases.
+4. A frozen policy-specific classifier trained and tested on separated data.
+5. A judge from a different model family, blinded and calibrated against humans.
+6. Multiple LLM judges.
+7. The generator reviewing its own output.
+
+Different model families reduce direct self-preference but do not guarantee independence: training corpora, preference data, and superficial quality biases may still overlap. Inter-LLM agreement is therefore evidence of consistency, not truth.
+
+## Evidence gaps
+
+- **Known-unknown:** No strong head-to-head literature establishes that one-validator-per-policy is universally more accurate than a single global reviewer for arbitrary prose guidance. Existing evidence supports better auditability and sometimes better agreement, but counterexamples exist.
+- **Known-unknown:** There is no universal calibration-set size, κ threshold, or acceptable false-block rate for LLM judges. These depend on policy prevalence and the cost of false blocks versus missed violations.
+- **Known-unknown:** Prompt ablation is recognizable causal methodology, but “instruction binding” is not yet a mature named oracle class with accepted build-gating standards.
+- **Known-unknown:** Linter evidence concerns human developers, not coding agents authoring documents. Transfer should be treated as a hypothesis and measured.
+- **Unknowable from output alone:** Whether one policy causally affected one already-acceptable artifact. That counterfactual execution was not observed.
+
+The repository was not modified, and no git write or remote-freshness command was run.

--- a/docs/product/research/behavior-controls-inventory.md
+++ b/docs/product/research/behavior-controls-inventory.md
@@ -1,0 +1,421 @@
+# Behavior controls inventory: what enforces, and what only appears to
+
+> Discipline: repository inventory (measured)
+
+Commissioned 2026-09-02 for the `cross-adapter-behavior-enforcement` brief. Independent desk research; findings are cited to their sources and labelled by evidence class. Retained so the briefs can cite it rather than restate it.
+
+---
+
+Legend: **[M]** measured directly from code/search; **[C]** repository-declared contract; **[I]** inference from measured implementation. Paths are relative to `.`.
+
+## Highest-value conclusions
+
+| Set | Inventory |
+|---|---|
+| Portable across all five | **[M]** `agentbundle` schema validation, projection safety, path confinement, scope rails, seed delivery, and catalogue verification. Skill directories—including scripts/assets—are copied without semantic rewriting. **[I]** Their files are portable, but prose-triggered behavior still depends on model compliance. |
+| Host-specific | **[M]** Hooks have different event names/paths; commands are dropped on Codex and Copilot; Cursor drops fine-grained agent tool lists; agent model aliases differ; only Gemini receives the `AGENTS.md` context bridge; root `.codex/config.toml` restricts Codex only. |
+| Model-invariant | **[M]** Process exit codes; installer write fences; schema/lint failures; CI job failures; native host tool/sandbox restrictions; deterministic artifact checks. |
+| Model-dependent | **[M]** Hook stdout reminders, command bodies, agent-body instructions, seed prose, Markdown templates, semantic eval judging, and anything requiring a model to select a skill/subagent. |
+| Adopter-facing | **[M]** Pack `.apm` primitives, seeds, projected hooks/agents/commands, skill assets/scripts, and installer safety. |
+| Maintainer-only | **[M]** Root `Makefile`, `.github/workflows/**`, most `tools/**`, root `.codex/config.toml`, current self-host projections, catalogue source tests. `tools/hooks/pre-pr.py` is the deliberate adopter-safe exception. |
+| Can stop mid-loop | **[M]** Native agent tool/sandbox denial and host `PreToolUse` hooks could stop actions in principle, but this repository ships no `PreToolUse` wiring. Installer safety stops writes before projection. |
+| Cannot presently stop mid-loop | **[M]** Both lifecycle-wired hook bodies return `0`. Eval is report-only. Commands, seeds, templates, and reminder output are advisory. |
+| Can stop later | **[M]** `pre-pr.py` can reject a push if separately wired; local gates return nonzero; CI jobs can fail. **[I]** Whether a failed CI job blocks merge depends on branch protection, which is not encoded here. |
+
+## Hooks
+
+### Shipped sources
+
+| Control and anchor | Trigger | Enforcement and contract | HARD/advisory | Hosts | Model swap |
+|---|---|---|---|---|---|
+| User-prompt wiring: [`work-loop-check.toml:19`](packs/core/.apm/hook-wiring/work-loop-check.toml:19). Body: [`work-loop-check.py:13`](packs/core/.apm/hooks/work-loop-check.py:13), [`:26`](packs/core/.apm/hooks/work-loop-check.py:26). | **[M] Mechanical:** every `UserPromptSubmit`/mapped equivalent runs `python tools/hooks/work-loop-check.py`. | **[M]** Prints a fixed reminder that non-trivial repository changes use work-loop; performs no classification; always returns `0`; reads no hook input. | Advisory. Cannot block. | All five, with host mappings below. | Process invocation survives; behavioral effect requires model to read/obey stdout. |
+| Session wiring: [`session-start.toml:34`](packs/core/.apm/hook-wiring/session-start.toml:34). Body: [`session-start.py:260`](packs/core/.apm/hooks/session-start.py:260). | **[M] Mechanical:** `SessionStart`/mapped equivalent. | **[M]** Emits pending adaptation context; wired invocation omits `--show-knowledge`, so knowledge replay does not run. Normal path returns `0`; malformed explicit CLI arguments return `2` at [`:119`](packs/core/.apm/hooks/session-start.py:119). Environment-selected paths are confined at [`:102`](packs/core/.apm/hooks/session-start.py:102). | Normal lifecycle path advisory. | All five, with mappings below. | Confinement/exit behavior survives; emitted context requires model consumption. |
+| Pre-PR body: [`pre-pr.py:5`](packs/core/.apm/hooks/pre-pr.py:5), [`:81`](packs/core/.apm/hooks/pre-pr.py:81), [`:117`](packs/core/.apm/hooks/pre-pr.py:117), [`:133`](packs/core/.apm/hooks/pre-pr.py:133). | **[M] Discretionary:** manual execution or consumer-installed Git pre-push hook. No `.apm/hook-wiring` entry invokes it. | **[M]** Runs available knowledge, loop-cohort, and adopter artifact checks; child failure returns `1`; missing optional tools are skipped; clean/empty path returns `0`. | HARD only when invoked/wired; otherwise dormant. | Python body is host-neutral; no automatic host activation. | Yes—deterministic subprocess results. |
+| Kiro IDE companion: `packs/core/.apm/kiro-ide-hooks/work-loop-check.kiro.hook:5`. | **[M] Mechanical on Kiro IDE only:** `promptSubmit`. | **[M]** `askAgent` injects the reminder. | Advisory; no stop action. | None of the requested five; Kiro-only supplemental primitive. | Requires model compliance. |
+
+### Host projections
+
+| Host | Projection and event | Blocking implication |
+|---|---|---|
+| Claude Code | **[M]** Bodies → `tools/hooks/`; wiring → `.claude/settings.local.json`; commands preserved: [`adapter.toml:183`](packages/agentbundle/agentbundle/_data/adapter.toml:183), [`:219`](packages/agentbundle/agentbundle/_data/adapter.toml:219), [`:227`](packages/agentbundle/agentbundle/_data/adapter.toml:227). Events remain `SessionStart` and `UserPromptSubmit`. | **[M]** Shipped bodies return `0`; no block. |
+| Codex | **[M]** Bodies → `tools/hooks/`; wiring → `.codex/hooks.json`; command dropped: [`adapter.toml:574`](packages/agentbundle/agentbundle/_data/adapter.toml:574). Current projection confirms both events at [`.codex/hooks.json:3`](.codex/hooks.json:3). | Same. |
+| Copilot | **[M]** Bodies and generated hook JSON → `.github/hooks/`; command dropped: [`adapter.toml:501`](packages/agentbundle/agentbundle/_data/adapter.toml:501). Events become `sessionStart` and `userPromptSubmitted`, mapped in `copilot_hooks_json.py:61`. Unmapped events fail projection. | Same for shipped hooks. Mapping failure is build-time HARD. |
+| Cursor | **[M]** Bodies → `.cursor/hooks/`; wiring → `.cursor/hooks.json`; events become `sessionStart` and `beforeSubmitPrompt`: [`adapter.toml:632`](packages/agentbundle/agentbundle/_data/adapter.toml:632), [`:669`](packages/agentbundle/agentbundle/_data/adapter.toml:669). Unmapped events are dropped with a build log. | Shipped hooks do not block. Unknown event handling is fail-open. |
+| Gemini CLI | **[M]** Bodies → `.gemini/hooks/`; wiring → `.gemini/settings.json`; events remain `SessionStart` and map `UserPromptSubmit` → `BeforeAgent`: [`adapter.toml:725`](packages/agentbundle/agentbundle/_data/adapter.toml:725), [`:760`](packages/agentbundle/agentbundle/_data/adapter.toml:760). Unmapped events fail projection. | Shipped hooks do not block. Mapping failure is build-time HARD. |
+
+**[M]** The repository defines commands, mappings, and emitted files, but does not encode each host runtime’s general “nonzero means block” contract. That gap does not affect the shipped lifecycle hooks because both normal paths explicitly return `0`.
+
+**[C] Conflict:** [`tools/hooks/README.md:114`](tools/hooks/README.md:114) says non-Claude wiring is consumer-side, while the adapter contract mechanically projects wiring for Codex, Copilot, Cursor, and Gemini. The executable adapter contract is newer/more specific.
+
+## Subagents and agent definitions
+
+**[M]** Fifteen source agents exist. Every one declares both `tools:` and `model:`. Representative mechanical boundaries:
+
+| Source | Declared constraint | Host treatment |
+|---|---|---|
+| [`implementer.md:4`](packs/core/.apm/agents/implementer.md:4) | Edit/Write/Bash-capable, model `sonnet`. | Claude allowlist; Codex maps to `workspace-write`; Copilot retains list; Cursor loses list/coarsens to `readonly=false`; Gemini maps allowlist. |
+| [`shaping-reviewer.md:4`](packs/core/.apm/agents/shaping-reviewer.md:4) | Read-only tool set, `opus`. | Codex maps to `read-only`; Cursor derives `readonly=true`; Gemini/Copilot/Claude retain native restriction. |
+| [`adversarial-reviewer.md:4`](packs/core/.apm/agents/adversarial-reviewer.md:4), [`quality-engineer.md:4`](packs/core/.apm/agents/quality-engineer.md:4), [`security-reviewer.md:4`](packs/core/.apm/agents/security-reviewer.md:4) | Read/search plus bounded Bash, model pinned. | Same host degradation differences. |
+| Codex mapping | [`adapter.toml:869`](packages/agentbundle/agentbundle/_data/adapter.toml:869) | **[M]** Tool intents become sandbox/features; model aliases become Codex model/effort. |
+| Copilot mapping | [`adapter.toml:895`](packages/agentbundle/agentbundle/_data/adapter.toml:895) | **[M]** Tools retained after validation; model dropped. |
+| Cursor mapping | [`adapter.toml:914`](packages/agentbundle/agentbundle/_data/adapter.toml:914) | **[M]** Fine-grained tools dropped; model retained; read-only intent becomes Boolean `readonly`. |
+| Gemini mapping | [`adapter.toml:934`](packages/agentbundle/agentbundle/_data/adapter.toml:934) | **[M]** Tool allowlist and model tier both mapped. |
+
+- **[M] Trigger:** subagent definition becomes active only when a user/orchestrator selects that agent. Selection is discretionary.
+- **[M] HARD portion:** once loaded, native tool/sandbox restriction is host-enforced and model-invariant.
+- **[M] Advisory portion:** role, review discipline, output format, and completion language in the body remain prose/model-dependent.
+- **[M] No all-five-identical constraint:** Cursor’s Boolean degradation and Copilot’s dropped model prevent parity.
+
+## Commands
+
+| Control | Trigger/enforcement | Hosts | Model dependence |
+|---|---|---|---|
+| `packs/core/.apm/commands/conventions-check.md:1`, body at `:10` | **[M] Discretionary:** explicit command selection. It asks the model to inspect/report and expressly does not auto-fix. Advisory. | **[M]** Claude → `.claude/commands/`; Cursor → `.cursor/commands/`; Gemini → `.gemini/commands/*.toml`. Codex and Copilot drop it. Anchors: [`adapter.toml:210`](packages/agentbundle/agentbundle/_data/adapter.toml:210), [`:671`](packages/agentbundle/agentbundle/_data/adapter.toml:671), [`:768`](packages/agentbundle/agentbundle/_data/adapter.toml:768). | Entire command body depends on model execution. Any subprocess linter it subsequently invokes is model-invariant once started. |
+
+## Settings, permissions, and projection safety
+
+| Control | Scope | What it enforces | Strength/model |
+|---|---|---|---|
+| [`.codex/config.toml:1`](.codex/config.toml:1) | Maintainer checkout, Codex only. | **[M]** `approval_policy="on-request"`; default `repo-codex-authoring`; root read, narrowly listed write prefixes for `.codex`/`.agents`. | HARD native runtime restriction; model-invariant. Not exported as a pack seed. |
+| Adapter allowed prefixes, e.g. [`adapter.toml:235`](packages/agentbundle/agentbundle/_data/adapter.toml:235) | All adapter installs. | **[M]** Constrains installer writes under adapter/scope-specific prefixes. | HARD during install; not a runtime tool permission. |
+| `safety.py:175`, `:317` | Installer/build. | **[M]** Refuses path escape, unsafe target, or writes outside allowed prefixes; atomic write path. | HARD/model-invariant. |
+| `scope_rails.py:16`, `:85` | Installer scope selection. | **[M]** Refuses non-empty seeds and incompatible hook wiring at user scope. | HARD/model-invariant. |
+| `install.py:488`, `:694`, `:1078`, `:1280`, `:1393` | Pack installation. | **[M]** Validates metadata/scope/adapter, reports dropped primitives, confines paths, and detects conflicts. | Validation/path errors HARD. Dropped primitive is warning-only unless its projector fails closed. |
+
+**[M] Absence:** no checked-in Claude settings, Cursor settings/rules, Gemini settings, or Copilot instruction file exists in this checkout. Those settings are generated at install/self-host time where supported.
+
+## Mechanical authored-artifact gates
+
+| Gate family and anchor | Trigger | Enforcement | Audience/portability |
+|---|---|---|---|
+| Catalogue verifier: [`verify.py:2197`](packages/agentbundle/agentbundle/catalogue_tooling/verify.py:2197) | `agentbundle catalogue verify`, build/release CI. | **[M]** Nineteen ordered checks: config/schema, source lint, versions, profiles, dependencies, adapter compatibility, primitive layout, clean build, projected agents, marketplace/manifests, drift, self-host defaults, preflight, fixtures, integration. Stops nonzero. | Engine portable and model-invariant. Adopters receive it with CLI; this repository’s invocation policy is maintainer-only. |
+| Catalogue lint: `catalogue_tooling/lint.py:1578`, `:1775`, `:1822`, `:2255`; `skill_spec_lint.py:191`, `:320`, `:831` | `catalogue lint`, verifier, pre-PR. | **[M]** Validates manifests, agent metadata/tool/model shape, opt-in seeds, skill/eval schema, and pack/eval cross-references. | HARD when invoked; portable CLI. |
+| Projection validation | `verify.py:834`; adapter implementations and [`adapter.toml:118`](packages/agentbundle/agentbundle/_data/adapter.toml:118). | **[M]** Checks generated agent artifacts and adapter-supported primitive mappings. | HARD build-time; adapter-specific results, model-invariant. |
+| Maintainer pre-PR aggregator: [`pre_pr_catalogue.py:1`](tools/catalogue/pre_pr_catalogue.py:1), [`:59`](tools/catalogue/pre_pr_catalogue.py:59), [`:110`](tools/catalogue/pre_pr_catalogue.py:110) | `make pre-pr` at [`Makefile:91`](Makefile:91), or build chain. | **[M]** Stops at child nonzero. Runs verify, deep skill lint, build lint, SSO configuration checks, knowledge/eval/journey/OKF checks, then adopter pre-PR. | HARD when invoked. Explicitly never projected to adopters. |
+| Full build chain: [`build_gate_chain.py:220`](tools/repo/build_gate_chain.py:220) | `make build-check` at [`Makefile:156`](Makefile:156), Windows mirror, CI. | **[M]** Sequential nonzero-stop chain. | Maintainer-only, model-invariant. |
+| Delivery state/traceability | [`build_gate_chain.py:250`](tools/repo/build_gate_chain.py:250) | Build-check. | **[M]** Tests and runs spec-status, delivery-brief coverage, traceability, and workspace-status contracts. | HARD maintainer gate. The underlying scripts ship in skills and can be run by adopters. |
+| Catalogue leaks | [`verify_host_checks.py:209`](tools/catalogue/verify_host_checks.py:209), [`:266`](tools/catalogue/verify_host_checks.py:266) | Build-check at [`build_gate_chain.py:284`](tools/repo/build_gate_chain.py:284). | **[M]** Fails on maintainer-only names/RFC/knowledge identifiers leaked into linted seeds or core skill Markdown; refuses unsafe linked trees; returns `1` on findings. | HARD maintainer gate; model-invariant. |
+| Catalogue/release route policy | [`build_gate_chain.py:296`](tools/repo/build_gate_chain.py:296) | Build-check. | **[M]** Curation guard, experience-agnostic check, scope differential, plugin membership/roster, publish refusals, route docs/site parity, pack descriptions, maintainer-email privacy. | HARD maintainer-only. |
+| Supply-chain/security policy | [`build_gate_chain.py:423`](tools/repo/build_gate_chain.py:423), [`Makefile:324`](Makefile:324) | Build-check; `make sast`. | **[M]** npm install-script permission, `nosec`/`nosemgrep` form, Bandit, Semgrep, dependency audits, workflow posture. Missing required SAST binaries fail the SAST target. | HARD maintainer-only when invoked; model-invariant. |
+| CI/workflow integrity | [`build_gate_chain.py:476`](tools/repo/build_gate_chain.py:476) | Build-check. | **[M]** Local/CI parity, Windows workflow, security workflow, CodeQL posture, SAST reachability, test roster, contract drift. | HARD maintainer-only. CodeQL itself is repository-declared advisory. |
+| Architecture/ownership | [`build_gate_chain.py:568`](tools/repo/build_gate_chain.py:568) | Build-check. | **[M]** Adapter-layer boundary, dependency declaration, generated-path ownership, each paired with self-test; catalogue-curation test floors. | HARD maintainer-only. |
+| Composite CI | [`Makefile:670`](Makefile:670), [`.github/workflows/build-check.yml:67`](.github/workflows/build-check.yml:67) | Local `make ci`; GitHub events. | **[M]** Build-check + Ruff + mypy + test roster; workflows also provision dependencies and run publication/security-specific checks. | Process-HARD. Merge-blocking status not proven without branch-protection data. |
+
+## Eval harness
+
+| Surface | Measured control |
+|---|---|
+| Activation input | **[M]** `eval_queries.json` queries test whether the expected skill activates. Runner contract at `pack_evals.py:1`; threshold `0.5` at `:52`; repeated runs default to three. |
+| Driver | **[M]** In-harness live activation supports headless Claude only. Cursor/Kiro GUI routes are rejected; no Codex, Copilot, or Gemini activation detector exists at `pack_evals.py:222`. |
+| Output grading | **[M]** `evals.json` supplies deterministic file/output assertions and semantic rubrics. B-lite checks occur at `pack_evals.py:806`; semantic judge at `:944`. Missing workspace/evidence fails grading closed. |
+| Non-Claude model | **[M]** Yes for judging: built-in judge backends include Claude and `codex exec --sandbox read-only` at `pack_evals.py:327`. **No** for the live activation driver. Custom judge configuration can add backends. |
+| Blocking | **[M]** `pack-evals.yml:3` declares report-only; weekly/manual workflow at `:17`; bounded summary upload at `:71`. CLI live-detection misses exit `0` at `pack_evals.py:1277`. It does not gate PRs or runtime actions. |
+| Model invariance | **[M]** Deterministic output/file assertions survive a model swap. Activation and semantic judge results are model-dependent. |
+
+## Seeds, projections, templates, and assets
+
+### Seeds
+
+- **[M]** Twenty-four seed files exist under `packs/{core,governance,monorepo}/seeds/`.
+- **[M]** Delivery behavior is implemented at `_common.py:80`, classification at `:120`, and write policy at `:170`: absent targets are created, identical files skipped, changed files preserved with an `.upstream` companion, fragments are not emitted standalone, and paths are jailed below the target root.
+- **[M]** Seeds are adapter-neutral and adopter-facing at repo scope.
+- **[M]** User-scope installation with non-empty seeds is refused by `scope_rails.py:16`.
+- **[I]** Seed delivery and conflict preservation are model-invariant; behavior expressed by the delivered Markdown remains dependent on host discovery and model obedience.
+- **[M]** Gemini alone gets an explicit `context.fileName = ["AGENTS.md", "GEMINI.md"]` bridge at [`adapter.toml:760`](packages/agentbundle/agentbundle/_data/adapter.toml:760). No equivalent generated context bridge exists for Copilot or Cursor.
+
+### Shape-constraining assets outside `SKILL.md`
+
+**[M]** These 33 files are delivered inside skill directories. Their presence/bytes are mechanically portable; Markdown shapes are advisory unless a script consumes them.
+
+| Class | Exact anchored inventory |
+|---|---|
+| Governance/spec/state | `new-rfc/assets/rfc.md:1`; `new-adr/assets/adr.md:1`; `new-spec/assets/spec.md:1`; `new-spec/assets/plan.md:1`; `intake-intent/assets/minimal-intent.md:1`; `work-loop/assets/state.json:1`; `adapt-to-project/assets/reference.md:1`. |
+| Product/experience | `align-value-stream/assets/rollup.md:1`; `ux-writing/assets/voice-chart.md:1`; `discovery-loop/assets/plan-tree.md:1`; `frame-intent/assets/intent-template.md:1`; `map-capabilities/assets/capability-map.md:9`; `identify-opportunities/assets/opportunity-template.md:8`; `creative-direction/assets/creative-direction.md:1`; `service-blueprint/assets/service-blueprint.md:8`; `user-flow/assets/handover.md:1`; `user-flow/assets/screen-brief.md:1`; `tone-of-voice/assets/voice-chart.md:8`; `content-design/assets/content-brief.md:8`; `journey-mapping/assets/journey-map.md:9`; `process-mapping/assets/process-map.md:8`; `copy-direction/assets/copy-direction.md:7`. |
+| Architecture | `architect-design/assets/design-doc.md:1`; `architect-design/assets/concept.md:8`; `architect-assess/assets/assessment.md:1`; `architect-review/assets/risk-register.md:7`; `architect-review/assets/critique.md:5`; `architect-diagram/assets/c4-container.md:1`. |
+| Compiler/converter/research | `compile-okf/assets/output-rendering.md:1`; `compile-okf/assets/procedure-wrapper.md:12`; `compile-okf/assets/router-wrapper.md:11`; desk-research methodology template `:1`; `markdown-to-html/scripts/template.html:1`. |
+
+Mechanical exceptions:
+
+- **[M]** `work-loop/assets/state.json` is machine-read/validated once its workflow executes.
+- **[M]** Compile-OKF wrappers and the HTML template are consumed by deterministic generators.
+- **[M]** All other listed Markdown assets constrain shape only when the invoking model follows the associated skill.
+
+## Counts and absence searches
+
+Commands used for reported counts:
+
+```sh
+rg --files --hidden packs |
+  rg '/\.apm/(hooks|hook-wiring|kiro-ide-hooks|agents|commands)/' |
+  awk -F'/.apm/' '{k=$2; sub("/.*","",k); n[k]++} END {for (k in n) print k, n[k]}' |
+  sort
+# agents 15; commands 1; hook-wiring 2; hooks 3; kiro-ide-hooks 1
+
+rg --files --hidden packs | rg '/seeds/' | wc -l
+# 24
+
+rg --files --hidden packs |
+  rg '/\.apm/skills/[^/]+/(assets/|references/[^/]*template|scripts/template\.)' |
+  wc -l
+# 33
+```
+
+Absence searches:
+
+```sh
+rg --files --hidden |
+  rg '(^|/)(settings[^/]*\.json|hooks\.json|copilot-instructions\.md|GEMINI\.md)$|/\.cursor/rules/|/\.github/instructions/'
+# Only .codex/hooks.json in the current checkout.
+
+rg --hidden -l 'default_permissions|repo-codex-authoring|approval_policy' \
+  . --glob '!dist/**' --glob '!packages/agentbundle/tests/**'
+# Runtime configuration: .codex/config.toml.
+# One documentation implementation note also mentions the terms.
+```
+
+**[M] Final blocking inventory:** installer/path/scope refusals, native subagent tool restrictions, invoked local gates, and failed CI processes are the only model-invariant stopping controls found. No shipped lifecycle hook currently blocks a tool call or prompt; no `PreToolUse` wiring is shipped; the eval harness, commands, seed prose, agent prose, and ordinary templates cannot stop an action.
+
+---
+
+# Appendix A: cognitive-load and readability controls
+
+## Governing result
+
+- **[Cited] `docs/product/briefs/*.md` is governed by the artifact-writing rules in [`docs/AGENTS.md`](docs/AGENTS.md:3>)** because that file applies to all of `docs/`.
+- **[Measured] No active mechanical readability, word-count, token-count, or line-count gate selects brief files.**
+- **[Measured] No artifact class has a different Flesch/grade calibration.** The only implemented readability numbers are Flesch ≥70, grade ≤8, minimum 30 eligible words. Artifact-specific numeric controls instead concern lines, characters, columns, paragraphs, router rows, and reference depth.
+- **[Measured] The strongest differing thresholds are:** skill body warning above 500 lines/error above 1,000; AGENTS files 35–120 lines by class; skill description 1,024 characters; skill compatibility 500; skill name 64; journey tagline 120; knowledge title advisory under 80; rule-router maximum 12 rows; tables near five columns; narrative paragraphs two or three sentences.
+
+## Controls
+
+| Control and anchor | Artifact selection | Exact property | Enforcement | Briefs |
+|---|---|---|---|---|
+| **Scoped documentation rules:** [`docs/AGENTS.md:3`](docs/AGENTS.md:3>), [`:11`](docs/AGENTS.md:11>) | Every artifact below `docs/`, by directory scope | Concrete outcome/plain terms; define terms; descriptive headings; short resumable parts; one main point per section; numbered sequences vs bullets; group rather than truncate long material; self-contained arithmetic/dates/link evidence; current state without dead ends/draft notes/unrequested advice; merge duplicate rules/history/navigation; visuals only when materially clearer. | **Prose-only repository instruction.** Tests pin parts of the rule text, but no gate scans each document for compliance. | **Inside, directly.** |
+| **Documentation consolidation and genre:** [`docs/CONVENTIONS.md:654`](docs/CONVENTIONS.md:654>), [`:735`](docs/CONVENTIONS.md:735>), [`:767`](docs/CONVENTIONS.md:767>) | Documentation by semantic class; guides additionally declare a Diátaxis `kind` | Current-state documentation; concise architecture docs; one subsystem file linked to ADRs; each guide is exactly one of tutorial/how-to/reference/explanation and links out instead of mixing forms; short orientation without duplicating code/spec. | **Prose-only.** Guide schema validates the declared `kind`, not prose purity. | **Inside for general current-state/no-duplication rules; outside guide-only rules.** |
+| **Universal output-rendering block:** [`guides/_shared/reference/output-rendering.md:25`](guides/_shared/reference/output-rendering.md:25>), artifact clause [`:34`](guides/_shared/reference/output-rendering.md:34>) | Outputs of any skill carrying the managed block; canonical skills selected by `packs/*/.apm/skills/*/SKILL.md`, with the contract-test exclusions below | Prose artifacts: descriptive headings, short resumable sections, one fact/sentence, no repeated summary, at most one load-bearing point/section, group inventories rather than truncate; standalone arithmetic/dates/link proof; consolidate maintained prose; preserve evidence, constraints, warnings and exact names. | Artifact properties are **prose-only**. Presence and self-containedness of the block are **HARD under `make test`**, via [`test_cognitive_load_repository_contract.py:430`](tests/roster/test_cognitive_load_repository_contract.py:430>) and [`Makefile:511`](Makefile:511>). | **Conditional/indirect:** inside when a skill such as `author-delivery-brief` creates the brief; not selected by pathname. |
+| **Shape-specific rendering:** [`output-rendering.md:110`](guides/_shared/reference/output-rendering.md:110>) | Opt-in shape directive used by a producing skill | Tables near **5 columns** maximum; narrative uses short `##` headings and **2–3-sentence paragraphs**; one status/item per line; trees rather than nested bullets; visuals only for material relationships. | **Advisory/prose-only.** No shape linter. | Conditional when the authoring skill uses those shapes. |
+| **Managed-block synchronizer:** [`add-rendering-directives.py:305`](tools/add-rendering-directives.py:305>), [`:365`](tools/add-rendering-directives.py:365>), [`:516`](tools/add-rendering-directives.py:516>) | Canonical `packs/*/.apm/skills/*/SKILL.md`; compiler-generated sources are excluded because their compiler owns them | Rejects duplicate/misplaced/unmatched managed markers and block drift; inserts the universal block and selected shape directives. | `--check` exits nonzero, but **not wired to any Makefile/workflow target**. Manual hard check only. | Outside. |
+| **Readability scorer:** [`check-output-readability.py:16`](tools/check-output-readability.py:16>), [`:197`](tools/check-output-readability.py:197>), CLI [`:319`](tools/check-output-readability.py:319>) | Only explicit CLI path arguments. Its test selects cognitive-load `.md` fixtures plus three allowlisted guidance files | Aggregate eligible prose must have at least **30 words**, Flesch ≥**70**, grade ≤**8**. Input cap **1 MiB**. Below 30 words is `insufficient`, which does **not** fail. | CLI fails on `fail`; test asserts results. **Neither checker nor its test is wired into a Makefile/CI target.** | Outside automatic selection; manually passable. |
+| **Readability exclusions:** regex [`check-output-readability.py:31`](tools/check-output-readability.py:31>), extraction [`:144`](tools/check-output-readability.py:144>), test [`test_check_output_readability.py:125`](tools/test_check_output_readability.py:125>) | Any explicitly scored artifact containing a complete marker pair | `<!-- readability:exclude:start -->` through the next `<!-- readability:exclude:end -->` is removed from the Flesch corpus only. It does not deselect the file or waive other controls. Matching is non-greedy, case-insensitive and DOTALL; nesting is not parsed, and unmatched markers exclude nothing. Code, comments, tables, links, URLs, errors and technical tokens are separately removed. | Same orphan/manual checker status. | No brief currently uses the markers; briefs are not selected. |
+| **Per-pack cognitive-load scenarios:** coverage test [`test_cognitive_load_repository_contract.py:475`](tests/roster/test_cognitive_load_repository_contract.py:475>); readability selection [`test_check_output_readability.py:76`](tools/test_check_output_readability.py:76>) | `packs/*/.apm/skills/*/evals/evals.json`; scenario ID prefix `cognitive-load-`. Hard roster excludes `_` packs and deliberately carves out `agent-skill-engineering`; readability test includes every non-underscore pack | Hard contract requires at least one scenario per selected pack and requires serialized scenario text to address “optional assistant narration” and preserving substance. Every scenario names `evals/files/cognitive-load/ordinary-prose.md`; core also names two quiet-work JSON transcripts. Common assertions cover outcome-first/plain/scannable output, zero optional narration, and preservation of depth/evidence/constraints/warnings/errors. | Coverage is **HARD under `make test`**. Fixture Flesch scoring is presently **orphan/manual**, because its test is not in a gate. | Outside. |
+| **AGENTS progressive-disclosure lint:** constants [`lint-agents-md.py:29`](tools/lint-agents-md.py:29>), selection [`:204`](tools/lint-agents-md.py:204>), scope declarations [`:261`](tools/lint-agents-md.py:261>), duplicate runs [`:630`](tools/lint-agents-md.py:630>) | Root/scoped `AGENTS.md` and `AGENTS.local.md`, plus core seed AGENTS; explicit vendored/fixture/build exclusions | Maximum lines: root **120**, root local **60**, core seed **100**, scoped **80**, example **35**. Scoped files must state both scope and inheritance. Rejects copied runs of at least **3 nonblank lines** totaling at least **80 characters** from the nearest ancestor. | **HARD** in pre-PR catalogue checks via [`pre_pr_catalogue.py:124`](tools/catalogue/pre_pr_catalogue.py:124>), hence `make pre-pr` and `make build-check`. | Brief bodies outside; `docs/AGENTS.md` itself is inside. |
+| **`CAT-S002` skill metadata ceilings:** [`skill_spec_lint.py:440`](packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py:440>) | Deep lint over canonical skill directories | Skill name **1–64 chars**, description ≤**1,024**, compatibility ≤**500**. | **ERROR/HARD** under `catalogue lint --deep`, `make pre-pr`, and `make build-check`. | Outside. |
+| **`CAT-S003` skill body/depth:** [`skill_spec_lint.py:516`](packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py:516>), reference depth [`:543`](packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py:543>) | Same deep-lint skill selection; body excludes frontmatter | Body above **500 lines** is warning; above **1,000 lines** is error. Same-skill references deeper than **one directory level** are warnings. | >1,000 **HARD**; 501–1,000 and deep references **advisory warnings**. `catalogue lint --deep`, `make pre-pr`, `make build-check`. Ordinary `catalogue verify` does not run this deep check. | Outside. |
+| **`CAT-S004` progressive layout:** [`skill_spec_lint.py:549`](packages/agentbundle/agentbundle/catalogue_tooling/skill_spec_lint.py:549>) | Same deep-lint skills | Warns about loose skill-root files and top-level directories outside `scripts`, `references`, `assets`, `evals`. This supports progressive disclosure structurally; it does not inspect prose. | **Advisory warning**, deep lint/pre-PR/build-check. | Outside. |
+| **`CAT-L026` description ceiling:** code registration [`diagnostics.py:40`](packages/agentbundle/agentbundle/catalogue_tooling/diagnostics.py:40>), emission [`lint.py:1721`](packages/agentbundle/agentbundle/catalogue_tooling/lint.py:1721>) | Immediate `packs/<pack>/.apm/skills/<skill>/SKILL.md` entries | Description ≤**1,024 characters**. | **ERROR/HARD** under ordinary `catalogue lint`, `make lint-packs`, verify—reported there as `CAT-V-002`—and build-check. | Outside. |
+| **`CAT-L029` seed router bounded disclosure:** opt-in [`lint.py:1823`](packages/agentbundle/agentbundle/catalogue_tooling/lint.py:1823>), router checks [`seed_lint.py:570`](packages/agentbundle/agentbundle/catalogue_tooling/seed_lint.py:570>) | Pack seeds only when `[pack].lint-seeds = true`; declared seed allowlist and recognized guidance files | Root `AGENT_RULES.md` must be a compact routing table with **1–12 rows**, unique literal `.agents/rules/*.md` targets and no extra prose; topic/scoped guidance cannot route again. Also applies the seed blocklist/placeholders/pattern checks represented by `CAT-L029`. | **ERROR/HARD** under ordinary lint, verify as `CAT-V-002`, `make lint-packs`, and build-check. | Outside. |
+| **Journey tagline:** [`journey_validator.py:54`](packages/agentbundle/agentbundle/catalogue_tooling/journey_validator.py:54>), threshold [`:63`](packages/agentbundle/agentbundle/catalogue_tooling/journey_validator.py:63>), caller [`index_generator.py:354`](packages/agentbundle/agentbundle/catalogue_tooling/index_generator.py:354>) | Each pack’s optional `JOURNEY.md`, when catalogue index generation parses it | Frontmatter `tagline` ≤**120 characters**. | **Hard for `agentbundle catalogue index`**, but no Makefile target was found invoking it against the repository. | Outside. |
+| **Agent-skill-engineering progressive-disclosure doctrine:** [`instruction-density-and-progressive-disclosure.md:12`](packs/agent-skill-engineering/okf/agent-skill-engineering-foundation/concepts/instruction-density-and-progressive-disclosure.md:12>), decisions [`:18`](packs/agent-skill-engineering/okf/agent-skill-engineering-foundation/concepts/instruction-density-and-progressive-disclosure.md:18>), construction [`:25`](packs/agent-skill-engineering/okf/agent-skill-engineering-foundation/concepts/instruction-density-and-progressive-disclosure.md:25>) | Skill artifacts when this OKF topic is explicitly routed/retrieved | Keep purpose, mode choice, invariants and routes in `SKILL.md`; move substantial conditional procedures/schemas to focused references; every resource needs a real caller/load condition; one authority per rule; no unrelated preloading; no orphan resources or token-bearing duplication. | **Advisory reference**, no generic artifact gate. | Outside. |
+| **RFC fresh-reader review:** [`new-rfc/SKILL.md:170`](packs/governance-extras/.apm/skills/new-rfc/SKILL.md:170>), terminal gate [`:194`](packs/governance-extras/.apm/skills/new-rfc/SKILL.md:194>) | RFCs authored through `new-rfc`; condition fires when vocabulary is coined, unfamiliar sibling RFCs are assumed, or audience includes non-authors | Give a fresh reader only the RFC; gloss unresolved terms. | **Workflow-hard when triggered**—required before the skill’s handoff gate—but not a build/content linter. | Outside. |
+| **No hard AC word budgets:** [`new-spec/SKILL.md:502`](packs/core/.apm/skills/new-spec/SKILL.md:502>) | Specs authored through `new-spec`; specifically acceptance criteria | Shaping review must reject a hard acceptance-criterion word budget; semantic atomicity/testability owns the criterion instead. | **Workflow-hard shaping-review gate**, pinned by tests; no generic spec scanner. | Outside. |
+| **Knowledge-entry title target:** [`packs/core/seeds/docs/knowledge/README.md:70`](packs/core/seeds/docs/knowledge/README.md:70>) and repository copy [`docs/knowledge/README.md:79`](docs/knowledge/README.md:79>) | `docs/knowledge/patterns.jsonl` entries | One-line title; aim under **80 characters**. | **Advisory.** The knowledge linter does not enforce this maximum. | Outside. |
+
+## Marker users
+
+**[Measured]** The exhaustive source/projection classes returned by:
+
+```bash
+git grep -l 'readability:exclude:start'
+```
+
+are:
+
+- `.agents/rules/cognitive-load.md`;
+- `docs/AGENTS.md`;
+- `guides/_shared/reference/output-rendering.md`;
+- core seed copies of the cognitive-load rule and `docs/AGENTS.md`;
+- canonical governed `SKILL.md` files containing the managed output block;
+- generated/self-hosted `.agents/skills/**` and `.claude/skills/**` projections;
+- the `_example` skill/scaffold;
+- `compile-okf` output-rendering assets and projections.
+
+They surround the authority/safety override sentence, not ordinary artifact prose. No `docs/product/briefs/*.md` marker was found.
+
+## Scenario inventory
+
+**[Measured: 22 scenario IDs]**
+
+```bash
+git grep -h '"id": "cognitive-load-' -- \
+  'packs/*/.apm/skills/*/evals/evals.json' | wc -l
+# 22
+```
+
+There is currently one in every public pack. The hard repository contract requires one in every public pack **except** `agent-skill-engineering`; that pack nevertheless has one. Twenty-one use the `cognitive-load-output-quality` name; core uses `cognitive-load-quiet-work-and-readable-receipt`.
+
+## Mechanical versus prose-only
+
+**Active hard make/build controls**
+
+- AGENTS line ceilings, scope declaration and ancestor-duplication lint.
+- `CAT-S002`, `CAT-S003` error tier, `CAT-L026`, and opt-in `CAT-L029`.
+- Managed output-block presence/self-containedness.
+- Per-pack cognitive-scenario manifest coverage.
+
+**Advisory or workflow-only**
+
+- Actual prose-artifact readability and structure from `docs/AGENTS.md`, output-rendering, conventions, and the agent-skill doctrine.
+- `CAT-S003` warning tier and `CAT-S004`.
+- RFC fresh-reader review and spec rejection of word budgets are workflow gates, not build scanners.
+- Knowledge-title target.
+
+**Executable but not wired to a repository gate**
+
+- `check-output-readability.py`.
+- `add-rendering-directives.py --check`.
+- Journey tagline validation through catalogue-index generation.
+
+## Absences established
+
+- **[Measured] No CAT diagnostic implements Flesch, grade level, prose word count, or token count.**
+- **[Measured] `CAT-L025` is registered as “primitive name exceeds max length” at [`diagnostics.py:39`](packages/agentbundle/agentbundle/catalogue_tooling/diagnostics.py:39>) but has no emitter; the effective name cap is `CAT-S002`.**
+- **[Measured] No brief-specific readability or size gate exists.** The current brief’s proposed **1,599-word** spec body is proposal text, not implemented control.
+- **[Cited] Non-executable documentation is explicitly sized by coherence, not the review-line taxonomy:** [`docs/CONVENTIONS.md:952`](docs/CONVENTIONS.md:952>).
+- Changelog checking only verifies release/pack inventory; it imposes no cognitive-load or length property on changelog entries.
+
+Searches used for these absences:
+
+```bash
+git grep -n -I -E \
+  '(CAT-[LSV][0-9]{3}|CAT_[LSV][0-9]{3}).*(length|line|word|token|description|progressive|readab|reference|seed|router)' \
+  -- packages/agentbundle/agentbundle/catalogue_tooling
+
+git grep -n -E \
+  'test_check_output_readability|check-output-readability|pytest.*tools|tools/test_' \
+  -- Makefile .github tools packages pyproject.toml
+
+git grep -n -E \
+  '1599|2,392|2392|spec body.*words|body_words|word budget' \
+  -- ':!docs/product/briefs/**' ':!docs/specs/**' ':!docs/rfc/**' \
+     ':!docs/adr/**' ':!workspace.toml'
+
+git grep -n -I -E \
+  'fresh-reader|readability review|hard .*word budget|word budget|progressive disclosure' \
+  -- packs guides docs tools packages tests Makefile
+```
+
+All cited anchors were resolved with bounded `git blame -L` reads. No tests, network, origin probes, or write commands were run.
+
+---
+
+# Appendix B: OKF corpus pattern suitability
+
+## 1. Mechanical shape
+
+- **[Cited] Authored inputs:** a pack declares `[pack.metadata.okf]` with profile `agentbundle-okf/v1` and one or more bundles containing `id`, an `okf/...` source path, and a generated `router-skill`; see [core pack.toml](packs/core/pack.toml:49) and the [closed pack-profile schema](contracts/jsonschema/okf-pack-profile-v1.schema.json:12).
+
+- **[Cited] Bundle layout:** `okf/<bundle>/index.md`, plus Markdown concepts below `concepts/`. The root index declares `okf_version: "0.2"`; concepts typically declare `title`, `type`, `status`, `license`, compatibility/provenance fields, and domain metadata. Examples: [security index](packs/core/okf/security-checklists/index.md:1) and [access-control concept](packs/core/okf/security-checklists/concepts/access-control.md:1).
+
+- **[Cited] Schema strictness:** the compiler requires an OKF 0.2 root index, bounds YAML and lifecycle state, rejects executable or remote-retrieval metadata, but otherwise permits domain-specific concept keys; see [validation](.agents/skills/compile-okf/scripts/okf_compiler.py:222) and [metadata validation](.agents/skills/compile-okf/scripts/okf_compiler.py:2411). The optional `x-agentbundle` procedure projection is closed data: `profile`, then `skill.name`, `description`, `instruction-section`, and optional `include`; see [extension schema](contracts/jsonschema/okf-agentbundle-extension-v1.schema.json:9).
+
+- **[Cited] Compiler:** `.agents/skills/compile-okf/scripts/compile_okf.py` calls `compile_pack()` ([entry point](.agents/skills/compile-okf/scripts/compile_okf.py:16)). It deterministically validates twice, generates hierarchical indexes, copies concept files, renders a router `SKILL.md`, optionally renders reviewed procedure skills, and writes an ownership/digest manifest; see [rendering](.agents/skills/compile-okf/scripts/okf_compiler.py:327) and [pack compilation](.agents/skills/compile-okf/scripts/okf_compiler.py:464).
+
+- **[Cited] Generated outputs:** `.apm/skills/<router-skill>/SKILL.md`, `references/okf/**`, optional `.apm/skills/<procedure>/**`, and pack-root `.okf-generated.json`; output-path translation is in [the compiler](.agents/skills/compile-okf/scripts/okf_compiler.py:1107). The router itself contains only prose telling an agent to read the root index and descend selectively ([router template](.agents/skills/compile-okf/assets/router-wrapper.md:13)).
+
+- **[Measured] Current projections are byte-current:** read-only `--check` returned `OKF000 check clean` for both `core` and `architect`.
+
+## 2. Runtime path
+
+- **[Cited] Generic path:** authored `pack.toml` + `okf/**` → `compile_okf.py` → generated `.apm/skills/**` → AgentBundle build/install → host-specific skill directory. Raw `okf/**` is not the runtime surface: the installer reads `.apm/` and `seeds/`; `.apm/` is expressly the runtime export boundary ([pack layout](docs/architecture/pack-layout.md:44)).
+
+- **[Inferred from the host/file contract] Context path:** the host exposes or invokes the installed skill; its `SKILL.md` enters agent context. The router then tells the agent to read indexes and concepts. Those file-read results enter context through ordinary agent tool use. The compiler and installer do not retrieve relevant concepts during a task.
+
+### Security-checklists
+
+- **[Cited] Important split:** the runtime security-review path does **not** use the generated `security-checklists-reference` router. It uses the separate, hand-authored `.apm/skills/security-checklists/SKILL.md` and its hand-authored `references/*.md`. That skill bears the `router-handoff=author-owned` marker and explicitly describes itself as the reviewer’s depth library ([security-checklists](packs/core/.apm/skills/security-checklists/SKILL.md:6)).
+
+- **[Cited] Exact operational trace:**
+
+  1. `work-loop/SKILL.md` reaches the orchestrating agent.
+  2. The agent is instructed to detect crossed trust boundaries.
+  3. It reads the Markdown routing table in `security-checklists/SKILL.md`.
+  4. It reads matching `references/<module>.md`.
+  5. It constructs a subagent dispatch message containing that module text.
+  6. The host combines that caller-supplied brief with `security-reviewer.md`.
+
+- **[Cited] The decisive instruction is prose:**  
+  > “detect which trust boundaries the diff crosses, load only the matching `security-checklists` modules, inline them into the subagent’s brief”  
+  — [work-loop/SKILL.md](packs/core/.apm/skills/work-loop/SKILL.md:538).
+
+- **[Cited] The library says the same thing:**  
+  > “The orchestrator drives loading; the subagent does not.”  
+  It then instructs the orchestrator to detect boundaries, load modules, and inline their content ([security-checklists/SKILL.md](packs/core/.apm/skills/security-checklists/SKILL.md:47)).
+
+- **[Cited] Failure is tolerated by prose:** the reviewer says that if no modules were inlined, it should fall back to its universal method and report that fact ([security-reviewer.md](packs/core/.apm/agents/security-reviewer.md:106)).
+
+### Architecture references
+
+- **[Cited] Trace:** `packs/architect/okf/architecture-lenses/**` → compiler → `.apm/skills/architecture-lenses-reference/{SKILL.md,references/okf/**}` → adapter projection → consuming architect skill reads those files directly.
+
+- **[Cited] `architect-assess` instructs the agent:**  
+  > “Read `../architecture-lenses-reference/references/okf/index.md` first. Load the base concepts … then only the selected intent, observed shape, workload, quality, and enterprise concepts.”  
+  — [architect-assess/SKILL.md](packs/architect/.apm/skills/architect-assess/SKILL.md:93).
+
+- **[Cited] Routing remains Markdown prose:** “Every assessment loads” the base set, while intent, shape, workload, and quality concepts are chosen from textual trigger tables ([concept-routing.md](packs/architect/.apm/skills/architect-assess/references/concept-routing.md:6)).
+
+- **[Cited] `architect-design` and `architect-review` likewise tell the active agent to descend into selected concepts; they do not invoke a prompt-building process.** See [architect-design](packs/architect/.apm/skills/architect-design/SKILL.md:90) and [architect-review](packs/architect/.apm/skills/architect-review/SKILL.md:96).
+
+## 3. Central finding: PROSE-DIRECTED
+
+- **[Cited] Compilation and installation are mechanical. Runtime relevance selection, file loading, and security-brief inlining are agent actions directed by prose.** There is no repository process that classifies the current diff, selects modules, concatenates them, and supplies the resulting prompt.
+
+- **[Measured absence] Executable search:**
+
+```text
+$ rg -n 'security-reviewer|security-checklists|architecture-lenses-reference' \
+    packs/core/.apm/skills/work-loop/scripts \
+    packages/agentbundle/agentbundle tools \
+    -g '*.py' -g '*.sh' -g '*.toml'
+
+packages/agentbundle/agentbundle/commands/pack_evals.py:823:
+  **not** trust operator `*_ok` booleans (security-reviewer Blocker 3).
+```
+
+- **[Measured absence] No test asserts selected module content appears in a real subagent brief:**
+
+```text
+$ rg -n -i 'inline.*(security-checklists|module)|security-checklists.*inline|brief.*(module|security-checklists)|selected.*module|matching.*module' \
+    tests packs/core/tests packs/architect/tests packages/agentbundle/tests \
+    -g '*.py' -g '*.json' -g '*.md'
+# exit 1; no matches
+```
+
+- **[Cited] Existing tests check construction:** modules, routing-table strings, generated files, digests, and adapter-relative paths ([security construction tests](tests/roster/test_security_checklists_okf_projection.py:46), [architecture construction tests](packs/architect/tests/pack/test_architecture_lenses_corpus.py:203)). They do not observe a production dispatch prompt.
+
+- **[Cited] A report-only, agent-executed security routing measurement exists, but it measures returned paths, not brief assembly or module application** ([measurement](docs/rfc/0087-notes/pilot-measurements/security-checklists-in-harness.json:3)). The separate model-E2E baseline remains explicitly pending ([pending baseline](docs/rfc/0087-notes/pilot-baselines/security-checklists-pending-model-e2e.json:2)).
+
+- **[Inferred] Therefore the OKF pattern inherits the suspected activation failure:** it packages and routes prose more cleanly, but it does not mechanically ensure that the prose is selected, inserted, or applied.
+
+## 4. Suitability for behavior policies
+
+- **[Cited] Load conditions are prose.** Security uses the hand-authored Markdown boundary table; architecture uses “scope and routing signals” and textual trigger tables. The compiler’s generated indexes contain titles, statuses, types, and links; `_render_indexes()` does not interpret routing signals or boundary metadata ([index renderer](.agents/skills/compile-okf/scripts/okf_compiler.py:823)).
+
+- **[Inferred] Cognitive-load reduction and the razor fit the file format but not the present activation model.** They can be written as reference concepts, but “apply during almost every authoring act” provides no selective trigger. Making them a base module would still depend on every authoring agent obeying “always load this base module.”
+
+- **[Inferred] Repository anchoring fits conditional routing better:** it can fire on claims about named repository targets or current-system facts. It still would not be enforced mechanically under the present pattern.
+
+- **[Cited] An authoring-behavior OKF precedent exists:** `instruction-density-and-progressive-disclosure` covers instruction placement, duplicated context, conditional references, and token-bearing duplication ([concept](packs/agent-skill-engineering/okf/agent-skill-engineering-foundation/concepts/instruction-density-and-progressive-disclosure.md:10)). `progressive-result-presentation-and-next-actions` is another behavior-oriented concept ([concept](packs/agent-skill-engineering/okf/agent-skill-engineering-foundation/concepts/progressive-result-presentation-and-next-actions.md:10)). These are reference knowledge, not universal enforcement.
+
+## 5. Reach and cost
+
+- **[Cited] Adopters receive compiled `.apm` skills and references, not raw authored `okf/**`.** The five adapters all project skills: Claude Code to `.claude/skills/`; Codex, Copilot, Cursor, and Gemini to `.agents/skills/` ([adapter contract](contracts/adapter.toml:183), [Copilot](contracts/adapter.toml:509), [Codex](contracts/adapter.toml:568), [Cursor](contracts/adapter.toml:632), [Gemini](contracts/adapter.toml:725)).
+
+- **[Cited] Cross-adapter tests prove colocated files and resolvable relative paths, not behavioral honouring** ([adapter projection test](tests/roster/test_architect_architecture_lenses_corpus.py:124)). Agent projections also differ by host—direct Markdown, Codex TOML, or Copilot agent Markdown—so the parent-orchestrator behavior remains host/model-dependent.
+
+- **[Cited] Progressive disclosure is governed only by router prose:** “do not load the full bundle up front” ([generated router](packs/core/.apm/skills/security-checklists-reference/SKILL.md:13)).
+
+- **[Cited] There is no context-token ceiling or token measurement.** Compiler safety limits are filesystem limits: 4,096 files, 2,000 concepts, 32 MiB total, and 2 MiB per Markdown file ([limits](.agents/skills/compile-okf/scripts/okf_compiler.py:46)). These permit material far larger than a useful prompt.
+
+- **[Measured counts]:**
+
+```text
+$ find packs/core/okf/security-checklists/concepts -type f -name '*.md' -print | wc -l
+11
+
+$ find packs/architect/okf/architecture-lenses/concepts -type f -name '*.md' -not -name 'index.md' -print | wc -l
+47
+```
+
+- **[Measured] No files were created or edited by this inspection. The checkout already contains unrelated modified and untracked brief/workspace files.**
+
+**[Inferred verdict] UNSUITABLE — the strongest reason is that the critical selection-and-inlining step is an unchecked instruction to an orchestrating agent, not a mechanical operation, so the proposal preserves the same prose-activation failure it is meant to solve.**

--- a/docs/product/research/cross-model-steering-survey.md
+++ b/docs/product/research/cross-model-steering-survey.md
@@ -1,0 +1,444 @@
+# Steering agent-loop behavior across models and adapters
+
+> Discipline: applied (practitioner and peer-reviewed survey)
+
+Commissioned 2026-09-02 for the `cross-adapter-behavior-enforcement` brief. Independent desk research; findings are cited to their sources and labelled by evidence class. Retained so the briefs can cite it rather than restate it.
+
+---
+
+# Prior art: calibrating behavioral steering across models and host adapters
+
+> Discipline: applied (practitioner-pattern survey)
+
+## Bottom line
+
+Natural-language instructions are a probabilistic steering mechanism, not a portable enforcement layer. The evidence consistently shows variation by model family, model size, prompt form, instruction position, context length, turn count, language, and instruction composition.
+
+The correct qualification unit is:
+
+`pack version × host adapter version × model snapshot × inference/tool configuration`
+
+A result for one member of that tuple does not establish transfer to another. Transfer is measurable through paired evaluations, but it must be measured.
+
+External mechanisms can be model-invariant for narrowly encoded properties:
+
+- Grammar-constrained decoding can guarantee membership in a formal language.
+- Deterministic validators can reject nonconforming artifacts.
+- Tool allowlists, permissions, sandboxes, hooks, and state machines can prevent disallowed transitions or actions.
+- None of these guarantees that the model chose the right content, tool, arguments, or plan unless those properties are also mechanically checked.
+
+Therefore:
+
+- Use prose for judgment, priorities, heuristics, and soft preferences.
+- Convert safety boundaries, required lifecycle steps, artifact invariants, and machine-checkable outcomes into controls outside the model.
+- Publish prose compatibility only after testing every claimed model–adapter pair.
+
+Confidence: **high**, based on converging benchmark, constrained-decoding, and first-party adapter evidence.
+
+---
+
+## Mechanism 1 — Executable instruction-following evaluations
+
+### What it is
+
+Turn each prose requirement into one or more observable assertions. Score both:
+
+- **Clause accuracy:** fraction of individual requirements satisfied.
+- **Whole-response accuracy:** fraction of responses satisfying every applicable requirement.
+- **Trajectory accuracy:** whether the agent performed the required actions and reached the right final state.
+
+### Evidence it works
+
+IFEval introduced roughly 500 prompts built from 25 kinds of objectively verifiable constraints. Its strength is reproducible, programmatic grading; its limitation is that it mostly measures visible, single-turn output constraints, not an agent loop. [“Instruction-Following Evaluation for Large Language Models”](https://arxiv.org/abs/2311.07911) — preprint.
+
+FollowBench increased instructions from one to five constraints across content, scenario, style, format, and examples. It evaluated 13 open and closed models and used rule-based checks where possible, with an LLM judge for semantic constraints. [“FollowBench: A Multi-level Fine-grained Constraints Following Benchmark for Large Language Models”](https://aclanthology.org/2024.acl-long.257/) — peer-reviewed, ACL 2024.
+
+ComplexBench evaluated 15 models on composed `AND`, chain, and conditional-selection instructions. Scores varied substantially: GPT-4-1106 reached 0.800 overall, GPT-3.5-Turbo-1106 0.682, Llama-3-70B-Instruct 0.757, and Llama-3-8B-Instruct 0.638. Performance fell as composition and nesting became harder. Even GPT-4 failed about 20% of the benchmark’s requirements. [“Benchmarking Complex Instruction-Following with Multiple Constraints Composition”](https://arxiv.org/abs/2407.03978) — peer-reviewed, NeurIPS 2024 Datasets and Benchmarks.
+
+Multi-IF expanded IFEval into 4,501 three-turn conversations in eight languages. Every tested model degraded over turns; for example, o1-preview fell from 0.877 on turn one to 0.707 on turn three. Error profiles also differed by language and model family. [“Multi-IF: Benchmarking LLMs on Multi-Turn and Multilingual Instructions Following”](https://arxiv.org/abs/2410.15553) — preprint.
+
+### Model dependence and weaker-model degradation
+
+Instruction following is not a scalar capability that transfers uniformly. Models have distinct profiles for lexical, formatting, conditional, multi-turn, and multilingual requirements. Larger models generally do better in ComplexBench, but family and training effects prevent model size from being a dependable proxy.
+
+A weaker or differently trained model tends to:
+
+- satisfy common clauses but miss rare or negatively worded ones;
+- satisfy each clause occasionally while rarely satisfying all clauses together;
+- lose earlier requirements over multiple turns;
+- mishandle conditionals and irrelevant branches;
+- produce fluent artifacts that hide constraint failures.
+
+Confidence: **high** for the existence of model variance; **moderate** for any general prediction based only on model size.
+
+### How to verify transfer
+
+Run the same clause-linked cases through every model–adapter pair. Preserve identical task data but record the adapter’s actual rendered message sequence, tool schemas, context ordering, and inference settings. Compare paired clause outcomes, not only aggregate benchmark scores.
+
+IFEval alone is insufficient. A portable pack needs a pack-specific derivative containing its actual requirements and representative agent trajectories.
+
+---
+
+## Mechanism 2 — Prompt form, order, position, salience, and density
+
+### What it is
+
+The model’s response changes when semantically similar instructions differ in delimiters, headings, enumeration, order, message role, or location within a long context.
+
+### Evidence it works—and fails to transfer
+
+FormatSpread found changes of up to 76 accuracy points from plausible formatting variations on LLaMA-2-13B. Sensitivity remained after increasing model size, adding demonstrations, or instruction tuning. A format that helped one model transferred weakly: the probability that a pairwise format ranking persisted to another model was below 0.62, only slightly above chance. [“Quantifying Language Models’ Sensitivity to Spurious Features in Prompt Design”](https://proceedings.iclr.cc/paper_files/paper/2024/hash/6c0e99d736da621403018ca7b32b1a4d-Abstract-Conference.html) — peer-reviewed, ICLR 2024.
+
+Few-shot example ordering also changes performance, and a good ordering for one model does not reliably transfer to another. [“Fantastically Ordered Prompts and Where to Find Them”](https://aclanthology.org/2022.acl-long.556/) — peer-reviewed, ACL 2022.
+
+DOVE evaluated several model families across more than 250 million outputs and prompt perturbations involving delimiters, enumerators, wording, and other dimensions. It found both model-specific sensitivity and instances that remained difficult across perturbations. [“DOVE: A Large-Scale Multi-Dimensional Predictions Dataset Towards Meaningful LLM Evaluation”](https://aclanthology.org/2025.findings-acl.611/) — peer-reviewed, Findings of ACL 2025.
+
+“Lost in the Middle” found a U-shaped position effect: relevant information was often used best near the beginning or end and substantially worse in the middle, including by explicitly long-context models. The study tested retrieval and question answering, not instruction clauses directly, so applying it to project instructions is a supported risk inference rather than direct proof. [“Lost in the Middle: How Language Models Use Long Contexts”](https://aclanthology.org/2024.tacl-1.9/) — peer-reviewed, TACL 2024.
+
+### Instruction density
+
+ManyIFEval, with up to ten text instructions, and StyleMBPP, with up to six code requirements, found consistent degradation across ten LLMs as instructions accumulated. Its regression models estimated unseen instruction combinations with about 10% error using 500 and 300 examples respectively. [“When Instructions Multiply: Measuring and Estimating LLM Capabilities of Multiple Instructions Following”](https://aclanthology.org/2025.findings-emnlp.896/) — peer-reviewed, Findings of EMNLP 2025.
+
+IFScale tested 20 models with as many as 500 keyword-inclusion requirements. Even its best model reached only 68% individual-instruction accuracy at maximum density, with model-dependent degradation patterns and bias toward earlier instructions. Keyword inclusion is artificial, so 68% is not a general ceiling. [“How Many Instructions Can LLMs Follow at Once?”](https://arxiv.org/abs/2507.11538) — preprint.
+
+A recent five-model experiment reported zero perfect responses by 80 simultaneous rules, with no universal winner among Markdown, prose, tables, and plain text. System-versus-user placement helped some models and hurt others. It is a single-author, not-yet-reviewed preprint and should be treated as suggestive. [“Prompt Design at Scale: How Format, Instruction Count, and Context Length Shape Instruction Adherence and Hallucination in Large Language Models”](https://arxiv.org/abs/2607.19257) — preprint.
+
+There is no defensible universal limit such as “five rules” or “200 lines.” The ceiling depends on rule difficulty, independence, output length, model, and scoring method. Whole-response success also falls combinatorially: even independent clauses with 95% compliance yield only \(0.95^{20}\approx36\%\) perfect responses.
+
+Confidence: **high** that density reduces perfect adherence; **low** for any universal numeric ceiling.
+
+### How it degrades
+
+Different models:
+
+- favor different delimiters or enumeration styles;
+- forget different positions;
+- trade content correctness against format compliance differently;
+- fail abruptly rather than gradually when context becomes crowded;
+- exhibit different responses to repeating or moving instructions.
+
+### How to verify it
+
+For each model, perturb at least:
+
+- Markdown versus plain text;
+- bullets versus prose;
+- clause order;
+- important clause at beginning, middle, and end;
+- system/developer versus ordinary contextual placement where supported;
+- short context versus realistic maximum-history context;
+- single-turn versus multi-turn;
+- isolated clause versus the full pack.
+
+Report the performance range across variants, not only the best prompt.
+
+---
+
+## Mechanism 3 — Instruction roles and hierarchy
+
+### What it is
+
+Hosts label some content as system, developer, user, conversation history, tool output, or untrusted data. Models are expected to prefer higher-authority instructions when these conflict.
+
+### Evidence
+
+OpenAI demonstrated that targeted hierarchy training improved GPT-3.5’s resistance to lower-priority conflicting instructions, including attacks not seen in training. This shows that hierarchy adherence is learned model behavior, not a property automatically created by a `system` label. [“The Instruction Hierarchy: Training LLMs to Prioritize Privileged Instructions”](https://arxiv.org/abs/2404.13208) — vendor-authored preprint.
+
+SysBench evaluates system-message constraint violations, task misjudgment, and multi-turn instability. Its existence and findings support treating system-message adherence as a separately measured capability. [“SysBench: Can LLMs Follow System Message?”](https://proceedings.iclr.cc/paper_files/paper/2025/hash/b917f916e7eed84ffe8f5e63492b2be8-Abstract-Conference.html) — peer-reviewed, ICLR 2025.
+
+IHEval contains 3,538 examples across nine tasks. All tested models suffered a sharp decline when instructions at different priorities conflicted; the best open model reported in the paper resolved only 48% correctly. [“IHEval: Evaluating Language Models on Following the Instruction Hierarchy”](https://arxiv.org/abs/2502.08745) — preprint.
+
+Control Illusion tested six models and found that system/user separation did not reliably determine which formatting constraint won. Models sometimes followed their learned preference for a constraint type over the nominal message priority. [“Control Illusion: The Failure of Instruction Hierarchies in Large Language Models”](https://ojs.aaai.org/index.php/AAAI/article/view/40339) — peer-reviewed, AAAI 2026.
+
+### Model and adapter dependence
+
+Role labels matter only to the extent that:
+
+1. the adapter preserves them;
+2. the chat template represents them distinctly;
+3. the model was trained to interpret that representation;
+4. competing host instructions do not change the result.
+
+This is especially important for project files. Claude Code states that `CLAUDE.md` is delivered as a **user message after the system prompt**, not as part of the system prompt. It explicitly says the content is context, not enforced configuration. [Claude Code: “How Claude remembers your project”](https://code.claude.com/docs/en/memory) — vendor documentation.
+
+Thus, “the file loaded” and “the rule has high authority” are separate claims.
+
+### How to verify it
+
+Build an instruction-conflict matrix for each model–adapter pair:
+
+- project file versus direct user request;
+- root versus nested project file;
+- ordinary instructions versus retrieved file content;
+- system/developer versus user;
+- user versus tool output;
+- earlier versus later instruction at the same level;
+- format conflict versus substantive conflict.
+
+Record whether the model follows the expected winner, follows the loser, satisfies neither, or silently combines incompatible rules.
+
+Confidence: **high** that hierarchy behavior is model-dependent and must be tested.
+
+---
+
+## Mechanism 4 — Grammar-constrained and structured decoding
+
+### What it is
+
+At each token, a decoder masks tokens that cannot lead to a valid string under a grammar, automaton, parser, or JSON schema.
+
+### Evidence
+
+PICARD rejects inadmissible tokens through incremental parsing and substantially improved valid SQL generation from T5 models. [“PICARD: Parsing Incrementally for Constrained Auto-Regressive Decoding from Language Models”](https://aclanthology.org/2021.emnlp-main.779/) — peer-reviewed, EMNLP 2021.
+
+Grammar-constrained decoding can formally guarantee output membership in a supported context-free grammar, provided tokenizer alignment and the decoder implementation are sound. [“Flexible and Efficient Grammar-Constrained Decoding”](https://proceedings.mlr.press/v267/park25l.html) — peer-reviewed, ICML 2025.
+
+OpenAI reports that Structured Outputs combines schema-trained models with constrained decoding and achieved 100% schema conformance on its internal complex-JSON-schema evaluation. This is a vendor result, not independent evidence of semantic correctness. [OpenAI, “Introducing Structured Outputs in the API”](https://openai.com/index/introducing-structured-outputs-in-the-api/) — vendor documentation.
+
+### Model invariance
+
+**Invariant by construction:** syntactic membership in the exact grammar or supported schema subset.
+
+**Not invariant:**
+
+- factual correctness;
+- choosing the right enum member;
+- including meaningful rather than empty data;
+- selecting the correct tool;
+- correct tool arguments;
+- completeness beyond what the schema encodes;
+- termination and latency behavior.
+
+A weaker model commonly degrades into schema-valid but semantically wrong output. The grammar removes illegal exits from the search space; it does not add missing reasoning capability.
+
+### Verification
+
+Test two layers separately:
+
+1. Feed generated output to an independent parser/schema validator.
+2. Execute or semantically grade its contents against the task outcome.
+
+Also test unsupported schema features, truncation, refusal paths, parallel calls, nullable or empty structures, and impossible constraints. Fail closed when the validator cannot establish conformity.
+
+Confidence: **high** for syntax guarantees; **high** that semantic correctness remains model-dependent.
+
+---
+
+## Mechanism 5 — Tool schemas and forced function calls
+
+### What it is
+
+The adapter limits available tools, describes typed inputs, optionally forces a call, and validates arguments before execution.
+
+OpenAI’s API exposes `tool_choice: required` and allowed-tool subsets. Google documents `any` as forcing a function call and `validated` as enforcing schema adherence. [OpenAI Responses API reference](https://platform.openai.com/docs/api-reference/responses-streaming/response/refusal?lang=python), [Gemini function-calling documentation](https://ai.google.dev/gemini-api/docs/function-calling) — vendor documentation.
+
+### Model invariance
+
+- An external allowlist can make calling an unavailable tool impossible.
+- A forced-call mode can prevent free-text completion when implemented by the provider.
+- Validation and rejection can guarantee that executed arguments meet the encoded schema.
+
+The model still chooses poorly among allowed tools and can supply valid but wrong arguments. The Berkeley Function Calling Leaderboard exists because correct tool selection, relevance detection, argument construction, parallel use, and multi-turn use vary materially across models. [Berkeley Function Calling Leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) — academic benchmark and technical report.
+
+### Degradation
+
+A weaker model may:
+
+- call a permitted but irrelevant function;
+- omit necessary calls;
+- repeat calls;
+- hallucinate semantically invalid values that pass type checks;
+- fail to recover after a validator rejection;
+- exhaust retries without reaching a legal useful action.
+
+### Verification
+
+Run executable function-call cases for:
+
+- one tool, competing tools, and no applicable tool;
+- missing or conflicting parameters;
+- parallel versus serial requirements;
+- validator rejection and retry;
+- multi-turn state changes;
+- side-effecting calls in dry-run or simulated environments.
+
+Confidence: **high** that allowlists and validation constrain the action surface; **high** that useful tool selection remains model-dependent.
+
+---
+
+## Mechanism 6 — Deterministic scaffolding, state machines, and hooks
+
+### What it is
+
+The surrounding program owns lifecycle state and decides which transitions and actions are legal. The model proposes; the control plane validates, permits, modifies, defers, or rejects.
+
+Examples include:
+
+- explicit workflow states and legal transition tables;
+- artifact validators and required-gate predicates;
+- maximum retries and time budgets;
+- idempotency keys;
+- filesystem and network permissions;
+- transaction boundaries and human approval;
+- pre-tool and pre-stop interceptors.
+
+Claude Code documents that `PreToolUse` hooks can deny a call before execution and that a `Stop` hook can prevent the loop from stopping. GitHub Copilot exposes `preToolUse`; Cursor exposes `beforeShellExecution`, `beforeMCPExecution`, and related hooks. [Claude Code hooks reference](https://code.claude.com/docs/en/hooks), [GitHub Copilot hooks](https://docs.github.com/en/copilot/concepts/agents/hooks), [Cursor hooks](https://prod.cursor.com/docs/hooks) — vendor documentation.
+
+### Model invariance
+
+These are the strongest model-invariant mechanisms, provided that:
+
+- they run outside the model;
+- every relevant action passes through them;
+- they validate trusted state rather than model assertions;
+- failure is closed rather than open;
+- the model cannot edit or bypass the control plane.
+
+A shell hook with deterministic code can be invariant. A “prompt hook” that asks another LLM whether an action looks safe is still probabilistic.
+
+### Degradation
+
+On a weaker model, the safe failure modes are more blocks, retries, escalations, or inability to complete. The system should not relax the invariant merely because the model repeatedly proposes illegal actions.
+
+### Verification
+
+Unit-test the transition and policy code without any model. Then run adapter integration tests proving that every write, command, network call, completion event, and delegation event reaches the intended interception point. Include malformed hook output, hook timeout, adapter crash, restart, and concurrent action cases.
+
+Confidence: **high**, limited to the properties and action paths actually controlled.
+
+---
+
+## Mechanism 7 — Cross-adapter project instructions
+
+| Host | Native project mechanism | Scope and precedence | Host-specific behavior |
+|---|---|---|---|
+| Codex | `AGENTS.md`, `AGENTS.override.md` | Builds a chain from project root to current directory; one file per directory; 32 KiB combined default | Discovers once per run; supports configurable fallback filenames. [Codex documentation](https://developers.openai.com/codex/guides/agents-md) |
+| Claude Code | `CLAUDE.md`, `.claude/rules/*.md` | Ancestors load at launch; nested files can load when files below them are read | Does **not** natively treat `AGENTS.md` as the project file; use `@AGENTS.md` from `CLAUDE.md` or a symlink. `@path` imports recurse to four hops. Project instructions are delivered as user-context, not hard configuration. [Claude Code documentation](https://code.claude.com/docs/en/memory) |
+| Cursor | `AGENTS.md`, `.cursor/rules/*.mdc` | Current documentation supports nested rules and more-specific instructions; rule metadata can control automatic, intelligent, or manual inclusion | `.mdc` supports glob scope and `@filename` references; Cursor rules and hooks are not portable Markdown semantics. [Cursor Rules](https://prod.cursor.com/docs/rules) |
+| GitHub Copilot | `.github/copilot-instructions.md`, path-specific `.instructions.md`, and some agent files | Support differs across Copilot Chat, cloud agent, code review, IDE, and CLI | Some surfaces accept `AGENTS.md`; some accept `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`; others accept none of them. [GitHub support matrix](https://docs.github.com/en/copilot/reference/custom-instructions-support) |
+| Gemini CLI | `GEMINI.md` by default | Loads global, ancestor/project, and subdirectory context files and concatenates them | Supports `@file.md`; `context.fileName` can be configured to include `AGENTS.md`. [Gemini CLI documentation](https://google-gemini.github.io/gemini-cli/docs/cli/gemini-md.html) |
+
+The [AGENTS.md convention](https://agents.md/) standardizes a discoverable Markdown filename and describes nearest-file precedence. It does not standardize message role, byte limits, lazy loading, conflict semantics, imports, hooks, tool permissions, or model behavior.
+
+Therefore, a portable pack needs:
+
+- a canonical semantic source;
+- thin host projections or documented adapter configuration;
+- adapter conformance tests that inspect what was actually loaded;
+- model behavioral tests after adapter rendering.
+
+Confidence: **high** for the documented loader differences; **low** for undocumented internal prompt placement in hosts that do not expose it.
+
+---
+
+## Minimum per-model calibration before claiming support
+
+This is a recommended qualification floor, not a published universal standard.
+
+### 1. Fix the test identity
+
+Record exact pack revision, model identifier or snapshot, host and adapter versions, inference settings, tool definitions, permissions, context-window policy, and retry rules.
+
+### 2. Prove adapter delivery mechanically
+
+Use host diagnostics such as Codex’s reported instruction sources, Claude’s `/context`, or Gemini’s `/memory show`. Prefer source paths and content hashes from the adapter over asking the model whether it “read the instructions.”
+
+Test imports, nested scope, truncation limits, fallback names, and precedence.
+
+### 3. Give every load-bearing clause direct coverage
+
+For each clause, include:
+
+- a normal positive case;
+- a case where following the clause is inconvenient;
+- a direct conflict or tempting counter-instruction;
+- a long-context or middle-position case;
+- a multi-turn case if the clause must persist;
+- a non-applicable case to detect over-application.
+
+Use deterministic grading whenever the requirement can be expressed mechanically.
+
+### 4. Run repeated trials
+
+Anthropic recommends multiple trials because agent outputs vary and emphasizes grading final environment state, not merely the transcript. [“Demystifying evals for AI agents”](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) — vendor engineering guidance.
+
+As a minimal statistical interpretation, 30 independent trials with zero observed failures only support an approximate 95% upper failure bound of 10% under the tested distribution—the rule of three. That is a weak compatibility claim, not high assurance. For a 5% bound, use about 60 zero-failure trials; for 1%, about 300.
+
+### 5. Measure robustness, not one favored rendering
+
+Run at least three semantically equivalent prompt renderings and beginning/middle/end placement variants. Report median, worst variant, and confidence intervals. A prompt that succeeds only in its tuned wording is not portable.
+
+### 6. Use separate thresholds
+
+- **Hard safety or authority constraint:** mechanical enforcement required; prose score is diagnostic.
+- **Required workflow behavior:** high whole-trajectory threshold plus external completion checks.
+- **Formatting and style:** per-model threshold may differ if downstream validation or repair exists.
+- **Advisory preference:** report expected compliance rather than pass/fail support.
+
+### 7. Keep a canary suite
+
+On every model snapshot, host update, prompt change, or tool-schema change:
+
+- run a small clause-balanced canary first;
+- stop rollout on loader, hierarchy, tool, or hard-invariant regression;
+- then run the full golden suite;
+- retain traces so changed behavior can be attributed to model, adapter, or pack.
+
+### 8. Degrade safely
+
+If a startup capability probe shows that the adapter lacks an instruction file, hook, forced tool mode, schema feature, or permission boundary:
+
+- disable the affected feature;
+- switch to a mechanically safer workflow;
+- require human approval;
+- or declare that model–adapter tuple unsupported.
+
+Do not silently replace missing enforcement with stronger wording.
+
+---
+
+## Which mechanisms are model-invariant?
+
+| Mechanism | Model-invariant property | Important limit |
+|---|---|---|
+| External schema/parser validation | Invalid output is rejected | Does not make valid output correct |
+| Sound grammar-constrained decoding | Output belongs to the encoded grammar | Only supported syntactic/formal properties |
+| Tool allowlist or removal | Disallowed tool cannot be selected | Allowed tool may still be used wrongly |
+| Pre-execution permission check | Rejected action cannot execute through that path | Must cover every execution path and fail closed |
+| Filesystem/network sandbox | Operations outside the boundary fail | Boundary configuration may be wrong |
+| Deterministic state machine | Illegal transition cannot be committed | Model can stall or choose a poor legal transition |
+| Deterministic postcondition gate | Completion cannot be accepted without the predicate | Predicate may under-specify real success |
+| Human approval gate | Action waits for approval | Human review quality is outside the mechanism |
+
+Prose instructions, demonstrations, XML or Markdown structure, repetition, salience markers, system-role placement, chain-of-thought requests, LLM judges, and prompt-based hooks are **not** model-invariant.
+
+---
+
+## Can prose be reliable across models?
+
+The evidence supports this narrower position:
+
+- Prose can achieve high empirical reliability for a bounded task distribution on a qualified model–adapter pair.
+- Clear, concise, non-conflicting, salient instructions usually improve the odds.
+- There is no evidence that a prose instruction set can provide model-independent behavioral guarantees.
+- Adding more prose eventually reduces whole-set adherence and can create conflicts that are resolved differently across models.
+- A successful prompt on one model is useful prior information for another model, not proof of transfer.
+
+The honest publication language is therefore:
+
+> “This instruction set was evaluated on these named model–adapter versions, with these measured compliance rates and known failures.”
+
+It should not be:
+
+> “These instructions ensure that any supported agent behaves this way.”
+
+Only external mechanical enforcement supports the latter kind of claim, and only for the properties it actually encodes.
+
+## Known unknowns
+
+- **Known-unknown:** Comparative performance of the same real coding-agent pack across Codex, Claude Code, Cursor, Copilot, and Gemini under controlled model substitution. Would be closed by a shared cross-adapter harness capturing rendered messages, tools, trajectories, and final artifacts.
+- **Known-unknown:** How Codex, Cursor, Copilot, and Gemini internally assign message roles to every class of project instruction. Public documentation is incomplete outside the explicitly documented Claude behavior.
+- **Known-unknown:** A general instruction-density ceiling for realistic heterogeneous skill files. Existing studies use different constraint types and metrics, so their numerical ceilings do not transfer directly.
+- **Unknowable in advance:** Whether a future model or host release preserves today’s behavior. Closed models and adapters can change without exposing training or prompt-stack details; only recurring regression tests can answer it after release.
+
+No repository files or git state were modified.

--- a/docs/product/research/phase-scoped-policy-delivery.md
+++ b/docs/product/research/phase-scoped-policy-delivery.md
@@ -1,0 +1,143 @@
+# Phase-scoped policy delivery: what exists today
+
+> Discipline: repository inventory (measured)
+
+Commissioned 2026-09-03 for the `cross-adapter-behavior-enforcement` intent. Traces how guidance reaches an acting agent per phase, and whether prevention and detection coexist for any rule today. Retained so the intent can cite it rather than restate it.
+
+---
+
+## 1. Existing inlining precedents
+
+| Precedent | Relevance decision | Inlining instruction | Consumer | Actual control |
+|---|---|---|---|---|
+| `cloud-implementation-craft` | The `operational-safety` Module index says: “authoring infra / a managed-runtime deployment / live interaction” ([module row](packs/core/.apm/skills/operational-safety/SKILL.md:156)). “Infra-flavored” is further defined as the destructive/irreversible trigger plus the security index’s IaC/deploy-config match ([definition](packs/core/.apm/skills/work-loop/references/pre-execute-review.md:241)). | The infra reference says the orchestrator “inlines” the module into the implementer’s EXECUTE brief through the Module index ([instruction](packs/core/.apm/skills/work-loop/references/infra-verification.md:187)). | `implementer`; its contract expects the module as context and says not to load the skill itself ([consumer contract](packs/core/.apm/agents/implementer.md:31)). | **PROSE-DIRECTED decision and PROSE-DIRECTED inlining.** [Cited] The index calls itself deterministic, but an agent detects the trigger, reads the file, and composes the brief. No executable dispatcher implements those steps. |
+| Operational failure-mode modules: `state-and-idempotency`, `blast-radius`, `environment-isolation`, `cost-and-teardown`, `drift-and-rollback`, `observability-and-smoke`, and—when applicable—`cloud-implementation-craft` | The Module index’s `Load when` column maps observed failure modes to modules ([index](packs/core/.apm/skills/operational-safety/SKILL.md:126), [rows](packs/core/.apm/skills/operational-safety/SKILL.md:148)). The outer trigger is infra/destructive or persistent-representation/mixed-version work ([trigger](packs/core/.apm/skills/operational-safety/SKILL.md:51)). | The library instructs the orchestrator to detect failure modes, load matching files, and inline their contents into the reviewer brief ([three steps](packs/core/.apm/skills/operational-safety/SKILL.md:51)). Work-loop repeats that direction ([REVIEW instruction](packs/core/.apm/skills/work-loop/SKILL.md:540)). | `quality-engineer`, whose own contract expects those modules and forbids self-loading them ([consumer contract](packs/core/.apm/agents/quality-engineer.md:68)). | **PROSE-DIRECTED decision and PROSE-DIRECTED inlining.** [Cited] The routing table is deterministic data-like prose; applying it to a diff and inserting the selected text are model actions, not code. |
+
+The clearest deciding quotations are:
+
+> “Detects which operational failure modes the diff or spec crosses.”  
+> “Loads only the matching modules…”  
+> “Inlines the selected modules’ content…”  
+> — [operational-safety loading procedure](packs/core/.apm/skills/operational-safety/SKILL.md:51)
+
+> “On infra-flavored work, the orchestrator inlines the `cloud-implementation-craft` module … into the implementer’s EXECUTE brief.”  
+> — [infra-verification](packs/core/.apm/skills/work-loop/references/infra-verification.md:187)
+
+## 2. Current phase-to-guidance map
+
+| Phase/surface | Guidance that reaches the actor | Arrival |
+|---|---|---|
+| Spec authoring: `new-spec` | `new-spec/SKILL.md`; its managed output-rendering block; `assets/spec.md`; effective root/scoped `AGENTS.md`; mapped architecture, decisions, conventions, and analogous implementations ([procedure](packs/core/.apm/skills/new-spec/SKILL.md:60)). Interface-bearing specs conditionally use `contract-types`; UI specs conditionally use `creative-direction`/`design-review`. | Skill invocation plus actor-directed reads. Templates are copied. Conditional additions are selected by prose. [Cited] |
+| Plan authoring | The same `new-spec` skill authors `plan.md`; there is no separate plan-author skill. `assets/plan.md` supplies Design/LLD, task, dependency, `Tests:`-before-`Approach:`, and durable-output structure ([template](packs/core/.apm/skills/new-spec/assets/plan.md:91), [tasks](packs/core/.apm/skills/new-spec/assets/plan.md:161)). | Template plus prose in `new-spec`; `Shape:` controls which design subsections the author retains. [Cited] |
+| Work-loop PLAN / pre-EXECUTE | Work-loop itself; repository anchors; verification-mode guidance; conditional `tdd-stubs`, `verification-modes`, `infra-verification`, and `pre-execute-review`. Fired review roles are adversarial, security, design-intent, and frontend pre-flight ([trigger table](packs/core/.apm/skills/work-loop/SKILL.md:290)). Security review receives matching `security-checklists` modules. | Actor loads references when prose triggers fire. Security modules are prose-directed inline prompt text. FSM state mechanically prevents illegal phase transitions, but does not assemble prompts. [Cited] |
+| EXECUTE / implementation | Main actor: work-loop verification-mode discipline, conditional `contract-acquisition`, conditional `frontend-engineering`, and conditional infra reference ([EXECUTE](packs/core/.apm/skills/work-loop/SKILL.md:399)). Subagent: `implementer.md`, task body, worktree path, spec/plan paths, cited files, optional bundled-fix authorization, and conditional `cloud-implementation-craft`. | Base implementer contract is projected agent configuration. Task/spec/plan are brief fields or reads. `cloud-implementation-craft` is prose-directed inlining. [Cited] |
+| GATES | Repository-defined lint/typecheck/test commands; frontend pack’s GATES commands when activated; infra’s layered static/preview/apply/smoke/rollback doctrine when applicable ([GATES](packs/core/.apm/skills/work-loop/SKILL.md:437)). | Read from `AGENTS.md`, README, active pack guidance, and plan task. Exit codes and FSM transitions are mechanical. No policy module is inlined at this phase. [Cited] |
+| Post-gates REVIEW | Always adversarial review; then warranted specialists. Security gets boundary-matched `security-checklists`; quality gets failure-mode-matched `operational-safety`; quality also receives `contract-acquisition`; experience/frontend/design reviewers get their named artifacts and rubrics ([reviewers](packs/core/.apm/skills/work-loop/SKILL.md:527)). | Reviewer selection and module inlining are prose-directed. Report persistence, path validation, strict classification, counters, and FSM transitions are mechanical. [Cited] |
+| Closeout | Separate `close-work` skill, not work-loop. It consumes the work-loop evidence envelope, workspace state, durable-output map, semantic-surface resolver, and its own disposition/safety rules ([boundary](packs/core/.apm/skills/close-work/SKILL.md:42)). | Skill invocation and actor-directed reads. `close_work.py` and `cooling.py` provide the deterministic decision/effect seam ([seam](packs/core/.apm/skills/close-work/SKILL.md:119)). [Cited] |
+
+## 3. Can module arrival be checked?
+
+**No dispatched-brief arrival check exists.** [Measured]
+
+Searches used:
+
+```text
+rg -n "cloud-implementation-craft" packs/core/tests packages/agentbundle/tests tools .github
+```
+
+The only hit was the IaC canary’s module pathname. That canary checks that the reference file exists ([workflow](.github/workflows/iac-release-loop-canary.yml:34)); it does not inspect a brief.
+
+```text
+rg -n "inlined.{0,40}(brief|prompt)|brief.{0,40}inlined|prompt.{0,40}module|selected modules.{0,40}brief" \
+  packs/core/tests packages/agentbundle/tests tools .github
+```
+
+Exit status: `1`; no matches.
+
+```text
+rg -n "developer_instructions|prompt|brief" \
+  packs/core/.apm/skills/work-loop/scripts/loop-cohort.py \
+  packs/core/.apm/skills/work-loop/scripts/loop-engine.py \
+  packs/core/.apm/skills/work-loop/scripts/_loop_guards.py
+```
+
+No prompt or brief assembler appeared. [Measured]
+
+The supervisor procedure does enumerate ordinary brief fields—task ID/body, worktree, spec/plan paths, and bundled-fix authorization ([brief fields](packs/core/.apm/skills/work-loop/references/supervisor-mode.md:115)). Its mechanical report check validates the returned task heading, not the input brief or module presence ([report check](packs/core/.apm/skills/work-loop/references/supervisor-mode.md:128)). [Cited]
+
+## 4. Existing “taught and checked” rule
+
+**Yes: credential values must never travel through a credentialed CLI’s argv.** [Cited]
+
+| Half | Implementation |
+|---|---|
+| Prevention / teaching | The acting implementer reads `docs/CONVENTIONS.md`; that document says credentialed skills never touch the token ([architecture](docs/CONVENTIONS.md:1393)) and names the six forbidden value flags ([argv ban](docs/CONVENTIONS.md:1500)). Each credentialed skill must also carry an exact broker-specific “Never put … on the command line” instruction. |
+| Detection / deterministic check | `CAT-L031` requires the security heading and broker-specific teaching phrases ([phrase check](packages/agentbundle/agentbundle/catalogue_tooling/lint.py:2023)), then AST-walks credentialed CLI scripts and rejects banned `argparse.add_argument` flags ([artifact check](packages/agentbundle/agentbundle/catalogue_tooling/lint.py:2056)). A fixture proves `--api-key` produces `CAT-L031` ([test](packages/agentbundle/tests/unit/test_catalogue_tooling_lint.py:1944)). |
+
+Both halves live in the same `_check_credentialed_skills` check: required teaching phrases are data in `_CS_REQUIRED_PHRASES_BY_BROKER`, while executable prohibitions are data in `_CS_BANNED_FLAGS` ([constants](packages/agentbundle/agentbundle/catalogue_tooling/lint.py:784)). [Cited]
+
+They are co-located and tested, but not generated from one semantic rule: the prose flag list and `_CS_BANNED_FLAGS` remain duplicate representations. Thus this is a real “both” precedent, with a residual synchronization risk. [Inferred]
+
+## 5. Existing phase-scoped selection keys
+
+| Candidate key | Declared data or inferred? | Current mechanical use |
+|---|---|---|
+| Work-loop phase | **Declared, tool-written data.** `engine-state.json.state` has explicit FSM values from `SPEC-PLAN-DRAFTING` through `DONE` ([schema](packs/core/.apm/skills/work-loop/references/state-schema.md:84)). | Mechanical transition and guard enforcement. This is the strongest existing phase key. |
+| Spec `Shape:` | **Declared in `spec.md`, but selected by an agent or user.** Allowed values are `ui`, `service`, `data`, `integration`, `mixed` ([field](packs/core/.apm/skills/new-spec/assets/spec.md:10)). | Prose directs plan scaffolding and UI readiness. No `Shape:` reader was found in work-loop/new-spec scripts. [Measured] |
+| Task verification mode | **Declared in plan prose after agent selection.** TDD, goal-based, visual/manual, and infra/deploy are selected during PLAN ([selection](packs/core/.apm/skills/work-loop/SKILL.md:278)). | Implementer follows it. Search of work-loop/new-spec scripts for these mode names returned no matches, so declaration/presence is not mechanically parsed. [Measured] |
+| Task dependency fields | **Declared plan data-like prose:** task ID, `Depends on:`, optionally `Touches:` ([grammar](packs/core/.apm/skills/new-spec/assets/plan.md:188)). | Mechanically parsed for scheduling and overlap prediction. It does not currently select policy. |
+| Infra/task flavor | **Inferred by an agent.** The repository gives a closed prose definition, but no persisted `flavor` field or classifier function was found. | Drives infra references, reviewers, and module selection through prose. |
+| Pack membership | **Declared data** in `pack.toml`; integrations also declare consumer/provider/`when` metadata ([frontend integration](packs/core/pack.toml:77)). | Installation/projection is mechanical. Whether a phase condition fires is still evaluated by work-loop prose. |
+| Profile membership | **Declared data** as `[[packs]]` entries ([example](profiles/full-ceremony.toml:12)). | Mechanically selects installed packs, but profiles “introduce no new skills, agents, hooks, or commands”; they are coarse installation-time scope, not runtime phase state. |
+
+## 6. Implementer’s real contract
+
+| Aspect | Contract |
+|---|---|
+| Declared inputs | One plan task, worktree path, spec path, and plan path ([frontmatter description](packs/core/.apm/agents/implementer.md:2)); then `AGENTS.md`, `docs/CONVENTIONS.md`, the targeted spec/plan, cited files, and conditional cloud module ([load order](packs/core/.apm/agents/implementer.md:19)). [Cited] |
+| Source tool allowlist | `Read, Edit, Write, Grep, Glob, Bash` ([frontmatter](packs/core/.apm/agents/implementer.md:4)). No web, Skill, or agent-dispatch tool. [Cited] |
+| Source model | `sonnet` ([frontmatter](packs/core/.apm/agents/implementer.md:5)). [Cited] |
+| Current Codex projection | `gpt-5.5`, medium reasoning, `workspace-write`, web disabled ([projected config](.codex/agents/implementer.toml:1)). The adapter contract maps `sonnet` to those values and turns any write intent into a writable sandbox ([mapping](contracts/adapter.toml:854)). [Cited] |
+| Required | Implement only the assigned task; obey its verification mode; run documented gates; commit; return the fixed report shape. [Cited] |
+| Permitted | Edit within the assigned worktree. Optional ride-alongs are permitted only when the brief explicitly authorizes bundled fixes and they meet the three-tier carve-out ([envelope](packs/core/.apm/agents/implementer.md:46)). [Cited] |
+| Forbidden | Reviewing the spec/plan, dispatching subagents, merging, editing the primary worktree, silently widening scope, editing gates to pass, or reporting ready with failed gates ([anti-patterns](packs/core/.apm/agents/implementer.md:143)). [Cited] |
+
+Mechanically constrained: model choice, writable-vs-read-only sandbox, web disablement, and—with adapter differences—the exposed tool surface. The supervisor can mechanically check the returned task heading against the assigned ID. [Cited]
+
+Not mechanically constrained: “one task,” exact worktree confinement within the writable workspace, no self-review, no merge, verification-mode compliance, gate honesty, and inclusion of the cloud module. Those remain prose contracts. [Inferred]
+
+## 7. Cost and ceilings
+
+No implementer-brief token budget, prompt-size limit, line ceiling, or module-byte ceiling was found. [Measured]
+
+Search:
+
+```text
+rg -n -i \
+  "token budget|context budget|brief.{0,40}(limit|ceiling|max|budget)|prompt.{0,40}(limit|ceiling|max|budget)|line ceiling|line limit|max.{0,20}lines" \
+  packs/core/.apm/agents/implementer.md \
+  packs/core/.apm/skills/work-loop \
+  packs/core/.apm/skills/operational-safety \
+  contracts/adapter.toml docs/CONVENTIONS.md
+```
+
+Result: no matches.
+
+The only applicable cost control is progressive disclosure: load only matching modules so “the agent prompt stays lean” ([rationale](packs/core/.apm/skills/operational-safety/SKILL.md:8)). That is a selection rule, not a measured ceiling. [Cited]
+
+Measured source sizes:
+
+```text
+wc -l packs/core/.apm/agents/implementer.md \
+      packs/core/.apm/skills/operational-safety/references/cloud-implementation-craft.md
+```
+
+Result: 154 lines and 109 lines, 263 combined. [Measured]
+
+Work-loop explicitly says token-budget state fields are absent in Phase 1 ([state schema](packs/core/.apm/skills/work-loop/references/state-schema.md:76)). The implementer’s “be terse” rule applies to its returned report, not its input brief ([report rule](packs/core/.apm/agents/implementer.md:94)). [Cited]
+
+## Direct answer
+
+**Phase-scoped policy delivery is achievable by extending the current mechanism:** the work-loop’s orchestrator-driven `Module index → select matching reference → inline into phase-specific subagent brief` mechanism, keyed first by the mechanically recorded FSM phase and then by declared task/spec attributes. [Inferred]
+
+It does not need a new conceptual delivery mechanism. It **does need a new mechanical prompt-assembly/arrival validator** if “delivery” must be provable: today both selection and inlining are prose-directed, and nothing records or checks that the selected module reached the implementer’s brief.

--- a/workspace.toml
+++ b/workspace.toml
@@ -75,47 +75,112 @@ executing = [
 ]
 ready     = []
 draft     = [
-  # Ready candidate, not sealed. `author-delivery-brief continue` closed the
-  # owner's two open questions on 2026-09-02 -- appetite, and where the
-  # pre-creation pressure test fires -- and proposed, without confirming, two
-  # initial slices: the activation measurement, appetited first and alone, then
-  # the pre-creation pressure test. No slice is confirmed and no spec is
-  # authored. Ready waits on a revision-bound clean shaping review plus the
-  # owner's explicit confirmation; the status line stays Draft until both hold.
-  # Length: 3,582 words, up from 2,868 at Draft. The owner accepted the overage
-  # at 2,969 -- recording three decisions costs more than recording them open --
-  # and review added correctness fixes on top: two missing in-scope bullets, a
-  # corrected measurement subject, and four anchors for claims that did not
-  # resolve, against trims to the rubric categories and a duplicated rabbit
-  # hole. It does not license carrying the failure-point rubric, which this
-  # brief produces rather than contains.
-  # Owed at slice confirmation, not at the seal -- both carry a round-3
-  # reviewer verdict of "does not block Ready":
-  #   1. Name the assumption that the ownership survey can ship, observably run,
-  #      and still leave recognition failing. Every kill condition in the brief
-  #      is a necessity condition; none covers "it ran and did not work". Add it
-  #      as a Risks bullet before the survey becomes a confirmed slice.
-  #   2. Apply the guide shippability test (CONVENTIONS.md "A phase whose
-  #      tooling ships without its guide is not a complete slice"). No slice
-  #      names a guides/ artifact yet; the pressure test and the step-5a
-  #      widening both change documented author-facing behaviour.
-  #   3. The routing-decision spike added 2026-09-02 reuses step 5a's SHAPE,
-  #      not step 5a. 5a is a numbered step inside new-spec (SKILL.md:475,
-  #      between steps 5 and 6) and the spike fires before new-spec is entered,
-  #      so the two cannot be the same invocation. An earlier draft of this
-  #      comment recorded them as coupled; that was wrong, and round 5 caught
-  #      it. Killing the 5a widening leaves the routing spike intact. Keep the
-  #      two bounded-evidence instruments consistent in shape when either is
-  #      specified, but do not cut them as one slice.
-  # Promoted 2026-09-02 from a shaping intent of the same slug. Prevention:
-  # a rubric of the criterion and task shapes that have produced findings here,
-  # the authoring instructions derived from it, and a pressure test at spec
-  # creation that redirects to brief authoring when the upstream is unready.
-  # Carries its own activation design and measurement, because the load-bearing
-  # finding is that prose rules here do not fire -- what caught defects was
-  # parity checks, symbol binding, and mutation proofs. Its sibling
-  # agent-loop-escalation-recovery stays an intent: no defined outcome yet.
-  {path = "docs/product/briefs/agent-authoring-input-quality.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Author specs and plans that a review loop converges on, and refuse to open one over an undefined outcome: a failure-point rubric, non-fragile AC and plan-task instructions, a pre-creation pressure test with a redirect to brief authoring, and the activation measurement that decides whether any of it can ship as written guidance", needs = []},
+  # Split 2026-09-02 at 5ff0d3b19. One brief became three. The predecessor had
+  # outgrown its shape by accumulating scope rather than prose: it went from
+  # (rubric + pressure test + survey + measurement) to (+ two more readiness
+  # boundaries + review sequencing + a second worker + sizing discipline).
+  # Its own third finding says a readiness
+  # gate that checks presence cannot tell whether the next stage can work -- and
+  # the predecessor was the exhibit, because its first slice was unwritable
+  # while seven review rounds passed it.
+  # The seam, decided by the owner and preserved here: M gates both siblings, so
+  # burying it in A would have blocked B on A's first slice. A owns sizing,
+  # because the abandoned contract sat above the 96th percentile on ACs and
+  # within 3% of the longest spec ever written here, and consumed eleven rounds
+  # without converging -- sizing is a lever on A's outcome. B consumes the
+  # sizing signal as a stall and gets no copy of the regenerator. A retains the
+  # findings corpus; M and B cite it rather than duplicating it.
+  # All three stay Draft. Ready needs a revision-bound clean shaping review plus
+  # the owner's explicit confirmation, per brief.
+  #
+  # M -- the activation measurement, appetited first and alone (owner decision,
+  # 5ff0d3b19). It gates A entirely and B's routing-ask half only. Separate
+  # because burying it in either sibling makes the other wait on that sibling's
+  # first slice for a report it does not otherwise depend on.
+  # Estimand widened to PORTABLE by owner decision 2026-09-02, after a headless
+  # Codex investigation (session 01a0651e-e82a-70b2-846f-8607b8268351) surveyed
+  # the corpus options. The report's own recommendation was the narrower local
+  # set; the owner took its stated falsifier instead -- the claim is now "does
+  # this mechanism work across adopter repositories", not only here.
+  # Consequences, all recorded in the brief: two strata that the report may
+  # never blend, because all three sibling verdicts are LOCAL and a blended
+  # score resolves none of them; a six-rule local floor M1 may not silently
+  # drop; and a fourth slice for the external stratum whose enlarged appetite is
+  # NOT yet confirmed. The local stratum alone unblocks A and B, so M4 can slip
+  # or be dropped without stranding either sibling.
+  # External-only and synthetic-only corpora were ruled nonviable, not on
+  # principle but on decidability: neither can return a verdict for this repo's
+  # anchoring rule, step 5a, or routing prose. Synthetic material enters as
+  # seeded TASKS and known-compliant/known-violating artifacts, never as rules.
+  # Corpus needs its own home: the harness's unit is a skill (all 96 eval homes
+  # under packs/*/.apm/skills/*/evals/, and pack_evals.py hard-codes both the
+  # coverage unit and that path), while half the local floor is root-context.
+  # Fabricating skills to host them would change the context being measured.
+  # Four proposed slices, none confirmed: corpus contract, corpus surface +
+  # runner mode, local run and report, external stratum. The decision rule is
+  # pre-registered on purpose -- M1 lands as its own reviewed change before M2
+  # runs anything, because the Phase 3 harness validates its grader live while
+  # that slice is built, so a co-located decision rule could be tuned to it.
+  # Capability of the cross-adapter-behavior-enforcement intent. Measured: the
+  # `--adapter` flag and the codex *judge* backend already ship, so only a
+  # detector that drives a non-Claude model is missing.
+  # Capabilities of the cross-adapter-behavior-enforcement intent, authored
+  # 2026-09-03. Ordered by what unblocks what: the two dispatch envelopes come
+  # first because policy has nowhere to arrive without them, then delivery, then
+  # the validator that makes arrival provable.
+  {path = "docs/product/briefs/universal-implementer-dispatch.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Route every plan task through the implementer agent sequentially and move implementation logic out of work-loop's SKILL.md, creating the dispatch envelope policy delivery needs", needs = []},
+  {path = "docs/product/briefs/spec-author-agent.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Give spec authoring a dispatched agent so the SPEC-PLAN phases have an envelope, reusing the implementer's delivery and enforcement path", needs = [{type = "local", kind = "brief", path = "docs/product/briefs/universal-implementer-dispatch.md"}]},
+  {path = "docs/product/briefs/phase-scoped-policy-delivery.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Key policy-family selection to the recorded FSM phase and inline the matching families into the acting agent's brief, extending the existing module-index mechanism", needs = [{type = "local", kind = "brief", path = "docs/product/briefs/universal-implementer-dispatch.md"}]},
+  {path = "docs/product/briefs/policy-arrival-validator.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Make policy delivery provable: a deterministic check that every phase-selected family has a verdict, with a precise-family compliance branch that can block", needs = [{type = "local", kind = "brief", path = "docs/product/briefs/phase-scoped-policy-delivery.md"}]},
+  #
+  {path = "docs/product/briefs/multi-adapter-eval-runner.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Add a Codex detector so activation can be measured on a non-Claude model, keeping the default adapter and the scheduled workflow unchanged", needs = []},
+  #
+  {path = "docs/product/briefs/guidance-activation-measurement.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Measure whether the written-guidance mechanism binds -- graded on what an author produced while a rule was in context rather than on whether it was loaded -- across a mandatory local stratum of six named rules and a portability stratum of pinned adopter repositories, reported separately and never blended", needs = [{type = "local", kind = "brief", path = "docs/product/briefs/policy-arrival-validator.md"}]},
+  #
+  # A -- keeps the predecessor's slug and file. Two artifacts outside this
+  # split's scope link to it by path (work-loop-next-action.md and the
+  # agent-loop-escalation-recovery intent), and neither was in scope to edit, so
+  # deleting the file would have broken both. Residual: the intent's sentence
+  # "the activation analysis lives there" now points one hop short -- the
+  # analysis moved to M, which A links in its first section.
+  # `needs` carries the M edge because A genuinely waits on M's report. This is
+  # sequencing, unlike the edge removed from agent-loop-escalation-recovery,
+  # where the relationship was shared evidence.
+  # Five proposed slices, none confirmed: A1 rubric + instructions, A2 sizing
+  # regenerator, A3 delegation anchor, A4 step-5a widening, A5 ownership survey
+  # (conditional). Owed at slice confirmation, carried forward from the
+  # predecessor's round-3 verdict of "does not block Ready":
+  #   1. The "ran and did not work" assumption is now a Risks bullet, but must
+  #      be answered before A5 is confirmed.
+  #   2. The guide shippability test (CONVENTIONS.md "A phase whose tooling
+  #      ships without its guide is not a complete slice") is unapplied. No
+  #      slice names a guides/ artifact yet.
+  #   3. A4 reuses step 5a's POSITION; B's routing spike reuses its SHAPE. 5a is
+  #      a numbered step inside new-spec (SKILL.md:475, between steps 5 and 6)
+  #      and the spike fires before new-spec is entered, so the two cannot be
+  #      the same invocation. Killing A4 leaves B's spike intact. Keep the two
+  #      consistent in shape when either is specified; never cut them as one
+  #      slice. B now owns the full statement of this; A points at it.
+  {path = "docs/product/briefs/agent-authoring-input-quality.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Author specs and plans that a review loop converges on: a failure-point rubric and the authoring instructions derived from it, a delegation anchor, sizing discipline shipped as a regenerator, the step-5a satisfiability widening, and a conditional ownership survey", needs = [{type = "local", kind = "brief", path = "docs/product/briefs/guidance-activation-measurement.md"}]},
+  #
+  # B -- `needs` is deliberately empty. B1, the declared-shape gate, never
+  # depended on the activation measurement and can start in parallel with M
+  # (owner decision); a needs edge would mark the whole brief undispatchable and
+  # hide that. Only B2, the routing ask, waits on M's report, and the brief
+  # records that per slice. Five proposed slices, none confirmed: B1 gate, B2
+  # routing ask + spike-or-redirect disposition, B3 new-spec input readiness,
+  # B4 spec-and-plan-to-implementer readiness, B5 review sequencing.
+  # B3 and B4 are split although the owner's cut named them together: same
+  # question, two owning surfaces, and a two-file change resolves at roughly
+  # half the rate of a one-file change. Recorded as a sizing judgment, not a
+  # scope change.
+  # B3 and B4 carry a prose component whose activation is unmeasured. The owner
+  # gated only the routing ask on M's report, so these proceed without it; the
+  # brief records that as a risk rather than re-gating them.
+  # The non-goal on reviewers is narrowed by owner amendment: sequencing a
+  # readiness gate before review is in scope; the review lens and the
+  # adjudicator's contract stay out.
+  {path = "docs/product/briefs/stage-input-readiness.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Make each authoring handoff ask whether the next stage can work from its input and record the answer: a pre-creation pressure test with a redirect to brief authoring, a bounded-spike disposition for an open unknown, readiness checks at new-spec's input and at the spec-and-plan handoff, and a readiness gate sequenced ahead of review", needs = []},
   # Authored 2026-09-01 by `author-delivery-brief create` after the
   # work-loop-next-projection spec was abandoned at e1bdde746, ten pre-EXECUTE
   # review rounds in, on a model error no clause repair could reach. Draft only:
@@ -290,6 +355,11 @@ backlog = []
 # Distinct from [ini-NNN.shaping_queue].backlog (per-initiative non-active tier).
 [backlog]
 open = [
+  # Product-strategy parent of the three capability briefs below it, framed
+  # 2026-09-02. Re-gates them: the policy validator is the activation
+  # measurement's compliance test, so enforcement precedes measurement.
+  # Load-bearing unknown: no host is known to admit a blocking hook verdict.
+  {path = "docs/product/intents/cross-adapter-behavior-enforcement.md", kind = "intent", source = {mode = "repo-origin"}, summary = "Make a published behavior control run regardless of model or host by putting it on the pre-execution path rather than in prose: a structured policy primitive an adopter can extend, a blocking control whose per-host contract is established first, and a multi-adapter runner so a non-Claude model can be measured at all", needs = []},
   # Hypothesis, not accepted work. Spiked 2026-09-01 in core 2.22.0 and REVERTED
   # the same day because the spike did not pay out.
   #

--- a/workspace.toml
+++ b/workspace.toml
@@ -75,11 +75,38 @@ executing = [
 ]
 ready     = []
 draft     = [
-  # Authored 2026-09-01 by `author-delivery-brief create` after the
-  # work-loop-next-projection spec was abandoned at e1bdde746, ten pre-EXECUTE
-  # review rounds in, on a model error no clause repair could reach. Draft only:
-  # three load-bearing unknowns are open and no slices are proposed. `continue`
-  # owns Ready after the owner closes them.
+  # Ready candidate, not sealed. `author-delivery-brief continue` closed the
+  # owner's two open questions on 2026-09-02 -- appetite, and where the
+  # pre-creation pressure test fires -- and proposed, without confirming, two
+  # initial slices: the activation measurement, appetited first and alone, then
+  # the pre-creation pressure test. No slice is confirmed and no spec is
+  # authored. Ready waits on a revision-bound clean shaping review plus the
+  # owner's explicit confirmation; the status line stays Draft until both hold.
+  # Length: 3,582 words, up from 2,868 at Draft. The owner accepted the overage
+  # at 2,969 -- recording three decisions costs more than recording them open --
+  # and review added correctness fixes on top: two missing in-scope bullets, a
+  # corrected measurement subject, and four anchors for claims that did not
+  # resolve, against trims to the rubric categories and a duplicated rabbit
+  # hole. It does not license carrying the failure-point rubric, which this
+  # brief produces rather than contains.
+  # Owed at slice confirmation, not at the seal -- both carry a round-3
+  # reviewer verdict of "does not block Ready":
+  #   1. Name the assumption that the ownership survey can ship, observably run,
+  #      and still leave recognition failing. Every kill condition in the brief
+  #      is a necessity condition; none covers "it ran and did not work". Add it
+  #      as a Risks bullet before the survey becomes a confirmed slice.
+  #   2. Apply the guide shippability test (CONVENTIONS.md "A phase whose
+  #      tooling ships without its guide is not a complete slice"). No slice
+  #      names a guides/ artifact yet; the pressure test and the step-5a
+  #      widening both change documented author-facing behaviour.
+  #   3. The routing-decision spike added 2026-09-02 reuses step 5a's SHAPE,
+  #      not step 5a. 5a is a numbered step inside new-spec (SKILL.md:475,
+  #      between steps 5 and 6) and the spike fires before new-spec is entered,
+  #      so the two cannot be the same invocation. An earlier draft of this
+  #      comment recorded them as coupled; that was wrong, and round 5 caught
+  #      it. Killing the 5a widening leaves the routing spike intact. Keep the
+  #      two bounded-evidence instruments consistent in shape when either is
+  #      specified, but do not cut them as one slice.
   # Promoted 2026-09-02 from a shaping intent of the same slug. Prevention:
   # a rubric of the criterion and task shapes that have produced findings here,
   # the authoring instructions derived from it, and a pressure test at spec
@@ -89,6 +116,13 @@ draft     = [
   # parity checks, symbol binding, and mutation proofs. Its sibling
   # agent-loop-escalation-recovery stays an intent: no defined outcome yet.
   {path = "docs/product/briefs/agent-authoring-input-quality.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Author specs and plans that a review loop converges on, and refuse to open one over an undefined outcome: a failure-point rubric, non-fragile AC and plan-task instructions, a pre-creation pressure test with a redirect to brief authoring, and the activation measurement that decides whether any of it can ship as written guidance", needs = []},
+  # Authored 2026-09-01 by `author-delivery-brief create` after the
+  # work-loop-next-projection spec was abandoned at e1bdde746, ten pre-EXECUTE
+  # review rounds in, on a model error no clause repair could reach. Draft only:
+  # appetite and the slice cut are undecided, and two bounded observations are
+  # owed before the slices that depend on them -- the brief records those two as
+  # documentation, not unknowns. `continue` owns Ready after the owner closes
+  # the two open decisions.
   {path = "docs/product/briefs/work-loop-next-action.md", kind = "brief", source = {mode = "repo-origin"}, summary = "Give a work-loop turn one authoritative next action from persisted state, and decide separately what owns stopping a non-converging authoring loop", needs = []},
 ]
 # tech-site-completion is Status: Shipped, so `ready` was an impossible


### PR DESCRIPTION
Lands the 2026-09-02 split of `agent-authoring-input-quality` and puts a
product-strategy intent above it with five capability briefs. **Eight briefs,
one intent, four research artifacts — all `Draft`.** No brief met the Ready
gate, and Ready is the owner's decision.

## Why the intent exists

Commissioned research established that natural-language instruction is a
probabilistic steering mechanism, not a portable enforcement layer, and that a
compatibility claim is only valid for one
`pack x adapter x model x configuration` tuple. Fourteen shipped controls do not
enforce what they appear to, and the pattern across all of them is one thing:
**construction is tested, application is not.**

## The shape

Three layers, with a model in only one:

| Layer | What | Model? |
|---|---|---|
| Teach | policy families as data in a skill directory, selected by `engine-state.json.state` | no |
| Act | the dispatched authoring agent enumerates families and emits a per-policy verdict | yes |
| Check | coverage plus, for precise families only, a deterministic predicate | no |

Enforcement binds to an artifact a script can check rather than to a host hook,
because hook events are the least standardized surface we ship to.

## Sequence

`universal-implementer-dispatch` is the unconditional enabler — implementation
has no dispatch envelope today, so the two existing inlining precedents sit on a
path that ADR-0061 disabled. Then `spec-author-agent`, then delivery, then the
validator, with `multi-adapter-eval-runner` independent.

## Verification

- Eight individual shaping reviews plus two set-level rounds, all adjudicated;
  every finding repaired or refuted with evidence.
- Slice DAG walked and rewalked: 26 slices, no cycles, no backward dependency.
- Gates: `lint-spec-status`, `lint-brief-coverage`, workspace `reconcile`,
  `catalogue verify`, and `catalogue lint --deep` all exit 0.

Decision history and the corrections made against the tree are in the commit
message; rejected alternatives live in the artifacts that own them, with their
reasons.
