### PR TITLE
fix(tools): two CI/release-gate runnability chores

### DIFF
--- a/tools/audit-npm.py
+++ b/tools/audit-npm.py
@@ -124,6 +124,10 @@ class AuditError(Exception):
     """The gate could not run. Always exit 2 — never a pass, never a finding."""
 
 
+class AuditTimeoutError(AuditError):
+    """A transient npm registry timeout prevented the audit."""
+
+
 @dataclass(frozen=True)
 class Finding:
     advisory_id: str
@@ -261,6 +265,16 @@ def _require_report(report: object) -> dict:
                 or raw.get("code")
                 or report.get("message")
                 or raw
+            )
+        # The recorded reproduction printed npm's `network timeout at:` warning
+        # for the bulk-advisory endpoint. Assumption: its unmeasured JSON error
+        # payload carries that phrase too; the stall did not reproduce this run.
+        if any(
+            "network timeout at:" in str(value).casefold()
+            for value in (detail, report.get("message"))
+        ):
+            raise AuditTimeoutError(
+                f"npm audit registry timeout instead of a report: {detail}"
             )
         raise AuditError(
             f"npm audit reported an error instead of a report: "

--- a/tools/check-artifact-contents.py
+++ b/tools/check-artifact-contents.py
@@ -73,6 +73,7 @@ _EXPECTED_SKIP_REASONS = tuple(
         r"^Windows-only$",
         r"^hardcoded POSIX /tmp path$",
         r"^no seed primitives in core fixture; skip$",
+        r"^case-insensitive filesystem cannot hold both spellings$",
         # The only load-conditional entry, and deliberately the narrowest
         # pattern here: every number is required, so it admits this one
         # message shape and nothing else. Registered because

--- a/tools/test-audit-npm.py
+++ b/tools/test-audit-npm.py
@@ -124,6 +124,20 @@ CHAINED = _report(
 
 ERROR_PAYLOAD = {"error": {"code": "ENETUNREACH", "summary": "request to registry failed"}}
 
+TIMEOUT_PAYLOAD = {
+    # Assumed JSON form: the recorded reproduction captured this phrase only in
+    # npm's warn line, and the stall did not reproduce to capture its payload.
+    "message": "network timeout at: https://registry.npmjs.org/-/npm/v1/"
+    "security/advisories/bulk",
+    "error": {"summary": "", "detail": ""},
+}
+
+TIMEOUT_CODE_PAYLOAD = {
+    "message": "network timeout at: https://registry.npmjs.org/-/npm/v1/"
+    "security/advisories/bulk",
+    "error": {"summary": "", "detail": "", "code": "ETIMEDOUT"},
+}
+
 NO_VERSION = {"vulnerabilities": {}, "metadata": {}}
 
 # A shape npm does not emit: blocking severity with no advisories to explain it.
@@ -275,6 +289,60 @@ def main() -> int:
     print("evaluate() — fail-closed (spec AC1a)")
     expect_error("error_payload_is_tool_error", lambda: m.evaluate(ERROR_PAYLOAD, {}))
     expect_error("missing_report_version_is_tool_error", lambda: m.evaluate(NO_VERSION, {}))
+
+    print("evaluate() — assumed registry timeout payload")
+    try:
+        m.evaluate(TIMEOUT_PAYLOAD, {})
+        check("registry_timeout_has_a_distinct_error", False, "no AuditError raised")
+    except m.AuditError as exc:
+        check(
+            "registry_timeout_has_a_distinct_error",
+            type(exc).__name__ == "AuditTimeoutError",
+            f"raised {type(exc).__name__}: {exc}",
+        )
+
+    try:
+        m.evaluate(TIMEOUT_CODE_PAYLOAD, {})
+        check("code_timeout_has_a_distinct_error", False, "no AuditError raised")
+    except m.AuditError as exc:
+        check(
+            "code_timeout_has_a_distinct_error",
+            type(exc).__name__ == "AuditTimeoutError",
+            f"raised {type(exc).__name__}: {exc}",
+        )
+
+    print("main() — timeout in the lockfile loop")
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        _write_allowlist(root)
+        (root / "web").mkdir()
+        (root / "web" / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        def _live_probe() -> None:
+            return None
+
+        def _timeout_audit(_project_dir):
+            return TIMEOUT_PAYLOAD
+
+        original_probe, original_audit = m.run_canary_probe, m.run_audit_with_retry
+        stderr = io.StringIO()
+        try:
+            m.run_canary_probe = _live_probe
+            m.run_audit_with_retry = _timeout_audit
+            with contextlib.redirect_stderr(stderr):
+                exit_code = m.main(["--root", str(root)])
+        finally:
+            m.run_canary_probe, m.run_audit_with_retry = original_probe, original_audit
+        check(
+            "loop_registry_timeout_exit_is_2",
+            exit_code == 2,
+            f"exit_code={exit_code}; stderr={stderr.getvalue()}",
+        )
+        check(
+            "loop_registry_timeout_names_the_network_timeout",
+            "network timeout at:" in stderr.getvalue(),
+            stderr.getvalue(),
+        )
 
     print("_require_report() — name the cause npm actually supplied")
     MEASURED = {

--- a/tools/test_check_artifact_contents.py
+++ b/tools/test_check_artifact_contents.py
@@ -333,6 +333,7 @@ def test_sdist_skip_integrity_refuses_unrecognised_reasons(reason):
         "Windows-only",
         "hardcoded POSIX /tmp path",
         "no seed primitives in core fixture; skip",
+        "case-insensitive filesystem cannot hold both spellings",
         # Observed verbatim on a loaded macOS host, 2026-09-01.
         "wall-clock not asserted: load/core 2.8 exceeds 2.0. CPU (2.58s) "
         "and memory (27.4 MiB) were asserted unconditionally.",


### PR DESCRIPTION
Two independent `tools/` chores from `workspace.toml` `[backlog].open` (room `build`, source `pre-flight/2026-09-03`). Bounded direct-mode repair — no spec, plan, or queue entry, and none required.

## 1. The sdist release gate was unrunnable on macOS

`_EXPECTED_SKIP_REASONS` in `tools/check-artifact-contents.py` did not admit `case-insensitive filesystem cannot hold both spellings`, so a *correct* platform skip read as a forbidden one and `test_real_sdist_carries_and_executes_complete_engine_suite` failed on any case-insensitive filesystem.

Fixed with one anchored pattern, as narrow as its neighbours. The fixture is untouched — it lives under the protected `packages/agentbundle/**` tree, which would need an `Engine-Change-RFC:` trailer this chore does not carry.

## 2. A transient npm registry stall read as a SAST gate failure

`tools/audit-npm.py` raised one undifferentiated `AuditError` for every npm error payload. A timeout now raises `AuditTimeoutError` with its own message.

**Exit codes are unchanged.** Every `AuditError` subclass still exits 2, advisory findings remain the only route to 1, and `make sast` still fails on a timeout. This buys diagnosability, not leniency. An earlier draft added an exit code 3; no caller consumed it (`Makefile:397-398` and `tools/test-all.py:108` are the only callers, and neither branches on the value), so it was cut.

The predicate matches only npm's `network timeout at:` phrasing and checks both the resolved detail and the sibling `message` — a non-empty `error.code` such as `ETIMEDOUT` otherwise wins the first-non-empty chain and hides the message naming the timeout. `connect ECONNREFUSED` and `ENETUNREACH` stay generic and serve as negative controls.

### Recorded assumption

The stall did not reproduce this session — `npm audit --json` in `web/` returned a clean report at exit 0 — so the timeout **JSON payload shape is unmeasured**. The only recorded evidence is npm's stderr warn line, `npm warn audit network timeout at: <bulk URL>`. Both the code comment and the test fixture say so explicitly. Worst case if the assumption is wrong: the timeout is reported as a generic audit error, exactly as it is today.

## Gates (all run locally)

| Gate | Result |
|---|---|
| `python3 -m pytest -q tools/test_check_artifact_contents.py` | 82 passed (555s) |
| `python3 tools/test-audit-npm.py` | exit 0, 0 failures |
| `make sast` | exit 0 (pip-audit, npm SCA, semgrep --strict, 8/8 argv-boundary self-test) |
| `make lint-ruff` | exit 0 |
| `python3 tools/audit-npm.py --root .` | exit 0, 2 lockfiles clean |

## Mutation proofs (each run, each kills, each restored by editing back)

| Invariant | Mutation | Observed failure |
|---|---|---|
| The sdist reason is explicitly governed | delete the new regex from `_EXPECTED_SKIP_REASONS` | `ArtifactViolation: sdist suite used skips outside the explicit expected policy` — 1 failed, 38 passed |
| Only the recorded phrasing classifies as a timeout | `if "network timeout at:" ...` → `if False:` | `✖ registry_timeout_has_a_distinct_error` |
| The sibling `message` is consulted | `for value in (detail, report.get("message"))` → `for value in (detail,)` | `✖ code_timeout_has_a_distinct_error: raised AuditError: ... ETIMEDOUT` (all-empty case still passes — distinct coverage) |
| The loop path stays fail-closed at 2 | `audit-npm.py:572` `return 2` → `return 1` | `✖ loop_registry_timeout_exit_is_2` |

The sdist test's expected-reason list is an independent literal in the test file, not a mirror of the allowlist — mutation 1 confirms it.

## Review

Independent adversarial review by a session that did not write the code and was told not to edit. Two rounds: four supervisor findings (over-broad predicate, uncovered loop path, unstated reachability, unconsumed exit code) then one sustained reviewer finding (sibling `message` ignored when `error.code` is set). All repaired; the reviewer's evidence line records what it ruled out, including that no path downgrades a real audit failure.