### PR TITLE
ci: stop a third-party apt outage from redding a required gate

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -157,7 +157,16 @@ jobs:
         # gate-sast, and the scan would silently run twice.
         run: make build-check PACKS_DIR=packs SAST_DELEGATED=1
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        # A third-party Google index outage can otherwise red this required gate,
+        # even though ripgrep comes from Ubuntu. Remove this once runner images
+        # stop adding Google's unused Chrome source.
+        run: |
+          for source in /etc/apt/sources.list.d/*; do
+            if [ -f "$source" ] && grep -q 'dl.google.com' "$source"; then
+              sudo rm -- "$source"
+            fi
+          done
+          sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Install ruff + mypy
         run: pip install ruff mypy
       - name: ruff lint (style, imports, common bugs)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -105,7 +105,16 @@ jobs:
       # cached because the apt layer cannot be; the download itself could be, and
       # is not worth a cache key yet.
       - name: Install Playwright Chromium
-        run: npx --prefix web playwright install --with-deps chromium
+        # A third-party Google index outage can otherwise red this step, though
+        # Playwright downloads its own Chromium and uses nothing from that source.
+        # Remove this once runner images stop adding Google's unused Chrome source.
+        run: |
+          for source in /etc/apt/sources.list.d/*; do
+            if [ -f "$source" ] && grep -q 'dl.google.com' "$source"; then
+              sudo rm -- "$source"
+            fi
+          done
+          npx --prefix web playwright install --with-deps chromium
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0


### PR DESCRIPTION
**Unblocks all merges.** `gate-main` is a required check and is currently failing repo-wide for a reason no diff caused.

## What broke

Google's apt repository is serving a corrupt index. GitHub's `ubuntu-latest` image ships `dl.google.com/linux/chrome-stable` in its sources list, so every step calling `apt-get update` dies:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
##[error]Process completed with exit code 100.
```

Evidence it is environmental:

- `build-check` **succeeded** on `main` at 2026-09-09T13:04Z and on `eugenelim/sdlc-learning-paths` at 12:48Z.
- Every run created after ~17:38Z **failed** at the same step — including one whose only change is comment lines in `workspace.toml`.
- Three reruns of the same job over ~20 minutes reproduced it identically.

Two steps are hit: `build-check.yml`'s `Install ripgrep` (in `gate-main`, required) and `pages.yml`'s `Install Playwright Chromium` (`--with-deps` shells out to apt; not required, red for the same reason).

## The fix

Neither step consumes that repository. `ripgrep` comes from the Ubuntu archive; Playwright downloads its own Chromium from Microsoft's CDN and `--with-deps` only pulls system libraries. Both steps now drop any source file naming `dl.google.com` before their apt-using command.

**Fail-closed by construction** — no `|| true`, no `continue-on-error`. Under `bash -e`:

| Failure | Still fails the step? |
|---|---|
| `apt-get update` fails | yes — short-circuits its `&&` list |
| `apt-get install` fails | yes — final command |
| `sudo rm` fails | yes |
| `grep` matches nothing | no removal, install proceeds — it is an `if` condition, so `set -e` does not fire |
| sources dir empty or absent | glob stays literal, `[ -f ]` is false, install proceeds unchanged |

That last row is also the afterlife: once the runner image stops shipping the source, each guard becomes a silent no-op rather than a new failure. The comments state the removal condition.

## Verification

| Check | Result |
|---|---|
| `tools/test-build-check-workflow.py` | exit 0 |
| `tools/test-pages-workflow.py` | exit 0 |
| `tools/test-lint-ci-parity.py` | exit 0 |
| `tools/lint-ci-parity.py` | exit 0 |
| `tools/check-zizmor-excessive-permissions.py` | exit 0 |
| `actionlint` on both files | exit 0 |
| `zizmor --min-severity high .github/workflows/` (CI's exact invocation, `ci-security.yml:121`) | exit 0, no findings |

No mutation proof applies — nothing local can model whether a hosted runner consults Google's live apt index. The regression signal is the `build-check` run on this PR itself.

## Review

Independent adversarial review by a session that did not write the change and was told not to edit: **clean**, with an evidence line per check. It independently walked every `set -e` failure mode, confirmed `rg -n -i 'apt-get|\bapt\b' .github/workflows` finds no third exposed step, and confirmed no later step in either job needs a removed source.