### PR TITLE
fix(ci): give the roster's history-dependent check the history it reads

### DIFF
--- a/.github/workflows/test-corpus.yml
+++ b/.github/workflows/test-corpus.yml
@@ -49,6 +49,11 @@ jobs:
           # Nothing here needs the token after checkout, and leaving the default
           # would persist it into the working tree for the target's own git calls.
           persist-credentials: false
+          # `make test` sweeps `tests/`, which reaches
+          # test_ac1_inventory_is_resolvable_at_the_pinned_acceptance_ref. That case runs
+          # `git cat-file -e <pinned-ref>:<path>` against this repository's own history,
+          # so a depth-1 clone fails it on its first source without reaching the rest.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.github/workflows/test-roster.yml
+++ b/.github/workflows/test-roster.yml
@@ -43,6 +43,11 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           persist-credentials: false
+          # full history for test_ac1_inventory_is_resolvable_at_the_pinned_acceptance_ref,
+          # which runs `git cat-file -e <pinned-ref>:<path>` against this repository's
+          # own history. The default depth-1 clone does not contain that commit, so the
+          # check failed on its first source and never reached the other ten.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0


### PR DESCRIPTION
`test_ac1_inventory_is_resolvable_at_the_pinned_acceptance_ref` is **red on main right now**. This makes it green.

## Cause

The test runs `git cat-file -e 352595bd2bcf25bbbffb03deabfa8f5a9e4b248d:<path>` against this repository's own history for eleven sources, checking the recorded legacy source inventory still names real paths at its pinned acceptance ref.

Both workflows that reach it checked out with the `actions/checkout` default, `fetch-depth: 1`. That clone doesn't contain the pinned commit, so git exits 128:

```
fatal: path 'workspace.toml' exists on disk, but not in '352595bd...'
```

The assertion is inside the loop, so the run dies on the first source and the other ten are never checked — **the failure understates itself.**

## Fix

`fetch-depth: 0` on both. That's already this repo's idiom for a job needing history — `build-check.yml`, `ci-security.yml`, `docs.yml`, `pages.yml`, `catalogue-tooling-ci-gates.yml` and both release workflows set it, two with a comment naming the consumer.

- `test-roster.yml` runs the suite directly.
- `test-corpus.yml` runs `make test`, whose `pytest tests/ -q` line sweeps `tests/roster/`, so it hits the same case and failed the same way.

## Scope, measured rather than guessed

Searched `tests/` for consumers of repository history — `git cat-file`, `git log`, `git show`, `rev-list`, `merge-base`, and pinned 40-character SHAs. **Exactly one** exists.

- The other pinned SHA (`6e984d67`, in `test_close_work_extraction_and_immediate_disposition.py`) is a string compared against a parsed record; it never reaches git.
- `test_thirty_day_cooling_and_retirement.py` shells out to git but builds its own temp repos with `git init`, so it needs no repository history.

No other workflow needed changing.

## Evidence

Dispatched `test-roster` on **main**: `1 failed, 1335 passed` — the single failure being this case. So it is red on main today, independent of any branch. The same case **passes locally**, where the clone is complete, which is why no local gate ever surfaced it.

## Recorded, not fixed here

The same runs intermittently fail `test_identity_survives_five_history_shapes[no-git]` with `FileNotFoundError: 'maintenance.lock'` inside `shutil.rmtree`. That's a teardown race in a test that creates its own git repos — not an assertion failure — and it did not recur on re-run (`1 failed, 1341 passed`). Separate issue, not conflated with this one.

## Coordination

PR #1242 carries an identical `fetch-depth` change bundled into a 51-file feature branch. Landing it standalone here so main goes green now; #1242 can drop its two hunks at merge time.

## Verification

Both files parse as YAML and the checkout step resolves to `{persist-credentials: False, fetch-depth: 0}`. `lint-ci-parity` ok — 85 steps across 1 in-scope workflow, all dispositioned.