### PR TITLE
docs(license): name the copyright holder and year in LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <year> <copyright holders>
+Copyright (c) 2026 Eu Gene Lim
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What does this change?

Fills the MIT license notice, which still carried the upstream template placeholder `Copyright (c) <year> <copyright holders>`. It now names the repository's creation year and its copyright holder.

## Why?

A license file with an unfilled placeholder grants nothing to anyone — the notice has to name a holder to be operative. The year comes from the repository's first commit, `2026-05-03`.

## How do I verify it?

```
git show --stat HEAD          # one file, one line
head -3 LICENSE-MIT           # Copyright (c) 2026 Eu Gene Lim
git log --reverse --format=%ad --date=short | head -1   # 2026-05-03
```

## What did you not change that you considered?

- **`LICENSE-APACHE`.** Its only placeholder, at line 189, sits inside the `APPENDIX: How to apply the Apache License to your work` section — instructional boilerplate telling downstream users what to put in *their* files, not this repository's own notice. Substituting into the appendix is the common error; unmodified is correct.
- **`README.md:65` and the two `pyproject.toml` `license` fields.** Already consistent (`Apache-2.0 OR MIT`, both files linked); no drift to fix.
- **The `authors` field in `packages/agentbundle/pyproject.toml`.** It carries the GitHub handle rather than a personal name. That is published PyPI metadata on a pinned release surface, so it is out of scope for a license-notice fix.