### PR TITLE
chore(deps): take the docs-site group and migrate the Starlight 0.42 menu

### DIFF
--- a/docs-site/AGENTS.md
+++ b/docs-site/AGENTS.md
@@ -30,21 +30,17 @@ npm run build --prefix docs-site
   both themes, and reduced-motion behavior.
 - Run `python3 tools/lint-npm-allow-scripts.py`; when it fires, add a reviewed
   `allowScripts` entry or repin the dependency so it dedupes to a reviewed version.
-- `astro.config.ts` imports `@astrojs/markdown-remark` directly — it builds the
-  site's Markdown processor with `unified({...})` and passes it as
-  `markdown.processor`. Astro and Starlight both carry the package as an
-  *optional* peer, so npm neither installs it nor warns when the versions
-  drift, and the build once worked only because npm hoisted `@astrojs/mdx`'s
-  transitive copy to the root. When npm later placed that copy under
-  `@astrojs/mdx/node_modules/` instead, `astro build` exited 1: config
-  validation fails when the package is unresolvable from the root. The
-  declaration in `package.json` is what makes root placement a requirement
-  rather than a hoisting accident. Two duties come with it — keep the pin equal
-  to astro's exact optional-peer version, which
-  `tools/test_browser_gate_subset.py` refuses from `gate-main` when the
-  manifest, the lockfile and that peer disagree or when Starlight's declared
-  range stops accepting the pin; and expect an astro major to arrive alone and
-  need both moved together.
+- `astro.config.ts` imports `@astrojs/markdown-remark` directly to build the
+  site's Markdown processor with `unified({...})` as `markdown.processor`. Astro
+  and Starlight carry it as an *optional* peer, so npm neither installs it nor
+  warns on drift: the build once worked only because npm hoisted `@astrojs/mdx`'s
+  transitive copy to the root, and exited 1 once npm nested that copy instead.
+  The `package.json` declaration is what makes root placement a requirement
+  rather than a hoisting accident. Keep the pin exact and equal across the
+  manifest and the lockfile's two copies, and satisfying the peer astro and
+  Starlight each declare; `tools/test_browser_gate_subset.py` refuses the lot
+  from `gate-main`. Astro declared that peer exactly until 7.2.9 and as a caret
+  from 7.2.10 — expect the shape to change, not just the number.
 - The remark plugin that turns ```mermaid fences into placeholders is registered
   through that processor, and it has silently no-opped before. Nothing caught
   it, because no published page carried a fence. `getting-started/three-loops`
@@ -58,7 +54,11 @@ npm run build --prefix docs-site
   --root docs-site`. `--root` is load-bearing — astro resolves the project from the
   working directory, not `--prefix`; without it the command reports nothing running.
 - After a Starlight upgrade, re-verify integration contracts against the vendored
-  components.
+  components. 0.42 swapped `<starlight-menu-button>` and its `aria-expanded` for
+  the native popover API, silently breaking `PageFrame.astro`'s CSS reveal and
+  every selector keyed to the old markup. That pane is `popover="manual"`, not
+  `auto`, because an auto popover light-dismisses on the Product summary, which
+  `site-shared-chrome` forbids; manual costs UA Escape, restored in that component.
 - Starlight's `print:hidden` does **not** suppress an element whose own component
   `<style>` sets `display`, and it fails silently: both compile unlayered at
   `(0,1,0)` — Astro's `:where()` adds no specificity — and the print sheet links

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,12 +8,12 @@
       "name": "agent-ready-repo-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/markdown-remark": "7.2.4",
-        "@astrojs/starlight": "0.41.10",
+        "@astrojs/markdown-remark": "7.3.0",
+        "@astrojs/starlight": "0.42.0",
         "@fontsource-variable/inter": "5.3.0",
         "@fontsource-variable/source-serif-4": "5.3.0",
         "@fontsource/jetbrains-mono": "5.3.0",
-        "astro": "7.2.9",
+        "astro": "7.3.1",
         "mermaid": "11.17.2",
         "unist-util-visit": "5.1.0"
       },
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
-      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
+      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -239,15 +239,19 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.4.tgz",
-      "integrity": "sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.3.0.tgz",
+      "integrity": "sha512-mRwn2W2PKkOj8XEAiD3b9RIF4qq6FKB6U4c98GxFLkEJH7uA6ZZv8TiqVjJSPMANLb1NtwBTgkY+KO4mTXnT/Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "estree-util-visit": "^2.0.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
+        "hast-util-to-html": "^9.0.5",
         "hast-util-to-text": "^4.0.2",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
@@ -256,6 +260,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -264,235 +269,37 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
-      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
+      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "satteri": "^0.10.3"
       }
     },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-arm64": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
-      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-darwin-x64": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
-      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-gnu": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
-      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-arm64-musl": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
-      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-gnu": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
-      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-linux-x64-musl": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
-      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-wasm32-wasi": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
-      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-arm64-msvc": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
-      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@bruits/satteri-win32-x64-msvc": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
-      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@astrojs/markdown-satteri/node_modules/satteri": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
-      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree-jsx": "^1.0.5",
-        "@types/hast": "^3.0.5",
-        "@types/mdast": "^4.0.4",
-        "@types/unist": "^3.0.3"
-      },
-      "optionalDependencies": {
-        "@bruits/satteri-darwin-arm64": "0.10.5",
-        "@bruits/satteri-darwin-x64": "0.10.5",
-        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
-        "@bruits/satteri-linux-arm64-musl": "0.10.5",
-        "@bruits/satteri-linux-x64-gnu": "0.10.5",
-        "@bruits/satteri-linux-x64-musl": "0.10.5",
-        "@bruits/satteri-wasm32-wasi": "0.10.5",
-        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
-        "@bruits/satteri-win32-x64-msvc": "0.10.5"
-      }
-    },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.7.tgz",
-      "integrity": "sha512-hv+NJh2s+/KDrjXaYNOaS344e3M2ekMXHBR7x9EwBwE3VvE1y/9Ifh1rhR1H2zK2sMgXoUnakI9e9ZeCKPX9/Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-8.0.0.tgz",
+      "integrity": "sha512-4I/z+VgUO0B9I/+yhzIEpLyBYQZNJsInmrtqClP4lqX9yvUpbuV72zfRTZ8VqJLKABETUE5CYOl+23va8nqxZg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/markdown-remark": "7.2.4",
-        "@mdx-js/mdx": "^3.1.1",
-        "acorn": "^8.16.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-util-visit": "^2.0.0",
-        "hast-util-to-html": "^9.0.5",
-        "piccolore": "^0.1.3",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-smartypants": "^3.0.2",
-        "source-map": "^0.7.6",
-        "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3"
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
+        "es-module-lexer": "^2.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1",
-        "astro": "^7.0.0"
+        "@astrojs/markdown-remark": "^7.3.0",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "astro": "^7.2.6"
       },
       "peerDependenciesMeta": {
-        "@astrojs/markdown-satteri": {
+        "@astrojs/markdown-remark": {
           "optional": true
         }
       }
@@ -521,44 +328,43 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.41.10",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.10.tgz",
-      "integrity": "sha512-xE+OO2zzJkHPzc+giuFj+1c0sYw3//goo31PEksguNTd3XpXvV7TaJ0TzQzBUSCxYtBwWjAPkJfqR2W4aMQdhQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.42.0.tgz",
+      "integrity": "sha512-EVsGnyGJ6rRNwGRZFYmGABo0qTQ55F7OSmfSL0VK+5lsqD+u6GWcB8tFqXETcUvP8kyn90W+QBLSL2aer9jNJQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-satteri": "^0.3.5",
-        "@astrojs/mdx": "^7.0.5",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "@astrojs/mdx": "^8.0.0",
         "@astrojs/sitemap": "^3.7.3",
         "@pagefind/default-ui": "^1.3.0",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/js-yaml": "^4.0.9",
         "@types/mdast": "^4.0.4",
         "astro-expressive-code": "^0.44.0",
         "bcp-47": "^2.1.0",
-        "hast-util-from-html": "^2.0.3",
+        "hast-util-format": "^1.1.0",
         "hast-util-select": "^6.0.4",
+        "hast-util-to-html": "^9.0.5",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
         "i18next": "^26.0.7",
         "js-yaml": "^4.1.1",
         "klona": "^2.0.6",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.2.3",
         "mdast-util-directive": "^3.1.0",
         "mdast-util-to-markdown": "^2.1.2",
         "mdast-util-to-string": "^4.0.0",
         "pagefind": "^1.5.2",
-        "rehype": "^13.0.2",
-        "rehype-format": "^5.0.1",
         "remark-directive": "^4.0.0",
-        "satteri": "^0.9.1",
+        "satteri": "^0.10.3",
         "ultrahtml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
         "vfile": "^6.0.3"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "^7.2.0",
-        "astro": "^7.0.2"
+        "@astrojs/markdown-remark": "^7.3.0",
+        "astro": "^7.2.10"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -634,9 +440,9 @@
       "license": "MIT"
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
       "cpu": [
         "arm64"
       ],
@@ -647,9 +453,9 @@
       ]
     },
     "node_modules/@bruits/satteri-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
       "cpu": [
         "x64"
       ],
@@ -660,9 +466,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
-      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
       "cpu": [
         "arm64"
       ],
@@ -676,9 +482,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
-      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
       ],
@@ -692,9 +498,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
-      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
       "cpu": [
         "x64"
       ],
@@ -708,9 +514,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
-      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
       ],
@@ -724,9 +530,9 @@
       ]
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
-      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
       "cpu": [
         "wasm32"
       ],
@@ -735,7 +541,7 @@
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@napi-rs/wasm-runtime": "^1.2.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -773,9 +579,9 @@
       }
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
-      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
       "cpu": [
         "arm64"
       ],
@@ -786,9 +592,9 @@
       ]
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
-      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
       "cpu": [
         "x64"
       ],
@@ -1303,9 +1109,9 @@
       }
     },
     "node_modules/@expressive-code/core": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.1.tgz",
-      "integrity": "sha512-3dDo9N8D7hYrLNNMMWFovg3+aDUtnQm7c7z0GZc1c0LEFVBc0Q6lKG+tVT28gDadOvsgOANfCn35fgpe97Pmgg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.2.tgz",
+      "integrity": "sha512-Yw5KonQCD1HoOO2P89y4wifqS9qrJcGVY0LkVMUsVZjhi++bhz4WwQ37inenKFNOEVo50P7cjoVsCdaVnUbq8w==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.4",
@@ -1320,31 +1126,31 @@
       }
     },
     "node_modules/@expressive-code/plugin-frames": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.1.tgz",
-      "integrity": "sha512-HC/bdRao9225ApcgO/e3jn8ZOhldKO7ob1O/Tcipvtv7Vb5nMphZhMtD9uuywpvxkPYBHJi3504WhrKg05Dwqg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.2.tgz",
+      "integrity": "sha512-gVLm6TQMNIRWIaM7o+mCtxkGNjLZY5/2faSTLoXeo9wv/Pkj/0QAtZyXPVPrRsPARqiipATNFmfvQFLJudxPHQ==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.1"
+        "@expressive-code/core": "^0.44.2"
       }
     },
     "node_modules/@expressive-code/plugin-shiki": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.1.tgz",
-      "integrity": "sha512-YApiZt3buUzBwL5tqj8G+sYC5NjMjRCHgQwr9bmGl69rtcHy6fE9dooWUeKYB978fJT2BuxT5FeHcF47rA3SEg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.2.tgz",
+      "integrity": "sha512-ebWIvCDzXvjyD8rH6T6DfytYJw1GoArLR4nusIAE4VxXrCQf3d+owytiv010KU/dUg+SRLZskDn0N+HaFXeuSg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.1",
+        "@expressive-code/core": "^0.44.2",
         "shiki": "^4.0.2"
       }
     },
     "node_modules/@expressive-code/plugin-text-markers": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.1.tgz",
-      "integrity": "sha512-B3BsJoJ8CFMlcIX9f+X9tcI3C4zPDO601+YuLi9GheSTNro7ZfqSjLptMQKBHOWZvxnAtY5zvIX7iO/qtBhNBg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.2.tgz",
+      "integrity": "sha512-SNI7EgUSiADqbqUzzMbj1ZeC/r2pa5eg3KyFOGAd3a7EsIA4qzjXQLp+ODWQtHVDKFCdGs4J3ovSJUqvKIK96g==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.1"
+        "@expressive-code/core": "^0.44.2"
       }
     },
     "node_modules/@fontsource-variable/inter": {
@@ -3006,14 +2812,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.9.tgz",
-      "integrity": "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.1.tgz",
+      "integrity": "sha512-A/bJYHtc6n0UAdROY9W948fW6lX0pnUA+JWKW+IGCXRyDIGN2MsXC0OlS8onZGJjr+sv8htemwOc9W5PBRXCkw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/markdown-satteri": "0.3.8",
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -3063,7 +2869,7 @@
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -3081,7 +2887,7 @@
         "sharp": "^0.35.4"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.4"
+        "@astrojs/markdown-remark": "^7.3.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -3090,25 +2896,16 @@
       }
     },
     "node_modules/astro-expressive-code": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.1.tgz",
-      "integrity": "sha512-DT1LnCqbHasBKlvzJ3m6LR4VI94wwx3W9EV/YbP1te4rqjOHsvsezHYuqb5MeLWLftXms/1FA9QBbwCo43DnJQ==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.2.tgz",
+      "integrity": "sha512-avop7nZcRwC7quvIxVguhwEZ9Tp6IoTzKUCLwP30Fb7+er+pWQgcysP01dcuzRIJo81kLGg30q/YAI2Yb1Sdzg==",
       "license": "MIT",
       "dependencies": {
-        "rehype-expressive-code": "^0.44.1",
+        "rehype-expressive-code": "^0.44.2",
         "url-extras": "^0.1.0"
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
-      }
-    },
-    "node_modules/astro/node_modules/magic-string": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.0.tgz",
-      "integrity": "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/axobject-query": {
@@ -4290,9 +4087,9 @@
       }
     },
     "node_modules/estree-util-scope": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
-      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.1.tgz",
+      "integrity": "sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -4348,15 +4145,15 @@
       "license": "MIT"
     },
     "node_modules/expressive-code": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.1.tgz",
-      "integrity": "sha512-GakidxhapWDzpKLqEaFQ8wGk6gAqEtPQibu8+yPBfnDLgev5Vdsh1pasTxnrXL/mzIknyqeTwhMHTghdaiUrTg==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.2.tgz",
+      "integrity": "sha512-MLNghkvhyFgVW4oCD5DxBuYnnTXIf0PygzGmfT6OZeOOYWh/D4sH1j931biElkA5RG/J9wY/iuSMGAPF5vzHOg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.1",
-        "@expressive-code/plugin-frames": "^0.44.1",
-        "@expressive-code/plugin-shiki": "^0.44.1",
-        "@expressive-code/plugin-text-markers": "^0.44.1"
+        "@expressive-code/core": "^0.44.2",
+        "@expressive-code/plugin-frames": "^0.44.2",
+        "@expressive-code/plugin-shiki": "^0.44.2",
+        "@expressive-code/plugin-text-markers": "^0.44.2"
       }
     },
     "node_modules/extend": {
@@ -5414,9 +5211,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -7069,58 +6866,13 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
-    "node_modules/rehype": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "rehype-parse": "^9.0.0",
-        "rehype-stringify": "^10.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-expressive-code": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
-      "integrity": "sha512-+VZgs7Evw4LXRN3owpoBNSTpYuW6GeOdjqcUT1TuY8o/4MGPtbd0EU7Bgrju7X8KrQ6SslOBAuGWJ5fV5TriJQ==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.2.tgz",
+      "integrity": "sha512-jvjQpsfWKBquDrEl5YQA3CJybRRIuDOYsui1BJTs5oKDUK8pPkJSSxY8FjxNlIFIdtgrTjC1zuahuY4Cc1j9SQ==",
       "license": "MIT",
       "dependencies": {
-        "expressive-code": "^0.44.1"
-      }
-    },
-    "node_modules/rehype-format": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
-      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-format": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+        "expressive-code": "^0.44.2"
       }
     },
     "node_modules/rehype-raw": {
@@ -7413,26 +7165,26 @@
       "license": "MIT"
     },
     "node_modules/satteri": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
-      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/mdast": "^4.0.4",
         "@types/unist": "^3.0.3"
       },
       "optionalDependencies": {
-        "@bruits/satteri-darwin-arm64": "0.9.5",
-        "@bruits/satteri-darwin-x64": "0.9.5",
-        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
-        "@bruits/satteri-linux-arm64-musl": "0.9.5",
-        "@bruits/satteri-linux-x64-gnu": "0.9.5",
-        "@bruits/satteri-linux-x64-musl": "0.9.5",
-        "@bruits/satteri-wasm32-wasi": "0.9.5",
-        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
-        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
       }
     },
     "node_modules/sax": {
@@ -8243,9 +7995,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -14,12 +14,12 @@
     "test:plugins": "node --test src/plugins/rehype-scrollable-tables.test.ts src/components/shared-chrome.test.ts"
   },
   "dependencies": {
-    "@astrojs/markdown-remark": "7.2.4",
-    "@astrojs/starlight": "0.41.10",
+    "@astrojs/markdown-remark": "7.3.0",
+    "@astrojs/starlight": "0.42.0",
     "@fontsource-variable/inter": "5.3.0",
     "@fontsource-variable/source-serif-4": "5.3.0",
     "@fontsource/jetbrains-mono": "5.3.0",
-    "astro": "7.2.9",
+    "astro": "7.3.1",
     "mermaid": "11.17.2",
     "unist-util-visit": "5.1.0"
   },

--- a/docs-site/src/components/PageFrame.astro
+++ b/docs-site/src/components/PageFrame.astro
@@ -65,11 +65,56 @@ if (!productLabel) {
           </details>
         </nav>
         <MobileMenuToggle />
-        <div id="starlight__sidebar" class="sidebar-pane">
+        <script>
+          // Follows Starlight 0.42's own PageFrame, which moved this menu to the
+          // popover API, and contributes the same focus trapping and resize-close.
+          // Overriding PageFrame means Starlight's copy never renders, so its
+          // `sl-sidebar-pane` definition never runs — this is the only one on the page.
+          class StarlightSidebarPane extends HTMLElement {
+            constructor() {
+              super();
+              matchMedia('(min-width: 50em)').addEventListener('change', () => this.hidePopover());
+              this.addEventListener('toggle', ({ newState }) => this.trapFocus(newState === 'open'));
+              // Escape-to-close, which `popover="manual"` costs us — an `auto` popover
+              // gets this from the user agent at document scope. See the attribute's
+              // comment below for why manual is deliberate.
+              //
+              // Bound on `document`, NOT on the sidebar nav the way Starlight 0.41 was.
+              // The focus trap below only inerts `.main-frame` and `.sl-skip-link`, so
+              // the header's title, search and theme controls stay reachable by Tab
+              // while the menu is open. A nav-scoped listener never sees Escape once
+              // focus lands on one of them, which strands a keyboard user in an open
+              // menu. 0.41 had that gap too; manual popovers are what make it ours.
+              document.addEventListener('keyup', (event) => {
+                if (event.code !== 'Escape' || !this.matches(':popover-open')) return;
+                this.hidePopover();
+                this.closest('nav')?.querySelector<HTMLElement>('button.sl-menu-button')?.focus();
+              });
+            }
+            /** Trap keyboard focus inside the header and menu while the menu is open. */
+            trapFocus(shouldTrap: boolean) {
+              document.querySelectorAll<HTMLElement>('.main-frame, .sl-skip-link').forEach((el) => {
+                el.toggleAttribute('inert', shouldTrap);
+              });
+            }
+          }
+          customElements.define('sl-sidebar-pane', StarlightSidebarPane);
+        </script>
+        {/*
+          `manual`, not Starlight's default `auto`, and the difference is the whole
+          reason this override exists. An `auto` popover light-dismisses on any
+          outside click — including a click on the Product disclosure's own summary,
+          which would close the Docs menu as a side effect. `site-shared-chrome`
+          requires the two disclosures to keep isolated state: "Opening or closing it
+          does not open, close, rename, or replace Starlight's Docs menu." `manual`
+          reproduces Starlight 0.41's interaction model, which had no light dismiss.
+          The cost is Escape handling, restored in the script above.
+        */}
+        <sl-sidebar-pane popover="manual" id="starlight__sidebar" class="sidebar-pane">
           <div class="sidebar-content sl-flex">
             <slot name="sidebar" />
           </div>
-        </div>
+        </sl-sidebar-pane>
       </nav>
     )
   }
@@ -131,7 +176,15 @@ if (!productLabel) {
   }
 
   .sidebar-pane {
-    visibility: var(--docs-sidebar-visibility, hidden);
+    /* The pane is a popover as of Starlight 0.42, so the UA hides it until the
+       menu button opens it and there is no `aria-expanded` selector to key off.
+       These four resets drop the opinionated default popover styling, exactly as
+       Starlight's own PageFrame does. */
+    border: unset;
+    padding: unset;
+    height: unset;
+    color: unset;
+
     position: fixed;
     z-index: var(--sl-z-index-menu);
     inset-block: var(--sl-nav-height) 0;
@@ -140,10 +193,6 @@ if (!productLabel) {
     background-color: var(--sl-color-black);
     overflow-y: auto;
     scrollbar-gutter: stable;
-  }
-
-  :global(starlight-menu-button[aria-expanded='true']) ~ .sidebar-pane {
-    --docs-sidebar-visibility: visible;
   }
 
   .sidebar-content {
@@ -216,7 +265,9 @@ if (!productLabel) {
     }
     .docs-product-disclosure { display: none; }
     .sidebar-pane {
-      --docs-sidebar-visibility: visible;
+      /* Show the sidebar outright at desktop widths instead of deferring to
+         popover state, which is what Starlight's own PageFrame does here. */
+      display: block;
       width: var(--sl-sidebar-width);
       background-color: var(--sl-color-bg-sidebar);
       border-inline-end: 1px solid var(--sl-color-hairline-shade);

--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -14,8 +14,8 @@
 - `packages/credbroker/` is also Python standard-library-only and is the only
   credential path. Credentialed primitives use its public API and never read
   credential stores directly.
-- `web/` uses Astro 7.3.1; `docs-site/` uses Astro 7.2.9 with Starlight
-  0.41.10.
+- `web/` uses Astro 7.3.1; `docs-site/` uses Astro 7.3.1 with Starlight
+  0.42.0.
 - Portable contracts are TOML plus JSON Schema in `contracts/`; compatible
   changes preserve both the contract declaration and its schema validation.
 - Python quality tooling is pytest, ruff, and mypy. The SAST/SCA floor is

--- a/tools/test_browser_gate_subset.py
+++ b/tools/test_browser_gate_subset.py
@@ -9,7 +9,8 @@ unbound-helper-identifier check and the tap-target audit arithmetic below — is
 value that tracked site files must keep in a fixed relation, where nothing else
 would notice them diverging: the `base` the docs config must derive from the
 marketing one, and the `@astrojs/markdown-remark` version that
-`docs-site/package.json`, the lockfile and astro's optional peer must agree on.
+`docs-site/package.json` and the lockfile's two copies must agree on while
+satisfying the optional peer astro and Starlight each declare.
 They live here because this module runs from `gate-main`, a required context;
 `pages.yml` is not one, so a pin gate placed there could not block the merge that
 broke it.
@@ -173,6 +174,73 @@ EXACT_VERSION = re.compile(r"\d+\.\d+\.\d+")
 CARET_RANGE = re.compile(r"\^(\d+)\.(\d+)\.(\d+)")
 
 
+def _satisfies(pin: str, spec: str) -> bool:
+    """Does the exact version `pin` satisfy `spec`?
+
+    `spec` is a dependency declaration made by someone else — astro or Starlight —
+    so this understands exactly the two shapes they have been observed to use: an
+    exact version, and a caret range on a non-zero major. Anything else raises
+    rather than returning a verdict, because the alternative to "I do not know this
+    shape" is approximating it into a pass, and a check that silently widens to
+    accommodate an unrecognised declaration is not a check.
+
+    Caret on major 0 raises too: there caret semantics pin the minor instead of the
+    major, so treating it like the non-zero case would accept an incompatible pin.
+
+    Stdlib-only by construction, like the rest of this module — it runs in
+    `gate-main`, and a check that can fail on a missing `semver` import is one
+    someone import-guards away under pressure.
+    """
+    if EXACT_VERSION.fullmatch(spec):
+        return pin == spec
+    caret = CARET_RANGE.fullmatch(spec)
+    if not caret:
+        raise ValueError(
+            f"{spec!r} is neither an exact version nor an `^X.Y.Z` caret range. "
+            "Re-derive this comparison against the shape actually declared rather "
+            "than widening it to pass."
+        )
+    floor = tuple(int(group) for group in caret.groups())
+    if floor[0] == 0:
+        raise ValueError(
+            f"caret range {spec!r} is on major 0, where caret semantics pin the "
+            "minor instead of the major — re-derive this comparison."
+        )
+    got = tuple(int(part) for part in pin.split("."))
+    return got[0] == floor[0] and got >= floor
+
+
+def test_satisfies_accepts_and_refuses_the_shapes_the_peer_checks_rely_on() -> None:
+    """`_satisfies` is the whole re-derivation, so pin its behaviour directly.
+
+    The two checks below read live manifest and lockfile values, so on a healthy
+    tree they exercise exactly one point of this predicate and would keep passing
+    if it were widened into `return True`. These cases are the criterion that can
+    fail: the exact-declaration rows are the contract astro had before 7.2.10 and
+    must keep working, and the refusal rows are what stops an unrecognised
+    declaration from passing vacuously.
+    """
+    # Exact declaration — the pre-7.2.10 astro contract, which still has to hold.
+    assert _satisfies("7.3.0", "7.3.0")
+    assert not _satisfies("7.2.4", "7.3.0")
+    # Caret on a non-zero major — what astro and Starlight declare now.
+    assert _satisfies("7.3.0", "^7.3.0")
+    assert _satisfies("7.4.1", "^7.3.0")
+    assert not _satisfies("7.2.4", "^7.3.0")  # below the floor
+    assert not _satisfies("8.0.0", "^7.3.0")  # wrong major
+    # Shapes this predicate refuses to guess at, rather than widening to accept.
+    # Written without `pytest.raises` to keep this module's stdlib-only import list.
+    for unsupported in ("*", "^0.3.0", ">=7.3.0 <8", "~7.3.0", "latest", ""):
+        try:
+            _satisfies("7.3.0", unsupported)
+        except ValueError:
+            continue
+        raise AssertionError(
+            f"_satisfies accepted {unsupported!r} instead of refusing a shape it "
+            "does not understand"
+        )
+
+
 def _docs_site_versions() -> dict[str, str | None]:
     """Every recorded copy of the `@astrojs/markdown-remark` version, and astro's.
 
@@ -209,14 +277,27 @@ def _docs_site_versions() -> dict[str, str | None]:
     }
 
 
-def test_the_markdown_remark_pin_equals_astros_optional_peer() -> None:
-    """One `@astrojs/markdown-remark` version, agreed by all four files recording it.
+def test_the_markdown_remark_pin_satisfies_astros_optional_peer() -> None:
+    """One `@astrojs/markdown-remark` version, agreed by the three files we own,
+    and satisfying the peer astro declares.
 
-    astro declares it an *optional* peer at an exact version, so npm neither
-    installs it nor complains when the two drift — but `astro.config.ts` needs it
-    resolvable at the root, and a mismatched copy is a resolution failure at build
-    time, not an install-time warning. The duty to move both together was prose in
-    `docs-site/AGENTS.md` that no gate read.
+    astro declares it an *optional* peer, so npm neither installs it nor complains
+    when the two drift — but `astro.config.ts` needs it resolvable at the root, and
+    a mismatched copy is a resolution failure at build time, not an install-time
+    warning. The duty to move both together was prose in `docs-site/AGENTS.md` that
+    no gate read.
+
+    This check used to assert that all FOUR recorded versions were equal, because
+    astro declared the peer at an exact version (7.2.9 declared `7.2.4`). astro
+    7.2.10 changed the declaration's shape to the caret range `^7.3.0`, which made
+    equality unstateable rather than merely false. Equality was never the
+    requirement; it was what satisfaction collapsed to while the declaration was
+    exact. So the contract is split along the line of who controls each value: the
+    three copies this repository writes must still agree exactly and be exact, and
+    the pin must satisfy whatever astro declares. `_satisfies` refuses any
+    declaration shape it does not recognise, so this is a re-derivation and not a
+    loosening — a `*` or an unrecognised range fails here rather than passing
+    vacuously.
 
     Read from the lockfile rather than `node_modules/astro/package.json`: this
     module runs in `gate-main`, which installs no Node, and a check that skips
@@ -245,18 +326,19 @@ def test_the_markdown_remark_pin_equals_astros_optional_peer() -> None:
         "before concluding anything about the duty."
     )
 
-    # Exact equality is the whole contract. A range on any of the three means the
-    # premise changed, and "make them equal" would be the wrong instruction.
+    # The versions THIS repository writes stay exact. A range in either would make
+    # the installed version a resolution outcome rather than a recorded decision,
+    # which is the whole point of pinning them. astro's peer is deliberately absent
+    # from this loop: astro owns its own declaration's shape, and `_satisfies` is
+    # what judges it.
     for key, what in (
         ("manifest_pin", "the markdown-remark pin"),
-        ("astro_peer", "astro's declared peer"),
         ("manifest_astro", "the astro pin"),
     ):
         assert EXACT_VERSION.fullmatch(v[key] or ""), (
-            f"{what} is {v[key]!r}, not an exact version. This test asserts exact "
-            "equality because astro declared an exact optional peer; a range means "
-            "that premise no longer holds and the check needs re-deriving, not "
-            "loosening."
+            f"{what} is {v[key]!r}, not an exact version. docs-site pins both "
+            "exactly so the installed version is a decision this repository "
+            "records, not whatever resolution happens to produce."
         )
 
     # The peer range is evidence about the pinned astro only if the lockfile still
@@ -270,13 +352,21 @@ def test_the_markdown_remark_pin_equals_astros_optional_peer() -> None:
         "docs-site/package.json": v["manifest_pin"],
         "package-lock.json root dependencies": v["lock_root_pin"],
         "package-lock.json resolved version": v["installed"],
-        f"astro {v['installed_astro']} optional peer": v["astro_peer"],
     }
     assert len(set(agreed.values())) == 1, (
-        f"the four recorded `{MARKDOWN_REMARK}` versions disagree: "
+        f"the three recorded `{MARKDOWN_REMARK}` versions disagree: "
         + ", ".join(f"{where} = {ver!r}" for where, ver in agreed.items())
         + " — they move together, or `astro build` fails to resolve the package "
         "astro.config.ts imports"
+    )
+
+    # `_satisfies` raises on a declaration shape it does not recognise; let that
+    # surface rather than converting it into a pass.
+    assert _satisfies(v["manifest_pin"], v["astro_peer"]), (
+        f"docs-site pins `{MARKDOWN_REMARK}` {v['manifest_pin']!r}, which does not "
+        f"satisfy astro {v['installed_astro']}'s declared optional peer "
+        f"{v['astro_peer']!r} — move the pin to a version that does, and keep the "
+        "lockfile's two copies with it"
     )
 
 
@@ -288,11 +378,9 @@ def test_starlight_also_accepts_the_markdown_remark_pin() -> None:
     equal to astro's peer, this site's other guard green, and Starlight's
     requirement unsatisfied. Checking only astro would miss it.
 
-    Caret satisfaction is computed here rather than pulled from a semver library:
-    this module is stdlib-only by construction, it runs in a required job, and a
-    test that can fail on a missing import is one someone import-guards under
-    pressure. Any range shape other than a caret on a non-zero major fails loudly
-    instead of being approximated.
+    Satisfaction is computed by `_satisfies`, the same predicate the astro check
+    uses, so the two consumers are judged by one rule. Any shape it does not
+    recognise fails loudly instead of being approximated.
     """
     v = _docs_site_versions()
     # Guard the early return: "Starlight is installed and stopped declaring the
@@ -305,27 +393,15 @@ def test_starlight_also_accepts_the_markdown_remark_pin() -> None:
     )
     spec = v["starlight_peer"]
     if spec is None:
-        return  # Starlight stopped declaring it; astro's exact peer is the contract.
+        return  # Starlight stopped declaring it; astro's declared peer is the contract.
 
-    caret = CARET_RANGE.fullmatch(spec)
-    assert caret, (
-        f"Starlight {v['starlight_version']} declares `{MARKDOWN_REMARK}` as "
-        f"{spec!r}, which is not the `^X.Y.Z` shape this check understands — "
-        "re-derive the comparison rather than widening it to pass."
-    )
-    floor = tuple(int(g) for g in caret.groups())
-    assert floor[0] != 0, (
-        f"Starlight's range {spec!r} is a caret on major 0, where caret semantics "
-        "pin the minor instead of the major — re-derive this comparison."
-    )
     pin = v["manifest_pin"] or ""
     assert EXACT_VERSION.fullmatch(pin), f"the pin is {pin!r}, not an exact version"
-    got = tuple(int(part) for part in pin.split("."))
-    assert got[0] == floor[0] and got >= floor, (
+    assert _satisfies(pin, spec), (
         f"docs-site pins `{MARKDOWN_REMARK}` {pin!r}, which does not satisfy "
         f"Starlight {v['starlight_version']}'s declared range {spec!r} — a "
         "Starlight bump moved the floor and the pin has to follow it too, not "
-        "only astro's exact peer"
+        "only astro's declared peer"
     )
 
 

--- a/web/src/test/e2e/site-quality-gate.spec.ts
+++ b/web/src/test/e2e/site-quality-gate.spec.ts
@@ -338,16 +338,15 @@ test.describe('docs search and theme controls are keyboard-operable', () => {
       // that menu first. Measured, not assumed — the first version of this case
       // failed at 360 for exactly this reason.
       await gotoSettled(page, withDocsBase('/'), ctx);
-      const menuButton = page.locator('starlight-menu-button button').first();
+      const menuButton = page.locator('button.sl-menu-button').first();
       if (await menuButton.isVisible()) {
-        await tabToAndAssertFocus(page, 'starlight-menu-button button', ctx, 30);
+        await tabToAndAssertFocus(page, 'button.sl-menu-button', ctx, 30);
         await page.keyboard.press('Enter');
-        // Asserted on the OBSERVABLE state, not on `aria-expanded`. Measured:
-        // Starlight's menu button opens on Enter but leaves `aria-expanded="false"`,
-        // so asserting the attribute fails on a menu that did open. That is pinned
-        // framework behaviour, recorded as an observation in the tap-target audit
-        // rather than worked around here — and the thing a keyboard user needs is
-        // that the control becomes reachable, which is what this asserts.
+        // Asserted on the OBSERVABLE state, not on an expansion attribute. Starlight
+        // 0.42 drives this menu through the popover API, so there is no DOM
+        // `aria-expanded` to read at all — the invoker's expanded state lives only in
+        // the accessibility tree. The thing a keyboard user needs is that the control
+        // becomes reachable, which is what this asserts.
       }
       const select = page.locator('starlight-theme-select select').locator('visible=true').first();
       await expect(
@@ -488,7 +487,7 @@ async function expectDocsChromeIsKeyboardOperable(
   // The Docs menu trigger is Starlight's and must remain keyboard-operable too.
   // It is a phone affordance, so on a phone width its absence is a failure rather
   // than a reason to skip.
-  const docsMenu = page.locator('starlight-menu-button button');
+  const docsMenu = page.locator('button.sl-menu-button');
   const docsMenuVisible = await docsMenu.isVisible();
   if (isPhone) {
     expect(docsMenuVisible, `${where}: the Docs menu trigger must render at phone widths`).toBe(
@@ -496,14 +495,17 @@ async function expectDocsChromeIsKeyboardOperable(
     );
   }
   if (docsMenuVisible) {
-    await tabToAndAssertFocus(page, 'starlight-menu-button button', ctx, 'derive');
+    await tabToAndAssertFocus(page, 'button.sl-menu-button', ctx, 'derive');
     await expect(docsMenu, `${where}: Docs menu trigger takes focus`).toBeFocused();
     await expectVisibleFocusIndicator(page, ctx);
     await page.keyboard.press('Enter');
+    // Starlight 0.42 opens this menu as a popover, so read the PANE's popover state.
+    // There is no `aria-expanded` attribute on the invoker any more, and
+    // `getAttribute` would return null and make this assert nothing.
     expect(
-      await page.locator('starlight-menu-button').getAttribute('aria-expanded'),
+      await page.locator('#starlight__sidebar').evaluate((el) => el.matches(':popover-open')),
       `${where}: Enter opens the Docs menu`
-    ).toBe('true');
+    ).toBe(true);
     await page.keyboard.press('Enter');
   }
 }
@@ -539,9 +541,9 @@ async function expectDocsChromeIsWellPlaced(
       headerPosition: frameHeader ? getComputedStyle(frameHeader).position : null,
       nativeHeaders: document.querySelectorAll('header.header > div.header').length,
       menuButtons: document.querySelectorAll(
-        'starlight-menu-button button[aria-controls="starlight__sidebar"]'
+        'button.sl-menu-button[popovertarget="starlight__sidebar"]'
       ).length,
-      sidebars: document.querySelectorAll('#starlight__sidebar').length,
+      sidebars: document.querySelectorAll('#starlight__sidebar[popover]').length,
       productNavs: document.querySelectorAll('nav[aria-label="Product navigation"]').length,
       // A direct link as the trigger is explicitly forbidden.
       productTriggerIsLink: !!document.querySelector(
@@ -716,27 +718,26 @@ test.describe('docs Product and Docs disclosures stay independent', () => {
 
       const productDetails = page.locator('nav[aria-label="Product navigation"] details');
       const docsMenuButton = page.locator(
-        'starlight-menu-button button[aria-controls="starlight__sidebar"]'
+        'button.sl-menu-button[popovertarget="starlight__sidebar"]'
       );
-      // Read expansion off the CUSTOM ELEMENT, not the button. Starlight's
-      // `setExpanded` does `this.setAttribute('aria-expanded', …)` on
-      // `<starlight-menu-button>`; the inner button's `aria-expanded="false"` is
-      // static markup that never changes, so reading the button reports the menu
-      // permanently closed and makes this whole test assert nothing.
-      const docsMenuHost = page.locator('starlight-menu-button');
+      // Read expansion off the PANE's popover state. Starlight 0.42 replaced the
+      // `<starlight-menu-button>` custom element and its `aria-expanded` bookkeeping
+      // with the native popover API, so the open/closed state now lives on the pane
+      // and there is no expansion attribute anywhere in the DOM to read.
+      const docsPane = page.locator('#starlight__sidebar');
       const productOpen = () => productDetails.evaluate((el: HTMLDetailsElement) => el.open);
-      const docsOpen = async () =>
-        (await docsMenuHost.getAttribute('aria-expanded')) === 'true';
+      const docsOpen = () => docsPane.evaluate((el) => el.matches(':popover-open'));
       const triggerText = () =>
         page.locator('nav[aria-label="Product navigation"] summary').innerText();
-      // Not just the attribute: the requirement is that the Docs MENU does not
-      // open. Starlight reveals it by CSS keyed off the menu button, so assert
-      // the pane's computed visibility as well — an attribute-only check would
-      // miss a selector change that reveals the sidebar without touching state.
+      // Not just the state: the requirement is that the Docs MENU does not open, so
+      // assert what the user can see as well. Read `display`, NOT `visibility` — a
+      // closed popover is `display: none` and its computed `visibility` stays
+      // `visible`, so the old visibility predicate would report every closed menu as
+      // shown and invert this test's meaning.
       const docsSidebarShown = () =>
         page
           .locator('#starlight__sidebar')
-          .evaluate((el) => getComputedStyle(el).visibility === 'visible');
+          .evaluate((el) => getComputedStyle(el).display !== 'none');
 
       await expect(productDetails).toHaveCount(1);
       await expect(docsMenuButton).toHaveCount(1);
@@ -774,6 +775,48 @@ test.describe('docs Product and Docs disclosures stay independent', () => {
       await docsMenuButton.click();
       expect(await docsOpen(), `${label(ctx)}: Docs closed`).toBe(false);
       expect(await productOpen(), `${label(ctx)}: closing Docs must not open Product`).toBe(false);
+    });
+
+    test(`/docs/ Escape closes the Docs menu and returns focus @${width}`, async ({ page }) => {
+      // The pane is `popover="manual"` so that closing the Product disclosure cannot
+      // light-dismiss it (spec/site-shared-chrome's isolated-disclosure-state rule).
+      // A manual popover gets NO Escape handling from the user agent, so docs-site's
+      // PageFrame override restores it — that handler is docs-local code, and without
+      // this case nothing exercises it. Starlight 0.41 closed on Escape and returned
+      // focus to the trigger; both halves are asserted, because a close that strands
+      // focus inside an inert pane is its own defect.
+      const ctx = { route: '/', width };
+      await page.setViewportSize({ width, height: 900 });
+      await gotoSettled(page, withDocsBase('/'), ctx);
+
+      const trigger = page.locator('button.sl-menu-button[popovertarget="starlight__sidebar"]');
+      const pane = page.locator('#starlight__sidebar');
+      const paneOpen = () => pane.evaluate((el) => el.matches(':popover-open'));
+
+      await trigger.click();
+      expect(await paneOpen(), `${label(ctx)}: the Docs menu opened`).toBe(true);
+
+      await page.keyboard.press('Escape');
+      expect(await paneOpen(), `${label(ctx)}: Escape closes the Docs menu`).toBe(false);
+      await expect(trigger, `${label(ctx)}: Escape returns focus to the trigger`).toBeFocused();
+
+      // Escape must still reach from the HEADER. The focus trap inerts only
+      // `.main-frame` and `.sl-skip-link`, so Starlight's title, search and theme
+      // controls stay tabbable while the menu is open. A listener scoped to the
+      // sidebar nav — which is what Starlight 0.41 used — never sees this Escape,
+      // and a keyboard user who tabs into the header is stranded in an open menu.
+      await trigger.click();
+      expect(await paneOpen(), `${label(ctx)}: the Docs menu reopened`).toBe(true);
+      await page.locator('header a.site-title').focus();
+      await expect(
+        page.locator('header a.site-title'),
+        `${label(ctx)}: the header stays reachable while the menu is open`
+      ).toBeFocused();
+      await page.keyboard.press('Escape');
+      expect(
+        await paneOpen(),
+        `${label(ctx)}: Escape closes the Docs menu from the header too`
+      ).toBe(false);
     });
   }
 });

--- a/web/src/test/rendered-output.test.ts
+++ b/web/src/test/rendered-output.test.ts
@@ -698,7 +698,18 @@ describe.skipIf(!webBuilt)('built marketing output', () => {
         `docs disclosure ${expected.product_navigation[index].id}`
       );
     }
-    expect(home.querySelectorAll('starlight-menu-button button[aria-controls="starlight__sidebar"]').length).toBe(1);
+    // Starlight 0.42 moved the mobile menu to the popover API: the trigger is a bare
+    // `button[popovertarget]` and the pane is an `sl-sidebar-pane[popover]`, so the
+    // old `starlight-menu-button` / `aria-controls` pair no longer exists. Assert the
+    // WIRING, not just the button's presence — `popovertarget` is inert unless it
+    // names an element that actually carries `popover`, and when docs-site's
+    // PageFrame override still emitted a plain `<div>` the menu could not open at
+    // all while a presence-only check stayed green.
+    const menuTrigger = home.querySelectorAll<HTMLButtonElement>('button.sl-menu-button');
+    expect(menuTrigger.length).toBe(1);
+    const sidebarPane = home.querySelector('#starlight__sidebar');
+    expect(menuTrigger[0].getAttribute('popovertarget')).toBe('starlight__sidebar');
+    expect(sidebarPane?.hasAttribute('popover')).toBe(true);
     expect(home.querySelectorAll('.sl-skip-link').length).toBe(1);
     expect(home.body.querySelector('a, button, summary')?.classList.contains('sl-skip-link')).toBe(true);
     // `.header` is not a singularity proxy. Starlight's own Header renders a
@@ -733,7 +744,7 @@ describe.skipIf(!webBuilt)('built marketing output', () => {
       // Ownership is proved at the override seam below, not by a generated Astro
       // scope hash: a hash is brittle, and a docs-local replacement emitted by any
       // other component would carry a different one and pass.
-      only('starlight-menu-button');        // Docs menu trigger
+      only('button.sl-menu-button');        // Docs menu trigger (popover invoker)
       only('#starlight__sidebar');          // sidebar
       only('nav.sidebar');
       only('.sl-skip-link');                // skip link


### PR DESCRIPTION
## What does this change?

Takes Dependabot's `docs-site-minor-and-patch` group — astro 7.2.9 → 7.3.1,
`@astrojs/starlight` 0.41.10 → 0.42.0, `@astrojs/markdown-remark` 7.2.4 → 7.3.0
— and adapts the three contracts the bump broke.

Supersedes #1236, which fails `gate-main` and `build` on exactly these two
breakages.

## Why?

Routine dependency maintenance, except that Starlight 0.42.0 is a behavioural
change. Two independent breakages, both real:

**1. The mobile sidebar could not open at all.** Starlight 0.42 replaced
`<starlight-menu-button>` and its `aria-expanded` bookkeeping with the native
popover API. `docs-site` overrides `PageFrame.astro` — the component that
composes the menu — and its CSS revealed the sidebar with
`starlight-menu-button[aria-expanded='true'] ~ .sidebar-pane`. That element no
longer exists, and the pane carried no `popover` attribute for the new
`popovertarget` invoker to act on, so the trigger was inert. The override now
follows the vendored 0.42 component: an `sl-sidebar-pane[popover]` with the same
focus trapping and resize-close. The CI assertion that failed was pointing at
this, not at a stale selector.

**2. astro changed the *shape* of its optional-peer declaration.** 7.2.9
declared `@astrojs/markdown-remark` as the exact `7.2.4`; 7.2.10 onward declares
the caret range `^7.3.0`. `test_the_markdown_remark_pin_equals_astros_optional_peer`
asserted all four recorded versions were equal, and its own text said a range
means "that premise no longer holds and the check needs re-deriving, not
loosening". It is re-derived along the line of who owns each value: the three
copies this repository writes still agree exactly, and the pin must *satisfy*
whatever astro declares. Equality was never the requirement — it was what
satisfaction collapsed to while the declaration was exact.

### The one decision that needed a human

An `auto` popover light-dismisses on any outside click — including a click on
the Product disclosure's own summary. `docs/specs/site-shared-chrome/spec.md` is
**Shipped** and requires the two disclosures to keep isolated state: "Opening or
closing it does not open, close, rename, or replace Starlight's Docs menu." The
e2e gate caught this at all four phone widths (`closing Product must not close
Docs`).

Resolved by setting `popover="manual"`, which reproduces Starlight 0.41's
interaction model — it had no light dismiss either. The alternative, adopting
upstream's light-dismiss and amending the Shipped AC, was rejected: a
dependency's internal change should not silently renegotiate product behaviour.

The cost is that a manual popover gets no user-agent Escape handling, so
Escape-to-close is restored in the override — bound on `document`, **not** on the
sidebar nav the way 0.41 bound it. Adversarial review caught why that distinction
matters: the focus trap inerts only `.main-frame` and `.sl-skip-link`, so
Starlight's header title, search and theme controls stay tabbable while the menu
is open, and a nav-scoped listener never sees Escape once focus lands on one of
them. 0.41 stranded a keyboard user that way; choosing `manual` is what makes
that gap ours to close, so this is deliberately better than 0.41 rather than
merely equal to it. Focus still returns to the trigger.

No changelog entry — this bumps no released artifact (`docs/CONVENTIONS.md` § 5b).

## How do I verify it?

```bash
npm ci --prefix docs-site                          # 465 packages, 0 vulnerabilities
python3 tools/build-site.py                        # exit 0
npm run build --prefix web                         # exit 0, 50 pages
npm run build --prefix docs-site                   # exit 0, 239 pages
npm run test --prefix web                          # 19 files, 158 tests passed
python3 -m pytest tools/test_browser_gate_subset.py -q   # 17 passed
npm run test:e2e:gate --prefix web                 # 186 passed, 1.5m
python3 tools/lint-agents-md.py                    # docs-site/AGENTS.md 80 lines (≤ 80)
```

Both new controls were mutation-proved rather than merely observed passing:

- Removing the Escape handler from `PageFrame.astro` fails the new e2e case at
  all four phone widths (4 failed); restoring it returns 4 passed.
- Narrowing that handler back to 0.41's `this.closest('nav')` scope fails the same
  case 4/4 on the header assertion specifically ("Escape closes the Docs menu from
  the header too"), so the widened scope is pinned rather than merely asserted.
- The re-derived peer check was walked against 21 mutations — pin below the
  caret floor, pin in the wrong major, either repo pin turned into a range,
  each lockfile copy drifting independently, the absent-pin case from #1036,
  astro dropping the peer, a wildcard, a caret on major 0, and an unrecognised
  range. All 21 behaved as required. Crucially the two exact-declaration rows
  still behave as the old contract did, so this generalises rather than loosens.
  A new `_satisfies` self-test pins that table permanently.

**Lockfile scope.** Dependabot's own resolution is used, not a local
regeneration. Regenerating from `main` floats 104 packages — including
vite 8.1.5 → 8.3.0 (desynchronising from `web/`) and esbuild 0.28.1 → 0.28.2
(which would force an `allowScripts` review into this PR). Dependabot's
resolution changes 29. Both carry the same two transitive majors,
`@astrojs/mdx` 7.0.7 → 8.0.0 and `magic-string` 0.30.21 → 1.2.3, so those are
genuinely required by astro 7.3.1 rather than an artefact of re-resolution.
`allowScripts` stays exactly `esbuild@0.28.1` + `fsevents@2.3.3`.

**One local gate leg is red from load, not from this diff.** `make build-check`
failed with 3 `semgrep --strict` timeout diagnostics across 2 files at 1-minute
load average 75.3 on 10 CPUs. Neither file is in this diff
(`packages/agentbundle/agentbundle/_data/workspace_status_engine.py`,
`tools/test-build-check-workflow.py`). The gate's own prescribed check — its
exact invocation per file — exits 0 for both, and for the one `tools/` file this
diff does change. Every leg before SAST passed. CI on an unloaded runner is the
gate of record.

## What did you not change that you considered?

- **Did not adopt upstream's `auto` popover.** See the decision above; it would
  have required amending a Shipped AC.
- **Did not hold Starlight at 0.41.10.** That was a live option — 0.41.10's
  declared ranges (`astro ^7.0.2`, `markdown-remark ^7.2.0`) still accept the
  bumped pair — but it defers the migration rather than resolving it, and
  Dependabot would immediately re-open the bump.
- **Did not loosen the peer check's regex to accept a caret.** The check's own
  text forbids exactly that, and a `*` declaration would then pass vacuously.
  `_satisfies` refuses any shape it does not recognise instead.
- **Did not remove the `--docs-sidebar-visibility` custom property's replacement
  with a JS toggle.** The popover API is the mechanism upstream chose;
  reimplementing visibility in JS would diverge further, not less.
- **Did not restructure `docs/architecture/reference.md:17`.** A reviewer flagged
  its compound sentence during #1273; that structure predates both PRs and this
  change only updates version numbers inside it.
- **Did not touch vitest.** `@vitest/ui` and `vitest` 4 → 5 are a coupled major
  pair landing separately.

---

## Checklist

- [x] Tests pass locally (`npm run test --prefix web`, `npm run test:e2e:gate --prefix web`, `pytest tools/test_browser_gate_subset.py`)
- [x] Lint and typecheck pass (`make build-check`, modulo the load-attributed semgrep timeouts above)
- [x] Self-review run via the relevant reviewer — adversarial review below; every finding carries a recorded disposition
- [x] Spec and code agree — `site-shared-chrome`'s shipped isolated-disclosure rule is preserved rather than amended
- [x] Living docs match reality
  - [x] No changelog entry — bumps no released artifact (`docs/CONVENTIONS.md` § 5b)
  - [x] No `guides/` change — no user-facing behaviour change; the menu behaves as it did on 0.41
  - [x] `docs/architecture/reference.md` and `docs-site/AGENTS.md` updated
  - [x] No roadmap item completed
- [x] No new top-level directories
- [x] Conventional commit format
- [x] Learnings captured — the popover migration, the `manual` rationale, and the peer-declaration shape change are all recorded in `docs-site/AGENTS.md`
