### PR TITLE
fix(tests): stop Git auto-maintenance racing the no-git fixture teardown

### DIFF
--- a/tests/roster/test_thirty_day_cooling_and_retirement.py
+++ b/tests/roster/test_thirty_day_cooling_and_retirement.py
@@ -761,6 +761,13 @@ def _build_repository(tmp_path: Path, topology: str):
     origin = tmp_path / "origin"
     origin.mkdir()
     _git(origin, "init")
+    # Committing below makes Git spawn background auto-maintenance, which
+    # creates and then removes .git/maintenance.lock. The "no-git" topology
+    # deletes .git with shutil.rmtree, so that concurrent removal lands
+    # between rmtree's scandir and its unlink and raises FileNotFoundError on
+    # the lock. This fixture never needs maintenance, so switch it off.
+    _git(origin, "config", "gc.auto", "0")
+    _git(origin, "config", "maintenance.auto", "false")
     base = _git(origin, "branch", "--show-current").stdout.strip()
     artifact = origin / "docs/specs/example/spec.md"
     artifact.parent.mkdir(parents=True)

--- a/tools/test_local_ci_shared_test_deduplication.py
+++ b/tools/test_local_ci_shared_test_deduplication.py
@@ -1964,6 +1964,19 @@ def _plan_digest(plan: list[str]) -> str:
     return hashlib.sha256(("\n".join(plan) + "\n").encode()).hexdigest()
 
 
+def _drift_diagnostic(label: str, plan: list[str]) -> list[str]:
+    """Report the computed digest and plan so a drift names its own cause.
+
+    A bare "drift" verdict cannot be acted on from a CI log, where the plan is
+    not reproducible by hand: the reader needs the digest to re-pin and the
+    lines to diff against the approved baseline.
+    """
+    return [
+        f"{label} computed digest: {_plan_digest(plan)}",
+        *(f"{label} plan[{index}]: {line}" for index, line in enumerate(plan)),
+    ]
+
+
 def _effective_composition_errors(makefile_text: str | None = None) -> list[str]:
     """Return drift in GNU Make's effective standalone and composed commands."""
     errors: list[str] = []
@@ -2023,11 +2036,10 @@ def _effective_composition_errors(makefile_text: str | None = None) -> list[str]
         errors.append("standalone construction coverage drift")
     if composed.stdout.count(CONSTRUCTION_TEST_PATH) != 1:
         errors.append("composed construction coverage drift")
-    if (
-        _plan_digest(_without_construction_addition(standalone_full_plan))
-        != APPROVED_STANDALONE_PLAN_DIGEST
-    ):
+    standalone_baseline = _without_construction_addition(standalone_full_plan)
+    if _plan_digest(standalone_baseline) != APPROVED_STANDALONE_PLAN_DIGEST:
         errors.append("approved standalone command plan drift")
+        errors.extend(_drift_diagnostic("standalone", standalone_baseline))
 
     standalone_plan: list[str] = []
     workspace_command_count = 0
@@ -2046,11 +2058,10 @@ def _effective_composition_errors(makefile_text: str | None = None) -> list[str]
             line = line.replace(f" --ignore={path}", "")
         composed_plan.append(" ".join(line.split()))
 
-    if (
-        _plan_digest(_without_construction_addition(composed_plan))
-        != APPROVED_COMPOSED_PLAN_DIGEST
-    ):
+    composed_baseline = _without_construction_addition(composed_plan)
+    if _plan_digest(composed_baseline) != APPROVED_COMPOSED_PLAN_DIGEST:
         errors.append("approved composed command plan drift")
+        errors.extend(_drift_diagnostic("composed", composed_baseline))
 
     if workspace_command_count != 1 or standalone_plan != composed_plan:
         errors.append("effective non-shared command plan drift")


### PR DESCRIPTION
Clears one of the two remaining roster failures on main.

**Authored by the `distribution-route-registry` session** — a clean `git cherry-pick -x` of `81cc1ebfe`, landed standalone by agreement because that session's own PR (#1242, 51 files) is far from merging. It will drop the commit on its next merge from main.

## The race

`test_identity_survives_five_history_shapes[no-git]` deletes `.git` with `shutil.rmtree`. Committing in the fixture makes Git spawn background auto-maintenance, which creates and then removes `.git/maintenance.lock`. That removal lands between `rmtree`'s `scandir` and its `unlink`, so the walk raises `FileNotFoundError: 'maintenance.lock'`.

Intermittent, and it is a **teardown crash rather than an assertion failure** — which is exactly why it was easy to mistake for noise. I saw it on my own branch earlier and settled for a re-run; that was the weaker response.

## Why this is a fix and not a mask

Setting `gc.auto=0` and `maintenance.auto=false` on the fixture repo removes the only concurrent writer. **Verified here rather than relayed** — a `GIT_TRACE2_EVENT` probe on two throwaway repos:

| repo | maintenance invocations on commit |
|---|---|
| default | **5** |
| `gc.auto=0` + `maintenance.auto=false` | **0** |

That matters more than a green test run: this failure is intermittent, so passing proves little on its own. The trace shows the writer is gone, not merely unlucky.

## Second half of the commit

`81cc1ebfe` also makes a plan-digest drift name its own cause. The guard previously reported a bare `"...drift"`, which cannot be acted on from a CI log where the plan is not reproducible by hand; it now also reports the computed digest and the plan lines.

I checked this does not weaken the guard: both `errors.append("approved standalone command plan drift")` and the composed equivalent are **retained**, with the diagnostic appended alongside, so the existing membership assertions — which test `in` — still hold. This is also the instrument that found #1246's root cause in the first place, by printing `composed plan[62]: make[2]: Leaving directory '/home/runner/...'`.

## Gates

| Gate | Result |
|---|---|
| `tests/roster/test_thirty_day_cooling_and_retirement.py` | ✅ 253 passed |
| `tools/test_local_ci_shared_test_deduplication.py` | ✅ 27 passed |
| `make lint-ruff` | ✅ clean |

`test-roster` dispatched on this ref.

## Context

This is the fourth environment-dependent failure in a chain that `make`'s halt-on-first-failure had been concealing: the depth-1 clone (#1245), Make's recursion notices (#1246), the `credbroker` `sys.modules` stub and the `-I` child import (#1247, other session), and this race.
