### PR TITLE
feat(core): document the intents artifact class and keep admission from overwriting a framed intent

### DIFF
--- a/.agents/skills/intake-intent/SKILL.md
+++ b/.agents/skills/intake-intent/SKILL.md
@@ -45,7 +45,8 @@ Higher-priority instructions, repository and scoped security or privacy rules, t
 
 Write only the minimum needed for repository admission:
 
-- `Status` (`Draft` on creation);
+- `Status` — `Draft` on creation, and `Draft` when an update finds the field
+  absent; never re-level a status the artifact already carries;
 - outcome;
 - boundary;
 - owner;
@@ -59,7 +60,11 @@ product altitude to make the template look complete.
 
 When a repository intent already exists, update that artifact in place. Its
 path is its identity; do not create a renamed copy merely to match this pack's
-default `docs/product/intents/<slug>.md` convention.
+default `docs/product/intents/<slug>.md` convention. Minimization governs
+creation only. On an update, apply the missing required fields with `Edit` and
+keep every field already present, carrying an existing `Level` through rather
+than re-deriving it; the renderer emits a whole document and never replaces an
+existing intent.
 
 ### Source admission
 
@@ -98,10 +103,12 @@ destination, not permission to write or register it.
 3. Preserve an existing repository path; otherwise confirm the proposed
    repository-relative destination.
 4. Minimize source provenance without dereferencing it. Stop on a refusal.
-5. Render the required fields and only the optional fields supported by the
-   source.
-6. Write the confined artifact, then let the calling intake workflow register
-   one non-dispatchable pointer when registration was requested.
+5. For a new artifact, render the required fields and only the optional fields
+   supported by the source. For an existing one, do not render: apply the
+   missing required fields to that artifact with `Edit`.
+6. Write the confined artifact — the rendered new file, or the in-place edit —
+   then let the calling intake workflow register one non-dispatchable pointer
+   when registration was requested.
 7. Run the shaping-review gate below before an intent can become `Accepted`.
 8. Stop with the intent path, authority mode, changed state, verification, and
    remaining unresolved questions. Do not begin delivery work.

--- a/.agents/skills/intake-intent/evals/evals.json
+++ b/.agents/skills/intake-intent/evals/evals.json
@@ -62,6 +62,17 @@
         "Withholds Clean",
         "Does not let the caller treat the result as approval-ready"
       ]
+    },
+    {
+      "id": "update-accretes-onto-an-already-framed-intent",
+      "prompt": "Admit docs/product/intents/retention-controls.md, which an upstream shaping pass already framed with Level: feature, Scale: app, an outcome, an opportunity, and assumptions. It has no Status, boundary, owner, unresolved questions, projection, or source.",
+      "expected_output": "Edit that artifact in place, adding only the missing required fields and Status: Draft, and preserve every field it already carries.",
+      "assertions": [
+        "Edits the existing artifact in place rather than rendering a replacement",
+        "Adds Status: Draft, boundary, owner, unresolved questions, projection, and source",
+        "Preserves the existing Level, Scale, outcome, opportunity, and assumptions",
+        "Does not re-level the intent or restate its framing"
+      ]
     }
   ]
 }

--- a/.claude/skills/intake-intent/SKILL.md
+++ b/.claude/skills/intake-intent/SKILL.md
@@ -45,7 +45,8 @@ Higher-priority instructions, repository and scoped security or privacy rules, t
 
 Write only the minimum needed for repository admission:
 
-- `Status` (`Draft` on creation);
+- `Status` — `Draft` on creation, and `Draft` when an update finds the field
+  absent; never re-level a status the artifact already carries;
 - outcome;
 - boundary;
 - owner;
@@ -59,7 +60,11 @@ product altitude to make the template look complete.
 
 When a repository intent already exists, update that artifact in place. Its
 path is its identity; do not create a renamed copy merely to match this pack's
-default `docs/product/intents/<slug>.md` convention.
+default `docs/product/intents/<slug>.md` convention. Minimization governs
+creation only. On an update, apply the missing required fields with `Edit` and
+keep every field already present, carrying an existing `Level` through rather
+than re-deriving it; the renderer emits a whole document and never replaces an
+existing intent.
 
 ### Source admission
 
@@ -98,10 +103,12 @@ destination, not permission to write or register it.
 3. Preserve an existing repository path; otherwise confirm the proposed
    repository-relative destination.
 4. Minimize source provenance without dereferencing it. Stop on a refusal.
-5. Render the required fields and only the optional fields supported by the
-   source.
-6. Write the confined artifact, then let the calling intake workflow register
-   one non-dispatchable pointer when registration was requested.
+5. For a new artifact, render the required fields and only the optional fields
+   supported by the source. For an existing one, do not render: apply the
+   missing required fields to that artifact with `Edit`.
+6. Write the confined artifact — the rendered new file, or the in-place edit —
+   then let the calling intake workflow register one non-dispatchable pointer
+   when registration was requested.
 7. Run the shaping-review gate below before an intent can become `Accepted`.
 8. Stop with the intent path, authority mode, changed state, verification, and
    remaining unresolved questions. Do not begin delivery work.

--- a/.claude/skills/intake-intent/evals/evals.json
+++ b/.claude/skills/intake-intent/evals/evals.json
@@ -62,6 +62,17 @@
         "Withholds Clean",
         "Does not let the caller treat the result as approval-ready"
       ]
+    },
+    {
+      "id": "update-accretes-onto-an-already-framed-intent",
+      "prompt": "Admit docs/product/intents/retention-controls.md, which an upstream shaping pass already framed with Level: feature, Scale: app, an outcome, an opportunity, and assumptions. It has no Status, boundary, owner, unresolved questions, projection, or source.",
+      "expected_output": "Edit that artifact in place, adding only the missing required fields and Status: Draft, and preserve every field it already carries.",
+      "assertions": [
+        "Edits the existing artifact in place rather than rendering a replacement",
+        "Adds Status: Draft, boundary, owner, unresolved questions, projection, and source",
+        "Preserves the existing Level, Scale, outcome, opportunity, and assumptions",
+        "Does not re-level the intent or restate its framing"
+      ]
     }
   ]
 }

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -720,6 +720,20 @@ right now?"
   nested inside it. A published package also keeps its own `CHANGELOG.md`
   beside its source — `packages/<name>/CHANGELOG.md` in this layout — for
   readers who get the package and not the repository.
+- `intents/<slug>.md` (optional) — one admitted outcome, recorded before a
+  solution artifact is chosen. Two axes. **Altitude** is `Level:`, an open set
+  running `product-vision › product-strategy › capability › feature`: only a
+  feature intent becomes a spec directly (recorded in that spec's `Discovery:`
+  header), a higher one decomposes into child intents first, and `Level` is
+  absent until the altitude is settled. **Stage** is which fields it carries —
+  *framed* states the bet (outcome, opportunity, assumptions); *admitted* adds
+  what routing needs (status, boundary, owner, unresolved questions,
+  projection, source); *ratified* reaches `Status: Accepted` after independent
+  shaping review and human confirmation. Admission adds fields: it never
+  re-levels the intent or rewrites its framing. Distinct from work-loop's
+  *accepted intent*, the agreed scope of a change
+  ([§ Intent-scoped completion](#intent-scoped-completion)). Authored by
+  `intake-intent`, or by `frame-intent` from the product-engineering pack.
 - `briefs/<slug>.md` (optional) — a multi-feature delivery brief and its
   auto-rolled-up coverage map. Created or continued by the
   `author-delivery-brief` skill; one file per brief. See the delivery-brief altitude under
@@ -1042,10 +1056,10 @@ kind of learning belongs.
 
 ### Intent-scoped completion
 
-Completion answers to the original accepted intent, not to the current pull
-request. A pull request is a review unit: one accepted intent may need more
-than one independently reviewed unit in the same session. Only the owner may
-narrow or waive that intent.
+Completion answers to the original accepted intent — the agreed scope of this
+change — not to the current pull request. A pull request is a review unit: one
+accepted intent may need more than one independently reviewed unit in the same
+session. Only the owner may narrow or waive that intent.
 
 For every implementation or review discovery, determine intent fit before the
 session decision:

--- a/docs/product/AGENTS.md
+++ b/docs/product/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md — `docs/product/`
+
+Applies to `docs/product/`. Inherits the root `AGENTS.md`. Scope-specific deltas only.
+
+## Regenerate `/now/` with the changelog change
+
+The public `/now/` page is projected from the `### Highlights` blocks of
+released sections in `changelog.md`. When you add or edit one, regenerate the
+projection in the same change and commit both files:
+
+```bash
+python3 tools/build-site.py --journeys-only   # writes web/src/lib/now-highlights.generated.json
+python3 -m pytest tools/test_build_site_routing.py -k now -q
+```
+
+A changelog edit committed without the regenerated JSON fails
+`test_the_committed_now_projection_matches_the_changelog_source` with
+``web/src/lib/now-highlights.generated.json is stale — run `python3
+tools/build-site.py --journeys-only` ``.
+
+`changelog.md`'s own header owns how to write a highlight and which releases
+owe one; [`packs/AGENTS.local.md`](../../packs/AGENTS.local.md) owns the pack
+release pipeline that records that decision.

--- a/docs/product/CLAUDE.md
+++ b/docs/product/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -7,17 +7,35 @@
 
 ## What lives here
 
-- [`roadmap.md`](roadmap.md) — direction for the next 2-4 quarters.
-  Direction, not commitments. Updated quarterly.
-- [`changelog.md`](changelog.md) — user-visible changes by release,
-  in [Keep a Changelog](https://keepachangelog.com/) format. Updated
-  every PR that changes user-visible behavior.
-- [`personas.md`](personas.md) — who we're building for. Optional;
-  add only if it's actively used to make decisions.
-- [`release-checklist.md`](release-checklist.md) — manual-QA rows
-  CI cannot exercise. Copy each spec's section into the release PR
-  description before tagging. Optional; add the file the first time a
-  spec needs out-of-band verification.
+### Governed by the conventions
+
+[`../CONVENTIONS.md` § 5b](../CONVENTIONS.md#5b-docsproduct--for-maintainers)
+is the one source for what these hold and how they are maintained. Read it
+there, not here:
+
+[`roadmap.md`](roadmap.md) · [`changelog.md`](changelog.md) ·
+[`intents/`](intents/) · [`briefs/`](briefs/) · [`shaping/`](shaping/) ·
+[`findings/`](findings/) · [`initiatives/`](initiatives/) ·
+[`research/`](research/)
+
+One local delta: a released `changelog.md` highlight also needs the `/now/`
+projection regenerated in the same change — see [`AGENTS.md`](AGENTS.md).
+
+### Local to this repository
+
+§ 5b does not cover these; they are described and governed here.
+
+- [`release-checklist.md`](release-checklist.md) — manual-QA rows CI cannot
+  exercise. Copy each spec's section into the release PR description before
+  tagging. Add the file the first time a spec needs out-of-band verification.
+- [`journeys/`](journeys/) — role journeys: what each audience does end to end.
+- [`design/`](design/) — experience and lifecycle design records for surfaces
+  that are decided but not yet specced.
+- [`voice/`](voice/) — the product's voice and register.
+- [`ini-003-phase0-reconciliation.md`](ini-003-phase0-reconciliation.md) — a
+  one-off parity audit retained as evidence.
+- [`workspace-toml-deps.md`](workspace-toml-deps.md) — the `workspace.toml`
+  inline dependency notation.
 
 ## What does NOT live here
 
@@ -25,7 +43,8 @@
 - **What we're proposing to change** → [`../rfc/`](../rfc/) (governance).
 - **What an individual feature does** → [`../specs/<feature>/spec.md`](../specs/).
 - **The mission and scope of the project** → [`../CHARTER.md`](../CHARTER.md).
-- **How users actually use the product** → [`../guides/`](../guides/) (Diátaxis-organized user docs).
+- **How users actually use the product** → [`../../guides/`](../../guides/)
+  (Diátaxis-organized user docs).
 
 ## The product/ layer is *living*
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -54,6 +54,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- The block-scalar and CAT-L027 entries that sat here are published under [agentbundle][0.41.0] and [core][2.16.3] below; one canonical location per change. -->
 
+## [core][2.25.10] — 2026-09-10
+
+### Highlights
+
+- **The directory your intents land in is now described in the conventions you
+  install with them.** `CONVENTIONS.md` reads an intent on two axes: the
+  altitude it sits at, and how far it has travelled from a framed bet to a
+  ratified outcome. Only a feature-level intent becomes a spec directly.
+- **Admitting an intent that was already shaped upstream adds to it instead of
+  overwriting it.** The outcome, altitude and assumptions you framed survive
+  the handoff into repository work.
+
+### Added
+
+- `CONVENTIONS.md` § 5b documents `docs/product/intents/`. **Altitude** is the
+  `Level:` field, an open set running
+  `product-vision › product-strategy › capability › feature`: a feature intent
+  becomes a spec directly and that spec names it in its `Discovery:` header, a
+  higher altitude decomposes into child intents first, and `Level` stays absent
+  until the altitude is settled. **Stage** is which fields the artifact
+  carries — framed states the bet, admitted adds status, boundary, owner,
+  unresolved questions, projection and source, and ratified reaches
+  `Status: Accepted` after an independent shaping review and human
+  confirmation.
+
+### Changed
+
+- `intake-intent` now scopes its minimization rule to creation. Updating an
+  existing intent applies the missing required fields in place and keeps every
+  field already present, including an altitude an upstream shaping pass
+  stamped; the renderer's whole-document output never replaces an existing
+  intent. Previously the creation contract — write only the minimum, omit what
+  the source does not establish — read as licence to re-render over a framed
+  intent, dropping its opportunity, assumptions and altitude.
+- `CONVENTIONS.md` § Intent-scoped completion names which sense of "intent" it
+  governs: the agreed scope of a change, not the artifact class above.
+
 ## [core][2.25.9] — 2026-09-09
 
 ### Highlights

--- a/guides/core/how-to/start-or-remember-work.md
+++ b/guides/core/how-to/start-or-remember-work.md
@@ -66,8 +66,8 @@ The agent creates a Draft artifact, registers non-dispatchable membership, and
 stops. A future `workspace-status` call can surface it, but `work-loop` cannot
 execute it until the required artifact and approvals exist.
 
-For intent-only capture, `intake-intent` records the outcome, boundary, owner,
-unresolved questions, projection, and source. Product altitude, opportunity,
+For intent-only capture, `intake-intent` records the status, outcome, boundary,
+owner, unresolved questions, projection, and source. Product altitude, opportunity,
 assumptions, scale, and JTBD context are optional. Before it can become
 `Accepted`, the owner sends the intent and one attributed evidence packet to an
 independent cold shaping review. Findings return to the owner for revision; a

--- a/guides/core/reference/workspace-toml-schema.md
+++ b/guides/core/reference/workspace-toml-schema.md
@@ -379,14 +379,19 @@ finding identifier as a path only after confirming it is one.
 
 ## Minimal Intent
 
-The shared intent artifact contains:
+The repository intent artifact requires:
 
 - `Status`
-- `Level`
 - `Outcome`
-- `Opportunity`
-- `Assumptions`
-- `Source`
+- `Boundary`
+- `Owner`
+- `Unresolved questions`
+- `Projection`
+- `Source` — the source data the authority mode requires
+
+`Level`, `Opportunity`, `Assumptions`, `Scale`, and job-to-be-done context are
+optional enrichment. An upstream shaping pass supplies them; admission
+preserves what is already there rather than re-deriving it.
 
 The default path is `docs/product/intents/<slug>.md`. A repository may relocate
 the parent through its configured core layout, but the resolved output must stay

--- a/guides/product-engineering/how-to/hand-an-intent-to-build.md
+++ b/guides/product-engineering/how-to/hand-an-intent-to-build.md
@@ -32,6 +32,12 @@ If the work only needs minimum repository admission before a solution artifact
 is selected, Core uses `intake-intent`. That route creates or updates the
 repository intent and stops after admission; it does not begin delivery work.
 
+When your shaped intent already sits at the destination path, admission
+**accretes**: Core adds the fields routing needs — status, boundary, owner,
+unresolved questions, projection, and source — to that artifact in place, and
+keeps the framing you wrote, including its altitude. It does not re-render the
+file or restate your outcome.
+
 The handoff supplies bounded context and provenance. It does not approve an
 artifact or skip a human gate, so continue only when Core shows the next route
 and its required approval.

--- a/packs/core/.apm/skills/intake-intent/SKILL.md
+++ b/packs/core/.apm/skills/intake-intent/SKILL.md
@@ -45,7 +45,8 @@ Higher-priority instructions, repository and scoped security or privacy rules, t
 
 Write only the minimum needed for repository admission:
 
-- `Status` (`Draft` on creation);
+- `Status` — `Draft` on creation, and `Draft` when an update finds the field
+  absent; never re-level a status the artifact already carries;
 - outcome;
 - boundary;
 - owner;
@@ -59,7 +60,11 @@ product altitude to make the template look complete.
 
 When a repository intent already exists, update that artifact in place. Its
 path is its identity; do not create a renamed copy merely to match this pack's
-default `docs/product/intents/<slug>.md` convention.
+default `docs/product/intents/<slug>.md` convention. Minimization governs
+creation only. On an update, apply the missing required fields with `Edit` and
+keep every field already present, carrying an existing `Level` through rather
+than re-deriving it; the renderer emits a whole document and never replaces an
+existing intent.
 
 ### Source admission
 
@@ -98,10 +103,12 @@ destination, not permission to write or register it.
 3. Preserve an existing repository path; otherwise confirm the proposed
    repository-relative destination.
 4. Minimize source provenance without dereferencing it. Stop on a refusal.
-5. Render the required fields and only the optional fields supported by the
-   source.
-6. Write the confined artifact, then let the calling intake workflow register
-   one non-dispatchable pointer when registration was requested.
+5. For a new artifact, render the required fields and only the optional fields
+   supported by the source. For an existing one, do not render: apply the
+   missing required fields to that artifact with `Edit`.
+6. Write the confined artifact — the rendered new file, or the in-place edit —
+   then let the calling intake workflow register one non-dispatchable pointer
+   when registration was requested.
 7. Run the shaping-review gate below before an intent can become `Accepted`.
 8. Stop with the intent path, authority mode, changed state, verification, and
    remaining unresolved questions. Do not begin delivery work.

--- a/packs/core/.apm/skills/intake-intent/evals/evals.json
+++ b/packs/core/.apm/skills/intake-intent/evals/evals.json
@@ -62,6 +62,17 @@
         "Withholds Clean",
         "Does not let the caller treat the result as approval-ready"
       ]
+    },
+    {
+      "id": "update-accretes-onto-an-already-framed-intent",
+      "prompt": "Admit docs/product/intents/retention-controls.md, which an upstream shaping pass already framed with Level: feature, Scale: app, an outcome, an opportunity, and assumptions. It has no Status, boundary, owner, unresolved questions, projection, or source.",
+      "expected_output": "Edit that artifact in place, adding only the missing required fields and Status: Draft, and preserve every field it already carries.",
+      "assertions": [
+        "Edits the existing artifact in place rather than rendering a replacement",
+        "Adds Status: Draft, boundary, owner, unresolved questions, projection, and source",
+        "Preserves the existing Level, Scale, outcome, opportunity, and assumptions",
+        "Does not re-level the intent or restate its framing"
+      ]
     }
   ]
 }

--- a/packs/core/.claude-plugin/plugin.json
+++ b/packs/core/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "core",
-  "version": "2.25.9",
+  "version": "2.25.10",
   "description": "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 }

--- a/packs/core/pack.toml
+++ b/packs/core/pack.toml
@@ -1,6 +1,6 @@
 [pack]
 name = "core"
-version = "2.25.9"
+version = "2.25.10"
 
 description = "Supervised coding, brief to merged PR. The agent writes a spec, works it, runs your gates, and hands the diff to reviewers that argue with it before you ever look."
 readme = "README.md"

--- a/packs/core/seeds/docs/CONVENTIONS.md
+++ b/packs/core/seeds/docs/CONVENTIONS.md
@@ -720,6 +720,20 @@ right now?"
   nested inside it. A published package also keeps its own `CHANGELOG.md`
   beside its source — `packages/<name>/CHANGELOG.md` in this layout — for
   readers who get the package and not the repository.
+- `intents/<slug>.md` (optional) — one admitted outcome, recorded before a
+  solution artifact is chosen. Two axes. **Altitude** is `Level:`, an open set
+  running `product-vision › product-strategy › capability › feature`: only a
+  feature intent becomes a spec directly (recorded in that spec's `Discovery:`
+  header), a higher one decomposes into child intents first, and `Level` is
+  absent until the altitude is settled. **Stage** is which fields it carries —
+  *framed* states the bet (outcome, opportunity, assumptions); *admitted* adds
+  what routing needs (status, boundary, owner, unresolved questions,
+  projection, source); *ratified* reaches `Status: Accepted` after independent
+  shaping review and human confirmation. Admission adds fields: it never
+  re-levels the intent or rewrites its framing. Distinct from work-loop's
+  *accepted intent*, the agreed scope of a change
+  ([§ Intent-scoped completion](#intent-scoped-completion)). Authored by
+  `intake-intent`, or by `frame-intent` from the product-engineering pack.
 - `briefs/<slug>.md` (optional) — a multi-feature delivery brief and its
   auto-rolled-up coverage map. Created or continued by the
   `author-delivery-brief` skill; one file per brief. See the delivery-brief altitude under
@@ -1042,10 +1056,10 @@ kind of learning belongs.
 
 ### Intent-scoped completion
 
-Completion answers to the original accepted intent, not to the current pull
-request. A pull request is a review unit: one accepted intent may need more
-than one independently reviewed unit in the same session. Only the owner may
-narrow or waive that intent.
+Completion answers to the original accepted intent — the agreed scope of this
+change — not to the current pull request. A pull request is a review unit: one
+accepted intent may need more than one independently reviewed unit in the same
+session. Only the owner may narrow or waive that intent.
 
 For every implementation or review discovery, determine intent fit before the
 session decision:

--- a/packs/core/tests/skills/intake-intent/test_intake_intent.py
+++ b/packs/core/tests/skills/intake-intent/test_intake_intent.py
@@ -198,3 +198,43 @@ def test_prompt_like_source_data_cannot_change_the_contract() -> None:
     assert "allowed-tools: Bash" not in rendered
     assert "reviewer verdict" not in rendered
     assert "[omitted untrusted instruction]" in rendered
+
+
+def test_renderer_output_never_replaces_an_already_framed_intent() -> None:
+    """An update accretes; it does not re-render over what the artifact holds.
+
+    Two halves, because either alone would pass while the hazard stayed open.
+    The first pins the shipped behaviour that makes the rule load-bearing: the
+    renderer emits a whole document, and the optional sections it omits are
+    exactly the directional fields an upstream shaping skill writes. The second
+    pins the caller obligation in `SKILL.md` — without it, a caller reading
+    "write only the minimum" applies a creation contract to an update and
+    overwrites the framing.
+    """
+    renderer = load_renderer()
+    intake = _intake(mode="repo-origin", locator="docs/source.md")
+
+    rendered = renderer.render_minimal_intent(
+        intake=intake, title="Admitted intent", level=None
+    )
+
+    # Whole document, and silent about everything the framing stage owns.
+    assert rendered.lstrip().startswith("# ")
+    for absent in ("## Opportunity", "## Assumptions", "**Level:**", "**Scale:**"):
+        assert absent not in rendered, absent
+
+    # An existing Level is carried through rather than re-derived.
+    carried = renderer.render_minimal_intent(
+        intake=intake, title="Admitted intent", level="feature"
+    )
+    assert "- **Level:** feature" in carried
+
+    skill = (CORE_SKILLS / "intake-intent" / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill.split())
+    assert "Minimization governs creation only." in normalized
+    for obligation in (
+        "apply the missing required fields with `Edit`",
+        "keep every field already present",
+        "never replaces an existing intent",
+    ):
+        assert obligation in normalized, obligation

--- a/tests/roster/test_cognitive_load_repository_contract.py
+++ b/tests/roster/test_cognitive_load_repository_contract.py
@@ -161,6 +161,7 @@ def test_rule_linter_rejects_nested_topic_path(tmp_path: Path) -> None:
 _SYMLINK_SHIMS = ("CLAUDE.md", "web/CLAUDE.md", "docs-site/CLAUDE.md")
 _IMPORT_SHIMS = (
     "docs/CLAUDE.md",
+    "docs/product/CLAUDE.md",
     "guides/CLAUDE.md",
     "packages/CLAUDE.md",
     "packages/_example/CLAUDE.md",

--- a/web/src/lib/now-highlights.generated.json
+++ b/web/src/lib/now-highlights.generated.json
@@ -5,6 +5,53 @@
       "packages": [
         {
           "name": "core",
+          "version": "2.25.10"
+        }
+      ],
+      "date": "2026-09-10",
+      "heading": "[core][2.25.10] — 2026-09-10",
+      "changelogAnchor": "core22510--2026-09-10",
+      "highlights": [
+        {
+          "source": "**The directory your intents land in is now described in the conventions you install with them.** `CONVENTIONS.md` reads an intent on two axes: the altitude it sits at, and how far it has travelled from a framed bet to a ratified outcome. Only a feature-level intent becomes a spec directly.",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "The directory your intents land in is now described in the conventions you install with them."
+            },
+            {
+              "type": "text",
+              "value": " "
+            },
+            {
+              "type": "code",
+              "value": "CONVENTIONS.md"
+            },
+            {
+              "type": "text",
+              "value": " reads an intent on two axes: the altitude it sits at, and how far it has travelled from a framed bet to a ratified outcome. Only a feature-level intent becomes a spec directly."
+            }
+          ]
+        },
+        {
+          "source": "**Admitting an intent that was already shaped upstream adds to it instead of overwriting it.** The outcome, altitude and assumptions you framed survive the handoff into repository work.",
+          "segments": [
+            {
+              "type": "strong",
+              "value": "Admitting an intent that was already shaped upstream adds to it instead of overwriting it."
+            },
+            {
+              "type": "text",
+              "value": " The outcome, altitude and assumptions you framed survive the handoff into repository work."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "packages": [
+        {
+          "name": "core",
           "version": "2.25.9"
         }
       ],


### PR DESCRIPTION
## What does this change?

`CONVENTIONS.md` § 5b now documents `docs/product/intents/`, the repository's most-cited product artifact class, which had no documented home. `intake-intent`'s minimization rule is scoped to creation, so admitting an intent an upstream shaping pass already framed accretes the missing fields in place instead of re-rendering a whole document over it.

## Why?

`docs/product/intents/` holds 112 files and was absent from § 5b, from the hierarchy diagram, and from `docs/product/README.md`. Adopters install the `core` pack and get `intake-intent`, which writes that directory — but the conventions shipped alongside never described it.

The update contract was a live hazard, not a hypothetical one: `admit_repository_intent(existing_path=…)` preserves the path and returns a **complete replacement body**, while the field contract said "write only the minimum" and "omit them when the source does not establish them". Following the skill on a framed intent dropped its opportunity, assumptions, `Level` and `Scale`. The one real accretion in the corpus (`tdd-stub-replaces-prose.md`, `f84829a62`) was a hand migration, not that path.

- Follows from: ADR-0019 (recursive level-tagged intent tree; the leaf is a shippable spec), ADR-0033 (`Level` is an open recognized set decoupled from `Scale`), ADR-0098 (the seven-field minimum repository-intent contract)
- No spec: light-mode work-loop against a temporary spec/plan; no risk trigger fired.

## How do I verify it?

```bash
python3 -m pytest packs/core/tests/skills/intake-intent/ packs/core/tests/pack \
  tests/roster/test_shaping_review_documentation_contract.py \
  tests/roster/test_direct_light_documentation_boundary.py \
  tests/roster/test_cognitive_load_repository_contract.py \
  tools/test_build_site_routing.py -q          # 282 passed, 1 skipped
make pre-pr                                     # 12 checks, exit 0
python3 tools/lint-agents-md.py                 # exit 0
python3 -m agentbundle catalogue lint --root . --deep && \
python3 -m agentbundle catalogue verify --root .
```

`test_renderer_output_never_replaces_an_already_framed_intent` pins both halves: the renderer emits a whole document omitting exactly the directional fields, and the caller obligation that guards it. It was red before the `SKILL.md` rule existed.

Three adversarial review rounds ran to adjudicated clean: 19 findings, 13 sustained and applied, 6 refuted.

## What did you not change that you considered?

- **The `workspace-status` `[shape]` return path.** `frame-intent` never registers in `workspace.toml`, so a `[shape]` slug re-renders forever. Left alone: this repository has zero `type = "shape"` entries — the form is legacy under the compatibility window — and the owner declined to log it.
- **The capability rung's missing chain down-edge and the unreachable `Kind:` rungs.** All 11 capability intents are `lint-traceability` orphans and `Kind:` has zero uses, so the chain root can never be populated. Both need a decision record, not a docs edit.
- **A `Stage:` marker field.** The required attributes already are the admission signal; a marker would duplicate derivable state.
- **Backfilling `Level:` onto the 9 Level-less intents.** ADR-0033 makes `Level` optional; a backfill would invent altitudes.
- **The core seed's `docs/product/README.md`.** Still carries the older changelog wording. Adjudication refuted correcting it: RFC-0002 classifies seed product docs as Manual placeholder templates with no parity obligation to this repo's living copy.
- **A merge path in `intent_renderer.py`.** The caller already has `Edit`; prose plus a test is the smaller correct change.

---

## Checklist

- [x] Tests pass locally
- [x] Lint and typecheck pass (`make pre-pr`, `catalogue lint --deep`, `lint-agents-md`)
- [x] Self-review run via `adversarial-reviewer` — three rounds to adjudicated clean; no security boundary crossed
- [x] Spec and code agree (no persisted spec; temporary spec/plan under light mode)
- [x] Living docs match reality
  - [x] `docs/product/changelog.md` updated — core 2.25.9 → 2.25.10, with the `/now/` projection regenerated
  - [x] `guides/` updated — two corrections
  - [ ] `docs/architecture/` — no code structure change
  - [ ] `docs/product/roadmap.md` — completes no roadmap item
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — `docs/product/AGENTS.md` records the `/now/` regeneration obligation
