### PR TITLE
fix(tests): unpin two environment-dependent roster and parity assertions

### DIFF
--- a/packs/linear/tests/skills/linear/test_linear_primitive.py
+++ b/packs/linear/tests/skills/linear/test_linear_primitive.py
@@ -13,6 +13,7 @@ import importlib.util
 import json
 import sys
 import types
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -35,18 +36,33 @@ def _unreached_acquire(_locator: str, _revision: str) -> dict[str, object]:
 
 
 @pytest.fixture(scope="module")
-def linear_mod() -> types.ModuleType:
-    """Load linear.py once per session; stub credbroker to avoid import-time auth."""
+def linear_mod() -> Iterator[types.ModuleType]:
+    """Load linear.py once per module; stub credbroker to avoid import-time auth.
+
+    The stub is removed again on teardown. `types.ModuleType` carries no
+    `__spec__`, and `importlib.util.find_spec` raises `ValueError` rather than
+    returning None for a spec-less entry — so leaving this installed makes any
+    later test in the same process that probes for `credbroker` fail on a
+    module this one invented.
+    """
     credbroker_stub = types.ModuleType("credbroker")
     credbroker_stub.CredentialsMissingError = Exception  # type: ignore[attr-defined]
     credbroker_stub.load_credentials = lambda *a, **kw: None  # type: ignore[attr-defined]
-    sys.modules.setdefault("credbroker", credbroker_stub)
+    # Only uninstall what this fixture installed, and only while it is still
+    # ours: a real credbroker imported meanwhile must survive.
+    stubbed = "credbroker" not in sys.modules
+    if stubbed:
+        sys.modules["credbroker"] = credbroker_stub
 
-    spec = importlib.util.spec_from_file_location("linear_script", LINEAR_SCRIPT)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    return mod
+    try:
+        spec = importlib.util.spec_from_file_location("linear_script", LINEAR_SCRIPT)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        yield mod
+    finally:
+        if stubbed and sys.modules.get("credbroker") is credbroker_stub:
+            del sys.modules["credbroker"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/roster/test_linear_refresh_processor.py
+++ b/tests/roster/test_linear_refresh_processor.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 import sys
 import types
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -32,18 +33,33 @@ def _unreached_acquire(_locator: str, _revision: str) -> dict[str, object]:
 
 
 @pytest.fixture(scope="module")
-def linear_mod() -> types.ModuleType:
-    """Load linear.py once per session; stub credbroker to avoid import-time auth."""
+def linear_mod() -> Iterator[types.ModuleType]:
+    """Load linear.py once per module; stub credbroker to avoid import-time auth.
+
+    The stub is removed again on teardown. `types.ModuleType` carries no
+    `__spec__`, and `importlib.util.find_spec` raises `ValueError` rather than
+    returning None for a spec-less entry — so leaving this installed makes any
+    later test in the same process that probes for `credbroker` fail on a
+    module this one invented.
+    """
     credbroker_stub = types.ModuleType("credbroker")
     credbroker_stub.CredentialsMissingError = Exception  # type: ignore[attr-defined]
     credbroker_stub.load_credentials = lambda *a, **kw: None  # type: ignore[attr-defined]
-    sys.modules.setdefault("credbroker", credbroker_stub)
+    # Only uninstall what this fixture installed, and only while it is still
+    # ours: a real credbroker imported meanwhile must survive.
+    stubbed = "credbroker" not in sys.modules
+    if stubbed:
+        sys.modules["credbroker"] = credbroker_stub
 
-    spec = importlib.util.spec_from_file_location("linear_script", LINEAR_SCRIPT)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
-    return mod
+    try:
+        spec = importlib.util.spec_from_file_location("linear_script", LINEAR_SCRIPT)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        yield mod
+    finally:
+        if stubbed and sys.modules.get("credbroker") is credbroker_stub:
+            del sys.modules["credbroker"]
 
 
 @pytest.fixture(scope="module")

--- a/tests/roster/test_roster_module_state_isolation.py
+++ b/tests/roster/test_roster_module_state_isolation.py
@@ -1,0 +1,42 @@
+"""Roster suites must not leave invented modules in `sys.modules`.
+
+A module-scoped fixture that installs a stub under a real distribution's name
+outlives its own file: within one pytest process the entry is still there when
+the next file runs. `types.ModuleType` carries no `__spec__`, and
+`importlib.util.find_spec` raises `ValueError` for a spec-less entry rather than
+returning None — so a later test that merely *asks whether* the real package is
+importable fails on a module it never heard of.
+
+That is how `tests/roster/test_credential_brokers_atlassian_integration.py`
+failed on CI while passing locally: `--dist loadfile` put the Linear file in the
+same worker, ahead of it, and the outcome depended on which worker got which
+file. Ordering decided it, so no single-file run could show it.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# The polluter first, then the prober: the order that fails when the stub is
+# left installed. The reverse order passes either way, which is why it is not
+# the control here.
+LEAK_ORDER = (
+    "tests/roster/test_linear_refresh_processor.py",
+    "tests/roster/test_credential_brokers_atlassian_integration.py",
+)
+
+
+def test_credbroker_stub_does_not_outlive_its_fixture() -> None:
+    """Run the two files in the order that reproduced the CI failure."""
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", *LEAK_ORDER, "-q", "-p", "no:cacheprovider"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert "credbroker.__spec__ is None" not in completed.stdout, completed.stdout[-3000:]
+    assert completed.returncode == 0, completed.stdout[-3000:]

--- a/tools/test_marketplace_envelope_parity.py
+++ b/tools/test_marketplace_envelope_parity.py
@@ -1313,5 +1313,18 @@ def test_resolved_layer_refuses_a_module_from_another_tree(tmp_path: Path) -> No
     """
     root = tmp_path / "no-package-here"
     root.mkdir()  # must exist: it is the child's cwd
-    with pytest.raises(ParityError, match="provenance mismatch"):
+    with pytest.raises(ParityError) as raised:
         resolve_build_main_constants(root)
+    # One required outcome reached by two routes, decided by what is installed
+    # rather than by the layer. Where some install still makes the package
+    # importable -- an editable install on a contributor's machine -- the finder
+    # resolves a sibling tree and the layer reports a provenance mismatch. Where
+    # nothing provides it -- CI, where `-I` strips the PYTHONPATH the suite
+    # otherwise relies on -- the child cannot import it at all and the layer
+    # reports the failed child. Both are the refusal this test exists for, so
+    # matching only the first would pin the contributor's environment.
+    message = str(raised.value)
+    assert (
+        "provenance mismatch" in message
+        or "No module named 'agentbundle'" in message
+    ), message


### PR DESCRIPTION
Two of main's red checks. Both pass locally and fail on runners, for unrelated reasons; neither is a product defect.

## 1. `credbroker.__spec__ is None` — a fixture leaking a stub across files

`tests/roster/test_credential_brokers_atlassian_integration.py` failed with `ValueError: credbroker.__spec__ is None` at line 87. It is not that test's defect.

`test_linear_refresh_processor.py`'s module-scoped `linear_mod` fixture installs a `types.ModuleType("credbroker")` stub so `linear.py` imports without import-time auth, and never removed it. `types.ModuleType` carries no `__spec__`, and `importlib.util.find_spec` **raises `ValueError`** for a spec-less entry rather than returning None — so the next file in the same worker that merely asks whether the real `credbroker` is importable dies on a module this fixture invented.

Ordering decided it, which is why no single-file run showed it. `--dist loadfile` distributes whole files, so it only fires when the Linear file lands in the same worker ahead of the Atlassian one. Measured both ways, same two files, same process:

| Order | Result |
|---|---|
| Linear file, then Atlassian | `1 failed, 20 passed` |
| Atlassian file, then Linear | `21 passed` |

The fixture now removes the stub on teardown — only what it installed, and only while it is still the object it installed, so a real `credbroker` imported meanwhile survives.

**Guard:** `tests/roster/test_roster_module_state_isolation.py` runs the two files in the order that reproduced CI and asserts the run is clean. The reverse order is deliberately *not* the control — it passes either way. Mutation proof: dropping the teardown fails that guard at line 41; restored by editing back, 22 passed after.

Not changed: the sibling `refresh_mod` fixture leaks `work_intake_refresh` the same way, but three roster files register that name from the same source file, so the colliding entry is identical and carries a real spec. Different class, no observable defect.

## 2. `test_resolved_layer_refuses_a_module_from_another_tree` — cherry-picked

Cherry-picked from `cce33c03d` on `eugenelim/distribution-route-registry` with `-x`, authorship preserved. I verified the mechanism independently rather than relaying it:

- `tools/test_marketplace_envelope_parity.py` is byte-identical to main before the fix, so the failure is not introduced by any branch.
- The test passes on this machine and fails on runners. Cause confirmed here: `python3 -I -c "import importlib.util; importlib.util.find_spec('agentbundle')"` **resolves**, from a stale `~/.pyenv/.../site-packages/agentbundle`. `-I` strips the suite's PYTHONPATH but not site-packages, so the finder returns a sibling tree and the provenance branch fires. On a runner nothing provides the package, the child exits `ModuleNotFoundError`, and the layer refuses through its failed-child branch instead.

Both branches are the refusal the test exists for, so it now accepts either while still rejecting an unrelated `ParityError` and a normal return. Worth noting as a residual: which branch runs is decided by the environment, not the layer. A deterministic version would need an interpreter seam so both cases could be exercised on purpose.

That stale site-packages install is itself the hazard `AGENTS.local.md` warns about — "Never install this repo's own packages … a global install can silently shadow the tree."

## 3. The same fixture in `packs/linear/` — latent, fixed here

`packs/linear/tests/skills/linear/test_linear_primitive.py` carries a byte-identical copy of the roster fixture: same spec-less stub, same missing teardown. It is latent, not red — the Makefile gives that pack its own invocation and nothing inside it probes for `credbroker` today. That isolation is incidental, and a declared pack-test compatibility class putting this file in one process with a prober would reproduce the defect immediately, pointing again at the innocent file.

Fixed rather than registered: the repair is the same four lines already written next door, so a backlog entry would cost more to carry than to close.

**Measured, correcting an earlier note of mine:** only this one other file has the defect. The other four that build a `credbroker` stub all use `monkeypatch` and revert automatically — `monkeypatch.setitem(sys.modules, ...)` in `jira/test_setup_sso.py`, `confluence-crawler/test_setup_sso.py` and `jira/test_check_sso_login.py`, and `monkeypatch.setattr(importlib, "import_module", ...)` in `confluence-crawler/test_check_sso_login.py`. Those were already correct.

`packs/linear/tests/skills/{linear,linear-brief-intake}` — 32 passed, the Makefile's own invocation for this class.

## Verification

- `tests/roster/{module_state_isolation,linear_refresh_processor,credential_brokers_atlassian_integration}` — 22 passed
- `tools/test_marketplace_envelope_parity.py` — 60 passed
- `ruff` clean on every touched file

## Not in scope

- The intermittent `FileNotFoundError: 'maintenance.lock'` teardown race in `shutil.rmtree` — main's other roster failure. Owned by the run-22 session.
- The Make recursion-notice digest drift — already open as #1246.

These three environment-pinned assertions surfaced one after another because `make test` halts at the first failing invocation, so each was shadowing the next. A green `test-corpus` is the first real signal that the tail runs at all.
